### PR TITLE
ROX-18185: Update wording in netpol simulator panel

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -28,7 +28,11 @@ import {
     SetNetworkPolicyModification,
 } from '../hooks/useNetworkPolicySimulator';
 import NetworkPoliciesYAML from './NetworkPoliciesYAML';
-import { getDisplayYAMLFromNetworkPolicyModification } from '../utils/simulatorUtils';
+import {
+    getDisplayYAMLFromNetworkPolicyModification,
+    getSimulationPanelHeaderText,
+    getSimulationPanelResultsText,
+} from '../utils/simulatorUtils';
 import UploadYAMLButton from './UploadYAMLButton';
 import NetworkSimulatorActions from './NetworkSimulatorActions';
 import NotifyYAMLModal from './NotifyYAMLModal';
@@ -155,7 +159,7 @@ function NetworkPolicySimulatorSidePanel({
                             title={
                                 simulator.error
                                     ? simulator.error
-                                    : `Policies generated from the baseline for cluster “${scopeHierarchy.cluster.name}”`
+                                    : getSimulationPanelResultsText(scopeHierarchy)
                             }
                         />
                     </StackItem>
@@ -296,7 +300,7 @@ function NetworkPolicySimulatorSidePanel({
                                 component={TextVariants.h2}
                                 className="pf-u-font-size-xl pf-u-mr-xl"
                             >
-                                Simulate network policy for cluster “{scopeHierarchy.cluster.name}”
+                                {getSimulationPanelHeaderText(scopeHierarchy)}
                             </Text>
                         </TextContent>
                     </FlexItem>
@@ -374,9 +378,8 @@ function NetworkPolicySimulatorSidePanel({
                                         <TextContent>
                                             <Text component={TextVariants.p}>
                                                 Generate a set of recommended network policies based
-                                                on your cluster baseline. Cluster baseline is the
-                                                aggregatation of the baselines of the deployments
-                                                that belong to the cluster.
+                                                on the baseline of deployments in your selected
+                                                scope.
                                             </Text>
                                         </TextContent>
                                     </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.test.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.test.ts
@@ -1,0 +1,66 @@
+import { getSimulationPanelHeaderText } from './simulatorUtils';
+
+describe('getSimulationPanelHeaderText', () => {
+    it('should return the text that describes the scope of the generated network policies', () => {
+        const cluster = { id: '1', name: 'production' };
+
+        expect(getSimulationPanelHeaderText({ cluster, namespaces: [], deployments: [] })).toEqual(
+            'Simulate network policies for all deployments in cluster "production"'
+        );
+        expect(
+            getSimulationPanelHeaderText({ cluster, namespaces: ['payments'], deployments: [] })
+        ).toEqual(
+            'Simulate network policies for all deployments in namespace "payments" in cluster "production"'
+        );
+
+        expect(
+            getSimulationPanelHeaderText({
+                cluster,
+                namespaces: ['payments', 'backend', 'frontend'],
+                deployments: [],
+            })
+        ).toEqual(
+            'Simulate network policies for all deployments in namespaces "payments", "backend", "frontend" in cluster "production"'
+        );
+
+        expect(
+            getSimulationPanelHeaderText({
+                cluster,
+                namespaces: ['payments', 'backend', 'frontend', 'too-many'],
+                deployments: [],
+            })
+        ).toEqual(
+            'Simulate network policies for all deployments in 4 namespaces in cluster "production"'
+        );
+
+        expect(
+            getSimulationPanelHeaderText({
+                cluster,
+                namespaces: ['payments'],
+                deployments: ['visa-processor'],
+            })
+        ).toEqual(
+            'Simulate network policies for deployment "payments/visa-processor" in cluster "production"'
+        );
+
+        expect(
+            getSimulationPanelHeaderText({
+                cluster,
+                namespaces: ['payments'],
+                deployments: ['visa-processor', 'gateway'],
+            })
+        ).toEqual(
+            'Simulate network policies for deployments "payments/visa-processor", "payments/gateway" in cluster "production"'
+        );
+
+        // Note we don't scope deployment names to a single namespace, so the query result is
+        // the combination of "namespaces x deployments"
+        expect(
+            getSimulationPanelHeaderText({
+                cluster,
+                namespaces: ['payments', 'backend'],
+                deployments: ['visa-processor', 'gateway'],
+            })
+        ).toEqual('Simulate network policies for 4 deployments in cluster "production"');
+    });
+});

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
@@ -1,4 +1,7 @@
+import pluralize from 'pluralize';
 import { NetworkPolicyModification } from 'types/networkPolicy.proto';
+import { ensureExhaustive } from 'utils/type.utils';
+import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 
 export function getDisplayYAMLFromNetworkPolicyModification(
     modification: NetworkPolicyModification | null
@@ -26,4 +29,103 @@ export function getDisplayYAMLFromNetworkPolicyModification(
     }
 
     return displayYaml;
+}
+
+export function getSimulationPanelHeaderText(
+    scopeHierarchy: Omit<NetworkScopeHierarchy, 'remainingQuery'>
+): string {
+    const scopeTextFormat = getScopeTextFormat(scopeHierarchy);
+    const cluster = scopeHierarchy.cluster.name;
+
+    switch (scopeTextFormat.type) {
+        case 'CLUSTER_ONLY':
+            return `Simulate network policies for all deployments in cluster "${cluster}"`;
+        case 'FEW_NAMESPACES': {
+            const namespaceText = pluralize('namespace', scopeTextFormat.namespaces.length);
+            const namespaces = scopeTextFormat.namespaces.join('", "');
+            return `Simulate network policies for all deployments in ${namespaceText} "${namespaces}" in cluster "${cluster}"`;
+        }
+        case 'MANY_NAMESPACES':
+            return `Simulate network policies for all deployments in ${scopeTextFormat.count} namespaces in cluster "${cluster}"`;
+        case 'FEW_DEPLOYMENTS': {
+            const deploymentText = pluralize('deployment', scopeTextFormat.deployments.length);
+            const deployments = scopeTextFormat.deployments.join('", "');
+            return `Simulate network policies for ${deploymentText} "${deployments}" in cluster "${cluster}"`;
+        }
+        case 'MANY_DEPLOYMENTS':
+            return `Simulate network policies for ${scopeTextFormat.count} deployments in cluster "${cluster}"`;
+        default:
+            return ensureExhaustive(scopeTextFormat);
+    }
+}
+
+export function getSimulationPanelResultsText(
+    scopeHierarchy: Omit<NetworkScopeHierarchy, 'remainingQuery'>
+): string {
+    const scopeTextFormat = getScopeTextFormat(scopeHierarchy);
+    const cluster = scopeHierarchy.cluster.name;
+
+    switch (scopeTextFormat.type) {
+        case 'CLUSTER_ONLY':
+            return `Policies generated from the baseline of all deployments in cluster "${cluster}"`;
+        case 'FEW_NAMESPACES': {
+            const namespaceText = pluralize('namespace', scopeTextFormat.namespaces.length);
+            const namespaces = scopeTextFormat.namespaces.join('", "');
+            return `Policies generated from the baseline of all deployments in ${namespaceText} "${namespaces}" in cluster "${cluster}"`;
+        }
+        case 'MANY_NAMESPACES':
+            return `Policies generated from the baseline of all deployments in ${scopeTextFormat.count} namespaces in cluster "${cluster}"`;
+        case 'FEW_DEPLOYMENTS': {
+            const deploymentText = pluralize('deployment', scopeTextFormat.deployments.length);
+            const deployments = scopeTextFormat.deployments.join('", "');
+            return `Policies generated from the baseline of ${deploymentText} "${deployments}" in cluster "${cluster}"`;
+        }
+        case 'MANY_DEPLOYMENTS':
+            return `Policies generated from the baseline of ${scopeTextFormat.count} deployments in cluster "${cluster}"`;
+        default:
+            return ensureExhaustive(scopeTextFormat);
+    }
+}
+
+type ScopeTextFormat =
+    | { type: 'CLUSTER_ONLY' }
+    | { type: 'FEW_NAMESPACES'; namespaces: string[] }
+    | { type: 'MANY_NAMESPACES'; count: number }
+    | { type: 'FEW_DEPLOYMENTS'; deployments: string[] }
+    | { type: 'MANY_DEPLOYMENTS'; count: number };
+
+/**
+ * Given a selected scope, return the descriptive text format used to display longer text in the UI.
+ * By encapsulating this logic we can make reuse and i16n easier in the future, as well as increase
+ * readability of the text generators that uses this function.
+ * @param scopeHierarchy The selected scope.
+ * @param abbreviationLength The number of namespaces or deployments that can be displayed before
+ *    the text is abbreviated.
+ * @returns The descriptive text format used to display longer text in the UI.
+ */
+function getScopeTextFormat(
+    scopeHierarchy: Omit<NetworkScopeHierarchy, 'remainingQuery'>,
+    abbreviationLength = 3
+): ScopeTextFormat {
+    const { namespaces, deployments } = scopeHierarchy;
+    // Cartesian product of selected namespaces and deployments
+    const namespaceDeploymentPairs = namespaces.flatMap((n) => deployments.map((d) => `${n}/${d}`));
+
+    if (namespaceDeploymentPairs.length === 0 && namespaces.length === 0) {
+        return { type: 'CLUSTER_ONLY' };
+    }
+    if (namespaceDeploymentPairs.length === 0 && namespaces.length > abbreviationLength) {
+        return { type: 'MANY_NAMESPACES', count: namespaces.length };
+    }
+    if (namespaceDeploymentPairs.length === 0 && namespaces.length <= abbreviationLength) {
+        return { type: 'FEW_NAMESPACES', namespaces };
+    }
+    if (deployments.length > 0 && namespaceDeploymentPairs.length > abbreviationLength) {
+        return { type: 'MANY_DEPLOYMENTS', count: namespaceDeploymentPairs.length };
+    }
+    if (deployments.length > 0) {
+        return { type: 'FEW_DEPLOYMENTS', deployments: namespaceDeploymentPairs };
+    }
+
+    return { type: 'CLUSTER_ONLY' };
 }


### PR DESCRIPTION
## Description

Updates the wording in the net graph simulator panel to more accurately describe the scope of the deployments that are going into the generated policies.

This does so by attempting to list all the clusters/namespaces/deployments that are part of the scope, abbreviating to "# entities" type text when there are too many to list.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Only cluster selected:
- Not possible in current UI, covered in unit test

Single/few namespaces:
![image](https://github.com/stackrox/stackrox/assets/1292638/89178e43-31d4-4449-9528-adb9bba1289b)
![image](https://github.com/stackrox/stackrox/assets/1292638/a0aca5ee-d093-459a-aa3b-6371c42acec4)

Many namespaces:
![image](https://github.com/stackrox/stackrox/assets/1292638/bd898f53-3bfc-4a48-bb92-fcaa8c77fe37)

Single/few deployments:
![image](https://github.com/stackrox/stackrox/assets/1292638/a75ec33e-4ad5-4166-9147-9c095efc84a5)
![image](https://github.com/stackrox/stackrox/assets/1292638/1c4afa49-5bf2-4695-9fa7-098ce57987c8)

Many deployments:
![image](https://github.com/stackrox/stackrox/assets/1292638/867bae2d-59ce-421b-bd3f-33761c21cd85)

The same logic in use post-generation:
![image](https://github.com/stackrox/stackrox/assets/1292638/40e6fe5f-3b25-48a4-b65c-e9f6794a8813)




