### PR TITLE
ROX-18200: Handle error object when networkpolicy request fails

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -20,6 +20,7 @@ import download from 'utils/download';
 import SelectSingle from 'Components/SelectSingle';
 import { useTheme } from 'Containers/ThemeProvider';
 import useFetchNetworkPolicies from 'hooks/useFetchNetworkPolicies';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 type NetworkPoliciesProps = {
     entityName: string;
@@ -100,7 +101,12 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
 
     if (error) {
         return (
-            <Alert isInline variant={AlertVariant.danger} title={error} className="pf-u-mb-lg" />
+            <Alert
+                isInline
+                variant={AlertVariant.danger}
+                title={getAxiosErrorMessage(error)}
+                className="pf-u-mb-lg"
+            />
         );
     }
 

--- a/ui/apps/platform/src/hooks/useFetchNetworkPolicies.ts
+++ b/ui/apps/platform/src/hooks/useFetchNetworkPolicies.ts
@@ -4,7 +4,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import { fetchNetworkPolicies } from 'services/NetworkService';
 import { NetworkPolicy } from 'types/networkPolicy.proto';
 
-type Result = { isLoading: boolean; networkPolicies: NetworkPolicy[]; error: string | null };
+type Result = { isLoading: boolean; networkPolicies: NetworkPolicy[]; error: Error | null };
 
 const defaultResultState = { networkPolicies: [], error: null, isLoading: true };
 


### PR DESCRIPTION
## Description

Fixes a UI crash caused by deleting a NetworkPolicy while the Network Graph is open, and then clicking on the impacted deployment.

This fixes the immediate issue, but a better follow up would be to still display the remaining network policies if possible. (A single error for any one policy prevents the users from viewing _any_ other policies for the deployment.)


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

View the network graph with a deployment containing a network policy in the selected scope.
![image](https://github.com/stackrox/stackrox/assets/1292638/7988dbbf-7153-4103-8771-548d57edf507)

Select anything other than the deployment (or nothing) in the graph. Delete one of the network policies that impacts the deployment via `kubectl`. (`kubectl -n ui-testing delete networkpolicy/nginx2-http`)
![image](https://github.com/stackrox/stackrox/assets/1292638/b950b3e9-28cd-4cd1-b05f-697833d9ec35)

Click the deployment again in the graph. The UI should not crash, and the Network Policies tab in the side panel should display an error.
![image](https://github.com/stackrox/stackrox/assets/1292638/496e8b32-7c01-416e-b85d-a2fa951fe075)
