### PR TITLE
ROX-17953: Use live data for listening endpoints table

### DIFF
--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.test.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+
+import renderWithRouter from 'test-utils/renderWithRouter';
+import * as DeploymentsService from 'services/DeploymentsService';
+import * as ProcessListeningOnPortsService from 'services/ProcessListeningOnPortsService';
+import ListeningEndpointsPage from './ListeningEndpointsPage';
+
+const setup = () => {
+    const user = userEvent.setup();
+    const utils = renderWithRouter(<ListeningEndpointsPage />);
+
+    return { user, utils };
+};
+
+/**
+ * Mocks the DeploymentsService.listDeployments and ListeningEndpointsService.getListeningEndpointsForDeployment
+ * methods to return the provided deployments instead of making a real API call.
+ *
+ * @param deployments The deployments to return. A `Partial<Deployment>[]` is sufficient.
+ */
+function mockDeploymentsWithListeningEndpoints(deployments) {
+    jest.spyOn(DeploymentsService, 'listDeployments').mockImplementation((_1, _2, page, count) => {
+        const offset = page * count;
+        return Promise.resolve(deployments.slice(offset, offset + count));
+    });
+
+    jest.spyOn(
+        ProcessListeningOnPortsService,
+        'getListeningEndpointsForDeployment'
+    ).mockImplementation((deploymentId) => ({
+        request: Promise.resolve(
+            deployments.find((d) => d.id === deploymentId)?.listeningEndpoints ?? []
+        ),
+        cancel: jest.fn(),
+    }));
+}
+
+describe('ListeningEndpointsPage', () => {
+    it('should render a default message when no deployments are found', async () => {
+        setup();
+
+        mockDeploymentsWithListeningEndpoints([]);
+
+        expect(
+            await screen.findByText('No deployments with listening endpoints found')
+        ).toBeInTheDocument();
+    });
+
+    it('should not render deployments without listening endpoints', async () => {
+        setup();
+
+        mockDeploymentsWithListeningEndpoints([
+            {
+                id: 'd-1',
+                name: 'deployment-1',
+                listeningEndpoints: [],
+            },
+            {
+                id: 'd-2',
+                name: 'deployment-2',
+                listeningEndpoints: [
+                    { id: '1', endpoint: { port: 80, protocol: 'TCP' }, signal: {} },
+                ],
+            },
+        ]);
+
+        expect(await screen.findByText('deployment-2')).toBeInTheDocument();
+        expect(screen.queryByText('deployment-1')).not.toBeInTheDocument();
+    });
+});

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -1,70 +1,21 @@
 import React from 'react';
-import { Divider, PageSection, Title } from '@patternfly/react-core';
+import { Bullseye, Divider, PageSection, Spinner, Title } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
-import { ProcessListeningOnPort } from 'services/ProcessListeningOnPortsService';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate/EmptyStateTemplate';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { useDeploymentListeningEndpoints } from './hooks/useDeploymentListeningEndpoints';
 import ListeningEndpointsTable from './ListeningEndpointsTable';
 
