### PR TITLE
ROX-18145, ROX-18144, ROX-18143, ROX-18142, ROX-18141: Fix scanner generate test

### DIFF
--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -114,5 +114,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 			strings.Join(istioutils.ListKnownIstioVersions(), ", ")))
 	c.PersistentFlags().BoolVar(&scannerGenerateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", true, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
 
+	flags.AddTimeout(c)
+
 	return c
 }


### PR DESCRIPTION
## Description

After refactoring the timeout, the timeout flag wasn't added to the generate command for scanner.

This fixes that.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI.
