### PR TITLE
fix(ci): TLSChallengeTest: Retry env update

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -574,18 +574,20 @@ class Kubernetes implements OrchestratorMain {
         }
         envVars.get(index).value = value
 
-        client.apps().deployments().inNamespace(ns).withName(name)
-            .edit { d -> new DeploymentBuilder(d)
-                .editSpec()
-                .editTemplate()
-                .editSpec()
-                .editContainer(0)
-                .withEnv(envVars)
-                .endContainer()
-                .endSpec()
-                .endTemplate()
-                .endSpec()
-            .build() }
+        withRetry(2, 3) {
+            client.apps().deployments().inNamespace(ns).withName(name)
+                .edit { d -> new DeploymentBuilder(d)
+                    .editSpec()
+                    .editTemplate()
+                    .editSpec()
+                    .editContainer(0)
+                    .withEnv(envVars)
+                    .endContainer()
+                    .endSpec()
+                    .endTemplate()
+                    .endSpec()
+                .build() }
+        }
     }
 
     def scaleDeployment(String ns, String name, Integer replicas) {


### PR DESCRIPTION
## Description

Since the removal of auto-retry from qa-e2e tests, this one has been flaking. It often relied on the retry to patch over a failing patch when sensor is just restarting following AdmissionControllerTest. This PR adds a retry to the env update.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient