### PR TITLE
ROX-17157: Trigger k8s reconciliation on restart

### DIFF
--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"context"
+
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/pkg/centralsensor"
@@ -29,6 +31,13 @@ type SensorComponent interface {
 
 	ProcessMessage(msg *central.MsgToSensor) error
 	ResponsesC() <-chan *central.MsgFromSensor
+}
+
+// ExpiringSensorMessage carries a message with a context.Context which will be canceled if the message is no longer
+// valid.
+type ExpiringSensorMessage struct {
+	Context context.Context
+	Message *central.MsgFromSensor
 }
 
 // MessageToComplianceWithAddress adds the Hostname to sensor.MsgToCompliance so we know where to send it to.

--- a/sensor/kubernetes/eventpipeline/component/component.go
+++ b/sensor/kubernetes/eventpipeline/component/component.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"context"
+
 	"github.com/stackrox/rox/sensor/common"
 )
 
@@ -25,4 +27,10 @@ type OutputQueue interface {
 	PipelineComponent
 	Send(event *ResourceEvent)
 	ResponsesC() <-chan common.ExpiringSensorMessage
+}
+
+// Listener component contains all the Kubernetes informers and processes incoming events.
+type Listener interface {
+	PipelineComponent
+	SetContext(ctx context.Context)
 }

--- a/sensor/kubernetes/eventpipeline/component/component.go
+++ b/sensor/kubernetes/eventpipeline/component/component.go
@@ -1,6 +1,8 @@
 package component
 
