### PR TITLE
refactor(pg): replace store template with generics

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ActiveComponent, *storage.ActiveComponent]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ActiveComponent) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.ActiveComponent) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ActiveComponent")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ActiveComponent")
 }
 
 func insertIntoActiveComponents(ctx context.Context, batch *pgx.Batch, obj *storage.ActiveComponent) error {
@@ -268,21 +271,12 @@ func (s *storeImpl) copyFromActiveComponentsActiveContextsSlices(ctx context.Con
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ActiveComponent) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ActiveComponent")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -302,11 +296,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ActiveCompone
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ActiveComponent) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ActiveComponent")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -329,9 +323,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ActiveComponent
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ActiveComponent) error {
@@ -373,11 +366,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ActiveCompon
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -401,4 +392,4 @@ func dropTableActiveComponentsActiveContextsSlices(ctx context.Context, db postg
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -63,7 +63,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.Alert, *storage.Alert]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -75,13 +74,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.Alert) string {
 	return obj.GetId()
@@ -89,6 +88,10 @@ func pkGetter(obj *storage.Alert) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "Alert")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "Alert")
 }
 
 func insertIntoAlerts(_ context.Context, batch *pgx.Batch, obj *storage.Alert) error {
@@ -318,21 +321,12 @@ func (s *storeImpl) copyFromAlerts(ctx context.Context, tx *postgres.Tx, objs ..
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Alert) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Alert")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -352,11 +346,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Alert) error 
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Alert) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Alert")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -379,9 +373,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Alert) error {
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Alert) error {
@@ -433,11 +426,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Alert) error
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -455,4 +446,4 @@ func dropTableAlerts(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.TokenMetadata, *storage.TokenMetadata]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.TokenMetadata) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.TokenMetadata) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "TokenMetadata")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "TokenMetadata")
 }
 
 func insertIntoAPITokens(_ context.Context, batch *pgx.Batch, obj *storage.TokenMetadata) error {
@@ -181,21 +184,12 @@ func (s *storeImpl) copyFromAPITokens(ctx context.Context, tx *postgres.Tx, objs
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TokenMetadata) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TokenMetadata")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -215,11 +209,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TokenMetadata
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TokenMetadata) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TokenMetadata")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -242,9 +236,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TokenMetadata) 
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TokenMetadata) error {
@@ -286,11 +279,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TokenMetadat
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -308,4 +299,4 @@ func dropTableAPITokens(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.AuthProvider, *storage.AuthProvider]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.AuthProvider) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.AuthProvider) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "AuthProvider")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "AuthProvider")
 }
 
 func insertIntoAuthProviders(_ context.Context, batch *pgx.Batch, obj *storage.AuthProvider) error {
@@ -176,21 +179,12 @@ func (s *storeImpl) copyFromAuthProviders(ctx context.Context, tx *postgres.Tx, 
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.AuthProvider) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "AuthProvider")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -210,11 +204,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.AuthProvider)
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.AuthProvider) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "AuthProvider")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -237,9 +231,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.AuthProvider) e
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.AuthProvider) error {
@@ -281,11 +274,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.AuthProvider
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -303,4 +294,4 @@ func dropTableAuthProviders(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/blob/datastore/store/postgres/store.go
+++ b/central/blob/datastore/store/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.Blob, *storage.Blob]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.Blob) string {
 	return obj.GetName()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.Blob) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "Blob")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "Blob")
 }
 
 func insertIntoBlobs(_ context.Context, batch *pgx.Batch, obj *storage.Blob) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromBlobs(ctx context.Context, tx *postgres.Tx, objs ...
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Blob) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Blob")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Blob) error {
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Blob) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Blob")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Blob) error {
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Blob) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Blob) error 
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableBlobs(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/clustercveedge/datastore/store/postgres/store.go
+++ b/central/clustercveedge/datastore/store/postgres/store.go
@@ -51,7 +51,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ClusterCVEEdge, *storage.ClusterCVEEdge]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -63,13 +62,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ClusterCVEEdge) string {
 	return obj.GetId()
@@ -79,24 +78,13 @@ func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ClusterCVEEdge")
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ClusterCVEEdge")
 }
 
-//// Helper functions - END
+// endregion Helper functions
 
