### PR TITLE
refactor: Metadata service authorization is explicit

### DIFF
--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -18,11 +18,28 @@ import (
 	"github.com/stackrox/rox/pkg/cryptoutils"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/authn"
+	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
+	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
+	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/version"
 	"google.golang.org/grpc"
+)
+
+var (
+	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
+		user.With(): {
+			"/v1.MetadataService/GetDatabaseBackupStatus",
+			"/v1.MetadataService/GetCentralCapabilities",
+		},
+		allow.Anonymous(): {
+			"/v1.MetadataService/GetMetadata",
+			"/v1.MetadataService/TLSChallenge",
+			"/v1.MetadataService/GetDatabaseStatus",
+		},
+	})
 )
 
 // Service is the struct that manages the Metadata API
@@ -45,7 +62,7 @@ func (s *serviceImpl) RegisterServiceHandler(ctx context.Context, mux *runtime.S
 
 // AuthFuncOverride specifies the auth criteria for this API.
 func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
-	return ctx, allow.Anonymous().Authorized(ctx, fullMethodName)
+	return ctx, authorizer.Authorized(ctx, fullMethodName)
 }
 
 // GetMetadata returns the metadata for Rox.
@@ -181,9 +198,5 @@ func (s *serviceImpl) GetDatabaseBackupStatus(ctx context.Context, _ *v1.Empty) 
 
 // GetCentralCapabilities returns central services capabilities.
 func (s *serviceImpl) GetCentralCapabilities(ctx context.Context, _ *v1.Empty) (*v1.CentralServicesCapabilities, error) {
-	if authn.IdentityFromContextOrNil(ctx) == nil {
-		return nil, errox.NotAuthorized
-	}
-
 	return centralcapabilities.GetCentralCapabilities(), nil
 }

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -197,6 +197,6 @@ func (s *serviceImpl) GetDatabaseBackupStatus(ctx context.Context, _ *v1.Empty) 
 }
 
 // GetCentralCapabilities returns central services capabilities.
-func (s *serviceImpl) GetCentralCapabilities(ctx context.Context, _ *v1.Empty) (*v1.CentralServicesCapabilities, error) {
+func (s *serviceImpl) GetCentralCapabilities(_ context.Context, _ *v1.Empty) (*v1.CentralServicesCapabilities, error) {
 	return centralcapabilities.GetCentralCapabilities(), nil
 }

--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	mockIdentity "github.com/stackrox/rox/pkg/grpc/authn/mocks"
+	"github.com/stackrox/rox/pkg/grpc/testutils"
 	testutilsMTLS "github.com/stackrox/rox/pkg/mtls/testutils"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
@@ -35,6 +36,10 @@ const (
 
 func TestServiceImpl(t *testing.T) {
 	suite.Run(t, new(serviceImplTestSuite))
+}
+
+func TestAuthz(t *testing.T) {
+	testutils.AssertAuthzWorks(t, &serviceImpl{})
 }
 
 type serviceImplTestSuite struct {
@@ -194,13 +199,6 @@ func (s *serviceImplTestSuite) TestDatabaseBackupStatus() {
 }
 
 func (s *serviceImplTestSuite) TestGetCentralCapabilities() {
-	s.Run("when not authenticated", func() {
-		caps, err := (&serviceImpl{}).GetCentralCapabilities(context.Background(), nil)
-
-		s.Nil(caps)
-		s.ErrorContains(err, "not authorized")
-	})
-
 	mockID := mockIdentity.NewMockIdentity(s.mockCtrl)
 	ctx := authn.ContextWithIdentity(sac.WithNoAccess(context.Background()), mockID, s.T())
 

--- a/generated/api/v1/metadata_service.pb.go
+++ b/generated/api/v1/metadata_service.pb.go
@@ -770,6 +770,11 @@ const _ = grpc.SupportPackageIsVersion6
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConnInterface.NewStream.
 type MetadataServiceClient interface {
 	GetMetadata(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*Metadata, error)
+	// TLSChallenge
+	//
+	// Returns all trusted CAs, i.e., secret/additional-ca and Central's cert
+	// chain. This is necessary if Central is running behind a load balancer
+	// with self-signed certificates. Does not require authentication.
 	TLSChallenge(ctx context.Context, in *TLSChallengeRequest, opts ...grpc.CallOption) (*TLSChallengeResponse, error)
 	GetDatabaseStatus(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*DatabaseStatus, error)
 	GetDatabaseBackupStatus(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*DatabaseBackupStatus, error)
@@ -832,6 +837,11 @@ func (c *metadataServiceClient) GetCentralCapabilities(ctx context.Context, in *
 // MetadataServiceServer is the server API for MetadataService service.
 type MetadataServiceServer interface {
 	GetMetadata(context.Context, *Empty) (*Metadata, error)
+	// TLSChallenge
+	//
+	// Returns all trusted CAs, i.e., secret/additional-ca and Central's cert
+	// chain. This is necessary if Central is running behind a load balancer
+	// with self-signed certificates. Does not require authentication.
 	TLSChallenge(context.Context, *TLSChallengeRequest) (*TLSChallengeResponse, error)
 	GetDatabaseStatus(context.Context, *Empty) (*DatabaseStatus, error)
 	GetDatabaseBackupStatus(context.Context, *Empty) (*DatabaseBackupStatus, error)

--- a/generated/api/v1/metadata_service.swagger.json
+++ b/generated/api/v1/metadata_service.swagger.json
@@ -101,6 +101,8 @@
     },
     "/v1/tls-challenge": {
       "get": {
+        "summary": "TLSChallenge",
+        "description": "Returns all trusted CAs, i.e., secret/additional-ca and Central's cert\nchain. This is necessary if Central is running behind a load balancer\nwith self-signed certificates. Does not require authentication.",
         "operationId": "MetadataService_TLSChallenge",
         "responses": {
           "200": {

--- a/proto/api/v1/metadata_service.proto
+++ b/proto/api/v1/metadata_service.proto
@@ -106,6 +106,11 @@ service MetadataService {
         };
     }
 
+    // TLSChallenge
+    //
+    // Returns all trusted CAs, i.e., secret/additional-ca and Central's cert
+    // chain. This is necessary if Central is running behind a load balancer
+    // with self-signed certificates. Does not require authentication.
     rpc TLSChallenge(TLSChallengeRequest) returns (TLSChallengeResponse) {
         option(google.api.http) = {
             get: "/v1/tls-challenge"


### PR DESCRIPTION
## Description

Prior to this patch, Metadata service was giving unauthenticated access to all of its endpoints by default. Some endpoints, however, overrode this behavior in their handlers.

This PR refactors authorization in the Metadata endpoint so that it follows the per-service authorizer pattern used in the codebase. The default is changed to "deny" and every service's endpoint is explicitly called out in the authz map. This ensures consistent error messaging and more importantly prevents giving public access to future endpoints in this service by oversight.

## Checklist
- [x] Investigated and inspected CI test results
  - `ci/prow/gke-sensor-integration-tests` is a known flake, https://issues.redhat.com/browse/ROX-18148
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI run;
Manual test verifying calls to the affected endpoints behave the same w.r.t. authentication.
