### PR TITLE
refactor: Update TLSChallenge error messages for clarity

### DIFF
--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -75,10 +75,10 @@ func (s *serviceImpl) TLSChallenge(_ context.Context, req *v1.TLSChallengeReques
 	sensorChallenge := req.GetChallengeToken()
 	sensorChallengeBytes, err := base64.URLEncoding.DecodeString(sensorChallenge)
 	if err != nil {
-		return nil, errors.Wrapf(errox.InvalidArgs, "challenge token must be a valid base64 string, received %q", err)
+		return nil, errox.InvalidArgs.CausedByf("challenge token must be a valid base64 string: %v", err)
 	}
 	if len(sensorChallengeBytes) != centralsensor.ChallengeTokenLength {
-		return nil, errors.Wrapf(errox.InvalidArgs, "base64 decoded challenge token must be %d bytes long, received challenge %q was %d bytes", centralsensor.ChallengeTokenLength, sensorChallenge, len(sensorChallengeBytes))
+		return nil, errox.InvalidArgs.CausedByf("base64 decoded challenge token must be %d bytes long, received challenge %q was %d bytes", centralsensor.ChallengeTokenLength, sensorChallenge, len(sensorChallengeBytes))
 	}
 
 	// Create central challenge token

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -75,10 +75,10 @@ func (s *serviceImpl) TLSChallenge(_ context.Context, req *v1.TLSChallengeReques
 	sensorChallenge := req.GetChallengeToken()
 	sensorChallengeBytes, err := base64.URLEncoding.DecodeString(sensorChallenge)
 	if err != nil {
-		return nil, errors.Wrapf(errox.InvalidArgs, "challenge token must be a valid base64 string: %s", err)
+		return nil, errors.Wrapf(errox.InvalidArgs, "challenge token must be a valid base64 string, received %q", err)
 	}
 	if len(sensorChallengeBytes) != centralsensor.ChallengeTokenLength {
-		return nil, errors.Wrapf(errox.InvalidArgs, "base64 decoded challenge token must be %d bytes long, got %s", centralsensor.ChallengeTokenLength, sensorChallenge)
+		return nil, errors.Wrapf(errox.InvalidArgs, "base64 decoded challenge token must be %d bytes long, received challenge %q was %d bytes", centralsensor.ChallengeTokenLength, sensorChallenge, len(sensorChallengeBytes))
 	}
 
 	// Create central challenge token

--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -118,7 +118,7 @@ func (s *serviceImplTestSuite) TestTLSChallenge_ShouldFailWithInvalidToken() {
 
 	resp, err := service.TLSChallenge(context.TODO(), req)
 	s.Require().Error(err)
-	s.EqualError(err, "challenge token must be a valid base64 string: illegal base64 data at input byte 4: invalid arguments")
+	s.EqualError(err, "invalid arguments: challenge token must be a valid base64 string: illegal base64 data at input byte 4")
 	s.Nil(resp)
 }
 

--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -110,6 +110,16 @@ func (s *serviceImplTestSuite) TestTLSChallenge_VerifySignatureWithCACert_Should
 	s.Equal("failed to verify rsa signature: crypto/rsa: verification error", err.Error())
 }
 
+func (s *serviceImplTestSuite) TestTLSChallenge_ShouldFailWithoutChallenge() {
+	service := serviceImpl{}
+	req := &v1.TLSChallengeRequest{}
+
+	resp, err := service.TLSChallenge(context.TODO(), req)
+	s.Require().Error(err)
+	s.EqualError(err, "invalid arguments: base64 decoded challenge token must be 32 bytes long, received challenge \"\" was 0 bytes")
+	s.Nil(resp)
+}
+
 func (s *serviceImplTestSuite) TestTLSChallenge_ShouldFailWithInvalidToken() {
 	service := serviceImpl{}
 	req := &v1.TLSChallengeRequest{

--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -18,6 +18,7 @@ import (
 	systemInfoStorage "github.com/stackrox/rox/central/systeminfo/store/postgres"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	mockIdentity "github.com/stackrox/rox/pkg/grpc/authn/mocks"
 	testutilsMTLS "github.com/stackrox/rox/pkg/mtls/testutils"
@@ -116,7 +117,7 @@ func (s *serviceImplTestSuite) TestTLSChallenge_ShouldFailWithoutChallenge() {
 
 	resp, err := service.TLSChallenge(context.TODO(), req)
 	s.Require().Error(err)
-	s.EqualError(err, "invalid arguments: base64 decoded challenge token must be 32 bytes long, received challenge \"\" was 0 bytes")
+	s.ErrorIs(err, errox.InvalidArgs)
 	s.Nil(resp)
 }
 
@@ -128,7 +129,7 @@ func (s *serviceImplTestSuite) TestTLSChallenge_ShouldFailWithInvalidToken() {
 
 	resp, err := service.TLSChallenge(context.TODO(), req)
 	s.Require().Error(err)
-	s.EqualError(err, "invalid arguments: challenge token must be a valid base64 string: illegal base64 data at input byte 4")
+	s.ErrorIs(err, errox.InvalidArgs)
 	s.Nil(resp)
 }
 

--- a/pkg/errox/roxerror.go
+++ b/pkg/errox/roxerror.go
@@ -105,7 +105,7 @@ func (e *RoxError) Newf(format string, args ...interface{}) *RoxError {
 //
 // Example:
 //
-//	return errox.InvalidArgument.CausedBy(err)
+//	return errox.InvalidArgs.CausedBy(err)
 //
 // or
 //
@@ -120,7 +120,7 @@ func (e *RoxError) CausedBy(cause interface{}) error {
 //
 // Example:
 //
-//	return errox.InvalidArgument.CausedByf("unknown parameter %v", p)
+//	return errox.InvalidArgs.CausedByf("unknown parameter %v", p)
 func (e *RoxError) CausedByf(format string, args ...interface{}) error {
 	return e.CausedBy(fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
## Description

In case of absent TLS challenge, the error message currently looks like this:
```
{"error":"base64 decoded challenge token must be 32 bytes long, got : invalid arguments","code":3,"message":"base64 decoded challenge token must be 32 bytes long, got : invalid arguments","details":[]}
```
which is hard to parse, especially if the challenge is empty.

This PR ensures that the challenge appears in quotes to enhance readability. 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI run with a newly added test; manual check of the returned error message.