-//// Interface functions
-
-//// Stubs for satisfying legacy interfaces
-
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -114,4 +102,4 @@ func dropTableClusterCveEdges(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
+++ b/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ComplianceConfig, *storage.ComplianceConfig]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ComplianceConfig) string {
 	return obj.GetStandardId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.ComplianceConfig) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ComplianceConfig")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ComplianceConfig")
 }
 
 func insertIntoComplianceConfigs(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceConfig) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromComplianceConfigs(ctx context.Context, tx *postgres.
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceConfig) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceConfig")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceCon
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceConfig) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceConfig")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceConfi
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceConfig) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceCo
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableComplianceConfigs(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ComplianceDomain, *storage.ComplianceDomain]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ComplianceDomain) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.ComplianceDomain) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ComplianceDomain")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ComplianceDomain")
 }
 
 func insertIntoComplianceDomains(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceDomain) error {
@@ -171,21 +174,12 @@ func (s *storeImpl) copyFromComplianceDomains(ctx context.Context, tx *postgres.
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceDomain) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceDomain")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -205,11 +199,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceDom
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceDomain) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceDomain")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -232,9 +226,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceDomai
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceDomain) error {
@@ -276,11 +269,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceDo
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -298,4 +289,4 @@ func dropTableComplianceDomains(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -63,7 +63,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ComplianceRunMetadata, *storage.ComplianceRunMetadata]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -75,13 +74,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ComplianceRunMetadata) string {
 	return obj.GetRunId()
@@ -89,6 +88,10 @@ func pkGetter(obj *storage.ComplianceRunMetadata) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ComplianceRunMetadata")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ComplianceRunMetadata")
 }
 
 func insertIntoComplianceRunMetadata(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceRunMetadata) error {
@@ -188,21 +191,12 @@ func (s *storeImpl) copyFromComplianceRunMetadata(ctx context.Context, tx *postg
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceRunMetadata) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceRunMetadata")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -222,11 +216,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceRun
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceRunMetadata) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceRunMetadata")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -249,9 +243,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceRunMe
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceRunMetadata) error {
@@ -303,11 +296,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRu
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -325,4 +316,4 @@ func dropTableComplianceRunMetadata(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -63,7 +63,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ComplianceRunResults, *storage.ComplianceRunResults]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -75,13 +74,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ComplianceRunResults) string {
 	return obj.GetRunMetadata().GetRunId()
@@ -89,6 +88,10 @@ func pkGetter(obj *storage.ComplianceRunResults) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ComplianceRunResults")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ComplianceRunResults")
 }
 
 func insertIntoComplianceRunResults(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceRunResults) error {
@@ -188,21 +191,12 @@ func (s *storeImpl) copyFromComplianceRunResults(ctx context.Context, tx *postgr
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceRunResults) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceRunResults")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -222,11 +216,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceRun
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceRunResults) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceRunResults")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -249,9 +243,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceRunRe
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceRunResults) error {
@@ -303,11 +296,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRu
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -325,4 +316,4 @@ func dropTableComplianceRunResults(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ComplianceStrings, *storage.ComplianceStrings]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ComplianceStrings) string {
 	return obj.GetId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.ComplianceStrings) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ComplianceStrings")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ComplianceStrings")
 }
 
 func insertIntoComplianceStrings(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceStrings) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromComplianceStrings(ctx context.Context, tx *postgres.
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceStrings) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceStrings")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceStr
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceStrings) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceStrings")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceStrin
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceStrings) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceSt
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableComplianceStrings(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ComplianceOperatorCheckResult, *storage.ComplianceOperatorCheckResult]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ComplianceOperatorCheckResult) string {
 	return obj.GetId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.ComplianceOperatorCheckResult) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ComplianceOperatorCheckResult")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ComplianceOperatorCheckResult")
 }
 
 func insertIntoComplianceOperatorCheckResults(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorCheckResult) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromComplianceOperatorCheckResults(ctx context.Context, 
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceOperatorCheckResult) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceOperatorCheckResult")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceOpe
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOperatorCheckResult) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceOperatorCheckResult")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorCheckResult) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableComplianceOperatorCheckResults(ctx context.Context, db postgres.DB
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ComplianceOperatorProfile, *storage.ComplianceOperatorProfile]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ComplianceOperatorProfile) string {
 	return obj.GetId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.ComplianceOperatorProfile) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ComplianceOperatorProfile")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ComplianceOperatorProfile")
 }
 
 func insertIntoComplianceOperatorProfiles(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorProfile) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromComplianceOperatorProfiles(ctx context.Context, tx *
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceOperatorProfile) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceOperatorProfile")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceOpe
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOperatorProfile) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceOperatorProfile")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorProfile) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableComplianceOperatorProfiles(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ComplianceOperatorRule, *storage.ComplianceOperatorRule]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ComplianceOperatorRule) string {
 	return obj.GetId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.ComplianceOperatorRule) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ComplianceOperatorRule")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ComplianceOperatorRule")
 }
 
 func insertIntoComplianceOperatorRules(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorRule) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromComplianceOperatorRules(ctx context.Context, tx *pos
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceOperatorRule) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceOperatorRule")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceOpe
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOperatorRule) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceOperatorRule")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorRule) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableComplianceOperatorRules(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ComplianceOperatorScan, *storage.ComplianceOperatorScan]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ComplianceOperatorScan) string {
 	return obj.GetId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.ComplianceOperatorScan) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ComplianceOperatorScan")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ComplianceOperatorScan")
 }
 
 func insertIntoComplianceOperatorScans(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorScan) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromComplianceOperatorScans(ctx context.Context, tx *pos
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceOperatorScan) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceOperatorScan")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceOpe
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOperatorScan) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceOperatorScan")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorScan) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableComplianceOperatorScans(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ComplianceOperatorScanSettingBinding, *storage.ComplianceOperatorScanSettingBinding]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ComplianceOperatorScanSettingBinding) string {
 	return obj.GetId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.ComplianceOperatorScanSettingBinding) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ComplianceOperatorScanSettingBinding")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ComplianceOperatorScanSettingBinding")
 }
 
 func insertIntoComplianceOperatorScanSettingBindings(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorScanSettingBinding) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromComplianceOperatorScanSettingBindings(ctx context.Co
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceOperatorScanSettingBinding) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceOperatorScanSettingBinding")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ComplianceOpe
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOperatorScanSettingBinding) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ComplianceOperatorScanSettingBinding")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ComplianceOpera
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ComplianceOperatorScanSettingBinding) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableComplianceOperatorScanSettingBindings(ctx context.Context, db post
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ClusterCVE, *storage.ClusterCVE]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ClusterCVE) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.ClusterCVE) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ClusterCVE")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ClusterCVE")
 }
 
 func insertIntoClusterCves(_ context.Context, batch *pgx.Batch, obj *storage.ClusterCVE) error {
@@ -216,21 +219,12 @@ func (s *storeImpl) copyFromClusterCves(ctx context.Context, tx *postgres.Tx, ob
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ClusterCVE) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ClusterCVE")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -250,11 +244,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ClusterCVE) e
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ClusterCVE) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ClusterCVE")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -277,9 +271,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ClusterCVE) err
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ClusterCVE) error {
@@ -321,11 +314,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterCVE) 
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -343,4 +334,4 @@ func dropTableClusterCves(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ImageCVE, *storage.ImageCVE]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ImageCVE) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.ImageCVE) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ImageCVE")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ImageCVE")
 }
 
 func insertIntoImageCves(_ context.Context, batch *pgx.Batch, obj *storage.ImageCVE) error {
@@ -216,21 +219,12 @@ func (s *storeImpl) copyFromImageCves(ctx context.Context, tx *postgres.Tx, objs
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ImageCVE) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ImageCVE")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -250,11 +244,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ImageCVE) err
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ImageCVE) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ImageCVE")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -277,9 +271,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ImageCVE) error
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageCVE) error {
@@ -321,11 +314,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageCVE) er
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -343,4 +334,4 @@ func dropTableImageCves(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.NodeCVE, *storage.NodeCVE]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.NodeCVE) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.NodeCVE) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "NodeCVE")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "NodeCVE")
 }
 
 func insertIntoNodeCves(_ context.Context, batch *pgx.Batch, obj *storage.NodeCVE) error {
@@ -216,21 +219,12 @@ func (s *storeImpl) copyFromNodeCves(ctx context.Context, tx *postgres.Tx, objs 
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.NodeCVE) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NodeCVE")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -250,11 +244,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.NodeCVE) erro
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NodeCVE) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NodeCVE")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -277,9 +271,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NodeCVE) error 
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NodeCVE) error {
@@ -321,11 +314,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NodeCVE) err
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -343,4 +334,4 @@ func dropTableNodeCves(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -63,7 +63,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.Deployment, *storage.Deployment]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -75,13 +74,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.Deployment) string {
 	return obj.GetId()
@@ -89,6 +88,10 @@ func pkGetter(obj *storage.Deployment) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "Deployment")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "Deployment")
 }
 
 func insertIntoDeployments(ctx context.Context, batch *pgx.Batch, obj *storage.Deployment) error {
@@ -874,21 +877,12 @@ func (s *storeImpl) copyFromDeploymentsPortsExposureInfos(ctx context.Context, t
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Deployment) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Deployment")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -908,11 +902,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Deployment) e
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Deployment) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Deployment")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -935,9 +929,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Deployment) err
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Deployment) error {
@@ -989,11 +982,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Deployment) 
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -1047,4 +1038,4 @@ func dropTableDeploymentsPortsExposureInfos(ctx context.Context, db postgres.DB)
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ExternalBackup, *storage.ExternalBackup]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ExternalBackup) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.ExternalBackup) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ExternalBackup")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ExternalBackup")
 }
 
 func insertIntoExternalBackups(_ context.Context, batch *pgx.Batch, obj *storage.ExternalBackup) error {
@@ -171,21 +174,12 @@ func (s *storeImpl) copyFromExternalBackups(ctx context.Context, tx *postgres.Tx
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ExternalBackup) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ExternalBackup")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -205,11 +199,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ExternalBacku
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ExternalBackup) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ExternalBackup")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -232,9 +226,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ExternalBackup)
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ExternalBackup) error {
@@ -276,11 +269,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ExternalBack
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -298,4 +289,4 @@ func dropTableExternalBackups(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.Group, *storage.Group]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.Group) string {
 	return obj.GetProps().GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.Group) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "Group")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "Group")
 }
 
 func insertIntoGroups(_ context.Context, batch *pgx.Batch, obj *storage.Group) error {
@@ -191,21 +194,12 @@ func (s *storeImpl) copyFromGroups(ctx context.Context, tx *postgres.Tx, objs ..
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Group) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Group")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -225,11 +219,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Group) error 
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Group) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Group")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -252,9 +246,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Group) error {
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Group) error {
@@ -296,11 +289,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Group) error
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -318,4 +309,4 @@ func dropTableGroups(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/hash/datastore/store/postgres/store.go
+++ b/central/hash/datastore/store/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.Hash, *storage.Hash]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.Hash) string {
 	return obj.GetClusterId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.Hash) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "Hash")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "Hash")
 }
 
 func insertIntoHashes(_ context.Context, batch *pgx.Batch, obj *storage.Hash) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromHashes(ctx context.Context, tx *postgres.Tx, objs ..
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Hash) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Hash")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Hash) error {
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Hash) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Hash")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Hash) error {
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Hash) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Hash) error 
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableHashes(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ImageComponent, *storage.ImageComponent]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ImageComponent) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.ImageComponent) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ImageComponent")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ImageComponent")
 }
 
 func insertIntoImageComponents(_ context.Context, batch *pgx.Batch, obj *storage.ImageComponent) error {
@@ -206,21 +209,12 @@ func (s *storeImpl) copyFromImageComponents(ctx context.Context, tx *postgres.Tx
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ImageComponent) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ImageComponent")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -240,11 +234,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ImageComponen
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ImageComponent) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ImageComponent")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -267,9 +261,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ImageComponent)
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageComponent) error {
@@ -311,11 +304,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageCompone
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -333,4 +324,4 @@ func dropTableImageComponents(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -51,7 +51,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ImageComponentEdge, *storage.ImageComponentEdge]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -63,13 +62,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ImageComponentEdge) string {
 	return obj.GetId()
@@ -79,24 +78,13 @@ func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ImageComponentEdge")
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ImageComponentEdge")
 }
 
