### PR TITLE
ROX-17280: Skip slack & JIRA for release branches

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1213,7 +1213,7 @@ post_process_test_results() {
 
     set +u
     {
-        if is_in_PR_context; then
+        if is_in_PR_context || [[ "${PULL_BASE_REF:-unknown}" =~ ^release ]]; then
             info "Converting JUNIT found in ${ARTIFACT_DIR} to CSV"
             extra_args=(--dry-run)
         else
@@ -1252,9 +1252,8 @@ send_slack_notice_for_failures_on_merge() {
         return 0
     fi
 
-    local tag
-    tag="$(make --quiet --no-print-directory tag)"
-    if [[ "$tag" =~ $RELEASE_RC_TAG_BASH_REGEX ]]; then
+    if [[ "${PULL_BASE_REF:-unknown}" =~ ^release ]]; then
+        info "Skipping slack message for release branches"
         return 0
     fi
 


### PR DESCRIPTION
## Description

It is an open question as to how to best handle slack and JIRA notifications on release branches in order to support the release engineer and the process. So this PR removes them 'for now'. I've verified that `PULL_BASE_REF` exists in a pull and merge context in openshift CI.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient
