### PR TITLE
ROX-18011: Delete Network Graph 1.0 route

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -5,7 +5,6 @@ import { PageSection } from '@patternfly/react-core';
 import {
     mainPath,
     dashboardPath,
-    networkPath,
     networkPathPF,
     violationsPath,
     compliancePath,
@@ -53,7 +52,6 @@ function NotFoundPage(): ReactElement {
 const AsyncSearchPage = asyncComponent(() => import('Containers/Search/SearchPage'));
 const AsyncApiDocsPage = asyncComponent(() => import('Containers/Docs/ApiPage'));
 const AsyncDashboardPage = asyncComponent(() => import('Containers/Dashboard/DashboardPage'));
-const AsyncNetworkPage = asyncComponent(() => import('Containers/Network/Page'));
 const AsyncNetworkGraphPage = asyncComponent(
     () => import('Containers/NetworkGraph/NetworkGraphPage')
 );
@@ -132,7 +130,6 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     <Route path="/" exact render={() => <Redirect to={dashboardPath} />} />
                     <Route path={mainPath} exact render={() => <Redirect to={dashboardPath} />} />
                     <Route path={dashboardPath} component={AsyncDashboardPage} />
-                    <Route path={networkPath} component={AsyncNetworkPage} />
                     {isNetworkGraphPatternflyEnabled && (
                         <Route path={networkPathPF} component={AsyncNetworkGraphPage} />
                     )}

--- a/ui/apps/platform/src/utils/URLParser.ts
+++ b/ui/apps/platform/src/utils/URLParser.ts
@@ -14,7 +14,6 @@ import {
     riskPath,
     violationsPath,
     policiesPath,
-    networkPath,
     userRolePath,
     accessControlPath,
 } from '../routePaths';
@@ -29,7 +28,6 @@ const nonWorkflowUseCasePathEntries = Object.entries({
     RISK: riskPath,
     VIOLATIONS: violationsPath,
     POLICIES: policiesPath,
-    NETWORK: networkPath,
     USER: userRolePath, // however, it matches workflow list path
     ACCESS_CONTROL: accessControlPath,
 });


### PR DESCRIPTION
## Description

### Analysis

1. Find in Files `networkBasePath` 1 result in 1 file
    * routePaths: delete with network reducers and sagas
2. Find in Files `networkPath` 9 results in 5 files
    * Body: delete now
    * integrationSagas: delete with network reducers and sagas
    * networkSagas: delete with network reducers and sagas
    * routePaths: delete with network reducers and sagas
    * URLParser: delete now

### Build weight

TL;DR Decrease 666K in static js implies webpack understands deletion of async import.

Time will tell how much (if any) additional decrease from careful deletion:
* css style
* js code
* media images, and so on
* dependencies

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui
    * `wc build/static/css/*.css`
        branch - master total: -4223 = 5796730 - 5800953
        branch - master main.css: 0 = 4974847 - 4974847
    * `ls -al build/static/css/*.css | wc`
        branch - master: -1 = 27 - 28 files
    * `wc build/static/js/*.js`
        branch - master total: -665747 = 11123705 - 11789452 
        branch - master main.js: -24717 = 4857452 - 4882169
    * `ls -al build/static/js/*.js | wc`
        branch - master: -2 = 75 - 77 files
    * `wc build/static/media/*.*`
        branch - master: -9844 = 4476497 - 4487341
    * `ls -al build/static/media | wc`
        branch - master: -11 = 144 - 155 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/dashboard

2. Click **Network Graph** in left navigation to visit /main/network-graph

3. Continue to visit every link in left navigation

### Integration testing

1. `yarn cypress-open` in ui/apps/platform
    * networkGraphPF/networkDeploymentSidebar.test.js
    * networkGraphPF/networkGraphPF.test.js