### PR TITLE
chore(test): upgrade test all suspicious postgres entry

### DIFF
--- a/scripts/ci/logcheck/allowlist-patterns
+++ b/scripts/ci/logcheck/allowlist-patterns
@@ -11,6 +11,8 @@ FATAL:  terminating autovacuum process due to administrator command
 Error: Fetching signature for image .* unexpected status code 500
 # postgres trying to send data on a connection closed by the client (ROX-13258)
 FATAL:  connection to client lost
+# postgres can terminate these if we upgrade central during the middle of operations
+FATAL:  terminating connection because protocol synchronization was lost
 # with operator installs, sensor logs contain this error w.r.t. refreshing a cert for local scanning.
 # TODO: check if this is benign and/or if sensor is configured appropriately for test.
 unexpected owner for certificate secrets


### PR DESCRIPTION
## Description

If central is upgraded in the middle of some longer postgres operations it can get an error of:
```
FATAL:  terminating connection because protocol synchronization was lost
```
Central reconnects when it comes back up and everything functions as it should.  This issue is caused by central going down due to the upgrade.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
