### PR TITLE
ROX-16828: Add "generated" label to build-time generated netpols

### DIFF
--- a/roxctl/generate/netpol/cta.go
+++ b/roxctl/generate/netpol/cta.go
@@ -13,6 +13,10 @@ import (
 	v1 "k8s.io/api/networking/v1"
 )
 
+const (
+	generatedNetworkPolicyLabel = `network-policy-buildtime-generator.stackrox.io/generated`
+)
+
 type netpolGenerator interface {
 	PoliciesFromFolderPath(string) ([]*v1.NetworkPolicy, error)
 	Errors() []npguard.FileProcessingError
@@ -55,6 +59,10 @@ func (cmd *generateNetpolCommand) ouputNetpols(recommendedNetpols []*v1.NetworkP
 	var mergedPolicy string
 	yamlPolicies := make([]string, 0, len(recommendedNetpols))
 	for _, netpol := range recommendedNetpols {
+		if netpol.Labels == nil {
+			netpol.Labels = make(map[string]string)
+		}
+		netpol.Labels[generatedNetworkPolicyLabel] = "true"
 		yamlPolicy, err := networkpolicy.KubernetesNetworkPolicyWrap{NetworkPolicy: netpol}.ToYaml()
 		if err != nil {
 			return errors.Wrap(err, "error converting Network Policy object to YAML")

--- a/tests/roxctl/bats-tests/local/roxctl-netpol-generate-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-generate-development.bats
@@ -45,18 +45,30 @@ teardown() {
   assert_file_exist "$ofile"
   yaml_valid "$ofile"
 
-  # There must be at least 2 yaml documents in the output
+  # There must be at least 3 yaml documents in the output
   # yq version 4.16.2 has problems with handling 'document_index', thus we use 'di'
   run yq e 'di' "${ofile}"
   assert_line '0'
   assert_line '1'
+  assert_line '2'
 
-  # Ensure that both yaml docs are of kind 'NetworkPolicy'
+  # Ensure that all yaml docs are of kind 'NetworkPolicy'
   run yq e '.kind | ({"match": ., "doc": di})' "${ofile}"
   assert_line --index 0 'match: NetworkPolicy'
   assert_line --index 1 'doc: 0'
   assert_line --index 2 'match: NetworkPolicy'
   assert_line --index 3 'doc: 1'
+  assert_line --index 4 'match: NetworkPolicy'
+  assert_line --index 5 'doc: 2'
+
+  # Ensure that all NetworkPolicies have the generated-by-stackrox label
+  run yq e '.metadata.labels | ({"match": ."network-policy-buildtime-generator.stackrox.io/generated", "doc": di})' "${ofile}"
+  assert_line --index 0 'match: "true"'
+  assert_line --index 1 'doc: 0'
+  assert_line --index 2 'match: "true"'
+  assert_line --index 3 'doc: 1'
+  assert_line --index 4 'match: "true"'
+  assert_line --index 5 'doc: 2'
 }
 
 @test "roxctl-development generate netpol produces no output when all yamls are templated" {


### PR DESCRIPTION
As specified in [ROX-16828](https://issues.redhat.com/browse/ROX-16828).