### PR TITLE
ROX-18173: Authenticate 'v1/metadata'

### DIFF
--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -31,12 +31,12 @@ import (
 var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
 		user.With(): {
+			"/v1.MetadataService/GetMetadata",
 			"/v1.MetadataService/GetDatabaseStatus",
 			"/v1.MetadataService/GetDatabaseBackupStatus",
 			"/v1.MetadataService/GetCentralCapabilities",
 		},
 		allow.Anonymous(): {
-			"/v1.MetadataService/GetMetadata",
 			"/v1.MetadataService/TLSChallenge",
 		},
 	})

--- a/sensor/common/centralclient/client.go
+++ b/sensor/common/centralclient/client.go
@@ -240,7 +240,7 @@ func (c *Client) doHTTPRequest(ctx context.Context, method, route string, params
 
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "creating tls-challenge request")
+		return nil, nil, errors.Wrapf(err, "creating request for %s", route)
 	}
 
 	req.Header.Set("User-Agent", clientconn.GetUserAgent())
@@ -261,7 +261,7 @@ func (c *Client) doHTTPRequest(ctx context.Context, method, route string, params
 		if err != nil {
 			return nil, peerCertificates, errors.Wrapf(err, "reading response body with HTTP status code '%s'", resp.Status)
 		}
-		return nil, peerCertificates, errors.Errorf("HTTP request %s%s with code '%s', body: %s", c.endpoint, tlsChallengeRoute, resp.Status, body)
+		return nil, peerCertificates, errors.Errorf("HTTP request %s%s with code '%s', body: %s", c.endpoint, route, resp.Status, body)
 	}
 	return resp, peerCertificates, nil
 }

--- a/sensor/common/centralclient/client.go
+++ b/sensor/common/centralclient/client.go
@@ -34,7 +34,7 @@ var (
 const (
 	requestTimeout          = 10 * time.Second
 	tlsChallengeRoute       = "/v1/tls-challenge"
-	metadataRoute           = "/v1/metadata"
+	pingRoute               = "/v1/ping"
 	challengeTokenParamName = "challengeToken"
 )
 
@@ -99,21 +99,21 @@ func NewClient(endpoint string) (*Client, error) {
 	}, nil
 }
 
-// GetMetadata returns Central's metadata
-func (c *Client) GetMetadata(ctx context.Context) (*v1.Metadata, error) {
-	resp, _, err := c.doHTTPRequest(ctx, http.MethodGet, metadataRoute, nil, nil)
+// GetPing pings Central.
+func (c *Client) GetPing(ctx context.Context) (*v1.PongMessage, error) {
+	resp, _, err := c.doHTTPRequest(ctx, http.MethodGet, pingRoute, nil, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "receiving Central metadata")
+		return nil, errors.Wrap(err, "pinging Central")
 	}
 	defer utils.IgnoreError(resp.Body.Close)
 
-	var metadata v1.Metadata
-	err = jsonutil.JSONReaderToProto(resp.Body, &metadata)
+	var pong v1.PongMessage
+	err = jsonutil.JSONReaderToProto(resp.Body, &pong)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing Central %s response with status code %d", metadataRoute, resp.StatusCode)
+		return nil, errors.Wrapf(err, "parsing Central %s response with status code %d", pingRoute, resp.StatusCode)
 	}
 
-	return &metadata, nil
+	return &pong, nil
 }
 
 // GetTLSTrustedCerts returns all certificates which are trusted by Central and its leaf certificates.

--- a/sensor/common/centralclient/client_test.go
+++ b/sensor/common/centralclient/client_test.go
@@ -104,28 +104,37 @@ func (t *ClientTestSuite) newSelfSignedCertificate(commonName string) *tls.Certi
 	return &cert
 }
 
-func (t *ClientTestSuite) TestGetMetadata() {
+func (t *ClientTestSuite) TestGetPingOK() {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Equal(metadataRoute, r.URL.Path)
+		t.Equal(pingRoute, r.URL.Path)
 
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"version":       "3.0.51.x-47-g15440b8be2",
-			"buildFlavor":   "development",
-			"releaseBuild":  false,
-			"licenseStatus": "VALID",
-		})
+		_ = json.NewEncoder(w).Encode(
+			v1.PongMessage{ Status: "ok"},
+		)
 	}))
 	defer ts.Close()
 
 	c, err := NewClient(ts.URL)
 	t.Require().NoError(err)
 
