### PR TITLE
ROX-18281: Telemetry - add Flavor to central properties

### DIFF
--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/grpc/client/authn/basic"
+	"github.com/stackrox/rox/pkg/images/defaults"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sync"
@@ -86,6 +87,7 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 			Endpoint:     env.TelemetryEndpoint.Setting(),
 			PushInterval: env.TelemetryFrequency.DurationSetting(),
 		}, map[string]any{
+			"Flavor":             defaults.GetImageFlavorNameFromEnv(),
 			"Central version":    version.GetMainVersion(),
 			"Chart version":      version.GetChartVersion(),
 			"Orchestrator":       orchestrator,

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -87,7 +87,7 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 			Endpoint:     env.TelemetryEndpoint.Setting(),
 			PushInterval: env.TelemetryFrequency.DurationSetting(),
 		}, map[string]any{
-			"Flavor":             defaults.GetImageFlavorNameFromEnv(),
+			"Image Flavor":       defaults.GetImageFlavorNameFromEnv(),
 			"Central version":    version.GetMainVersion(),
 			"Chart version":      version.GetChartVersion(),
 			"Orchestrator":       orchestrator,


### PR DESCRIPTION
## Description

See ROX-18281. The change is to add the previously missing Flavor property to the central backend user.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Local deployment, event seen on Segment:
```json
{
...
    "traits": {
      "Auth Providers": null,
      "Central version": "4.1.x-299-g54326a88f4",
      "Chart version": "400.1.0-299-g54326a88f4",
      "Flavor": "opensource",
      "Kubernetes version": "v1.25.3",
      "Managed": false,
      "Orchestrator": "KUBERNETES_CLUSTER",
...
    }
}
```