### PR TITLE
fix(ui): Fix accessibility problems in KeyValuePairs for Risk

### DIFF
--- a/ui/apps/platform/src/Containers/Risk/ContainerConfigurations.js
+++ b/ui/apps/platform/src/Containers/Risk/ContainerConfigurations.js
@@ -4,8 +4,9 @@ import lowerCase from 'lodash/lowerCase';
 import capitalize from 'lodash/capitalize';
 
 import { vulnManagementPath } from 'routePaths';
-import KeyValuePairs from 'Components/KeyValuePairs';
 import CollapsibleCard from 'Components/CollapsibleCard';
+
+import KeyValuePairs from './KeyValuePairs';
 
 const containerConfigMap = {
     command: { label: 'Commands' },
@@ -123,9 +124,9 @@ const ContainerConfigurations = ({ deployment }) => {
                         <>
                             <div className="py-3 border-b border-base-300">
                                 <div className="pr-1 font-700 ">Resources:</div>
-                                <ul className="ml-2 mt-2 w-full">
+                                <div className="ml-2 mt-2 w-full">
                                     <Resources resources={resources} />
-                                </ul>
+                                </div>
                             </div>
                             <div className="py-3 border-b border-base-300">
                                 <div className="pr-1 font-700">Volumes:</div>
@@ -135,9 +136,9 @@ const ContainerConfigurations = ({ deployment }) => {
                             </div>
                             <div className="py-3 border-b border-base-300">
                                 <div className="pr-1 font-700">Secrets:</div>
-                                <ul className="ml-2 mt-2 w-full">
+                                <div className="ml-2 mt-2 w-full">
                                     <ContainerSecrets secrets={secrets} />
-                                </ul>
+                                </div>
                             </div>
                         </>
                     )}

--- a/ui/apps/platform/src/Containers/Risk/DeploymentDetails.js
+++ b/ui/apps/platform/src/Containers/Risk/DeploymentDetails.js
@@ -5,11 +5,11 @@ import { Message } from '@stackrox/ui-components';
 
 import dateTimeFormat from 'constants/dateTimeFormat';
 import { fetchDeployment } from 'services/DeploymentsService';
-import KeyValuePairs from 'Components/KeyValuePairs';
 import CollapsibleCard from 'Components/CollapsibleCard';
 import { portExposureLabels } from 'messages/common';
 import SecurityContext from './SecurityContext';
 import ContainerConfigurations from './ContainerConfigurations';
+import KeyValuePairs from './KeyValuePairs';
 
 export const formatDeploymentPorts = (ports) => {
     return ports.map(({ exposure, exposureInfos, ...rest }) => {

--- a/ui/apps/platform/src/Containers/Risk/KeyValuePairs.js
+++ b/ui/apps/platform/src/Containers/Risk/KeyValuePairs.js
@@ -65,9 +65,8 @@ class KeyValuePairs extends Component {
 
             return (
                 <div
-                    className="py-3 pb-2 leading-normal tracking-normal border-b border-base-300 last:border-b-0"
+                    className="py-3 pb-2 leading-normal border-b border-base-300 last:border-b-0"
                     key={key}
-                    data-testid={label}
                 >
                     <div className="pr-1 font-700 inline">{label}:</div>
                     <span className={`flex-1 min-w-0 ${className}`}>

--- a/ui/apps/platform/src/Containers/Risk/Process/ProcessBaselineElementList.js
+++ b/ui/apps/platform/src/Containers/Risk/Process/ProcessBaselineElementList.js
@@ -27,7 +27,7 @@ const ProcessBaselineElementList = ({ baselineKey, elements, processEpoch, setPr
             {elements.map(({ element }) => (
                 <li
                     key={element.processName}
-                    className="py-3 pb-2 leading-normal tracking-normal border-b border-base-300 flex justify-between items-center"
+                    className="py-3 pb-2 leading-normal border-b border-base-300 flex justify-between items-center"
                 >
                     <span>{element.processName}</span>
                     <Tooltip content="Remove process from baseline">

--- a/ui/apps/platform/src/Containers/Risk/RiskDetails.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskDetails.js
@@ -14,7 +14,7 @@ const Factor = ({ message, url }) => {
 
     return (
         <div className="px-3">
-            <div className="py-3 pb-2 leading-normal tracking-normal border-b border-base-300">
+            <div className="py-3 pb-2 leading-normal border-b border-base-300">
                 {renderedMessage}
             </div>
         </div>

--- a/ui/apps/platform/src/Containers/Risk/SecurityContext.js
+++ b/ui/apps/platform/src/Containers/Risk/SecurityContext.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import KeyValuePairs from 'Components/KeyValuePairs';
 import CollapsibleCard from 'Components/CollapsibleCard';
+
+import KeyValuePairs from './KeyValuePairs';
 
 const containerSecurityContextMap = {
     privileged: { label: 'Privileged' },


### PR DESCRIPTION
## Description

### Problems

**Deployment Details** tab

> 4 serious: List element has direct children that are not allowed: `div`

Under **Resources**:

* CPU Request (cores)
* CPU Limit (cores)
* Memory Request (MB)
* Memory Limit (MB)

More under **Secrets** if I select a deployment that has them.

### Analysis

1. src/Components/KeyValuePairs,js is used only in Risk:
    * src/Containers/Risk/ContainerConfigurations.js
    * src/Containers/Risk/DeploymentDetails.js
    * src/Containers/Risk/SecurityContext.js
2. It looks like copy-paste. `ContainerVolumes` renders `li` elements, but `Resources` and `ContainerSecrets` render `div` elements.
3. Found only 3 ocurrences of `tracking-normal` Tailwind class: obsolete and in Risk.
4. No integration tests depend on `data-testid` attributes for KeyValuePairs.

### Solution

1. Move KeyValueMap.js from src/Components to src/Containers/Risk
2. Replace `ul` with `div` element so **Resources** and **Secrets** have consistent layout without accessibility warning.
3. Delete `tracking-normal` class.
4. Delete `data-testid` prop.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Visit /main/risk, click **Deployment Details** and inspect
    * Resources
    * Volumes
    * Secrets

        ![Resources](https://github.com/stackrox/stackrox/assets/11862657/5441a75b-7811-4739-a5c5-7e4b3ccb18b4)

        ![Volumes_Secrets](https://github.com/stackrox/stackrox/assets/11862657/bac38257-4e83-4e43-8ade-38f277e3d452)

### Integration testing

1. `yarn cypress-open` in ui/apps/platform
    * risk/risk.test.js
