### PR TITLE
ROX-17992: Try bearer auth as fallback in jira notifier

### DIFF
--- a/pkg/notifiers/jira/jira_fake_test.go
+++ b/pkg/notifiers/jira/jira_fake_test.go
@@ -25,8 +25,8 @@ import (
 // This is in no way intended to be a realistic model of the JIRA API, it only allows us to exercise notifier code paths
 // in this test.
 type fakeJira struct {
-	t                  *testing.T
-	username, password string
+	t                         *testing.T
+	username, password, token string
 
 	priorities []jiraLib.Priority
 	project    jiraLib.MetaProject
@@ -44,9 +44,10 @@ func (j *fakeJira) Handler() http.Handler {
 		return mux
 	}
 
-	expectedAuthHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", j.username, j.password))))
+	basicAuthHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", j.username, j.password))))
+	tokenAuthHeader := fmt.Sprintf("Bearer %s", j.token)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.Header.Get("Authorization") != expectedAuthHeader {
+		if req.Header.Get("Authorization") != basicAuthHeader && req.Header.Get("Authorization") != tokenAuthHeader {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
@@ -105,6 +106,7 @@ func TestWithFakeJira(t *testing.T) {
 	const (
 		username = "fakejirauser"
 		password = "fakejirapassword"
+		token    = "faketoken"
 
 		projectKey = "FJ"
 	)
@@ -152,6 +154,7 @@ func TestWithFakeJira(t *testing.T) {
 		t:          t,
 		username:   username,
 		password:   password,
+		token:      token,
 		priorities: priorities,
 		project:    project,
 	}
@@ -159,18 +162,19 @@ func TestWithFakeJira(t *testing.T) {
 	testSrv := httptest.NewServer(fj.Handler())
 	defer testSrv.Close()
 
+	fakeJiraStorageConfig := storage.Jira{
+		Url:       testSrv.URL,
+		Username:  "fakejirauser",
+		Password:  "badpassword",
+		IssueType: "IssueWithPrio",
+	}
 	fakeJiraConfig := &storage.Notifier{
 		Name:         "FakeJIRA",
 		UiEndpoint:   "https://central.stackrox",
 		Type:         "jira",
 		LabelDefault: projectKey,
 		Config: &storage.Notifier_Jira{
-			Jira: &storage.Jira{
-				Url:       testSrv.URL,
-				Username:  "fakejirauser",
-				Password:  "fakejirapassword",
-				IssueType: "IssueWithPrio",
-			},
+			Jira: &fakeJiraStorageConfig,
 		},
 	}
 
@@ -179,9 +183,20 @@ func TestWithFakeJira(t *testing.T) {
 	metadataGetter := notifierMocks.NewMockMetadataGetter(mockCtrl)
 	metadataGetter.EXPECT().GetAnnotationValue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(projectKey).AnyTimes()
 	mitreStore.EXPECT().Get(gomock.Any()).Return(&storage.MitreAttackVector{}, nil).AnyTimes()
-	j, err := NewJira(fakeJiraConfig, metadataGetter, mitreStore)
 	defer mockCtrl.Finish()
 
+	// Test with invalid password
+	_, err := NewJira(fakeJiraConfig, metadataGetter, mitreStore)
+	assert.Contains(t, err.Error(), "could not get the priority list")
+
+	// Test with valid username/password combo
+	fakeJiraStorageConfig.Password = password
+	_, err = NewJira(fakeJiraConfig, metadataGetter, mitreStore)
+	require.NoError(t, err)
+
+	// Test with valid bearer token
+	fakeJiraStorageConfig.Password = token
+	j, err := NewJira(fakeJiraConfig, metadataGetter, mitreStore)
 	require.NoError(t, err)
 
 	assert.NoError(t, j.Test(context.Background()))


### PR DESCRIPTION
## Description

Currently only basic auth is tried. If a user provides an oauth token or JWT in the password field, then auth will fail.

With this change, a user can provide the token in the "password or api token" field (with a dummy username value), and bearer auth will succeed after a failed basic auth attempt.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Deployed the PR image to a cluster and tried to add a Jira integration to issues.redhat.com using my Personal Access Token.  Successfully created this [test issue](https://issues.redhat.com/browse/ROX-18333).