### PR TITLE
refactor(ui): Increase type safety of DeploymentDetails tab

### DIFF
--- a/ui/apps/platform/cypress/fixtures/alerts/deploymentForAlertFirstInAlerts.json
+++ b/ui/apps/platform/cypress/fixtures/alerts/deploymentForAlertFirstInAlerts.json
@@ -454,5 +454,15 @@
                 "gid": 4294967295
             }
         }
-    ]
+    ],
+    "serviceAccountPermissionLevel": "NONE",
+    "automountServiceAccountToken": true,
+    "hostNetwork": false,
+    "hostPid": false,
+    "hostIpc": false,
+    "runtimeClass": "",
+    "tolerations": [],
+    "ports": [],
+    "stateTimestamp": "1688993859040137",
+    "riskScore": 5.7972984
 }

--- a/ui/apps/platform/cypress/fixtures/alerts/deploymentWithEmptyContainerConfig.json
+++ b/ui/apps/platform/cypress/fixtures/alerts/deploymentWithEmptyContainerConfig.json
@@ -41,5 +41,18 @@
         "value": "1"
         }
     ],
-    "priority": "0"
+    "imagePullSecrets": [],
+    "serviceAccount": "ip-masq-agent",
+    "processes": [],
+    "priority": "0",
+    "serviceAccountPermissionLevel": "NONE",
+    "automountServiceAccountToken": true,
+    "hostNetwork": false,
+    "hostPid": false,
+    "hostIpc": false,
+    "runtimeClass": "",
+    "tolerations": [],
+    "ports": [],
+    "stateTimestamp": "1688993859040137",
+    "riskScore": 5.7972984
 }

