### PR TITLE
ROX-18148: skip reconciliation test on release builds

### DIFF
--- a/sensor/tests/connection/k8sreconciliation/reconcile_test.go
+++ b/sensor/tests/connection/k8sreconciliation/reconcile_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/sensor/tests/helper"
 	"github.com/stretchr/testify/require"
 	appsV1 "k8s.io/api/apps/v1"
@@ -18,6 +19,9 @@ var (
 )
 
 func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
+	if buildinfo.ReleaseBuild {
+		t.Skip("ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT is not enabled on release builds")
+	}
 	t.Setenv("ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT", "true")
 	t.Setenv("ROX_RESYNC_DISABLED", "true")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", "1s")

--- a/sensor/tests/connection/k8sreconciliation/reconcile_test.go
+++ b/sensor/tests/connection/k8sreconciliation/reconcile_test.go
@@ -19,10 +19,11 @@ var (
 )
 
 func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
-	if buildinfo.ReleaseBuild {
-		t.Skip("ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT is not enabled on release builds")
-	}
-	t.Setenv("ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT", "true")
+        s.T().Setenv(features.PreventSensorRestartOnDisconnect.EnvVar(), "true")
+        if !features.PreventSensorRestartOnDisconnect.Enabled() {
+          s.T().Skip("Skip tests when ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT is disabled")
+          s.T().SkipNow()
+        }
 	t.Setenv("ROX_RESYNC_DISABLED", "true")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", "1s")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL", "2s")

--- a/sensor/tests/connection/k8sreconciliation/reconcile_test.go
+++ b/sensor/tests/connection/k8sreconciliation/reconcile_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/pkg/buildinfo"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/sensor/tests/helper"
 	"github.com/stretchr/testify/require"
 	appsV1 "k8s.io/api/apps/v1"
@@ -19,11 +19,11 @@ var (
 )
 
 func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
-        s.T().Setenv(features.PreventSensorRestartOnDisconnect.EnvVar(), "true")
-        if !features.PreventSensorRestartOnDisconnect.Enabled() {
-          s.T().Skip("Skip tests when ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT is disabled")
-          s.T().SkipNow()
-        }
+	t.Setenv(features.PreventSensorRestartOnDisconnect.EnvVar(), "true")
+	if !features.PreventSensorRestartOnDisconnect.Enabled() {
+		t.Skip("Skip tests when ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT is disabled")
+		t.SkipNow()
+	}
 	t.Setenv("ROX_RESYNC_DISABLED", "true")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", "1s")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL", "2s")


### PR DESCRIPTION
## Description

The `ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT` feature flag is not enabled in release builds making this test fail constantly in nightlies.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- [ ] CI
