### PR TITLE
ROX-17225: install service monitor in monitoring

### DIFF
--- a/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
@@ -48,12 +48,12 @@ subjects:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: central-monitor
-  namespace: {{ .Release.Namespace }}
+  name: central-monitor-{{ .Release.Name }}-{{ .Release.Namespace }}
+  namespace: openshift-monitoring
   labels:
-    {{- include "srox.labels" (list . "servicemonitor" "central-monitor") | nindent 4 }}
+    {{- include "srox.labels" (list . "servicemonitor" (print "central-monitor-" .Release.Name "-" .Release.Namespace )) | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "servicemonitor" "central-monitor") | nindent 4 }}
+    {{- include "srox.annotations" (list . "servicemonitor" (print "central-monitor-" .Release.Name "-" .Release.Namespace )) | nindent 4 }}
 spec:
   endpoints:
   - interval: 30s

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -16,7 +16,7 @@ tests:
       expect: |
         .roles["central-prometheus-k8s"] | assertThat(. != null)
         .rolebindings["central-prometheus-k8s"] | assertThat(. != null)
-        .servicemonitors["central-monitor"] | assertThat(. != null)
+        .servicemonitors["central-monitor-stackrox-central-services-stackrox"] | assertThat(. != null)
 
     - name: "monitoring is exposed"
     - name: "enableOpenShiftMonitoring overrides central.exposeMonitoring"


### PR DESCRIPTION
## Description

ServiceMonitor only works is namespace has certain label.
As Helm does not control the namespace it installs we cannot simply add 
a label to that namespace. This PR installs ServiceMonitor in openshift-monitoring 
namespace that is guaranteed to exist and have proper labels.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
