### PR TITLE
ROX-18173, ROX-18243, ROX-18244: Fix `/v1/metadata` in tests

### DIFF
--- a/tests/endpoints_test.go
+++ b/tests/endpoints_test.go
@@ -225,15 +225,15 @@ func (c *endpointsTestCase) runGRPCTest(t *testing.T, testCtx *endpointsTestCont
 		defer utils.IgnoreError(conn.Close)
 	}
 
-	mdClient := v1.NewMetadataServiceClient(conn)
+	pingClient := v1.NewPingServiceClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	_, err = mdClient.GetMetadata(ctx, &v1.Empty{})
+	_, err = pingClient.Ping(ctx, &v1.Empty{})
 	if !c.expectGRPCSuccess {
-		assert.Error(t, err, "expected GetMetadata request to fail")
+		assert.Error(t, err, "expected Ping request to fail")
 		return
 	}
-	assert.NoError(t, err, "expected GetMetadata request to succeed")
+	assert.NoError(t, err, "expected ping request to succeed")
 
 	authClient := v1.NewAuthServiceClient(conn)
 	ctx, cancel = context.WithTimeout(context.Background(), timeout)
@@ -294,7 +294,7 @@ func (c *endpointsTestCase) runHTTPTest(t *testing.T, testCtx *endpointsTestCont
 		Timeout:   timeout,
 	}
 
-	resp, err := client.Get(fmt.Sprintf("%s://%s/v1/metadata", scheme, targetHost))
+	resp, err := client.Get(fmt.Sprintf("%s://%s/v1/ping", scheme, targetHost))
 	if resp != nil {
 		defer utils.IgnoreError(resp.Body.Close)
 	}
@@ -312,9 +312,9 @@ func (c *endpointsTestCase) runHTTPTest(t *testing.T, testCtx *endpointsTestCont
 		return
 	}
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 status code for metadata request")
-	var md v1.Metadata
-	assert.NoError(t, jsonpb.Unmarshal(resp.Body, &md), "expected response for metadata request to be unmarshalable into metadata PB")
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 status code for ping request")
+	var pong v1.PongMessage
+	assert.NoError(t, jsonpb.Unmarshal(resp.Body, &pong), "expected response for ping request to be unmarshalable into Pong protobuf")
 
 	resp, err = client.Get(fmt.Sprintf("%s://%s/v1/auth/status", scheme, targetHost))
 	if !assert.NoError(t, err, "expected HTTP request to succeed at the transport level") {

--- a/tests/metadata_test.go
+++ b/tests/metadata_test.go
@@ -36,10 +36,4 @@ func TestMetadataIsSetCorrectly(t *testing.T) {
 	assert.Equal(t, buildinfo.BuildFlavor, metadataWithAuth.GetBuildFlavor())
 	assert.Equal(t, buildinfo.ReleaseBuild, metadataWithAuth.GetReleaseBuild())
 	assert.Equal(t, version.GetMainVersion(), metadataWithAuth.GetVersion())
-
-	// Test that an unauthenticated connection doesn't get the version.
-	metadataWithoutAuth := getMetadata(t, centralgrpc.UnauthenticatedGRPCConnectionToCentral(t))
-	assert.Equal(t, buildinfo.BuildFlavor, metadataWithoutAuth.GetBuildFlavor())
-	assert.Equal(t, buildinfo.ReleaseBuild, metadataWithoutAuth.GetReleaseBuild())
-	assert.Equal(t, "", metadataWithoutAuth.GetVersion())
 }


### PR DESCRIPTION
## Description

Addendum to https://github.com/stackrox/stackrox/pull/6718. This PR replaces the use of `/v1/metadata` with `/v1/ping` in `endpoints_tests.go`. In that test file, `/v1/metadata` is used as an example of an unauthenticated endpoint, which it is not any more.

Also, since `/v1/metadata` requires authentication, removed unauthenticated path from its test.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI run.
