### PR TITLE
ROX-17952: Add ability to lazy load listening endpoints

### DIFF
--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.test.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.test.tsx
@@ -70,4 +70,43 @@ describe('ListeningEndpointsPage', () => {
         expect(await screen.findByText('deployment-2')).toBeInTheDocument();
         expect(screen.queryByText('deployment-1')).not.toBeInTheDocument();
     });
+
+    it('should render a view more button to allow loading more deployments', async () => {
+        const { user } = setup();
+
+        // Generate 15 mock deployments with names `deployment-1` through `deployment-15`
+        mockDeploymentsWithListeningEndpoints(
+            Array.from({ length: 15 }).map((_, i) => ({
+                id: `d-${i + 1}`,
+                name: `deployment-${i + 1}`,
+                listeningEndpoints: [
+                    { id: `${i + 1}`, endpoint: { port: 80, protocol: 'TCP' }, signal: {} },
+                ],
+            }))
+        );
+
+        // Check that only 1-10 are loaded
+        expect(await screen.findByText('deployment-1')).toBeInTheDocument();
+        expect(screen.getByText('deployment-10')).toBeInTheDocument();
+        expect(screen.queryByText('deployment-11')).not.toBeInTheDocument();
+
+        // Check that view more button is present
+        const viewMoreButton = screen.getByRole('button', { name: 'View more' });
+        expect(viewMoreButton).toBeInTheDocument();
+        // Click it
+        await user.click(viewMoreButton);
+
+        // Expect the button to be disabled during loading
+        expect(viewMoreButton).toBeDisabled();
+
+        // Check that 11-15 are loaded
+        expect(await screen.findByText('deployment-11')).toBeInTheDocument();
+        expect(screen.getByText('deployment-15')).toBeInTheDocument();
+        // Check that the originals are still there too
+        expect(screen.getByText('deployment-1')).toBeInTheDocument();
+        expect(screen.getByText('deployment-10')).toBeInTheDocument();
+
+        // Since all results are loaded, the button should be gone
+        expect(screen.queryByRole('button', { name: 'View more' })).not.toBeInTheDocument();
+    });
 });

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { Bullseye, Divider, PageSection, Spinner, Title } from '@patternfly/react-core';
+import {
+    Bullseye,
+    Button,
+    Divider,
+    PageSection,
+    Spinner,
+    Stack,
+    Title,
+} from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate/EmptyStateTemplate';
@@ -8,7 +16,7 @@ import { useDeploymentListeningEndpoints } from './hooks/useDeploymentListeningE
 import ListeningEndpointsTable from './ListeningEndpointsTable';
 
 function ListeningEndpointsPage() {
-    const { data, lastFetchError, isFetchingNextPage, isEndOfResults } =
+    const { data, lastFetchError, isFetchingNextPage, isEndOfResults, fetchNextPage } =
         useDeploymentListeningEndpoints();
     const isInitialLoad =
         data.length === 0 && !lastFetchError && isFetchingNextPage && !isEndOfResults;
@@ -38,7 +46,7 @@ function ListeningEndpointsPage() {
                 )}
                 {isInitialLoad && (
                     <Bullseye>
-                        <Spinner />
+                        <Spinner aria-label="Loading listening endpoints for deployments" />
                     </Bullseye>
                 )}
                 {!lastFetchError && !isInitialLoad && (
@@ -48,7 +56,18 @@ function ListeningEndpointsPage() {
                                 No deployments with listening endpoints found
                             </Title>
                         ) : (
-                            <ListeningEndpointsTable deployments={deployments} />
+                            <Stack>
+                                <ListeningEndpointsTable deployments={deployments} />
+                                {!isEndOfResults && (
+                                    <Button
+                                        onClick={() => fetchNextPage(true)}
+                                        isLoading={isFetchingNextPage}
+                                        isDisabled={isFetchingNextPage}
+                                    >
+                                        View more
+                                    </Button>
+                                )}
+                            </Stack>
                         )}
                     </>
                 )}


### PR DESCRIPTION
## Description

Adds a "View more" button to allow lazy loading of more deployments with listening endpoints.

Again, the design is not finalized by UX, this PR uses a simple design in order to get the necessary functionality in place.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

View the listening endpoints page directly at `/audit/listening-endpoints` and scroll to the bottom. A "View more" button should be present:
![image](https://github.com/stackrox/stackrox/assets/1292638/645836be-ebaf-41be-b030-3b98bdc84642)

Click the button, it should become disabled while more data is loading:
![image](https://github.com/stackrox/stackrox/assets/1292638/a31c952e-8955-4201-8dc2-54e67e673911)

Continue to click the "view more" button until all data has loaded. Once all data has loaded the button will disappear:
![image](https://github.com/stackrox/stackrox/assets/1292638/b68af40a-142f-4f5f-95af-145db90ec45a)


