### PR TITLE
added download repo2cpe

### DIFF
--- a/.github/workflows/repo2cpe-download.yaml
+++ b/.github/workflows/repo2cpe-download.yaml
@@ -22,7 +22,6 @@ jobs:
 
     - name: Download repository mappings
       run: |
-        mkdir redhat-repository-mappings
         curl --fail --silent --show-error --max-time 60 --retry 3 --create-dirs \
           -o 'redhat-repository-mappings/#1' \
           'https://access.redhat.com/security/data/metrics/{repository-to-cpe.json,container-name-repos-map.json}'
@@ -30,16 +29,11 @@ jobs:
           jq empty "$f"
         done
 
-    - name: Send Slack notification on failure
-      if: failure()
-      run: |
-        curl -X POST -H 'Content-type: application/json' --data '{"text":"<!subteam^S04S96AAVND|acs-scanner-primary> Failed to download Red Hat repository mapping to storage"}' ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
-
     - name: Upload repository mappings to Google Cloud Storage
       run: |
         gsutil cp -r "redhat-repository-mappings" "gs://scanner-v4-test/"
 
-    - name: Send Slack notification on gsutil failure
+    - name: Send Slack notification on workflow failure
       if: failure()
       run: |
-        curl -X POST -H 'Content-type: application/json' --data '{"text":"<!subteam^S04S96AAVND|acs-scanner-primary> Failed to upload Redhat repository mapping to storage"}' ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
+        curl -X POST -H 'Content-type: application/json' --data '{"text":"<!subteam^S04S96AAVND|acs-scanner-primary> Failure in Scanner V4 Updater Workflow: Download and Upload Repository Mappings"}' ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}

--- a/.github/workflows/repo2cpe-download.yaml
+++ b/.github/workflows/repo2cpe-download.yaml
@@ -12,19 +12,26 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+
+    - name: Authenticate with Google Cloud
+      uses: google-github-actions/auth@v1
+      with:
+        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v1
 
     - name: Create Repo2CPE directory
-      run: mkdir Repo2CPE
+      run: mkdir -p Repo2CPE
 
     - name: Download repository-to-cpe.json
       run: |
         cd Repo2CPE
         wget -q https://access.redhat.com/security/data/metrics/repository-to-cpe.json
-      # Alternatively, you can use curl:
-      # run: |
-      #   cd Repo2CPE
-      #   curl -sSL -O https://access.redhat.com/security/data/metrics/repository-to-cpe.json
 
     - name: Check downloaded file
       run: ls -l Repo2CPE/repository-to-cpe.json
+
+    - name: Upload file to Google Cloud Storage
+      run: gsutil cp -r "Repo2CPE" "gs://scanner-v4-test/"

--- a/.github/workflows/repo2cpe-download.yaml
+++ b/.github/workflows/repo2cpe-download.yaml
@@ -1,10 +1,10 @@
-name: Download Repo2CPE and Name2CPE
+name: Download repository-to-cpe and name-to-cpe
 on:
   push:
     branches:
-    - "yli3/**"
+    - "master"
   schedule:
-  - cron: "0 */3 * * *"
+  - cron: "0 0 * * *"
 
 jobs:
   download:
@@ -22,28 +22,21 @@ jobs:
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
 
-    - name: Create Repo2CPE directory
-      run: mkdir -p Repo2CPE
-
     - name: Download repository-to-cpe.json
       run: |
-        cd Repo2CPE
-        wget -q https://access.redhat.com/security/data/metrics/repository-to-cpe.json
-
-    - name: Create Name2CPE directory
-      run: mkdir -p Name2CPE
+        mkdir -p repo-to-cpe
+        cd repo-to-cpe
+        curl --fail --silent --show-error --max-time 60 --retry 3 --output repo-to-cpe.json https://access.redhat.com/security/data/metrics/repository-to-cpe.json
+        jq . repo-to-cpe.json
 
     - name: Download container-name-repos-map.json
       run: |