-	metadata, err := c.GetMetadata(context.Background())
+	pong, err := c.GetPing(context.Background())
+	t.Require().NoError(err)
+	t.Equal("ok", pong.GetStatus())
+}
+
+func (t *ClientTestSuite) TestGetPingFailure() {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Equal(pingRoute, r.URL.Path)
+
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	c, err := NewClient(ts.URL)
 	t.Require().NoError(err)
 
-	t.Equal("3.0.51.x-47-g15440b8be2", metadata.GetVersion())
-	t.Equal(v1.Metadata_LicenseStatus(4), metadata.GetLicenseStatus())
-	t.False(metadata.GetReleaseBuild())
+	_, err = c.GetPing(context.Background())
+	t.Require().Error(err)
 }
 
 func (t *ClientTestSuite) TestGetTLSTrustedCerts_ErrorHandling() {

--- a/sensor/common/centralclient/client_test.go
+++ b/sensor/common/centralclient/client_test.go
@@ -109,7 +109,7 @@ func (t *ClientTestSuite) TestGetPingOK() {
 		t.Equal(pingRoute, r.URL.Path)
 
 		_ = json.NewEncoder(w).Encode(
-			v1.PongMessage{ Status: "ok"},
+			v1.PongMessage{Status: "ok"},
 		)
 	}))
 	defer ts.Close()

--- a/sensor/common/centralclient/grpc_connection.go
+++ b/sensor/common/centralclient/grpc_connection.go
@@ -65,23 +65,23 @@ func (f *centralConnectionFactoryImpl) Reset() {
 	f.okSignal.Reset()
 }
 
-func (f *centralConnectionFactoryImpl) pollMetadata() error {
+func (f *centralConnectionFactoryImpl) pollPing() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	// Metadata result doesn't matter, as long as central is reachable.
-	_, err := f.httpClient.GetMetadata(ctx)
+	// Ping result doesn't matter, as long as Central is reachable.
+	_, err := f.httpClient.GetPing(ctx)
 	return err
 }
 
-// waitUntilCentralIsReady blocks until central responds with a valid license status on its metadata API,
-// or until the retry budget is exhausted (in which case the sensor is marked as stopped and the program
-// will exit).
+// waitUntilCentralIsReady blocks until Central responds to a ping or until the
+// retry budget is exhausted, in which case the sensor is marked as stopped and
+// the program will exit.
 func (f *centralConnectionFactoryImpl) waitUntilCentralIsReady() error {
 	exponential := backoff.NewExponentialBackOff()
 	exponential.MaxElapsedTime = 5 * time.Minute
 	exponential.MaxInterval = 32 * time.Second
 	err := backoff.RetryNotify(func() error {
-		return f.pollMetadata()
+		return f.pollPing()
 	}, exponential, func(err error, d time.Duration) {
 		log.Infof("Check Central status failed: %s. Retrying after %s...", err, d.Round(time.Millisecond))
 	})

--- a/sensor/common/centralclient/grpc_connection.go
+++ b/sensor/common/centralclient/grpc_connection.go
@@ -65,7 +65,7 @@ func (f *centralConnectionFactoryImpl) Reset() {
 	f.okSignal.Reset()
 }
 
-func (f *centralConnectionFactoryImpl) pollPing() error {
+func (f *centralConnectionFactoryImpl) pingCentral() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	// Ping result doesn't matter, as long as Central is reachable.
@@ -81,7 +81,7 @@ func (f *centralConnectionFactoryImpl) waitUntilCentralIsReady() error {
 	exponential.MaxElapsedTime = 5 * time.Minute
 	exponential.MaxInterval = 32 * time.Second
 	err := backoff.RetryNotify(func() error {
-		return f.pollPing()
+		return f.pingCentral()
 	}, exponential, func(err error, d time.Duration) {
 		log.Infof("Check Central status failed: %s. Retrying after %s...", err, d.Round(time.Millisecond))
 	})


### PR DESCRIPTION
## Description

Originally, `/v1/metadata` was open to the world to serve license information and enable ACS UI to prompt user to enter a license on the login screen. However, licensing has been removed from the product and now we can tighten access for the endpoint to only authenticated users.

Since Sensor needs on a public endpoint to test connection to Central, `/v1/metadata` is replaced by `/v1/ping`.

## Checklist
- [x] Investigated and inspected CI test results
  - CI failure is a known flake: https://issues.redhat.com/browse/ROX-17416
- [X] Unit test and regression tests added: updated and added a unit test for Sensor
- [x] Evaluated and added CHANGELOG entry if required, see https://github.com/stackrox/stackrox/pull/6726
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Deployed `4.1.x-259-g9faa2d010e` and checked that:
* `v1/database/status`, `v1/mitreattackvectors/*`, `v1/metadata` require authentication
* `v1/ping` and `v1/tls-challenge` do not
* Sensor's can connect to Central
* UI seems to function normally
