### PR TITLE
ROX-18170: Use the ComplianceAsCode/compliance-operator for CI

### DIFF
--- a/scripts/ci/complianceoperator/create.sh
+++ b/scripts/ci/complianceoperator/create.sh
@@ -3,12 +3,18 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 echo "Deploying Compliance Operator"
-git clone git@github.com:openshift/compliance-operator.git
+git clone git@github.com:ComplianceAsCode/compliance-operator.git
 cd compliance-operator
 
-oc create -f deploy/ns.yaml
-for f in $(ls -1 deploy/crds/*crd.yaml); do oc apply -f $f -n openshift-compliance; done
-oc apply -n openshift-compliance -f deploy/
+# Install the Compliance Operator through its own tooling. This helps simplify
+# the installation process, so that what we're using here doesn't diverge from
+# what the Compliance Operator does. Specifically, this builds the container
+# images based on the latest source and uploads them to the image registry
+# available in the cluster before installing the operator. This requires that
+# you've authenticated to the cluster using `oc login` and is
+# OpenShift-specific.
+make deploy-local
+
 
 # Due to reconciliation bug in compliance operator, ensure that the profile exists prior to creating the
 # tailored profile


### PR DESCRIPTION
Update the CI script to install the Compliance Operator from the ComplianceAsCode/compliance-operator repository instead of openshift/compliance-operator (which was moved to
ComplianceAsCode/compliance-operator last year).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Invoke testing using the existing compliance operator testing scripts, which should invoke the `create.sh` script being updated in this PR.
