### PR TITLE
ROX-17224: TLS configurer

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -276,7 +276,7 @@ func main() {
 	}
 
 	// Start the prometheus metrics server
-	pkgMetrics.NewServer(pkgMetrics.CentralSubsystem).RunForever()
+	pkgMetrics.NewServer(pkgMetrics.CentralSubsystem, pkgMetrics.NewTLSConfigurerFromEnv()).RunForever()
 	pkgMetrics.GatherThrottleMetricsForever(pkgMetrics.CentralSubsystem.String())
 
 	if env.PrivateDiagnosticsEnabled.BooleanSetting() {

--- a/compliance/collection/compliance/node_scanner.go
+++ b/compliance/collection/compliance/node_scanner.go
@@ -37,7 +37,7 @@ func (n *NodeInventoryComponentScanner) Connect(address string) {
 		log.Infof("Compliance will not call the node-inventory container, because this is not Openshift 4 cluster")
 	} else if env.RHCOSNodeScanning.BooleanSetting() {
 		// Start the prometheus metrics server
-		metrics.NewServer(metrics.ComplianceSubsystem).RunForever()
+		metrics.NewServer(metrics.ComplianceSubsystem, metrics.NewTLSConfigurerFromEnv()).RunForever()
 		metrics.GatherThrottleMetricsForever(metrics.ComplianceSubsystem.String())
 
 		// Set up Compliance <-> NodeInventory connection

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -44,7 +44,7 @@ func TestMetricsServerAddressEnvs(t *testing.T) {
 			t.Setenv(env.EnableSecureMetrics.EnvVar(), c.enableSecureMetrics)
 			t.Setenv(env.SecureMetricsPort.EnvVar(), c.secureMetricsPort)
 
-			server := NewServer(CentralSubsystem, &NilTLSConfigurer{})
+			server := NewServer(CentralSubsystem, &nilTLSConfigurer{})
 
 			require.NotNil(t, server)
 			assert.Equal(t, env.MetricsPort.Setting(), server.metricsServer.Addr)
@@ -99,7 +99,7 @@ func TestMetricsServerPanic(t *testing.T) {
 			t.Setenv(env.MetricsPort.EnvVar(), c.metricsPort)
 			t.Setenv(env.EnableSecureMetrics.EnvVar(), c.enableSecureMetrics)
 			t.Setenv(env.SecureMetricsPort.EnvVar(), c.secureMetricsPort)
-			server := NewServer(CentralSubsystem, &NilTLSConfigurer{})
+			server := NewServer(CentralSubsystem, &nilTLSConfigurer{})
 			defer server.Stop(context.TODO())
 
 			if c.releaseBuild {

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -44,7 +44,7 @@ func TestMetricsServerAddressEnvs(t *testing.T) {
 			t.Setenv(env.EnableSecureMetrics.EnvVar(), c.enableSecureMetrics)
 			t.Setenv(env.SecureMetricsPort.EnvVar(), c.secureMetricsPort)
 
-			server := NewServer(CentralSubsystem)
+			server := NewServer(CentralSubsystem, &NilTLSConfigurer{})
 
 			require.NotNil(t, server)
 			assert.Equal(t, env.MetricsPort.Setting(), server.metricsServer.Addr)
@@ -99,7 +99,7 @@ func TestMetricsServerPanic(t *testing.T) {
 			t.Setenv(env.MetricsPort.EnvVar(), c.metricsPort)
 			t.Setenv(env.EnableSecureMetrics.EnvVar(), c.enableSecureMetrics)
 			t.Setenv(env.SecureMetricsPort.EnvVar(), c.secureMetricsPort)
-			server := NewServer(CentralSubsystem)
+			server := NewServer(CentralSubsystem, &NilTLSConfigurer{})
 			defer server.Stop(context.TODO())
 
 			if c.releaseBuild {

--- a/pkg/metrics/tls.go
+++ b/pkg/metrics/tls.go
@@ -41,21 +41,21 @@ func (t *NilTLSConfigurer) TLSConfig() (*tls.Config, error) {
 
 var _ TLSConfigurer = (*NilTLSConfigurer)(nil)
 
-// TLSConfigurerImpl holds the current TLS configuration. The configurer
+// tlsConfigurerImpl holds the current TLS configuration. The configurer
 // watches the certificate directory for changes and updates the server
 // certificates in the TLS config. The client CA is updated based on a
 // Kubernetes config map watcher.
-type TLSConfigurerImpl struct {
+type tlsConfigurerImpl struct {
 	certDir           string
 	clientCAConfigMap string
 	clientCANamespace string
 }
 
-var _ TLSConfigurer = (*TLSConfigurerImpl)(nil)
+var _ TLSConfigurer = (*tlsConfigurerImpl)(nil)
 
 // NewTLSConfigurer creates a new TLS configurer.
 func NewTLSConfigurer(certDir string, clientCANamespace, clientCAConfigMap string) (TLSConfigurer, error) {
-	cfgr := &TLSConfigurerImpl{
+	cfgr := &tlsConfigurerImpl{
 		certDir:           certDir,
 		clientCANamespace: clientCANamespace,
 		clientCAConfigMap: clientCAConfigMap,
@@ -80,11 +80,11 @@ func NewTLSConfigurerFromEnv() TLSConfigurer {
 }
 
 // WatchForChanges watches for changes of the server TLS certificate files and the client CA config map.
-func (t *TLSConfigurerImpl) WatchForChanges() {
+func (t *tlsConfigurerImpl) WatchForChanges() {
 }
 
 // TLSConfig returns the current TLS config.
-func (t *TLSConfigurerImpl) TLSConfig() (*tls.Config, error) {
+func (t *tlsConfigurerImpl) TLSConfig() (*tls.Config, error) {
 	if t == nil {
 		return nil, nil
 	}

--- a/pkg/metrics/tls.go
+++ b/pkg/metrics/tls.go
@@ -1,8 +1,10 @@
 package metrics
 
 import (
+	"crypto/tls"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/env"
 )
 
@@ -16,4 +18,75 @@ func keyFilePath() string {
 	certDir := env.SecureMetricsCertDir.Setting()
 	keyFile := filepath.Join(certDir, env.TLSKeyFileName)
 	return keyFile
+}
+
+// TLSConfigurer instantiates and updates the TLS configuration of a web server.
+//
+//go:generate mockgen-wrapper
+type TLSConfigurer interface {
+	TLSConfig() (*tls.Config, error)
+	WatchForChanges()
+}
+
+// NilTLSConfigurer is a no-op configurer.
+type NilTLSConfigurer struct{}
+
+// WatchForChanges does nothing.
+func (t *NilTLSConfigurer) WatchForChanges() {}
+
+// TLSConfig returns nil.
+func (t *NilTLSConfigurer) TLSConfig() (*tls.Config, error) {
+	return nil, nil
+}
+
+var _ TLSConfigurer = (*NilTLSConfigurer)(nil)
+
+// TLSConfigurerImpl holds the current TLS configuration. The configurer
+// watches the certificate directory for changes and updates the server
+// certificates in the TLS config. The client CA is updated based on a
+// Kubernetes config map watcher.
+type TLSConfigurerImpl struct {
+	certDir           string
+	clientCAConfigMap string
+	clientCANamespace string
+}
+
+var _ TLSConfigurer = (*TLSConfigurerImpl)(nil)
+
+// NewTLSConfigurer creates a new TLS configurer.
+func NewTLSConfigurer(certDir string, clientCANamespace, clientCAConfigMap string) (TLSConfigurer, error) {
+	cfgr := &TLSConfigurerImpl{
+		certDir:           certDir,
+		clientCANamespace: clientCANamespace,
+		clientCAConfigMap: clientCAConfigMap,
+	}
+	return cfgr, nil
+}
+
+// NewTLSConfigurerFromEnv creates a new TLS configurer based on environment variables.
+func NewTLSConfigurerFromEnv() TLSConfigurer {
+	if !secureMetricsEnabled() {
+		return nil
+	}
+
+	certDir := env.SecureMetricsCertDir.Setting()
+	clientCANamespace := env.SecureMetricsClientCANamespace.Setting()
+	clientCAConfigMap := env.SecureMetricsClientCAConfigMap.Setting()
+	cfgr, err := NewTLSConfigurer(certDir, clientCANamespace, clientCAConfigMap)
+	if err != nil {
+		log.Error(errors.Wrap(err, "failed to create TLS config loader"))
+	}
+	return cfgr
+}
+
+// WatchForChanges watches for changes of the server TLS certificate files and the client CA config map.
+func (t *TLSConfigurerImpl) WatchForChanges() {
+}
+
+// TLSConfig returns the current TLS config.
+func (t *TLSConfigurerImpl) TLSConfig() (*tls.Config, error) {
+	if t == nil {
+		return nil, nil
+	}
+	return nil, nil
 }

--- a/pkg/metrics/tls.go
+++ b/pkg/metrics/tls.go
@@ -22,6 +22,11 @@ func keyFilePath() string {
 
 // TLSConfigurer instantiates and updates the TLS configuration of a web server.
 //
+// The TLS configuration contains both server certificates and client CA, which
+// are both watched for changes to dynamically reload the TLS configuration.
+// The server certificates are read from file-mounted secrets. The client CA is
+// read from an external config map via the Kubernetes API.
+//
 //go:generate mockgen-wrapper
 type TLSConfigurer interface {
 	TLSConfig() (*tls.Config, error)

--- a/pkg/metrics/tls.go
+++ b/pkg/metrics/tls.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/env"
 )
 
@@ -33,18 +32,18 @@ type TLSConfigurer interface {
 	WatchForChanges()
 }
 
-// NilTLSConfigurer is a no-op configurer.
-type NilTLSConfigurer struct{}
+// nilTLSConfigurer is a no-op configurer.
+type nilTLSConfigurer struct{}
 
 // WatchForChanges does nothing.
-func (t *NilTLSConfigurer) WatchForChanges() {}
+func (t *nilTLSConfigurer) WatchForChanges() {}
 
 // TLSConfig returns nil.
-func (t *NilTLSConfigurer) TLSConfig() (*tls.Config, error) {
+func (t *nilTLSConfigurer) TLSConfig() (*tls.Config, error) {
 	return nil, nil
 }
 
-var _ TLSConfigurer = (*NilTLSConfigurer)(nil)
+var _ TLSConfigurer = (*nilTLSConfigurer)(nil)
 
 // tlsConfigurerImpl holds the current TLS configuration. The configurer
 // watches the certificate directory for changes and updates the server
@@ -59,28 +58,25 @@ type tlsConfigurerImpl struct {
 var _ TLSConfigurer = (*tlsConfigurerImpl)(nil)
 
 // NewTLSConfigurer creates a new TLS configurer.
-func NewTLSConfigurer(certDir string, clientCANamespace, clientCAConfigMap string) (TLSConfigurer, error) {
+func NewTLSConfigurer(certDir string, clientCANamespace, clientCAConfigMap string) TLSConfigurer {
 	cfgr := &tlsConfigurerImpl{
 		certDir:           certDir,
 		clientCANamespace: clientCANamespace,
 		clientCAConfigMap: clientCAConfigMap,
 	}
-	return cfgr, nil
+	return cfgr
 }
 
 // NewTLSConfigurerFromEnv creates a new TLS configurer based on environment variables.
 func NewTLSConfigurerFromEnv() TLSConfigurer {
 	if !secureMetricsEnabled() {
-		return nil
+		return &nilTLSConfigurer{}
 	}
 
 	certDir := env.SecureMetricsCertDir.Setting()
 	clientCANamespace := env.SecureMetricsClientCANamespace.Setting()
 	clientCAConfigMap := env.SecureMetricsClientCAConfigMap.Setting()
-	cfgr, err := NewTLSConfigurer(certDir, clientCANamespace, clientCAConfigMap)
-	if err != nil {
-		log.Error(errors.Wrap(err, "failed to create TLS config loader"))
-	}
+	cfgr := NewTLSConfigurer(certDir, clientCANamespace, clientCAConfigMap)
 	return cfgr
 }
 

--- a/pkg/metrics/tls.go
+++ b/pkg/metrics/tls.go
@@ -57,8 +57,8 @@ type tlsConfigurerImpl struct {
 
 var _ TLSConfigurer = (*tlsConfigurerImpl)(nil)
 
-// NewTLSConfigurer creates a new TLS configurer.
-func NewTLSConfigurer(certDir string, clientCANamespace, clientCAConfigMap string) TLSConfigurer {
+// newTLSConfigurer creates a new TLS configurer.
+func newTLSConfigurer(certDir string, clientCANamespace, clientCAConfigMap string) TLSConfigurer {
 	cfgr := &tlsConfigurerImpl{
 		certDir:           certDir,
 		clientCANamespace: clientCANamespace,
@@ -76,7 +76,7 @@ func NewTLSConfigurerFromEnv() TLSConfigurer {
 	certDir := env.SecureMetricsCertDir.Setting()
 	clientCANamespace := env.SecureMetricsClientCANamespace.Setting()
 	clientCAConfigMap := env.SecureMetricsClientCAConfigMap.Setting()
-	cfgr := NewTLSConfigurer(certDir, clientCANamespace, clientCAConfigMap)
+	cfgr := newTLSConfigurer(certDir, clientCANamespace, clientCAConfigMap)
 	return cfgr
 }
 

--- a/sensor/kubernetes/main.go
+++ b/sensor/kubernetes/main.go
@@ -32,7 +32,7 @@ func main() {
 	log.Infof("Running StackRox Version: %s", version.GetMainVersion())
 
 	// Start the prometheus metrics server
-	metrics.NewServer(metrics.SensorSubsystem).RunForever()
+	metrics.NewServer(metrics.SensorSubsystem, metrics.NewTLSConfigurerFromEnv()).RunForever()
 	metrics.GatherThrottleMetricsForever(metrics.SensorSubsystem.String())
 
 	sigs := make(chan os.Signal, 1)

--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -249,7 +249,7 @@ func main() {
 	localConfig := mustGetCommandLineArgs()
 	if localConfig.WithMetrics {
 		// Start the prometheus metrics server
-		metrics.NewServer(metrics.SensorSubsystem).RunForever()
+		metrics.NewServer(metrics.SensorSubsystem, metrics.NewTLSConfigurerFromEnv()).RunForever()
 		metrics.GatherThrottleMetricsForever(metrics.SensorSubsystem.String())
 	}
 	var fakeClient client.Interface


### PR DESCRIPTION
## Description

Add a TLS configurer interface responsible for updating the TLS config when either the TLS server certs (mounted via secret) or the client CA (read from config map) is rotated.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.