### PR TITLE
ROX-18310: Add separate CI job specifically for Compliance e2e testing

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -147,6 +147,20 @@ class UIE2eTest(BaseTest):
         )
 
 
+class ComplianceE2eTest(BaseTest):
+    TEST_TIMEOUT = 2 * 60 * 60
+
+    def run(self):
+        print("Executing compliance e2e test")
+
+        self.run_with_graceful_kill(
+            [
+                "tests/e2e/run-compliance-e2e.sh",
+            ],
+            ComplianceE2eTest.TEST_TIMEOUT,
+        )
+
+
 class NonGroovyE2e(BaseTest):
     TEST_TIMEOUT = 90 * 60
     TEST_OUTPUT_DIR = "/tmp/e2e-test-logs"

--- a/scripts/ci/jobs/ocp_compliance_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_compliance_e2e_tests.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run integration tests with the compliance operator in a OCP cluster provided
+via an openshift/release hive cluster_claim.
+"""
+import os
+from runners import ClusterTestRunner
+from clusters import OpenShiftScaleWorkersCluster
+from pre_tests import PreSystemTests
+from ci_tests import ComplianceE2eTest
+from post_tests import PostClusterTest, FinalPost
+
+# set required test parameters
+os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
+os.environ["INSTALL_COMPLIANCE_OPERATOR"] = "true"
+os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+
+# Scale up the cluster to support postgres
+cluster = OpenShiftScaleWorkersCluster(increment=1)
+
+ClusterTestRunner(
+    cluster=cluster,
+    pre_test=PreSystemTests(),
+    test=ComplianceE2eTest(),
+    post_test=PostClusterTest(
+        check_stackrox_logs=True,
+    ),
+    final_post=FinalPost(),
+).run()

--- a/scripts/style/shellcheck_skip.txt
+++ b/scripts/style/shellcheck_skip.txt
@@ -101,6 +101,7 @@ scripts/release-tools/setup-central-access.sh
 scripts/release-tools/upgrade-cluster-client.sh
 scripts/style/shellcheck.sh
 scripts/sync-release-branch.sh
+tests/e2e/run-compliance-e2e.sh
 tests/e2e/run-e2e-tests.sh
 tests/e2e/run-scale.sh
 tests/e2e/run-ui-e2e.sh

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,4 +22,9 @@ external-backup-tests:
 	@GOTAGS=$(GOTAGS),test,externalbackups ../scripts/go-test.sh -cover -v -run TestGCSExternalBackup 2>&1 | tee test.log
 	@$(MAKE) report JUNIT_OUT=external-backup-tests-results
 
+.PHONY: compliance-tests
+compliance-tests:
+	../scripts/go-test.sh -cover -v -run compliance_operator_test.go 2>&1 | tee test.log
+	@$(MAKE) report JUNIT_OUT=compliance-tests-results
+
 include ../make/stackrox.mk

--- a/tests/e2e/run-compliance-e2e.sh
+++ b/tests/e2e/run-compliance-e2e.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Runs compliance e2e tests.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/ci/lib.sh
+source "$ROOT/scripts/ci/lib.sh"
+# shellcheck source=../../scripts/ci/sensor-wait.sh
+source "$ROOT/scripts/ci/sensor-wait.sh"
+# shellcheck source=../../tests/e2e/lib.sh
+source "$ROOT/tests/e2e/lib.sh"
+# shellcheck source=../../tests/scripts/setup-certs.sh
+source "$ROOT/tests/scripts/setup-certs.sh"
+
+set -euo pipefail
+
+test_compliance_e2e() {
+    info "Starting compliance e2e tests"
+
+    require_environment "ORCHESTRATOR_FLAVOR"
+    require_environment "KUBECONFIG"
+
+    export DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}"
+
+    export_test_environment
+
+    setup_deployment_env false false
+    remove_existing_stackrox_resources
+    setup_default_TLS_certs
+
+    deploy_stackrox
+    # This is what installs the Compliance Operator if the
+    # INSTALL_COMPLIANCE_OPERATOR environment variable is set to "true".
+    deploy_optional_e2e_components
+
+    run_compliance_e2e_tests
+}
+
+run_compliance_e2e_tests() {
+    info "Running compliance e2e tests"
+
+    make -C tests compliance-tests || touch FAIL
+
+    store_test_results "compliance/test-results/reports" "reports"
+
+    if is_OPENSHIFT_CI; then
+        cp -a compliance/test-results/artifacts/* "${ARTIFACT_DIR}/" || true
+    fi
+
+    [[ ! -f FAIL ]] || die "Compliance e2e tests failed"
+}
+
+test_compliance_e2e


### PR DESCRIPTION
Previously, we ran the compliance end-to-end testing with the UI end-to-end testing. While this is good, and we should continue to do it since compliance can impact UI functionality, we can separate the compliance testing out into its own CI job.

This gives us the flexibility to invoke the compliance end-to-end testing on backend-specific changes, instead of only UI related changes.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

We should be able to test this change with `ocp-4-13-compliance-e2e-tests` CI, which should install the Compliance Operator and run the nongroovy compliance tests. Once that is passing, we should be good to merge this change.