-//// Helper functions - END
+// endregion Helper functions
 
-//// Interface functions
-
-//// Stubs for satisfying legacy interfaces
-
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -114,4 +102,4 @@ func dropTableImageComponentEdges(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/imagecveedge/datastore/postgres/store.go
+++ b/central/imagecveedge/datastore/postgres/store.go
@@ -51,7 +51,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ImageCVEEdge, *storage.ImageCVEEdge]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -63,13 +62,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ImageCVEEdge) string {
 	return obj.GetId()
@@ -79,24 +78,13 @@ func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ImageCVEEdge")
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ImageCVEEdge")
 }
 
-//// Helper functions - END
+// endregion Helper functions
 
-//// Interface functions
-
-//// Stubs for satisfying legacy interfaces
-
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -114,4 +102,4 @@ func dropTableImageCveEdges(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -62,7 +62,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ImageIntegration, *storage.ImageIntegration]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -74,13 +73,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ImageIntegration) string {
 	return obj.GetId()
@@ -88,6 +87,10 @@ func pkGetter(obj *storage.ImageIntegration) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ImageIntegration")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ImageIntegration")
 }
 
 func insertIntoImageIntegrations(_ context.Context, batch *pgx.Batch, obj *storage.ImageIntegration) error {
@@ -182,21 +185,12 @@ func (s *storeImpl) copyFromImageIntegrations(ctx context.Context, tx *postgres.
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ImageIntegration) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ImageIntegration")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -216,11 +210,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ImageIntegrat
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ImageIntegration) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ImageIntegration")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -243,9 +237,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ImageIntegratio
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ImageIntegration) error {
@@ -287,11 +280,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageIntegra
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -309,4 +300,4 @@ func dropTableImageIntegrations(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.IntegrationHealth, *storage.IntegrationHealth]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.IntegrationHealth) string {
 	return obj.GetId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.IntegrationHealth) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "IntegrationHealth")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "IntegrationHealth")
 }
 
 func insertIntoIntegrationHealths(_ context.Context, batch *pgx.Batch, obj *storage.IntegrationHealth) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromIntegrationHealths(ctx context.Context, tx *postgres
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.IntegrationHealth) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "IntegrationHealth")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.IntegrationHe
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.IntegrationHealth) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "IntegrationHealth")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.IntegrationHeal
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.IntegrationHealth) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.IntegrationH
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableIntegrationHealths(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.NetworkGraphConfig, *storage.NetworkGraphConfig]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.NetworkGraphConfig) string {
 	return obj.GetId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.NetworkGraphConfig) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "NetworkGraphConfig")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "NetworkGraphConfig")
 }
 
 func insertIntoNetworkGraphConfigs(_ context.Context, batch *pgx.Batch, obj *storage.NetworkGraphConfig) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromNetworkGraphConfigs(ctx context.Context, tx *postgre
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.NetworkGraphConfig) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NetworkGraphConfig")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.NetworkGraphC
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkGraphConfig) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NetworkGraphConfig")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkGraphCon
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkGraphConfig) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkGraph
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableNetworkGraphConfigs(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -59,7 +59,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.NetworkEntity, *storage.NetworkEntity]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -71,13 +70,13 @@ func New(db postgres.DB) Store {
 			permissionCheckerSingleton(),
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.NetworkEntity) string {
 	return obj.GetInfo().GetId()
@@ -85,6 +84,10 @@ func pkGetter(obj *storage.NetworkEntity) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "NetworkEntity")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "NetworkEntity")
 }
 
 func insertIntoNetworkEntities(_ context.Context, batch *pgx.Batch, obj *storage.NetworkEntity) error {
@@ -174,21 +177,12 @@ func (s *storeImpl) copyFromNetworkEntities(ctx context.Context, tx *postgres.Tx
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.NetworkEntity) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NetworkEntity")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -208,11 +202,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.NetworkEntity
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkEntity) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NetworkEntity")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -235,9 +229,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkEntity) 
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkEntity) error {
@@ -281,11 +274,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkEntit
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -303,4 +294,4 @@ func dropTableNetworkEntities(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -63,7 +63,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.NetworkPolicy, *storage.NetworkPolicy]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -75,13 +74,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.NetworkPolicy) string {
 	return obj.GetId()
@@ -89,6 +88,10 @@ func pkGetter(obj *storage.NetworkPolicy) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "NetworkPolicy")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "NetworkPolicy")
 }
 
 func insertIntoNetworkpolicies(_ context.Context, batch *pgx.Batch, obj *storage.NetworkPolicy) error {
@@ -183,21 +186,12 @@ func (s *storeImpl) copyFromNetworkpolicies(ctx context.Context, tx *postgres.Tx
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.NetworkPolicy) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NetworkPolicy")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -217,11 +211,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.NetworkPolicy
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicy) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NetworkPolicy")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -244,9 +238,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicy) 
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicy) error {
@@ -298,11 +291,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -320,4 +311,4 @@ func dropTableNetworkpolicies(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.NetworkPolicyApplicationUndoDeploymentRecord, *storage.NetworkPolicyApplicationUndoDeploymentRecord]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.NetworkPolicyApplicationUndoDeploymentRecord) string {
 	return obj.GetDeploymentId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.NetworkPolicyApplicationUndoDeploymentRecord) string 
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "NetworkPolicyApplicationUndoDeploymentRecord")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "NetworkPolicyApplicationUndoDeploymentRecord")
 }
 
 func insertIntoNetworkpoliciesundodeployments(_ context.Context, batch *pgx.Batch, obj *storage.NetworkPolicyApplicationUndoDeploymentRecord) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromNetworkpoliciesundodeployments(ctx context.Context, 
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.NetworkPolicyApplicationUndoDeploymentRecord) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NetworkPolicyApplicationUndoDeploymentRecord")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.NetworkPolicy
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicyApplicationUndoDeploymentRecord) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NetworkPolicyApplicationUndoDeploymentRecord")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicyAp
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicyApplicationUndoDeploymentRecord) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableNetworkpoliciesundodeployments(ctx context.Context, db postgres.DB
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.NetworkPolicyApplicationUndoRecord, *storage.NetworkPolicyApplicationUndoRecord]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.NetworkPolicyApplicationUndoRecord) string {
 	return obj.GetClusterId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.NetworkPolicyApplicationUndoRecord) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "NetworkPolicyApplicationUndoRecord")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "NetworkPolicyApplicationUndoRecord")
 }
 
 func insertIntoNetworkpolicyapplicationundorecords(_ context.Context, batch *pgx.Batch, obj *storage.NetworkPolicyApplicationUndoRecord) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromNetworkpolicyapplicationundorecords(ctx context.Cont
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.NetworkPolicyApplicationUndoRecord) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NetworkPolicyApplicationUndoRecord")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.NetworkPolicy
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicyApplicationUndoRecord) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NetworkPolicyApplicationUndoRecord")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NetworkPolicyAp
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NetworkPolicyApplicationUndoRecord) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableNetworkpolicyapplicationundorecords(ctx context.Context, db postgr
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.NodeComponent, *storage.NodeComponent]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.NodeComponent) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.NodeComponent) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "NodeComponent")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "NodeComponent")
 }
 
 func insertIntoNodeComponents(_ context.Context, batch *pgx.Batch, obj *storage.NodeComponent) error {
@@ -201,21 +204,12 @@ func (s *storeImpl) copyFromNodeComponents(ctx context.Context, tx *postgres.Tx,
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.NodeComponent) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NodeComponent")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -235,11 +229,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.NodeComponent
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NodeComponent) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "NodeComponent")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -262,9 +256,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.NodeComponent) 
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.NodeComponent) error {
@@ -306,11 +299,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NodeComponen
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -328,4 +319,4 @@ func dropTableNodeComponents(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/nodecomponentcveedge/datastore/store/postgres/store.go
+++ b/central/nodecomponentcveedge/datastore/store/postgres/store.go
@@ -51,7 +51,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.NodeComponentCVEEdge, *storage.NodeComponentCVEEdge]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -63,13 +62,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.NodeComponentCVEEdge) string {
 	return obj.GetId()
@@ -79,24 +78,13 @@ func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "NodeComponentCVEEdge")
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "NodeComponentCVEEdge")
 }
 
