### PR TITLE
ROX-17950: Add hidden page route for listening endpoints

### DIFF
--- a/ui/apps/platform/cypress/integration/audit/listeningEndpoints/ListeningEndpoints.helpers.js
+++ b/ui/apps/platform/cypress/integration/audit/listeningEndpoints/ListeningEndpoints.helpers.js
@@ -1,0 +1,10 @@
+import { visit } from '../../../helpers/visit';
+
+const basePath = '/main/audit/listening-endpoints/';
+
+export function visitListeningEndpoints() {
+    visit(basePath);
+
+    cy.get('h1:contains("Listening endpoints")');
+    cy.location('pathname').should('eq', basePath);
+}

--- a/ui/apps/platform/cypress/integration/audit/listeningEndpoints/listeningEndpointsTable.test.js
+++ b/ui/apps/platform/cypress/integration/audit/listeningEndpoints/listeningEndpointsTable.test.js
@@ -1,0 +1,10 @@
+import withAuth from '../../../helpers/basicAuth';
+import { visitListeningEndpoints } from './ListeningEndpoints.helpers';
+
+describe('Listening endpoints page table', () => {
+    withAuth();
+
+    it('should render the listening endpoints audit page', () => {
+        visitListeningEndpoints();
+    });
+});

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Divider, PageSection, Title } from '@patternfly/react-core';
+
+import PageTitle from 'Components/PageTitle';
+
+function ListeningEndpointsPage() {
+    return (
+        <>
+            <PageTitle title="Listening Endpoints" />
+            <PageSection variant="light">
+                <Title headingLevel="h1">Listening endpoints</Title>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection />
+        </>
+    );
+}
+
+export default ListeningEndpointsPage;

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -29,6 +29,7 @@ import {
     collectionsPath,
     vulnerabilitiesWorkloadCvesPath,
     vulnerabilityReportsPath,
+    listeningEndpointsBasePath,
 } from 'routePaths';
 import { useTheme } from 'Containers/ThemeProvider';
 
@@ -95,6 +96,10 @@ const AsyncVulnMgmtRiskAcceptancePage = asyncComponent(
 );
 const AsyncVulnMgmtPage = asyncComponent(() => import('Containers/Workflow/WorkflowLayout'));
 const AsyncSystemHealthPage = asyncComponent(() => import('Containers/SystemHealth/DashboardPage'));
+
+const AsyncListeningEndpointsPage = asyncComponent(
+    () => import('Containers/Audit/ListeningEndpoints/ListeningEndpointsPage')
+);
 
 type BodyProps = {
     hasReadAccess: HasReadAccess;
@@ -183,6 +188,14 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                         <Route path={clustersListPath} component={AsyncPFClustersPage} />
                     )}
                     <Route path={systemHealthPath} component={AsyncSystemHealthPage} />
+                    {/* 
+                    TODO - Add any necessary permissions to the following route. The user will need read access to
+                          'Cluster' and 'Deployment' at the very least.
+                     */}
+                    <Route
+                        path={listeningEndpointsBasePath}
+                        component={AsyncListeningEndpointsPage}
+                    />
                     <Route component={NotFoundPage} />
                 </Switch>
             </ErrorBoundary>

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -48,6 +48,7 @@ export const dataRetentionPath = `${mainPath}/retention`;
 export const systemHealthPath = `${mainPath}/system-health`;
 export const collectionsBasePath = `${mainPath}/collections`;
 export const collectionsPath = `${mainPath}/collections/:collectionId?`;
+export const listeningEndpointsBasePath = `${mainPath}/audit/listening-endpoints`;
 
 // Configuration Management
 


### PR DESCRIPTION
## Description

Adds a route handler and page stub for the "Listening endpoints" page that will display what processes/ports are exposed on deployments.

The current design is in progress and displays the page under a new top level nav item titled "Audit" with a child item called "Listening endpoints". The URL structure follows the anticipated navigation.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manually visit the `/audit/listening-endpoints` URL and view the page stub.

![image](https://github.com/stackrox/stackrox/assets/1292638/cca7e550-d060-4756-97d2-ce3b7d35c78b)

