### PR TITLE
[ROX:18152] : Add report metadata search fields to report config search options

### DIFF
--- a/central/globalindex/mapping/mapping.go
+++ b/central/globalindex/mapping/mapping.go
@@ -98,6 +98,12 @@ func GetEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 	if features.VulnMgmtReportingEnhancements.Enabled() {
 		entityOptionsMap[v1.SearchCategory_REPORT_METADATA] = schema.ReportMetadataSchema.OptionsMap
 		entityOptionsMap[v1.SearchCategory_REPORT_SNAPSHOT] = schema.ReportSnapshotsSchema.OptionsMap
+
+		reportConfigurationSearchOptions := search.CombineOptionsMaps(
+			schema.ReportConfigurationsSchema.OptionsMap,
+			schema.ReportMetadataSchema.OptionsMap,
+		)
+		entityOptionsMap[v1.SearchCategory_REPORT_CONFIGURATIONS] = reportConfigurationSearchOptions
 	}
 
 	return entityOptionsMap

--- a/central/reportconfigurations/datastore/datastore_impl_v2_test.go
+++ b/central/reportconfigurations/datastore/datastore_impl_v2_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/reportconfigurations/datastore/datastore_impl_v2_test.go
+++ b/central/reportconfigurations/datastore/datastore_impl_v2_test.go
@@ -1,0 +1,127 @@
+//go:build sql_integration
+
+package datastore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+	metadataDS "github.com/stackrox/rox/central/reports/metadata/datastore"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestReportConfigurationDatastoreV2(t *testing.T) {
+	suite.Run(t, new(ReportConfigurationDatastoreV2Tests))
+}
+
+type ReportConfigurationDatastoreV2Tests struct {
+	suite.Suite
+
+	testDB              *pgtest.TestPostgres
+	datastore           DataStore
+	reportMetadataStore metadataDS.DataStore
+	ctx                 context.Context
+}
+
+func (s *ReportConfigurationDatastoreV2Tests) SetupSuite() {
+	s.T().Setenv(features.VulnMgmtReportingEnhancements.EnvVar(), "true")
+	if !features.VulnMgmtReportingEnhancements.Enabled() {
+		s.T().Skip("Skip tests when ROX_VULN_MGMT_REPORTING_ENHANCEMENTS disabled")
+		s.T().SkipNow()
+	}
+
+	var err error
+	s.testDB = pgtest.ForT(s.T())
+	s.datastore, err = GetTestPostgresDataStore(s.T(), s.testDB.DB)
+	s.NoError(err)
+	s.reportMetadataStore, err = metadataDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
+	s.NoError(err)
+
+	s.ctx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.WorkflowAdministration)))
+}
+
+func (s *ReportConfigurationDatastoreV2Tests) TearDownSuite() {
+	s.testDB.Teardown(s.T())
+}
+
+func (s *ReportConfigurationDatastoreV2Tests) TestSortReportConfigByCompletionTime() {
+	reportConfig1 := fixtures.GetValidReportConfigWithMultipleNotifiers()
+	reportConfig1.Id = ""
+	configID1, err := s.datastore.AddReportConfiguration(s.ctx, reportConfig1)
+	s.NoError(err)
+
+	reportConfig2 := fixtures.GetValidReportConfigWithMultipleNotifiers()
+	reportConfig2.Id = ""
+	configID2, err := s.datastore.AddReportConfiguration(s.ctx, reportConfig2)
+	s.NoError(err)
+
+	reportConfig3 := fixtures.GetValidReportConfigWithMultipleNotifiers()
+	reportConfig3.Id = ""
+	configID3, err := s.datastore.AddReportConfiguration(s.ctx, reportConfig3)
+	s.NoError(err)
+
+	// time1 is the most recent, time6 is the least recent
+	time1, err := types.TimestampProto(time.Now().Add(-1 * time.Hour))
+	s.NoError(err)
+	time2, err := types.TimestampProto(time.Now().Add(-2 * time.Hour))
+	s.NoError(err)
+	time3, err := types.TimestampProto(time.Now().Add(-3 * time.Hour))
+	s.NoError(err)
+	time4, err := types.TimestampProto(time.Now().Add(-4 * time.Hour))
+	s.NoError(err)
+	time5, err := types.TimestampProto(time.Now().Add(-5 * time.Hour))
+	s.NoError(err)
+	time6, err := types.TimestampProto(time.Now().Add(-6 * time.Hour))
+	s.NoError(err)
+
+	reportMetadatas := []*storage.ReportMetadata{
+		generateReportMetadata(configID3, time1),
+		generateReportMetadata(configID2, time2),
+		generateReportMetadata(configID2, time3),
+		generateReportMetadata(configID1, time4),
+		generateReportMetadata(configID3, time5),
+		generateReportMetadata(configID1, time6),
+	}
+	expectedSortedConfigIDs := []string{configID3, configID2, configID1}
+
+	for _, metadata := range reportMetadatas {
+		_, err = s.reportMetadataStore.AddReportMetadata(s.ctx, metadata)
+		s.NoError(err)
+	}
+
+	query := search.NewQueryBuilder().
+		AddExactMatches(search.ReportState, storage.ReportStatus_SUCCESS.String(), storage.ReportStatus_FAILURE.String()).
+		WithPagination(search.NewPagination().
+			AddSortOption(search.NewSortOption(search.ReportCompletionTime).Reversed(true))).ProtoQuery()
+
+	configs, err := s.datastore.GetReportConfigurations(s.ctx, query)
+	s.NoError(err)
+	s.Equal(3, len(configs))
+
+	configIDs := make([]string, 0, len(configs))
+	for _, conf := range configs {
+		configIDs = append(configIDs, conf.Id)
+	}
+	s.Equal(expectedSortedConfigIDs, configIDs)
+}
+
+func generateReportMetadata(configID string, completionTime *types.Timestamp) *storage.ReportMetadata {
+	metadata := fixtures.GetReportMetadata()
+	metadata.ReportId = ""
+	metadata.ReportStatus.CompletedAt = completionTime
+	metadata.ReportConfigId = configID
+
+	return metadata
+}

--- a/central/reportconfigurations/store/postgres/gen.go
+++ b/central/reportconfigurations/store/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.ReportConfiguration --search-category REPORT_CONFIGURATIONS
+//go:generate pg-table-bindings-wrapper --type=storage.ReportConfiguration --search-category REPORT_CONFIGURATIONS --search-scope REPORT_METADATA

--- a/pkg/postgres/schema/report_configurations.go
+++ b/pkg/postgres/schema/report_configurations.go
@@ -28,6 +28,9 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ReportConfiguration)(nil)), "report_configurations")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_REPORT_CONFIGURATIONS, "reportconfiguration", (*storage.ReportConfiguration)(nil)))
+		schema.SetSearchScope([]v1.SearchCategory{
+			v1.SearchCategory_REPORT_METADATA,
+		}...)
 		RegisterTable(schema, CreateTableReportConfigurationsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_REPORT_CONFIGURATIONS, schema)
 		return schema


### PR DESCRIPTION
## Description

This will enable sorting RpeortConfigurations by LastReport's completion time.

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Unit tests

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
