### PR TITLE
ROX-18147: Fix pod hierarchy test flake

### DIFF
--- a/sensor/tests/resource/pod/pod_test.go
+++ b/sensor/tests/resource/pod/pod_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 var (
-	NginxDeployment = helper.K8sResourceInfo{Kind: "Deployment", YamlFile: "nginx.yaml"}
-	NginxPod        = helper.K8sResourceInfo{Kind: "Pod", YamlFile: "nginx-pod.yaml"}
+	NginxDeployment = helper.K8sResourceInfo{Kind: "Deployment", YamlFile: "nginx.yaml", Name: "nginx-deployment"}
+	NginxPod        = helper.K8sResourceInfo{Kind: "Pod", YamlFile: "nginx-pod.yaml", Name: "nginx-rogue"}
 )
 
 type PodHierarchySuite struct {

--- a/sensor/tests/resource/pod/pod_test.go
+++ b/sensor/tests/resource/pod/pod_test.go
@@ -84,7 +84,7 @@ func (s *PodHierarchySuite) Test_ContainerSpecOnDeployment() {
 		}),
 		helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, objects map[string]k8s.Object) {
 			// wait until pods are created
-			err := wait.For(conditions.New(testC.Resources()).ResourceMatch(objects[NginxDeployment.YamlFile], func(object k8s.Object) bool {
+			err := wait.For(conditions.New(testC.Resources()).ResourceMatch(objects[NginxDeployment.Name], func(object k8s.Object) bool {
 				d := object.(*appsv1.Deployment)
 				return d.Status.AvailableReplicas == 3 && d.Status.ReadyReplicas == 3
 			}), wait.WithTimeout(time.Second*10))
@@ -110,7 +110,7 @@ func (s *PodHierarchySuite) Test_ParentlessPodsAreTreatedAsDeployments() {
 		}),
 		helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, objects map[string]k8s.Object) {
 			// wait until pods are created
-			err := wait.For(conditions.New(testC.Resources()).ResourceMatch(objects[NginxDeployment.YamlFile], func(object k8s.Object) bool {
+			err := wait.For(conditions.New(testC.Resources()).ResourceMatch(objects[NginxDeployment.Name], func(object k8s.Object) bool {
 				d := object.(*appsv1.Deployment)
 				return d.Status.AvailableReplicas == 3 && d.Status.ReadyReplicas == 3
 			}), wait.WithTimeout(time.Second*10))


### PR DESCRIPTION
## Description

This happens due to this change in the k8s listener PR: https://github.com/stackrox/stackrox/pull/6376#discussion_r1246370815

Failing tests were ignored and the PR was merged prematurely. 😞 

This should fix the failing `Test_PodHierarchy`. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~


## Testing Performed

- [ ] CI