### PR TITLE
ROX-18216: Fix NodeInventory flake

### DIFF
--- a/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
@@ -56,7 +56,7 @@ class NodeInventoryTest extends BaseSpecification {
                         orchestrator.daemonSetReady(Constants.STACKROX_NAMESPACE, "collector")
                     }
                 }
-                catch (RuntimeException ignored) {
+                catch (Exception ignored) {
                     log.info("Unable to bring collector ds to the desired state")
                     return false
                 }


### PR DESCRIPTION
## Description

The problem was that the Collector DS restarted with new env var updated all but one pod. 
⚠️ I was unable to reproduce this locally.

This PR:
- Adds one more repetition of the entire process (setting env var to the DS, waiting for pods to be updated)
- Changes the wait time between checking the node-inventory containers from 6s to 10s. This should give more time for the change to propagate (if that is the reason of this failure).

## Checklist
- [x] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]

## Testing Performed

- CI
- Locally running tests
