### PR TITLE
refactor: telemetry storage key management

### DIFF
--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -2,10 +2,7 @@ package centralclient
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/installation/store"
@@ -14,7 +11,6 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/grpc/client/authn/basic"
-	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sync"
@@ -37,87 +33,25 @@ var (
 	enabled  bool
 )
 
-const (
-	disabledKey    = "DISABLED"
-	selfManagedKey = "eDd6QP8uWm0jCkAowEvijOPgeqtlulwR"
-)
-
-type remoteConfig struct {
-	Key string `json:"storage_key_v1,omitempty"`
-}
-
-func downloadConfig(u string) (*remoteConfig, error) {
-	if u == "hardcoded" {
-		// TODO(ROX-17726): Use the hardcoded key for now.
-		return &remoteConfig{Key: selfManagedKey}, nil
-	}
-	client := http.Client{
-		Timeout:   5 * time.Second,
-		Transport: proxy.RoundTripper(),
-	}
-	resp, err := client.Get(u)
-	if err != nil {
-		return nil, errors.Wrap(err, "cannot download telemetry configuration")
-	}
-	var cfg *remoteConfig
-	err = json.NewDecoder(resp.Body).Decode(&cfg)
-	return cfg, errors.Wrap(err, "cannot decode telemetry configuration")
-}
-
-// toDownload decides if a configuration with the key need to be downloaded.
-// We want to prevent accidental use of the production key, but still allow
-// developers to test the functionality. So download will only happen for
-// development installations if both a key and an URL are provided. For release
-// versions the key may be empty.
-// See unit tests for the examples.
-func toDownload(isRelease bool, key, cfgURL string) bool {
-	if cfgURL == "" {
-		return false
-	}
-	if !isRelease {
-		// Development versions must provide a key on top of the URL.
-		return key != ""
-	}
-	return true
-}
-
-// useRemoteKey decides if the key from the downloaded configuration has to be
-// used.
-// We want to prevent accidental use of the production key, but still allow
-// developers to test the functionality. So the key from the environment
-// has to match the one from the downloaded configuration for development
-// installations.
-// See unit tests for the examples.
-func useRemoteKey(isRelease bool, cfg *remoteConfig, localKey string) bool {
-	if cfg == nil {
-		return false
-	}
-	if !isRelease {
-		// The key from the environment has to match for development versions.
-		return cfg.Key == localKey
-	}
-	return true
-}
-
 func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 	key := env.TelemetryStorageKey.Setting()
