### PR TITLE
fix(GHA): disable psps in upgrade tests with roxctl flag

### DIFF
--- a/.github/workflows/scripts/prepare-upgrade-test.sh
+++ b/.github/workflows/scripts/prepare-upgrade-test.sh
@@ -27,6 +27,7 @@ deploy_central() {
     rm -rf bundle-test1
     ./roxctl-"${PREVIOUS_RELEASE}" central generate k8s pvc \
         --lb-type lb \
+        --enable-pod-security-policies=false \
         --image-defaults development_build \
         --output-dir bundle-test1
 

--- a/.github/workflows/scripts/prepare-upgrade-test.sh
+++ b/.github/workflows/scripts/prepare-upgrade-test.sh
@@ -81,6 +81,9 @@ deploy_sensor() {
 
     "./artifacts/${CLUSTER_NAME}/connect"
     unzip -d "sensor-${CLUSTER_NAME}" "sensor-${CLUSTER_NAME}.zip"
+
+    rm "./sensor-${CLUSTER_NAME}/*-pod-security.yaml"
+
     "./sensor-${CLUSTER_NAME}/sensor.sh"
 }
 

--- a/.github/workflows/scripts/prepare-upgrade-test.sh
+++ b/.github/workflows/scripts/prepare-upgrade-test.sh
@@ -82,7 +82,7 @@ deploy_sensor() {
     "./artifacts/${CLUSTER_NAME}/connect"
     unzip -d "sensor-${CLUSTER_NAME}" "sensor-${CLUSTER_NAME}.zip"
 
-    rm "./sensor-${CLUSTER_NAME}/*-pod-security.yaml"
+    rm ./sensor-"${CLUSTER_NAME}"/*-pod-security.yaml
 
     "./sensor-${CLUSTER_NAME}/sensor.sh"
 }


### PR DESCRIPTION
## Description

Prepare upgrade tests uses (previous) roxctl binary to generate Helm charts. 
Roxctl has an option to disable PSP generation.  

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

See https://github.com/stackrox/stackrox/actions/runs/5376028827
