### PR TITLE
ROX-18173: Authenticate 'v1/mitreattackvectors/*'

### DIFF
--- a/central/mitre/service/service_impl.go
+++ b/central/mitre/service/service_impl.go
@@ -6,17 +6,19 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/grpc/authz"
-	"github.com/stackrox/rox/pkg/grpc/authz/allow"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
+	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/mitre/datastore"
 	"google.golang.org/grpc"
 )
 
 var (
-	// No permission enforcement since the APIs do not leak any information about RHACS resources,
-	// and that MITRE ATT&CK is a globally available knowledge base. Unlike CVEs, we do not add any extra insights to MITRE data.
+	// While the data served by these endpoints is globally available knowledge,
+	// we limit access to authenticated users only to reduce the surface for DoS
+	// attacks. Note that `ListMitreAttackVectors()`'s response size is around
+	// 1 MB.
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
-		allow.Anonymous(): {
+		user.With(): {
 			"/v1.MitreAttackService/ListMitreAttackVectors",
 			"/v1.MitreAttackService/GetMitreAttackVector",
 		},


### PR DESCRIPTION
## Description

Originally, 'v1/mitreattackvectors/*' were open to the world because they have nothing to hide. However, to reduce our surface for DoS attacks, this PR tightens access for the endpoints to only authenticated users.

## Checklist
- [x] Investigated and inspected CI test results
  - `ci/prow/gke-sensor-integration-tests` failure is a known flake: https://issues.redhat.com/browse/ROX-18153 
- [ ] ~Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required, see https://github.com/stackrox/stackrox/pull/6726
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Manual test in the last PR of the chain, see https://github.com/stackrox/stackrox/pull/6718.