-        cd Name2CPE
-        wget -q https://access.redhat.com/security/data/metrics/container-name-repos-map.json
-
-    - name: Check downloaded files
-      run: |
-        ls -l Repo2CPE/
-        ls -l Name2CPE/
+        mkdir -p name-to-cpe
+        cd name-to-cpe
+        curl --fail --silent --show-error --max-time 60 --retry 3 --output name-to-cpe.json https://access.redhat.com/security/data/metrics/container-name-repos-map.json
+        jq . name-to-cpe.json
 
     - name: Upload files to Google Cloud Storage
       run: |
-        gsutil cp -r "Repo2CPE" "gs://scanner-v4-test/"
-        gsutil cp -r "Name2CPE" "gs://scanner-v4-test/"
+        gsutil cp -r "repo-to-cpe" "gs://scanner-v4-test/"
+        gsutil cp -r "name-to-cpe" "gs://scanner-v4-test/"

--- a/.github/workflows/repo2cpe-download.yaml
+++ b/.github/workflows/repo2cpe-download.yaml
@@ -1,4 +1,4 @@
-name: Download Repo2CPE
+name: Download Repo2CPE and Name2CPE
 on:
   push:
     branches:
@@ -30,8 +30,20 @@ jobs:
         cd Repo2CPE
         wget -q https://access.redhat.com/security/data/metrics/repository-to-cpe.json
 
-    - name: Check downloaded file
-      run: ls -l Repo2CPE/repository-to-cpe.json
+    - name: Create Name2CPE directory
+      run: mkdir -p Name2CPE
 
-    - name: Upload file to Google Cloud Storage
-      run: gsutil cp -r "Repo2CPE" "gs://scanner-v4-test/"
+    - name: Download container-name-repos-map.json
+      run: |
+        cd Name2CPE
+        wget -q https://access.redhat.com/security/data/metrics/container-name-repos-map.json
+
+    - name: Check downloaded files
+      run: |
+        ls -l Repo2CPE/
+        ls -l Name2CPE/
+
+    - name: Upload files to Google Cloud Storage
+      run: |
+        gsutil cp -r "Repo2CPE" "gs://scanner-v4-test/"
+        gsutil cp -r "Name2CPE" "gs://scanner-v4-test/"

--- a/.github/workflows/repo2cpe-download.yaml
+++ b/.github/workflows/repo2cpe-download.yaml
@@ -22,21 +22,16 @@ jobs:
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
 
-    - name: Download repository-to-cpe.json
+    - name: Download repository mappings
       run: |
-        mkdir -p repo-to-cpe
-        cd repo-to-cpe
-        curl --fail --silent --show-error --max-time 60 --retry 3 --output repo-to-cpe.json https://access.redhat.com/security/data/metrics/repository-to-cpe.json
-        jq . repo-to-cpe.json
-
-    - name: Download container-name-repos-map.json
+        curl \
+            --fail --silent --show-error \
+            --max-time 60 --retry 3 \
+            --create-dirs -o 'redhat-repository-mappings/#1' \
+            'https://access.redhat.com/security/data/metrics/{repository-to-cpe.json,container-name-repos-map.json}'
+        for f in redhat-repository-mappings; do
+            jq empty $f
+        done
+    - name: Upload repository mappings to Google Cloud Storage
       run: |
-        mkdir -p name-to-cpe
-        cd name-to-cpe
-        curl --fail --silent --show-error --max-time 60 --retry 3 --output name-to-cpe.json https://access.redhat.com/security/data/metrics/container-name-repos-map.json
-        jq . name-to-cpe.json
-
-    - name: Upload files to Google Cloud Storage
-      run: |
-        gsutil cp -r "repo-to-cpe" "gs://scanner-v4-test/"
-        gsutil cp -r "name-to-cpe" "gs://scanner-v4-test/"
+        gsutil cp -r "redhat-repository-mappings" "gs://scanner-v4-test/"

--- a/.github/workflows/repo2cpe-download.yaml
+++ b/.github/workflows/repo2cpe-download.yaml
@@ -5,7 +5,7 @@ on:
     branches:
     - "yli3/**"
   schedule:
-  - cron: "0 */3 * * *"
+    - cron: "0 0 * * *"
 
 jobs:
   download-and-upload:
@@ -33,6 +33,16 @@ jobs:
           jq empty "$f"
         done
 
