### PR TITLE
fix(readme): Update Helm command to install secured-cluster-services

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,10 @@ CLUSTER_NAME="my-secured-cluster"
 ```
 Then install stackrox-secured-cluster-services (with the init bundle you generated earlier) using this command:
 ```sh
-helm install -n stackrox stackrox-secured-cluster-services stackrox/stackrox-secured-cluster-services \
-  -f stackrox-init-bundle.yaml \
-  --set clusterName="$CLUSTER_NAME"
+helm upgrade --install --create-namespace -n stackrox stackrox-secured-cluster-services stackrox/stackrox-secured-cluster-services \
+  -f simon-test-cluster-init-bundle.yaml \
+  --set clusterName="$CLUSTER_NAME" \
+  --set centralEndpoint="central.stackrox.svc:443"
 ```
 When deploying stackrox-secured-cluster-services on a different cluster than the one where stackrox-central-services is deployed, you will also need to specify the endpoint (address and port number) of Central via `--set centralEndpoint=<endpoint_of_central_service>` command-line argument.
 
@@ -164,6 +165,7 @@ When deploying StackRox Secured Cluster Services on a small node, you can instal
 helm install -n stackrox stackrox-secured-cluster-services stackrox/stackrox-secured-cluster-services \
   -f stackrox-init-bundle.yaml \
   --set clusterName="$CLUSTER_NAME" \
+  --set centralEndpoint="central.stackrox.svc:443" \
   --set sensor.resources.requests.memory=500Mi \
   --set sensor.resources.requests.cpu=500m \
   --set sensor.resources.limits.memory=500Mi \


### PR DESCRIPTION
## Description

Customers rarely deploy secured-cluster-services to the same namespace as Central. 
To provide a convinient way to copy the Helm command I've added the `centralEndpoint` parameter.
Additionally for re-usability if no Central was installed before the `--create-namespace` flag is provided.
To reuse the command after installation the command uses now `upgrade --install` as an option

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

 - Install secured cluster service with changed command