### PR TITLE
ROX-18137: Generic notifiers to trust `serviceaccount/service-ca.crt`

### DIFF
--- a/pkg/auth/authproviders/openshift/backend_impl.go
+++ b/pkg/auth/authproviders/openshift/backend_impl.go
@@ -31,11 +31,11 @@ const (
 	// serviceOperatorCAPath points to the secret of the service account, which within an OpenShift environment
 	// also has the service-ca.crt, which includes the CA to verify certificates issued by the service-ca operator.
 	// This could be i.e. the default ingress controller certificate.
-	serviceOperatorCAPath = "/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+	serviceOperatorCAPath = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 	// internalServicesCAPath points to the secret of the service account, which includes the internal CAs to
 	// verify internal cluster services.
 	// This could be i.e. the openshiftAPIUrl or other internal services.
-	internalServicesCAPath = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	internalServicesCAPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	// injectedCAPath points to the bundle of user-provided and system CA certificates
 	// merged by the Cluster Network Operator.
 	injectedCAPath = "/etc/pki/injected-ca-trust/tls-ca-bundle.pem"

--- a/pkg/notifiers/generic/generic.go
+++ b/pkg/notifiers/generic/generic.go
@@ -40,7 +40,7 @@ const (
 	// serviceOperatorCAPath points to the secret of the service account, which within an OpenShift environment
 	// also has the service-ca.crt, which includes the CA to verify certificates issued by the service-ca operator.
 	// This could be i.e. the default ingress controller certificate.
-	serviceOperatorCAPath = "/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+	serviceOperatorCAPath = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 )
 
 // generic notifier plugin

--- a/pkg/notifiers/generic/generic.go
+++ b/pkg/notifiers/generic/generic.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -35,6 +36,11 @@ const (
 	alertMessageKey         = "alert"
 	auditMessageKey         = "audit"
 	networkPolicyMessageKey = "networkpolicy"
+
+	// serviceOperatorCAPath points to the secret of the service account, which within an OpenShift environment
+	// also has the service-ca.crt, which includes the CA to verify certificates issued by the service-ca operator.
+	// This could be i.e. the default ingress controller certificate.
+	serviceOperatorCAPath = "/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 )
 
 // generic notifier plugin
@@ -120,6 +126,10 @@ func newGeneric(notifier *storage.Notifier) (*generic, error) {
 		if ok := rootCAs.AppendCertsFromPEM([]byte(conf.GetCaCert())); !ok {
 			return nil, errors.New("could not add CA Cert passed in configuration")
 		}
+	}
+	// Trust local cluster services.
+	if serviceCA, err := os.ReadFile(serviceOperatorCAPath); err == nil {
+		rootCAs.AppendCertsFromPEM(serviceCA)
 	}
 	extraFieldsJSON, err := getExtraFieldJSON(conf.ExtraFields)
 	if err != nil {


### PR DESCRIPTION
## Description

ROX-18137.

The `service-ca.crt` is a self-signed CA certificate, which issues internal certificates for services annotated with `service.alpha.openshift.io/serving-cert-secret-name`, like the future vector aggregator:
```
subject=CN = openshift-service-serving-signer@1687766551
issuer=CN = openshift-service-serving-signer@1687766551
```

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Deployed test `hop` HTTPS server to the default namespace with an Openshift service signed certificate:
```
Certificate chain
 0 s:CN = hop.default.svc
   i:CN = openshift-service-serving-signer@1687766551
   a:PKEY: rsaEncryption, 2048 (bit); sigalg: RSA-SHA256
   v:NotBefore: Jun 26 10:43:37 2023 GMT; NotAfter: Jun 25 10:43:38 2025 GMT
 1 s:CN = openshift-service-serving-signer@1687766551
   i:CN = openshift-service-serving-signer@1687766551
   a:PKEY: rsaEncryption, 2048 (bit); sigalg: RSA-SHA256
   v:NotBefore: Jun 26 08:02:31 2023 GMT; NotAfter: Aug 24 08:02:32 2025 GMT
```
Before the change:
![image](https://github.com/stackrox/stackrox/assets/20665445/dfb20c69-ef0f-4644-809d-6771303e1914)

After the change:
![image](https://github.com/stackrox/stackrox/assets/20665445/374d6f13-556b-4e77-a7f3-69e3c493395f)