+    - name: Send Slack notification on failure
+      if: failure()
+      run: |
+        curl -X POST -H 'Content-type: application/json' --data '{"text":"<!subteam^S04S96AAVND|acs-scanner-primary> Failed to download Red Hat repository mapping to storage"}' ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
+
     - name: Upload repository mappings to Google Cloud Storage
       run: |
         gsutil cp -r "redhat-repository-mappings" "gs://scanner-v4-test/"
+
+    - name: Send Slack notification on gsutil failure
+      if: failure()
+      run: |
+        curl -X POST -H 'Content-type: application/json' --data '{"text":"<!subteam^S04S96AAVND|acs-scanner-primary> Failed to upload Redhat repository mapping to storage"}' ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}

--- a/.github/workflows/repo2cpe-download.yaml
+++ b/.github/workflows/repo2cpe-download.yaml
@@ -1,13 +1,14 @@
-name: Download repository-to-cpe and name-to-cpe
+name: Download and Upload Repository Mappings
+
 on:
   push:
     branches:
-    - "master"
+    - "yli3/**"
   schedule:
-  - cron: "0 0 * * *"
+  - cron: "0 */3 * * *"
 
 jobs:
-  download:
+  download-and-upload:
     runs-on: ubuntu-latest
 
     steps:
@@ -24,14 +25,14 @@ jobs:
 
     - name: Download repository mappings
       run: |
-        curl \
-            --fail --silent --show-error \
-            --max-time 60 --retry 3 \
-            --create-dirs -o 'redhat-repository-mappings/#1' \
-            'https://access.redhat.com/security/data/metrics/{repository-to-cpe.json,container-name-repos-map.json}'
-        for f in redhat-repository-mappings; do
-            jq empty $f
+        mkdir redhat-repository-mappings
+        curl --fail --silent --show-error --max-time 60 --retry 3 --create-dirs \
+          -o 'redhat-repository-mappings/#1' \
+          'https://access.redhat.com/security/data/metrics/{repository-to-cpe.json,container-name-repos-map.json}'
+        for f in redhat-repository-mappings/*; do
+          jq empty "$f"
         done
+
     - name: Upload repository mappings to Google Cloud Storage
       run: |
         gsutil cp -r "redhat-repository-mappings" "gs://scanner-v4-test/"

--- a/.github/workflows/repo2cpe-download.yaml
+++ b/.github/workflows/repo2cpe-download.yaml
@@ -1,0 +1,30 @@
+name: Download Repo2CPE
+on:
+  push:
+    branches:
+    - "yli3/**"
+  schedule:
+  - cron: "0 */3 * * *"
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Create Repo2CPE directory
+      run: mkdir Repo2CPE
+
+    - name: Download repository-to-cpe.json
+      run: |
+        cd Repo2CPE
+        wget -q https://access.redhat.com/security/data/metrics/repository-to-cpe.json
+      # Alternatively, you can use curl:
+      # run: |
+      #   cd Repo2CPE
+      #   curl -sSL -O https://access.redhat.com/security/data/metrics/repository-to-cpe.json
+
+    - name: Check downloaded file
+      run: ls -l Repo2CPE/repository-to-cpe.json

--- a/.github/workflows/repo2cpe-download.yaml
+++ b/.github/workflows/repo2cpe-download.yaml
@@ -1,9 +1,6 @@
 name: Download and Upload Repository Mappings
 
 on:
-  push:
-    branches:
-    - "yli3/**"
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
## Description

This GitHub workflow is designed to keep the repo2cpe and name2cpe mapping JSON files updated for Claircore's RHEL scanning in the on-prem scanner V4. Since the on-prem scanner V4 does not have direct internet access, it relies on the files being available in Google Cloud Storage. The workflow handles the download of these files using a CI process and then stores them in Google Cloud Storage. Subsequently, the scanner V4 retrieves the files from Google Cloud Storage to perform scanning operations.

By automating this update process through the workflow, the repo2cpe and name2cpe mapping files remain current, ensuring accurate and efficient RHEL scanning within the on-prem scanner environment.

## Checklist
- [x] Investigated and inspected CI test results
## Testing Performed

Run CI in GH action
