### PR TITLE
ROX-17836: Adding fields for report parameters

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/CheckboxSelect.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/CheckboxSelect.tsx
@@ -11,6 +11,7 @@ export type CheckboxSelectProps = {
     onChange: (selection: string[]) => void;
     ariaLabel: string;
     children: ReactElement<SelectOptionProps>[];
+    placeholderText?: string;
 };
 
 function CheckboxSelect({
@@ -18,6 +19,7 @@ function CheckboxSelect({
     onChange,
     ariaLabel,
     children,
+    placeholderText = 'Filter by value',
 }: CheckboxSelectProps): ReactElement {
     const [isOpen, setIsOpen] = useState(false);
 
@@ -46,7 +48,7 @@ function CheckboxSelect({
             onSelect={onSelect}
             selections={selections}
             isOpen={isOpen}
-            placeholderText="Filter by value"
+            placeholderText={placeholderText}
             aria-label={ariaLabel}
         >
             {children}

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -166,13 +166,9 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                                 component={AsyncVulnerabilityReportingPage}
                             />
                         )}
-                    {hasVulnerabilityReportsPermission &&
-                        !isVulnerabilityReportingEnhancementsEnabled && (
-                            <Route
-                                path={vulnManagementReportsPath}
-                                component={AsyncVulnMgmtReports}
-                            />
-                        )}
+                    {hasVulnerabilityReportsPermission && (
+                        <Route path={vulnManagementReportsPath} component={AsyncVulnMgmtReports} />
+                    )}
                     <Route
                         path={vulnManagementRiskAcceptancePath}
                         component={AsyncVulnMgmtRiskAcceptancePage}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
@@ -11,12 +11,14 @@ import {
 } from '@patternfly/react-core';
 
 import { vulnerabilityReportsPath } from 'routePaths';
+import useReportFormValues from 'Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues';
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-import ReportParametersForm from '../forms/ReportParametersForm';
+import ReportParametersForm from 'Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm';
 
 function VulnReportsPage() {
+    const { formValues, setFormValues } = useReportFormValues();
     return (
         <>
             <PageTitle title="Create vulnerability report" />
@@ -50,7 +52,12 @@ function VulnReportsPage() {
                     steps={[
                         {
                             name: 'Configure report parameters',
-                            component: <ReportParametersForm />,
+                            component: (
+                                <ReportParametersForm
+                                    formValues={formValues}
+                                    setFormValues={setFormValues}
+                                />
+                            ),
                         },
                         { name: 'Configure delivery destinations (Optional)', component: <p /> },
                         {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
@@ -19,6 +19,7 @@ import ReportParametersForm from 'Containers/Vulnerabilities/VulnerablityReporti
 
 function VulnReportsPage() {
     const { formValues, setFormValues } = useReportFormValues();
+
     return (
         <>
             <PageTitle title="Create vulnerability report" />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
@@ -1,0 +1,207 @@
+import React, { useMemo, useState, ReactElement, useCallback, useEffect } from 'react';
+import {
+    Button,
+    ButtonVariant,
+    Flex,
+    FlexItem,
+    Select,
+    SelectOption,
+    SelectProps,
+    SelectVariant,
+    ValidatedOptions,
+} from '@patternfly/react-core';
+import sortBy from 'lodash/sortBy';
+import uniqBy from 'lodash/uniqBy';
+
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+import { Collection, listCollections } from 'services/CollectionsService';
+import CollectionsFormModal from 'Containers/Collections/CollectionFormModal';
+import { useCollectionFormSubmission } from 'Containers/Collections/hooks/useCollectionFormSubmission';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { usePaginatedQuery } from 'hooks/usePaginatedQuery';
+import { ReportScope } from 'hooks/useFetchReport';
+
+const COLLECTION_PAGE_SIZE = 10;
+
+type CollectionSelectionProps = {
+    selectedScopeId: string;
+    initialReportScope: ReportScope | null;
+    onChange: (selection: string) => void;
+    allowCreate: boolean;
+};
+
+function CollectionSelection({
+    selectedScopeId,
+    initialReportScope,
+    onChange,
+    allowCreate,
+}: CollectionSelectionProps): ReactElement {
+    const { isOpen, onToggle } = useSelectToggle();
+    const { configError, setConfigError, onSubmit } = useCollectionFormSubmission({
+        type: 'create',
+    });
+    const [search, setSearch] = useState('');
+
+    const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
+
+    const requestFn = useCallback(
+        (page: number) => {
+            return listCollections(
+                { 'Collection Name': search },
+                { field: 'Collection Name', reversed: false },
+                page,
+                COLLECTION_PAGE_SIZE
+            ).request;
+        },
+        [search]
+    );
+
+    const { data, isEndOfResults, isFetchingNextPage, fetchNextPage } = usePaginatedQuery(
+        requestFn,
+        COLLECTION_PAGE_SIZE
+    );
+
+    const isLegacyReportScopeSelected =
+        initialReportScope?.type === 'AccessControlScope' &&
+        initialReportScope?.id === selectedScopeId;
+
+    // Combines the server-side fetched pages of collections data with the local cache
+    // of created collections to create a flattened array sorted by name. This is intended to keep
+    // the collection dropdown up to date with any collections that the user creates while in the form.
+    //
+    // Previously this was not needed since the component would refetch _all_ access scopes
+    // upon creation of a new access scope, but we cannot do that efficiently since the collection dropdown
+    // is paginated.
+    //
+    // This functionality can likely be removed if we move to a library based method of data fetching.
+    const [createdCollections, setCreatedCollections] = useState<Collection[]>([]);
+    const sortedCollections = useMemo(() => {
+        const availableScopes: Pick<Collection, 'id' | 'name' | 'description'>[] = [
+            ...data.flat(),
+            ...createdCollections,
+        ];
+        // Adding the initial report scope, if available, allows the collection name to be displayed even
+        // if it has not yet been fetched via the dropdown's pagination.
+        if (initialReportScope && initialReportScope.type === 'CollectionScope') {
+            availableScopes.push(initialReportScope);
+        }
+
+        // This is inefficient due to the multiple loops and the fact that we are already tracking
+        // uniqueness for the _server side_ values, but need to do it twice to handle possible client
+        // side values. However, 'N' should be small here and we are memoizing the result.
+        const sorted = sortBy(availableScopes, ({ name }) => name.toLowerCase());
+        return uniqBy(sorted, 'id');
+    }, [data, createdCollections, initialReportScope]);
+
+    // This makes sure that if a collection was deleted then we clear the scopeId
+    useEffect(() => {
+        const selectedCollection = sortedCollections.find(
+            (collection) => collection.id === selectedScopeId
+        );
+        if (!selectedCollection) {
+            onChange('');
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [data]);
+
+    function onToggleCollectionModal() {
+        setIsCollectionModalOpen((current) => !current);
+    }
+
+    function onScopeChange(_id, selection) {
+        onToggle(false);
+        onChange(selection);
+    }
+
+    let selectLoadingVariant: SelectProps['loadingVariant'];
+
+    if (isFetchingNextPage) {
+        selectLoadingVariant = 'spinner';
+    } else if (!isEndOfResults) {
+        selectLoadingVariant = {
+            text: 'View more',
+            onClick: () => fetchNextPage(),
+        };
+    }
+
+    return (
+        <>
+            <Flex alignItems={{ default: 'alignItemsFlexEnd' }}>
+                <FlexItem>
+                    <FormLabelGroup
+                        className="pf-u-mb-md"
+                        isRequired
+                        label="Configure report scope"
+                        fieldId="scopeId"
+                        touched={isLegacyReportScopeSelected ? { scopeId: true } : {}}
+                        errors={
+                            isLegacyReportScopeSelected
+                                ? { scopeId: 'Choose a new collection to use as the report scope' }
+                                : {}
+                        }
+                    >
+                        <Select
+                            id="scopeId"
+                            onSelect={onScopeChange}
+                            selections={isLegacyReportScopeSelected ? '' : selectedScopeId}
+                            placeholderText="Select a collection"
+                            variant={SelectVariant.typeahead}
+                            isOpen={isOpen}
+                            onToggle={onToggle}
+                            onTypeaheadInputChanged={setSearch}
+                            loadingVariant={selectLoadingVariant}
+                            onBlur={() => setSearch('')}
+                            style={{
+                                maxHeight: '275px',
+                                overflowY: 'auto',
+                            }}
+                            validated={
+                                isLegacyReportScopeSelected
+                                    ? ValidatedOptions.error
+                                    : ValidatedOptions.default
+                            }
+                        >
+                            {sortedCollections.map(({ id, name, description }) => (
+                                <SelectOption key={id} value={id} description={description}>
+                                    {name}
+                                </SelectOption>
+                            ))}
+                        </Select>
+                    </FormLabelGroup>
+                </FlexItem>
+                {allowCreate && (
+                    <FlexItem>
+                        <Button
+                            className="pf-u-mb-md"
+                            variant={ButtonVariant.secondary}
+                            onClick={onToggleCollectionModal}
+                        >
+                            Create collection
+                        </Button>
+                    </FlexItem>
+                )}
+            </Flex>
+            {isCollectionModalOpen && (
+                <CollectionsFormModal
+                    hasWriteAccessForCollections={allowCreate}
+                    modalAction={{ type: 'create' }}
+                    onClose={() => setIsCollectionModalOpen(false)}
+                    configError={configError}
+                    setConfigError={setConfigError}
+                    onSubmit={(collection) =>
+                        onSubmit(collection).then((collectionResponse) => {
+                            onChange(collectionResponse.id);
+                            setIsCollectionModalOpen(false);
+                            setCreatedCollections((oldCollections) => [
+                                ...oldCollections,
+                                collectionResponse,
+                            ]);
+                        })
+                    }
+                />
+            )}
+        </>
+    );
+}
+
+export default CollectionSelection;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
@@ -15,10 +15,12 @@ import {
     ReportFormValues,
     SetReportFormValues,
 } from 'Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues';
+import usePermissions from 'hooks/usePermissions';
 
 import CheckboxSelect from 'Components/PatternFly/CheckboxSelect';
 import SeverityIcons from 'Components/PatternFly/SeverityIcons';
 import SelectSingle from 'Components/SelectSingle/SelectSingle';
+import CollectionSelection from './CollectionSelection';
 
 export type ReportParametersFormParams = {
     formValues: ReportFormValues;
@@ -34,6 +36,9 @@ function ReportParametersForm({
     formValues,
     setFormValues,
 }: ReportParametersFormParams): ReactElement {
+    const { hasReadWriteAccess } = usePermissions();
+    const canWriteCollections = hasReadWriteAccess('WorkflowAdministration');
+
     const handleTextChange = (fieldName: string) => (value: string) => {
         setFormValues((prevValues) => {
             const newValues = { ...prevValues };
@@ -62,6 +67,14 @@ function ReportParametersForm({
         setFormValues((prevValues) => {
             const newValues = { ...prevValues };
             set(newValues, fieldName, str);
+            return newValues;
+        });
+    };
+
+    const handleCollectionSelection = (fieldName: string) => (selection) => {
+        setFormValues((prevValues) => {
+            const newValues = { ...prevValues };
+            set(newValues, fieldName, selection);
             return newValues;
         });
     };
@@ -209,6 +222,14 @@ function ReportParametersForm({
                     />
                 </FormGroup>
             )}
+            <FormGroup isRequired fieldId="reportParameters.reportScope">
+                <CollectionSelection
+                    selectedScopeId={formValues.reportParameters.reportScope}
+                    initialReportScope={null}
+                    onChange={handleCollectionSelection('reportParameters.reportScope')}
+                    allowCreate={canWriteCollections}
+                />
+            </FormGroup>
         </Form>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
@@ -1,22 +1,215 @@
-import { Divider, Flex, FlexItem, PageSection, Title } from '@patternfly/react-core';
 import React, { ReactElement } from 'react';
+import {
+    DatePicker,
+    Flex,
+    FlexItem,
+    Form,
+    FormGroup,
+    SelectOption,
+    TextArea,
+    TextInput,
+} from '@patternfly/react-core';
+import set from 'lodash/set';
 
-function ReportParametersForm(): ReactElement {
+import {
+    ReportFormValues,
+    SetReportFormValues,
+} from 'Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues';
+
+import CheckboxSelect from 'Components/PatternFly/CheckboxSelect';
+import SeverityIcons from 'Components/PatternFly/SeverityIcons';
+import SelectSingle from 'Components/SelectSingle/SelectSingle';
+
+export type ReportParametersFormParams = {
+    formValues: ReportFormValues;
+    setFormValues: SetReportFormValues;
+};
+
+const CriticalSeverityIcon = SeverityIcons.CRITICAL_VULNERABILITY_SEVERITY;
+const ImportantSeverityIcon = SeverityIcons.IMPORTANT_VULNERABILITY_SEVERITY;
+const ModerateSeverityIcon = SeverityIcons.MODERATE_VULNERABILITY_SEVERITY;
+const LowSeverityIcon = SeverityIcons.LOW_VULNERABILITY_SEVERITY;
+
+function ReportParametersForm({
+    formValues,
+    setFormValues,
+}: ReportParametersFormParams): ReactElement {
+    const handleTextChange = (fieldName: string) => (value: string) => {
+        setFormValues((prevValues) => {
+            const newValues = { ...prevValues };
+            set(newValues, fieldName, value);
+            return newValues;
+        });
+    };
+
+    const handleSelectChange = (name: string, value: string) => {
+        setFormValues((prevValues) => {
+            const newValues = { ...prevValues };
+            set(newValues, name, value);
+            return newValues;
+        });
+    };
+
+    const handleCheckboxSelectChange = (fieldName: string) => (selection: string[]) => {
+        setFormValues((prevValues) => {
+            const newValues = { ...prevValues };
+            set(newValues, fieldName, selection);
+            return newValues;
+        });
+    };
+
+    const handleDateSelection = (fieldName: string) => (_event, str) => {
+        setFormValues((prevValues) => {
+            const newValues = { ...prevValues };
+            set(newValues, fieldName, str);
+            return newValues;
+        });
+    };
+
+    const handleCVEsDiscoveredStartDate = handleDateSelection(
+        'reportParameters.cvesDiscoveredStartDate'
+    );
+
     return (
-        <>
-            <PageSection variant="light" padding={{ default: 'noPadding' }}>
-                <Flex direction={{ default: 'column' }} className="pf-u-py-lg pf-u-px-lg">
-                    <FlexItem>
-                        <Title headingLevel="h2">Configure report parameters</Title>
-                    </FlexItem>
-                    <FlexItem>
-                        Configure report&apos;s name, CVE attributes, and setup schedule to send
-                        reports on a recurring basis.
-                    </FlexItem>
-                </Flex>
-            </PageSection>
-            <Divider component="div" />
-        </>
+        <Form className="pf-u-py-lg pf-u-px-lg">
+            <FormGroup label="Report name" isRequired fieldId="reportParameters.reportName">
+                <TextInput
+                    isRequired
+                    type="text"
+                    id="reportName"
+                    name="reportName"
+                    value={formValues.reportParameters.reportName}
+                    onChange={handleTextChange('reportParameters.reportName')}
+                />
+            </FormGroup>
+            <FormGroup label="Description" fieldId="reportParameters.description">
+                <TextArea
+                    type="text"
+                    id="description"
+                    name="description"
+                    value={formValues.reportParameters.description}
+                    onChange={handleTextChange('reportParameters.description')}
+                />
+            </FormGroup>
+            <FormGroup label="CVE severity" isRequired fieldId="reportParameters.cveSeverities">
+                <CheckboxSelect
+                    ariaLabel="CVE severity checkbox select"
+                    selections={formValues.reportParameters.cveSeverities}
+                    onChange={handleCheckboxSelectChange('reportParameters.cveSeverities')}
+                    placeholderText="CVE severity"
+                >
+                    <SelectOption value="CRITICAL_VULNERABILITY_SEVERITY">
+                        <Flex
+                            className="pf-u-mx-sm"
+                            spaceItems={{ default: 'spaceItemsSm' }}
+                            alignItems={{ default: 'alignItemsCenter' }}
+                        >
+                            <FlexItem>
+                                <CriticalSeverityIcon />
+                            </FlexItem>
+                            <FlexItem>Critical</FlexItem>
+                        </Flex>
+                    </SelectOption>
+                    <SelectOption value="IMPORTANT_VULNERABILITY_SEVERITY">
+                        <Flex
+                            className="pf-u-mx-sm"
+                            spaceItems={{ default: 'spaceItemsSm' }}
+                            alignItems={{ default: 'alignItemsCenter' }}
+                        >
+                            <FlexItem>
+                                <ImportantSeverityIcon />
+                            </FlexItem>
+                            <FlexItem>Important</FlexItem>
+                        </Flex>
+                    </SelectOption>
+                    <SelectOption value="MODERATE_VULNERABILITY_SEVERITY">
+                        <Flex
+                            className="pf-u-mx-sm"
+                            spaceItems={{ default: 'spaceItemsSm' }}
+                            alignItems={{ default: 'alignItemsCenter' }}
+                        >
+                            <FlexItem>
+                                <ModerateSeverityIcon />
+                            </FlexItem>
+                            <FlexItem>Moderate</FlexItem>
+                        </Flex>
+                    </SelectOption>
+                    <SelectOption value="LOW_VULNERABILITY_SEVERITY">
+                        <Flex
+                            className="pf-u-mx-sm"
+                            spaceItems={{ default: 'spaceItemsSm' }}
+                            alignItems={{ default: 'alignItemsCenter' }}
+                        >
+                            <FlexItem>
+                                <LowSeverityIcon />
+                            </FlexItem>
+                            <FlexItem>Low</FlexItem>
+                        </Flex>
+                    </SelectOption>
+                </CheckboxSelect>
+            </FormGroup>
+            <FormGroup label="CVE status" isRequired fieldId="reportParameters.cveStatus">
+                <CheckboxSelect
+                    ariaLabel="CVE status checkbox select"
+                    selections={formValues.reportParameters.cveStatus}
+                    onChange={handleCheckboxSelectChange('reportParameters.cveStatus')}
+                    placeholderText="CVE status"
+                >
+                    <SelectOption value="FIXABLE">Fixable</SelectOption>
+                    <SelectOption value="NOT_FIXABLE">Not fixable</SelectOption>
+                </CheckboxSelect>
+            </FormGroup>
+            <FormGroup label="Image type" isRequired fieldId="reportParameters.imageType">
+                <CheckboxSelect
+                    ariaLabel="Image type checkbox select"
+                    selections={formValues.reportParameters.imageType}
+                    onChange={handleCheckboxSelectChange('reportParameters.imageType')}
+                    placeholderText="Image type"
+                >
+                    <SelectOption value="DEPLOYED">Deployed images</SelectOption>
+                    <SelectOption value="WATCHED">Watched images</SelectOption>
+                </CheckboxSelect>
+            </FormGroup>
+            <FormGroup
+                label="CVEs discovered since"
+                isRequired
+                fieldId="reportParameters.cvesDiscoveredSince"
+            >
+                <SelectSingle
+                    id="reportParameters.cvesDiscoveredSince"
+                    value={formValues.reportParameters.cvesDiscoveredSince}
+                    handleSelect={handleSelectChange}
+                >
+                    <SelectOption
+                        value="SINCE_LAST_REPORT"
+                        description="Only applicable if there is a schedule configured in the report"
+                    >
+                        Last successful scheduled run report
+                    </SelectOption>
+                    <SelectOption
+                        value="START_DATE"
+                        description="Custom start date for the discovered CVE that were run on-demand or downloaded"
+                    >
+                        Custom start date
+                    </SelectOption>
+                    <SelectOption
+                        value="ALL_VULN"
+                        description="Show all detected CVEs from the beginning of cluster setup"
+                    >
+                        All time
+                    </SelectOption>
+                </SelectSingle>
+            </FormGroup>
+            {formValues.reportParameters.cvesDiscoveredSince === 'START_DATE' && (
+                <FormGroup isRequired fieldId="reportParameters.cvesDiscoveredStartDate">
+                    <DatePicker
+                        value={formValues.reportParameters.cvesDiscoveredStartDate}
+                        onBlur={handleCVEsDiscoveredStartDate}
+                        onChange={handleCVEsDiscoveredStartDate}
+                    />
+                </FormGroup>
+            )}
+        </Form>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
@@ -1,0 +1,52 @@
+import { Dispatch, SetStateAction, useState } from 'react';
+
+import { VulnerabilitySeverity } from 'types/cve.proto';
+import { ImageType } from 'types/reportConfigurationService.proto';
+
+export type ReportFormValuesResult = {
+    formValues: ReportFormValues;
+    setFormValues: SetReportFormValues;
+};
+
+export type SetReportFormValues = Dispatch<SetStateAction<ReportFormValues>>;
+
+export type ReportFormValues = {
+    reportParameters: ReportParametersFormValues;
+};
+
+export type ReportParametersFormValues = {
+    reportName: string;
+    description: string;
+    cveSeverities: VulnerabilitySeverity[];
+    cveStatus: CVEStatus[];
+    imageType: ImageType[];
+    cvesDiscoveredSince: CVESDiscoveredSince;
+    cvesDiscoveredStartDate: string | undefined;
+};
+
+export type CVEStatus = 'FIXABLE' | 'NOT_FIXABLE';
+
+export type CVESDiscoveredSince = 'ALL_VULN' | 'SINCE_LAST_REPORT' | 'START_DATE';
+
+const defaultFormValues: ReportFormValues = {
+    reportParameters: {
+        reportName: '',
+        description: '',
+        cveSeverities: [],
+        cveStatus: [],
+        imageType: [],
+        cvesDiscoveredSince: 'ALL_VULN',
+        cvesDiscoveredStartDate: undefined,
+    },
+};
+
+function useReportFormValues(): ReportFormValuesResult {
+    const [formValues, setFormValues] = useState<ReportFormValues>(defaultFormValues);
+
+    return {
+        formValues,
+        setFormValues,
+    };
+}
+
+export default useReportFormValues;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
@@ -22,13 +22,14 @@ export type ReportParametersFormValues = {
     imageType: ImageType[];
     cvesDiscoveredSince: CVESDiscoveredSince;
     cvesDiscoveredStartDate: string | undefined;
+    reportScope: string;
 };
 
 export type CVEStatus = 'FIXABLE' | 'NOT_FIXABLE';
 
 export type CVESDiscoveredSince = 'ALL_VULN' | 'SINCE_LAST_REPORT' | 'START_DATE';
 
-const defaultFormValues: ReportFormValues = {
+export const defaultReportFormValues: ReportFormValues = {
     reportParameters: {
         reportName: '',
         description: '',
@@ -37,11 +38,12 @@ const defaultFormValues: ReportFormValues = {
         imageType: [],
         cvesDiscoveredSince: 'ALL_VULN',
         cvesDiscoveredStartDate: undefined,
+        reportScope: '',
     },
 };
 
 function useReportFormValues(): ReportFormValuesResult {
-    const [formValues, setFormValues] = useState<ReportFormValues>(defaultFormValues);
+    const [formValues, setFormValues] = useState<ReportFormValues>(defaultReportFormValues);
 
     return {
         formValues,


### PR DESCRIPTION
## Description

This PR does the following:

### New

- Creates a hook called `useReportFormValues`. This defines the types of form values. It also allows us to reuse the hook between the `CreateVulnReportPage`, `EditVulnReportPage`, and `CloneVulnReportPage`.
- Creates a component called `ReportParametersForm`, which will render the fields used in the wizard's first step. We will pass the state value and state setter for the hook to this component to update the form values. Since we're keeping track of the form value state in the parent component, the values persist between wizard steps.

### Updates

- Updated the `CheckboxSelect` to allow passing a custom placeholder text.

## Screenshot / Screen recording

https://github.com/stackrox/stackrox/assets/4805485/56482cbb-22d4-4445-b1fc-4e01ee8d31df
