### PR TITLE
ROX-18318: Add general filters to network policy simulation API call

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
@@ -130,6 +130,7 @@ function useNetworkPolicySimulator({ simulation }: UseNetworkPolicySimulatorPara
                         getRequestQueryStringForSearchFilter({
                             Namespace: options.scopeHierarchy.namespaces,
                             Deployment: options.scopeHierarchy.deployments,
+                            ...options.scopeHierarchy.remainingQuery,
                         }),
                         options.networkDataSince,
                         options.excludePortsAndProtocols


### PR DESCRIPTION
## Description

Passes additional "general" filters that have been applied via the search bar to the network policy simulator API. Due to the fact that these filters also reduce the scope of the graph, they should also be used to reduce the scope of the generated policies.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Generate policies for two namespaces, with no additional filter - policies for deployments in `ui-testing` and `ui-testing2` are generated
![image](https://github.com/stackrox/stackrox/assets/1292638/ae6dd8b7-f799-4e6b-81d7-1f19568bd32a)

Add a general filter ("Deployment Label: app=wordpress") - only the Wordpress deployment has generated policies.
![image](https://github.com/stackrox/stackrox/assets/1292638/b6bd68db-0292-4a01-8cb1-d4de89561efe)

