### PR TITLE
ROX-18208: Mark v4.1.0 as skipped version

### DIFF
--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -1087,6 +1087,8 @@ spec:
   relatedImages:
   - image: ''
     name: ''
+  skips:
+  - rhacs-operator.v4.1.0
   version: 0.0.1
   webhookdefinitions:
   - admissionReviewVersions:

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -874,4 +874,6 @@ spec:
   minKubeVersion: 1.15.0
   provider:
     name: Red Hat
+  skips:
+  - rhacs-operator.v4.1.0
   version: 0.0.0


### PR DESCRIPTION
## Description

Because installing ACS v4.1.0 breaks OLM for customers that use `KernelModule` collection method, this version should be marked as broken so that it's always skipped by OLM.

See ROX-18208

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
