### PR TITLE
fix(ui): Fix accessibility problems in Clusters

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CheckCircle, Download } from 'react-feather';
+import { Button } from '@patternfly/react-core';
+import { DownloadIcon } from '@patternfly/react-icons';
+import { CheckCircle } from 'react-feather';
 import { ClipLoader } from 'react-spinners';
 import { Message } from '@stackrox/ui-components';
-import { Spinner } from '@patternfly/react-core';
 
 import CollapsibleCard from 'Components/CollapsibleCard';
 import ToggleSwitch from 'Components/ToggleSwitch';
@@ -39,10 +40,7 @@ const ClusterDeploymentPage = ({
                 )}
                 {managerType !== 'MANAGER_TYPE_KUBERNETES_OPERATOR' && (
                     <div className={baseClass}>
-                        <CollapsibleCard
-                            title="1. Download files"
-                            titleClassName="border-b px-1 border-primary-300 leading-normal cursor-pointer flex justify-between items-center bg-primary-200 hover:border-primary-400"
-                        >
+                        <CollapsibleCard title="1. Download files">
                             <div className="w-full h-full p-3 leading-normal">
                                 <div className="border-b pb-3 mb-3 border-primary-300">
                                     Download the required configuration files, keys, and scripts.
@@ -62,20 +60,15 @@ const ClusterDeploymentPage = ({
                                     />
                                 </div>
                                 <div className="flex justify-center px-3">
-                                    {isDownloadingBundle ? (
-                                        <Spinner isSVG size="lg" />
-                                    ) : (
-                                        <button
-                                            type="button"
-                                            className="download uppercase text-primary-600 p-2 text-center text-sm border border-solid bg-primary-200 border-primary-300 hover:bg-primary-100 flex items-center"
-                                            onClick={onFileDownload}
-                                        >
-                                            <span className="pr-2">
-                                                Download YAML file and keys
-                                            </span>
-                                            <Download className="h-3 w-3" />
-                                        </button>
-                                    )}
+                                    <Button
+                                        variant="secondary"
+                                        icon={<DownloadIcon />}
+                                        onClick={onFileDownload}
+                                        isDisabled={isDownloadingBundle}
+                                        isLoading={isDownloadingBundle}
+                                    >
+                                        Download YAML file and keys
+                                    </Button>
                                 </div>
                                 <div className="py-2 text-xs text-center text-base-600">
                                     <p className="pb-2">
@@ -86,10 +79,7 @@ const ClusterDeploymentPage = ({
                             </div>
                         </CollapsibleCard>
                         <div className="mt-4">
-                            <CollapsibleCard
-                                title="2. Deploy"
-                                titleClassName="border-b px-1 border-primary-300 leading-normal cursor-pointer flex justify-between items-center bg-primary-200 hover:border-primary-400"
-                            >
+                            <CollapsibleCard title="2. Deploy">
                                 <div className="w-full h-full p-3 leading-normal">
                                     Use the deploy script inside the bundle to set up your cluster.
                                 </div>

--- a/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
@@ -77,7 +77,7 @@ function ClusterLabelsTable({
                 <Tr>
                     <Th>Key</Th>
                     <Th>Value</Th>
-                    {hasAction && <Th aria-label="Action" />}
+                    {hasAction && <Td />}
                 </Tr>
             </Thead>
             <Tbody>

--- a/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
@@ -77,7 +77,7 @@ function ClusterLabelsTable({
                 <Tr>
                     <Th>Key</Th>
                     <Th>Value</Th>
-                    {hasAction && <Td />}
+                    {hasAction && <Th>Action</Th>}
                 </Tr>
             </Thead>
             <Tbody>

--- a/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { ArrowRight, Check } from 'react-feather';
+import { Button } from '@patternfly/react-core';
 import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
 import set from 'lodash/set';
@@ -8,7 +8,6 @@ import { Message } from '@stackrox/ui-components';
 
 import CloseButton from 'Components/CloseButton';
 import { PanelNew, PanelBody, PanelHead, PanelHeadEnd, PanelTitle } from 'Components/Panel';
-import PanelButton from 'Components/PanelButton';
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';
 import { useTheme } from 'Containers/ThemeProvider';
 import useInterval from 'hooks/useInterval';
@@ -306,26 +305,19 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
 
     // @TODO: improve error handling when adding support for new clusters
     const isForm = wizardStep === 'FORM';
-    const iconClassName = 'h-4 w-4';
 
     const panelButtons = isBlocked ? (
         <div />
     ) : (
-        <PanelButton
-            icon={
-                isForm ? (
-                    <ArrowRight className={iconClassName} />
-                ) : (
-                    <Check className={iconClassName} />
-                )
-            }
-            className={`mr-2 btn ${isForm ? 'btn-base' : 'btn-success'}`}
+        <Button
+            variant={isForm ? 'secondary' : 'primary'}
+            isSmall
+            className="pf-u-mr-md"
             onClick={onNext}
             disabled={isForm && Object.keys(validate(selectedCluster)).length !== 0}
-            tooltip={isForm ? 'Next' : 'Finish'}
         >
             {isForm ? 'Next' : 'Finish'}
-        </PanelButton>
+        </Button>
     );
 
     return (

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
@@ -1,14 +1,18 @@
 import React, { useState, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { DownloadCloud, Trash2 } from 'react-feather';
 import get from 'lodash/get';
-import { Dropdown, DropdownItem, DropdownPosition, DropdownToggle } from '@patternfly/react-core';
+import {
+    Button,
+    Dropdown,
+    DropdownItem,
+    DropdownPosition,
+    DropdownToggle,
+} from '@patternfly/react-core';
 
 import CheckboxTable from 'Components/CheckboxTable';
 import CloseButton from 'Components/CloseButton';
 import Dialog from 'Components/Dialog';
-import PanelButton from 'Components/PanelButton';
 import { DEFAULT_PAGE_SIZE } from 'Components/Table';
 import TableHeader from 'Components/TableHeader';
 import { PanelNew, PanelBody, PanelHead, PanelHeadEnd } from 'Components/Panel';
@@ -215,24 +219,22 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
     const headerActions = (
         <>
             <AutoUpgradeToggle />
-            <PanelButton
-                icon={<DownloadCloud className="h-4 w-4 ml-1" />}
-                tooltip={`Upgrade (${upgradableClusters.length})`}
-                className="btn btn-tertiary ml-2"
+            <Button
+                variant="secondary"
+                className="pf-u-ml-sm"
                 onClick={upgradeSelectedClusters}
-                disabled={upgradableClusters.length === 0 || !!selectedClusterId}
+                isDisabled={upgradableClusters.length === 0 || !!selectedClusterId}
             >
                 {`Upgrade (${upgradableClusters.length})`}
-            </PanelButton>
-            <PanelButton
-                icon={<Trash2 className="h-4 w-4 ml-1" />}
-                tooltip={`Delete (${checkedClusterIds.length})`}
-                className="btn btn-alert ml-2 mr-2"
+            </Button>
+            <Button
+                variant="danger"
+                className="pf-u-ml-sm pf-u-mr-sm"
                 onClick={deleteSelectedClusters}
-                disabled={checkedClusterIds.length === 0 || !!selectedClusterId}
+                isDisabled={checkedClusterIds.length === 0 || !!selectedClusterId}
             >
                 {`Delete (${checkedClusterIds.length})`}
-            </PanelButton>
+            </Button>
             <Dropdown
                 className="mr-4"
                 onSelect={onSelectInstallMenuItem}

--- a/ui/apps/platform/src/Containers/Clusters/DownloadHelmValues.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DownloadHelmValues.tsx
@@ -1,6 +1,7 @@
 import React, { useState, ReactElement } from 'react';
 import { connect } from 'react-redux';
-import { SuccessButton } from '@stackrox/ui-components';
+import { Button } from '@patternfly/react-core';
+import { DownloadIcon } from '@patternfly/react-icons';
 
 import CollapsibleCard from 'Components/CollapsibleCard';
 import { actions as notificationActions } from 'reducers/notifications';
@@ -38,15 +39,20 @@ const DownloadHelmValues = ({
             cardClassName="flex-grow border border-base-400 md:self-start"
             isCollapsible={false}
             title="Download helm values"
-            titleClassName="border-b px-1 border-primary-300 leading-normal cursor-pointer flex justify-between items-center bg-primary-200 hover:border-primary-400"
         >
             <div className="w-full p-3 leading-normal border-b pb-3 border-primary-300">
                 {description}
             </div>
             <div className="flex justify-center items-center p-4">
-                <SuccessButton type="button" onClick={downloadValues} isDisabled={isFetchingValues}>
+                <Button
+                    variant="secondary"
+                    icon={<DownloadIcon />}
+                    onClick={downloadValues}
+                    isDisabled={isFetchingValues}
+                    isLoading={isFetchingValues}
+                >
                     Download Helm values
-                </SuccessButton>
+                </Button>
             </div>
         </CollapsibleCard>
     );


### PR DESCRIPTION
## Description

### Problems

1. Visit /main/clusters and then click a row

    Minor: Table header text should not be empty `<th class="" aria-label="Action"></th>`

2. Click **Next**

    Serious: Elements must meet minimum color contrast ratio

    * Element has insufficient color contrast of 4.32 (foreground color: #2c8820, background color: #edffeb, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1

        `<button type="button" class="mr-2 btn btn-success" data-testid="">`

    * Element has insufficient color contrast of 2.08 (foreground color: #5fb2f7, background color: #ebf6ff, font size: 9.0pt (12px), font weight: normal). Expected contrast ratio of 4.5:1

        `<button type="button" class="download uppercase text-primary-600 p-2 text-center text-sm border border-solid bg-primary-200 border-primary-300 hover:bg-primary-100 flex items-center">`

    * Element has insufficient color contrast of 4.32 (foreground color: #2c8820, background color: #edffeb, font size: 9.0pt (12px), font weight: normal). Expected contrast ratio of 4.5:1

        `<button class="border-2 font-600 inline-flex items-center justify-center rounded-sm uppercase text-sm border-success-500 bg-success-200 hover:bg-success-300 hover:text-success-800 text-success-700 p-2" type="button">Download Helm values</button>`

### Analysis and Solutions

1. Replace `Th` with `Td` element.

2. Replace the following with PatternFly `Button` element:

    * Upgrade and Delete buttons: `PanelButton` from src/Components

    * Next or Finish button: `PanelButton` from src/Components

    * Download YAML file and keys: HTML `button` element

    * Download Helm values: `SuccessButton` from ui-components package

3. Bonus to remove another leftover blue background from StackRox branding.

    * Remove `titleClassName` prop so collapsible cards have default header style.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -173 = 4231696 - 4231869
        total -1848 = 10310740 - 10312588
    * `ls -al build/static/js/*.js | wc`
        files 0 = 80 - 80
3. `yarn start` in ui

### Manual testing

1. Visit /main/clusters
    * See **Upgrade** and **Delete** buttons disabled in first picture, and with **Delete** enabled in second picture.
        ![clusters](https://github.com/stackrox/stackrox/assets/11862657/7b22edb8-a915-4979-ae33-6bb5b362a8e1)
        ![clusters_Delete](https://github.com/stackrox/stackrox/assets/11862657/417e2ed0-5335-48e0-92f3-08551ec116d6)

2. Click a row to open side panel.
    * See **Next** button.
        ![clusters_Next](https://github.com/stackrox/stackrox/assets/11862657/63ecfe07-ac5e-478a-b2c5-8230922e6633)

3. Click **Next**.
    * See **Finish** button.
    * See collapsible headings with default heading style.
    * See both **Download** buttons, and then click to see disabled and loading state (temporary change to leave it spinning long enough to take the second picture).
        ![clusters_Finish](https://github.com/stackrox/stackrox/assets/11862657/7e38203a-963c-4f76-b3f8-77a3a86f3442)
        ![clusters_Download](https://github.com/stackrox/stackrox/assets/11862657/4bf0968e-8476-4f52-8fbe-282102e25964)

### Integration testing

1. `yarn cypress-open` in ui/apps/platform
    * clusters/clusterDeletion.test.js
    * clusters/clusters.test.js
    * clusters/clusterCertificateExpiration.test.js
    * clusters/clusterHealthStatus.test.js
    * clusters/clustersManager.test.js
    * clusters/delegateScanning.test.js
    * clusters/redirectFromDashboard.test.js