### PR TITLE
chore(scanner): remove bleve from go.mod

### DIFF
--- a/scanner/go.mod
+++ b/scanner/go.mod
@@ -82,7 +82,6 @@ replace (
 	// The following is a manual copy of replacements done in github.com/stackrox/rox.
 	// Go mod does not recursively apply them, hence the copy.  If you are
 	// here to update, strip all comments and sort alphabetically.
-	github.com/blevesearch/bleve => github.com/stackrox/bleve v0.0.0-20220907150529-4ecbd2543f9e
 	github.com/facebookincubator/nvdtools => github.com/stackrox/nvdtools v0.0.0-20210326191554-5daeb6395b56
 	github.com/fullsailor/pkcs7 => github.com/stackrox/pkcs7 v0.0.0-20220914154527-cfdb0aa47179
 	github.com/gogo/protobuf => github.com/connorgorman/protobuf v1.2.2-0.20210115205927-b892c1b298f7


### PR DESCRIPTION
## Description

Bleve was removed in https://github.com/stackrox/stackrox/pull/6524, so we no longer need this replace in Scanner's go.mod

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

nah
