### PR TITLE
ROX-15868: Remove offline-mode flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Added Features
 
 ### Removed Features
+- The `--offline-mode` flag for the `roxctl scanner generate` command was removed, as Scanner's default behavior is
+  to fetch vulnerability updates from Central.
 
 ### Deprecated Features
 - RBAC risk was deprecated in release 4.0 due to poor performance.

--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stackrox/rox/pkg/apiparams"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/istioutils"
-	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
@@ -114,11 +113,6 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 			"Generate deployment files supporting the given Istio version. Valid versions: %s",
 			strings.Join(istioutils.ListKnownIstioVersions(), ", ")))
 	c.PersistentFlags().BoolVar(&scannerGenerateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", true, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
-
-	// TODO(ROX-15868): Remove the offline-mode flag after the deprecation notice has passed.
-	c.Flags().BoolVar(&scannerGenerateCmd.apiParams.OfflineMode, "offline-mode", false, "Whether to run the scanner in offline mode (so "+
-		"it doesn't reach out to the internet for updates)")
-	utils.Must(c.Flags().MarkDeprecated("offline-mode", "The offline mode option has been deprecated, scanner will reach out to central for updates"))
 
 	return c
 }


### PR DESCRIPTION
## Description

As previously announced within the changelog, the `--offline-mode` flag within the `roxctl scanner generate` command was deprecated, since the default behavior of Scanner on secured clusters is to not reach out to the internet directly but rather to Central for vulnerability updates.

Since the deprecation cycle of two releases has been reached, fully removing this flag now.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI.
