### PR TITLE
ROX-17963: CI: Fix central channel handling

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/BaseService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/BaseService.groovy
@@ -2,6 +2,7 @@ package services
 
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
+import groovy.util.logging.Slf4j
 import io.grpc.CallOptions
 import io.grpc.Channel
 import io.grpc.ClientCall
@@ -21,6 +22,7 @@ import util.Env
 import util.Keys
 
 @CompileStatic
+@Slf4j
 class BaseService {
 
     static final String BASIC_AUTH_USERNAME = Env.mustGetUsername()
@@ -57,6 +59,7 @@ class BaseService {
                 transportChannel.shutdownNow()
                 transportChannel = null
                 effectiveChannel = null
+                log.debug("The gRPC channel to central was closed")
             }
         }
         if (authInterceptor != newAuthInterceptor) {
@@ -128,6 +131,8 @@ class BaseService {
                     .sslContext(sslContext)
                     .build()
             effectiveChannel = null
+
+            log.debug("The gRPC channel to central was opened (useClientCert: ${useClientCert})")
         }
 
         if (authInterceptor == null) {

--- a/qa-tests-backend/src/main/groovy/services/BaseService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/BaseService.groovy
@@ -51,7 +51,7 @@ class BaseService {
     }
 
     private static updateAuthConfig(Boolean newUseClientCert, ClientInterceptor newAuthInterceptor) {
-        synchronized(BaseService.class) {
+        synchronized(BaseService) {
             if (useClientCert == newUseClientCert && authInterceptor == newAuthInterceptor) {
                 return
             }
@@ -146,7 +146,7 @@ class BaseService {
 
     static Channel getChannel() {
         if (effectiveChannel == null) {
-            synchronized(BaseService.class) {
+            synchronized(BaseService) {
                 initializeChannel()
             }
         }


### PR DESCRIPTION
## Description

#6590 changed the test<->central channel state to use ThreadLocal variables. The intent being that each concurrent test thread would not have to be concerned with other tests altering its central connection. However a side effect of this change is that when threads complete and the ThreadLocal vars are GC'd the gRPC package produces a nasty error message:

```
    Jun 30, 2023 9:29:07 AM io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference cleanQueue
    SEVERE: *~*~*~ Channel ManagedChannelImpl{logId=16, target=localhost:8000} was not shutdown properly!!! ~*~*~*
        Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
    java.lang.RuntimeException: ManagedChannel allocation site
    	at io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference.<init>(ManagedChannelOrphanWrapper.java:94)
    	at io.grpc.internal.ManagedChannelOrphanWrapper.<init>(ManagedChannelOrphanWrapper.java:52)
... snip very long stack trace ...
```

It also turns out that because of the use of `org.junit.rules.Timeout`, each spock test feature is executed in a separate thread. And so along with #6590, a new channel is now created for each test feature.

This PR reverts most of #6590 and switches back to using global state to manage the test<->central channel. Changes to the channel are protected with synchronized blocks in anticipation of future concurrent test work. Note: with this change, tests that test the central connection (e.g. AuthServiceTest, ClientCertAuthTest) will not be parallel-able. 

ref: https://redhat-internal.slack.com/archives/CLUNQEEMA/p1688074475205819
cc @rukletsov 

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.