### PR TITLE
ROX-17502: Add a slot for parallel testing

### DIFF
--- a/qa-tests-backend/Makefile
+++ b/qa-tests-backend/Makefile
@@ -52,12 +52,12 @@ clean-generated-srcs:
 .PHONY: test
 test: compile
 	@echo "+ $@"
-	$(GRADLE) testBegin testRest $(GRADLE_TEST_ARGS)
+	$(GRADLE) testBegin testParallel testRest $(GRADLE_TEST_ARGS)
 
 .PHONY: bat-test
 bat-test: compile
 	@echo "+ $@"
-	$(GRADLE) testBegin testBAT $(GRADLE_TEST_ARGS)
+	$(GRADLE) testBegin testParallelBAT testBAT $(GRADLE_TEST_ARGS)
 
 .PHONY: smoke-test
 smoke-test: compile

--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -154,15 +154,30 @@ task testBegin(type: Test) {
     }
 }
 
+task testParallel(type: Test) {
+  systemProperty 'spock.configuration', rootProject.file('src/test/resources/ParallelSpockConfig.groovy')
+  useJUnitPlatform {
+      includeTags "Parallel"
+  }
+}
+
 task testRest(type: Test) {
     useJUnitPlatform {
-        excludeTags "Begin", "Upgrade", "SensorBounce", "SensorBounceNext"
+        excludeTags "Begin", "Parallel", "Upgrade", "SensorBounce", "SensorBounceNext"
     }
+}
+
+task testParallelBAT(type: Test) {
+  systemProperty 'spock.configuration', rootProject.file('src/test/resources/ParallelSpockConfig.groovy')
+  useJUnitPlatform {
+      includeTags "Parallel & BAT"
+  }
 }
 
 task testBAT(type: Test) {
     useJUnitPlatform {
         includeTags "BAT"
+        excludeTags "Parallel"
     }
 }
 

--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -32,17 +32,18 @@ import org.junit.Rule
 import org.junit.rules.Timeout
 import spock.lang.Tag
 
+@Tag("Parallel")
 class DeclarativeConfigTest extends BaseSpecification {
     static final private String DEFAULT_NAMESPACE = "stackrox"
 
     static final private String CONFIGMAP_NAME = "declarative-configurations"
 
     // The keys are used within the config map to indicate the specific resources.
-    static final private String PERMISSION_SET_KEY = "permission-set"
-    static final private String ACCESS_SCOPE_KEY = "access-scope"
-    static final private String ROLE_KEY = "role"
-    static final private String AUTH_PROVIDER_KEY = "auth-provider"
-    static final private String NOTIFIER_KEY = "notifier"
+    static final private String PERMISSION_SET_KEY = "declarative-config-test--permission-set"
+    static final private String ACCESS_SCOPE_KEY = "declarative-config-test--access-scope"
+    static final private String ROLE_KEY = "declarative-config-test--role"
+    static final private String AUTH_PROVIDER_KEY = "declarative-config-test--auth-provider"
+    static final private String NOTIFIER_KEY = "declarative-config-test--notifier"
 
     static final private int CREATED_RESOURCES = 7
 

--- a/qa-tests-backend/src/test/resources/ParallelSpockConfig.groovy
+++ b/qa-tests-backend/src/test/resources/ParallelSpockConfig.groovy
@@ -1,0 +1,12 @@
+import org.spockframework.runtime.model.parallel.ExecutionMode
+
+runner {
+  parallel {
+    enabled true
+    // Specifications run concurrently by default
+    defaultSpecificationExecutionMode ExecutionMode.CONCURRENT
+    // Features run serially by default
+    defaultExecutionMode ExecutionMode.SAME_THREAD
+    fixed(8)
+  }
+}


### PR DESCRIPTION
## Description

This PR creates a tag to use to denote test specifications that could run in parallel with other tests and picks DeclarativeConfigTest.groovy as the first candidate.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.