### PR TITLE
ROX-17849: Allowing creating a vuln report

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
 import {
     PageSection,
     Title,
@@ -8,6 +9,11 @@ import {
     Breadcrumb,
     BreadcrumbItem,
     Wizard,
+    Alert,
+    AlertVariant,
+    Button,
+    WizardFooter,
+    WizardContextConsumer,
 } from '@patternfly/react-core';
 
 import { vulnerabilityReportsPath } from 'routePaths';
@@ -17,13 +23,56 @@ import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import ReportParametersForm from 'Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm';
 import ReportReviewForm from '../forms/ReportReviewForm';
+import useCreateReport from '../api/useCreateReport';
+
+const wizardSteps = [
+    'Configure report parameters',
+    'Configure delivery destinations (Optional)',
+    'Review and create',
+];
 
 function VulnReportsPage() {
-    const { formValues, setFormValues } = useReportFormValues();
+    const alertRef = React.useRef<HTMLInputElement>(null);
+    const history = useHistory();
+
+    const { formValues, setFormFieldValue, clearFormValues } = useReportFormValues();
+    const { data, isLoading, error, createReport } = useCreateReport();
+
+    // When report is created, navigate to the vuln reports page
+    useEffect(() => {
+        if (data) {
+            clearFormValues();
+            history.push(vulnerabilityReportsPath);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [data]);
+
+    // When an error occurs, scroll the message into view
+    useEffect(() => {
+        if (error && alertRef.current) {
+            alertRef.current?.scrollIntoView({
+                behavior: 'smooth',
+            });
+        }
+    }, [error]);
+
+    function onSave() {
+        createReport(formValues);
+    }
 
     return (
         <>
             <PageTitle title="Create vulnerability report" />
+            {error && (
+                <div ref={alertRef}>
+                    <Alert
+                        isInline
+                        variant={AlertVariant.danger}
+                        title={error}
+                        className="pf-u-mb-sm"
+                    />
+                </div>
+            )}
             <PageSection variant="light" className="pf-u-py-md">
                 <Breadcrumb>
                     <BreadcrumbItemLink to={vulnerabilityReportsPath}>
@@ -51,24 +100,66 @@ function VulnReportsPage() {
                     navAriaLabel="Report creation steps"
                     // @TODO: Make the mainAriaLabel dynamic based on whether you're creating, editing, or cloning
                     mainAriaLabel="Report creation content"
+                    hasNoBodyPadding
                     steps={[
                         {
-                            name: 'Configure report parameters',
+                            name: wizardSteps[0],
                             component: (
                                 <ReportParametersForm
                                     formValues={formValues}
-                                    setFormValues={setFormValues}
+                                    setFormFieldValue={setFormFieldValue}
                                 />
                             ),
                         },
-                        { name: 'Configure delivery destinations (Optional)', component: <p /> },
+                        { name: wizardSteps[1], component: <p /> },
                         {
-                            name: 'Review and create',
+                            name: wizardSteps[2],
                             component: <ReportReviewForm formValues={formValues} />,
                             nextButtonText: 'Create',
                         },
                     ]}
-                    hasNoBodyPadding
+                    onSave={onSave}
+                    footer={
+                        <WizardFooter>
+                            <WizardContextConsumer>
+                                {({ activeStep, onNext, onBack, onClose }) => {
+                                    const lastStep = wizardSteps[wizardSteps.length - 1];
+                                    return (
+                                        <>
+                                            {activeStep.name !== lastStep ? (
+                                                <Button
+                                                    variant="primary"
+                                                    type="submit"
+                                                    onClick={onNext}
+                                                >
+                                                    Next
+                                                </Button>
+                                            ) : (
+                                                <Button
+                                                    variant="primary"
+                                                    type="submit"
+                                                    onClick={onSave}
+                                                    isLoading={isLoading}
+                                                >
+                                                    Create
+                                                </Button>
+                                            )}
+                                            <Button
+                                                variant="secondary"
+                                                onClick={onBack}
+                                                isDisabled={activeStep.name !== lastStep}
+                                            >
+                                                Back
+                                            </Button>
+                                            <Button variant="link" onClick={onClose}>
+                                                Cancel
+                                            </Button>
+                                        </>
+                                    );
+                                }}
+                            </WizardContextConsumer>
+                        </WizardFooter>
+                    }
                 />
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
@@ -25,7 +25,7 @@ import ReportParametersForm from 'Containers/Vulnerabilities/VulnerablityReporti
 import ReportReviewForm from '../forms/ReportReviewForm';
 import useCreateReport from '../api/useCreateReport';
 
-const wizardSteps = [
+const wizardStepNames = [
     'Configure report parameters',
     'Configure delivery destinations (Optional)',
     'Review and create',
@@ -39,6 +39,7 @@ function VulnReportsPage() {
     const { data, isLoading, error, createReport } = useCreateReport();
 
     // When report is created, navigate to the vuln reports page
+    // @TODO: We want to change this in the future to navigate to the read-only report page to verify the details
     useEffect(() => {
         if (data) {
             clearFormValues();
@@ -103,7 +104,7 @@ function VulnReportsPage() {
                     hasNoBodyPadding
                     steps={[
                         {
-                            name: wizardSteps[0],
+                            name: wizardStepNames[0],
                             component: (
                                 <ReportParametersForm
                                     formValues={formValues}
@@ -111,9 +112,9 @@ function VulnReportsPage() {
                                 />
                             ),
                         },
-                        { name: wizardSteps[1], component: <p /> },
+                        { name: wizardStepNames[1], component: <p /> },
                         {
-                            name: wizardSteps[2],
+                            name: wizardStepNames[2],
                             component: <ReportReviewForm formValues={formValues} />,
                             nextButtonText: 'Create',
                         },
@@ -123,10 +124,11 @@ function VulnReportsPage() {
                         <WizardFooter>
                             <WizardContextConsumer>
                                 {({ activeStep, onNext, onBack, onClose }) => {
-                                    const lastStep = wizardSteps[wizardSteps.length - 1];
+                                    const lastStepName =
+                                        wizardStepNames[wizardStepNames.length - 1];
                                     return (
                                         <>
-                                            {activeStep.name !== lastStep ? (
+                                            {activeStep.name !== lastStepName ? (
                                                 <Button
                                                     variant="primary"
                                                     type="submit"
@@ -147,7 +149,7 @@ function VulnReportsPage() {
                                             <Button
                                                 variant="secondary"
                                                 onClick={onBack}
-                                                isDisabled={activeStep.name !== lastStep}
+                                                isDisabled={activeStep.name !== lastStepName}
                                             >
                                                 Back
                                             </Button>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -35,10 +35,17 @@ const reportConfigurations: ReportConfiguration[] = [
             imageTypes: ['DEPLOYED', 'WATCHED'],
             allVuln: true,
         },
-        emailConfig: {
-            notifierId: 'notifier-1',
-            mailingLists: ['bob@example.com', 'alice@example.com'],
-        },
+        notifiers: [
+            {
+                emailConfig: [
+                    {
+                        notifierId: 'notifier-1',
+                        mailingLists: ['bob@example.com', 'alice@example.com'],
+                    },
+                ],
+                notifierName: 'notifier-1',
+            },
+        ],
         resourceScope: {
             collectionScope: {
                 collectionId: 'collection-1',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useCreateReport.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useCreateReport.ts
@@ -1,0 +1,117 @@
+import { useCallback, useState } from 'react';
+
+import { createReportConfiguration } from 'services/ReportsService';
+import {
+    Fixability,
+    ReportConfiguration,
+    VulnerabilityReportFilters,
+    VulnerabilityReportFiltersBase,
+} from 'types/reportConfigurationService.proto';
+import { ReportFormValues } from '../forms/useReportFormValues';
+
+type Result = {
+    data: ReportConfiguration | null;
+    isLoading: boolean;
+    error: string | null;
+};
+
+type CreateReportResult = {
+    createReport: (formValues: ReportFormValues) => void;
+} & Result;
+
+const defaultResult = {
+    data: null,
+    isLoading: false,
+    error: null,
+};
+
+function useCreateReport(): CreateReportResult {
+    const [result, setResult] = useState<Result>(defaultResult);
+
+    const createReport = useCallback((formValues: ReportFormValues) => {
+        setResult({
+            data: null,
+            isLoading: true,
+            error: null,
+        });
+
+        const { reportParameters } = formValues;
+
+        // transform form values to values to be sent through API
+        const fixability: Fixability =
+            reportParameters.cveStatus.length > 1 ? 'BOTH' : reportParameters.cveStatus[0];
+        const vulnReportFiltersBase: VulnerabilityReportFiltersBase = {
+            fixability,
+            severities: reportParameters.cveSeverities,
+            imageTypes: reportParameters.imageType,
+        };
+        let vulnReportFilters: VulnerabilityReportFilters;
+
+        if (reportParameters.cvesDiscoveredSince === 'SINCE_LAST_REPORT') {
+            vulnReportFilters = {
+                ...vulnReportFiltersBase,
+                lastSuccessfulReport: true,
+            };
+        } else if (
+            reportParameters.cvesDiscoveredSince === 'START_DATE' &&
+            reportParameters.cvesDiscoveredStartDate
+        ) {
+            vulnReportFilters = {
+                ...vulnReportFiltersBase,
+                startDate: new Date(reportParameters.cvesDiscoveredStartDate).toISOString(),
+            };
+        } else {
+            vulnReportFilters = {
+                ...vulnReportFiltersBase,
+                allVuln: true,
+            };
+        }
+
+        const reportData: ReportConfiguration = {
+            id: '',
+            name: reportParameters.reportName,
+            description: reportParameters.description,
+            type: 'VULNERABILITY',
+            vulnReportFilters,
+            resourceScope: {
+                collectionScope: {
+                    collectionId: reportParameters.reportScope?.id || '',
+                    collectionName: reportParameters.reportScope?.name || '',
+                },
+            },
+            notifiers: [],
+            schedule: {
+                intervalType: 'WEEKLY',
+                hour: 0,
+                minute: 0,
+                daysOfWeek: {
+                    days: [3],
+                },
+            },
+        };
+
+        // send API call
+        createReportConfiguration(reportData)
+            .then((response) => {
+                setResult({
+                    data: response,
+                    isLoading: false,
+                    error: null,
+                });
+            })
+            .catch((err) => {
+                setResult({
+                    data: null,
+                    isLoading: false,
+                    error: err.response.data.message,
+                });
+            });
+    }, []);
+
+    return {
+        ...result,
+        createReport,
+    };
+}
+
+export default useCreateReport;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useCreateReport.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useCreateReport.ts
@@ -79,6 +79,7 @@ function useCreateReport(): CreateReportResult {
                     collectionName: reportParameters.reportScope?.name || '',
                 },
             },
+            // @TODO: Replace hardcoded values when we do notifiers and schedule
             notifiers: [],
             schedule: {
                 intervalType: 'WEEKLY',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
@@ -12,11 +12,10 @@ import {
     TextInput,
     Title,
 } from '@patternfly/react-core';
-import set from 'lodash/set';
 
 import {
     ReportFormValues,
-    SetReportFormValues,
+    SetReportFormFieldValue,
 } from 'Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues';
 import usePermissions from 'hooks/usePermissions';
 import { fixabilityLabels } from 'constants/reportConstants';
@@ -32,54 +31,34 @@ import CollectionSelection from './CollectionSelection';
 
 export type ReportParametersFormParams = {
     formValues: ReportFormValues;
-    setFormValues: SetReportFormValues;
+    setFormFieldValue: SetReportFormFieldValue;
 };
 
 function ReportParametersForm({
     formValues,
-    setFormValues,
+    setFormFieldValue,
 }: ReportParametersFormParams): ReactElement {
     const { hasReadWriteAccess } = usePermissions();
     const canWriteCollections = hasReadWriteAccess('WorkflowAdministration');
 
     const handleTextChange = (fieldName: string) => (value: string) => {
-        setFormValues((prevValues) => {
-            const newValues = { ...prevValues };
-            set(newValues, fieldName, value);
-            return newValues;
-        });
+        setFormFieldValue(fieldName, value);
     };
 
     const handleSelectChange = (name: string, value: string) => {
-        setFormValues((prevValues) => {
-            const newValues = { ...prevValues };
-            set(newValues, name, value);
-            return newValues;
-        });
+        setFormFieldValue(name, value);
     };
 
     const handleCheckboxSelectChange = (fieldName: string) => (selection: string[]) => {
-        setFormValues((prevValues) => {
-            const newValues = { ...prevValues };
-            set(newValues, fieldName, selection);
-            return newValues;
-        });
+        setFormFieldValue(fieldName, selection);
     };
 
-    const handleDateSelection = (fieldName: string) => (_event, str) => {
-        setFormValues((prevValues) => {
-            const newValues = { ...prevValues };
-            set(newValues, fieldName, str);
-            return newValues;
-        });
+    const handleDateSelection = (fieldName: string) => (_event, selection) => {
+        setFormFieldValue(fieldName, selection);
     };
 
     const handleCollectionSelection = (fieldName: string) => (selection) => {
-        setFormValues((prevValues) => {
-            const newValues = { ...prevValues };
-            set(newValues, fieldName, selection);
-            return newValues;
-        });
+        setFormFieldValue(fieldName, selection);
     };
 
     const handleCVEsDiscoveredStartDate = handleDateSelection(

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
@@ -1,19 +1,25 @@
 import { Dispatch, SetStateAction, useState } from 'react';
-import { Collection } from 'services/CollectionsService';
+import cloneDeep from 'lodash/cloneDeep';
+import set from 'lodash/set';
 
+import { Collection } from 'services/CollectionsService';
 import { VulnerabilitySeverity } from 'types/cve.proto';
 import { ImageType } from 'types/reportConfigurationService.proto';
 
 export type ReportFormValuesResult = {
     formValues: ReportFormValues;
     setFormValues: SetReportFormValues;
+    clearFormValues: () => void;
+    setFormFieldValue: SetReportFormFieldValue;
 };
-
-export type SetReportFormValues = Dispatch<SetStateAction<ReportFormValues>>;
 
 export type ReportFormValues = {
     reportParameters: ReportParametersFormValues;
 };
+
+export type SetReportFormValues = Dispatch<SetStateAction<ReportFormValues>>;
+
+export type SetReportFormFieldValue = (fieldName: string, value: string | string[]) => void;
 
 export type ReportParametersFormValues = {
     reportName: string;
@@ -46,9 +52,23 @@ export const defaultReportFormValues: ReportFormValues = {
 function useReportFormValues(): ReportFormValuesResult {
     const [formValues, setFormValues] = useState<ReportFormValues>(defaultReportFormValues);
 
+    function setFormFieldValue(fieldName: string, value: string | string[]) {
+        setFormValues((prevValues) => {
+            const newValues = cloneDeep(prevValues);
+            set(newValues, fieldName, value);
+            return newValues;
+        });
+    }
+
+    function clearFormValues() {
+        setFormValues(defaultReportFormValues);
+    }
+
     return {
         formValues,
         setFormValues,
+        clearFormValues,
+        setFormFieldValue,
     };
 }
 

--- a/ui/apps/platform/src/services/ReportsService.ts
+++ b/ui/apps/platform/src/services/ReportsService.ts
@@ -98,3 +98,13 @@ export function fetchReportConfigurations(): Promise<ReportConfiguration[]> {
             return response?.data?.reportConfigs ?? [];
         });
 }
+
+export function createReportConfiguration(
+    report: ReportConfiguration
+): Promise<ReportConfiguration> {
+    return axios
+        .post<ReportConfiguration>('/v2/reports/configurations', report)
+        .then((response) => {
+            return response.data;
+        });
+}

--- a/ui/apps/platform/src/setupProxy.js
+++ b/ui/apps/platform/src/setupProxy.js
@@ -45,6 +45,7 @@ module.exports = function main(app) {
 
     const proxy = proxyWithTarget(process.env.YARN_START_TARGET || 'https://localhost:8000');
     app.use('/v1', proxy);
+    app.use('/v2', proxy);
     app.use('/api', proxy);
     app.use('/docs', proxy);
     app.use('/sso', proxy);

--- a/ui/apps/platform/src/types/reportConfigurationService.proto.ts
+++ b/ui/apps/platform/src/types/reportConfigurationService.proto.ts
@@ -10,12 +10,12 @@ export type ReportConfiguration = {
     description: string;
     type: ReportType;
     vulnReportFilters: VulnerabilityReportFilters;
-    emailConfig: EmailNotifierConfiguration;
+    notifiers: NotifierConfiguration[];
     schedule: Schedule;
     resourceScope: ResourceScope;
 };
 
-type VulnerabilityReportFiltersBase = {
+export type VulnerabilityReportFiltersBase = {
     fixability: Fixability;
     severities: VulnerabilitySeverity[];
     imageTypes: ImageType[];
@@ -35,6 +35,14 @@ export type VulnerabilityReportFilters =
 export type Fixability = 'BOTH' | 'FIXABLE' | 'NOT_FIXABLE';
 
 export type ImageType = 'DEPLOYED' | 'WATCHED';
+
+export type NotifierConfiguration = {
+    emailConfig: {
+        notifierId: string;
+        mailingLists: string[];
+    }[];
+    notifierName: string;
+};
 
 export type EmailNotifierConfiguration = {
     notifierId: string;


### PR DESCRIPTION
## Description

This PR allows the user to actually create a report using the v2 Reports API. Some things to note in this PR:
- I created a function to send an API call to create a report
- I created a hook that manages the data returned, error state, loading state, and function to send an API call
- I have to update `setupProxy` to allow proxying v2 API endpoints
- I tweaked the types for the ReportConfiguration type due to a change in the API
- I updated the `useReportFormValues` hook to export two new functions. One is the `clearFormValues` function which basically changes the state to the default state. We will also export a new function called `setReportFormFieldValue`, which helps with duplicated logic in the `ReportParametersForm` component
- I added a custom footer for the wizard, which was primarily due to the fact that I wanted the `Create` button to show the loading indicator after clicking it. Seems like the wizard component didn't have a prop to do that.
- I added an Alert component to display an error message when creating a report configuration. It will also scroll the message into view