### PR TITLE
refactor(ui): Allow netpol YAML to display in UI after partial errors

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo } from 'react';
 import {
     Alert,
+    AlertGroup,
     AlertVariant,
     Bullseye,
     Button,
@@ -35,7 +36,8 @@ type NetworkPolicyYAML = {
 const allNetworkPoliciesId = 'All network policies';
 
 function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React.ReactElement {
-    const { networkPolicies, isLoading, error } = useFetchNetworkPolicies(policyIds);
+    const { networkPolicies, networkPolicyErrors, isLoading, error } =
+        useFetchNetworkPolicies(policyIds);
     const { isDarkMode } = useTheme();
     const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
 
@@ -110,20 +112,42 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
         );
     }
 
+    let policyErrorBanner: React.ReactNode = null;
+
+    if (networkPolicyErrors.length > 0) {
+        policyErrorBanner = (
+            <AlertGroup className="pf-u-mb-lg">
+                {networkPolicyErrors.map((networkPolicyError) => (
+                    <Alert
+                        isInline
+                        variant={AlertVariant.danger}
+                        title="There was an error loading network policy data"
+                    >
+                        {getAxiosErrorMessage(networkPolicyError)}
+                    </Alert>
+                ))}
+            </AlertGroup>
+        );
+    }
+
     if (networkPolicies.length === 0) {
         return (
-            <Bullseye>
-                <EmptyState variant={EmptyStateVariant.xs}>
-                    <Title headingLevel="h4" size="md">
-                        No network policies
-                    </Title>
-                </EmptyState>
-            </Bullseye>
+            <>
+                {policyErrorBanner}
+                <Bullseye>
+                    <EmptyState variant={EmptyStateVariant.xs}>
+                        <Title headingLevel="h4" size="md">
+                            No network policies
+                        </Title>
+                    </EmptyState>
+                </Bullseye>
+            </>
         );
     }
 
     return (
         <div className="pf-u-h-100 pf-u-p-md">
+            {policyErrorBanner}
             <Stack hasGutter>
                 <StackItem>
                     <SelectSingle

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -120,7 +120,7 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
                 {networkPolicyErrors.map((networkPolicyError) => (
                     <Alert
                         isInline
-                        variant={AlertVariant.danger}
+                        variant={AlertVariant.warning}
                         title="There was an error loading network policy data"
                     >
                         {getAxiosErrorMessage(networkPolicyError)}

--- a/ui/apps/platform/src/hooks/useFetchNetworkPolicies.ts
+++ b/ui/apps/platform/src/hooks/useFetchNetworkPolicies.ts
@@ -4,9 +4,22 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import { fetchNetworkPolicies } from 'services/NetworkService';
 import { NetworkPolicy } from 'types/networkPolicy.proto';
 
-type Result = { isLoading: boolean; networkPolicies: NetworkPolicy[]; error: Error | null };
+type Result = {
+    isLoading: boolean;
+    networkPolicies: NetworkPolicy[];
+    // This error array represents errors that occurred while fetching the individual network policies when
+    // the overall request chain succeeded
+    networkPolicyErrors: Error[];
+    // This single error represents a unrecoverable error that occurred after the overall request chain failed
+    error: Error | null;
+};
 
-const defaultResultState = { networkPolicies: [], error: null, isLoading: true };
+const defaultResultState = {
+    networkPolicies: [],
+    networkPolicyErrors: [],
+    error: null,
+    isLoading: true,
+};
 
 /*
  * This hook does an API call to the network policies API to get a list of network policies
@@ -19,15 +32,21 @@ function useFetchNetworkPolicies(policyIds: string[]): Result {
 
         if (policyIds) {
             fetchNetworkPolicies(policyIds)
-                .then((data) => {
+                .then(({ policies, errors }) => {
                     setResult({
-                        networkPolicies: data?.response as NetworkPolicy[],
+                        networkPolicies: policies,
+                        networkPolicyErrors: errors,
                         error: null,
                         isLoading: false,
                     });
                 })
                 .catch((error) => {
-                    setResult({ networkPolicies: [], error, isLoading: false });
+                    setResult({
+                        networkPolicies: [],
+                        networkPolicyErrors: [],
+                        error,
+                        isLoading: false,
+                    });
                 });
         }
 

--- a/ui/apps/platform/src/services/NetworkService.js
+++ b/ui/apps/platform/src/services/NetworkService.js
@@ -291,9 +291,21 @@ export function fetchNetworkPolicies(policyIds) {
     const networkPoliciesPromises = policyIds.map((policyId) =>
         axios.get(`${networkPoliciesBaseUrl}/${policyId}`)
     );
-    return Promise.all(networkPoliciesPromises).then((response) => ({
-        response: response.map((networkPolicy) => networkPolicy.data),
-    }));
+    return Promise.allSettled(networkPoliciesPromises).then((responses) => {
+        const responseData = {
+            policies: [],
+            errors: [],
+        };
+
+        responses.forEach((response) => {
+            if (response.status === 'fulfilled') {
+                responseData.policies.push(response.value.data);
+            } else {
+                responseData.errors.push(response.reason);
+            }
+        });
+        return responseData;
+    });
 }
 
 /**


### PR DESCRIPTION
## Description

Builds on #6798 to allow some data to display in partial error cases.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Perform the testing steps in #6798 to view an error in the sidebar. If some netpol requests succeeded, display both the errors from the failed requests as well as the usable data.
![image](https://github.com/stackrox/stackrox/assets/1292638/36226493-cf08-4d4f-9710-13345c973ac5)

Error state + empty state if every possible request fails:
![image](https://github.com/stackrox/stackrox/assets/1292638/7c9cbcc5-9b73-4989-9a36-f9261fc80332)

Error state if there is an error in the `Promise.allSettled` resolver:
![image](https://github.com/stackrox/stackrox/assets/1292638/c80c8871-784f-4a7c-86c0-8caaa86aff5c)

Happy path:
![image](https://github.com/stackrox/stackrox/assets/1292638/b78f5c60-25d3-4caa-a222-97e49db97b2f)