-	if key == disabledKey || env.OfflineModeEnv.BooleanSetting() {
+	if key == phonehome.DisabledKey || env.OfflineModeEnv.BooleanSetting() {
 		return nil, nil, nil
 	}
 
-	if cfgURL := env.TelemetryConfigURL.Setting(); toDownload(version.IsReleaseVersion(), key, cfgURL) {
-		remoteCfg, err := downloadConfig(cfgURL)
+	if cfgURL := env.TelemetryConfigURL.Setting(); phonehome.ToDownload(version.IsReleaseVersion(), key, cfgURL) {
+		remoteCfg, err := phonehome.DownloadConfig(cfgURL)
 		if err != nil {
 			return nil, nil, err
 		}
-		if useRemoteKey(version.IsReleaseVersion(), remoteCfg, key) {
+		if phonehome.UseRemoteKey(version.IsReleaseVersion(), remoteCfg, key) {
 			key = remoteCfg.Key
 			log.Info("Telemetry configuration has been downloaded from ", cfgURL)
 		}
 	}
 
 	// The downloaded key can be empty or 'DISABLED', so check again here.
-	if key == "" || key == disabledKey {
+	if key == "" || key == phonehome.DisabledKey {
 		return nil, nil, nil
 	}
 

--- a/operator/pkg/central/values/translation/translation.go
+++ b/operator/pkg/central/values/translation/translation.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/operator/pkg/central/extensions"
 	"github.com/stackrox/rox/operator/pkg/values/translation"
 	helmUtil "github.com/stackrox/rox/pkg/helm/util"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/version"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -26,8 +27,6 @@ import (
 var (
 	//go:embed base-values.yaml
 	baseValuesYAML []byte
-
-	disabledTelemetryKey = "DISABLED"
 )
 
 const (
@@ -306,7 +305,7 @@ func getTelemetryValues(t *platform.Telemetry) *translation.ValuesBuilder {
 		tv := translation.NewValuesBuilder()
 		tv.SetBoolValue("enabled", false)
 		storage := translation.NewValuesBuilder()
-		storage.SetString("key", &disabledTelemetryKey)
+		storage.SetString("key", pointer.String(phonehome.DisabledKey))
 		tv.AddChild("storage", &storage)
 		return &tv
 	} else if t != nil && t.Storage != nil {

--- a/operator/pkg/central/values/translation/translation_test.go
+++ b/operator/pkg/central/values/translation/translation_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/operator/pkg/central/extensions"
 	"github.com/stackrox/rox/operator/pkg/values/translation"
 	"github.com/stackrox/rox/pkg/buildinfo"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 	"github.com/stackrox/rox/pkg/version/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,7 +48,7 @@ func TestTranslate(t *testing.T) {
 	telemetryKey := "key"
 	telemetryDisabledKey := map[string]interface{}{
 		"enabled": false,
-		"storage": map[string]interface{}{"key": disabledTelemetryKey}}
+		"storage": map[string]interface{}{"key": phonehome.DisabledKey}}
 	dirtyVersion := "1.2.3-dirty"
 	releaseVersion := "1.2.3"
 

--- a/pkg/telemetry/phonehome/key_management.go
+++ b/pkg/telemetry/phonehome/key_management.go
@@ -1,0 +1,75 @@
+package phonehome
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/httputil/proxy"
+)
+
+const (
+	// DisabledKey is a key value which disables the telemetry collection.
+	DisabledKey = "DISABLED"
+	// TODO(ROX-17726): Remove hardcoded key.
+	selfManagedKey = "eDd6QP8uWm0jCkAowEvijOPgeqtlulwR"
+)
+
+type remoteConfig struct {
+	Key string `json:"storage_key_v1,omitempty"`
+}
+
+// DownloadConfig downloads the configuration from the provided url.
+func DownloadConfig(u string) (*remoteConfig, error) {
+	if u == "hardcoded" {
+		// TODO(ROX-17726): Use the hardcoded key for now.
+		return &remoteConfig{Key: selfManagedKey}, nil
+	}
+	client := http.Client{
+		Timeout:   5 * time.Second,
+		Transport: proxy.RoundTripper(),
+	}
+	resp, err := client.Get(u)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot download telemetry configuration")
+	}
+	var cfg *remoteConfig
+	err = json.NewDecoder(resp.Body).Decode(&cfg)
+	return cfg, errors.Wrap(err, "cannot decode telemetry configuration")
+}
+
+// ToDownload decides if a configuration with the key need to be downloaded.
+// We want to prevent accidental use of the production key, but still allow
+// developers to test the functionality. So download will only happen for
+// development installations if both a key and an URL are provided. For release
+// versions the key may be empty.
+// See unit tests for the examples.
+func ToDownload(isRelease bool, key, cfgURL string) bool {
+	if cfgURL == "" {
+		return false
+	}
+	if !isRelease {
+		// Development versions must provide a key on top of the URL.
+		return key != ""
+	}
+	return true
+}
+
+// UseRemoteKey decides if the key from the downloaded configuration has to be
+// used.
+// We want to prevent accidental use of the production key, but still allow
+// developers to test the functionality. So the key from the environment
+// has to match the one from the downloaded configuration for development
+// installations.
+// See unit tests for the examples.
+func UseRemoteKey(isRelease bool, cfg *remoteConfig, localKey string) bool {
+	if cfg == nil {
+		return false
+	}
+	if !isRelease {
+		// The key from the environment has to match for development versions.
+		return cfg.Key == localKey
+	}
+	return true
+}

--- a/pkg/telemetry/phonehome/key_management_test.go
+++ b/pkg/telemetry/phonehome/key_management_test.go
@@ -1,10 +1,10 @@
-package centralclient
+package phonehome
 
 import (
 	"testing"
 )
 
-func Test_toDownload(t *testing.T) {
+func Test_ToDownload(t *testing.T) {
 	tests := map[string]struct {
 		release bool
 		key     string
@@ -24,14 +24,14 @@ func Test_toDownload(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			if got := toDownload(tt.release, tt.key, tt.cfgURL); got != tt.download {
+			if got := ToDownload(tt.release, tt.key, tt.cfgURL); got != tt.download {
 				t.Errorf("toDownload() = %v, want %v", got, tt.download)
 			}
 		})
 	}
 }
 
-func Test_useRemoteKey(t *testing.T) {
+func Test_UseRemoteKey(t *testing.T) {
 	tests := map[string]struct {
 		release  bool
 		cfg      *remoteConfig
@@ -53,7 +53,7 @@ func Test_useRemoteKey(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			if got := useRemoteKey(tt.release, tt.cfg, tt.localKey); got != tt.useRemote {
+			if got := UseRemoteKey(tt.release, tt.cfg, tt.localKey); got != tt.useRemote {
 				t.Errorf("useRemoteKey() = %v, want %v", got, tt.useRemote)
 			}
 		})

--- a/pkg/telemetry/phonehome/key_management_test.go
+++ b/pkg/telemetry/phonehome/key_management_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func Test_ToDownload(t *testing.T) {
+func Test_toDownload(t *testing.T) {
 	tests := map[string]struct {
 		release bool
 		key     string
@@ -31,7 +31,7 @@ func Test_ToDownload(t *testing.T) {
 	}
 }
 
-func Test_UseRemoteKey(t *testing.T) {
+func Test_useRemoteKey(t *testing.T) {
 	tests := map[string]struct {
 		release  bool
 		cfg      *remoteConfig

--- a/pkg/telemetry/phonehome/key_management_test.go
+++ b/pkg/telemetry/phonehome/key_management_test.go
@@ -24,7 +24,7 @@ func Test_ToDownload(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			if got := ToDownload(tt.release, tt.key, tt.cfgURL); got != tt.download {
+			if got := toDownload(tt.release, tt.key, tt.cfgURL); got != tt.download {
 				t.Errorf("toDownload() = %v, want %v", got, tt.download)
 			}
 		})
@@ -53,7 +53,7 @@ func Test_UseRemoteKey(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			if got := UseRemoteKey(tt.release, tt.cfg, tt.localKey); got != tt.useRemote {
+			if got := useRemoteKey(tt.release, tt.cfg, tt.localKey); got != tt.useRemote {
 				t.Errorf("useRemoteKey() = %v, want %v", got, tt.useRemote)
 			}
 		})

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/renderer"
 	"github.com/stackrox/rox/pkg/roxctl"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/version"
 	"github.com/stackrox/rox/pkg/zip"
@@ -207,7 +208,7 @@ func updateConfig(config *renderer.Config) error {
 			config.K8sConfig.Telemetry.StorageKey = env.TelemetryStorageKey.Setting()
 			config.K8sConfig.Telemetry.StorageEndpoint = env.TelemetryEndpoint.Setting()
 		} else {
-			config.K8sConfig.Telemetry.StorageKey = "DISABLED"
+			config.K8sConfig.Telemetry.StorageKey = phonehome.DisabledKey
 			config.K8sConfig.Telemetry.Enabled = false
 		}
 	}

--- a/roxctl/central/generate/generate_test.go
+++ b/roxctl/central/generate/generate_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/images/defaults"
 	"github.com/stackrox/rox/pkg/renderer"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 	"github.com/stackrox/rox/pkg/version"
 	"github.com/stackrox/rox/pkg/version/testutils"
 	io2 "github.com/stackrox/rox/roxctl/common/io"
@@ -147,7 +148,7 @@ func TestTelemetryConfiguration(t *testing.T) {
 	releaseVersion := "1.2.3"
 	var disabledInDebug any
 	if !buildinfo.ReleaseBuild || buildinfo.TestBuild {
-		disabledInDebug = "DISABLED"
+		disabledInDebug = phonehome.DisabledKey
 	}
 
 	testCases := []struct {
@@ -157,15 +158,15 @@ func TestTelemetryConfiguration(t *testing.T) {
 		key       string
 		expected  result
 	}{
-		{testName: "test1", version: dirtyVersion, telemetry: true, key: "", expected: result{enabled: false, key: "DISABLED"}},
-		{testName: "test2", version: dirtyVersion, telemetry: false, key: "", expected: result{enabled: false, key: "DISABLED"}},
+		{testName: "test1", version: dirtyVersion, telemetry: true, key: "", expected: result{enabled: false, key: phonehome.DisabledKey}},
+		{testName: "test2", version: dirtyVersion, telemetry: false, key: "", expected: result{enabled: false, key: phonehome.DisabledKey}},
 		{testName: "test3", version: dirtyVersion, telemetry: true, key: "KEY", expected: result{enabled: true, key: "KEY"}},
-		{testName: "test4", version: dirtyVersion, telemetry: false, key: "KEY", expected: result{enabled: false, key: "DISABLED"}},
+		{testName: "test4", version: dirtyVersion, telemetry: false, key: "KEY", expected: result{enabled: false, key: phonehome.DisabledKey}},
 
 		{testName: "test5", version: releaseVersion, telemetry: true, key: "", expected: result{enabled: buildinfo.ReleaseBuild && !buildinfo.TestBuild, key: disabledInDebug}},
-		{testName: "test6", version: releaseVersion, telemetry: false, key: "", expected: result{enabled: false, key: "DISABLED"}},
+		{testName: "test6", version: releaseVersion, telemetry: false, key: "", expected: result{enabled: false, key: phonehome.DisabledKey}},
 		{testName: "test7", version: releaseVersion, telemetry: true, key: "KEY", expected: result{enabled: true, key: "KEY"}},
-		{testName: "test8", version: releaseVersion, telemetry: false, key: "KEY", expected: result{enabled: false, key: "DISABLED"}},
+		{testName: "test8", version: releaseVersion, telemetry: false, key: "KEY", expected: result{enabled: false, key: phonehome.DisabledKey}},
 	}
 
 	logio, _, _, _ := io2.TestIO()


### PR DESCRIPTION
## Description

Moved the storage key download logic from `central/telemetry/centralclient/instance_config.go` to `pkg/telemetry/phonehome/key_management.go`, update references.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Unit tests.