### PR TITLE
ROX-18313: Introduce compliance v2 integration test suite 

### DIFF
--- a/scripts/ci/jobs/ocp_compliance_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_compliance_e2e_tests.py
@@ -15,6 +15,7 @@ os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["INSTALL_COMPLIANCE_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_COMPLIANCE_ENHANCEMENTS"] = "true"
 
 ClusterTestRunner(
     cluster=AutomationFlavorsCluster(),

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,9 +22,9 @@ external-backup-tests:
 	@GOTAGS=$(GOTAGS),test,externalbackups ../scripts/go-test.sh -cover -v -run TestGCSExternalBackup 2>&1 | tee test.log
 	@$(MAKE) report JUNIT_OUT=external-backup-tests-results
 
-.PHONY: compliance-tests
-compliance-tests:
-	../scripts/go-test.sh -cover -v -run compliance_operator_test.go 2>&1 | tee test.log
-	@$(MAKE) report JUNIT_OUT=compliance-tests-results
+.PHONY: compliance-v2-tests
+compliance-v2-tests:
+	@GOTAGS=$(GOTAGS),test,compliance ../scripts/go-test.sh -cover -v -run TestComplianceV2 2>&1 | tee test.log
+	@$(MAKE) report JUNIT_OUT=compliance-v2-tests-results
 
 include ../make/stackrox.mk

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -1,0 +1,10 @@
+//go:build compliance
+
+package tests
+
+import (
+	"testing"
+)
+
+// ACS API test suite for integration testing for the Compliance Operator.
+func TestComplianceV2(t *testing.T) {}

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -25,3 +25,23 @@ func TestComplianceV2Integration(t *testing.T) {
 	assert.Equal(t, resp.Integrations[0].ClusterName, "remote", "failed to find integration for cluster called \"remote\"")
 	assert.Equal(t, resp.Integrations[0].Namespace, "openshift-compliance", "failed to find integration for \"openshift-compliance\" namespace")
 }
+
+func TestComplianceV2ProfileCount(t *testing.T) {
+	conn := centralgrpc.GRPCConnectionToCentral(t)
+	client := v2.NewComplianceProfileServiceClient(conn)
+	profileCount, err := client.GetComplianceProfileCount(context.TODO(), &v2.RawQuery{Query: ""})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Greater(t, profileCount.Count, int32(0), "unable to verify any compliance profiles were ingested")
+}
+
+func TestComplianceV2ProfileGet(t *testing.T) {
+	conn := centralgrpc.GRPCConnectionToCentral(t)
+	client := v2.NewComplianceProfileServiceClient(conn)
+	profile, err := client.GetComplianceProfile(context.TODO(), &v2.ResourceByID{Id: "ocp4-cis"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Greater(t, len(profile.Rules), 0, "failed to verify ocp4-cis profile contains any rules")
+}

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -3,8 +3,25 @@
 package tests
 
 import (
+	"context"
 	"testing"
+
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
+	"github.com/stretchr/testify/assert"
 )
 
 // ACS API test suite for integration testing for the Compliance Operator.
-func TestComplianceV2(t *testing.T) {}
+func TestComplianceV2Integration(t *testing.T) {
+	conn := centralgrpc.GRPCConnectionToCentral(t)
+	client := v2.NewComplianceIntegrationServiceClient(conn)
+
+	q := &v2.RawQuery{Query: ""}
+	resp, err := client.ListComplianceIntegrations(context.TODO(), q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Len(t, resp.Integrations, 1, "failed to assert there is only a single compliance integration")
+	assert.Equal(t, resp.Integrations[0].ClusterName, "remote", "failed to find integration for cluster called \"remote\"")
+	assert.Equal(t, resp.Integrations[0].Namespace, "openshift-compliance", "failed to find integration for \"openshift-compliance\" namespace")
+}

--- a/tests/complianceoperator/README.md
+++ b/tests/complianceoperator/README.md
@@ -1,0 +1,16 @@
+# Compliance V1 Integration Testing Data
+
+The `create.sh` script simulates the installation of the [Compliance
+Operator](https://github.com/ComplianceAsCode/compliance-operator) and creates
+various resources that make it look like it scanned the cluster. These
+resources are useful for testing against known state, making the tests more stable.
+
+These resources are used in assertions in the
+`tests/compliance_operator_tests.go` test cases, which are specific to the v1
+integration of the Compliance Operator into stackrox/ACS.
+
+The compliance v2 integration tests should not use these resources. Instead,
+they install the Compliance Operator and perform integration tests by
+interacting with the Compliance Operator directly.
+
+This directory can be removed when Compliance v1 is no longer supported.

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -374,6 +374,7 @@ install_the_compliance_operator() {
         info "Reusing existing compliance operator deployment from $csv subscription"
     fi
 
+    wait_for_profile_bundles_to_be_ready
     oc get csv -n openshift-compliance
 }
 
@@ -635,6 +636,24 @@ remove_existing_stackrox_resources() {
         kubectl get namespace -o name | grep -E '^namespace/qa' | xargs kubectl delete --wait
     # (prefix output to avoid triggering prow log focus)
     ) 2>&1 | sed -e 's/^/out: /' || true
+}
+
+remove_compliance_operator_resources() {
+    info "Will remove any existing compliance operator resources"
+    if kubectl get crd compliancecheckresults.compliance.openshift.io; then
+        (
+            kubectl -n openshift-compliance delete ssb --all --wait --ignore-not-found=true
+            # The profilebundles must be deleted before the csv. If not, the finalizers
+            # will prevent the profilebundles from deleting because the CRDs are gone.
+            kubectl -n openshift-compliance delete pb --all --wait --ignore-not-found=true
+            kubectl -n openshift-compliance delete sub --all  --ignore-not-found=true
+            kubectl -n openshift-compliance delete csv --all  --ignore-not-found=true
+            kubectl -n openshift-compliance delete operatorgroup --all  --ignore-not-found=true
+            kubectl -n openshift-marketplace delete catalogsource compliance-operator  --ignore-not-found=true
+            kubectl delete namespace openshift-compliance --wait --ignore-not-found=true
+        # (prefix output to avoid triggering prow log focus)
+        ) 2>&1 | sed -e 's/^/out: /' || true
+    fi
 }
 
 wait_for_api() {
@@ -936,6 +955,28 @@ wait_for_object_to_appear() {
     done
 
     return 0
+}
+
+wait_for_profile_bundles_to_be_ready() {
+    wait_for_object_to_appear openshift-compliance profilebundle/ocp4
+    wait_for_object_to_appear openshift-compliance profilebundle/rhcos4
+    for pb in $(oc get pb -n openshift-compliance -o jsonpath="{.items[*].metadata.name}"); do
+        local delay="300"
+        local waitInterval=10
+        local tries=$(( delay / waitInterval ))
+        local count=0
+        until [ "$(oc get pb "$pb" -n openshift-compliance -o jsonpath="{.status.dataStreamStatus}")" = "VALID" ]; do
+            count=$((count + 1))
+            if [[ $count -ge "$tries" ]]; then
+                info "Failed to validate $pb profilebundle after $count tries"
+                oc get pb "$pb" -n openshift-compliance
+                return 1
+            fi
+            info "Validating $pb profilebundle"
+            sleep "$waitInterval"
+        done
+        info "Validated $pb profilebundle"
+    done
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/tests/e2e/run-compliance-e2e.sh
+++ b/tests/e2e/run-compliance-e2e.sh
@@ -15,7 +15,7 @@ source "$ROOT/tests/scripts/setup-certs.sh"
 set -euo pipefail
 
 test_compliance_e2e() {
-    info "Starting compliance e2e tests"
+    info "Starting compliance v2 e2e tests"
 
     require_environment "ORCHESTRATOR_FLAVOR"
     require_environment "KUBECONFIG"
@@ -24,22 +24,25 @@ test_compliance_e2e() {
 
     export_test_environment
 
+    export SENSOR_HELM_DEPLOY=true
+
     setup_deployment_env false false
     remove_existing_stackrox_resources
+    remove_compliance_operator_resources
     setup_default_TLS_certs
 
+    # Compliance v2 requires the Compliance Operator to be installed.
+    install_the_compliance_operator
     deploy_stackrox
-    # This is what installs the Compliance Operator if the
-    # INSTALL_COMPLIANCE_OPERATOR environment variable is set to "true".
-    deploy_optional_e2e_components
 
     run_compliance_e2e_tests
 }
 
 run_compliance_e2e_tests() {
-    info "Running compliance e2e tests"
+    info "Running compliance v2 e2e tests"
 
-    make -C tests compliance-tests || touch FAIL
+    rm -f FAIL
+    make -C tests compliance-v2-tests || touch FAIL
 
     store_test_results "compliance/test-results/reports" "reports"
 

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -31,6 +31,7 @@ test_e2e() {
     setup_deployment_env false false
     remove_existing_stackrox_resources
     setup_default_TLS_certs
+    info "Creating mocked compliance operator data for compliance v1 tests"
     "$ROOT/tests/complianceoperator/create.sh"
 
     deploy_stackrox

--- a/tests/e2e/yaml/compliance-operator/nist-moderate.yaml
+++ b/tests/e2e/yaml/compliance-operator/nist-moderate.yaml
@@ -1,0 +1,13 @@
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: nist-moderate
+  namespace: openshift-compliance
+profiles:
+  - name: ocp4-moderate
+    kind: Profile
+    apiGroup: compliance.openshift.io/v1alpha1
+settingsRef:
+  name: default
+  kind: ScanSetting
+  apiGroup: compliance.openshift.io/v1alpha1

--- a/tests/e2e/yaml/compliance-operator/rhcos4-moderate.yaml
+++ b/tests/e2e/yaml/compliance-operator/rhcos4-moderate.yaml
@@ -1,0 +1,13 @@
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: rhcos4-moderate
+  namespace: openshift-compliance
+profiles:
+  - name: rhcos4-moderate
+    kind: Profile
+    apiGroup: compliance.openshift.io/v1alpha1
+settingsRef:
+  name: default
+  kind: ScanSetting
+  apiGroup: compliance.openshift.io/v1alpha1


### PR DESCRIPTION
Legacy compliance operator testing relies on the ability to install the
operator from source (specifically, GKE integration testing). While the
OpenShift testing uses installs from subscriptions, we can clean up the install
code from the GKE test path.

This patch does a few things:

1. Uses the new ComplianceAsCode/compliance-operator repository
2. Uses `make deploy-local` as the preferred method for deploying the Compliance Operator from source
3. Adds a new environment variable for installing from source so that we can enable source installs for non-OpenShift testing
4. Adds a new set of compliance e2e tests meant to exercise the v2 compliance integration APIs

Subsequent patches can remove the manifests for Compliance Operator CRDs and
resources, since they're likely outdated.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

The Compliance Operator installation using subscriptions should continue to work (`ocp-4-13-ui-e2e-tests`) and the end-to-end tests should execute successfully without installing CO from source. We should be able to adequately test this change with existing CI.