### PR TITLE
Jv test upgrade with kernel module collection

### DIFF
--- a/operator/tests/common/secured-cluster-cr.yaml
+++ b/operator/tests/common/secured-cluster-cr.yaml
@@ -20,6 +20,7 @@ spec:
         requests:
           memory: 100Mi
           cpu: 100m
+      collection: KernelModule
     compliance:
       resources:
         requests:


### PR DESCRIPTION
Just for testing. The operator e2e test is expected to fail in this case.