### PR TITLE
ROX-17738: Allow selecting ALL or SPECIFIC registry setting

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/delegateScanning.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/delegateScanning.test.js
@@ -33,5 +33,10 @@ describe('Delegate Image Scanning', () => {
 
         getInputByLabel('All registries').should('be.checked');
         getInputByLabel('Specified registries').should('not.be.checked');
+
+        // change the type of enabled for
+        getInputByLabel('Specified registries').click();
+        getInputByLabel('All registries').should('not.be.checked');
+        getInputByLabel('Specified registries').should('be.checked');
     });
 });

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesList.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesList.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {
+    Bullseye,
+    Button,
+    Card,
+    CardBody,
+    EmptyState,
+    EmptyStateBody,
+    Title,
+} from '@patternfly/react-core';
+
+import { DelegatedRegistry } from 'types/dedicatedRegistryConfig.proto';
+
+type DelegatedRegistriesListProps = {
+    registries: DelegatedRegistry[];
+};
+
+function DelegatedRegistriesList({ registries }: DelegatedRegistriesListProps) {
+    return (
+        <Card className="pf-u-mb-lg">
+            {registries.length > 0 ? (
+                <CardBody>
+                    <p>(table goes here)</p>
+                </CardBody>
+            ) : (
+                <Bullseye className="pf-u-flex-grow-1">
+                    <EmptyState>
+                        <Title headingLevel="h2" size="lg">
+                            No registries specified.
+                        </Title>
+                        <EmptyStateBody>
+                            <p>All scans will be delegated to the default cluster.</p>
+                            <p>You can override thise for specific registries.</p>
+                        </EmptyStateBody>
+                        <Button variant="primary">Add registry</Button>
+                    </EmptyState>
+                </Bullseye>
+            )}
+        </Card>
+    );
+}
+
+export default DelegatedRegistriesList;

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesList.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesList.tsx
@@ -30,7 +30,7 @@ function DelegatedRegistriesList({ registries }: DelegatedRegistriesListProps) {
                         </Title>
                         <EmptyStateBody>
                             <p>All scans will be delegated to the default cluster.</p>
-                            <p>You can override thise for specific registries.</p>
+                            <p>You can override this for specific registries.</p>
                         </EmptyStateBody>
                         <Button variant="primary">Add registry</Button>
                     </EmptyState>

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Card, CardBody, Flex, FlexItem, Radio } from '@patternfly/react-core';
+
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+import { EnabledSelections } from 'types/dedicatedRegistryConfig.proto';
+
+type DelegatedScanningSettingsProps = {
+    enabledFor: EnabledSelections;
+    onChangeEnabledFor: (EnabledSelections) => void;
+};
+
+function DelegatedScanningSettings({
+    enabledFor,
+    onChangeEnabledFor,
+}: DelegatedScanningSettingsProps) {
+    return (
+        <Card className="pf-u-mb-lg">
+            <CardBody>
+                <FormLabelGroup
+                    label="Delegate scanning for"
+                    isRequired
+                    fieldId="enabledFor"
+                    touched={{}}
+                    errors={{}}
+                >
+                    <Flex className="pf-u-mt-md pf-u-mb-lg">
+                        <FlexItem>
+                            <Radio
+                                label="All registries"
+                                isChecked={enabledFor === 'ALL'}
+                                id="choose-all-registries"
+                                name="enabledFor"
+                                onChange={() => {
+                                    onChangeEnabledFor('ALL');
+                                }}
+                            />
+                        </FlexItem>
+                        <FlexItem>
+                            <Radio
+                                label="Specified registries"
+                                isChecked={enabledFor === 'SPECIFIC'}
+                                id="chose-specified-registries"
+                                name="enabledFor"
+                                onChange={() => {
+                                    onChangeEnabledFor('SPECIFIC');
+                                }}
+                            />
+                        </FlexItem>
+                    </Flex>
+                </FormLabelGroup>
+            </CardBody>
+        </Card>
+    );
+}
+
+export default DelegatedScanningSettings;

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
@@ -6,7 +6,7 @@ import { EnabledSelections } from 'types/dedicatedRegistryConfig.proto';
 
 type DelegatedScanningSettingsProps = {
     enabledFor: EnabledSelections;
-    onChangeEnabledFor: (EnabledSelections) => void;
+    onChangeEnabledFor: (newEnabledState: EnabledSelections) => void;
 };
 
 function DelegatedScanningSettings({

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -4,23 +4,21 @@ import {
     AlertVariant,
     Breadcrumb,
     BreadcrumbItem,
-    Card,
-    CardBody,
     Flex,
     FlexItem,
     PageSection,
-    Radio,
     Title,
 } from '@patternfly/react-core';
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import PageTitle from 'Components/PageTitle';
 import { clustersBasePath } from 'routePaths';
 import { fetchDelegatedRegistryConfig } from 'services/DelegatedRegistryConfigService';
 import { DelegatedRegistryConfig } from 'types/dedicatedRegistryConfig.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import ToggleDelegatedScanning from './Components/ToggleDelegatedScanning';
+import DelegatedScanningSettings from './Components/DelegatedScanningSettings';
+import DelegatedRegistriesList from './Components/DelegatedRegistriesList';
 
 const initialDelegatedState: DelegatedRegistryConfig = {
     enabledFor: 'NONE',
@@ -58,6 +56,14 @@ function DelegateScanningPage() {
         } else {
             newState.enabledFor = 'NONE';
         }
+        setDedicatedRegistryConfig(newState);
+    }
+
+    function onChangeEnabledFor(newEnabledState) {
+        const newState: DelegatedRegistryConfig = { ...delegatedRegistryConfig };
+
+        newState.enabledFor = newEnabledState;
+
         setDedicatedRegistryConfig(newState);
     }
 
@@ -99,40 +105,13 @@ function DelegateScanningPage() {
                 />
                 {/* TODO: decide who to structure this form, where the `enabledFor` value spans multiple inputs */}
                 {delegatedRegistryConfig.enabledFor !== 'NONE' && (
-                    <Card>
-                        <CardBody>
-                            <FormLabelGroup
-                                label="Delegate scanning for"
-                                isRequired
-                                fieldId="delegatedRegistryConfig.enabledFor"
-                                touched={{}}
-                                errors={{}}
-                            >
-                                <Flex className="pf-u-mt-md pf-u-mb-lg">
-                                    <FlexItem>
-                                        <Radio
-                                            label="All registries"
-                                            isChecked={delegatedRegistryConfig.enabledFor === 'ALL'}
-                                            id="choose-all-registries"
-                                            name="enabledFor"
-                                            onChange={() => {}}
-                                        />
-                                    </FlexItem>
-                                    <FlexItem>
-                                        <Radio
-                                            label="Specified registries"
-                                            isChecked={
-                                                delegatedRegistryConfig.enabledFor === 'SPECIFIC'
-                                            }
-                                            id="chose-specified-registries"
-                                            name="enabledFor"
-                                            onChange={() => {}}
-                                        />
-                                    </FlexItem>
-                                </Flex>
-                            </FormLabelGroup>
-                        </CardBody>
-                    </Card>
+                    <>
+                        <DelegatedScanningSettings
+                            enabledFor={delegatedRegistryConfig.enabledFor}
+                            onChangeEnabledFor={onChangeEnabledFor}
+                        />
+                        <DelegatedRegistriesList registries={delegatedRegistryConfig.registries} />
+                    </>
                 )}
             </PageSection>
         </>

--- a/ui/apps/platform/src/types/dedicatedRegistryConfig.proto.ts
+++ b/ui/apps/platform/src/types/dedicatedRegistryConfig.proto.ts
@@ -1,5 +1,7 @@
 export type DelegatedRegistryConfigEnabledFor = 'NONE' | 'ALL' | 'SPECIFIC';
 
+export type EnabledSelections = Exclude<DelegatedRegistryConfigEnabledFor, 'NONE'>;
+
 export type DelegatedRegistry = {
     path: string;
     clusterId: string;


### PR DESCRIPTION
## Description

This is an incremental change to allow selecting whether all internal registries will use the same default cluster, or whether the user will specify that certain registries will use each their own specific cluster.

Follow-up:
1. Picking the default cluster from a list of available clusters will come in a later PR.
2. Adding and listing specific registries and their specific cluster to use for scanning will come in another later PR.

(Note: I investigated using Formik to manage the state, but because one backend concept, the `enabledFor` property, is split between the checkbox and radio buttons in the design, and the form object isn't that complicated, I elected not to add the extra Formik handling.)


## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

## Testing Performed

With ALL selected
<img width="1609" alt="Screen Shot 2023-06-28 at 1 13 22 PM" src="https://github.com/stackrox/stackrox/assets/715729/ae384d42-c82d-4683-9fd1-f8b7b4fb9e52">


With SPECIFIC selected
<img width="1609" alt="Screen Shot 2023-06-28 at 1 03 43 PM" src="https://github.com/stackrox/stackrox/assets/715729/79c782a6-fb4e-47f6-9a2c-b96153e9e47f">

e2e test run locally
<img width="1897" alt="Screen Shot 2023-06-28 at 1 03 36 PM" src="https://github.com/stackrox/stackrox/assets/715729/1d6b55b9-112b-4c30-8af8-c9161980883c">