-import "github.com/stackrox/rox/generated/internalapi/central"
+import (
+	"github.com/stackrox/rox/sensor/common"
+)
 
 // PipelineComponent components that constitute the eventPipeline
 type PipelineComponent interface {
@@ -22,5 +24,5 @@ type Resolver interface {
 type OutputQueue interface {
 	PipelineComponent
 	Send(event *ResourceEvent)
-	ResponsesC() <-chan *central.MsgFromSensor
+	ResponsesC() <-chan common.ExpiringSensorMessage
 }

--- a/sensor/kubernetes/eventpipeline/component/message.go
+++ b/sensor/kubernetes/eventpipeline/component/message.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"context"
+
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/sensor/common/store/resolver"
@@ -52,6 +54,10 @@ type ResourceEvent struct {
 
 	// DeploymentReferences returns a list of deployment references generated from a Kubernetes Event
 	DeploymentReferences []DeploymentReference
+
+	// Context should be checked for the message validity. The context will be cancelled if the message should
+	// no longer be considered (e.g. if the connection broke and the resource will eventually be reconciled).
+	Context context.Context
 }
 
 // NewEvent creates a resource event with preset sensor event messages.

--- a/sensor/kubernetes/eventpipeline/output/output.go
+++ b/sensor/kubernetes/eventpipeline/output/output.go
@@ -3,7 +3,7 @@ package output
 import (
 	"sync/atomic"
 
-	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
@@ -11,7 +11,7 @@ import (
 // New instantiates a an output Queue component
 func New(detector detector.Detector, queueSize int) component.OutputQueue {
 	ch := make(chan *component.ResourceEvent, queueSize)
-	forwardQueue := make(chan *central.MsgFromSensor)
+	forwardQueue := make(chan common.ExpiringSensorMessage)
 	outputQueue := &outputQueueImpl{
 		detector:     detector,
 		innerQueue:   ch,

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -57,11 +57,15 @@ func (q *outputQueueImpl) runOutputQueue() {
 			return
 		}
 
-		select {
-		case <-msg.Context.Done():
-			log.Infof("Message from dispatcher %s dropped (context canceled)", msg.DeploymentTiming.GetDispatcher())
-			continue
-		default:
+		if msg.Context != nil {
+			select {
+			case <-msg.Context.Done():
+				log.Infof("Message from dispatcher %s dropped (context canceled)", msg.DeploymentTiming.GetDispatcher())
+				continue
+			default:
+			}
+		} else {
+			log.Warnf("Message has no context: (%+v)", msg)
 		}
 
 		for _, resourceUpdates := range msg.ForwardMessages {

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -46,6 +46,5 @@ func New(client client.Interface, configHandler config.Handler, detector detecto
 		reprocessor:   reprocessor,
 		offlineMode:   offlineMode,
 		storeProvider: storeProvider,
-		disconnected:  concurrency.NewSignal(),
 	}
 }

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/detector"
@@ -24,7 +25,7 @@ import (
 func New(client client.Interface, configHandler config.Handler, detector detector.Detector, reprocessor reprocessor.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, storeProvider *resources.InMemoryStoreProvider, queueSize int) common.SensorComponent {
 	outputQueue := output.New(detector, queueSize)
 	var depResolver component.Resolver
-	var resourceListener component.PipelineComponent
+	var resourceListener component.Listener
 	if env.ResyncDisabled.BooleanSetting() {
 		depResolver = resolver.New(outputQueue, storeProvider, queueSize)
 		resourceListener = listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, depResolver, storeProvider)
@@ -46,5 +47,6 @@ func New(client client.Interface, configHandler config.Handler, detector detecto
 		reprocessor:   reprocessor,
 		offlineMode:   offlineMode,
 		storeProvider: storeProvider,
+		contextMutex:  &sync.RWMutex{},
 	}
 }

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -37,13 +37,15 @@ func New(client client.Interface, configHandler config.Handler, detector detecto
 
 	pipelineResponses := make(chan *central.MsgFromSensor)
 	return &eventPipeline{
-		eventsC:     pipelineResponses,
-		stopSig:     concurrency.NewSignal(),
-		output:      outputQueue,
-		resolver:    depResolver,
-		listener:    resourceListener,
-		detector:    detector,
-		reprocessor: reprocessor,
-		offlineMode: offlineMode,
+		eventsC:       pipelineResponses,
+		stopSig:       concurrency.NewSignal(),
+		output:        outputQueue,
+		resolver:      depResolver,
+		listener:      resourceListener,
+		detector:      detector,
+		reprocessor:   reprocessor,
+		offlineMode:   offlineMode,
+		storeProvider: storeProvider,
+		disconnected:  concurrency.NewSignal(),
 	}
 }

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -29,7 +29,6 @@ type eventPipeline struct {
 	detector      detector.Detector
 	reprocessor   reprocessor.Handler
 	storeProvider *resources.InMemoryStoreProvider
-	disconnected  concurrency.Signal
 
 	offlineMode *atomic.Bool
 

--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -20,7 +20,7 @@ var (
 )
 
 // New returns a new kubernetes listener.
-func New(client client.Interface, configHandler config.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, queue component.Resolver, storeProvider *resources.InMemoryStoreProvider) component.PipelineComponent {
+func New(client client.Interface, configHandler config.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, queue component.Resolver, storeProvider *resources.InMemoryStoreProvider) component.Listener {
 	k := &listenerImpl{
 		client:             client,
 		stopSig:            concurrency.NewSignal(),

--- a/sensor/kubernetes/listener/listener_impl.go
+++ b/sensor/kubernetes/listener/listener_impl.go
@@ -1,6 +1,7 @@
 package listener
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -29,6 +30,7 @@ type listenerImpl struct {
 	traceWriter        io.Writer
 	outputQueue        component.Resolver
 	storeProvider      *resources.InMemoryStoreProvider
+	cancelContext      context.CancelFunc
 }
 
 func (k *listenerImpl) Start() error {
@@ -53,6 +55,7 @@ func (k *listenerImpl) Stop(_ error) {
 	if k.credentialsManager != nil {
 		k.credentialsManager.Stop()
 	}
+	k.cancelContext()
 	k.stopSig.Signal()
 }
 

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -53,7 +53,7 @@ func managedFieldsTransformer(obj interface{}) (interface{}, error) {
 
 func (k *listenerImpl) handleAllEvents() {
 	ctx, cancel := context.WithCancel(context.Background())
-	k.cancelContext = cancel
+	k.setCancelContext(cancel)
 
 	// TODO(ROX-14194): remove resyncingSif once all resources are adapted
 	var resyncingSif informers.SharedInformerFactory
@@ -265,6 +265,7 @@ func (k *listenerImpl) handleAllEvents() {
 	syncingResources.Set(false)
 
 	k.outputQueue.Send(&component.ResourceEvent{
+		Context: ctx,
 		ForwardMessages: []*central.SensorEvent{
 			{
 				Resource: &central.SensorEvent_Synced{

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -51,10 +51,7 @@ func managedFieldsTransformer(obj interface{}) (interface{}, error) {
 	return obj, nil
 }
 
-func (k *listenerImpl) handleAllEvents() {
-	ctx, cancel := context.WithCancel(context.Background())
-	k.setCancelContext(cancel)
-
+func (k *listenerImpl) handleAllEvents(ctx context.Context) {
 	// TODO(ROX-14194): remove resyncingSif once all resources are adapted
 	var resyncingSif informers.SharedInformerFactory
 	if env.ResyncDisabled.BooleanSetting() {

--- a/sensor/kubernetes/listener/resource_event_handler_impl.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl.go
@@ -1,6 +1,8 @@
 package listener
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -27,6 +29,7 @@ type resourceEventHandlerImpl struct {
 	seenIDs                    map[types.UID]struct{}
 	missingInitialIDs          map[types.UID]struct{}
 	hasSeenAllInitialIDsSignal concurrency.Signal
+	context                    context.Context
 }
 
 func (h *resourceEventHandlerImpl) OnAdd(obj interface{}) {
@@ -106,6 +109,7 @@ func (h *resourceEventHandlerImpl) sendResourceEvent(obj, oldObj interface{}, ac
 	}
 
 	message := h.dispatcher.ProcessEvent(obj, oldObj, action)
+	message.Context = h.context
 	h.resolver.Send(message)
 }
 

--- a/sensor/tests/connection/k8sreconciliation/reconcile_test.go
+++ b/sensor/tests/connection/k8sreconciliation/reconcile_test.go
@@ -16,7 +16,16 @@ import (
 var (
 	NginxDeployment1 = helper.K8sResourceInfo{Kind: "Deployment", YamlFile: "nginx.yaml", Name: "nginx-deployment"}
 	NginxDeployment2 = helper.K8sResourceInfo{Kind: "Deployment", YamlFile: "nginx2.yaml", Name: "nginx-deployment-2"}
+	NginxDeployment3 = helper.K8sResourceInfo{Kind: "Deployment", YamlFile: "nginx3.yaml", Name: "nginx-deployment-3"}
+
+	NetpolBlockEgress = helper.K8sResourceInfo{Kind: "NetworkPolicy", YamlFile: "netpol-block-egress.yaml", Name: "block-all-egress"}
 )
+
+// Test_SensorReconcilesKubernetesEvents creates a timeline of events that asserts the behavior of kubernetes listeners
+// offline mode.
+//
+// The following timeline is used:
+//
 
 func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
 	t.Setenv(features.PreventSensorRestartOnDisconnect.EnvVar(), "true")
@@ -31,17 +40,38 @@ func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
 	c, err := helper.NewContext(t)
 	require.NoError(t, err)
 
+	// Timeline of the events in this test:
+	// 1) Create deployment Nginx1
+	// 2) Create deployment Nginx2
+	// 3) Create NetworkPolicy block-all-egress
+	// 4) gRPC Connection interrupted
+	// 5) Delete deployment Nginx2
+	// 6) Create deployment Nginx3
+	// 7) gRPC Connection re-established
+	// 8) Sensor transmits current state with SYNC event type:
+	//  Deployment 		Nginx1
+	//  Deployment 		Nginx3
+	//  NetworkPolicy 	block-all-egress
+	//
+	// Using a NetworkPolicy here will make sure that no deployments that were removed while the connection
+	// was down will be used for
+	//
 	c.RunTest(helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {
 		ctx := context.Background()
 
 		testContext.WaitForSyncEvent(2 * time.Minute)
 		_, err = c.ApplyResourceAndWaitNoObject(ctx, helper.DefaultNamespace, NginxDeployment1, nil)
+		deleteDeployment2, err := c.ApplyResourceAndWaitNoObject(ctx, helper.DefaultNamespace, NginxDeployment2, nil)
+
+		_, _ = c.ApplyResourceAndWaitNoObject(ctx, helper.DefaultNamespace, NetpolBlockEgress, nil)
 
 		testContext.StopCentralGRPC()
 
 		obj := &appsV1.Deployment{}
-		_, err = c.ApplyResource(ctx, helper.DefaultNamespace, &NginxDeployment2, obj, nil)
+		_, err = c.ApplyResource(ctx, helper.DefaultNamespace, &NginxDeployment3, obj, nil)
 		require.NoError(t, err)
+
+		require.NoError(t, deleteDeployment2())
 
 		testContext.StartFakeGRPC()
 
@@ -49,9 +79,15 @@ func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
 		require.Len(t, archived, 1)
 		deploymentMessageInArchive(t, archived[0], helper.DefaultNamespace, NginxDeployment1.Name)
 
+		// Wait for sync event to be sent, then expect the following state to be transmitted:
+		//   SYNC nginx-deployment-1
+		//   SYNC nginx-deployment-3
+		//   No event for nginx-deployment-2 (was deleted while connection was down)
+		// This reconciliation state will make Central delete Nginx2, keep Nginx1 and create Nginx3
 		testContext.WaitForSyncEvent(2 * time.Minute)
 		testContext.DeploymentActionReceived(NginxDeployment1.Name, central.ResourceAction_SYNC_RESOURCE)
-		testContext.DeploymentActionReceived(NginxDeployment2.Name, central.ResourceAction_SYNC_RESOURCE)
+		testContext.DeploymentActionReceived(NginxDeployment3.Name, central.ResourceAction_SYNC_RESOURCE)
+		testContext.DeploymentNotReceived(NginxDeployment2.Name)
 	}))
 
 }

--- a/sensor/tests/connection/k8sreconciliation/reconcile_test.go
+++ b/sensor/tests/connection/k8sreconciliation/reconcile_test.go
@@ -85,8 +85,8 @@ func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
 		//   No event for nginx-deployment-2 (was deleted while connection was down)
 		// This reconciliation state will make Central delete Nginx2, keep Nginx1 and create Nginx3
 		testContext.WaitForSyncEvent(2 * time.Minute)
-		testContext.DeploymentActionReceived(NginxDeployment1.Name, central.ResourceAction_SYNC_RESOURCE)
-		testContext.DeploymentActionReceived(NginxDeployment3.Name, central.ResourceAction_SYNC_RESOURCE)
+		testContext.FirstDeploymentReceivedWithAction(NginxDeployment1.Name, central.ResourceAction_SYNC_RESOURCE)
+		testContext.FirstDeploymentReceivedWithAction(NginxDeployment3.Name, central.ResourceAction_SYNC_RESOURCE)
 		testContext.DeploymentNotReceived(NginxDeployment2.Name)
 	}))
 

--- a/sensor/tests/connection/k8sreconciliation/yaml/netpol-block-egress.yaml
+++ b/sensor/tests/connection/k8sreconciliation/yaml/netpol-block-egress.yaml
@@ -1,0 +1,10 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: block-all-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: nginx-2
+  policyTypes:
+     - Egress

--- a/sensor/tests/connection/k8sreconciliation/yaml/nginx.yaml
+++ b/sensor/tests/connection/k8sreconciliation/yaml/nginx.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: nginx
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: nginx

--- a/sensor/tests/connection/k8sreconciliation/yaml/nginx3.yaml
+++ b/sensor/tests/connection/k8sreconciliation/yaml/nginx3.yaml
@@ -1,18 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment-2
+  name: nginx-deployment-3
   labels:
-    app: nginx-2
+    app: nginx-3
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nginx-2
+      app: nginx-3
   template:
     metadata:
       labels:
-        app: nginx-2
+        app: nginx-3
     spec:
       containers:
       - name: nginx

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/sensor"
 	"github.com/stackrox/rox/sensor/testutils"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -520,6 +521,13 @@ func (c *TestContext) DeploymentActionReceived(name string, expectedAction centr
 		}
 		return nil
 	}, fmt.Sprintf("Deployment %s should be received with action %s", name, expectedAction))
+}
+
+// DeploymentNotReceived checks that a deployment event for deployment with name should not have been received by fake central.
+func (c *TestContext) DeploymentNotReceived(name string) {
+	messages := c.GetFakeCentral().GetAllMessages()
+	lastDeploymentUpdate := GetLastMessageWithDeploymentName(messages, DefaultNamespace, name)
+	assert.Nilf(c.t, lastDeploymentUpdate, "should not have found deployment with name %s: %+v", name, lastDeploymentUpdate)
 }
 
 // GetLastMessageMatching finds last element in slice matching `matchFn`.

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -483,6 +483,31 @@ func (c *TestContext) LastDeploymentState(name string, assertion AssertFunc, mes
 	c.LastDeploymentStateWithTimeout(name, assertion, message, defaultWaitTimeout)
 }
 
+// FirstDeploymentStateMatchesWithTimeout checks that the first deployment received with name matches the assertion function.
+func (c *TestContext) FirstDeploymentStateMatchesWithTimeout(name string, assertion AssertFunc, message string, timeout time.Duration) {
+	timer := time.NewTimer(timeout)
+	ticker := time.NewTicker(defaultTicker)
+	lastErr := errors.New("no deployment found")
+	for {
+		select {
+		case <-timer.C:
+			c.t.Errorf("timeout reached waiting for state: (%s): %s", message, lastErr)
+			return
+		case <-ticker.C:
+			messages := c.GetFakeCentral().GetAllMessages()
+			deploymentMessage := GetFirstMessageWithDeploymentName(messages, DefaultNamespace, name)
+			deployment := deploymentMessage.GetEvent().GetDeployment()
+			action := deploymentMessage.GetEvent().GetAction()
+			if deployment != nil {
+				// Always return when deployment is found. As soon as deployment != nil it should be the deployment
+				// that matches assertion. If it isn't, the test should fail immediately. There's no point in waiting.
+				lastErr = assertion(deployment, action)
+				return
+			}
+		}
+	}
+}
+
 // LastDeploymentStateWithTimeout checks that a deployment reaches a state asserted by `assertion`. If the deployment does not reach
 // that state until `timeout` the test fails.
 func (c *TestContext) LastDeploymentStateWithTimeout(name string, assertion AssertFunc, message string, timeout time.Duration) {
@@ -510,17 +535,17 @@ func (c *TestContext) LastDeploymentStateWithTimeout(name string, assertion Asse
 
 // DeploymentCreateReceived checks if a deployment object was received with CREATE action.
 func (c *TestContext) DeploymentCreateReceived(name string) {
-	c.DeploymentActionReceived(name, central.ResourceAction_CREATE_RESOURCE)
+	c.FirstDeploymentReceivedWithAction(name, central.ResourceAction_CREATE_RESOURCE)
 }
 
-// DeploymentActionReceived checks if a deployment object was received with specific action type.
-func (c *TestContext) DeploymentActionReceived(name string, expectedAction central.ResourceAction) {
-	c.LastDeploymentState(name, func(_ *storage.Deployment, action central.ResourceAction) error {
+// FirstDeploymentReceivedWithAction checks if a deployment object was received with specific action type.
+func (c *TestContext) FirstDeploymentReceivedWithAction(name string, expectedAction central.ResourceAction) {
+	c.FirstDeploymentStateMatchesWithTimeout(name, func(_ *storage.Deployment, action central.ResourceAction) error {
 		if action != expectedAction {
 			return errors.Errorf("event action is %s, but expected %s", action, expectedAction)
 		}
 		return nil
-	}, fmt.Sprintf("Deployment %s should be received with action %s", name, expectedAction))
+	}, fmt.Sprintf("Deployment %s should be received with action %s", name, expectedAction), defaultWaitTimeout)
 }
 
 // DeploymentNotReceived checks that a deployment event for deployment with name should not have been received by fake central.
@@ -803,6 +828,17 @@ func (c *TestContext) waitForResource(timeout time.Duration, fn condition) error
 			}
 		}
 	}
+}
+
+// GetFirstMessageWithDeploymentName find the first sensor message by namespace and deployment name
+func GetFirstMessageWithDeploymentName(messages []*central.MsgFromSensor, ns, name string) *central.MsgFromSensor {
+	for _, msg := range messages {
+		deployment := msg.GetEvent().GetDeployment()
+		if deployment.GetName() == name && deployment.GetNamespace() == ns {
+			return msg
+		}
+	}
+	return nil
 }
 
 // GetLastMessageWithDeploymentName find most recent sensor messages by namespace and deployment name


### PR DESCRIPTION
## Description

This PR builds up on the work from #6376 and #6692. 

This PR fixes the cases where simply restarting the listeners was not sufficient to get a correct state being transmitted to Central during the reconciliation. In introduces three new behaviors in Sensor:

1. It cleans up the stores when going into offline mode. This will fix the cases where other resources being updated (e.g. Network Policies) can trigger updates on Deployments that were already deleted (see integration test case).
2. It adds a `context.Context` to the pipeline resource message. This allows Sensor to identify if the message in the pipeline is "invalid".
3. It adds "connection awareness" to the admission control forwarder. This is the component that sends messages directly to the central sender. So it's the last step before communicating kubernetes messages to Central. 

(2) and (3) are needed to avoid the case where messages are stuck in some chan in the pipeline (e.g. waiting to be processed by the resolver) when the connection is broken. What happens in this case is that once the connection is up again, these queues will be read, and old messages will be sent first in to central, before the reconciliation takes place. There is a possibility that sensor will report an UPDATE event for a deployment that was shortly after deleted (and thus won't be sent during the reconciliation). Making Central believe that a deployment that no longer exists in the cluster is still there. 


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- Implemented integration (`sensor/tests/connection/k8sreconciliation`) to cover this case
- Ran the test in a loop (40+ times) to make sure there was no flakiness 