### PR TITLE
fix(test): Fix node datastore sac test by pruning orphaned nodes

### DIFF
--- a/central/cluster/datastore/datastore.go
+++ b/central/cluster/datastore/datastore.go
@@ -126,7 +126,5 @@ func New(
 	if err := ds.registerClusterForNetworkGraphExtSrcs(); err != nil {
 		return ds, err
 	}
-
-	go ds.cleanUpNodeStore()
 	return ds, nil
 }

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -2033,11 +2033,11 @@ func (s *PruningTestSuite) TestRemoveOrphanedNodes() {
 
 	nodeDS := s.generateNodeDataStructures()
 
-	// Add some pods to Cluster 1
-	cluster1PodCount := 20
+	// Add some nodes to Cluster 1
+	cluster1NodeCount := 20
 	cluster2NodeCount := 15
 
-	s.addNodes(nodeDS, clusterID1, cluster1PodCount)
+	s.addNodes(nodeDS, clusterID1, cluster1NodeCount)
 	s.addNodes(nodeDS, clusterID2, cluster2NodeCount)
 
 	gci := &garbageCollectorImpl{

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -366,7 +366,6 @@ func (s *PruningTestSuite) generateClusterDataStructures() (configDatastore.Data
 	deployments, err := deploymentDatastore.New(s.pool, nil, mockBaselineDataStore, clusterFlows, mockRiskDatastore, nil, mockFilter, ranking.NewRanker(), ranking.NewRanker(), ranking.NewRanker())
 	require.NoError(s.T(), err)
 
-	nodeDataStore.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, nil)
 	clusterDataStore, err := clusterDatastore.New(
 		clusterPostgres.New(s.pool),
 		clusterHealthPostgres.New(s.pool),


### PR DESCRIPTION
## Description

Try deflaking the node sac test by running serially

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests. Ran `go test -failfast -tags sql_integration . --count 500` locally in the directory. Was failing consistently and now passes