### PR TITLE
fix: new fetch option for images enriched via roxctl

### DIFF
--- a/central/detection/service/service_impl.go
+++ b/central/detection/service/service_impl.go
@@ -424,7 +424,7 @@ func getFetchOptionFromRequest(request interface {
 		return enricher.NoExternalMetadata, nil
 	}
 	if request.GetForce() {
-		return enricher.ForceRefetch, nil
+		return enricher.UseImageNamesRefetchCachedValues, nil
 	}
 	return enricher.UseCachesIfPossible, nil
 }

--- a/central/detection/service/service_impl_test.go
+++ b/central/detection/service/service_impl_test.go
@@ -664,7 +664,7 @@ func TestFetchOptionFromRequest(t *testing.T) {
 		},
 		"force set and no external metadata should result in ForceRefetch": {
 			req:         &v1.BuildDetectionRequest{Force: true},
-			fetchOption: enricher.ForceRefetch,
+			fetchOption: enricher.UseImageNamesRefetchCachedValues,
 		},
 		"both force and no external metadata set should result in an error": {
 			req:         &v1.BuildDetectionRequest{NoExternalMetadata: true, Force: true},

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -301,7 +301,7 @@ func (s *serviceImpl) ScanImage(ctx context.Context, request *v1.ScanImageReques
 		Delegable: true,
 	}
 	if request.GetForce() {
-		enrichmentCtx.FetchOpt = enricher.ForceRefetch
+		enrichmentCtx.FetchOpt = enricher.UseImageNamesRefetchCachedValues
 	}
 	img, err := enricher.EnrichImageByName(ctx, s.enricher, enrichmentCtx, request.GetImageName())
 	if err != nil {

--- a/pkg/images/enricher/enricher.go
+++ b/pkg/images/enricher/enricher.go
@@ -35,6 +35,7 @@ const (
 	ForceRefetchScansOnly
 	ForceRefetchSignaturesOnly
 	ForceRefetchCachedValuesOnly
+	UseImageNamesRefetchCachedValues
 )
 
 // forceRefetchCachedValues implies whether the cached values within the database should be skipped and refetched.

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/images/integration"
 	"github.com/stackrox/rox/pkg/images/integration/mocks"
+	imgTypes "github.com/stackrox/rox/pkg/images/types"
+	"github.com/stackrox/rox/pkg/images/utils"
 	reporterMocks "github.com/stackrox/rox/pkg/integrationhealth/mocks"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	registryMocks "github.com/stackrox/rox/pkg/registries/mocks"
@@ -1196,4 +1198,29 @@ func TestEnrichImage_Delegate(t *testing.T) {
 		assert.True(t, result.ImageUpdated)
 		assert.NoError(t, err)
 	})
+}
+
+func TestFetchFromDatabase_ForceFetch(t *testing.T) {
+	cimg, err := utils.GenerateImageFromString("docker.io/test")
+	require.NoError(t, err)
+	img := imgTypes.ToImage(cimg)
+	img.Id = "some-SHA-for-testing"
+
+	secondImageName, _, err := utils.GenerateImageNameFromString("docker.io/test2")
+	require.NoError(t, err)
+	e := &enricherImpl{
+		imageGetter: func(ctx context.Context, id string) (*storage.Image, bool, error) {
+			img.Signature = &storage.ImageSignature{Signatures: []*storage.Signature{createSignature("test", "test")}}
+			img.SignatureVerificationData = &storage.ImageSignatureVerificationData{Results: []*storage.ImageSignatureVerificationResult{
+				createSignatureVerificationResult("test", storage.ImageSignatureVerificationResult_VERIFIED)}}
+			img.Names = append(img.Names, secondImageName)
+			return img, true, nil
+		},
+	}
+	imgFetchedFromDB, exists := e.fetchFromDatabase(context.Background(), img, UseImageNamesRefetchCachedValues)
+	assert.False(t, exists)
+	assert.Equal(t, img.GetName(), imgFetchedFromDB.GetName())
+	assert.ElementsMatch(t, img.GetNames(), imgFetchedFromDB.GetNames())
+	assert.Nil(t, img.GetSignature())
+	assert.Nil(t, img.GetSignatureVerificationData())
 }

--- a/pkg/signatures/public_key_verifier.go
+++ b/pkg/signatures/public_key_verifier.go
@@ -132,11 +132,8 @@ func verifyImageSignatures(ctx context.Context, signatures []oci.Signature, imag
 		// as well as the claims.
 		_, err := cosign.VerifyImageSignature(ctx, signature, imageHash, &cosignOpts)
 
-		// Short circuit on the first public key that successfully verified the signature, since they are bundled
-		// within a single signature integration.
 		if err == nil {
 			verifiedImageReferences, err = getVerifiedImageReference(signature, image)
-			return verifiedImageReferences, err
 		}
 		verificationErrors = multierror.Append(verificationErrors, err)
 	}

--- a/pkg/signatures/public_key_verifier.go
+++ b/pkg/signatures/public_key_verifier.go
@@ -132,10 +132,14 @@ func verifyImageSignatures(ctx context.Context, signatures []oci.Signature, imag
 		// as well as the claims.
 		_, err := cosign.VerifyImageSignature(ctx, signature, imageHash, &cosignOpts)
 
-		if err == nil {
-			verifiedImageReferences, err = getVerifiedImageReference(signature, image)
+		if err != nil {
+			verificationErrors = multierror.Append(verificationErrors, err)
+			continue
 		}
-		verificationErrors = multierror.Append(verificationErrors, err)
+
+		if verifiedImageReferences, err = getVerifiedImageReference(signature, image); err != nil {
+			verificationErrors = multierror.Append(verificationErrors, err)
+		}
 	}
 	return verifiedImageReferences, verificationErrors
 }


### PR DESCRIPTION
## Description

Currently when trying to make use of the `image.Names` field (i.e. when having an image with the same digest across either multiple repositories or different tags) then it currently isn't possible to receive valid signatures and signature verification results.

While it is possible to upsert both images within Central's database, it won't be possible to trigger a re-fetching of signatures and signature verification by passing the `--force` flag.

When the `--force` flag is passed, the `Names` field will be overwritten and upserted within Central. This is due to the fact that we do not attempt to fetch the previously existing `Names` due to the `ForceRefetch` option within the enrichment context.

For other consumers of the image enricher such as the reprocessing loop or the "internal scan flow" (i.e. via the `ScanImageInternal` API of the image service) this hasn't really been an issue. Within the internal scan flow, typically the `UseCachesIfPossible` option will be used. For the reprocessing loop, the previously existing image will be fetched from the database outside of the enricher context, hence `ForceRefetch` won't actually reset the `Names` field.

For other APIs that construct an image based on a given name (i.e. they do not receive a "full" image object) such as the detection service and the image scan's `ScanImage` API, this currently leads to a complete overwrite of the stored image.

To counter this, a new fetch option for those particular APIs was created. When this fetch option is used, it will be attempted to fetch the image within Central's DB, if it exists, and only the `Names` field will be taken into account. Hence, it won't be reset as previously and retained.

The reason for a new fetch option was to not decrease the performance of existing usages of `ForceRefetch`. If the behavior of e.g. `ForceRefetch` or `ForceRefetchCachedValuesOnly` was changed, then images would be potentially pulled twice from Central's database (such as within the reprocessing loop). 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI passing.

Manual tests:


