### PR TITLE
ROX-17951: Add basic table display of listening endpoints data

### DIFF
--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -2,6 +2,67 @@ import React from 'react';
 import { Divider, PageSection, Title } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
+import { ProcessListeningOnPort } from 'services/ProcessListeningOnPortsService';
+import ListeningEndpointsTable from './ListeningEndpointsTable';
+
+const listeningEndpointsSampleData: ProcessListeningOnPort[] = [
+    {
+        endpoint: {
+            port: 9090,
+            protocol: 'L4_PROTOCOL_TCP',
+        },
+        deploymentId: 'c83ca25c-1097-4dd0-bca1-1df5c496ac5e',
+        containerName: 'central',
+        podId: 'central-5d88f6fcb5-zvgw5',
+        podUid: '79d49039-a2b3-5d05-b929-e74bc82da71c',
+        signal: {
+            id: '706f77e8-167d-11ee-a384-fe93f92a2b33',
+            containerId: '3ccef27a1cf5',
+            time: '2023-06-29T13:00:52.138198746Z',
+            name: 'central',
+            args: '',
+            execFilePath: '/stackrox/central',
+            pid: 12530,
+            uid: 4000,
+            gid: 0,
+            lineage: [],
+            scraped: true,
+            lineageInfo: [],
+        },
+        clusterId: '9b217bfd-1c3f-4836-9d57-c0b6d410ccda',
+        namespace: 'stackrox',
+        containerStartTime: '2023-06-29T13:00:52Z',
+        imageId: 'sha256:a245029c808486cd18e1ade1a4c1d2db9210cfa87ffa894f5837df37e4bccebd',
+    },
+    {
+        endpoint: {
+            port: 8443,
+            protocol: 'L4_PROTOCOL_TCP',
+        },
+        deploymentId: 'c83ca25c-1097-4dd0-bca1-1df5c496ac5e',
+        containerName: 'central',
+        podId: 'central-5d88f6fcb5-zvgw5',
+        podUid: '79d49039-a2b3-5d05-b929-e74bc82da71c',
+        signal: {
+            id: '706f77e8-167d-11ee-a384-fe93f92a2b33',
+            containerId: '3ccef27a1cf5',
+            time: '2023-06-29T13:00:52.138198746Z',
+            name: 'central',
+            args: '',
+            execFilePath: '/stackrox/central',
+            pid: 12530,
+            uid: 4000,
+            gid: 0,
+            lineage: [],
+            scraped: true,
+            lineageInfo: [],
+        },
+        clusterId: '9b217bfd-1c3f-4836-9d57-c0b6d410ccda',
+        namespace: 'stackrox',
+        containerStartTime: '2023-06-29T13:00:52Z',
+        imageId: 'sha256:a245029c808486cd18e1ade1a4c1d2db9210cfa87ffa894f5837df37e4bccebd',
+    },
+];
 
 function ListeningEndpointsPage() {
     return (
@@ -11,7 +72,9 @@ function ListeningEndpointsPage() {
                 <Title headingLevel="h1">Listening endpoints</Title>
             </PageSection>
             <Divider component="div" />
-            <PageSection />
+            <PageSection isFilled>
+                <ListeningEndpointsTable listeningEndpoints={listeningEndpointsSampleData} />
+            </PageSection>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Bullseye } from '@patternfly/react-core';
+import { Tbody, Tr, Td, TableComposable, Th, Thead } from '@patternfly/react-table';
+
+import { ProcessListeningOnPort } from 'services/ProcessListeningOnPortsService';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+import { l4ProtocolLabels } from 'constants/networkFlow';
+
+export type ListeningEndpointsTableProps = {
+    listeningEndpoints: ProcessListeningOnPort[];
+};
+
+function ListeningEndpointsTable({ listeningEndpoints }: ListeningEndpointsTableProps) {
+    return (
+        <TableComposable borders={false} variant="compact">
+            <Thead noWrap>
+                <Tr>
+                    <Th>Program name</Th>
+                    <Th>PID</Th>
+                    <Th>Port</Th>
+                    <Th>Protocol</Th>
+                    <Th>Namespace</Th>
+                    <Th>Cluster ID</Th>
+                    <Th>Pod ID</Th>
+                    <Th>Container name</Th>
+                </Tr>
+            </Thead>
+            <Tbody>
+                {listeningEndpoints.length === 0 && (
+                    <Tr>
+                        <Td colSpan={8}>
+                            <Bullseye>
+                                <EmptyStateTemplate title="No results found" headingLevel="h2" />
+                            </Bullseye>
+                        </Td>
+                    </Tr>
+                )}
+                {listeningEndpoints.map(
+                    ({ podId, endpoint, signal, containerName, namespace, clusterId }) => (
+                        <Tr key={`${podId}/${endpoint.port}`}>
+                            <Td dataLabel="Program name">{signal.name}</Td>
+                            <Td dataLabel="PID">{signal.pid}</Td>
+                            <Td dataLabel="Port">{endpoint.port}</Td>
+                            <Td dataLabel="Protocol">{l4ProtocolLabels[endpoint.protocol]}</Td>
+                            <Td dataLabel="Namespace">{namespace}</Td>
+                            <Td dataLabel="Cluster ID">{clusterId}</Td>
+                            <Td dataLabel="Pod ID">{podId}</Td>
+                            <Td dataLabel="Container name">{containerName}</Td>
+                        </Tr>
+                    )
+                )}
+            </Tbody>
+        </TableComposable>
+    );
+}
+
+export default ListeningEndpointsTable;

--- a/ui/apps/platform/src/constants/networkFlow.ts
+++ b/ui/apps/platform/src/constants/networkFlow.ts
@@ -1,0 +1,11 @@
+import { L4Protocol } from 'types/networkFlow.proto';
+
+export const l4ProtocolLabels: Record<L4Protocol, string> = {
+    L4_PROTOCOL_UNKNOWN: 'Unknown',
+    L4_PROTOCOL_TCP: 'TCP',
+    L4_PROTOCOL_UDP: 'UDP',
+    L4_PROTOCOL_ICMP: 'ICMP',
+    L4_PROTOCOL_RAW: 'Raw',
+    L4_PROTOCOL_SCTP: 'SCTP',
+    L4_PROTOCOL_ANY: 'Any Protocol',
+};

--- a/ui/apps/platform/src/services/ProcessListeningOnPortsService.ts
+++ b/ui/apps/platform/src/services/ProcessListeningOnPortsService.ts
@@ -1,0 +1,61 @@
+import { L4Protocol } from 'types/networkFlow.proto';
+import { ProcessSignal } from 'types/processIndicator.proto';
+import axios from './instance';
+import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
+
+export const listeningEndpointsBaseUrl = '/v1/listening_endpoints';
+
+/*
+A destroyed ProcessListeningOnPort will sometimes be returned by the API before it can be pruned from the database. In these
+cases, the following fields will be empty as a JOIN to the table that contains the data is not possible:
+
+podUid
+processSignal.id
+processSignal.containerId
+processSignal.time
+processSignal.pid
+processSignal.uid
+processSignal.gid
+processSignal.lineage
+processSignal.scraped
+processSignal.lineageInfo
+clusterId
+namespace
+containerStartTime
+imageId
+
+In most cases this will result in an empty string, but fields that represent time as a string will return `null`:
+
+processSignal.time
+containerStartTime
+*/
+export type ProcessListeningOnPort = {
+    endpoint: {
+        port: number;
+        protocol: L4Protocol;
+    };
+    clusterId: string;
+    namespace: string;
+    deploymentId: string;
+    imageId: string;
+    containerName: string;
+    podId: string;
+    podUid: string;
+    signal: ProcessSignal;
+    containerStartTime: string | null;
+};
+
+/**
+ * Get all listening endpoints for a deployment
+ */
+export function getListeningEndpointsForDeployment(
+    deploymentId: string
+): CancellableRequest<ProcessListeningOnPort[]> {
+    return makeCancellableAxiosRequest((signal) =>
+        axios
+            .get<{
+                listeningEndpoints: ProcessListeningOnPort[];
+            }>(`${listeningEndpointsBaseUrl}/deployment/${deploymentId}`, { signal })
+            .then((response) => response.data.listeningEndpoints)
+    );
+}

--- a/ui/apps/platform/src/types/processIndicator.proto.ts
+++ b/ui/apps/platform/src/types/processIndicator.proto.ts
@@ -16,7 +16,7 @@ export type ProcessIndicator = {
 export type ProcessSignal = {
     id: string;
     containerId: string;
-    time: string; // ISO 8601 date string
+    time: string | null; // ISO 8601 date string
     name: string;
     args: string;
     execFilePath: string;


### PR DESCRIPTION
## Description

Adds a plain table structure to the listening endpoints page with sample data.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the listening endpoints page:
![image](https://github.com/stackrox/stackrox/assets/1292638/8b1d5ec0-22ce-453c-8731-cb772ca92073)

Minimal non-mobile size:
![image](https://github.com/stackrox/stackrox/assets/1292638/4f63e312-e0c6-4131-82b0-8493664a6309)

