### PR TITLE
ROX-18389: Fix query builders for ImageRegistry & ImageRemote criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 correctly for the specified values.
 - Rollback to a 3.y release or the 4.0 release will no longer be supported starting from 4.3.
 - Rollbacks from future releases to the 4.2 or later release will no longer require `ForceRollbackVersion` to be set.
-
+- ROX-18389: The  implementation of Image Registry and Image Remote policy criteria has been fixed to ensure violations are generated \
+  correctly for the specified values.
 ## [4.1.0]
 
 

--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -2068,6 +2068,7 @@ func (suite *DefaultPoliciesTestSuite) TestPortExposure() {
 func (suite *DefaultPoliciesTestSuite) TestImageRegistry() {
 	depMatcher, err := BuildDeploymentMatcher(policyWithSingleFieldAndValues(
 		fieldnames.ImageRegistry, []string{"^$", "quay.io"}, true, storage.BooleanOperator_OR))
+	require.NoError(suite.T(), err)
 
 	imgNoReg := imageWithNoRegistry()
 	dep := fixtures.GetDeployment().Clone()

--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -380,7 +380,7 @@ func initializeFieldMetadata() FieldMetadata {
 		[]RuntimeFieldType{})
 
 	f.registerFieldMetadata(fieldnames.ImageRegistry,
-		querybuilders.ForFieldLabelRegex(search.ImageRegistry),
+		querybuilders.ForFieldLabelMultipleValues(search.ImageRegistry),
 		violationmessages.ImageContextFields,
 		func(*validateConfiguration) *regexp.Regexp {
 			return stringValueRegex
@@ -389,7 +389,7 @@ func initializeFieldMetadata() FieldMetadata {
 		[]RuntimeFieldType{})
 
 	f.registerFieldMetadata(fieldnames.ImageRemote,
-		querybuilders.ForFieldLabelRegex(search.ImageRemote),
+		querybuilders.ForFieldLabelMultipleValues(search.ImageRemote),
 		violationmessages.ImageContextFields,
 		func(*validateConfiguration) *regexp.Regexp {
 			return stringValueRegex

--- a/pkg/booleanpolicy/querybuilders/builders.go
+++ b/pkg/booleanpolicy/querybuilders/builders.go
@@ -169,6 +169,18 @@ func ForFieldLabelNil(label search.FieldLabel) QueryBuilder {
 	})
 }
 
+// ForFieldLabelMultipleValues returns the field queries for multiple re
+func ForFieldLabelMultipleValues(label search.FieldLabel) QueryBuilder {
+	return queryBuilderFunc(func(group *storage.PolicyGroup) []*query.FieldQuery {
+		return []*query.FieldQuery{{
+			Field:    label.String(),
+			Values:   mapValues(group, valueToStringRegex),
+			Operator: operatorProtoMap[group.GetBooleanOperator()],
+			Negate:   group.GetNegate(),
+		}}
+	})
+}
+
 func fieldQueryFromGroup(group *storage.PolicyGroup, label search.FieldLabel, mapFunc func(string) string) *query.FieldQuery {
 	return &query.FieldQuery{
 		Field:    label.String(),


### PR DESCRIPTION
## Description
Fix the query builders for ImageRegistry and ImageRemote criteria to consume all specified values, and treat each value as a regex with appropriate anding/oring between values as specified by the user.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
CI only