### PR TITLE
ROX-17895: Don't write the inner channels if the component is stopped

### DIFF
--- a/sensor/kubernetes/eventpipeline/output/output.go
+++ b/sensor/kubernetes/eventpipeline/output/output.go
@@ -1,6 +1,8 @@
 package output
 
 import (
+	"sync/atomic"
+
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
@@ -14,6 +16,8 @@ func New(detector detector.Detector, queueSize int) component.OutputQueue {
 		detector:     detector,
 		innerQueue:   ch,
 		forwardQueue: forwardQueue,
+		stopped:      &atomic.Bool{},
 	}
+	outputQueue.stopped.Store(false)
 	return outputQueue
 }

--- a/sensor/kubernetes/eventpipeline/output/output.go
+++ b/sensor/kubernetes/eventpipeline/output/output.go
@@ -18,6 +18,5 @@ func New(detector detector.Detector, queueSize int) component.OutputQueue {
 		forwardQueue: forwardQueue,
 		stopped:      &atomic.Bool{},
 	}
-	outputQueue.stopped.Store(false)
 	return outputQueue
 }

--- a/sensor/kubernetes/eventpipeline/resolver/resolver.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver.go
@@ -9,12 +9,10 @@ import (
 
 // New instantiates a Resolver component
 func New(outputQueue component.OutputQueue, provider store.Provider, queueSize int) component.Resolver {
-	resolver := &resolverImpl{
+	return &resolverImpl{
 		outputQueue:   outputQueue,
 		innerQueue:    make(chan *component.ResourceEvent, queueSize),
 		storeProvider: provider,
 		stopped:       &atomic.Bool{},
 	}
-	resolver.stopped.Store(false)
-	return resolver
 }

--- a/sensor/kubernetes/eventpipeline/resolver/resolver.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver.go
@@ -1,15 +1,20 @@
 package resolver
 
 import (
+	"sync/atomic"
+
 	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
 
 // New instantiates a Resolver component
 func New(outputQueue component.OutputQueue, provider store.Provider, queueSize int) component.Resolver {
-	return &resolverImpl{
+	resolver := &resolverImpl{
 		outputQueue:   outputQueue,
 		innerQueue:    make(chan *component.ResourceEvent, queueSize),
 		storeProvider: provider,
+		stopped:       &atomic.Bool{},
 	}
+	resolver.stopped.Store(false)
+	return resolver
 }


### PR DESCRIPTION
## Description

This is a known issue when we stop sensor. There are some race conditions when we stop some of the components and consequently a component that is still running might try to write in a channel that was already closed in another component. We have plans to organize the start up and stopping of components to address this but in the mean time we make sure to not write in the inner channels in the `outputQueue` and the `Resolver` components.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* [x] CI