-const listeningEndpointsSampleData: ProcessListeningOnPort[] = [
-    {
-        endpoint: {
-            port: 9090,
-            protocol: 'L4_PROTOCOL_TCP',
-        },
-        deploymentId: 'c83ca25c-1097-4dd0-bca1-1df5c496ac5e',
-        containerName: 'central',
-        podId: 'central-5d88f6fcb5-zvgw5',
-        podUid: '79d49039-a2b3-5d05-b929-e74bc82da71c',
-        signal: {
-            id: '706f77e8-167d-11ee-a384-fe93f92a2b33',
-            containerId: '3ccef27a1cf5',
-            time: '2023-06-29T13:00:52.138198746Z',
-            name: 'central',
-            args: '',
-            execFilePath: '/stackrox/central',
-            pid: 12530,
-            uid: 4000,
-            gid: 0,
-            lineage: [],
-            scraped: true,
-            lineageInfo: [],
-        },
-        clusterId: '9b217bfd-1c3f-4836-9d57-c0b6d410ccda',
-        namespace: 'stackrox',
-        containerStartTime: '2023-06-29T13:00:52Z',
-        imageId: 'sha256:a245029c808486cd18e1ade1a4c1d2db9210cfa87ffa894f5837df37e4bccebd',
-    },
-    {
-        endpoint: {
-            port: 8443,
-            protocol: 'L4_PROTOCOL_TCP',
-        },
-        deploymentId: 'c83ca25c-1097-4dd0-bca1-1df5c496ac5e',
-        containerName: 'central',
-        podId: 'central-5d88f6fcb5-zvgw5',
-        podUid: '79d49039-a2b3-5d05-b929-e74bc82da71c',
-        signal: {
-            id: '706f77e8-167d-11ee-a384-fe93f92a2b33',
-            containerId: '3ccef27a1cf5',
-            time: '2023-06-29T13:00:52.138198746Z',
-            name: 'central',
-            args: '',
-            execFilePath: '/stackrox/central',
-            pid: 12530,
-            uid: 4000,
-            gid: 0,
-            lineage: [],
-            scraped: true,
-            lineageInfo: [],
-        },
-        clusterId: '9b217bfd-1c3f-4836-9d57-c0b6d410ccda',
-        namespace: 'stackrox',
-        containerStartTime: '2023-06-29T13:00:52Z',
-        imageId: 'sha256:a245029c808486cd18e1ade1a4c1d2db9210cfa87ffa894f5837df37e4bccebd',
-    },
-];
-
 function ListeningEndpointsPage() {
+    const { data, lastFetchError, isFetchingNextPage, isEndOfResults } =
+        useDeploymentListeningEndpoints();
+    const isInitialLoad =
+        data.length === 0 && !lastFetchError && isFetchingNextPage && !isEndOfResults;
+    const deployments = data
+        .flat()
+        .filter((deployment) => deployment.listeningEndpoints.length > 0);
+
     return (
         <>
             <PageTitle title="Listening Endpoints" />
@@ -73,7 +24,34 @@ function ListeningEndpointsPage() {
             </PageSection>
             <Divider component="div" />
             <PageSection isFilled>
-                <ListeningEndpointsTable listeningEndpoints={listeningEndpointsSampleData} />
+                {lastFetchError && (
+                    <div className="pf-u-background-color-100">
+                        <EmptyStateTemplate
+                            title="Error loading deployments with listening endpoints"
+                            headingLevel="h2"
+                            icon={ExclamationCircleIcon}
+                            iconClassName="pf-u-danger-color-100"
+                        >
+                            {lastFetchError.message}
+                        </EmptyStateTemplate>
+                    </div>
+                )}
+                {isInitialLoad && (
+                    <Bullseye>
+                        <Spinner />
+                    </Bullseye>
+                )}
+                {!lastFetchError && !isInitialLoad && (
+                    <>
+                        {deployments.length === 0 ? (
+                            <Title headingLevel="h2">
+                                No deployments with listening endpoints found
+                            </Title>
+                        ) : (
+                            <ListeningEndpointsTable deployments={deployments} />
+                        )}
+                    </>
+                )}
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -5,12 +5,13 @@ import { Tbody, Tr, Td, TableComposable, Th, Thead } from '@patternfly/react-tab
 import { ProcessListeningOnPort } from 'services/ProcessListeningOnPortsService';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { l4ProtocolLabels } from 'constants/networkFlow';
+import { ListDeployment } from 'types/deployment.proto';
 
 export type ListeningEndpointsTableProps = {
-    listeningEndpoints: ProcessListeningOnPort[];
+    deployments: (ListDeployment & { listeningEndpoints: ProcessListeningOnPort[] })[];
 };
 
-function ListeningEndpointsTable({ listeningEndpoints }: ListeningEndpointsTableProps) {
+function ListeningEndpointsTable({ deployments }: ListeningEndpointsTableProps) {
     return (
         <TableComposable borders={false} variant="compact">
             <Thead noWrap>
@@ -19,14 +20,15 @@ function ListeningEndpointsTable({ listeningEndpoints }: ListeningEndpointsTable
                     <Th>PID</Th>
                     <Th>Port</Th>
                     <Th>Protocol</Th>
+                    <Th>Deployment</Th>
                     <Th>Namespace</Th>
-                    <Th>Cluster ID</Th>
+                    <Th>Cluster</Th>
                     <Th>Pod ID</Th>
                     <Th>Container name</Th>
                 </Tr>
             </Thead>
             <Tbody>
-                {listeningEndpoints.length === 0 && (
+                {deployments.length === 0 && (
                     <Tr>
                         <Td colSpan={8}>
                             <Bullseye>
@@ -35,19 +37,20 @@ function ListeningEndpointsTable({ listeningEndpoints }: ListeningEndpointsTable
                         </Td>
                     </Tr>
                 )}
-                {listeningEndpoints.map(
-                    ({ podId, endpoint, signal, containerName, namespace, clusterId }) => (
-                        <Tr key={`${podId}/${endpoint.port}`}>
+                {deployments.flatMap(({ id, name, namespace, cluster, listeningEndpoints }) =>
+                    listeningEndpoints.map(({ podId, endpoint, signal, containerName }) => (
+                        <Tr key={`${id}/${podId}/${endpoint.port}`}>
                             <Td dataLabel="Program name">{signal.name}</Td>
                             <Td dataLabel="PID">{signal.pid}</Td>
                             <Td dataLabel="Port">{endpoint.port}</Td>
                             <Td dataLabel="Protocol">{l4ProtocolLabels[endpoint.protocol]}</Td>
+                            <Td dataLabel="Deployment">{name}</Td>
                             <Td dataLabel="Namespace">{namespace}</Td>
-                            <Td dataLabel="Cluster ID">{clusterId}</Td>
+                            <Td dataLabel="Cluster">{cluster}</Td>
                             <Td dataLabel="Pod ID">{podId}</Td>
                             <Td dataLabel="Container name">{containerName}</Td>
                         </Tr>
-                    )
+                    ))
                 )}
             </Tbody>
         </TableComposable>

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/hooks/useDeploymentListeningEndpoints.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/hooks/useDeploymentListeningEndpoints.tsx
@@ -1,0 +1,34 @@
+import { useCallback } from 'react';
+import { UsePaginatedQueryReturn, usePaginatedQuery } from 'hooks/usePaginatedQuery';
+import { listDeployments } from 'services/DeploymentsService';
+import {
+    ProcessListeningOnPort,
+    getListeningEndpointsForDeployment,
+} from 'services/ProcessListeningOnPortsService';
+import { ListDeployment } from 'types/deployment.proto';
+
+const sortOptions = { field: 'Deployment', reversed: 'false' };
+const pageSize = 10;
+
+/**
+ * Returns a paginated list of deployments with their listening endpoints.
+ */
+export function useDeploymentListeningEndpoints(): UsePaginatedQueryReturn<
+    ListDeployment & { listeningEndpoints: ProcessListeningOnPort[] }
+> {
+    const queryFn = useCallback((page: number) => {
+        return listDeployments({}, sortOptions, page, pageSize).then((res) => {
+            return Promise.all(
+                res.map((deployment) => {
+                    const { request } = getListeningEndpointsForDeployment(deployment.id);
+                    return request.then((listeningEndpoints) => ({
+                        ...deployment,
+                        listeningEndpoints,
+                    }));
+                })
+            );
+        });
+    }, []);
+
+    return usePaginatedQuery(queryFn, pageSize);
+}


### PR DESCRIPTION
## Description

Replaces the inline mock data with live data from central to display deployments and their associated listening endpoints. This currently will load data for only the first ten deployments in the system.

**Note that a design is not finalized for this page. This is a basic display to get the necessary data loading code in place while UX finishes design work.**

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the listening endpoints page at `/audit/listening-endpoints`:
![image](https://github.com/stackrox/stackrox/assets/1292638/0ef94fe2-00ba-4f42-99be-925567b093ba)

Small screen:
![image](https://github.com/stackrox/stackrox/assets/1292638/372780cf-6380-4b3f-8413-1aec2bf6bd57)

Loading state:
![image](https://github.com/stackrox/stackrox/assets/1292638/4cf8e018-0c3b-4714-859f-40c22f71abbe)

Error state:
![image](https://github.com/stackrox/stackrox/assets/1292638/e3e8fd2d-81dd-47b3-98ba-17d3d410552e)

