### PR TITLE
Jv rox 18208 rhacs operator upgrade failed test

### DIFF
--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -196,8 +196,8 @@ type PerNodeSpec struct {
 	TaintToleration *TaintTolerationPolicy `json:"taintToleration,omitempty"`
 }
 
-// CollectionMethod defines the method of collection used by collector. Options are 'EBPF', 'CORE_BPF' or 'None'. Note that 'CORE_BPF' is on Tech Preview stage.
-// +kubebuilder:validation:Enum=EBPF;CORE_BPF;NoCollection
+// CollectionMethod defines the method of collection used by collector. Options are 'EBPF', 'CORE_BPF', 'None', or 'KernelModule'. Note that 'CORE_BPF' is on Tech Preview stage and that the collection method will be switched to EBPF if KernelModule is used.
+// +kubebuilder:validation:Enum=EBPF;CORE_BPF;NoCollection;KernelModule
 type CollectionMethod string
 
 const (
@@ -207,6 +207,8 @@ const (
 	CollectionCOREBPF CollectionMethod = "CORE_BPF"
 	// CollectionNone means: NO_COLLECTION.
 	CollectionNone CollectionMethod = "NoCollection"
+	// CollectionKernelModule means: use KERNEL_MODULE collection.
+	CollectionKernelModule CollectionMethod = "KernelModule"
 )
 
 // Pointer returns the given CollectionMethod as a pointer, needed in k8s resource structs.

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -403,6 +403,7 @@ spec:
                         - EBPF
                         - CORE_BPF
                         - NoCollection
+                        - KernelModule
                         type: string
                       imageFlavor:
                         default: Regular

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -404,6 +404,7 @@ spec:
                         - EBPF
                         - CORE_BPF
                         - NoCollection
+                        - KernelModule
                         type: string
                       imageFlavor:
                         default: Regular

--- a/operator/tests/common/secured-cluster-cr.yaml
+++ b/operator/tests/common/secured-cluster-cr.yaml
@@ -20,6 +20,7 @@ spec:
         requests:
           memory: 100Mi
           cpu: 100m
+      collection: KernelModule
     compliance:
       resources:
         requests:


### PR DESCRIPTION
Just for testing. This is a copy of https://github.com/stackrox/stackrox/pull/6797, with the one change being that KernelModule is used as the collection method for the operator e2e test.