### PR TITLE
fix: detect test builds

### DIFF
--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -4,6 +4,9 @@ const (
 	// ReleaseBuild indicates whether this build is a release build.
 	ReleaseBuild bool = releaseBuild
 
+	// TestBuild indicates whether this build is a test build.
+	TestBuild bool = testBuild
+
 	// BuildFlavor indicates the build flavor ("release" for release builds, "development" for development builds).
 	BuildFlavor string = buildFlavor
 

--- a/pkg/buildinfo/buildinfo_intest.go
+++ b/pkg/buildinfo/buildinfo_intest.go
@@ -1,0 +1,7 @@
+//go:build test
+
+package buildinfo
+
+const (
+	testBuild = true
+)

--- a/pkg/buildinfo/buildinfo_notest.go
+++ b/pkg/buildinfo/buildinfo_notest.go
@@ -1,0 +1,7 @@
+//go:build !test
+
+package buildinfo
+
+const (
+	testBuild = false
+)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -187,7 +187,7 @@ func deriveChartVersion(mainVersion string) (string, error) {
 
 // IsReleaseVersion tells whether the binary is built for a release.
 func IsReleaseVersion() bool {
-	return buildinfo.ReleaseBuild &&
+	return buildinfo.ReleaseBuild && !buildinfo.TestBuild &&
 		GetMainVersion() != "" &&
 		!strings.Contains(GetMainVersion(), "-")
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -14,7 +14,7 @@ func TestParseCurrentVersion(t *testing.T) {
 }
 
 func TestIsReleaseVersion(t *testing.T) {
-	if buildinfo.ReleaseBuild {
+	if buildinfo.ReleaseBuild && !buildinfo.TestBuild {
 		internal.MainVersion = "1.2.3"
 		assert.True(t, IsReleaseVersion())
 		internal.MainVersion = "1.2.3-dirty"


### PR DESCRIPTION
## Description

We want to detect `release && test` builds to disable telemetry for them.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Unit tests.