### PR TITLE
ROX-17712: Remove deprecated kubeBuilder markers

### DIFF
--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -62,7 +62,6 @@ type CentralSpec struct {
 type Egress struct {
 	// Configures whether Red Hat Advanced Cluster Security should run in online or offline (disconnected) mode.
 	// In offline mode, automatic updates of vulnerability definitions and kernel modules are disabled.
-	//+kubebuilder:validation:Default=Online
 	//+kubebuilder:default=Online
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName=Connectivity Policy,order=1
 	ConnectivityPolicy *ConnectivityPolicy `json:"connectivityPolicy,omitempty"`
@@ -180,7 +179,6 @@ type CentralDBSpec struct {
 	// Deprecated field. It is no longer necessary to specify it.
 	// This field will be removed in a future release.
 	// Central is configured to use PostgreSQL by default.
-	//+kubebuilder:validation:Default=Default
 	//+kubebuilder:default=Default
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	IsEnabled *CentralDBEnabled `json:"isEnabled,omitempty"`
@@ -302,7 +300,6 @@ type PersistentVolumeClaim struct {
 	// The name of the PVC to manage persistent data. If no PVC with the given name exists, it will be
 	// created. Defaults to "stackrox-db" if not set.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Claim Name",order=1
-	//+kubebuilder:validation:Default=stackrox-db
 	//+kubebuilder:default=stackrox-db
 	ClaimName *string `json:"claimName,omitempty"`
 
@@ -357,7 +354,6 @@ type DBPersistentVolumeClaim struct {
 	// The name of the PVC to manage persistent data. If no PVC with the given name exists, it will be
 	// created. Defaults to "central-db" if not set.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Claim Name",order=1
-	//+kubebuilder:validation:Default=central-db
 	//+kubebuilder:default=central-db
 	ClaimName *string `json:"claimName,omitempty"`
 
@@ -391,7 +387,6 @@ type Exposure struct {
 
 // ExposureLoadBalancer defines settings for exposing central via a LoadBalancer.
 type ExposureLoadBalancer struct {
-	//+kubebuilder:validation:Default=false
 	//+kubebuilder:default=false
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	Enabled *bool `json:"enabled,omitempty"`
@@ -399,7 +394,6 @@ type ExposureLoadBalancer struct {
 	// Defaults to 443 if not set.
 	//+kubebuilder:validation:Minimum=1
 	//+kubebuilder:validation:Maximum=65535
-	//+kubebuilder:validation:Default=443
 	//+kubebuilder:default=443
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=2,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldDependency:.enabled:true"}
 	Port *int32 `json:"port,omitempty"`
@@ -411,7 +405,6 @@ type ExposureLoadBalancer struct {
 
 // ExposureNodePort defines settings for exposing central via a NodePort.
 type ExposureNodePort struct {
-	//+kubebuilder:validation:Default=false
 	//+kubebuilder:default=false
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	Enabled *bool `json:"enabled,omitempty"`
@@ -425,7 +418,6 @@ type ExposureNodePort struct {
 
 // ExposureRoute defines settings for exposing central via a Route.
 type ExposureRoute struct {
-	//+kubebuilder:validation:Default=false
 	//+kubebuilder:default=false
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	Enabled *bool `json:"enabled,omitempty"`
@@ -466,7 +458,6 @@ type ScannerComponentSpec struct {
 	// If you do not want to deploy the Red Hat Advanced Cluster Security Scanner, you can disable it here
 	// (not recommended). By default, the scanner is enabled.
 	// If you do so, all the settings in this section will have no effect.
-	//+kubebuilder:validation:Default=Enabled
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Scanner Component",order=1
 	ScannerComponent *ScannerComponentPolicy `json:"scannerComponent,omitempty"`
 

--- a/operator/apis/platform/v1alpha1/common_types.go
+++ b/operator/apis/platform/v1alpha1/common_types.go
@@ -138,25 +138,21 @@ func (s *ScannerAnalyzerComponent) GetScaling() *ScannerAnalyzerScaling {
 type ScannerAnalyzerScaling struct {
 	// When enabled, the number of analyzer replicas is managed dynamically based on the load, within the limits
 	// specified below.
-	//+kubebuilder:validation:Default=Enabled
 	//+kubebuilder:default=Enabled
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Autoscaling",order=1
 	AutoScaling *AutoScalingPolicy `json:"autoScaling,omitempty"`
 
 	// When autoscaling is disabled, the number of replicas will always be configured to match this value.
-	//+kubebuilder:validation:Default=3
 	//+kubebuilder:default=3
 	//+kubebuilder:validation:Minimum=1
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Replicas",order=2
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	//+kubebuilder:validation:Default=2
 	//+kubebuilder:default=2
 	//+kubebuilder:validation:Minimum=1
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Autoscaling Minimum Replicas",order=3,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldDependency:.autoScaling:Enabled"}
 	MinReplicas *int32 `json:"minReplicas,omitempty"`
 
-	//+kubebuilder:validation:Default=5
 	//+kubebuilder:default=5
 	//+kubebuilder:validation:Minimum=1
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Autoscaling Maximum Replicas",order=4,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldDependency:.autoScaling:Enabled"}

--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -94,7 +94,6 @@ type SensorComponentSpec struct {
 // AdmissionControlComponentSpec defines settings for the admission controller configuration.
 type AdmissionControlComponentSpec struct {
 	// Set this to 'true' to enable preventive policy enforcement for object creations.
-	//+kubebuilder:validation:Default=true
 	//+kubebuilder:default=true
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	ListenOnCreates *bool `json:"listenOnCreates,omitempty"`
@@ -102,13 +101,11 @@ type AdmissionControlComponentSpec struct {
 	// Set this to 'true' to enable preventive policy enforcement for object updates.
 	//
 	// Note: this will not have any effect unless 'Listen On Creates' is set to 'true' as well.
-	//+kubebuilder:validation:Default=true
 	//+kubebuilder:default=true
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	ListenOnUpdates *bool `json:"listenOnUpdates,omitempty"`
 
 	// Set this to 'true' to enable monitoring and enforcement for Kubernetes events (port-forward and exec).
-	//+kubebuilder:validation:Default=true
 	//+kubebuilder:default=true
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=3
 	ListenOnEvents *bool `json:"listenOnEvents,omitempty"`
@@ -136,7 +133,6 @@ type AdmissionControlComponentSpec struct {
 	DeploymentSpec `json:",inline"`
 
 	// The number of replicas of the admission control pod.
-	//+kubebuilder:validation:Default=3
 	//+kubebuilder:default=3
 	//+kubebuilder:validation:Minimum=1
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Replicas",order=8
@@ -195,7 +191,6 @@ type PerNodeSpec struct {
 	// To ensure comprehensive monitoring of your cluster activity, Red Hat Advanced Cluster Security
 	// will run services on every node in the cluster, including tainted nodes by default. If you do
 	// not want this behavior, please select 'AvoidTaints' here.
-	//+kubebuilder:validation:Default=TolerateTaints
 	//+kubebuilder:default=TolerateTaints
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=4
 	TaintToleration *TaintTolerationPolicy `json:"taintToleration,omitempty"`
@@ -224,7 +219,6 @@ type AuditLogsSpec struct {
 	// Whether collection of Kubernetes audit logs should be enabled or disabled. Currently, this is only
 	// supported on OpenShift 4, and trying to enable it on non-OpenShift 4 clusters will result in an error.
 	// Use the 'Auto' setting to enable it on compatible environments, and disable it elsewhere.
-	//+kubebuilder:validation:Default=Auto
 	//+kubebuilder:default=Auto
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	Collection *AuditLogsCollectionSetting `json:"collection,omitempty"`
@@ -271,7 +265,6 @@ type CollectorContainerSpec struct {
 	// If you select "NoCollection", you will not be able to see any information about network activity
 	// and process executions. The remaining settings in these section will not have any effect.
 	// Note that CORE_BPF is on Tech Preview stage.
-	//+kubebuilder:validation:Default=EBPF
 	//+kubebuilder:default=EBPF
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	Collection *CollectionMethod `json:"collection,omitempty"`
@@ -280,7 +273,6 @@ type CollectorContainerSpec struct {
 	// for most kernels. If you use the "Slim" image flavor, you must ensure that your Central instance
 	// is connected to the internet, or regularly receives Collector Support Package updates (for further
 	// instructions, please refer to the documentation).
-	//+kubebuilder:validation:Default=Regular
 	//+kubebuilder:default=Regular
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	ImageFlavor *CollectorImageFlavor `json:"imageFlavor,omitempty"`


### PR DESCRIPTION
The `+kubebuilder:validation:Default` is not a valid kubebuilder marker

see https://book.kubebuilder.io/reference/markers/crd-validation.html

https://github.com/kubernetes-sigs/controller-tools/blob/47cdd8814d6dce89accf5496f0c369685dcd1894/pkg/crd/markers/validation.go#L38
