### PR TITLE
ROX-18023: Add delegate image scanning toggle

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/Clusters.helpers.js
+++ b/ui/apps/platform/cypress/integration/clusters/Clusters.helpers.js
@@ -5,6 +5,7 @@ import { visit } from '../../helpers/visit';
 export const sensorUpgradesConfigAlias = 'sensorupgrades/config';
 export const clustersAlias = 'clusters';
 export const clusterDefaultsAlias = 'cluster-defaults';
+export const delegatedRegistryConfigAlias = 'delegatedregistryconfig';
 
 const routeMatcherMapForClusterDefaults = {
     [clusterDefaultsAlias]: {
@@ -24,7 +25,12 @@ const routeMatcherMapForClusters = {
     },
     ...routeMatcherMapForClusterDefaults,
 };
-const routeMatcherMapForDelegateScanning = null;
+const routeMatcherMapForDelegateScanning = {
+    [delegatedRegistryConfigAlias]: {
+        method: 'GET',
+        url: '/v1/delegatedregistryconfig',
+    },
+};
 
 const basePath = '/main/clusters';
 const delegateScanningPath = `${basePath}/delegate-scanning`;

--- a/ui/apps/platform/cypress/integration/clusters/delegateScanning.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/delegateScanning.test.js
@@ -1,14 +1,17 @@
 import withAuth from '../../helpers/basicAuth';
 
+import { getInputByLabel } from '../../helpers/formHelpers';
+
 import { visitDelegateScanning } from './Clusters.helpers';
 
 // There is some overlap between tests for Certificate Expiration and Health Status.
 describe('Delegate Image Scanning', () => {
     withAuth();
 
-    it(`should be a page in the cluster hierarchy`, () => {
+    it(`should load the page in the cluster hierarchy`, () => {
         visitDelegateScanning();
 
+        // make sure the static page loads
         cy.get('h1:contains("Delegate Image Scanning")');
 
         cy.get('.pf-c-breadcrumb__item a:contains("Clusters")').should(
@@ -18,5 +21,17 @@ describe('Delegate Image Scanning', () => {
         );
 
         cy.get('.pf-c-breadcrumb__item:contains("Delegate Image Scanning")');
+
+        // check the initial state of the delegate config
+        getInputByLabel('Enable delegated image scanning').should('not.be.checked');
+
+        cy.get('label:contains("All registries")').should('not.be.exist');
+        cy.get('label:contains("Specified registries")').should('not.be.exist');
+
+        // Enable delegate scanning with default
+        getInputByLabel('Enable delegated image scanning').click();
+
+        getInputByLabel('All registries').should('be.checked');
+        getInputByLabel('Specified registries').should('not.be.checked');
     });
 });

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/ToggleDelegatedScanning.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/ToggleDelegatedScanning.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Card, CardBody, Checkbox } from '@patternfly/react-core';
+
+import { DelegatedRegistryConfigEnabledFor } from 'types/dedicatedRegistryConfig.proto';
+
+type ToggleDelegatedScanningProps = {
+    enabledFor: DelegatedRegistryConfigEnabledFor;
+    toggleDelegation: () => void;
+};
+
+function ToggleDelegatedScanning({ enabledFor, toggleDelegation }: ToggleDelegatedScanningProps) {
+    return (
+        <Card className="pf-u-mb-lg">
+            <CardBody>
+                <Checkbox
+                    label="Enable delegated image scanning"
+                    isChecked={enabledFor !== 'NONE'}
+                    onChange={toggleDelegation}
+                    id="enabledFor"
+                    name="enabledFor"
+                />
+            </CardBody>
+        </Card>
+    );
+}
+
+export default ToggleDelegatedScanning;

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -19,6 +19,7 @@ import PageTitle from 'Components/PageTitle';
 import { clustersBasePath } from 'routePaths';
 import { fetchDelegatedRegistryConfig } from 'services/DelegatedRegistryConfigService';
 import { DelegatedRegistryConfig } from 'types/dedicatedRegistryConfig.proto';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import ToggleDelegatedScanning from './Components/ToggleDelegatedScanning';
 
 const initialDelegatedState: DelegatedRegistryConfig = {
@@ -31,15 +32,16 @@ function DelegateScanningPage() {
     const displayedPageTitle = 'Delegate Image Scanning';
     const [delegatedRegistryConfig, setDedicatedRegistryConfig] =
         useState<DelegatedRegistryConfig>(initialDelegatedState);
-    const [errMessage, setErrMessage] = useState<string | null>(null);
+    const [errMessage, setErrMessage] = useState<string>('');
 
     useEffect(() => {
+        setErrMessage('');
         fetchDelegatedRegistryConfig()
-            .then((result) => {
-                setDedicatedRegistryConfig(result.response);
+            .then((configFetched) => {
+                setDedicatedRegistryConfig(configFetched);
             })
-            .catch((err) => {
-                setErrMessage(err.message);
+            .catch((error) => {
+                setErrMessage(getAxiosErrorMessage(error));
                 setDedicatedRegistryConfig(initialDelegatedState);
             });
     }, []);

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -9,10 +9,12 @@ import {
     Flex,
     FlexItem,
     PageSection,
+    Radio,
     Title,
 } from '@patternfly/react-core';
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import PageTitle from 'Components/PageTitle';
 import { clustersBasePath } from 'routePaths';
 import { fetchDelegatedRegistryConfig } from 'services/DelegatedRegistryConfigService';
@@ -93,9 +95,43 @@ function DelegateScanningPage() {
                     enabledFor={delegatedRegistryConfig.enabledFor}
                     toggleDelegation={toggleDelegation}
                 />
-                <Card>
-                    <CardBody>{delegatedRegistryConfig.enabledFor}</CardBody>
-                </Card>
+                {/* TODO: decide who to structure this form, where the `enabledFor` value spans multiple inputs */}
+                {delegatedRegistryConfig.enabledFor !== 'NONE' && (
+                    <Card>
+                        <CardBody>
+                            <FormLabelGroup
+                                label="Delegate scanning for"
+                                isRequired
+                                fieldId="delegatedRegistryConfig.enabledFor"
+                                touched={{}}
+                                errors={{}}
+                            >
+                                <Flex className="pf-u-mt-md pf-u-mb-lg">
+                                    <FlexItem>
+                                        <Radio
+                                            label="All registries"
+                                            isChecked={delegatedRegistryConfig.enabledFor === 'ALL'}
+                                            id="choose-all-registries"
+                                            name="enabledFor"
+                                            onChange={() => {}}
+                                        />
+                                    </FlexItem>
+                                    <FlexItem>
+                                        <Radio
+                                            label="Specified registries"
+                                            isChecked={
+                                                delegatedRegistryConfig.enabledFor === 'SPECIFIC'
+                                            }
+                                            id="chose-specified-registries"
+                                            name="enabledFor"
+                                            onChange={() => {}}
+                                        />
+                                    </FlexItem>
+                                </Flex>
+                            </FormLabelGroup>
+                        </CardBody>
+                    </Card>
+                )}
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/services/DelegatedRegistryConfigService.ts
+++ b/ui/apps/platform/src/services/DelegatedRegistryConfigService.ts
@@ -7,10 +7,8 @@ const delegatedRegistryUrl = '/v1/delegatedregistryconfig';
 /**
  * Fetches the declarative config health objects.
  */
-export function fetchDelegatedRegistryConfig(): Promise<{
-    response: DelegatedRegistryConfig;
-}> {
-    return axios.get<DelegatedRegistryConfig>(delegatedRegistryUrl).then((response) => ({
-        response: response.data,
-    }));
+export function fetchDelegatedRegistryConfig(): Promise<DelegatedRegistryConfig> {
+    return axios
+        .get<DelegatedRegistryConfig>(delegatedRegistryUrl)
+        .then((response) => response.data);
 }

--- a/ui/apps/platform/src/services/DelegatedRegistryConfigService.ts
+++ b/ui/apps/platform/src/services/DelegatedRegistryConfigService.ts
@@ -1,0 +1,16 @@
+import axios from './instance';
+
+import { DelegatedRegistryConfig } from '../types/dedicatedRegistryConfig.proto';
+
+const delegatedRegistryUrl = '/v1/delegatedregistryconfig';
+
+/**
+ * Fetches the declarative config health objects.
+ */
+export function fetchDelegatedRegistryConfig(): Promise<{
+    response: DelegatedRegistryConfig;
+}> {
+    return axios.get<DelegatedRegistryConfig>(delegatedRegistryUrl).then((response) => ({
+        response: response.data,
+    }));
+}

--- a/ui/apps/platform/src/types/dedicatedRegistryConfig.proto.ts
+++ b/ui/apps/platform/src/types/dedicatedRegistryConfig.proto.ts
@@ -1,0 +1,12 @@
+export type DelegatedRegistryConfigEnabledFor = 'NONE' | 'ALL' | 'SPECIFIC';
+
+export type DelegatedRegistry = {
+    path: string;
+    clusterId: string;
+};
+
+export type DelegatedRegistryConfig = {
+    enabledFor: DelegatedRegistryConfigEnabledFor;
+    defaultClusterId: string;
+    registries: DelegatedRegistry[];
+};


### PR DESCRIPTION
## Description

This implements the basic transition between mock
https://www.sketch.com/s/a7c5e8bd-524f-4396-b273-a8ccc33b3a77/a/WdY75g0

and mock
https://www.sketch.com/s/a7c5e8bd-524f-4396-b273-a8ccc33b3a77/a/nQVa89a

## Checklist
- [x] Investigated and inspected CI test results (current e2e flavor failure was OCP CI crash)
- [x] Unit test and regression tests added

## Testing Performed

Off
<img width="1516" alt="Screen Shot 2023-06-23 at 1 42 56 PM" src="https://github.com/stackrox/stackrox/assets/715729/0106176b-71d0-4137-8a74-707795bbdde8">

On
<img width="1516" alt="Screen Shot 2023-06-23 at 1 42 59 PM" src="https://github.com/stackrox/stackrox/assets/715729/f340e105-ec72-48ba-bd17-06012ef85d07">

CI test expanded to cover this interaction
<img width="1972" alt="Screen Shot 2023-06-23 at 1 43 07 PM" src="https://github.com/stackrox/stackrox/assets/715729/eec088bf-b477-448c-b329-1d66e0dfbcf1">
