### PR TITLE
chore(ui): Import consistently from lodash

### DIFF
--- a/ui/apps/platform/cypress/helpers/scopeSelectors.js
+++ b/ui/apps/platform/cypress/helpers/scopeSelectors.js
@@ -1,4 +1,7 @@
-import { isString, isPlainObject, isFunction, mapValues } from 'lodash';
+import isString from 'lodash/isString';
+import isPlainObject from 'lodash/isPlainObject';
+import isFunction from 'lodash/isFunction';
+import mapValues from 'lodash/mapValues';
 
 function appendPrefixDeep(prefix, selector) {
     if (isPlainObject(selector)) {

--- a/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkBaselines.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkBaselines.ts
@@ -1,5 +1,5 @@
-import { uniqBy } from 'lodash';
 import { useEffect, useState } from 'react';
+import uniqBy from 'lodash/uniqBy';
 
 import { fetchNetworkBaselines } from 'services/NetworkService';
 import { NetworkBaseline } from 'types/networkBaseline.proto';

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -12,9 +12,9 @@ import {
     TextContent,
     TextVariants,
 } from '@patternfly/react-core';
+import uniq from 'lodash/uniq';
 
 import useTabs from 'hooks/patternfly/useTabs';
-import { uniq } from 'lodash';
 import {
     getDeploymentNodesInNamespace,
     getNodeById,

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -1,4 +1,4 @@
-import { uniq } from 'lodash';
+import uniq from 'lodash/uniq';
 
 import { L4Protocol, NetworkEntityInfoType as EntityType } from 'types/networkFlow.proto';
 import { GroupedDiffFlows } from 'types/networkPolicyService';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client';
+import sortBy from 'lodash/sortBy';
 import { severityRankings } from 'constants/vulnerabilities';
-import { sortBy } from 'lodash';
 import { VulnerabilitySeverity, isVulnerabilitySeverity } from 'types/cve.proto';
 import { ApiSortOption } from 'types/search';
 

--- a/ui/apps/platform/src/hooks/usePaginatedQuery.ts
+++ b/ui/apps/platform/src/hooks/usePaginatedQuery.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useMemo } from 'react';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 function filterNextPage<Item, ItemKey>(
     results: Item[],

--- a/ui/apps/platform/src/utils/securityContextUtils.ts
+++ b/ui/apps/platform/src/utils/securityContextUtils.ts
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import { ContainerSecurityContext } from 'types/deployment.proto';
 


### PR DESCRIPTION
## Description

Recent work to delete unused dependencies reminded me of an inconsistency that the team had discussed, and then forgotten. I became curious whether rewrite named imports as default imports from lodash subfolder affects either bundle size or yarn.lock file.

1. In ui/apps/platform folder:
    ```sh
    find src \( -name '*.js' -o -name '*.ts' -o -name '*.tsx' \) -exec fgrep -h "'lodash" \{\} >> somewhere/lodash.txt \;
    ```
2. Find in File `'lodash'` 6 named out of 150 total
    * `import { isEmpty } from 'lodash';`
    * `import { debounce } from 'lodash';`
    * `import { uniq } from 'lodash';`
    * `import { uniq } from 'lodash';`
    * `import { uniqBy } from 'lodash';`
    * `import { sortBy } from 'lodash';`

Although I do not have a preference between named import from `'lodash'` versus default import from `'lodash/whatever'` a small number of exceptions to a pattern sometimes defeats my old school style to search the code.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

TL;DR You don’t know unless you measure.

1. `yarn lint` in ui
2. `yarn` in ui
3. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -108 = 4231761 - 4231869
        total -76834 = 10235754 - 10312588
    * `ls -al build/static/js/*.js | wc`
        files -1 = 79 - 80
4. `yarn start` in ui

### Manual testing

1. Visit /main/dashboard and while there analyze page with aXe DevTools to assess accessibility (pardon pun)

2. Continue to visit every link in left navigation and ditto