### PR TITLE
ROX-17739: Input for specifying default adhoc cluster

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/delegateScanning.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/delegateScanning.test.js
@@ -38,5 +38,22 @@ describe('Delegate Image Scanning', () => {
         getInputByLabel('Specified registries').click();
         getInputByLabel('All registries').should('not.be.checked');
         getInputByLabel('Specified registries').should('be.checked');
+
+        // choose the first cluster in the list as the default
+        cy.get('.cluster-select').click();
+        cy.get('.cluster-select .pf-c-select__menu .pf-c-select__menu-item').then(
+            ($clusterNames) => {
+                expect($clusterNames.length).to.be.gte(0);
+            }
+        );
+        cy.get('.cluster-select .pf-c-select__menu .pf-c-select__menu-item')
+            .first()
+            .then(($firstCluster) => {
+                const firstClusterName = $firstCluster.text();
+
+                $firstCluster.click();
+
+                cy.get('.cluster-select').should('have.text', firstClusterName);
+            });
     });
 });

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
@@ -81,18 +81,18 @@ function DelegatedScanningSettings({
                         </FlexItem>
                     </Flex>
                 </FormLabelGroup>
-                <Flex className="pf-u-mt-md pf-u-mb-lg">
-                    <FlexItem>
-                        <FormLabelGroup
-                            label="Select default cluster to delegate to"
-                            isRequired
-                            fieldId="selectedClusterId"
-                            touched={{}}
-                            errors={{}}
-                        >
+                <FormLabelGroup
+                    label="Select default cluster to delegate to"
+                    helperText="Select a cluster to process CLI and API-originated scanning requests"
+                    isRequired
+                    fieldId="selectedClusterId"
+                    touched={{}}
+                    errors={{}}
+                >
+                    <Flex>
+                        <FlexItem>
                             <Select
                                 className="cluster-select"
-                                isPlain
                                 placeholderText={
                                     <span>
                                         <span style={{ position: 'relative', top: '1px' }}>
@@ -108,9 +108,9 @@ function DelegatedScanningSettings({
                             >
                                 {clusterSelectOptions}
                             </Select>
-                        </FormLabelGroup>
-                    </FlexItem>
-                </Flex>
+                        </FlexItem>
+                    </Flex>
+                </FormLabelGroup>
             </CardBody>
         </Card>
     );

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
@@ -1,18 +1,51 @@
 import React from 'react';
-import { Card, CardBody, Flex, FlexItem, Radio } from '@patternfly/react-core';
+import {
+    Card,
+    CardBody,
+    Flex,
+    FlexItem,
+    Radio,
+    Select,
+    SelectOption,
+} from '@patternfly/react-core';
 
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import { EnabledSelections } from 'types/dedicatedRegistryConfig.proto';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { Cluster } from 'types/cluster.proto';
 
 type DelegatedScanningSettingsProps = {
     enabledFor: EnabledSelections;
     onChangeEnabledFor: (newEnabledState: EnabledSelections) => void;
+    clusters?: Cluster[];
+    selectedClusterId?: string;
+    setSelectedClusterId: (newClusterId: string) => void;
 };
 
 function DelegatedScanningSettings({
     enabledFor,
     onChangeEnabledFor,
+    clusters = [],
+    selectedClusterId = '',
+    setSelectedClusterId,
 }: DelegatedScanningSettingsProps) {
+    const {
+        isOpen: isClusterOpen,
+        toggleSelect: toggleIsClusterOpen,
+        closeSelect: closeClusterSelect,
+    } = useSelectToggle();
+
+    const clusterSelectOptions: JSX.Element[] = clusters.map((cluster) => (
+        <SelectOption key={cluster.id} value={cluster.id}>
+            <span>{cluster.name}</span>
+        </SelectOption>
+    ));
+
+    const onClusterSelect = (_, value) => {
+        closeClusterSelect();
+        setSelectedClusterId(value);
+    };
+
     return (
         <Card className="pf-u-mb-lg">
             <CardBody>
@@ -48,6 +81,36 @@ function DelegatedScanningSettings({
                         </FlexItem>
                     </Flex>
                 </FormLabelGroup>
+                <Flex className="pf-u-mt-md pf-u-mb-lg">
+                    <FlexItem>
+                        <FormLabelGroup
+                            label="Select default cluster to delegate to"
+                            isRequired
+                            fieldId="enabledFor"
+                            touched={{}}
+                            errors={{}}
+                        >
+                            <Select
+                                className="cluster-select"
+                                isPlain
+                                placeholderText={
+                                    <span>
+                                        <span style={{ position: 'relative', top: '1px' }}>
+                                            None
+                                        </span>
+                                    </span>
+                                }
+                                toggleAriaLabel="Select a cluster"
+                                onToggle={toggleIsClusterOpen}
+                                onSelect={onClusterSelect}
+                                isOpen={isClusterOpen}
+                                selections={selectedClusterId}
+                            >
+                                {clusterSelectOptions}
+                            </Select>
+                        </FormLabelGroup>
+                    </FlexItem>
+                </Flex>
             </CardBody>
         </Card>
     );

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
@@ -86,7 +86,7 @@ function DelegatedScanningSettings({
                         <FormLabelGroup
                             label="Select default cluster to delegate to"
                             isRequired
-                            fieldId="enabledFor"
+                            fieldId="selectedClusterId"
                             touched={{}}
                             errors={{}}
                         >

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -13,6 +13,7 @@ import {
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import PageTitle from 'Components/PageTitle';
 import { clustersBasePath } from 'routePaths';
+import useFetchClustersForPermissions from 'hooks/useFetchClustersForPermissions';
 import { fetchDelegatedRegistryConfig } from 'services/DelegatedRegistryConfigService';
 import { DelegatedRegistryConfig } from 'types/dedicatedRegistryConfig.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -31,6 +32,8 @@ function DelegateScanningPage() {
     const [delegatedRegistryConfig, setDedicatedRegistryConfig] =
         useState<DelegatedRegistryConfig>(initialDelegatedState);
     const [errMessage, setErrMessage] = useState<string>('');
+
+    const { clusters } = useFetchClustersForPermissions(['Deployment']);
 
     useEffect(() => {
         setErrMessage('');
@@ -63,6 +66,14 @@ function DelegateScanningPage() {
         const newState: DelegatedRegistryConfig = { ...delegatedRegistryConfig };
 
         newState.enabledFor = newEnabledState;
+
+        setDedicatedRegistryConfig(newState);
+    }
+
+    function onChangeCluster(newClusterId) {
+        const newState: DelegatedRegistryConfig = { ...delegatedRegistryConfig };
+
+        newState.defaultClusterId = newClusterId;
 
         setDedicatedRegistryConfig(newState);
     }
@@ -109,6 +120,9 @@ function DelegateScanningPage() {
                         <DelegatedScanningSettings
                             enabledFor={delegatedRegistryConfig.enabledFor}
                             onChangeEnabledFor={onChangeEnabledFor}
+                            clusters={clusters}
+                            selectedClusterId={delegatedRegistryConfig.defaultClusterId}
+                            setSelectedClusterId={onChangeCluster}
                         />
                         <DelegatedRegistriesList registries={delegatedRegistryConfig.registries} />
                     </>

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -6,6 +6,7 @@ import {
     BreadcrumbItem,
     Flex,
     FlexItem,
+    Form,
     PageSection,
     Title,
 } from '@patternfly/react-core';
@@ -33,7 +34,7 @@ function DelegateScanningPage() {
         useState<DelegatedRegistryConfig>(initialDelegatedState);
     const [errMessage, setErrMessage] = useState<string>('');
 
-    const { clusters } = useFetchClustersForPermissions(['Deployment']);
+    const { clusters } = useFetchClustersForPermissions(['Cluster']);
 
     useEffect(() => {
         setErrMessage('');
@@ -110,23 +111,27 @@ function DelegateScanningPage() {
                         <p>Try reloading the page. If this problem persists, contact support.</p>
                     </Alert>
                 )}
-                <ToggleDelegatedScanning
-                    enabledFor={delegatedRegistryConfig.enabledFor}
-                    toggleDelegation={toggleDelegation}
-                />
-                {/* TODO: decide who to structure this form, where the `enabledFor` value spans multiple inputs */}
-                {delegatedRegistryConfig.enabledFor !== 'NONE' && (
-                    <>
-                        <DelegatedScanningSettings
-                            enabledFor={delegatedRegistryConfig.enabledFor}
-                            onChangeEnabledFor={onChangeEnabledFor}
-                            clusters={clusters}
-                            selectedClusterId={delegatedRegistryConfig.defaultClusterId}
-                            setSelectedClusterId={onChangeCluster}
-                        />
-                        <DelegatedRegistriesList registries={delegatedRegistryConfig.registries} />
-                    </>
-                )}
+                <Form>
+                    <ToggleDelegatedScanning
+                        enabledFor={delegatedRegistryConfig.enabledFor}
+                        toggleDelegation={toggleDelegation}
+                    />
+                    {/* TODO: decide who to structure this form, where the `enabledFor` value spans multiple inputs */}
+                    {delegatedRegistryConfig.enabledFor !== 'NONE' && (
+                        <>
+                            <DelegatedScanningSettings
+                                enabledFor={delegatedRegistryConfig.enabledFor}
+                                onChangeEnabledFor={onChangeEnabledFor}
+                                clusters={clusters}
+                                selectedClusterId={delegatedRegistryConfig.defaultClusterId}
+                                setSelectedClusterId={onChangeCluster}
+                            />
+                            <DelegatedRegistriesList
+                                registries={delegatedRegistryConfig.registries}
+                            />
+                        </>
+                    )}
+                </Form>
             </PageSection>
         </>
     );


### PR DESCRIPTION
## Description

This adds the same type of cluster selector that is used in Network Graph 2.0, to select a cluster that roxctl will use as the default scanner for ad-hoc scans in private registries local to the customer's internal network.

Possible followup:
Consolidate selectors for clusters, namespaces, and deployments into one shared spot for all sections of the app to use.

## Checklist
- [x] Investigated and inspected CI test results (most flavors of ui-e2e tests passed; ocp-4-10-ui-e2e-tests flavor infrastructure crashed)
- [x] Unit test and regression tests added


## Testing Performed

On initial load, with no cluster selected
<img width="1609" alt="Screen Shot 2023-06-29 at 3 57 52 PM" src="https://github.com/stackrox/stackrox/assets/715729/87dc5b15-3daa-4873-afa6-dbd7b8808e7f">

Cluster dropdown open
<img width="1609" alt="Screen Shot 2023-06-29 at 3 57 57 PM" src="https://github.com/stackrox/stackrox/assets/715729/663ade24-f864-46a4-b620-356849244da9">

Cluster selected
<img width="1609" alt="Screen Shot 2023-06-29 at 3 58 00 PM" src="https://github.com/stackrox/stackrox/assets/715729/1f10769c-0286-47b9-a229-d96fec453668">

CI test run locally
<img width="1898" alt="Screen Shot 2023-06-29 at 3 58 41 PM" src="https://github.com/stackrox/stackrox/assets/715729/0de9f918-c672-464b-af65-1f64200e3091">
