### PR TITLE
ROX-18045: Remove Splunk panic handler unit test

### DIFF
--- a/central/splunk/violations_test.go
+++ b/central/splunk/violations_test.go
@@ -613,7 +613,6 @@ var (
 )
 
 func TestViolations(t *testing.T) {
-	t.Skip("ROX-18045: Test is flaky under Postgres")
 	suite.Run(t, &violationsTestSuite{})
 }
 
@@ -1331,12 +1330,9 @@ func (s *violationsTestSuite) TestResponseContentType() {
 }
 
 func (s *violationsTestSuite) TestViolationsHandlerError() {
-	w := httptest.NewRecorder()
-
-	// context.Background() did not go through our context validation and will not include any global access scope.
-	// We use this to make datastore generate an error which will make the request fail.
+	// A nil writer will cause a panic
 	s.Panics(func() {
-		s.prepare().setContext(context.Background()).setAlerts(s.deployAlert).runRequest(w)
+		s.prepare().setAlerts(s.deployAlert).runRequest(nil)
 	})
 }
 

--- a/central/splunk/violations_test.go
+++ b/central/splunk/violations_test.go
@@ -1329,13 +1329,6 @@ func (s *violationsTestSuite) TestResponseContentType() {
 	s.Equal("application/json", w.Header().Get("Content-Type"))
 }
 
-func (s *violationsTestSuite) TestViolationsHandlerError() {
-	// A nil writer will cause a panic
-	s.Panics(func() {
-		s.prepare().setAlerts(s.deployAlert).runRequest(nil)
-	})
-}
-
 func (s *violationsTestSuite) TestViolationsHandlerWriteError() {
 	w := mock.NewFailingResponseWriter(errors.New("mock http write error"))
 	s.PanicsWithError("net/http: abort Handler", func() {


### PR DESCRIPTION
## Description

Panic not using utils.Must which forks a goroutine to panic that cannot be caught

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI