### PR TITLE
fix(check-pr): Revert "ROX-14204: enable `TestReaderReturnsErrorIfFileExistsButCannotBeRead` (#6344)"

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,10 +20,6 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    # Needed for FS permissions sensitive tests, see ROX-14204.
-    - name: Create user
-      run: useradd tester
-
     - name: Checkout
       uses: actions/checkout@v3
       with:
@@ -33,17 +29,12 @@ jobs:
       run: |
         # Prevent fatal error "detected dubious ownership in repository" from recent git.
         git config --global --add safe.directory "$(pwd)"
-        su tester -c "git config --global --add safe.directory \"$(pwd)\""
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
 
     - name: Go Unit Tests
-      env:
-        TMPDIR: ${{ runner.temp }}
-      run: |
-        chmod a+wx . roxctl/connectivity-map "$TMPDIR"
-        ${{ matrix.gotags }} su tester -c "make go-unit-tests"
+      run: ${{ matrix.gotags }} make go-unit-tests
 
     - name: Generate junit report
       if: always()

--- a/compliance/collection/auditlog/auditlog_impl_test.go
+++ b/compliance/collection/auditlog/auditlog_impl_test.go
@@ -54,6 +54,10 @@ func (s *ComplianceAuditLogReaderTestSuite) TestReaderStopDoesNotBlockIfStartFai
 }
 
 func (s *ComplianceAuditLogReaderTestSuite) TestReaderReturnsErrorIfFileExistsButCannotBeRead() {
+	// TODO(ROX-14204): enable this test on GHA
+	if _, ok := os.LookupEnv("GITHUB_ACTIONS"); ok {
+		s.T().Skip("ROX-14204: This test is not working on GHA.")
+	}
 	tempDir := s.T().TempDir()
 	logPath := filepath.Join(tempDir, "testaudit_notopenable.log")
 


### PR DESCRIPTION
## Description

These changes (temporarily) fix the permission issues in the go dep caches GitHub actions.

Reverts https://github.com/stackrox/stackrox/pull/6344 and https://github.com/stackrox/stackrox/pull/6601

Relevant Slack threads:
- https://redhat-internal.slack.com/archives/CELUQKESC/p1687878824317229
- https://redhat-internal.slack.com/archives/C0321S70YK1/p1687874219753839

## Testing Performed

CI