-//// Helper functions - END
+// endregion Helper functions
 
-//// Interface functions
-
-//// Stubs for satisfying legacy interfaces
-
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -114,4 +102,4 @@ func dropTableNodeComponentsCvesEdges(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -51,7 +51,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.NodeComponentEdge, *storage.NodeComponentEdge]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -63,13 +62,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.NodeComponentEdge) string {
 	return obj.GetId()
@@ -79,24 +78,13 @@ func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "NodeComponentEdge")
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "NodeComponentEdge")
 }
 
-//// Helper functions - END
+// endregion Helper functions
 
-//// Interface functions
-
-//// Stubs for satisfying legacy interfaces
-
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -114,4 +102,4 @@ func dropTableNodeComponentEdges(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.Notifier, *storage.Notifier]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.Notifier) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.Notifier) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "Notifier")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "Notifier")
 }
 
 func insertIntoNotifiers(_ context.Context, batch *pgx.Batch, obj *storage.Notifier) error {
@@ -176,21 +179,12 @@ func (s *storeImpl) copyFromNotifiers(ctx context.Context, tx *postgres.Tx, objs
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Notifier) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Notifier")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -210,11 +204,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Notifier) err
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Notifier) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Notifier")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -237,9 +231,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Notifier) error
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Notifier) error {
@@ -281,11 +274,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Notifier) er
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -303,4 +294,4 @@ func dropTableNotifiers(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -63,7 +63,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.Pod, *storage.Pod]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -75,13 +74,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.Pod) string {
 	return obj.GetId()
@@ -89,6 +88,10 @@ func pkGetter(obj *storage.Pod) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "Pod")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "Pod")
 }
 
 func insertIntoPods(ctx context.Context, batch *pgx.Batch, obj *storage.Pod) error {
@@ -275,21 +278,12 @@ func (s *storeImpl) copyFromPodsLiveInstances(ctx context.Context, tx *postgres.
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Pod) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Pod")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -309,11 +303,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Pod) error {
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Pod) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Pod")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -336,9 +330,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Pod) error {
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Pod) error {
@@ -390,11 +383,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Pod) error {
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -418,4 +409,4 @@ func dropTablePodsLiveInstances(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -62,7 +62,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.PolicyCategory, *storage.PolicyCategory]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -74,13 +73,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.PolicyCategory) string {
 	return obj.GetId()
@@ -88,6 +87,10 @@ func pkGetter(obj *storage.PolicyCategory) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "PolicyCategory")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "PolicyCategory")
 }
 
 func insertIntoPolicyCategories(_ context.Context, batch *pgx.Batch, obj *storage.PolicyCategory) error {
@@ -177,21 +180,12 @@ func (s *storeImpl) copyFromPolicyCategories(ctx context.Context, tx *postgres.T
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.PolicyCategory) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "PolicyCategory")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -211,11 +205,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.PolicyCategor
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PolicyCategory) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "PolicyCategory")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -238,9 +232,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PolicyCategory)
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PolicyCategory) error {
@@ -282,11 +275,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PolicyCatego
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -304,4 +295,4 @@ func dropTablePolicyCategories(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -63,7 +63,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ProcessBaseline, *storage.ProcessBaseline]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -75,13 +74,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ProcessBaseline) string {
 	return obj.GetId()
@@ -89,6 +88,10 @@ func pkGetter(obj *storage.ProcessBaseline) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ProcessBaseline")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ProcessBaseline")
 }
 
 func insertIntoProcessBaselines(_ context.Context, batch *pgx.Batch, obj *storage.ProcessBaseline) error {
@@ -188,21 +191,12 @@ func (s *storeImpl) copyFromProcessBaselines(ctx context.Context, tx *postgres.T
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ProcessBaseline) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ProcessBaseline")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -222,11 +216,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ProcessBaseli
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessBaseline) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ProcessBaseline")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -249,9 +243,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessBaseline
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaseline) error {
@@ -303,11 +296,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBasel
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -325,4 +316,4 @@ func dropTableProcessBaselines(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -63,7 +63,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ProcessBaselineResults, *storage.ProcessBaselineResults]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -75,13 +74,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ProcessBaselineResults) string {
 	return obj.GetDeploymentId()
@@ -89,6 +88,10 @@ func pkGetter(obj *storage.ProcessBaselineResults) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ProcessBaselineResults")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ProcessBaselineResults")
 }
 
 func insertIntoProcessBaselineResults(_ context.Context, batch *pgx.Batch, obj *storage.ProcessBaselineResults) error {
@@ -183,21 +186,12 @@ func (s *storeImpl) copyFromProcessBaselineResults(ctx context.Context, tx *post
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ProcessBaselineResults) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ProcessBaselineResults")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -217,11 +211,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ProcessBaseli
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessBaselineResults) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ProcessBaselineResults")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -244,9 +238,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessBaseline
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessBaselineResults) error {
@@ -298,11 +291,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBasel
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -320,4 +311,4 @@ func dropTableProcessBaselineResults(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -63,7 +63,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ProcessIndicator, *storage.ProcessIndicator]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -75,13 +74,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ProcessIndicator) string {
 	return obj.GetId()
@@ -89,6 +88,10 @@ func pkGetter(obj *storage.ProcessIndicator) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ProcessIndicator")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ProcessIndicator")
 }
 
 func insertIntoProcessIndicators(_ context.Context, batch *pgx.Batch, obj *storage.ProcessIndicator) error {
@@ -228,21 +231,12 @@ func (s *storeImpl) copyFromProcessIndicators(ctx context.Context, tx *postgres.
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ProcessIndicator) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ProcessIndicator")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -262,11 +256,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ProcessIndica
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessIndicator) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ProcessIndicator")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -289,9 +283,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ProcessIndicato
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ProcessIndicator) error {
@@ -343,11 +336,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessIndic
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -365,4 +356,4 @@ func dropTableProcessIndicators(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -63,7 +63,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.K8SRole, *storage.K8SRole]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -75,13 +74,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.K8SRole) string {
 	return obj.GetId()
@@ -89,6 +88,10 @@ func pkGetter(obj *storage.K8SRole) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "K8SRole")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "K8SRole")
 }
 
 func insertIntoK8sRoles(_ context.Context, batch *pgx.Batch, obj *storage.K8SRole) error {
@@ -208,21 +211,12 @@ func (s *storeImpl) copyFromK8sRoles(ctx context.Context, tx *postgres.Tx, objs 
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.K8SRole) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "K8SRole")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -242,11 +236,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.K8SRole) erro
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.K8SRole) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "K8SRole")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -269,9 +263,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.K8SRole) error 
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.K8SRole) error {
@@ -323,11 +316,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRole) err
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -345,4 +336,4 @@ func dropTableK8sRoles(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -63,7 +63,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.K8SRoleBinding, *storage.K8SRoleBinding]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -75,13 +74,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.K8SRoleBinding) string {
 	return obj.GetId()
@@ -89,6 +88,10 @@ func pkGetter(obj *storage.K8SRoleBinding) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "K8SRoleBinding")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "K8SRoleBinding")
 }
 
 func insertIntoRoleBindings(ctx context.Context, batch *pgx.Batch, obj *storage.K8SRoleBinding) error {
@@ -300,21 +303,12 @@ func (s *storeImpl) copyFromRoleBindingsSubjects(ctx context.Context, tx *postgr
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.K8SRoleBinding) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "K8SRoleBinding")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -334,11 +328,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.K8SRoleBindin
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.K8SRoleBinding) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "K8SRoleBinding")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -361,9 +355,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.K8SRoleBinding)
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.K8SRoleBinding) error {
@@ -415,11 +408,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRoleBindi
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -443,4 +434,4 @@ func dropTableRoleBindingsSubjects(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.PermissionSet, *storage.PermissionSet]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.PermissionSet) string {
 	return obj.GetId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.PermissionSet) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "PermissionSet")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "PermissionSet")
 }
 
 func insertIntoPermissionSets(_ context.Context, batch *pgx.Batch, obj *storage.PermissionSet) error {
@@ -175,21 +178,12 @@ func (s *storeImpl) copyFromPermissionSets(ctx context.Context, tx *postgres.Tx,
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.PermissionSet) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "PermissionSet")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -209,11 +203,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.PermissionSet
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PermissionSet) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "PermissionSet")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -236,9 +230,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PermissionSet) 
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PermissionSet) error {
@@ -280,11 +273,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSe
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -302,4 +293,4 @@ func dropTablePermissionSets(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.Role, *storage.Role]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.Role) string {
 	return obj.GetName()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.Role) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "Role")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "Role")
 }
 
 func insertIntoRoles(_ context.Context, batch *pgx.Batch, obj *storage.Role) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromRoles(ctx context.Context, tx *postgres.Tx, objs ...
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Role) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Role")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Role) error {
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Role) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Role")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Role) error {
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Role) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Role) error 
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableRoles(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.SimpleAccessScope, *storage.SimpleAccessScope]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.SimpleAccessScope) string {
 	return obj.GetId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.SimpleAccessScope) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "SimpleAccessScope")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "SimpleAccessScope")
 }
 
 func insertIntoSimpleAccessScopes(_ context.Context, batch *pgx.Batch, obj *storage.SimpleAccessScope) error {
@@ -175,21 +178,12 @@ func (s *storeImpl) copyFromSimpleAccessScopes(ctx context.Context, tx *postgres
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.SimpleAccessScope) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "SimpleAccessScope")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -209,11 +203,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.SimpleAccessS
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.SimpleAccessScope) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "SimpleAccessScope")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -236,9 +230,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.SimpleAccessSco
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SimpleAccessScope) error {
@@ -280,11 +273,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SimpleAccess
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -302,4 +293,4 @@ func dropTableSimpleAccessScopes(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -63,7 +63,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.Secret, *storage.Secret]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -75,13 +74,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.Secret) string {
 	return obj.GetId()
@@ -89,6 +88,10 @@ func pkGetter(obj *storage.Secret) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "Secret")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "Secret")
 }
 
 func insertIntoSecrets(ctx context.Context, batch *pgx.Batch, obj *storage.Secret) error {
@@ -372,21 +375,12 @@ func (s *storeImpl) copyFromSecretsFilesRegistries(ctx context.Context, tx *post
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Secret) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Secret")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -406,11 +400,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Secret) error
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Secret) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "Secret")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -433,9 +427,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Secret) error {
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Secret) error {
@@ -487,11 +480,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Secret) erro
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -521,4 +512,4 @@ func dropTableSecretsFilesRegistries(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -63,7 +63,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ServiceAccount, *storage.ServiceAccount]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -75,13 +74,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ServiceAccount) string {
 	return obj.GetId()
@@ -89,6 +88,10 @@ func pkGetter(obj *storage.ServiceAccount) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ServiceAccount")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ServiceAccount")
 }
 
 func insertIntoServiceAccounts(_ context.Context, batch *pgx.Batch, obj *storage.ServiceAccount) error {
@@ -203,21 +206,12 @@ func (s *storeImpl) copyFromServiceAccounts(ctx context.Context, tx *postgres.Tx
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ServiceAccount) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ServiceAccount")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -237,11 +231,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ServiceAccoun
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ServiceAccount) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ServiceAccount")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -264,9 +258,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ServiceAccount)
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ServiceAccount) error {
@@ -318,11 +311,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceAccou
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -340,4 +331,4 @@ func dropTableServiceAccounts(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.ServiceIdentity, *storage.ServiceIdentity]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.ServiceIdentity) string {
 	return obj.GetSerialStr()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.ServiceIdentity) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "ServiceIdentity")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "ServiceIdentity")
 }
 
 func insertIntoServiceIdentities(_ context.Context, batch *pgx.Batch, obj *storage.ServiceIdentity) error {
@@ -171,21 +174,12 @@ func (s *storeImpl) copyFromServiceIdentities(ctx context.Context, tx *postgres.
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ServiceIdentity) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ServiceIdentity")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -205,11 +199,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.ServiceIdenti
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ServiceIdentity) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "ServiceIdentity")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -232,9 +226,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ServiceIdentity
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ServiceIdentity) error {
@@ -276,11 +269,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceIdent
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -298,4 +289,4 @@ func dropTableServiceIdentities(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.SignatureIntegration, *storage.SignatureIntegration]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.SignatureIntegration) string {
 	return obj.GetId()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.SignatureIntegration) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "SignatureIntegration")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "SignatureIntegration")
 }
 
 func insertIntoSignatureIntegrations(_ context.Context, batch *pgx.Batch, obj *storage.SignatureIntegration) error {
@@ -175,21 +178,12 @@ func (s *storeImpl) copyFromSignatureIntegrations(ctx context.Context, tx *postg
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.SignatureIntegration) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "SignatureIntegration")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -209,11 +203,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.SignatureInte
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.SignatureIntegration) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "SignatureIntegration")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -236,9 +230,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.SignatureIntegr
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.SignatureIntegration) error {
@@ -280,11 +273,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SignatureInt
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -302,4 +293,4 @@ func dropTableSignatureIntegrations(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -59,7 +59,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.VulnerabilityRequest, *storage.VulnerabilityRequest]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -71,13 +70,13 @@ func New(db postgres.DB) Store {
 			permissionCheckerSingleton(),
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.VulnerabilityRequest) string {
 	return obj.GetId()
@@ -85,6 +84,10 @@ func pkGetter(obj *storage.VulnerabilityRequest) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "VulnerabilityRequest")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "VulnerabilityRequest")
 }
 
 func insertIntoVulnerabilityRequests(ctx context.Context, batch *pgx.Batch, obj *storage.VulnerabilityRequest) error {
@@ -371,21 +374,12 @@ func (s *storeImpl) copyFromVulnerabilityRequestsComments(ctx context.Context, t
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.VulnerabilityRequest) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "VulnerabilityRequest")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -405,11 +399,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Vulnerability
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.VulnerabilityRequest) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "VulnerabilityRequest")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -432,9 +426,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.VulnerabilityRe
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.VulnerabilityRequest) error {
@@ -478,11 +471,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Vulnerabilit
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -512,4 +503,4 @@ func dropTableVulnerabilityRequestsComments(ctx context.Context, db postgres.DB)
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -60,7 +60,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.WatchedImage, *storage.WatchedImage]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -72,13 +71,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.WatchedImage) string {
 	return obj.GetName()
@@ -86,6 +85,10 @@ func pkGetter(obj *storage.WatchedImage) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "WatchedImage")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "WatchedImage")
 }
 
 func insertIntoWatchedImages(_ context.Context, batch *pgx.Batch, obj *storage.WatchedImage) error {
@@ -170,21 +173,12 @@ func (s *storeImpl) copyFromWatchedImages(ctx context.Context, tx *postgres.Tx, 
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.WatchedImage) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "WatchedImage")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -204,11 +198,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.WatchedImage)
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.WatchedImage) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "WatchedImage")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -231,9 +225,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.WatchedImage) e
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.WatchedImage) error {
@@ -275,11 +268,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.WatchedImage
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -297,4 +288,4 @@ func dropTableWatchedImages(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.TestChild1, *storage.TestChild1]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.TestChild1) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.TestChild1) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "TestChild1")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "TestChild1")
 }
 
 func insertIntoTestChild1(_ context.Context, batch *pgx.Batch, obj *storage.TestChild1) error {
@@ -176,21 +179,12 @@ func (s *storeImpl) copyFromTestChild1(ctx context.Context, tx *postgres.Tx, obj
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestChild1) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestChild1")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -210,11 +204,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestChild1) e
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestChild1) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestChild1")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -237,9 +231,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestChild1) err
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestChild1) error {
@@ -281,11 +274,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild1) 
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -303,4 +294,4 @@ func dropTableTestChild1(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.TestChild1P4, *storage.TestChild1P4]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.TestChild1P4) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.TestChild1P4) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "TestChild1P4")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "TestChild1P4")
 }
 
 func insertIntoTestChild1P4(_ context.Context, batch *pgx.Batch, obj *storage.TestChild1P4) error {
@@ -181,21 +184,12 @@ func (s *storeImpl) copyFromTestChild1P4(ctx context.Context, tx *postgres.Tx, o
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestChild1P4) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestChild1P4")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -215,11 +209,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestChild1P4)
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestChild1P4) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestChild1P4")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -242,9 +236,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestChild1P4) e
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestChild1P4) error {
@@ -286,11 +279,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild1P4
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -308,4 +299,4 @@ func dropTableTestChild1P4(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.TestG2GrandChild1, *storage.TestG2GrandChild1]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.TestG2GrandChild1) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.TestG2GrandChild1) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "TestG2GrandChild1")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "TestG2GrandChild1")
 }
 
 func insertIntoTestG2GrandChild1(_ context.Context, batch *pgx.Batch, obj *storage.TestG2GrandChild1) error {
@@ -186,21 +189,12 @@ func (s *storeImpl) copyFromTestG2GrandChild1(ctx context.Context, tx *postgres.
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestG2GrandChild1) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestG2GrandChild1")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -220,11 +214,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestG2GrandCh
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestG2GrandChild1) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestG2GrandChild1")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -247,9 +241,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestG2GrandChil
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestG2GrandChild1) error {
@@ -291,11 +284,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG2GrandC
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -313,4 +304,4 @@ func dropTableTestG2GrandChild1(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.TestG3GrandChild1, *storage.TestG3GrandChild1]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.TestG3GrandChild1) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.TestG3GrandChild1) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "TestG3GrandChild1")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "TestG3GrandChild1")
 }
 
 func insertIntoTestG3GrandChild1(_ context.Context, batch *pgx.Batch, obj *storage.TestG3GrandChild1) error {
@@ -176,21 +179,12 @@ func (s *storeImpl) copyFromTestG3GrandChild1(ctx context.Context, tx *postgres.
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestG3GrandChild1) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestG3GrandChild1")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -210,11 +204,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestG3GrandCh
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestG3GrandChild1) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestG3GrandChild1")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -237,9 +231,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestG3GrandChil
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestG3GrandChild1) error {
@@ -281,11 +274,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG3GrandC
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -303,4 +294,4 @@ func dropTableTestG3GrandChild1(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.TestGGrandChild1, *storage.TestGGrandChild1]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.TestGGrandChild1) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.TestGGrandChild1) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "TestGGrandChild1")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "TestGGrandChild1")
 }
 
 func insertIntoTestGGrandChild1(_ context.Context, batch *pgx.Batch, obj *storage.TestGGrandChild1) error {
@@ -176,21 +179,12 @@ func (s *storeImpl) copyFromTestGGrandChild1(ctx context.Context, tx *postgres.T
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestGGrandChild1) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestGGrandChild1")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -210,11 +204,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestGGrandChi
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestGGrandChild1) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestGGrandChild1")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -237,9 +231,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestGGrandChild
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGGrandChild1) error {
@@ -281,11 +274,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGGrandCh
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -303,4 +294,4 @@ func dropTableTestGGrandChild1(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.TestGrandChild1, *storage.TestGrandChild1]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.TestGrandChild1) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.TestGrandChild1) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "TestGrandChild1")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "TestGrandChild1")
 }
 
 func insertIntoTestGrandChild1(_ context.Context, batch *pgx.Batch, obj *storage.TestGrandChild1) error {
@@ -186,21 +189,12 @@ func (s *storeImpl) copyFromTestGrandChild1(ctx context.Context, tx *postgres.Tx
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestGrandChild1) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestGrandChild1")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -220,11 +214,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestGrandChil
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestGrandChild1) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestGrandChild1")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -247,9 +241,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestGrandChild1
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGrandChild1) error {
@@ -291,11 +284,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandChi
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -313,4 +304,4 @@ func dropTableTestGrandChild1(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.TestGrandparent, *storage.TestGrandparent]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.TestGrandparent) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.TestGrandparent) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "TestGrandparent")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "TestGrandparent")
 }
 
 func insertIntoTestGrandparents(ctx context.Context, batch *pgx.Batch, obj *storage.TestGrandparent) error {
@@ -355,21 +358,12 @@ func (s *storeImpl) copyFromTestGrandparentsEmbeddedsEmbedded2(ctx context.Conte
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestGrandparent) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestGrandparent")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -389,11 +383,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestGrandpare
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestGrandparent) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestGrandparent")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -416,9 +410,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestGrandparent
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestGrandparent) error {
@@ -460,11 +453,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandpar
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -494,4 +485,4 @@ func dropTableTestGrandparentsEmbeddedsEmbedded2(ctx context.Context, db postgre
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.TestParent1, *storage.TestParent1]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.TestParent1) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.TestParent1) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "TestParent1")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "TestParent1")
 }
 
 func insertIntoTestParent1(ctx context.Context, batch *pgx.Batch, obj *storage.TestParent1) error {
@@ -263,21 +266,12 @@ func (s *storeImpl) copyFromTestParent1Childrens(ctx context.Context, tx *postgr
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestParent1) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestParent1")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -297,11 +291,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestParent1) 
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestParent1) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestParent1")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -324,9 +318,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestParent1) er
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent1) error {
@@ -368,11 +361,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent1)
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -396,4 +387,4 @@ func dropTableTestParent1Childrens(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.TestParent2, *storage.TestParent2]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.TestParent2) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.TestParent2) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "TestParent2")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "TestParent2")
 }
 
 func insertIntoTestParent2(_ context.Context, batch *pgx.Batch, obj *storage.TestParent2) error {
@@ -181,21 +184,12 @@ func (s *storeImpl) copyFromTestParent2(ctx context.Context, tx *postgres.Tx, ob
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestParent2) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestParent2")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -215,11 +209,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestParent2) 
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestParent2) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestParent2")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -242,9 +236,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestParent2) er
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent2) error {
@@ -286,11 +279,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent2)
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -308,4 +299,4 @@ func dropTableTestParent2(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.TestParent3, *storage.TestParent3]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.TestParent3) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.TestParent3) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "TestParent3")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "TestParent3")
 }
 
 func insertIntoTestParent3(_ context.Context, batch *pgx.Batch, obj *storage.TestParent3) error {
@@ -181,21 +184,12 @@ func (s *storeImpl) copyFromTestParent3(ctx context.Context, tx *postgres.Tx, ob
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestParent3) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestParent3")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -215,11 +209,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestParent3) 
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestParent3) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestParent3")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -242,9 +236,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestParent3) er
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestParent3) error {
@@ -286,11 +279,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent3)
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -308,4 +299,4 @@ func dropTableTestParent3(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -61,7 +61,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.TestShortCircuit, *storage.TestShortCircuit]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -73,13 +72,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.TestShortCircuit) string {
 	return obj.GetId()
@@ -87,6 +86,10 @@ func pkGetter(obj *storage.TestShortCircuit) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "TestShortCircuit")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "TestShortCircuit")
 }
 
 func insertIntoTestShortCircuits(_ context.Context, batch *pgx.Batch, obj *storage.TestShortCircuit) error {
@@ -181,21 +184,12 @@ func (s *storeImpl) copyFromTestShortCircuits(ctx context.Context, tx *postgres.
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestShortCircuit) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestShortCircuit")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -215,11 +209,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestShortCirc
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestShortCircuit) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestShortCircuit")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -242,9 +236,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestShortCircui
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestShortCircuit) error {
@@ -286,11 +279,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestShortCir
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -308,4 +299,4 @@ func dropTableTestShortCircuits(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
@@ -62,7 +62,6 @@ type Store interface {
 
 type storeImpl struct {
 	*pgSearch.GenericStore[storage.TestSingleUUIDKeyStruct, *storage.TestSingleUUIDKeyStruct]
-	db    postgres.DB
 	mutex sync.RWMutex
 }
 
@@ -74,13 +73,13 @@ func New(db postgres.DB) Store {
 			targetResource,
 			schema,
 			metricsSetPostgresOperationDurationTime,
+			metricsSetAcquireDBConnDuration,
 			pkGetter,
 		),
-		db: db,
 	}
 }
 
-//// Helper functions
+// region Helper functions
 
 func pkGetter(obj *storage.TestSingleUUIDKeyStruct) string {
 	return obj.GetKey()
@@ -88,6 +87,10 @@ func pkGetter(obj *storage.TestSingleUUIDKeyStruct) string {
 
 func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 	metrics.SetPostgresOperationDurationTime(start, op, "TestSingleUUIDKeyStruct")
+}
+
+func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
+	metrics.SetAcquireDBConnDuration(start, op, "TestSingleUUIDKeyStruct")
 }
 
 func insertIntoTestSingleUUIDKeyStructs(_ context.Context, batch *pgx.Batch, obj *storage.TestSingleUUIDKeyStruct) error {
@@ -222,21 +225,12 @@ func (s *storeImpl) copyFromTestSingleUUIDKeyStructs(ctx context.Context, tx *po
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestSingleUUIDKeyStruct) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestSingleUUIDKeyStruct")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -256,11 +250,11 @@ func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.TestSingleUUI
 }
 
 func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestSingleUUIDKeyStruct) error {
-	conn, release, err := s.acquireConn(ctx, ops.Get, "TestSingleUUIDKeyStruct")
+	conn, err := s.AcquireConn(ctx, ops.Get)
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer conn.Release()
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
@@ -283,9 +277,8 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.TestSingleUUIDK
 	return nil
 }
 
-//// Helper functions - END
-
-//// Interface functions
+// endregion Helper functions
+// region Interface functions
 
 // Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.TestSingleUUIDKeyStruct) error {
@@ -327,11 +320,9 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestSingleUU
 	})
 }
 
-//// Stubs for satisfying legacy interfaces
+// endregion Interface functions
 
-//// Interface functions - END
-
-//// Used for testing
+// region Used for testing
 
 // CreateTableAndNewStore returns a new Store instance for testing.
 func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB) Store {
@@ -349,4 +340,4 @@ func dropTableTestSingleUUIDKeyStructs(ctx context.Context, db postgres.DB) {
 
 }
 
-//// Used for testing - END
+// endregion Used for testing


### PR DESCRIPTION
## Description

This PR replaces huge portion of postgres store generated code with `GenericStore` that implements all methods except Upserting data.

Look at:
- `pkg/search/postgres/store.go`
- `tools/generate-helpers/pg-table-bindings/store.go.tpl`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI