### PR TITLE
ROX-17687: Operator PSP recovery

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -49,7 +49,7 @@ jobs:
     - name: Go Integration Unit Tests
       run: ${{ matrix.gotags }} make integration-unit-tests
 
-    - name: Go Operator Integration Unit Tests
+    - name: Go Operator Integration Tests
       run: ${{ matrix.gotags }} make -C operator/ test-integration
 
     - name: Generate junit report

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -49,6 +49,9 @@ jobs:
     - name: Go Integration Unit Tests
       run: ${{ matrix.gotags }} make integration-unit-tests
 
+    - name: Go Operator Integration Unit Tests
+      run: ${{ matrix.gotags }} make -C operator/ test-integration
+
     - name: Generate junit report
       if: always()
       run: make generate-junit-reports

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SILENT ?= @
 # UNIT_TEST_IGNORE ignores a set of file patterns from the unit test make command.
 # the pattern is passed to: grep -Ev
 #  usage: "path/to/ignored|another/path"
-UNIT_TEST_IGNORE := "stackrox/rox/sensor/tests"
+UNIT_TEST_IGNORE := "stackrox/rox/sensor/tests|stackrox/rox/operator/tests"
 
 ifeq ($(TAG),)
 TAG=$(shell git describe --tags --abbrev=10 --dirty --long --exclude '*-nightly-*')

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/georgysavva/scany v1.2.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.4
+	github.com/go-logr/zapr v1.2.3
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/gogo/protobuf v1.3.2
@@ -55,6 +56,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.3
 	github.com/heimdalr/dag v1.2.1
+	github.com/helm/helm-mapkubeapis v0.4.1
 	github.com/heroku/docker-registry-client v0.0.0
 	github.com/jackc/pgconn v1.14.0
 	github.com/jackc/pgproto3/v2 v2.3.2
