### PR TITLE
ROX-17965: Add thread to logs

### DIFF
--- a/qa-tests-backend/src/test/resources/logback-test.xml
+++ b/qa-tests-backend/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
     <withJansi>true</withJansi>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%-8.8thread | %d{HH:mm:ss} | %-5level | %-25logger{0} | %m%n%rEx{full,
+            <pattern>%replace(%replace(%thread){"^Test worker", ""}){".*worker-(\d+)", "thread-$1 | "}%d{HH:mm:ss} | %-5level | %-25logger{0} | %m%n%rEx{full,
                 com.sun,
                 com.jayway.restassured.internal,
                 groovy.lang,

--- a/qa-tests-backend/src/test/resources/logback-test.xml
+++ b/qa-tests-backend/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
     <withJansi>true</withJansi>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%replace(%replace(%thread){"^(Time-limited test|Test worker)", ""}){".*worker-(\d+)", "thread-$1 | "}%d{HH:mm:ss} | %-5level | %-25logger{0} | %m%n%rEx{full,
+            <pattern>%replace(%replace(%thread){"^(Time-limited test|Test worker)", ""}){"^(.*worker|Thread)-(\d+)", "thread-$1 | "}%d{HH:mm:ss} | %-5level | %-25logger{0} | %m%n%rEx{full,
                 com.sun,
                 com.jayway.restassured.internal,
                 groovy.lang,

--- a/qa-tests-backend/src/test/resources/logback-test.xml
+++ b/qa-tests-backend/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
     <withJansi>true</withJansi>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss} | %-5level | %-25logger{0} | %m%n%rEx{full,
+            <pattern>%-8.8thread | %d{HH:mm:ss} | %-5level | %-25logger{0} | %m%n%rEx{full,
                 com.sun,
                 com.jayway.restassured.internal,
                 groovy.lang,

--- a/qa-tests-backend/src/test/resources/logback-test.xml
+++ b/qa-tests-backend/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
     <withJansi>true</withJansi>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%replace(%replace(%thread){"^(Time-limited test|Test worker)", ""}){"^(.*worker|Thread)-(\d+)", "thread-$1 | "}%d{HH:mm:ss} | %-5level | %-25logger{0} | %m%n%rEx{full,
+            <pattern>%replace(%replace(%thread){"^(Time-limited test|Test worker)", ""}){"^(.*worker|Thread)-(\d+)", "thread-$2 | "}%d{HH:mm:ss} | %-5level | %-25logger{0} | %m%n%rEx{full,
                 com.sun,
                 com.jayway.restassured.internal,
                 groovy.lang,

--- a/qa-tests-backend/src/test/resources/logback-test.xml
+++ b/qa-tests-backend/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
     <withJansi>true</withJansi>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%replace(%replace(%thread){"^Test worker", ""}){".*worker-(\d+)", "thread-$1 | "}%d{HH:mm:ss} | %-5level | %-25logger{0} | %m%n%rEx{full,
+            <pattern>%replace(%replace(%thread){"^(Time-limited test|Test worker)", ""}){".*worker-(\d+)", "thread-$1 | "}%d{HH:mm:ss} | %-5level | %-25logger{0} | %m%n%rEx{full,
                 com.sun,
                 com.jayway.restassured.internal,
                 groovy.lang,


### PR DESCRIPTION
## Description

When tests are running concurrently it will be useful to know which thread is generating a log message. Note: this is not intended as the final PR to deal with test output in a concurrent test world but merely a necessary first step. Also, if the pattern gets more complicated we should invest in a custom layout: https://logback.qos.ch/manual/layouts.html.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.