### PR TITLE
fix(ui): Fix accessibility problems in Process Details for Risk

### DIFF
--- a/ui/apps/platform/src/Components/Panel.js
+++ b/ui/apps/platform/src/Components/Panel.js
@@ -31,11 +31,15 @@ export function PanelHead({ children }) {
 export function PanelTitle({ testid = '', breakAll = true, text }) {
     return (
         <div
-            className="flex font-700 items-center leading-normal min-w-24 overflow-hidden px-4 text-base-600"
+            className="flex items-center leading-normal min-w-24 overflow-hidden px-4 text-base-600"
             data-testid={testid || null}
         >
             <Tooltip content={text}>
-                <div className={`line-clamp ${breakAll ? 'break-all' : ''}`}>{text}</div>
+                <h2>
+                    <div className={`font-700 line-clamp ${breakAll ? 'break-all' : ''}`}>
+                        {text}
+                    </div>
+                </h2>
             </Tooltip>
         </div>
     );

--- a/ui/apps/platform/src/Containers/Risk/Process/DiscoveryCardHeader.js
+++ b/ui/apps/platform/src/Containers/Risk/Process/DiscoveryCardHeader.js
@@ -45,8 +45,8 @@ function ProcessesDiscoveryCardHeader({
             data-testid={suspicious ? 'suspicious-process' : 'process'}
         >
             <div className={`p-3 ${textClass} flex flex-col`}>
-                <h1 className="font-700">{trimmedName}</h1>
-                <h2 className="text-sm">{`in container ${containerName} `}</h2>
+                <div className="font-700">{trimmedName}</div>
+                <div className="text-sm">{`in container ${containerName} `}</div>
             </div>
             <div className="flex content-center">
                 {suspicious && (
@@ -56,13 +56,18 @@ function ProcessesDiscoveryCardHeader({
                                 type="button"
                                 onClick={addBaseline}
                                 className="border rounded p-px mr-3 ml-3 border-alert-300 flex items-center hover:bg-alert-200"
+                                aria-label="Add process to baseline"
                             >
                                 <Icon.Plus className="h-4 w-4 text-alert-700" />
                             </button>
                         </Tooltip>
                     </div>
                 )}
-                <button type="button" className={`pl-3 pr-3 ${suspicious && 'text-alert-700'}`}>
+                <button
+                    type="button"
+                    className={`pl-3 pr-3 ${suspicious ? 'text-alert-700' : ''}`}
+                    aria-label="Expand or Collapse"
+                >
                     {icon}
                 </button>
             </div>

--- a/ui/apps/platform/src/Containers/Risk/Process/ProcessBaselineElementList.js
+++ b/ui/apps/platform/src/Containers/Risk/Process/ProcessBaselineElementList.js
@@ -35,6 +35,7 @@ const ProcessBaselineElementList = ({ baselineKey, elements, processEpoch, setPr
                             className="flex p-1 rounded border content-center hover:bg-base-300"
                             type="button"
                             onClick={deleteCurrentProcess(element)}
+                            aria-label="Remove process from baseline"
                         >
                             <Icon.Minus className="h-4 w-4" />
                         </button>

--- a/ui/apps/platform/src/Containers/Risk/Process/ProcessBaselineList.js
+++ b/ui/apps/platform/src/Containers/Risk/Process/ProcessBaselineList.js
@@ -49,7 +49,7 @@ const ProcessBaselineList = ({ process, processEpoch, setProcessEpoch }) => {
             key={containerName}
             className="bg-base-100 text-base-600 rounded border border-base-400"
         >
-            <div className="text-base-600 font-700 text-lg flex justify-between items-center border-b border-base-300 p-3">
+            <div className="text-base-600 font-700 flex justify-between items-center border-b border-base-300 p-3">
                 <span>{key.containerName}</span>
                 <Tooltip content={isLocked ? unlockTooltipText : lockTooltipText}>
                     <div>
@@ -61,6 +61,7 @@ const ProcessBaselineList = ({ process, processEpoch, setProcessEpoch }) => {
                             }`}
                             type="button"
                             onClick={toggleCurrentProcessLock}
+                            aria-label="Lock baseline"
                         >
                             <Icon.Lock className="h-4 w-4" />
                         </button>
@@ -72,6 +73,7 @@ const ProcessBaselineList = ({ process, processEpoch, setProcessEpoch }) => {
                             }`}
                             type="button"
                             onClick={toggleCurrentProcessLock}
+                            aria-label="Unlock baseline"
                         >
                             <Icon.Unlock className="h-4 w-4" />
                         </button>


### PR DESCRIPTION
## Description

### Problems

1. 4 serious: Buttons must have discernable text

2. 1 moderate: Heading levels should only increase by one h3 Event Timeline and so on

### Analysis

1. Indeed, buttons lack `aria-label` attribute:
    * DiscoveryCardHeader: hard to believe that it does not know if its state is collapsed or expanded!
    * ProcessBaselineList
    * ProcessBaselineElement
2. `PanelTitle` renders `div` instead of more semantic `h2` element. Therefore there is a gap to the semantic `h3` elements.

### Solution

1. Add `aria-label` attribute:
    * DiscoveryCardHeader: too bad, so sad: generic Expand or Collapse. Also replace conditional and that has `false` class with ternary that has empty string.
2. Renders `h2` element in `PanelHeader` component. Even if affects heading levels in other classic pages, we will adjust them for semantic page structure.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Visit /main/risk, click a deployment, and then click **Process Discovery**
    * See no visible change to `h2` element in side panel.
    * Verify `aria-label` attributes.
    * See space instead of `false` in `class` attribute for Expand or Collapse button.
        ![Process](https://github.com/stackrox/stackrox/assets/11862657/403359e6-ed8a-4456-bea9-a7eafbb133a5)

### Integration testing

1. `yarn cypress-open` in ui/apps/platform
    * risk/deploymentTimeline.test.js
    * risk/podTimeline.test.js
    * risk/risk.test.js
    * risk/timelineOverview.test.js
