### PR TITLE
ROX-18173: Authenticate 'v1/metadata'

### DIFF
--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -31,12 +31,12 @@ import (
 var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
 		user.With(): {
+			"/v1.MetadataService/GetMetadata",
 			"/v1.MetadataService/GetDatabaseStatus",
 			"/v1.MetadataService/GetDatabaseBackupStatus",
 			"/v1.MetadataService/GetCentralCapabilities",
 		},
 		allow.Anonymous(): {
-			"/v1.MetadataService/GetMetadata",
 			"/v1.MetadataService/TLSChallenge",
 		},
 	})

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -36,9 +36,9 @@ var (
 			"/v1.MetadataService/GetDatabaseBackupStatus",
 			"/v1.MetadataService/GetCentralCapabilities",
 		},
-		// When this endpoint was public, Sensor has been relying on it to check
-		// Central's availability. While Sensor might not do so today, we need
-		// to ensure backward compatibility with older Sensors.
+		// When this endpoint was public, Sensor relied on it to check Central's
+		// availability. While Sensor might not do so today, we need to ensure
+		// backward compatibility with older Sensors.
 		or.SensorOrAuthorizer(user.With()): {
 			"/v1.MetadataService/GetMetadata",
 		},

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -13,7 +13,6 @@ import (
 	systemInfoStorage "github.com/stackrox/rox/central/systeminfo/store/postgres"
 	"github.com/stackrox/rox/central/tlsconfig"
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/cryptoutils"
@@ -24,7 +23,6 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/or"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
-	"github.com/stackrox/rox/pkg/grpc/requestinfo"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/version"
@@ -70,39 +68,6 @@ func (s *serviceImpl) RegisterServiceHandler(ctx context.Context, mux *runtime.S
 
 // AuthFuncOverride specifies the auth criteria for this API.
 func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
-	traceF := func() {
-		if fullMethodName == "/v1.MetadataService/GetMetadata" {
-			id, err := authn.IdentityFromContext(ctx)
-			if err != nil {
-				log.Infof(" >>> /metadata is hit but identity can't be extracted: %v", err)
-				return
-			}
-
-			svc := id.Service()
-			if svc == nil {
-				log.Info(" >>> /metadata is hit but service identity is nil")
-				return
-			}
-
-			if svc.GetType() != storage.ServiceType_SENSOR_SERVICE {
-				log.Infof(" >>> /metadata is hit but requester service is %v", svc.GetType())
-			}
-
-			log.Infof(" >>> /metadata is hit by Sensor, id: %v, serialStr: %v", svc.GetId(), svc.GetSerialStr())
-
-			ri := requestinfo.FromContext(ctx)
-			if len(ri.VerifiedChains) != 0 {
-				log.Infof(" >>> top level chain size %d", len(ri.VerifiedChains))
-				if len(ri.VerifiedChains[0]) != 0 {
-					log.Infof(" >>> second level chain size %d", len(ri.VerifiedChains[0]))
-					log.Infof(" >>> leaf cert is '%v'", ri.VerifiedChains[0][0])
-				}
-			}
-		}
-	}
-
-	traceF()
-
 	return ctx, authorizer.Authorized(ctx, fullMethodName)
 }
 

--- a/sensor/common/centralclient/client.go
+++ b/sensor/common/centralclient/client.go
@@ -74,6 +74,10 @@ func NewClient(endpoint string) (*Client, error) {
 	// authentication, it is possible that a user has required client certificate authentication for the
 	// endpoint Sensor is connecting to. Since a client certificate can be used without harm even if the
 	// remote is not trusted, make it available here to be on the safe side.
+	//
+	// Moreover, authentication requirements can be tightened in future and thus having an older version
+	// of Sensor authenticating itself will enable backward compatibility with newer Centrals. This has
+	// indeed happened in the past when `/v1/metadata` became authenticated.
 	clientCert, err := mtls.LeafCertificateFromFile()
 	if err != nil {
 		return nil, errors.Wrap(err, "obtaining client certificate")

--- a/sensor/common/centralclient/client.go
+++ b/sensor/common/centralclient/client.go
@@ -112,8 +112,7 @@ func (c *Client) GetPing(ctx context.Context) (*v1.PongMessage, error) {
 	defer utils.IgnoreError(resp.Body.Close)
 
 	var pong v1.PongMessage
-	err = jsonutil.JSONReaderToProto(resp.Body, &pong)
-	if err != nil {
+	if err := jsonutil.JSONReaderToProto(resp.Body, &pong); err != nil {
 		return nil, errors.Wrapf(err, "parsing Central %s response with status code %d", pingRoute, resp.StatusCode)
 	}
 
@@ -244,7 +243,7 @@ func (c *Client) doHTTPRequest(ctx context.Context, method, route string, params
 
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "creating request for %s", route)
+		return nil, nil, errors.Wrapf(err, "creating request for %s", u.String())
 	}
 
 	req.Header.Set("User-Agent", clientconn.GetUserAgent())
@@ -265,7 +264,7 @@ func (c *Client) doHTTPRequest(ctx context.Context, method, route string, params
 		if err != nil {
 			return nil, peerCertificates, errors.Wrapf(err, "reading response body with HTTP status code '%s'", resp.Status)
 		}
-		return nil, peerCertificates, errors.Errorf("HTTP request %s%s with code '%s', body: %s", c.endpoint, route, resp.Status, body)
+		return nil, peerCertificates, errors.Errorf("HTTP request %s with code '%s', body: %s", u.String(), resp.Status, body)
 	}
 	return resp, peerCertificates, nil
 }

--- a/sensor/common/centralclient/client.go
+++ b/sensor/common/centralclient/client.go
@@ -34,7 +34,7 @@ var (
 const (
 	requestTimeout          = 10 * time.Second
 	tlsChallengeRoute       = "/v1/tls-challenge"
-	metadataRoute           = "/v1/metadata"
+	pingRoute               = "/v1/ping"
 	challengeTokenParamName = "challengeToken"
 )
 
@@ -99,21 +99,21 @@ func NewClient(endpoint string) (*Client, error) {
 	}, nil
 }
 
-// GetMetadata returns Central's metadata
-func (c *Client) GetMetadata(ctx context.Context) (*v1.Metadata, error) {
-	resp, _, err := c.doHTTPRequest(ctx, http.MethodGet, metadataRoute, nil, nil)
+// GetPing pings Central.
+func (c *Client) GetPing(ctx context.Context) (*v1.PongMessage, error) {
+	resp, _, err := c.doHTTPRequest(ctx, http.MethodGet, pingRoute, nil, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "receiving Central metadata")
+		return nil, errors.Wrap(err, "pinging Central")
 	}
 	defer utils.IgnoreError(resp.Body.Close)
 
-	var metadata v1.Metadata
-	err = jsonutil.JSONReaderToProto(resp.Body, &metadata)
+	var pong v1.PongMessage
+	err = jsonutil.JSONReaderToProto(resp.Body, &pong)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing Central %s response with status code %d", metadataRoute, resp.StatusCode)
+		return nil, errors.Wrapf(err, "parsing Central %s response with status code %d", pingRoute, resp.StatusCode)
 	}
 
-	return &metadata, nil
+	return &pong, nil
 }
 
 // GetTLSTrustedCerts returns all certificates which are trusted by Central and its leaf certificates.
@@ -240,7 +240,7 @@ func (c *Client) doHTTPRequest(ctx context.Context, method, route string, params
 
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "creating tls-challenge request")
+		return nil, nil, errors.Wrapf(err, "creating request for %s", route)
 	}
 
 	req.Header.Set("User-Agent", clientconn.GetUserAgent())
@@ -261,7 +261,7 @@ func (c *Client) doHTTPRequest(ctx context.Context, method, route string, params
 		if err != nil {
 			return nil, peerCertificates, errors.Wrapf(err, "reading response body with HTTP status code '%s'", resp.Status)
 		}
-		return nil, peerCertificates, errors.Errorf("HTTP request %s%s with code '%s', body: %s", c.endpoint, tlsChallengeRoute, resp.Status, body)
+		return nil, peerCertificates, errors.Errorf("HTTP request %s%s with code '%s', body: %s", c.endpoint, route, resp.Status, body)
 	}
 	return resp, peerCertificates, nil
 }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -687,7 +687,6 @@ _record_build_info() {
     local build_info
 
     local metadata_url="https://${API_ENDPOINT}/v1/metadata"
-    local metadata
     releaseBuild="$(curl -skS -u "admin:${ROX_PASSWORD}" "${metadata_url}" | jq -r '.releaseBuild')"
 
     if [[ "$releaseBuild" == "true" ]]; then

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -630,18 +630,18 @@ wait_for_api() {
         API_PORT=443
     fi
     API_ENDPOINT="${API_HOSTNAME}:${API_PORT}"
-    METADATA_URL="https://${API_ENDPOINT}/v1/metadata"
-    info "METADATA_URL is set to ${METADATA_URL}"
+    PING_URL="https://${API_ENDPOINT}/v1/ping"
+    info "PING_URL is set to ${PING_URL}"
 
     set +e
     NUM_SUCCESSES_IN_A_ROW=0
     SUCCESSES_NEEDED_IN_A_ROW=3
     # shellcheck disable=SC2034
     for i in $(seq 1 60); do
-        metadata="$(curl -sk --connect-timeout 5 --max-time 10 "${METADATA_URL}")"
-        metadata_exitstatus="$?"
-        status="$(echo "$metadata" | jq '.licenseStatus' -r)"
-        if [[ "$metadata_exitstatus" -eq "0" && "$status" != "RESTARTING" ]]; then
+        pong="$(curl -sk --connect-timeout 5 --max-time 10 "${PING_URL}")"
+        pong_exitstatus="$?"
+        status="$(echo "$pong" | jq -r '.status')"
+        if [[ "$pong_exitstatus" -eq "0" && "$status" == "ok" ]]; then
             NUM_SUCCESSES_IN_A_ROW=$((NUM_SUCCESSES_IN_A_ROW + 1))
             if [[ "${NUM_SUCCESSES_IN_A_ROW}" == "${SUCCESSES_NEEDED_IN_A_ROW}" ]]; then
                 break
@@ -682,11 +682,13 @@ _record_build_info() {
         return
     fi
 
+    require_environment "ROX_PASSWORD"
+
     local build_info
 
     local metadata_url="https://${API_ENDPOINT}/v1/metadata"
     local metadata
-    releaseBuild="$(curl -skS "${metadata_url}" | jq -r '.releaseBuild')"
+    releaseBuild="$(curl -skS -u "admin:${ROX_PASSWORD}" "${metadata_url}" | jq -r '.releaseBuild')"
 
     if [[ "$releaseBuild" == "true" ]]; then
         build_info="release"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -198,7 +198,8 @@ run_proxy_tests() {
 
     info "Test HTTP access to plain HTTP proxy"
     # --retry-connrefused only works when forcing IPv4, see https://github.com/appropriate/docker-curl/issues/5
-    local ping_response_http="$(
+    local ping_response_http
+    ping_response_http="$(
         curl --retry 5 --retry-connrefused -4 --retry-delay 1 --retry-max-time 10 \
         -f \
         http://"${server_name}":10080/"${ping_endpoint}" | jq -r '.status')"
@@ -207,7 +208,8 @@ run_proxy_tests() {
 
     info "Test HTTPS access to multiplexed TLS proxy"
     # --retry-connrefused only works when forcing IPv4, see https://github.com/appropriate/docker-curl/issues/5
-    local ping_response_https="$(
+    local ping_response_https
+    ping_response_https="$(
         curl --cacert "${PROXY_CERTS_DIR}/ca.crt" \
         --retry 5 --retry-connrefused -4 --retry-delay 1 --retry-max-time 10 \
         -f \

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -194,23 +194,26 @@ run_proxy_tests() {
     fi
 
     local server_name="$1"
+    local ping_endpoint="v1/ping"
 
     info "Test HTTP access to plain HTTP proxy"
     # --retry-connrefused only works when forcing IPv4, see https://github.com/appropriate/docker-curl/issues/5
-    local license_status
-    license_status="$(curl --retry 5 --retry-connrefused -4 --retry-delay 1 --retry-max-time 10 -f http://"${server_name}":10080/v1/metadata | jq -r '.licenseStatus')"
-    echo "Got license status ${license_status} from server"
-    [[ "$license_status" == "VALID" ]]
+    local ping_response_http="$(
+        curl --retry 5 --retry-connrefused -4 --retry-delay 1 --retry-max-time 10 \
+        -f \
+        http://"${server_name}":10080/"${ping_endpoint}" | jq -r '.status')"
+    echo "Got ping response '${ping_response_http}' from '${ping_endpoint}'"
+    [[ "${ping_response_http}" == "ok" ]]
 
     info "Test HTTPS access to multiplexed TLS proxy"
     # --retry-connrefused only works when forcing IPv4, see https://github.com/appropriate/docker-curl/issues/5
-    license_status="$(
+    local ping_response_https="$(
         curl --cacert "${PROXY_CERTS_DIR}/ca.crt" \
         --retry 5 --retry-connrefused -4 --retry-delay 1 --retry-max-time 10 \
         -f \
-        https://"${server_name}":10443/v1/metadata | jq -r '.licenseStatus')"
-    echo "Got license status ${license_status} from server"
-    [[ "$license_status" == "VALID" ]]
+        https://"${server_name}":10443/"${ping_endpoint}" | jq -r '.status')"
+    echo "Got ping response '${ping_response_https}' from '${ping_endpoint}'"
+    [[ "${ping_response_https}" == "ok" ]]
 
     info "Test roxctl access to proxies"
     local proxies=(

--- a/tests/endpoints_test.go
+++ b/tests/endpoints_test.go
@@ -225,15 +225,15 @@ func (c *endpointsTestCase) runGRPCTest(t *testing.T, testCtx *endpointsTestCont
 		defer utils.IgnoreError(conn.Close)
 	}
 
-	mdClient := v1.NewMetadataServiceClient(conn)
+	pingClient := v1.NewPingServiceClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	_, err = mdClient.GetMetadata(ctx, &v1.Empty{})
+	_, err = pingClient.Ping(ctx, &v1.Empty{})
 	if !c.expectGRPCSuccess {
-		assert.Error(t, err, "expected GetMetadata request to fail")
+		assert.Error(t, err, "expected Ping request to fail")
 		return
 	}
-	assert.NoError(t, err, "expected GetMetadata request to succeed")
+	assert.NoError(t, err, "expected ping request to succeed")
 
 	authClient := v1.NewAuthServiceClient(conn)
 	ctx, cancel = context.WithTimeout(context.Background(), timeout)
@@ -294,7 +294,7 @@ func (c *endpointsTestCase) runHTTPTest(t *testing.T, testCtx *endpointsTestCont
 		Timeout:   timeout,
 	}
 
-	resp, err := client.Get(fmt.Sprintf("%s://%s/v1/metadata", scheme, targetHost))
+	resp, err := client.Get(fmt.Sprintf("%s://%s/v1/ping", scheme, targetHost))
 	if resp != nil {
 		defer utils.IgnoreError(resp.Body.Close)
 	}
@@ -312,9 +312,9 @@ func (c *endpointsTestCase) runHTTPTest(t *testing.T, testCtx *endpointsTestCont
 		return
 	}
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 status code for metadata request")
-	var md v1.Metadata
-	assert.NoError(t, jsonpb.Unmarshal(resp.Body, &md), "expected response for metadata request to be unmarshalable into metadata PB")
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 status code for ping request")
+	var pong v1.PongMessage
+	assert.NoError(t, jsonpb.Unmarshal(resp.Body, &pong), "expected response for ping request to be unmarshalable into Pong protobuf")
 
 	resp, err = client.Get(fmt.Sprintf("%s://%s/v1/auth/status", scheme, targetHost))
 	if !assert.NoError(t, err, "expected HTTP request to succeed at the transport level") {

--- a/tests/metadata_test.go
+++ b/tests/metadata_test.go
@@ -36,10 +36,4 @@ func TestMetadataIsSetCorrectly(t *testing.T) {
 	assert.Equal(t, buildinfo.BuildFlavor, metadataWithAuth.GetBuildFlavor())
 	assert.Equal(t, buildinfo.ReleaseBuild, metadataWithAuth.GetReleaseBuild())
 	assert.Equal(t, version.GetMainVersion(), metadataWithAuth.GetVersion())
-
-	// Test that an unauthenticated connection doesn't get the version.
-	metadataWithoutAuth := getMetadata(t, centralgrpc.UnauthenticatedGRPCConnectionToCentral(t))
-	assert.Equal(t, buildinfo.BuildFlavor, metadataWithoutAuth.GetBuildFlavor())
-	assert.Equal(t, buildinfo.ReleaseBuild, metadataWithoutAuth.GetReleaseBuild())
-	assert.Equal(t, "", metadataWithoutAuth.GetVersion())
 }


### PR DESCRIPTION
## Description

Second attempt to authenticate `v1/metadata`. First one was https://github.com/stackrox/stackrox/pull/6718.

Originally, `/v1/metadata` was open to the world to serve license information and enable ACS UI to prompt user to enter a license on the login screen. However, licensing has been removed from the product and now we can tighten access for the endpoint to only authenticated users.

Since Sensor needs a public endpoint to test connection to Central, `/v1/metadata` is replaced by `/v1/ping`. To support older Sensor versions with the new Central, allow Sensors to access the metadata endpoint; this works because Sensor always presents its certificate when communicating with Central, see [this comment](https://github.com/stackrox/stackrox/blob/06213bf8e6ba817223d2144a29e9b9410ff3f2cc/sensor/common/centralclient/client.go#L73-L76).

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added:
  - updated and added a unit test for Sensor
- [x] Evaluated and added CHANGELOG entry if required
  - see https://github.com/stackrox/stackrox/pull/6726
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

* ran `gke-version-compatibility-tests` with and without extra check for Sensor identity, observed them pass in the former case and fail in the latter.
* for the `gke-version-compatibility-tests` run with the extra check ^ and traces in the metadata handler, confirmed that an older Sensor presents its certificate and is hence authenticated.
* TBD manual Central upgrade test.
