### PR TITLE
ROX-18340: Stop asserting stackrox-db PVC in operator upgrade test

### DIFF
--- a/operator/tests/common/upgrade-assert.envsubst.yaml
+++ b/operator/tests/common/upgrade-assert.envsubst.yaml
@@ -23,22 +23,6 @@ metadata:
 status:
   availableReplicas: 1
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: stackrox-db
-  ownerReferences:
-  - apiVersion: platform.stackrox.io/v1alpha1
-    kind: Central
-    name: stackrox-central-services
-    controller: true
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 100Gi
----
 apiVersion: platform.stackrox.io/v1alpha1
 kind: SecuredCluster
 metadata:

--- a/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
+++ b/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
@@ -5,20 +5,3 @@ commands:
 # from the parent make: the namespace and operator version string (which are arguments to upgrade script).
 - script: make -C ../../.. upgrade-via-olm
   timeout: 600
-# Recover from ROX-14335:
-# Can be removed well after release 3.73.x is not supported.
-- script: |
-    ns=$NAMESPACE
-    # From 05-central-cr.yaml:
-    central_name="stackrox-central-services"
-
-    patch_file="$(mktemp)"
-    pvc_name="$(kubectl get -n "${ns}" central.platform.stackrox.io "${central_name}" -o json | jq -r '.spec?.central?.persistence?.persistentVolumeClaim?.claimName // "stackrox-db"')"
-    kubectl get -n "${ns}" central.platform.stackrox.io "${central_name}" -o json \
-      | jq '{"metadata":{"ownerReferences": [{"apiVersion": "platform.stackrox.io/v1alpha1","blockOwnerDeletion": true,"controller": true,"kind": "Central","name": .metadata.name, "uid": .metadata.uid}]}}' \
-      > "${patch_file}"
-    jq . < "${patch_file}" # make sure it looks sane
-    echo Before patch: && kubectl get -n "${ns}" pvc "${pvc_name}" -o json  # Additional debug output
-    kubectl patch -n "${ns}" pvc "${pvc_name}" --patch-file="${patch_file}"
-    echo After patch:  && kubectl get -n "${ns}" pvc "${pvc_name}" -o json  # Additional debug output
-    rm "${patch_file}"


### PR DESCRIPTION
## Description

A cherry-pick of https://github.com/stackrox/stackrox/pull/6871 to check if it fixes 4.1.0 -> 4.1.1 operator upgrade e2e tests.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
