### PR TITLE
ROX-17737: Add simple retry to ScanImage

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/ImageService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ImageService.groovy
@@ -39,15 +39,14 @@ class ImageService extends BaseService {
 
     static scanImage(String image, Boolean includeSnoozed = true, Boolean force = false) {
         try {
-def req = ImageServiceOuterClass.ScanImageRequest.newBuilder()
+            def req = ImageServiceOuterClass.ScanImageRequest.newBuilder()
                 .setImageName(image)
                 .setIncludeSnoozed(includeSnoozed)
                 .setForce(force)
-                .build();
-                    
-return withRetry(1, 15) {
-    return getImageClient().scanImage(req)
-};
+                .build()
+            return withRetry(1, 15) {
+                return getImageClient().scanImage(req)
+            }
         } catch (Exception e) {
             log.error("Image failed to scan: ${image}", e)
         }

--- a/qa-tests-backend/src/main/groovy/services/ImageService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ImageService.groovy
@@ -39,14 +39,15 @@ class ImageService extends BaseService {
 
     static scanImage(String image, Boolean includeSnoozed = true, Boolean force = false) {
         try {
-            def imageClient = getImageClient().scanImage(ImageServiceOuterClass.ScanImageRequest.newBuilder());
-            return withRetry(1, 15) {
-                return imageClient
-                        .setImageName(image)
-                        .setIncludeSnoozed(includeSnoozed)
-                        .setForce(force)
-                        .build()
-            };
+def req = ImageServiceOuterClass.ScanImageRequest.newBuilder()
+                .setImageName(image)
+                .setIncludeSnoozed(includeSnoozed)
+                .setForce(force)
+                .build();
+                    
+return withRetry(1, 15) {
+    return getImageClient().scanImage(req)
+};
         } catch (Exception e) {
             log.error("Image failed to scan: ${image}", e)
         }

--- a/qa-tests-backend/src/main/groovy/services/ImageService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ImageService.groovy
@@ -9,8 +9,6 @@ import io.stackrox.proto.api.v1.ImageServiceOuterClass
 import io.stackrox.proto.api.v1.SearchServiceOuterClass.RawQuery
 import io.stackrox.proto.storage.ImageOuterClass
 
-import util.Helpers
-
 @Slf4j
 class ImageService extends BaseService {
     static ImageServiceGrpc.ImageServiceBlockingStub getImageClient() {

--- a/qa-tests-backend/src/main/groovy/services/ImageService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ImageService.groovy
@@ -40,7 +40,7 @@ class ImageService extends BaseService {
     static scanImage(String image, Boolean includeSnoozed = true, Boolean force = false) {
         try {
             def imageClient = getImageClient().scanImage(ImageServiceOuterClass.ScanImageRequest.newBuilder());
-            return withRetry(3, 5) {
+            return withRetry(1, 15) {
                 return imageClient
                         .setImageName(image)
                         .setIncludeSnoozed(includeSnoozed)

--- a/qa-tests-backend/src/main/groovy/services/ImageService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ImageService.groovy
@@ -9,6 +9,8 @@ import io.stackrox.proto.api.v1.ImageServiceOuterClass
 import io.stackrox.proto.api.v1.SearchServiceOuterClass.RawQuery
 import io.stackrox.proto.storage.ImageOuterClass
 
+import util.Helpers
+
 @Slf4j
 class ImageService extends BaseService {
     static ImageServiceGrpc.ImageServiceBlockingStub getImageClient() {
@@ -37,11 +39,14 @@ class ImageService extends BaseService {
 
     static scanImage(String image, Boolean includeSnoozed = true, Boolean force = false) {
         try {
-            return getImageClient().scanImage(ImageServiceOuterClass.ScanImageRequest.newBuilder()
-                    .setImageName(image)
-                    .setIncludeSnoozed(includeSnoozed)
-                    .setForce(force)
-                    .build())
+            def imageClient = getImageClient().scanImage(ImageServiceOuterClass.ScanImageRequest.newBuilder());
+            return withRetry(3, 5) {
+                return imageClient
+                        .setImageName(image)
+                        .setIncludeSnoozed(includeSnoozed)
+                        .setForce(force)
+                        .build()
+            };
         } catch (Exception e) {
             log.error("Image failed to scan: ${image}", e)
         }

--- a/qa-tests-backend/src/main/groovy/services/ImageService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ImageService.groovy
@@ -42,9 +42,11 @@ class ImageService extends BaseService {
                 .setIncludeSnoozed(includeSnoozed)
                 .setForce(force)
                 .build()
-            return withRetry(1, 15) {
-                return getImageClient().scanImage(req)
+            def response
+            withRetry(1, 15) {
+                response = getImageClient().scanImage(req)
             }
+            return response
         } catch (Exception e) {
             log.error("Image failed to scan: ${image}", e)
         }

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -20,7 +20,7 @@ class Helpers {
             try {
                 return closure()
             } catch (Exception | PowerAssertionError | SpockAssertionError t) {
-                log.debug("Caught exception. Retrying in ${pauseSecs}s. " + t)
+                log.debug("Caught exception. Retrying in ${pauseSecs}s (attempt ${i} of ${retries}): " + t)
             }
             sleep pauseSecs * 1000
         }


### PR DESCRIPTION
## Description

Sometimes registries have glitches. Retrying a scan call at least once after a bit of a while should reduce the number of CI failures such as:

1. https://issues.redhat.com/browse/ROX-16319
2. https://issues.redhat.com/browse/ROX-17737

And maybe others.

## Checklist

- [ ] Investigated and inspected CI test results

### N/A

- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

CI