@@ -71,6 +73,8 @@ require (
 	github.com/np-guard/netpol-analyzer v0.2.2
 	github.com/nxadm/tail v1.4.8
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/onsi/ginkgo/v2 v2.11.0
+	github.com/onsi/gomega v1.27.8
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/openshift/api v0.0.0-20230502160752-c71432710382
 	github.com/openshift/client-go v0.0.0-20230120202327-72f107311084
@@ -125,6 +129,7 @@ require (
 	gorm.io/gorm v1.25.1
 	helm.sh/helm/v3 v3.11.3
 	k8s.io/api v0.26.6
+	k8s.io/apiextensions-apiserver v0.26.2
 	k8s.io/apimachinery v0.27.3
 	k8s.io/apiserver v0.26.6
 	k8s.io/cli-runtime v0.26.6
@@ -202,7 +207,6 @@ require (
 	github.com/go-gorp/gorp/v3 v3.0.5 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/analysis v0.21.4 // indirect
 	github.com/go-openapi/errors v0.20.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
@@ -216,6 +220,7 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.14.0 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gobuffalo/flect v1.0.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/glog v1.1.0 // indirect
@@ -224,6 +229,7 @@ require (
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/pprof v0.0.0-20221103000818-d260c55eee4c // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/trillian v1.5.2 // indirect
@@ -366,7 +372,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/apiextensions-apiserver v0.26.2 // indirect
 	k8s.io/component-base v0.26.6 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect

--- a/go.sum
+++ b/go.sum
@@ -517,8 +517,9 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-toolsmith/astcast v1.0.0/go.mod h1:mt2OdQTeAQcY4DQgPSArJjHCcOwlX+Wl/kwN+LbLGQ4=
@@ -705,6 +706,7 @@ github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20221103000818-d260c55eee4c h1:lvddKcYTQ545ADhBujtIJmqQrZBDsGo7XIMbAQe/sNY=
+github.com/google/pprof v0.0.0-20221103000818-d260c55eee4c/go.mod h1:dDKJzRmX4S37WGHujM7tX//fmj1uioxKzKxz3lo4HJo=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.4 h1:1kZ/sQM3srePvKs3tXAvQzo66XfcReoqFpIpIccE7Oc=
 github.com/google/s2a-go v0.1.4/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
@@ -802,6 +804,8 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hashicorp/vault/api v1.9.1 h1:LtY/I16+5jVGU8rufyyAkwopgq/HpUnxFBg+QLOAV38=
 github.com/heimdalr/dag v1.2.1 h1:XJOMaoWqJK1UKdp+4zaO2uwav9GFbHMGCirdViKMRIQ=
 github.com/heimdalr/dag v1.2.1/go.mod h1:Of/wUB7Yoj4dwiOcGOOYIq6MHlPF/8/QMBKFJpwg+yc=
+github.com/helm/helm-mapkubeapis v0.4.1 h1:Xu03dMzVv/zqp+Vw1+2ZHufnDQRqoGa8Ml4N/GBgqME=
+github.com/helm/helm-mapkubeapis v0.4.1/go.mod h1:o2qnBCfz2cbUod9QlbPjjXtsQI/X7QQjwU/rk7m1T2M=
 github.com/honeycombio/beeline-go v1.10.0 h1:cUDe555oqvw8oD76BQJ8alk7FP0JZ/M/zXpNvOEDLDc=
 github.com/honeycombio/libhoney-go v1.16.0 h1:kPpqoz6vbOzgp7jC6SR7SkNj7rua7rgxvznI6M3KdHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -1194,14 +1198,16 @@ github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vv
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
-github.com/onsi/ginkgo/v2 v2.9.1 h1:zie5Ly042PD3bsCvsSOPvRnFwyo3rKe64TJlD6nu0mk=
+github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU=
+github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
+github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
+github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJKFnNQ=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -62,8 +62,10 @@ ARG roxpath
 
 ARG ROX_IMAGE_FLAVOR
 ENV ROX_IMAGE_FLAVOR=${ROX_IMAGE_FLAVOR}
+ENV OPERATOR_CONFIG_DIR=/etc/operator
 
 COPY --from=builder ${roxpath}/stackrox-operator /usr/local/bin/
+COPY --from=builder ${roxpath}/operator/config/mapkubeapis ${OPERATOR_CONFIG_DIR}/mapkubeapis
 
 # The following are numeric uid and gid of `nobody` user in UBI.
 # We can't use symbolic names because otherwise k8s will fail to start the pod with an error like this:

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -62,10 +62,10 @@ ARG roxpath
 
 ARG ROX_IMAGE_FLAVOR
 ENV ROX_IMAGE_FLAVOR=${ROX_IMAGE_FLAVOR}
-ENV OPERATOR_CONFIG_DIR=/etc/operator
+ENV MAPKUBEAPIS_MAPFILE=/etc/operator/mapkubeapis/Map.yaml
 
 COPY --from=builder ${roxpath}/stackrox-operator /usr/local/bin/
-COPY --from=builder ${roxpath}/operator/config/mapkubeapis ${OPERATOR_CONFIG_DIR}/mapkubeapis
+COPY --from=builder ${roxpath}/operator/config/mapkubeapis/Map.yaml ${MAPKUBEAPIS_MAPFILE}
 
 # The following are numeric uid and gid of `nobody` user in UBI.
 # We can't use symbolic names because otherwise k8s will fail to start the pod with an error like this:

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -212,10 +212,10 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.24
+ENVTEST_K8S_VERSION = 1.25
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
+test: manifests generate fmt vet envtest mapkubeapis ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
 .PHONY: validate-crs
@@ -290,7 +290,7 @@ build/Dockerfile.gen: Dockerfile
 	sed -e 's,$${ROX_IMAGE_FLAVOR},$(ROX_IMAGE_FLAVOR),g; s,$${BUILD_IMAGE_VERSION},$(shell sed 's/\s*\#.*//' ../BUILD_IMAGE_VERSION),' < $< > $@
 
 .PHONY: docker-build
-docker-build: build/Dockerfile.gen test smuggled-status-sh ## Build docker image with the operator.
+docker-build: build/Dockerfile.gen test smuggled-status-sh mapkubeapis ## Build docker image with the operator.
 	DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain docker build \
 		-t ${IMG} \
 		-f $< \
@@ -457,3 +457,17 @@ docker-push-bundle: ## Push docker image with the bundle.
 .PHONY: docker-push-index
 docker-push-index: ## Push docker image with the index.
 	docker push "$(INDEX_IMG)"
+
+##@ Mapkubeapis
+
+MAPKUBEAPIS_SOURCE_DIR = $(shell cd $(PROJECT_DIR)/..; go list -m -f '{{ .Dir }}' github.com/helm/helm-mapkubeapis)
+ifeq (, $(MAPKUBEAPIS_SOURCE_DIR))
+	MAPKUBEAPIS_SOURCE_DIR = $(shell cd $(PROJECT_DIR)/..; go mod download github.com/helm/helm-mapkubeapis; go list -m -f '{{ .Dir }}' github.com/helm/helm-mapkubeapis)
+endif
+
+config/mapkubeapis/Map.yaml: $(MAPKUBEAPIS_SOURCE_DIR)/config/Map.yaml
+	$(SILENT)mkdir -p $(PROJECT_DIR)/config/mapkubeapis
+	$(SILENT)cp -pf $(MAPKUBEAPIS_SOURCE_DIR)/config/Map.yaml $(PROJECT_DIR)/$@
+
+.PHONY: mapkubeapis
+mapkubeapis: config/mapkubeapis/Map.yaml

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -215,8 +215,11 @@ vet: ## Run go vet against code.
 ENVTEST_K8S_VERSION = 1.25
 
 .PHONY: test
-test: manifests generate fmt vet envtest mapkubeapis ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+test: manifests generate fmt vet  ## Run go unit tests
+	go test $(shell go list ./... | grep -v '^github.com/stackrox/rox/operator/tests') -coverprofile cover.out
+
+test-integration: manifests generate envtest mapkubeapis ## Run go integration tests
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./tests/...
 
 .PHONY: validate-crs
 CRDS := centrals.platform.stackrox.io securedclusters.platform.stackrox.io

--- a/operator/config/.gitignore
+++ b/operator/config/.gitignore
@@ -1,1 +1,2 @@
 /local-deploy-versioned/
+/mapkubeapis/

--- a/operator/main.go
+++ b/operator/main.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-logr/zapr"
 	"github.com/pkg/errors"
 	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	centralReconciler "github.com/stackrox/rox/operator/pkg/central/reconciler"
@@ -34,6 +35,8 @@ import (
 	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/profiling"
 	"github.com/stackrox/rox/pkg/version"
+	rawZap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -100,7 +103,13 @@ func run() error {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	zapLogger := zap.NewRaw(zap.UseFlagOptions(&opts))
+	ctrl.SetLogger(zapr.NewLogger(zapLogger))
+	restore, err := rawZap.RedirectStdLogAt(zapLogger, zapcore.DebugLevel)
+	if err != nil {
+		return errors.Wrap(err, "unable to redirect std log")
+	}
+	defer restore()
 
 	mgr, err := ctrl.NewManager(utils.GetRHACSConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/operator/pkg/central/reconciler/reconciler.go
+++ b/operator/pkg/central/reconciler/reconciler.go
@@ -42,6 +42,7 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 		pkgReconciler.WithPreExtension(proxy.ReconcileProxySecretExtension(mgr.GetClient(), proxyEnv)),
 		pkgReconciler.WithPreExtension(commonExtensions.CheckForbiddenNamespacesExtension(commonExtensions.IsSystemNamespace)),
 		pkgReconciler.WithPreExtension(commonExtensions.ReconcileProductVersionStatusExtension(version.GetMainVersion())),
+		pkgReconciler.WithPreExtension(commonExtensions.MapKubeAPIsExtension()),
 		pkgReconciler.WithReconcilePeriod(extensions.InitBundleReconcilePeriod),
 		pkgReconciler.WithPauseReconcileAnnotation(pauseReconcileAnnotation),
 	}

--- a/operator/pkg/central/reconciler/reconciler.go
+++ b/operator/pkg/central/reconciler/reconciler.go
@@ -42,7 +42,6 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 		pkgReconciler.WithPreExtension(proxy.ReconcileProxySecretExtension(mgr.GetClient(), proxyEnv)),
 		pkgReconciler.WithPreExtension(commonExtensions.CheckForbiddenNamespacesExtension(commonExtensions.IsSystemNamespace)),
 		pkgReconciler.WithPreExtension(commonExtensions.ReconcileProductVersionStatusExtension(version.GetMainVersion())),
-		pkgReconciler.WithPreExtension(commonExtensions.MapKubeAPIsExtension()),
 		pkgReconciler.WithReconcilePeriod(extensions.InitBundleReconcilePeriod),
 		pkgReconciler.WithPauseReconcileAnnotation(pauseReconcileAnnotation),
 	}
@@ -51,6 +50,8 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 	if err != nil {
 		return err
 	}
+
+	opts = commonExtensions.AddMapKubeAPIsExtensionIfMapFileExists(opts)
 
 	return reconciler.SetupReconcilerWithManager(
 		mgr, platform.CentralGVK, image.CentralServicesChartPrefix,

--- a/operator/pkg/common/extensions/mapkubeapis.go
+++ b/operator/pkg/common/extensions/mapkubeapis.go
@@ -1,0 +1,78 @@
+package extensions
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/go-logr/logr"
+	mapkubeapisCommon "github.com/helm/helm-mapkubeapis/pkg/common"
+	mapkubeapisV3 "github.com/helm/helm-mapkubeapis/pkg/v3"
+	"github.com/operator-framework/helm-operator-plugins/pkg/extensions"
+	"github.com/pkg/errors"
+	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	"helm.sh/helm/v3/pkg/storage/driver"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// MapKubeAPIsExtensionConfig extension configuration
+type MapKubeAPIsExtensionConfig struct {
+	KubeConfig mapkubeapisCommon.KubeConfig
+	MapFile    string
+}
+
+// MapKubeAPIsExtension checks the latest release version for any deprecated or removed APIs and performs
+// // the cleanup using helm mapkubeapis extension
+func MapKubeAPIsExtension() extensions.ReconcileExtension {
+	configDir := os.Getenv("OPERATOR_CONFIG_DIR")
+	if configDir == "" {
+		configDir = "config"
+	}
+	config := MapKubeAPIsExtensionConfig{
+		MapFile: filepath.Join(configDir, "mapkubeapis", "Map.yaml"),
+	}
+	return MapKubeAPIsExtensionWithConfig(config)
+}
+
+// MapKubeAPIsExtensionWithConfig checks the latest release version for any deprecated or removed APIs and performs
+// the cleanup using helm mapkubeapis extension
+func MapKubeAPIsExtensionWithConfig(config MapKubeAPIsExtensionConfig) extensions.ReconcileExtension {
+	return func(ctx context.Context, obj *unstructured.Unstructured, statusUpdater func(statusFunc extensions.UpdateStatusFunc), log logr.Logger) error {
+		run := &mapKubeAPIsExtensionRun{
+			ctx:           ctx,
+			obj:           obj,
+			statusUpdater: statusUpdater,
+			log:           log,
+			config:        config,
+		}
+		return run.Execute()
+	}
+}
+
+type mapKubeAPIsExtensionRun struct {
+	ctx           context.Context
+	obj           *unstructured.Unstructured
+	conditions    *[]platform.StackRoxCondition
+	statusUpdater func(statusFunc extensions.UpdateStatusFunc)
+	log           logr.Logger
+	config        MapKubeAPIsExtensionConfig
+}
+
+func (r *mapKubeAPIsExtensionRun) Execute() error {
+	mapOptions := mapkubeapisCommon.MapOptions{
+		ReleaseName:      r.obj.GetName(),
+		ReleaseNamespace: r.obj.GetNamespace(),
+		MapFile:          r.config.MapFile,
+		KubeConfig:       r.config.KubeConfig,
+	}
+
+	if err := mapkubeapisV3.MapReleaseWithUnSupportedAPIs(mapOptions); err != nil {
+		if errors.Is(err, driver.ErrReleaseNotFound) {
+			r.log.V(1).Info("release not found, most likely it is not installed yet", "namespace", r.obj.GetNamespace(), "name", r.obj.GetName())
+		} else {
+			r.log.Error(err, "mapkubeapis run", "namespace", r.obj.GetNamespace(), "name", r.obj.GetName())
+		}
+	}
+
+	return nil
+}

--- a/operator/pkg/securedcluster/reconciler/reconciler.go
+++ b/operator/pkg/securedcluster/reconciler/reconciler.go
@@ -18,10 +18,8 @@ import (
 // RegisterNewReconciler registers a new helm reconciler in the given k8s controller manager
 func RegisterNewReconciler(mgr ctrl.Manager) error {
 	proxyEnv := proxy.GetProxyEnvVars() // fix at startup time
-	return reconciler.SetupReconcilerWithManager(
-		mgr, platform.SecuredClusterGVK,
-		image.SecuredClusterServicesChartPrefix,
-		proxy.InjectProxyEnvVars(translation.NewTranslator(mgr.GetClient()), proxyEnv),
+
+	opts := []pkgReconciler.Option{
 		pkgReconciler.WithExtraWatch(
 			&source.Kind{Type: &platform.Central{}},
 			reconciler.HandleSiblings(platform.SecuredClusterGVK, mgr),
@@ -32,7 +30,15 @@ func RegisterNewReconciler(mgr ctrl.Manager) error {
 		pkgReconciler.WithPreExtension(proxy.ReconcileProxySecretExtension(mgr.GetClient(), proxyEnv)),
 		pkgReconciler.WithPreExtension(commonExtensions.CheckForbiddenNamespacesExtension(commonExtensions.IsSystemNamespace)),
 		pkgReconciler.WithPreExtension(commonExtensions.ReconcileProductVersionStatusExtension(version.GetMainVersion())),
-		pkgReconciler.WithPreExtension(commonExtensions.MapKubeAPIsExtension()),
 		pkgReconciler.WithPreExtension(extensions.ReconcileLocalScannerDBPasswordExtension(mgr.GetClient())),
+	}
+
+	opts = commonExtensions.AddMapKubeAPIsExtensionIfMapFileExists(opts)
+
+	return reconciler.SetupReconcilerWithManager(
+		mgr, platform.SecuredClusterGVK,
+		image.SecuredClusterServicesChartPrefix,
+		proxy.InjectProxyEnvVars(translation.NewTranslator(mgr.GetClient()), proxyEnv),
+		opts...,
 	)
 }

--- a/operator/pkg/securedcluster/reconciler/reconciler.go
+++ b/operator/pkg/securedcluster/reconciler/reconciler.go
@@ -32,6 +32,7 @@ func RegisterNewReconciler(mgr ctrl.Manager) error {
 		pkgReconciler.WithPreExtension(proxy.ReconcileProxySecretExtension(mgr.GetClient(), proxyEnv)),
 		pkgReconciler.WithPreExtension(commonExtensions.CheckForbiddenNamespacesExtension(commonExtensions.IsSystemNamespace)),
 		pkgReconciler.WithPreExtension(commonExtensions.ReconcileProductVersionStatusExtension(version.GetMainVersion())),
+		pkgReconciler.WithPreExtension(commonExtensions.MapKubeAPIsExtension()),
 		pkgReconciler.WithPreExtension(extensions.ReconcileLocalScannerDBPasswordExtension(mgr.GetClient())),
 	)
 }

--- a/operator/tests/reconcile/mapkubeapis_test.go
+++ b/operator/tests/reconcile/mapkubeapis_test.go
@@ -1,0 +1,229 @@
+package reconcile
+
+import (
+	"context"
+	"os"
+
+	"github.com/go-logr/logr"
+	mapkubeapisCommon "github.com/helm/helm-mapkubeapis/pkg/common"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	helmClient "github.com/operator-framework/helm-operator-plugins/pkg/client"
+	"github.com/operator-framework/helm-operator-plugins/pkg/reconciler"
+	"github.com/pkg/errors"
+	commonExtensions "github.com/stackrox/rox/operator/pkg/common/extensions"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const mapFile = "../../config/mapkubeapis/Map.yaml"
+
+var (
+	pspTemplate = `apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: stackrox-psp
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+    - 'hostPath'
+
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 4000
+        max: 4000
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 4000
+        max: 4000
+`
+	chartWithPSP = chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "stackrox-test",
+			Version:    "0.1.0-alpha.1",
+			AppVersion: "1.0",
+		},
+		Templates: []*chart.File{
+			{Name: "templates/psp.tpl", Data: []byte(pspTemplate)},
+		},
+	}
+	chartWithoutPSP = chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       "stackrox-test",
+			Version:    "0.1.0-beta.2",
+			AppVersion: "1.1",
+		},
+		Templates: []*chart.File{},
+	}
+)
+
+var _ = Describe("MapKubeAPIsExtension", func() {
+	Describe("Execute", func() {
+		When("Upgrading the cluster with an existing release", func() {
+			var (
+				obj    *unstructured.Unstructured
+				objKey types.NamespacedName
+				req    reconcile.Request
+
+				mgr    manager.Manager
+				ctx    context.Context
+				cancel context.CancelFunc
+
+				ac                 helmClient.ActionInterface
+				actionClientGetter helmClient.ActionClientGetter
+				store              *storage.Storage
+			)
+
+			BeforeEach(func() {
+				mgr = getManagerOrFail()
+				ctx, cancel = context.WithCancel(context.Background())
+				go func() { Expect(mgr.GetCache().Start(ctx)) }()
+				Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+
+				obj = BuildTestCR(gvk)
+				objKey = types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+				req = reconcile.Request{NamespacedName: objKey}
+				Expect(mgr.GetClient().Create(ctx, obj)).To(Succeed())
+
+				actionConfigGetter, err := helmClient.NewActionConfigGetter(mgr.GetConfig(), mgr.GetRESTMapper(), logr.Discard())
+				Expect(err).NotTo(HaveOccurred())
+				acfg, err := actionConfigGetter.ActionConfigFor(obj)
+				Expect(err).NotTo(HaveOccurred())
+				store = acfg.Releases
+				actionClientGetter, err := helmClient.NewActionClientGetter(actionConfigGetter)
+				Expect(err).NotTo(HaveOccurred())
+				ac, err = actionClientGetter.ActionClientFor(obj)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			installWithPSP := func() {
+				install := action.NewInstall(&action.Configuration{
+					Releases: store,
+				})
+				install.ClientOnly = true
+				install.ReleaseName = obj.GetName()
+				install.Namespace = obj.GetNamespace()
+				rel, err := install.Run(&chartWithPSP, map[string]interface{}{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(store.Create(rel)).To(Succeed())
+			}
+
+			When("PSP is not supported on the new cluster", func() {
+				BeforeEach(func() {
+					_, err := mgr.GetRESTMapper().ResourceFor(schema.GroupVersionResource{
+						Group:    "policy",
+						Version:  "v1beta1",
+						Resource: "podsecuritypolicies",
+					})
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("should recover after the release is installed", func() {
+					installWithPSP()
+					r := newReconciler(chartWithoutPSP, actionClientGetter, mgr)
+					result, err := r.Reconcile(ctx, req)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).NotTo(BeNil())
+				})
+			})
+
+			AfterEach(func() {
+				By("ensuring the release is uninstalled", func() {
+					if _, err := ac.Get(obj.GetName()); errors.Is(err, driver.ErrReleaseNotFound) {
+						return
+					}
+					_, err := ac.Uninstall(obj.GetName())
+					if err != nil {
+						panic(err)
+					}
+				})
+
+				By("ensuring the CR is deleted", func() {
+					err := mgr.GetAPIReader().Get(ctx, objKey, obj)
+					if apiErrors.IsNotFound(err) {
+						return
+					}
+					Expect(err).NotTo(HaveOccurred())
+					obj.SetFinalizers([]string{})
+					Expect(mgr.GetClient().Update(ctx, obj)).To(Succeed())
+					err = mgr.GetClient().Delete(ctx, obj)
+					if apiErrors.IsNotFound(err) {
+						return
+					}
+					Expect(err).NotTo(HaveOccurred())
+				})
+				cancel()
+			})
+		})
+	})
+
+})
+
+func newReconciler(chrt chart.Chart, actionClientGetter helmClient.ActionClientGetter, mgr manager.Manager) *reconciler.Reconciler {
+	r, err := reconciler.New(
+		reconciler.WithChart(chrt),
+		reconciler.WithGroupVersionKind(gvk),
+		reconciler.WithActionClientGetter(actionClientGetter),
+		reconciler.WithPreExtension(commonExtensions.MapKubeAPIsExtensionWithConfig(commonExtensions.MapKubeAPIsExtensionConfig{
+			KubeConfig: getKubeConfig(),
+			MapFile:    mapFile,
+		})),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(r.SetupWithManager(mgr)).To(Succeed())
+	return r
+}
+
+func getManagerOrFail() manager.Manager {
+	mgr, err := manager.New(cfg, manager.Options{
+		MetricsBindAddress: "0",
+	})
+	Expect(err).NotTo(HaveOccurred())
+	return mgr
+}
+
+func getKubeConfig() mapkubeapisCommon.KubeConfig {
+	user, err := testEnv.AddUser(envtest.User{Name: "test", Groups: []string{"system:masters"}}, &rest.Config{})
+	Expect(err).NotTo(HaveOccurred())
+
+	// cleaning this up is handled when our tmpDir is deleted
+	out, err := os.CreateTemp(testEnv.ControlPlane.APIServer.CertDir, "*.kubecfg")
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		_ = out.Close()
+	}()
+	contents, err := user.KubeConfig()
+	Expect(err).NotTo(HaveOccurred())
+	_, err = out.Write(contents)
+	Expect(err).NotTo(HaveOccurred())
+
+	return mapkubeapisCommon.KubeConfig{
+		File: out.Name(),
+	}
+}

--- a/operator/tests/reconcile/mapkubeapis_test.go
+++ b/operator/tests/reconcile/mapkubeapis_test.go
@@ -190,7 +190,7 @@ func newReconciler(chrt chart.Chart, actionClientGetter helmClient.ActionClientG
 		reconciler.WithChart(chrt),
 		reconciler.WithGroupVersionKind(gvk),
 		reconciler.WithActionClientGetter(actionClientGetter),
-		reconciler.WithPreExtension(commonExtensions.MapKubeAPIsExtensionWithConfig(commonExtensions.MapKubeAPIsExtensionConfig{
+		reconciler.WithPreExtension(commonExtensions.MapKubeAPIsExtension(commonExtensions.MapKubeAPIsExtensionConfig{
 			KubeConfig: getKubeConfig(),
 			MapFile:    mapFile,
 		})),

--- a/operator/tests/reconcile/reconcile_suite_test.go
+++ b/operator/tests/reconcile/reconcile_suite_test.go
@@ -1,0 +1,103 @@
+package reconcile
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	testEnv *envtest.Environment
+	cfg     *rest.Config
+	gvk     = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "TestApp"}
+)
+
+func TestReconcileExtensions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Reconcile Extensions Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	testEnv = &envtest.Environment{
+		AttachControlPlaneOutput: false, // set to true to see kube-apiserver and etcd logs
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+
+	crd := BuildTestCRD(gvk)
+	_, err = envtest.InstallCRDs(cfg, envtest.CRDInstallOptions{CRDs: []*apiextv1.CustomResourceDefinition{&crd}})
+	Expect(err).To(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	Expect(testEnv.Stop()).To(Succeed())
+})
+
+// BuildTestCRD remove me. Use real stackrox CRDS instead
+func BuildTestCRD(gvk schema.GroupVersionKind) apiextv1.CustomResourceDefinition {
+	trueVal := true
+	singular := strings.ToLower(gvk.Kind)
+	plural := fmt.Sprintf("%ss", singular)
+	return apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s.%s", plural, gvk.Group),
+		},
+		Spec: apiextv1.CustomResourceDefinitionSpec{
+			Group: gvk.Group,
+			Names: apiextv1.CustomResourceDefinitionNames{
+				Kind:     gvk.Kind,
+				ListKind: fmt.Sprintf("%sList", gvk.Kind),
+				Singular: singular,
+				Plural:   plural,
+			},
+			Scope: apiextv1.NamespaceScoped,
+			Versions: []apiextv1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1",
+					Schema: &apiextv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextv1.JSONSchemaProps{
+							Type:                   "object",
+							XPreserveUnknownFields: &trueVal,
+						},
+					},
+					Subresources: &apiextv1.CustomResourceSubresources{
+						Status: &apiextv1.CustomResourceSubresourceStatus{},
+					},
+					Served:  true,
+					Storage: true,
+				},
+			},
+		},
+	}
+}
+
+// BuildTestCR remove me. Use real stackrox CRDS instead
+func BuildTestCR(gvk schema.GroupVersionKind) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{"replicas": 2},
+	}}
+	obj.SetName("test")
+	obj.SetNamespace("default")
+	obj.SetGroupVersionKind(gvk)
+	obj.SetUID("test-uid")
+	obj.SetAnnotations(map[string]string{
+		"helm.sdk.operatorframework.io/install-description":   "test install description",
+		"helm.sdk.operatorframework.io/upgrade-description":   "test upgrade description",
+		"helm.sdk.operatorframework.io/uninstall-description": "test uninstall description",
+	})
+	return obj
+}

--- a/operator/tests/reconcile/reconcile_suite_test.go
+++ b/operator/tests/reconcile/reconcile_suite_test.go
@@ -47,7 +47,7 @@ var _ = AfterSuite(func() {
 	Expect(testEnv.Stop()).To(Succeed())
 })
 
-// BuildTestCRD remove me. Use real stackrox CRDS instead
+// BuildTestCRD builds test CRD
 func BuildTestCRD(gvk schema.GroupVersionKind) apiextv1.CustomResourceDefinition {
 	trueVal := true
 	singular := strings.ToLower(gvk.Kind)
@@ -85,7 +85,7 @@ func BuildTestCRD(gvk schema.GroupVersionKind) apiextv1.CustomResourceDefinition
 	}
 }
 
-// BuildTestCR remove me. Use real stackrox CRDS instead
+// BuildTestCR builds test CR
 func BuildTestCR(gvk schema.GroupVersionKind) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{
 		"spec": map[string]interface{}{"replicas": 2},


### PR DESCRIPTION
## Description

This PR adds the new [mapkubeapis](https://github.com/helm/helm-mapkubeapis) extension to the operator. It checks if there're deprecated or removed objects in the release manifests and performs cleanup before the helm upgrade. This is especially useful when PSPs are removed from the cluster (i.e. by upgrading an OCP cluster to 4.12) and the operator is running a version that does not support PSP autosensing (i.e. 3.69.X).

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed
- Added an integration test.
- Tested the OCP upgrade on an infra cluster. 
