### PR TITLE
ROX-18208: rhacs operator upgrade failed 4.1

### DIFF
--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -196,8 +196,8 @@ type PerNodeSpec struct {
 	TaintToleration *TaintTolerationPolicy `json:"taintToleration,omitempty"`
 }
 
-// CollectionMethod defines the method of collection used by collector. Options are 'EBPF', 'CORE_BPF' or 'None'. Note that 'CORE_BPF' is on Tech Preview stage.
-// +kubebuilder:validation:Enum=EBPF;CORE_BPF;NoCollection
+// CollectionMethod defines the method of collection used by collector. Options are 'EBPF', 'CORE_BPF', 'None', or 'KernelModule'. Note that 'CORE_BPF' is on Tech Preview stage and that the collection method will be switched to EBPF if KernelModule is used.
+// +kubebuilder:validation:Enum=EBPF;CORE_BPF;NoCollection;KernelModule
 type CollectionMethod string
 
 const (
@@ -207,6 +207,8 @@ const (
 	CollectionCOREBPF CollectionMethod = "CORE_BPF"
 	// CollectionNone means: NO_COLLECTION.
 	CollectionNone CollectionMethod = "NoCollection"
+	// CollectionKernelModule means: use KERNEL_MODULE collection.
+	CollectionKernelModule CollectionMethod = "KernelModule"
 )
 
 // Pointer returns the given CollectionMethod as a pointer, needed in k8s resource structs.

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -403,6 +403,7 @@ spec:
                         - EBPF
                         - CORE_BPF
                         - NoCollection
+                        - KernelModule
                         type: string
                       imageFlavor:
                         default: Regular

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -404,6 +404,7 @@ spec:
                         - EBPF
                         - CORE_BPF
                         - NoCollection
+                        - KernelModule
                         type: string
                       imageFlavor:
                         default: Regular


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/stackrox/stackrox/pull/6800

Customers who are using the kernel module collection method are unable to upgrade as that option has option has been removed in 4.1. This adds kernel module as a valid collection method. If someone tries to use kernel module as a collection method, the collection method will be changed to EBPF.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Manual operator upgrade works when using the downstream build based on these changes
- [x] Operator e2e test fails on master branch when the collection method is set to KernelModule
- [x] Operator e2e test passes when the collection method is set to KernelModule with these changes
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Manual Upgrade Tests

Followed the directions [here](https://gitlab.cee.redhat.com/stackrox/downstream-utils/-/blob/main/testing/books/operator-catalog.ipynb) and [here](https://docs.engineering.redhat.com/display/StackRox/Managing+a+Downstream+RHACS+Release+on+Red+Hat+Infrastructure#ManagingaDownstreamRHACSReleaseonRedHatInfrastructure-test-prerequisitesTestPrerequisites) with some changes.

Much more detailed steps and results are given [here](https://docs.google.com/document/d/1eEYYnsPX1JjCeDc5wIUE3p5B6QH8ZnBAt-YA-t7UvII/edit)

A quick summary of the results is that the upgrade from 4.0.2 to 4.1.0 failed when the collection method was KernelModule. The upgrade succeeded for 4.0.2 to 4.1.1 for the same steps. The collection method in the collector pods was switched to EBPF, while the UI still showed KernelModule. An attempt was also made to perform the following upgrade path 4.0.2 -> 4.1.0 -> 4.1.1. This did not succeed as it was not possible to upgrade either 4.0.2 or 4.1.0 after the failed upgrade to 4.1.0. This was tried with both a manual upgrade and an automatic upgrade.

### Branch with KernelModule in Test CR but without KernelModule in Collection Method Enum

In this case the operator e2e tests failed as expected.

https://github.com/stackrox/stackrox/pull/6863

### Branch with KernelModule in Test CR and with KernelModule in Collection Method Enum

The operator e2e tests passed in this case 

https://github.com/stackrox/stackrox/pull/6862

These two tests show that the changes made in this PR enable the upgrade to succeed when the collection method is set to KernelModule.