### PR TITLE
refactor(helm): rename openshift monitoring

### DIFF
--- a/image/templates/helm/stackrox-central/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-central/internal/config-shape.yaml
@@ -145,6 +145,9 @@ customize:
 allowNonstandardNamespace: null # bool
 allowNonstandardReleaseName: null # bool
 enableOpenShiftMonitoring: null # bool
+monitoring:
+  openshift:
+    enabled: null # bool
 meta:
   useLookup: null # bool
   fileOverrides: {} # dict

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -170,7 +170,9 @@ defaults:
     enablePodSecurityPolicies: [< .EnablePodSecurityPolicies >]
     [<- end >]
 
-  enableOpenShiftMonitoring: false
+  monitoring:
+    openshift:
+      enabled: false
 
 pvcDefaults:
   claimName: "stackrox-db"

--- a/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
@@ -1,6 +1,6 @@
 {{- include "srox.init" . -}}
 
-{{- if ._rox.enableOpenShiftMonitoring -}}
+{{- if and ._rox.monitoring ._rox.monitoring.openshift ._rox.monitoring.openshift.enabled -}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -99,13 +99,19 @@
 
 {{/* Openshift monitoring */}}
 {{ if $._rox.enableOpenShiftMonitoring }}
+    {{ include "srox.warn" (list . "enableOpenShiftMonitoring option was replaced with monitoring.openshift.enabled") }}
+    {{ $_ := set $._rox "monitoring" dict }}
+    {{ $_ := set $._rox.monitoring "openshift" dict }}
+    {{ $_ := set $._rox.monitoring.openshift "enabled" true }}
+{{ end }}
+{{ if $._rox.monitoring.openshift.enabled }}
   {{ if (ne $._rox.env.openshift 4) }}
-    {{ include "srox.fail" "'enableOpenShiftMonitoring' is set to true, but the chart is not being deployed in an OpenShift 4 cluster." }}
+    {{ include "srox.fail" "'monitoring.openshift.enabled' is set to true, but the chart is not being deployed in an OpenShift 4 cluster." }}
   {{ end }}
 
   {{/* Override monitoring exposure when openshift monitoring is desired */}}
   {{ if not $._rox.central.exposeMonitoring }}
-    {{ include "srox.warn" (list . "The default or set value of 'central.exposeMonitoring' is false but 'enableOpenShiftMonitoring' is true.") }}
+    {{ include "srox.warn" (list . "The default or set value of 'central.exposeMonitoring' is false but 'monitoring.openshift.enabled' is true.") }}
     {{ include "srox.warn" (list . "'central.exposeMonitoring' will be overridden and set to true.") }}
     {{ $_ := set $._rox.central "exposeMonitoring" true }}
   {{ end }}

--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -145,6 +145,9 @@ customize:
 allowNonstandardNamespace: null # bool
 allowNonstandardReleaseName: null # bool
 enableOpenShiftMonitoring: null # bool
+monitoring:
+  openshift:
+    enabled: null # bool
 meta:
   namespaceOverride: null # bool
   useLookup: null # bool

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -87,31 +87,37 @@
 
 {{/* Openshift monitoring */}}
 {{ if $._rox.enableOpenShiftMonitoring }}
+    {{ include "srox.warn" (list . "enableOpenShiftMonitoring option was replaced with monitoring.openshift.enabled") }}
+    {{ $_ := set $._rox "monitoring" dict }}
+    {{ $_ := set $._rox.monitoring "openshift" dict }}
+    {{ $_ := set $._rox.monitoring.openshift "enabled" true }}
+{{ end }}
+{{ if $._rox.monitoring.openshift.enabled }}
   {{ if (ne $._rox.env.openshift 4) }}
-    {{ include "srox.fail" "'enableOpenShiftMonitoring' is set to true, but the chart is not being deployed in an OpenShift 4 cluster." }}
+    {{ include "srox.fail" "'monitoring.openshift.enabled' is set to true, but the chart is not being deployed in an OpenShift 4 cluster." }}
   {{ end }}
   
   {{/* Override monitoring exposure when openshift monitoring is desired */}}
   {{ if not $._rox.exposeMonitoring }}
-    {{ include "srox.warn" (list . "The default or set value of 'exposeMonitoring' is false but 'enableOpenShiftMonitoring' is true.") }}
+    {{ include "srox.warn" (list . "The default or set value of 'exposeMonitoring' is false but 'monitoring.openshift.enabled' is true.") }}
     {{ include "srox.warn" (list . "'exposeMonitoring' will be overridden and set to true.") }}
     {{ $_ := set $._rox "exposeMonitoring" true }}
   {{ end }}
   
   {{ if not $._rox.sensor.exposeMonitoring }}
-    {{ include "srox.warn" (list . "The default or set value of 'sensor.exposeMonitoring' is false but 'enableOpenShiftMonitoring' is true.") }}
+    {{ include "srox.warn" (list . "The default or set value of 'sensor.exposeMonitoring' is false but 'monitoring.openshift.enabled' is true.") }}
     {{ include "srox.warn" (list . "'sensor.exposeMonitoring' will be overridden and set to true.") }}
     {{ $_ := set $._rox.sensor "exposeMonitoring" true }}
   {{ end }}
   
   {{ if not $._rox.collector.exposeMonitoring }}
-    {{ include "srox.warn" (list . "The default or set value of 'collector.exposeMonitoring' is false but 'enableOpenShiftMonitoring' is true.") }}
+    {{ include "srox.warn" (list . "The default or set value of 'collector.exposeMonitoring' is false but 'monitoring.openshift.enabled' is true.") }}
     {{ include "srox.warn" (list . "'collector.exposeMonitoring' will be overridden and set to true.") }}
     {{ $_ := set $._rox.collector "exposeMonitoring" true }}
   {{ end }}
   
   {{ if not $._rox.admissionControl.exposeMonitoring }}
-    {{ include "srox.warn" (list . "The default or set value of 'admissionControl.exposeMonitoring' is false but 'enableOpenShiftMonitoring' is true.") }}
+    {{ include "srox.warn" (list . "The default or set value of 'admissionControl.exposeMonitoring' is false but 'monitoring.openshift.enabled' is true.") }}
     {{ include "srox.warn" (list . "'admissionControl.exposeMonitoring' will be overridden and set to true.") }}
     {{ $_ := set $._rox.admissionControl "exposeMonitoring" true }}
   {{ end }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
@@ -1,6 +1,6 @@
 {{- include "srox.init" . -}}
 
-{{- if ._rox.enableOpenShiftMonitoring -}}
+{{- if ._rox.monitoring.openshift.enabled -}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/pkg/helm/charts/tests/centralservices/testdata/all-values-explicit.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/all-values-explicit.yaml
@@ -45,6 +45,8 @@ scanner:
   dbServiceTLS:
     cert: "scanner-db tls cert pem"
     key: "scanner-db tls key pem"
-enableOpenShiftMonitoring: true
+monitoring:
+  openshift:
+    enabled: true
 system:
   enablePodSecurityPolicies: true

--- a/pkg/helm/charts/tests/centralservices/testdata/autogenerate-all.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/autogenerate-all.yaml
@@ -21,6 +21,8 @@ central:
     enabled: true
   persistence:
     none: true
-enableOpenShiftMonitoring: true
+monitoring:
+  openshift:
+    enabled: true
 system:
   enablePodSecurityPolicies: true

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -7,11 +7,11 @@ values:
     persistence:
       none: true
 tests:
-- name: "When enabled"
+- name: "When enabled (legacy)"
   set:
     enableOpenShiftMonitoring: true
     env.openshift: 4
-  tests:
+  tests: &enabled-test
     - name: "resources are created for prometheus-operator"
       expect: |
         .roles["central-prometheus-k8s"] | assertThat(. != null)
@@ -35,6 +35,12 @@ tests:
       expect:
         .notes | assertThat(contains("To have openshift-monitoring include metrics from the"))
 
+- name: "When enabled"
+  set:
+    monitoring.openshift.enabled: true
+    env.openshift: 4
+  tests: *enabled-test
+
 - name: "When disabled"
   set:
     env.openshift: 4
@@ -42,7 +48,7 @@ tests:
     - name: "resources are not created when disabled (by default)"
     - name: "resources are not created when explicitly disabled"
       set:
-        enableOpenShiftMonitoring: false
+        monitoring.openshift.enabled: false
       expect: |
         .roles["central-prometheus-k8s"] | assertThat(. == null)
         .rolebindings["central-prometheus-k8s"] | assertThat(. == null)
@@ -51,7 +57,7 @@ tests:
 - name: "An error is thrown when enableOpenShiftMonitoring is true in an env that does not support it"
   expectError: true
   set:
-    enableOpenShiftMonitoring: true
+    monitoring.openshift.enabled: true
   tests:
   - name: "cannot be enabled due to default env not being openshift"
   - name: "on an explicit non-OpenShift environment"
@@ -68,4 +74,4 @@ tests:
       kubeVersion:
         version: "v1.11.0"
     expect: |
-      .error | assertThat(contains("enableOpenShiftMonitoring") and contains("but the chart is not being deployed in an OpenShift 4 cluster"))
+      .error | assertThat(contains("monitoring.openshift.enabled") and contains("but the chart is not being deployed in an OpenShift 4 cluster"))

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/all-values-explicit.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/all-values-explicit.yaml
@@ -58,7 +58,9 @@ config:
   slimCollector: true
   exposeMonitoring: true
 
-enableOpenShiftMonitoring: true
+monitoring:
+  openshift:
+    enabled: true
 
 scanner:
   disable: false

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -3,38 +3,44 @@ server:
   - openshift-4.1.0
   - com.coreos
 tests:
-- name: "When enabled"
+- name: "When enabled (legacy)"
   set:
     enableOpenShiftMonitoring: true
     env.openshift: 4
-  tests:
-    - name: "resources are created for prometheus-operator"
-      expect: |
-        .roles["secured-cluster-prometheus-k8s"] | assertThat(. != null)
-        .rolebindings["secured-cluster-prometheus-k8s"] | assertThat(. != null)
-        .servicemonitors["sensor-monitor"] | assertThat(. != null)
-        .podmonitors["collector-monitor"] | assertThat(. != null)
+  tests: &enabled-test
+  - name: "resources are created for prometheus-operator"
+    expect: |
+      .roles["secured-cluster-prometheus-k8s"] | assertThat(. != null)
+      .rolebindings["secured-cluster-prometheus-k8s"] | assertThat(. != null)
+      .servicemonitors["sensor-monitor"] | assertThat(. != null)
+      .podmonitors["collector-monitor"] | assertThat(. != null)
 
-    - name: "monitoring is exposed"
-    - name: "enableOpenShiftMonitoring overrides exposeMonitoring"
-      set:
-        exposeMonitoring: false
-    - name: "enableOpenShiftMonitoring overrides x.exposeMonitoring"
-      set:
-        sensor.exposeMonitoring: false
-        collector.exposeMonitoring: false
-        admissionControl.exposeMonitoring: false
-      expect: |
-        verifyMonitoringExposed(.services.sensor)
-        verifyMonitoringContainerPortExposed(container(.deployments.sensor; "sensor"))
-        .networkpolicys["sensor-monitoring"] | assertThat(. != null)
-        verifyMonitoringContainerPortExposed(container(.daemonsets.collector; "collector"))
-        .networkpolicys["collector-monitoring"] | assertThat(. != null)
-        .networkpolicys["admission-control-monitoring"] | assertThat(. != null)
+  - name: "monitoring is exposed"
+  - name: "enableOpenShiftMonitoring overrides exposeMonitoring"
+    set:
+      exposeMonitoring: false
+  - name: "enableOpenShiftMonitoring overrides x.exposeMonitoring"
+    set:
+      sensor.exposeMonitoring: false
+      collector.exposeMonitoring: false
+      admissionControl.exposeMonitoring: false
+    expect: |
+      verifyMonitoringExposed(.services.sensor)
+      verifyMonitoringContainerPortExposed(container(.deployments.sensor; "sensor"))
+      .networkpolicys["sensor-monitoring"] | assertThat(. != null)
+      verifyMonitoringContainerPortExposed(container(.daemonsets.collector; "collector"))
+      .networkpolicys["collector-monitoring"] | assertThat(. != null)
+      .networkpolicys["admission-control-monitoring"] | assertThat(. != null)
 
-    - name: "a note for the namespace label is added"
-      expect:
-        .notes | assertThat(contains("To have openshift-monitoring include metrics from the"))
+  - name: "a note for the namespace label is added"
+    expect:
+      .notes | assertThat(contains("To have openshift-monitoring include metrics from the"))
+
+- name: "When enabled"
+  set:
+    monitoring.openshift.enabled: true
+    env.openshift: 4
+  tests: *enabled-test
 
 - name: "When disabled"
   set:
@@ -43,7 +49,7 @@ tests:
     - name: "resources are not created when disabled (by default)"
     - name: "resources are not created when explicitly disabled"
       set:
-        enableOpenShiftMonitoring: false
+        monitoring.openshift.enabled: false
       expect: |
         .roles["secured-cluster-prometheus-k8s"] | assertThat(. == null)
         .rolebindings["secured-cluster-prometheus-k8s"] | assertThat(. == null)
@@ -53,7 +59,7 @@ tests:
 - name: "An error is thrown when enableOpenShiftMonitoring is true in an env that does not support it"
   expectError: true
   set:
-    enableOpenShiftMonitoring: true
+    monitoring.openshift.enabled: true
   tests:
   - name: "cannot be enabled due to default env not being openshift"
   - name: "on an explicit non-OpenShift environment"
@@ -70,4 +76,4 @@ tests:
       kubeVersion:
         version: "v1.11.0"
     expect: |
-      .error | assertThat(contains("enableOpenShiftMonitoring") and contains("but the chart is not being deployed in an OpenShift 4 cluster"))
+      .error | assertThat(contains("monitoring.openshift.enabled") and contains("but the chart is not being deployed in an OpenShift 4 cluster"))


### PR DESCRIPTION
## Description

This PR renames `enableOpenShiftMonitoring` to `monitoring.openshift.enabled: true` and exposes it in operator.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
