### PR TITLE
trivial: fix the usage of PHONY in Makefile for sensor integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -489,7 +489,7 @@ go-unit-tests: build-prep test-prep
 		done; \
 	done
 
-.PHONE: sensor-integration-test
+.PHONY: sensor-integration-test
 sensor-integration-test: build-prep test-prep
 	set -eo pipefail ; \
 	rm -rf  $(GO_TEST_OUTPUT_PATH); \


### PR DESCRIPTION
Noticed a typo in the makefile target for sensor integration tests while investigating how they're invoked for compliance coverage.