### PR TITLE
ROX-17837: Adding a field for report scope

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -166,13 +166,9 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                                 component={AsyncVulnerabilityReportingPage}
                             />
                         )}
-                    {hasVulnerabilityReportsPermission &&
-                        !isVulnerabilityReportingEnhancementsEnabled && (
-                            <Route
-                                path={vulnManagementReportsPath}
-                                component={AsyncVulnMgmtReports}
-                            />
-                        )}
+                    {hasVulnerabilityReportsPermission && (
+                        <Route path={vulnManagementReportsPath} component={AsyncVulnMgmtReports} />
+                    )}
                     <Route
                         path={vulnManagementRiskAcceptancePath}
                         component={AsyncVulnMgmtRiskAcceptancePage}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
@@ -19,6 +19,7 @@ import ReportParametersForm from 'Containers/Vulnerabilities/VulnerablityReporti
 
 function VulnReportsPage() {
     const { formValues, setFormValues } = useReportFormValues();
+
     return (
         <>
             <PageTitle title="Create vulnerability report" />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
@@ -1,0 +1,207 @@
+import React, { useMemo, useState, ReactElement, useCallback, useEffect } from 'react';
+import {
+    Button,
+    ButtonVariant,
+    Flex,
+    FlexItem,
+    Select,
+    SelectOption,
+    SelectProps,
+    SelectVariant,
+    ValidatedOptions,
+} from '@patternfly/react-core';
+import sortBy from 'lodash/sortBy';
+import uniqBy from 'lodash/uniqBy';
+
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+import { Collection, listCollections } from 'services/CollectionsService';
+import CollectionsFormModal from 'Containers/Collections/CollectionFormModal';
+import { useCollectionFormSubmission } from 'Containers/Collections/hooks/useCollectionFormSubmission';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { usePaginatedQuery } from 'hooks/usePaginatedQuery';
+import { ReportScope } from 'hooks/useFetchReport';
+
+const COLLECTION_PAGE_SIZE = 10;
+
+type CollectionSelectionProps = {
+    selectedScopeId: string;
+    initialReportScope: ReportScope | null;
+    onChange: (selection: string) => void;
+    allowCreate: boolean;
+};
+
+function CollectionSelection({
+    selectedScopeId,
+    initialReportScope,
+    onChange,
+    allowCreate,
+}: CollectionSelectionProps): ReactElement {
+    const { isOpen, onToggle } = useSelectToggle();
+    const { configError, setConfigError, onSubmit } = useCollectionFormSubmission({
+        type: 'create',
+    });
+    const [search, setSearch] = useState('');
+
+    const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
+
+    const requestFn = useCallback(
+        (page: number) => {
+            return listCollections(
+                { 'Collection Name': search },
+                { field: 'Collection Name', reversed: false },
+                page,
+                COLLECTION_PAGE_SIZE
+            ).request;
+        },
+        [search]
+    );
+
+    const { data, isEndOfResults, isFetchingNextPage, fetchNextPage } = usePaginatedQuery(
+        requestFn,
+        COLLECTION_PAGE_SIZE
+    );
+
+    const isLegacyReportScopeSelected =
+        initialReportScope?.type === 'AccessControlScope' &&
+        initialReportScope?.id === selectedScopeId;
+
+    // Combines the server-side fetched pages of collections data with the local cache
+    // of created collections to create a flattened array sorted by name. This is intended to keep
+    // the collection dropdown up to date with any collections that the user creates while in the form.
+    //
+    // Previously this was not needed since the component would refetch _all_ access scopes
+    // upon creation of a new access scope, but we cannot do that efficiently since the collection dropdown
+    // is paginated.
+    //
+    // This functionality can likely be removed if we move to a library based method of data fetching.
+    const [createdCollections, setCreatedCollections] = useState<Collection[]>([]);
+    const sortedCollections = useMemo(() => {
+        const availableScopes: Pick<Collection, 'id' | 'name' | 'description'>[] = [
+            ...data.flat(),
+            ...createdCollections,
+        ];
+        // Adding the initial report scope, if available, allows the collection name to be displayed even
+        // if it has not yet been fetched via the dropdown's pagination.
+        if (initialReportScope && initialReportScope.type === 'CollectionScope') {
+            availableScopes.push(initialReportScope);
+        }
+
+        // This is inefficient due to the multiple loops and the fact that we are already tracking
+        // uniqueness for the _server side_ values, but need to do it twice to handle possible client
+        // side values. However, 'N' should be small here and we are memoizing the result.
+        const sorted = sortBy(availableScopes, ({ name }) => name.toLowerCase());
+        return uniqBy(sorted, 'id');
+    }, [data, createdCollections, initialReportScope]);
+
+    // This makes sure that if a collection was deleted then we clear the scopeId
+    useEffect(() => {
+        const selectedCollection = sortedCollections.find(
+            (collection) => collection.id === selectedScopeId
+        );
+        if (!selectedCollection) {
+            onChange('');
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [data]);
+
+    function onToggleCollectionModal() {
+        setIsCollectionModalOpen((current) => !current);
+    }
+
+    function onScopeChange(_id, selection) {
+        onToggle(false);
+        onChange(selection);
+    }
+
+    let selectLoadingVariant: SelectProps['loadingVariant'];
+
+    if (isFetchingNextPage) {
+        selectLoadingVariant = 'spinner';
+    } else if (!isEndOfResults) {
+        selectLoadingVariant = {
+            text: 'View more',
+            onClick: () => fetchNextPage(),
+        };
+    }
+
+    return (
+        <>
+            <Flex alignItems={{ default: 'alignItemsFlexEnd' }}>
+                <FlexItem>
+                    <FormLabelGroup
+                        className="pf-u-mb-md"
+                        isRequired
+                        label="Configure report scope"
+                        fieldId="scopeId"
+                        touched={isLegacyReportScopeSelected ? { scopeId: true } : {}}
+                        errors={
+                            isLegacyReportScopeSelected
+                                ? { scopeId: 'Choose a new collection to use as the report scope' }
+                                : {}
+                        }
+                    >
+                        <Select
+                            id="scopeId"
+                            onSelect={onScopeChange}
+                            selections={isLegacyReportScopeSelected ? '' : selectedScopeId}
+                            placeholderText="Select a collection"
+                            variant={SelectVariant.typeahead}
+                            isOpen={isOpen}
+                            onToggle={onToggle}
+                            onTypeaheadInputChanged={setSearch}
+                            loadingVariant={selectLoadingVariant}
+                            onBlur={() => setSearch('')}
+                            style={{
+                                maxHeight: '275px',
+                                overflowY: 'auto',
+                            }}
+                            validated={
+                                isLegacyReportScopeSelected
+                                    ? ValidatedOptions.error
+                                    : ValidatedOptions.default
+                            }
+                        >
+                            {sortedCollections.map(({ id, name, description }) => (
+                                <SelectOption key={id} value={id} description={description}>
+                                    {name}
+                                </SelectOption>
+                            ))}
+                        </Select>
+                    </FormLabelGroup>
+                </FlexItem>
+                {allowCreate && (
+                    <FlexItem>
+                        <Button
+                            className="pf-u-mb-md"
+                            variant={ButtonVariant.secondary}
+                            onClick={onToggleCollectionModal}
+                        >
+                            Create collection
+                        </Button>
+                    </FlexItem>
+                )}
+            </Flex>
+            {isCollectionModalOpen && (
+                <CollectionsFormModal
+                    hasWriteAccessForCollections={allowCreate}
+                    modalAction={{ type: 'create' }}
+                    onClose={() => setIsCollectionModalOpen(false)}
+                    configError={configError}
+                    setConfigError={setConfigError}
+                    onSubmit={(collection) =>
+                        onSubmit(collection).then((collectionResponse) => {
+                            onChange(collectionResponse.id);
+                            setIsCollectionModalOpen(false);
+                            setCreatedCollections((oldCollections) => [
+                                ...oldCollections,
+                                collectionResponse,
+                            ]);
+                        })
+                    }
+                />
+            )}
+        </>
+    );
+}
+
+export default CollectionSelection;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
@@ -15,10 +15,12 @@ import {
     ReportFormValues,
     SetReportFormValues,
 } from 'Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues';
+import usePermissions from 'hooks/usePermissions';
 
 import CheckboxSelect from 'Components/PatternFly/CheckboxSelect';
 import SeverityIcons from 'Components/PatternFly/SeverityIcons';
 import SelectSingle from 'Components/SelectSingle/SelectSingle';
+import CollectionSelection from './CollectionSelection';
 
 export type ReportParametersFormParams = {
     formValues: ReportFormValues;
@@ -34,6 +36,9 @@ function ReportParametersForm({
     formValues,
     setFormValues,
 }: ReportParametersFormParams): ReactElement {
+    const { hasReadWriteAccess } = usePermissions();
+    const canWriteCollections = hasReadWriteAccess('WorkflowAdministration');
+
     const handleTextChange = (fieldName: string) => (value: string) => {
         setFormValues((prevValues) => {
             const newValues = { ...prevValues };
@@ -62,6 +67,14 @@ function ReportParametersForm({
         setFormValues((prevValues) => {
             const newValues = { ...prevValues };
             set(newValues, fieldName, str);
+            return newValues;
+        });
+    };
+
+    const handleCollectionSelection = (fieldName: string) => (selection) => {
+        setFormValues((prevValues) => {
+            const newValues = { ...prevValues };
+            set(newValues, fieldName, selection);
             return newValues;
         });
     };
@@ -209,6 +222,14 @@ function ReportParametersForm({
                     />
                 </FormGroup>
             )}
+            <FormGroup isRequired fieldId="reportParameters.reportScope">
+                <CollectionSelection
+                    selectedScopeId={formValues.reportParameters.reportScope}
+                    initialReportScope={null}
+                    onChange={handleCollectionSelection('reportParameters.reportScope')}
+                    allowCreate={canWriteCollections}
+                />
+            </FormGroup>
         </Form>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
@@ -22,13 +22,14 @@ export type ReportParametersFormValues = {
     imageType: ImageType[];
     cvesDiscoveredSince: CVESDiscoveredSince;
     cvesDiscoveredStartDate: string | undefined;
+    reportScope: string;
 };
 
 export type CVEStatus = 'FIXABLE' | 'NOT_FIXABLE';
 
 export type CVESDiscoveredSince = 'ALL_VULN' | 'SINCE_LAST_REPORT' | 'START_DATE';
 
-const defaultFormValues: ReportFormValues = {
+export const defaultReportFormValues: ReportFormValues = {
     reportParameters: {
         reportName: '',
         description: '',
@@ -37,11 +38,12 @@ const defaultFormValues: ReportFormValues = {
         imageType: [],
         cvesDiscoveredSince: 'ALL_VULN',
         cvesDiscoveredStartDate: undefined,
+        reportScope: '',
     },
 };
 
 function useReportFormValues(): ReportFormValuesResult {
-    const [formValues, setFormValues] = useState<ReportFormValues>(defaultFormValues);
+    const [formValues, setFormValues] = useState<ReportFormValues>(defaultReportFormValues);
 
     return {
         formValues,


### PR DESCRIPTION
## Description

This PR adds the `Report scope` (ie. A collection) to scope the clusters/namespaces/deployments the user would like to get a vuln report for. I am reusing the `CollectionSelection` component we use in the old reporting feature


https://github.com/stackrox/stackrox/assets/4805485/074e20df-cbd7-45fd-842b-d66ae41f2ec3


https://github.com/stackrox/stackrox/assets/4805485/3e6b9da8-aecb-456b-afc8-ac5ded1f7c7c




