### PR TITLE
ROX-18208: rhacs operator upgrade failed 4.1

### DIFF
--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -194,8 +194,8 @@ type PerNodeSpec struct {
 	TaintToleration *TaintTolerationPolicy `json:"taintToleration,omitempty"`
 }
 
-// CollectionMethod defines the method of collection used by collector. Options are 'EBPF', 'CORE_BPF' or 'None'. Note that 'CORE_BPF' is on Tech Preview stage.
-// +kubebuilder:validation:Enum=EBPF;CORE_BPF;NoCollection
+// CollectionMethod defines the method of collection used by collector. Options are 'EBPF', 'CORE_BPF', 'None', or KernelModule. Note that 'CORE_BPF' is on Tech Preview stage and that the collection method will be switched to EBPF if KernelModule is used.
+// +kubebuilder:validation:Enum=EBPF;CORE_BPF;NoCollection;KernelModule
 type CollectionMethod string
 
 const (
@@ -205,6 +205,8 @@ const (
 	CollectionCOREBPF CollectionMethod = "CORE_BPF"
 	// CollectionNone means: NO_COLLECTION.
 	CollectionNone CollectionMethod = "NoCollection"
+	// CollectionKernelModule means: use KERNEL_MODULE collection.
+	CollectionKernelModule CollectionMethod = "KernelModule"
 )
 
 // Pointer returns the given CollectionMethod as a pointer, needed in k8s resource structs.

--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -194,7 +194,7 @@ type PerNodeSpec struct {
 	TaintToleration *TaintTolerationPolicy `json:"taintToleration,omitempty"`
 }
 
-// CollectionMethod defines the method of collection used by collector. Options are 'EBPF', 'CORE_BPF', 'None', or KernelModule. Note that 'CORE_BPF' is on Tech Preview stage and that the collection method will be switched to EBPF if KernelModule is used.
+// CollectionMethod defines the method of collection used by collector. Options are 'EBPF', 'CORE_BPF', 'None', or 'KernelModule'. Note that 'CORE_BPF' is on Tech Preview stage and that the collection method will be switched to EBPF if KernelModule is used.
 // +kubebuilder:validation:Enum=EBPF;CORE_BPF;NoCollection;KernelModule
 type CollectionMethod string
 

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -397,6 +397,7 @@ spec:
                         - EBPF
                         - CORE_BPF
                         - NoCollection
+                        - KernelModule
                         type: string
                       imageFlavor:
                         default: Regular

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -398,6 +398,7 @@ spec:
                         - EBPF
                         - CORE_BPF
                         - NoCollection
+                        - KernelModule
                         type: string
                       imageFlavor:
                         default: Regular


### PR DESCRIPTION
## Description

Customers who are using the kernel module collection method are unable to upgrade as that option has been removed in 4.1. This adds kernel module as a valid collection method. If someone tries to use kernel module as a collection method, the collection method will be changed to EBPF.

## Checklist
- [x] Investigated and inspected CI test results
           Discussed with @pedrottimark and concluded that the UI test failures are not the result of code changes here and that bringing in the fix to the 4.1 release branch would not be worth it.
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Operator Upgrade Test

Followed the directions [here](https://gitlab.cee.redhat.com/stackrox/downstream-utils/-/blob/main/testing/books/operator-catalog.ipynb) and [here](https://docs.engineering.redhat.com/display/StackRox/Managing+a+Downstream+RHACS+Release+on+Red+Hat+Infrastructure#ManagingaDownstreamRHACSReleaseonRedHatInfrastructure-test-prerequisitesTestPrerequisites) with some changes.


