### PR TITLE
ROX-18089: Add UI service definition for listening_endpoints endpoint

### DIFF
--- a/ui/apps/platform/src/services/ProcessListeningOnPortsService.ts
+++ b/ui/apps/platform/src/services/ProcessListeningOnPortsService.ts
@@ -1,0 +1,61 @@
+import { L4Protocol } from 'types/networkFlow.proto';
+import { ProcessSignal } from 'types/processIndicator.proto';
+import axios from './instance';
+import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
+
+export const listeningEndpointsBaseUrl = '/v1/listening_endpoints';
+
+/*
+A destroyed ProcessListeningOnPort will sometimes be returned by the API before it can be pruned from the database. In these
+cases, the following fields will be empty as a JOIN to the table that contains the data is not possible:
+
+podUid
+processSignal.id
+processSignal.containerId
+processSignal.time
+processSignal.pid
+processSignal.uid
+processSignal.gid
+processSignal.lineage
+processSignal.scraped
+processSignal.lineageInfo
+clusterId
+namespace
+containerStartTime
+imageId
+
+In most cases this will result in an empty string, but fields that represent time as a string will return `null`:
+
+processSignal.time
+containerStartTime
+*/
+export type ProcessListeningOnPort = {
+    endpoint: {
+        port: number;
+        protocol: L4Protocol;
+    };
+    clusterId: string;
+    namespace: string;
+    deploymentId: string;
+    imageId: string;
+    containerName: string;
+    podId: string;
+    podUid: string;
+    signal: ProcessSignal;
+    containerStartTime: string | null;
+};
+
+/**
+ * Get all listening endpoints for a deployment
+ */
+export function getListeningEndpointsForDeployment(
+    deploymentId: string
+): CancellableRequest<ProcessListeningOnPort[]> {
+    return makeCancellableAxiosRequest((signal) =>
+        axios
+            .get<{
+                listeningEndpoints: ProcessListeningOnPort[];
+            }>(`${listeningEndpointsBaseUrl}/deployment/${deploymentId}`, { signal })
+            .then((response) => response.data.listeningEndpoints)
+    );
+}

--- a/ui/apps/platform/src/types/processIndicator.proto.ts
+++ b/ui/apps/platform/src/types/processIndicator.proto.ts
@@ -16,7 +16,7 @@ export type ProcessIndicator = {
 export type ProcessSignal = {
     id: string;
     containerId: string;
-    time: string; // ISO 8601 date string
+    time: string | null; // ISO 8601 date string
     name: string;
     args: string;
     execFilePath: string;


### PR DESCRIPTION
## Description

Adds the service file for the listening endpoints API.

Manual testing of this endpoint revealed that the `ProcessSignal.time` field in `processIndicator.proto.ts` can actually be null so that has been updated as well, even though it doesn't affect any consuming code.

(My theory is that any string field that represents a `time` on the backend can result in `null` values when data cannot be found, as opposed to an empty string for plain string values.)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual endpoint testing.
