### PR TITLE
ROX-14249: Install the Compliance Operator from `stable` channel

### DIFF
--- a/tests/e2e/yaml/compliance-operator/subscription.yaml
+++ b/tests/e2e/yaml/compliance-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: compliance-operator-sub
   namespace: openshift-compliance
 spec:
-  channel: "release-0.1"
+  channel: "stable"
   installPlanApproval: Automatic
   name: compliance-operator
   source: redhat-operators


### PR DESCRIPTION
The Compliance Operator recently released version 1.0.0 on a new channel called `stable`, which will include all new Compliance Operator releases moving forward (at least up until a breaking change that requires a new channel).

https://docs.openshift.com/container-platform/4.13/security/compliance_operator/compliance-operator-release-notes.html#compliance-operator-release-notes-1-0-0

Previously, the `release-0.1` channel was used to install the latest version of the Compliance Operator, but that was prior to the 1.0.0 release. The latest release on the `release-0.1` channel was 0.1.61.

Does Compliance Operator 1.0.0 have any breaking changes?

No. Even though it's a major version bump, it does not contain any backwards incompatible changes and is essentially the same code as 0.1.61. This was done to make it easy for users to switch to the new `stable` channel.

A recent change added support for installing the Compliance Operator using subscriptions:

 089c6ee30e2fbc7ae3db8b5a62aab0e871d5fc27

But it used the older channel. This commit updates the channel to use `stable`.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI should test this change if a particular suite sets the `INSTALL_COMPLIANCE_OPERATOR` environment variable to `true`.