### PR TITLE
chore(ui): Delete normalizr from saveCluster and dependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -50,7 +50,6 @@
         "monaco-editor": "^0.21.3",
         "monaco-editor-webpack-plugin": "^2.1.0",
         "monaco-yaml": "^4.0.4",
-        "normalizr": "^3.6.1",
         "object-resolve-path": "^1.1.1",
         "pluralize": "^8.0.0",
         "prop-types": "^15.7.2",

--- a/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
@@ -251,17 +251,12 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
             setMessageState(null);
             setSubmissionError('');
             saveCluster(selectedCluster)
-                .then((response) => {
-                    /*
-                    setSelectedCluster(response.cluster);
-                    setClusterRetentionInfo(clusterResponse.clusterRetentionInfo);
-                    */
-                    // TODO After saveCluster returns response without normalize,
-                    // something like the preceding commented lines should replace the following:
+                .then((clusterResponse) => {
                     analyticsTrack(CLUSTER_CREATED);
-                    const newId = response.response.result.cluster; // really is nested like this
+                    const newId = clusterResponse.cluster.id;
                     const clusterWithId = { ...selectedCluster, id: newId };
                     setSelectedCluster(clusterWithId);
+                    setClusterRetentionInfo(clusterResponse.clusterRetentionInfo);
 
                     setWizardStep('DEPLOYMENT');
 

--- a/ui/apps/platform/src/services/ClustersService.ts
+++ b/ui/apps/platform/src/services/ClustersService.ts
@@ -1,4 +1,3 @@
-import { normalize } from 'normalizr';
 import qs from 'qs';
 
 import searchOptionsToQuery, { RestSearchOption } from 'services/searchOptionsToQuery';
@@ -9,7 +8,6 @@ import {
     ClustersResponse,
 } from 'types/clusterService.proto';
 import axios from './instance';
-import { cluster as clusterSchema } from './schemas';
 import { Empty } from './types';
 
 const clustersUrl = '/v1/clusters';
@@ -150,15 +148,13 @@ export function deleteClusters(ids: string[] = []): Promise<Empty[]> {
 /**
  * Creates or updates a cluster given the cluster fields.
  */
-// TODO specify return type after we rewrite without normalize
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function saveCluster(cluster: Cluster) {
-    const promise = cluster.id
-        ? axios.put(`${clustersUrl}/${cluster.id}`, cluster)
-        : axios.post(clustersUrl, cluster);
-    return promise.then((response) => ({
-        response: normalize(response.data, { cluster: clusterSchema }),
-    }));
+    if (cluster.id) {
+        return axios
+            .put<ClusterResponse>(`${clustersUrl}/${cluster.id}`, cluster)
+            .then((response) => response.data);
+    }
+    return axios.post<ClusterResponse>(clustersUrl, cluster).then((response) => response.data);
 }
 
 /**

--- a/ui/apps/platform/src/services/schemas.js
+++ b/ui/apps/platform/src/services/schemas.js
@@ -1,3 +1,0 @@
-import { schema } from 'normalizr';
-
-export const cluster = new schema.Entity('cluster');

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -13904,11 +13904,6 @@ normalize-url@^6.0.1:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
-normalizr@^3.6.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/normalizr/-/normalizr-3.6.1.tgz#d367ab840e031ff382141b8d81ce279292ff69fe"
-  integrity sha512-8iEmqXmPtll8PwbEFrbPoDxVw7MKnNvt3PZzR2Xvq9nggEEOgBlNICPXYzyZ4w4AkHUzCU998mdatER3n2VaMA==
-
 npm-bundled@^1.0.1:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"


### PR DESCRIPTION
## Description

Follow up delete next-to-last occurrences of normalizr in #6782

### Problems

1. Even more difficult than understanding data flow when containers share data in reducers via sagas, invisible **data transformations outside of containers** because classic network graph needed to access clusters as an object map with id as key.
2. Add external insult to internal injury: normalizr dependenct is no longer maintained.

### Analysis

1. The only `saveCluster` call is in ClustersSidePanel when user clicks **Next** button.
2. Response always included new or updated cluster. Since last year, it also includes `clusterRetentionInfo` property.

### Solution

1. Simplify service function and its call.

### Residue

1. I supposed that initial attempt to use `cluster` object in response as source of truth did not work for new cluster, because several fields are null for uninitialized cluster:

    * `healthStatus: null`
    * `helmConfig: null`
    * `status: null`

    But I see that `{ ...selectedCluster, id: newId }` also causes the same logimbue request for `overallHealthStatus` property. After I click **Finish** and click the row, there is no such error.

    Therefore, this contribution has minimal changes out of an abundance of caution, but it seems like clusters side panel has an invisible weakness.

2. @vjwilson Is this cluster creation workflow still enough on the critical path that you imagine we will ever update and unskip its integration test:

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/cypress/integration/clusters/clusters.test.js#L34-L104

    I have kept it as possible useful documentation of the flow, but if it has passed its expiry date and benefit-to-cost for active maintenance, I would like to delete it as a follow up.

3. Investigate console warning:

    > Failed prop type: The prop `clusterRetentionInfo` is marked as required in `ClusterSummary`, but its value is `null`.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -6245 = 4691544 - 4697789
        total -6225 = 11146821 - 11153046
    * `ls -al build/static/js/*.js | wc`
        files 0 = 82 - 82
3. `yarn start` in ui

### Manual testing

Add temporary `console.log` with `JSON.stringify` to compare:
* `cluster` property in response
* `clusterWithId` local value with updated with only `id` from response to support case of new cluster.

1. Visit /main/clusters and click a row
    * See GET /v1/clusters/id request

2. Click **Next**
    * See PUT /v1/clusters/id request

### Integration testing

Too bad, so sad. Cluster creation flow is skipped. See Residue item 2.