### PR TITLE
ROX-18030: AuditLogAlertsTest: Extend timeout to flush out outliers

### DIFF
--- a/qa-tests-backend/src/main/groovy/common/Constants.groovy
+++ b/qa-tests-backend/src/main/groovy/common/Constants.groovy
@@ -40,6 +40,11 @@ class Constants {
     static final INTERNET_EXTERNAL_SOURCE_ID = "afa12424-bde3-4313-b810-bb463cbe8f90" // pkg/networkgraph/constants.go
     static final STACKROX_NODE_ANNOTATION_TRUNCATION_LENGTH = 254
     static final CORE_IMAGE_INTEGRATION_NAME = "core quay"
+    // Padding required for test feature timeouts. This is used to configure the
+    // globalTimeout for long running tests. The value takes into consideration
+    // common functionality that occurs for all tests such as debug gathering when
+    // tests fail.
+    static final TEST_FEATURE_TIMEOUT_PAD = 360
 
     /*
         StackRox Product Feature Flags

--- a/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
@@ -12,6 +12,8 @@ import services.AlertService
 import services.ClusterService
 import services.PolicyService
 
+import org.junit.Rule
+import org.junit.rules.Timeout
 import spock.lang.Requires
 import spock.lang.Stepwise
 import spock.lang.Tag

--- a/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
@@ -20,6 +20,8 @@ import spock.lang.Tag
 import spock.lang.Unroll
 import util.Env
 
+import java.util.concurrent.TimeUnit
+
 // Audit Log alerts are only supported on OpenShift 4
 @Requires({ Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT })
 @Stepwise

--- a/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
@@ -31,7 +31,8 @@ class AuditLogAlertsTest extends BaseSpecification {
 
     @Rule
     @SuppressWarnings(["JUnitPublicProperty"])
-    Timeout globalTimeout = new Timeout(WAIT_FOR_VIOLATION_TIMEOUT + 360, TimeUnit.SECONDS)
+    Timeout globalTimeout = new Timeout(
+                WAIT_FOR_VIOLATION_TIMEOUT + Constants.TEST_FEATURE_TIMEOUT_PAD, TimeUnit.SECONDS)
 
     @Unroll
     @Tag("BAT")

--- a/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
@@ -23,7 +23,11 @@ import util.Env
 @Stepwise
 class AuditLogAlertsTest extends BaseSpecification {
     static final private Integer WAIT_FOR_VIOLATION_TIMEOUT =
-                isRaceBuild() ? 450 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 100 : 60)
+                isRaceBuild() ? 450 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 900 : 60)
+
+    @Rule
+    @SuppressWarnings(["JUnitPublicProperty"])
+    Timeout globalTimeout = new Timeout(WAIT_FOR_VIOLATION_TIMEOUT + 360, TimeUnit.SECONDS)
 
     @Unroll
     @Tag("BAT")


### PR DESCRIPTION
## Description

Failures from the `AuditLogAlertsTest > Verify Audit Log Event Source Policies Trigger: *` test continue to show up on merge PR runs despite an increase of the wait for violation timeout from 60s to 100s. This PR increases the timeout to 900s to help get more data on instances that require a longer timeout. [Repeat runs](https://prow.ci.openshift.org/pr-history/?org=stackrox&repo=stackrox&pr=6649) had no recorded test run time greater then **6s** despite running with parameters similar to a merge run.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient