### PR TITLE
ROX-18173: Authenticate 'v1/database/status'

### DIFF
--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -31,13 +31,13 @@ import (
 var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
 		user.With(): {
+			"/v1.MetadataService/GetDatabaseStatus",
 			"/v1.MetadataService/GetDatabaseBackupStatus",
 			"/v1.MetadataService/GetCentralCapabilities",
 		},
 		allow.Anonymous(): {
 			"/v1.MetadataService/GetMetadata",
 			"/v1.MetadataService/TLSChallenge",
-			"/v1.MetadataService/GetDatabaseStatus",
 		},
 	})
 )


### PR DESCRIPTION
## Description

Originally, `/v1/database/status` was open to the world to allow consumers—primarily ACS UI—to to zero in on the problem with the database before authentication because rendering login screen requires fetching info on auth providers from the database. However, ACS UI does not call this endpoint from the login screen and apparently does not plan to do so in the nearest future.

Given the primary use case is off the table, this PR tightens access for the endpoint to only authenticated users.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required, see https://github.com/stackrox/stackrox/pull/6726
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Manual test in the last PR of the chain, see https://github.com/stackrox/stackrox/pull/6718.