### PR TITLE
ROX-17321: Sensor offline mode for Compliance Node Scans

### DIFF
--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -79,7 +79,7 @@ func (c *nodeInventoryHandlerImpl) Notify(e common.SensorComponentEvent) {
 	case common.SensorComponentEventCentralReachable:
 		c.centralReady.Signal()
 	case common.SensorComponentEventOfflineMode:
-		// As Compliance enters a retry loop on receiving a NACK,
+		// As Compliance enters a retry loop when it is not receiving an ACK,
 		// make sure we send NACK as soon as we enter offline mode
 		c.centralReady.Reset()
 	}

--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -79,7 +79,9 @@ func (c *nodeInventoryHandlerImpl) Notify(e common.SensorComponentEvent) {
 	case common.SensorComponentEventCentralReachable:
 		c.centralReady.Signal()
 	case common.SensorComponentEventOfflineMode:
-		// TODO(ROX-17044): handle node_inventory in offline mode
+		// As Compliance enters a retry loop on receiving a NACK,
+		// make sure we send NACK as soon as we enter offline mode
+		c.centralReady.Reset()
 	}
 }
 

--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -80,7 +80,7 @@ func (c *nodeInventoryHandlerImpl) Notify(e common.SensorComponentEvent) {
 		c.centralReady.Signal()
 	case common.SensorComponentEventOfflineMode:
 		// As Compliance enters a retry loop when it is not receiving an ACK,
-		// make sure we send NACK as soon as we enter offline mode
+		// there is no need to do anything when entering offline mode
 		c.centralReady.Reset()
 	}
 }

--- a/sensor/common/compliance/node_inventory_handler_test.go
+++ b/sensor/common/compliance/node_inventory_handler_test.go
@@ -173,7 +173,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerOfflineACKNACK() {
 	s.NoError(h.Stopped().Wait())
 }
 
-func mockCentralAck(h *nodeInventoryHandlerImpl, s *NodeInventoryHandlerTestSuite) {
+func mockCentralAck(h *nodeInventoryHandlerImpl) error {
 	select {
 	case <-h.ResponsesC():
 		err := h.ProcessMessage(&central.MsgToSensor{
@@ -257,9 +257,9 @@ func consumeAndCountCompliance(ch <-chan common.MessageToComplianceWithAddress, 
 				}
 				switch msg.Msg.GetAck().GetAction() {
 				case sensor.MsgToCompliance_NodeInventoryACK_ACK:
-					ms.ACKCount = ms.ACKCount + 1
+					ms.ACKCount++
 				case sensor.MsgToCompliance_NodeInventoryACK_NACK:
-					ms.NACKCount = ms.NACKCount + 1
+					ms.NACKCount++
 				}
 			}
 		}

--- a/sensor/common/compliance/node_inventory_handler_test.go
+++ b/sensor/common/compliance/node_inventory_handler_test.go
@@ -176,13 +176,16 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerOfflineACKNACK() {
 func mockCentralAck(h *nodeInventoryHandlerImpl, s *NodeInventoryHandlerTestSuite) {
 	select {
 	case <-h.ResponsesC():
-		h.ProcessMessage(&central.MsgToSensor{
+		err := h.ProcessMessage(&central.MsgToSensor{
 			Msg: &central.MsgToSensor_NodeInventoryAck{NodeInventoryAck: &central.NodeInventoryACK{
 				ClusterId: "4",
 				NodeName:  "4",
 				Action:    central.NodeInventoryACK_ACK,
 			}},
 		})
+		if err != nil {
+			s.Fail("ProcessMessage failed processing the ACK")
+		}
 		break
 	case <-time.After(5 * time.Second): // Starts counting when select is triggered
 		s.Fail("ResponsesC msg didn't arrive after 5 seconds")


### PR DESCRIPTION
## Description

Small change for clarity: 
When Sensor sends a NACK to Compliance, Compliance will enter a retry loop and resend the inventory until it receives an ACK.
This PR resets the centralReady signal, therefore leading to Sensor sending NACKs to Compliance on receiving Node Inventories.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed
The branch was deployed on a OS 4.12 cluster with the FF enabled and Node Scan interval set to 1 minute.
Afterwards, `central` replicas were scaled to 0, to observe Sensor loosing connction to Central.
In that case, `NACK`s are sent out to Compliance immediately upon receiving a Node Inventory.
Finally, after scaling central back to 1 replica, Sensor and Compliance return to working function and transmit Node Scans to Central.