--- a/ui/apps/platform/cypress/integration/violations/Violations.helpers.js
+++ b/ui/apps/platform/cypress/integration/violations/Violations.helpers.js
@@ -202,9 +202,7 @@ export function clickDeploymentTabWithFixture(fixturePath) {
 
     interactAndWaitForResponses(
         () => {
-            cy.log('click tab');
             cy.get(deploymentTab).click();
-            cy.log('after click tab');
         },
         routeMatcherMapForDeployment,
         staticResponseMapForDeployment

--- a/ui/apps/platform/cypress/integration/violations/Violations.helpers.js
+++ b/ui/apps/platform/cypress/integration/violations/Violations.helpers.js
@@ -202,7 +202,9 @@ export function clickDeploymentTabWithFixture(fixturePath) {
 
     interactAndWaitForResponses(
         () => {
+            cy.log('click tab');
             cy.get(deploymentTab).click();
+            cy.log('after click tab');
         },
         routeMatcherMapForDeployment,
         staticResponseMapForDeployment

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import { Card, CardBody, DescriptionList, Divider, Flex, FlexItem } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
+import { Deployment } from 'types/deployment.proto';
 import ContainerVolumes from './ContainerVolumes';
 import ContainerSecrets from './ContainerSecrets';
 import ContainerResources from './ContainerResources';
@@ -74,11 +75,15 @@ function ContainerConfiguration({ container }): ReactElement {
     );
 }
 
-function ContainerConfigurations({ deployment }): ReactElement {
+export type ContainerConfigurationsProps = {
+    deployment: Deployment | null;
+};
+
+function ContainerConfigurations({ deployment }: ContainerConfigurationsProps): ReactElement {
     return (
         <Card isFlat>
             <CardBody>
-                {deployment?.containers?.length > 0
+                {deployment && deployment.containers.length > 0
                     ? deployment.containers.map((container, idx) => (
                           // eslint-disable-next-line react/no-array-index-key
                           <ContainerConfiguration container={container} key={idx} />

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import { Card, CardBody, DescriptionList, Divider, Flex, FlexItem } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import { Deployment } from 'types/deployment.proto';
+import { Container, Deployment } from 'types/deployment.proto';
 import ContainerVolumes from './ContainerVolumes';
 import ContainerSecrets from './ContainerSecrets';
 import ContainerResources from './ContainerResources';
@@ -21,7 +21,11 @@ function MultilineDescription({ descArr }) {
     );
 }
 
-function ContainerConfiguration({ container }): ReactElement {
+type ContainerConfigurationProps = {
+    container: Container;
+};
+
+function ContainerConfiguration({ container }: ContainerConfigurationProps): ReactElement {
     const { resources, volumes, secrets, config, image } = container;
     const { command, args } = config || {};
     return (
@@ -80,11 +84,12 @@ export type ContainerConfigurationsProps = {
 };
 
 function ContainerConfigurations({ deployment }: ContainerConfigurationsProps): ReactElement {
+    const containers = deployment?.containers || [];
     return (
         <Card isFlat>
             <CardBody>
-                {deployment && deployment.containers.length > 0
-                    ? deployment.containers.map((container, idx) => (
+                {containers.length > 0
+                    ? containers.map((container, idx) => (
                           // eslint-disable-next-line react/no-array-index-key
                           <ContainerConfiguration container={container} key={idx} />
                       ))

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
@@ -5,8 +5,13 @@ import { DescriptionList } from '@patternfly/react-core';
 import dateTimeFormat from 'constants/dateTimeFormat';
 import DescriptionListItem from 'Components/DescriptionListItem';
 import ObjectDescriptionList from 'Components/ObjectDescriptionList';
+import { Deployment } from 'types/deployment.proto';
 
-function DeploymentOverview({ deployment }): ReactElement {
+export type DeploymentOverviewProps = {
+    deployment: Deployment;
+};
+
+function DeploymentOverview({ deployment }: DeploymentOverviewProps): ReactElement {
     return (
         <DescriptionList isHorizontal>
             <DescriptionListItem term="Deployment ID" desc={deployment.id} />
@@ -32,7 +37,7 @@ function DeploymentOverview({ deployment }): ReactElement {
                 desc={<ObjectDescriptionList data={deployment.annotations} />}
             />
             <DescriptionListItem term="Service account" desc={deployment.serviceAccount} />
-            {deployment?.imagePullSecrets?.length > 0 && (
+            {deployment.imagePullSecrets.length > 0 && (
                 <DescriptionListItem
                     term="Image pull secrets"
                     desc={deployment.imagePullSecrets.join(', ')}

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
@@ -12,6 +12,7 @@ export type DeploymentOverviewProps = {
 };
 
 function DeploymentOverview({ deployment }: DeploymentOverviewProps): ReactElement {
+    const imagePullSecrets = deployment?.imagePullSecrets || [];
     return (
         <DescriptionList isHorizontal>
             <DescriptionListItem term="Deployment ID" desc={deployment.id} />
@@ -37,11 +38,8 @@ function DeploymentOverview({ deployment }: DeploymentOverviewProps): ReactEleme
                 desc={<ObjectDescriptionList data={deployment.annotations} />}
             />
             <DescriptionListItem term="Service account" desc={deployment.serviceAccount} />
-            {deployment.imagePullSecrets.length > 0 && (
-                <DescriptionListItem
-                    term="Image pull secrets"
-                    desc={deployment.imagePullSecrets.join(', ')}
-                />
+            {imagePullSecrets.length > 0 && (
+                <DescriptionListItem term="Image pull secrets" desc={imagePullSecrets.join(', ')} />
             )}
         </DescriptionList>
     );

--- a/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
@@ -86,10 +86,12 @@ const DeploymentDetails = ({ alertDeployment }: DeploymentDetailsProps) => {
     useEffect(() => {
         fetchNetworkPoliciesInNamespace(alertDeployment.clusterId, alertDeployment.namespace).then(
             // TODO Infer type from response once NetworkService.js is typed
-            (policies: NetworkPolicy[]) => setNamespacePolicies(policies),
+            (policies: NetworkPolicy[]) => setNamespacePolicies(policies ?? []),
             () => setNamespacePolicies([])
         );
     }, [alertDeployment.namespace, alertDeployment.clusterId, setNamespacePolicies]);
+
+    const relatedDeploymentPorts = relatedDeployment?.ports || [];
 
     return (
         <Flex
@@ -133,8 +135,8 @@ const DeploymentDetails = ({ alertDeployment }: DeploymentDetailsProps) => {
                     <FlexItem>
                         <Card isFlat data-testid="port-configuration">
                             <CardBody>
-                                {relatedDeployment && relatedDeployment.ports.length > 0
-                                    ? formatDeploymentPorts(relatedDeployment.ports).map(
+                                {relatedDeploymentPorts.length > 0
+                                    ? formatDeploymentPorts(relatedDeploymentPorts).map(
                                           (port, idx) => (
                                               // eslint-disable-next-line react/no-array-index-key
                                               <ObjectDescriptionList data={port} key={idx} />

--- a/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { Alert, Flex, FlexItem, Card, CardBody, Title, Divider } from '@patternfly/react-core';
+import { TableComposable, Caption, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 
-import { fetchDeployment } from 'services/DeploymentsService';
 import { fetchNetworkPoliciesInNamespace } from 'services/NetworkService';
 import { portExposureLabels } from 'messages/common';
 import ObjectDescriptionList from 'Components/ObjectDescriptionList';
-import { TableComposable, Caption, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import useFetchDeployment from 'hooks/useFetchDeployment';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { Alert as AlertViolation } from '../types/violationTypes';
 import DeploymentOverview from './Deployment/DeploymentOverview';
 import SecurityContext from './Deployment/SecurityContext';
 import ContainerConfiguration from './Deployment/ContainerConfiguration';
@@ -70,27 +72,24 @@ const compareNetworkPolicies = (a: NetworkPolicy, b: NetworkPolicy): number => {
     return a.name.localeCompare(b.name);
 };
 
-const DeploymentDetails = ({ deployment }) => {
+export type DeploymentDetailsProps = {
+    alertDeployment: NonNullable<AlertViolation['deployment']>;
+};
+
+const DeploymentDetails = ({ alertDeployment }: DeploymentDetailsProps) => {
+    const [namespacePolicies, setNamespacePolicies] = useState<NetworkPolicy[]>([]);
+
     // attempt to fetch related deployment to selected alert
-    const [relatedDeployment, setRelatedDeployment] = useState(deployment);
-    const [namespacePolicies, setNamespacePolicies] = useState([]);
+    const { deployment: relatedDeployment, error: relatedDeploymentFetchError } =
+        useFetchDeployment(alertDeployment.id);
 
     useEffect(() => {
-        fetchDeployment(deployment.id).then(
-            (dep) => setRelatedDeployment(dep),
-            () => setRelatedDeployment(null)
-        );
-    }, [deployment.id, setRelatedDeployment]);
-
-    useEffect(() => {
-        fetchNetworkPoliciesInNamespace(deployment.clusterId, deployment.namespace).then(
-            (policies) => setNamespacePolicies(policies.response.networkPolicies),
+        fetchNetworkPoliciesInNamespace(alertDeployment.clusterId, alertDeployment.namespace).then(
+            // TODO Infer type from response once NetworkService.js is typed
+            (policies: NetworkPolicy[]) => setNamespacePolicies(policies),
             () => setNamespacePolicies([])
         );
-    }, [deployment.namespace, deployment.clusterId, setNamespacePolicies]);
-
-    const deploymentObj = relatedDeployment || deployment;
-    const namespacePoliciesList = namespacePolicies || [];
+    }, [alertDeployment.namespace, alertDeployment.clusterId, setNamespacePolicies]);
 
     return (
         <Flex
@@ -98,13 +97,15 @@ const DeploymentDetails = ({ deployment }) => {
             flex={{ default: 'flex_1' }}
             data-testid="deployment-details"
         >
-            {!relatedDeployment && (
+            {!relatedDeployment && relatedDeploymentFetchError && (
                 <Alert
                     variant="warning"
                     isInline
-                    title="This data is a snapshot of a deployment that no longer exists."
+                    title="There was an error fetching the deployment details. This deployment may no longer exist."
                     data-testid="deployment-snapshot-warning"
-                />
+                >
+                    {getAxiosErrorMessage(relatedDeploymentFetchError)}
+                </Alert>
             )}
             <Flex flex={{ default: 'flex_1' }}>
                 <Flex direction={{ default: 'column' }} flex={{ default: 'flex_1' }}>
@@ -117,7 +118,9 @@ const DeploymentDetails = ({ deployment }) => {
                     <FlexItem>
                         <Card isFlat data-testid="deployment-overview">
                             <CardBody>
-                                <DeploymentOverview deployment={deploymentObj} />
+                                {relatedDeployment && (
+                                    <DeploymentOverview deployment={relatedDeployment} />
+                                )}
                             </CardBody>
                         </Card>
                     </FlexItem>
@@ -130,8 +133,8 @@ const DeploymentDetails = ({ deployment }) => {
                     <FlexItem>
                         <Card isFlat data-testid="port-configuration">
                             <CardBody>
-                                {deploymentObj?.ports?.length > 0
-                                    ? formatDeploymentPorts(deploymentObj.ports).map(
+                                {relatedDeployment && relatedDeployment.ports.length > 0
+                                    ? formatDeploymentPorts(relatedDeployment.ports).map(
                                           (port, idx) => (
                                               // eslint-disable-next-line react/no-array-index-key
                                               <ObjectDescriptionList data={port} key={idx} />
@@ -159,11 +162,11 @@ const DeploymentDetails = ({ deployment }) => {
                     <FlexItem>
                         <Card isFlat data-testid="network-policy">
                             <CardBody>
-                                {namespacePoliciesList?.length > 0 ? (
+                                {namespacePolicies.length > 0 ? (
                                     <TableComposable variant="compact">
                                         <Caption>
                                             <Title headingLevel="h3">All network policies</Title>
-                                            in &quot;{deploymentObj.namespace}&quot; namespace
+                                            in &quot;{alertDeployment.namespace}&quot; namespace
                                         </Caption>
                                         <Thead>
                                             <Tr>
@@ -171,7 +174,7 @@ const DeploymentDetails = ({ deployment }) => {
                                             </Tr>
                                         </Thead>
                                         <Tbody>
-                                            {namespacePoliciesList
+                                            {namespacePolicies
                                                 .sort(compareNetworkPolicies)
                                                 .map((netpol: NetworkPolicy) => (
                                                     // TODO(ROX-11034): This should be a link to the Network Policy yaml or detail screen.
@@ -184,7 +187,7 @@ const DeploymentDetails = ({ deployment }) => {
                                 ) : (
                                     <>
                                         No network policies found in &quot;
-                                        {deploymentObj.namespace}&quot; namespace
+                                        {alertDeployment.namespace}&quot; namespace
                                     </>
                                 )}
                             </CardBody>

--- a/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Header.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Header.tsx
@@ -37,14 +37,14 @@ function getRuntimeHeader(enforcementAction, enforcementCount) {
 
 type HeaderProps = {
     lifecycleStage: LifecycleStage;
-    enforcementCount?: number;
-    enforcementAction?: string;
+    enforcementCount: number;
+    enforcementAction: string;
 };
 
 function Header({
     lifecycleStage,
-    enforcementCount = 0,
-    enforcementAction = ENFORCEMENT_ACTIONS.UNSET_ENFORCEMENT,
+    enforcementCount,
+    enforcementAction,
 }: HeaderProps): ReactElement {
     let countMessage = '';
     if (lifecycleStage === LIFECYCLE_STAGES.DEPLOY) {

--- a/ui/apps/platform/src/Containers/Violations/Details/EnforcementDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/EnforcementDetails.tsx
@@ -14,17 +14,17 @@ function getRuntimeEnforcementCount(processViolation) {
 
 type EnforcementDetailsProps = {
     alert: Alert;
+    enforcement: NonNullable<Alert['enforcement']>;
 };
 
-function EnforcementDetails({ alert }: EnforcementDetailsProps): ReactElement {
-    const { lifecycleStage, processViolation, enforcement, policy } = alert;
+function EnforcementDetails({ alert, enforcement }: EnforcementDetailsProps): ReactElement {
+    const { lifecycleStage, processViolation, policy } = alert;
     let enforcementCount = 0;
     if (lifecycleStage === LIFECYCLE_STAGES.RUNTIME) {
-        if (enforcement?.action === ENFORCEMENT_ACTIONS.KILL_POD_ENFORCEMENT) {
-            enforcementCount =
-                enforcement && processViolation?.processes
-                    ? getRuntimeEnforcementCount(processViolation)
-                    : 0;
+        if (enforcement.action === ENFORCEMENT_ACTIONS.KILL_POD_ENFORCEMENT) {
+            enforcementCount = processViolation?.processes
+                ? getRuntimeEnforcementCount(processViolation)
+                : 0;
         } else {
             enforcementCount = 1;
         }
@@ -39,9 +39,9 @@ function EnforcementDetails({ alert }: EnforcementDetailsProps): ReactElement {
                     <Header
                         lifecycleStage={alert.lifecycleStage}
                         enforcementCount={enforcementCount}
-                        enforcementAction={enforcement?.action}
+                        enforcementAction={enforcement.action}
                     />
-                    {enforcement && enforcementCount && (
+                    {enforcementCount && (
                         <>
                             <Divider component="div" inset={{ default: 'insetMd' }} />
                             <Explanation

--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
@@ -58,7 +58,7 @@ function ViolationDetailsPage(): ReactElement {
         return <ViolationNotFoundPage />;
     }
 
-    const { policy, deployment, resource, commonEntityInfo } = alert;
+    const { policy, deployment, resource, commonEntityInfo, enforcement } = alert;
     const title = policy.name || 'Unknown violation';
     const { name: entityName } = resource || deployment || {};
     const resourceType = resource?.resourceType || commonEntityInfo?.resourceType || 'deployment';
@@ -90,17 +90,17 @@ function ViolationDetailsPage(): ReactElement {
                             />
                         </PageSection>
                     </Tab>
-                    {alert?.enforcement && (
+                    {enforcement && (
                         <Tab eventKey={1} title={<TabTitleText>Enforcement</TabTitleText>}>
                             <PageSection variant="default">
-                                <EnforcementDetails alert={alert} />
+                                <EnforcementDetails alert={alert} enforcement={enforcement} />
                             </PageSection>
                         </Tab>
                     )}
-                    {alert?.deployment && (
+                    {deployment && (
                         <Tab eventKey={2} title={<TabTitleText>Deployment</TabTitleText>}>
                             <PageSection variant="default">
-                                <DeploymentDetails deployment={alert.deployment} />
+                                <DeploymentDetails alertDeployment={deployment} />
                             </PageSection>
                         </Tab>
                     )}

--- a/ui/apps/platform/src/services/NetworkService.js
+++ b/ui/apps/platform/src/services/NetworkService.js
@@ -276,9 +276,7 @@ export function fetchNetworkPoliciesInNamespace(clusterId, namespaceId) {
         method: 'GET',
         url: `${networkPoliciesBaseUrl}?cluster_id=${clusterId}&namespace=${namespaceId}`,
     };
-    return axios(options).then((response) => ({
-        response: response.data,
-    }));
+    return axios(options).then((response) => response.data.networkPolicies);
 }
 
 /**


### PR DESCRIPTION
## Description

In preparation for ROX-11034, this updates the types in the Violations page's Deployment tab to remove usage of `any` in order to increase type safety and correctness.

Steps:
1. Use the destructured properties on alert in https://github.com/stackrox/stackrox/pull/6873/files#diff-5c53620827639310dcbb0614ba692ae5369b2680042b73d4edde5d2deec81773 instead of checking property access to allow TypeScript to automatically infer the types being passed to the child components as non-null.
2. Add explicit prop types to child components instead of using an implicit `any`.
3. Remove the now unneeded null/undefined checks in child components due to Step 1.
4. Split the `Alert['deployment']` and `Deployment` types from being used interchangeably [here](https://github.com/stackrox/stackrox/pull/6873/files?diff=unified&w=0#diff-a884c29bd6409ff914396744bf99d9696c4aef2312a61a36708f9e4dee0bf33fL92).
5. Use the new `useFetchDeployment` hook and check the error state to determine if the deployment details could not be loaded, instead of checking if the deployment details are null/undefined.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Happy path visiting the Violation details page, Deployment tab:
![image](https://github.com/stackrox/stackrox/assets/1292638/afe06065-b109-46ba-b397-150734edbac7)
![image](https://github.com/stackrox/stackrox/assets/1292638/468309cd-e31c-4a6d-aca6-4ef6be87ec64)


Visit the details page for a Violation, delete the deployment via `kubectl`, and then visit the Deployment tab:
![image](https://github.com/stackrox/stackrox/assets/1292638/7a859c3d-7b6a-42a0-9e5d-549a04461d00)

