### PR TITLE
ROX-11034: Add ability to view NetPol in modal on Violation/Deploy tab

### DIFF
--- a/ui/apps/platform/cypress/fixtures/network/networkPoliciesInNamespace.json
+++ b/ui/apps/platform/cypress/fixtures/network/networkPoliciesInNamespace.json
@@ -1,0 +1,411 @@
+{
+  "networkPolicies": [
+      {
+          "id": "981649e5-b0ed-4e9e-8cd5-cd2671cc4cdd",
+          "name": "central-db",
+          "clusterId": "a1f6cc4e-24d0-4c98-a0cc-22f79643d26b",
+          "clusterName": "remote",
+          "namespace": "stackrox",
+          "labels": {
+              "app.kubernetes.io/component": "central",
+              "app.kubernetes.io/instance": "stackrox-central-services",
+              "app.kubernetes.io/managed-by": "Helm",
+              "app.kubernetes.io/name": "stackrox",
+              "app.kubernetes.io/part-of": "stackrox-central-services",
+              "app.kubernetes.io/version": "4.1.x-337-g9d0cc4bed1",
+              "helm.sh/chart": "stackrox-central-services-400.1.0-337-g9d0cc4bed1"
+          },
+          "annotations": {
+              "email": "support@stackrox.com",
+              "meta.helm.sh/release-name": "stackrox-central-services",
+              "meta.helm.sh/release-namespace": "stackrox",
+              "owner": "stackrox"
+          },
+          "spec": {
+              "podSelector": {
+                  "matchLabels": {
+                      "app": "central-db"
+                  },
+                  "requirements": []
+              },
+              "ingress": [
+                  {
+                      "ports": [
+                          {
+                              "protocol": "TCP_PROTOCOL",
+                              "port": 5432
+                          }
+                      ],
+                      "from": [
+                          {
+                              "podSelector": {
+                                  "matchLabels": {
+                                      "app": "central"
+                                  },
+                                  "requirements": []
+                              },
+                              "namespaceSelector": null,
+                              "ipBlock": null
+                          }
+                      ]
+                  }
+              ],
+              "egress": [],
+              "policyTypes": [
+                  "INGRESS_NETWORK_POLICY_TYPE",
+                  "EGRESS_NETWORK_POLICY_TYPE"
+              ]
+          },
+          "yaml": "kind: NetworkPolicy\nmetadata:\n  annotations:\n    email: support@stackrox.com\n    meta.helm.sh/release-name: stackrox-central-services\n    meta.helm.sh/release-namespace: stackrox\n    owner: stackrox\n  creationTimestamp: \"2023-07-11T12:14:21Z\"\n  labels:\n    app.kubernetes.io/component: central\n    app.kubernetes.io/instance: stackrox-central-services\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/name: stackrox\n    app.kubernetes.io/part-of: stackrox-central-services\n    app.kubernetes.io/version: 4.1.x-337-g9d0cc4bed1\n    helm.sh/chart: stackrox-central-services-400.1.0-337-g9d0cc4bed1\n  name: central-db\n  namespace: stackrox\n  uid: 981649e5-b0ed-4e9e-8cd5-cd2671cc4cdd\nspec:\n  ingress:\n  - from:\n    - podSelector:\n        matchLabels:\n          app: central\n    ports:\n    - port: 5432\n      protocol: TCP\n  podSelector:\n    matchLabels:\n      app: central-db\n  policyTypes:\n  - Ingress\n  - Egress\n",
+          "apiVersion": "",
+          "created": "2023-07-11T12:14:21Z"
+      },
+      {
+          "id": "39f239fe-a3f9-44eb-8ccf-5be823a60105",
+          "name": "sensor",
+          "clusterId": "a1f6cc4e-24d0-4c98-a0cc-22f79643d26b",
+          "clusterName": "remote",
+          "namespace": "stackrox",
+          "labels": {
+              "app.kubernetes.io/component": "sensor",
+              "app.kubernetes.io/instance": "stackrox-secured-cluster-services",
+              "app.kubernetes.io/managed-by": "Helm",
+              "app.kubernetes.io/name": "stackrox",
+              "app.kubernetes.io/part-of": "stackrox-secured-cluster-services",
+              "app.kubernetes.io/version": "4.1.x-367-g81deadcf0f",
+              "auto-upgrade.stackrox.io/component": "sensor",
+              "helm.sh/chart": "stackrox-secured-cluster-services-400.1.0-367-g81deadcf0f"
+          },
+          "annotations": {
+              "email": "support@stackrox.com",
+              "meta.helm.sh/release-name": "stackrox-secured-cluster-services",
+              "meta.helm.sh/release-namespace": "stackrox",
+              "owner": "stackrox"
+          },
+          "spec": {
+              "podSelector": {
+                  "matchLabels": {
+                      "app": "sensor"
+                  },
+                  "requirements": []
+              },
+              "ingress": [
+                  {
+                      "ports": [
+                          {
+                              "protocol": "TCP_PROTOCOL",
+                              "port": 8443
+                          }
+                      ],
+                      "from": [
+                          {
+                              "podSelector": {
+                                  "matchLabels": {
+                                      "app": "collector"
+                                  },
+                                  "requirements": []
+                              },
+                              "namespaceSelector": null,
+                              "ipBlock": null
+                          },
+                          {
+                              "podSelector": {
+                                  "matchLabels": {
+                                      "service": "collector"
+                                  },
+                                  "requirements": []
+                              },
+                              "namespaceSelector": null,
+                              "ipBlock": null
+                          },
+                          {
+                              "podSelector": {
+                                  "matchLabels": {
+                                      "app": "admission-control"
+                                  },
+                                  "requirements": []
+                              },
+                              "namespaceSelector": null,
+                              "ipBlock": null
+                          }
+                      ]
+                  },
+                  {
+                      "ports": [
+                          {
+                              "protocol": "TCP_PROTOCOL",
+                              "port": 9443
+                          }
+                      ],
+                      "from": []
+                  }
+              ],
+              "egress": [],
+              "policyTypes": [
+                  "INGRESS_NETWORK_POLICY_TYPE"
+              ]
+          },
+          "yaml": "kind: NetworkPolicy\nmetadata:\n  annotations:\n    email: support@stackrox.com\n    meta.helm.sh/release-name: stackrox-secured-cluster-services\n    meta.helm.sh/release-namespace: stackrox\n    owner: stackrox\n  creationTimestamp: \"2023-07-11T12:15:47Z\"\n  labels:\n    app.kubernetes.io/component: sensor\n    app.kubernetes.io/instance: stackrox-secured-cluster-services\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/name: stackrox\n    app.kubernetes.io/part-of: stackrox-secured-cluster-services\n    app.kubernetes.io/version: 4.1.x-367-g81deadcf0f\n    auto-upgrade.stackrox.io/component: sensor\n    helm.sh/chart: stackrox-secured-cluster-services-400.1.0-367-g81deadcf0f\n  name: sensor\n  namespace: stackrox\n  uid: 39f239fe-a3f9-44eb-8ccf-5be823a60105\nspec:\n  ingress:\n  - from:\n    - podSelector:\n        matchLabels:\n          app: collector\n    - podSelector:\n        matchLabels:\n          service: collector\n    - podSelector:\n        matchLabels:\n          app: admission-control\n    ports:\n    - port: 8443\n      protocol: TCP\n  - ports:\n    - port: 9443\n      protocol: TCP\n  podSelector:\n    matchLabels:\n      app: sensor\n  policyTypes:\n  - Ingress\n",
+          "apiVersion": "",
+          "created": "2023-07-11T12:15:47Z"
+      },
+      {
+          "id": "f0b3784c-0a2b-4230-8d9a-683dac9b420d",
+          "name": "scanner-db",
+          "clusterId": "a1f6cc4e-24d0-4c98-a0cc-22f79643d26b",
+          "clusterName": "remote",
+          "namespace": "stackrox",
+          "labels": {
+              "app.kubernetes.io/component": "scanner",
+              "app.kubernetes.io/instance": "stackrox-central-services",
+              "app.kubernetes.io/managed-by": "Helm",
+              "app.kubernetes.io/name": "stackrox",
+              "app.kubernetes.io/part-of": "stackrox-central-services",
+              "app.kubernetes.io/version": "4.1.x-337-g9d0cc4bed1",
+              "helm.sh/chart": "stackrox-central-services-400.1.0-337-g9d0cc4bed1"
+          },
+          "annotations": {
+              "email": "support@stackrox.com",
+              "meta.helm.sh/release-name": "stackrox-central-services",
+              "meta.helm.sh/release-namespace": "stackrox",
+              "owner": "stackrox"
+          },
+          "spec": {
+              "podSelector": {
+                  "matchLabels": {
+                      "app": "scanner-db"
+                  },
+                  "requirements": []
+              },
+              "ingress": [
+                  {
+                      "ports": [
+                          {
+                              "protocol": "TCP_PROTOCOL",
+                              "port": 5432
+                          }
+                      ],
+                      "from": [
+                          {
+                              "podSelector": {
+                                  "matchLabels": {
+                                      "app": "scanner"
+                                  },
+                                  "requirements": []
+                              },
+                              "namespaceSelector": null,
+                              "ipBlock": null
+                          }
+                      ]
+                  }
+              ],
+              "egress": [],
+              "policyTypes": [
+                  "INGRESS_NETWORK_POLICY_TYPE"
+              ]
+          },
+          "yaml": "kind: NetworkPolicy\nmetadata:\n  annotations:\n    email: support@stackrox.com\n    meta.helm.sh/release-name: stackrox-central-services\n    meta.helm.sh/release-namespace: stackrox\n    owner: stackrox\n  creationTimestamp: \"2023-07-11T12:14:25Z\"\n  labels:\n    app.kubernetes.io/component: scanner\n    app.kubernetes.io/instance: stackrox-central-services\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/name: stackrox\n    app.kubernetes.io/part-of: stackrox-central-services\n    app.kubernetes.io/version: 4.1.x-337-g9d0cc4bed1\n    helm.sh/chart: stackrox-central-services-400.1.0-337-g9d0cc4bed1\n  name: scanner-db\n  namespace: stackrox\n  uid: f0b3784c-0a2b-4230-8d9a-683dac9b420d\nspec:\n  ingress:\n  - from:\n    - podSelector:\n        matchLabels:\n          app: scanner\n    ports:\n    - port: 5432\n      protocol: TCP\n  podSelector:\n    matchLabels:\n      app: scanner-db\n  policyTypes:\n  - Ingress\n",
+          "apiVersion": "",
+          "created": "2023-07-11T12:14:25Z"
+      },
+      {
+          "id": "c28f68d7-ec89-4977-b74f-5a44eaa1dedf",
+          "name": "collector-no-ingress",
+          "clusterId": "a1f6cc4e-24d0-4c98-a0cc-22f79643d26b",
+          "clusterName": "remote",
+          "namespace": "stackrox",
+          "labels": {
+              "app.kubernetes.io/component": "collector",
+              "app.kubernetes.io/instance": "stackrox-secured-cluster-services",
+              "app.kubernetes.io/managed-by": "Helm",
+              "app.kubernetes.io/name": "stackrox",
+              "app.kubernetes.io/part-of": "stackrox-secured-cluster-services",
+              "app.kubernetes.io/version": "4.1.x-367-g81deadcf0f",
+              "auto-upgrade.stackrox.io/component": "sensor",
+              "helm.sh/chart": "stackrox-secured-cluster-services-400.1.0-367-g81deadcf0f"
+          },
+          "annotations": {
+              "email": "support@stackrox.com",
+              "meta.helm.sh/release-name": "stackrox-secured-cluster-services",
+              "meta.helm.sh/release-namespace": "stackrox",
+              "owner": "stackrox"
+          },
+          "spec": {
+              "podSelector": {
+                  "matchLabels": {
+                      "app": "collector"
+                  },
+                  "requirements": []
+              },
+              "ingress": [],
+              "egress": [],
+              "policyTypes": [
+                  "INGRESS_NETWORK_POLICY_TYPE"
+              ]
+          },
+          "yaml": "kind: NetworkPolicy\nmetadata:\n  annotations:\n    email: support@stackrox.com\n    meta.helm.sh/release-name: stackrox-secured-cluster-services\n    meta.helm.sh/release-namespace: stackrox\n    owner: stackrox\n  creationTimestamp: \"2023-07-11T12:15:47Z\"\n  labels:\n    app.kubernetes.io/component: collector\n    app.kubernetes.io/instance: stackrox-secured-cluster-services\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/name: stackrox\n    app.kubernetes.io/part-of: stackrox-secured-cluster-services\n    app.kubernetes.io/version: 4.1.x-367-g81deadcf0f\n    auto-upgrade.stackrox.io/component: sensor\n    helm.sh/chart: stackrox-secured-cluster-services-400.1.0-367-g81deadcf0f\n  name: collector-no-ingress\n  namespace: stackrox\n  uid: c28f68d7-ec89-4977-b74f-5a44eaa1dedf\nspec:\n  podSelector:\n    matchLabels:\n      app: collector\n  policyTypes:\n  - Ingress\n",
+          "apiVersion": "",
+          "created": "2023-07-11T12:15:47Z"
+      },
+      {
+          "id": "b2a9b680-3702-4b08-9580-ab12bd85073e",
+          "name": "allow-ext-to-central",
+          "clusterId": "a1f6cc4e-24d0-4c98-a0cc-22f79643d26b",
+          "clusterName": "remote",
+          "namespace": "stackrox",
+          "labels": {
+              "app.kubernetes.io/component": "central",
+              "app.kubernetes.io/instance": "stackrox-central-services",
+              "app.kubernetes.io/managed-by": "Helm",
+              "app.kubernetes.io/name": "stackrox",
+              "app.kubernetes.io/part-of": "stackrox-central-services",
+              "app.kubernetes.io/version": "4.1.x-337-g9d0cc4bed1",
+              "helm.sh/chart": "stackrox-central-services-400.1.0-337-g9d0cc4bed1"
+          },
+          "annotations": {
+              "email": "support@stackrox.com",
+              "meta.helm.sh/release-name": "stackrox-central-services",
+              "meta.helm.sh/release-namespace": "stackrox",
+              "owner": "stackrox"
+          },
+          "spec": {
+              "podSelector": {
+                  "matchLabels": {
+                      "app": "central"
+                  },
+                  "requirements": []
+              },
+              "ingress": [
+                  {
+                      "ports": [
+                          {
+                              "protocol": "TCP_PROTOCOL",
+                              "port": 8443
+                          }
+                      ],
+                      "from": []
+                  }
+              ],
+              "egress": [],
+              "policyTypes": [
+                  "INGRESS_NETWORK_POLICY_TYPE"
+              ]
+          },
+          "yaml": "kind: NetworkPolicy\nmetadata:\n  annotations:\n    email: support@stackrox.com\n    meta.helm.sh/release-name: stackrox-central-services\n    meta.helm.sh/release-namespace: stackrox\n    owner: stackrox\n  creationTimestamp: \"2023-07-11T12:14:21Z\"\n  labels:\n    app.kubernetes.io/component: central\n    app.kubernetes.io/instance: stackrox-central-services\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/name: stackrox\n    app.kubernetes.io/part-of: stackrox-central-services\n    app.kubernetes.io/version: 4.1.x-337-g9d0cc4bed1\n    helm.sh/chart: stackrox-central-services-400.1.0-337-g9d0cc4bed1\n  name: allow-ext-to-central\n  namespace: stackrox\n  uid: b2a9b680-3702-4b08-9580-ab12bd85073e\nspec:\n  ingress:\n  - ports:\n    - port: 8443\n      protocol: TCP\n  podSelector:\n    matchLabels:\n      app: central\n  policyTypes:\n  - Ingress\n",
+          "apiVersion": "",
+          "created": "2023-07-11T12:14:21Z"
+      },
+      {
+          "id": "94b6c5d7-efcb-43d0-ba39-047797676a42",
+          "name": "admission-control-no-ingress",
+          "clusterId": "a1f6cc4e-24d0-4c98-a0cc-22f79643d26b",
+          "clusterName": "remote",
+          "namespace": "stackrox",
+          "labels": {
+              "app.kubernetes.io/component": "admission-control",
+              "app.kubernetes.io/instance": "stackrox-secured-cluster-services",
+              "app.kubernetes.io/managed-by": "Helm",
+              "app.kubernetes.io/name": "stackrox",
+              "app.kubernetes.io/part-of": "stackrox-secured-cluster-services",
+              "app.kubernetes.io/version": "4.1.x-367-g81deadcf0f",
+              "auto-upgrade.stackrox.io/component": "sensor",
+              "helm.sh/chart": "stackrox-secured-cluster-services-400.1.0-367-g81deadcf0f"
+          },
+          "annotations": {
+              "email": "support@stackrox.com",
+              "meta.helm.sh/release-name": "stackrox-secured-cluster-services",
+              "meta.helm.sh/release-namespace": "stackrox",
+              "owner": "stackrox"
+          },
+          "spec": {
+              "podSelector": {
+                  "matchLabels": {
+                      "app": "admission-control"
+                  },
+                  "requirements": []
+              },
+              "ingress": [
+                  {
+                      "ports": [
+                          {
+                              "protocol": "TCP_PROTOCOL",
+                              "port": 8443
+                          }
+                      ],
+                      "from": []
+                  }
+              ],
+              "egress": [],
+              "policyTypes": [
+                  "INGRESS_NETWORK_POLICY_TYPE"
+              ]
+          },
+          "yaml": "kind: NetworkPolicy\nmetadata:\n  annotations:\n    email: support@stackrox.com\n    meta.helm.sh/release-name: stackrox-secured-cluster-services\n    meta.helm.sh/release-namespace: stackrox\n    owner: stackrox\n  creationTimestamp: \"2023-07-11T12:15:47Z\"\n  labels:\n    app.kubernetes.io/component: admission-control\n    app.kubernetes.io/instance: stackrox-secured-cluster-services\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/name: stackrox\n    app.kubernetes.io/part-of: stackrox-secured-cluster-services\n    app.kubernetes.io/version: 4.1.x-367-g81deadcf0f\n    auto-upgrade.stackrox.io/component: sensor\n    helm.sh/chart: stackrox-secured-cluster-services-400.1.0-367-g81deadcf0f\n  name: admission-control-no-ingress\n  namespace: stackrox\n  uid: 94b6c5d7-efcb-43d0-ba39-047797676a42\nspec:\n  ingress:\n  - ports:\n    - port: 8443\n      protocol: TCP\n  podSelector:\n    matchLabels:\n      app: admission-control\n  policyTypes:\n  - Ingress\n",
+          "apiVersion": "",
+          "created": "2023-07-11T12:15:47Z"
+      },
+      {
+          "id": "aea30e8e-dff3-45c1-be11-c7734e5e56b2",
+          "name": "scanner",
+          "clusterId": "a1f6cc4e-24d0-4c98-a0cc-22f79643d26b",
+          "clusterName": "remote",
+          "namespace": "stackrox",
+          "labels": {
+              "app.kubernetes.io/component": "scanner",
+              "app.kubernetes.io/instance": "stackrox-central-services",
+              "app.kubernetes.io/managed-by": "Helm",
+              "app.kubernetes.io/name": "stackrox",
+              "app.kubernetes.io/part-of": "stackrox-central-services",
+              "app.kubernetes.io/version": "4.1.x-337-g9d0cc4bed1",
+              "helm.sh/chart": "stackrox-central-services-400.1.0-337-g9d0cc4bed1"
+          },
+          "annotations": {
+              "email": "support@stackrox.com",
+              "meta.helm.sh/release-name": "stackrox-central-services",
+              "meta.helm.sh/release-namespace": "stackrox",
+              "owner": "stackrox"
+          },
+          "spec": {
+              "podSelector": {
+                  "matchLabels": {
+                      "app": "scanner"
+                  },
+                  "requirements": []
+              },
+              "ingress": [
+                  {
+                      "ports": [
+                          {
+                              "protocol": "TCP_PROTOCOL",
+                              "port": 8080
+                          },
+                          {
+                              "protocol": "TCP_PROTOCOL",
+                              "port": 8443
+                          }
+                      ],
+                      "from": [
+                          {
+                              "podSelector": {
+                                  "matchLabels": {
+                                      "app": "central"
+                                  },
+                                  "requirements": []
+                              },
+                              "namespaceSelector": null,
+                              "ipBlock": null
+                          }
+                      ]
+                  }
+              ],
+              "egress": [],
+              "policyTypes": [
+                  "INGRESS_NETWORK_POLICY_TYPE"
+              ]
+          },
+          "yaml": "kind: NetworkPolicy\nmetadata:\n  annotations:\n    email: support@stackrox.com\n    meta.helm.sh/release-name: stackrox-central-services\n    meta.helm.sh/release-namespace: stackrox\n    owner: stackrox\n  creationTimestamp: \"2023-07-11T12:14:25Z\"\n  labels:\n    app.kubernetes.io/component: scanner\n    app.kubernetes.io/instance: stackrox-central-services\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/name: stackrox\n    app.kubernetes.io/part-of: stackrox-central-services\n    app.kubernetes.io/version: 4.1.x-337-g9d0cc4bed1\n    helm.sh/chart: stackrox-central-services-400.1.0-337-g9d0cc4bed1\n  name: scanner\n  namespace: stackrox\n  uid: aea30e8e-dff3-45c1-be11-c7734e5e56b2\nspec:\n  ingress:\n  - from:\n    - podSelector:\n        matchLabels:\n          app: central\n    ports:\n    - port: 8080\n      protocol: TCP\n    - port: 8443\n      protocol: TCP\n  podSelector:\n    matchLabels:\n      app: scanner\n  policyTypes:\n  - Ingress\n",
+          "apiVersion": "",
+          "created": "2023-07-11T12:14:25Z"
+      }
+  ]
+}

--- a/ui/apps/platform/cypress/integration/violations/Violations.helpers.js
+++ b/ui/apps/platform/cypress/integration/violations/Violations.helpers.js
@@ -1,6 +1,9 @@
+import path from 'path';
+
 import { visitFromLeftNav } from '../../helpers/nav';
 import { interactAndWaitForResponses } from '../../helpers/request';
 import { visit } from '../../helpers/visit';
+import { selectors } from './Violations.selectors';
 
 // Source of truth for keys in routeMatcherMap and staticResponseMap objects.
 export const alertsAlias = 'alerts';
@@ -182,17 +185,25 @@ export function interactAndWaitForSortedViolationsResponses(interactionCallback,
  */
 export function clickDeploymentTabWithFixture(fixturePath) {
     const deploymentAlias = 'deployments/id';
+    const networkPolicyAlias = 'networkpolicies';
 
     const routeMatcherMapForDeployment = {
         [deploymentAlias]: {
             method: 'GET',
             url: '/v1/deployments/*',
         },
+        [networkPolicyAlias]: {
+            method: 'GET',
+            url: '/v1/networkpolicies?*',
+        },
     };
 
     const staticResponseMapForDeployment = {
         [deploymentAlias]: {
             fixture: fixturePath,
+        },
+        [networkPolicyAlias]: {
+            fixture: 'network/networkPoliciesInNamespace.json',
         },
     };
 
@@ -209,4 +220,15 @@ export function clickDeploymentTabWithFixture(fixturePath) {
     );
 
     cy.get(deploymentTab).should('have.class', 'pf-m-current');
+}
+
+/**
+ * Click the Export YAML button in the Network Policy modal and wait for the file to be downloaded.
+ * @param {string} fileName
+ * @param {(yaml: string) => void} onDownload
+ */
+export function exportAndWaitForNetworkPolicyYaml(fileName, onDownload) {
+    cy.get(`${selectors.deployment.networkPolicyModal} button:contains('Export YAML')`).click();
+
+    cy.readFile(path.join(Cypress.config('downloadsFolder'), fileName)).then(onDownload);
 }

--- a/ui/apps/platform/cypress/integration/violations/Violations.selectors.js
+++ b/ui/apps/platform/cypress/integration/violations/Violations.selectors.js
@@ -25,5 +25,8 @@ export const selectors = {
             '[data-testid="deployment-details"] [data-testid="container-configuration"]',
         securityContext: '[data-testid="deployment-details"] [data-testid="security-context"]',
         portConfiguration: '[data-testid="deployment-details"] [data-testid="port-configuration"]',
+        networkPolicy:
+            '[data-testid="deployment-details"] [aria-label="Network policies in namespace"]',
+        networkPolicyModal: "[role='dialog']:contains('Network policy details')",
     },
 };

--- a/ui/apps/platform/cypress/integration/violations/violations.test.js
+++ b/ui/apps/platform/cypress/integration/violations/violations.test.js
@@ -157,6 +157,7 @@ describe('Violations', () => {
 
         // Check for substrings in the YAML code editor
         cy.get(`${selectors.deployment.networkPolicy} button:contains("central-db")`).click();
+        cy.get(`${selectors.deployment.networkPolicyModal} *:contains("Policy name: central-db")`);
         cy.get(`${selectors.deployment.networkPolicyModal}`)
             .invoke('text')
             .should('to.match', /name:\s*central-db/)
@@ -172,6 +173,7 @@ describe('Violations', () => {
         cy.get(`${selectors.deployment.networkPolicyModal} button[aria-label="Close"]`).click();
 
         cy.get(`${selectors.deployment.networkPolicy} button:contains("sensor")`).click();
+        cy.get(`${selectors.deployment.networkPolicyModal} *:contains("Policy name: sensor")`);
         cy.get(`${selectors.deployment.networkPolicyModal}`)
             .invoke('text')
             .should('to.match', /name:\s*sensor/)

--- a/ui/apps/platform/src/Components/PatternFly/CodeEditorDarkModeControl.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/CodeEditorDarkModeControl.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { CodeEditorControl } from '@patternfly/react-code-editor';
+import { MoonIcon, SunIcon } from '@patternfly/react-icons';
+
+export type CodeEditorDarkModeControlProps = {
+    isDarkMode: boolean;
+    onToggleDarkMode: () => void;
+};
+
+/**
+ * A PatternFly code editor control that toggles dark mode.
+ */
+function CodeEditorDarkModeControl({
+    isDarkMode,
+    onToggleDarkMode,
+}: CodeEditorDarkModeControlProps) {
+    return (
+        <CodeEditorControl
+            icon={isDarkMode ? <SunIcon /> : <MoonIcon />}
+            aria-label="Toggle code editor dark mode"
+            tooltipProps={{
+                content: isDarkMode ? 'Toggle to light mode' : 'Toggle to dark mode',
+            }}
+            onClick={onToggleDarkMode}
+            isVisible
+        />
+    );
+}
+
+export default CodeEditorDarkModeControl;

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -14,14 +14,14 @@ import {
     StackItem,
     Title,
 } from '@patternfly/react-core';
-import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
-import { MoonIcon, SunIcon } from '@patternfly/react-icons';
+import { CodeEditor, Language } from '@patternfly/react-code-editor';
 
 import download from 'utils/download';
 import SelectSingle from 'Components/SelectSingle';
 import { useTheme } from 'Containers/ThemeProvider';
 import useFetchNetworkPolicies from 'hooks/useFetchNetworkPolicies';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import CodeEditorDarkModeControl from 'Components/PatternFly/CodeEditorDarkModeControl';
 
 type NetworkPoliciesProps = {
     entityName: string;
@@ -82,16 +82,6 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
             download(`${fileName}.yml`, fileContent, 'yml');
         }
     }
-
-    const customControl = (
-        <CodeEditorControl
-            icon={customDarkMode ? <SunIcon /> : <MoonIcon />}
-            aria-label="Toggle dark mode"
-            toolTipText={customDarkMode ? 'Toggle to light mode' : 'Toggle to dark mode'}
-            onClick={onToggleDarkMode}
-            isVisible
-        />
-    );
 
     if (isLoading) {
         return (
@@ -179,7 +169,12 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
                         <div className="pf-u-h-100">
                             <CodeEditor
                                 isDarkTheme={customDarkMode}
-                                customControls={customControl}
+                                customControls={
+                                    <CodeEditorDarkModeControl
+                                        isDarkMode={customDarkMode}
+                                        onToggleDarkMode={onToggleDarkMode}
+                                    />
+                                }
                                 isCopyEnabled
                                 isLineNumbersVisible
                                 isReadOnly

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
-import { DownloadIcon, MoonIcon, SunIcon } from '@patternfly/react-icons';
+import { DownloadIcon } from '@patternfly/react-icons';
 
 import { useTheme } from 'Containers/ThemeProvider';
 import download from 'utils/download';
+import CodeEditorDarkModeControl from 'Components/PatternFly/CodeEditorDarkModeControl';
 
 type NetworkPoliciesYAMLProp = {
     yaml: string;
@@ -25,16 +26,6 @@ function NetworkPoliciesYAML({ yaml }: NetworkPoliciesYAMLProp) {
         setCustomDarkMode((prevValue) => !prevValue);
     }
 
-    const toggleDarkModeControl = (
-        <CodeEditorControl
-            icon={customDarkMode ? <SunIcon /> : <MoonIcon />}
-            aria-label="Toggle dark mode"
-            toolTipText={customDarkMode ? 'Toggle to light mode' : 'Toggle to dark mode'}
-            onClick={onToggleDarkMode}
-            isVisible
-        />
-    );
-
     const downloadYAMLControl = (
         <CodeEditorControl
             icon={<DownloadIcon />}
@@ -49,7 +40,13 @@ function NetworkPoliciesYAML({ yaml }: NetworkPoliciesYAMLProp) {
         <div className="pf-u-h-100">
             <CodeEditor
                 isDarkTheme={customDarkMode}
-                customControls={[toggleDarkModeControl, downloadYAMLControl]}
+                customControls={[
+                    <CodeEditorDarkModeControl
+                        isDarkMode={customDarkMode}
+                        onToggleDarkMode={onToggleDarkMode}
+                    />,
+                    downloadYAMLControl,
+                ]}
                 isCopyEnabled
                 isLineNumbersVisible
                 isReadOnly

--- a/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
@@ -167,7 +167,7 @@ const DeploymentDetails = ({ alertDeployment }: DeploymentDetailsProps) => {
                     </FlexItem>
                     <FlexItem>
                         <Title headingLevel="h3" className="pf-u-my-md">
-                            Network Policy
+                            Network policy
                         </Title>
                         <Divider component="div" />
                     </FlexItem>

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicyModal.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicyModal.tsx
@@ -44,7 +44,7 @@ function NetworkPolicyModal({ networkPolicy, isOpen, onClose }: NetworkPolicyMod
                     language={Language.yaml}
                     height="450px"
                 />
-                <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
+                <FlexItem>
                     <Button className="pf-u-display-inline-block" onClick={exportYAMLHandler}>
                         Export YAML
                     </Button>

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicyModal.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicyModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, Flex, FlexItem, Modal, ModalVariant, Title } from '@patternfly/react-core';
+import { Button, Flex, Modal, ModalVariant, Title } from '@patternfly/react-core';
 import { CodeEditor, Language } from '@patternfly/react-code-editor';
 
 import CodeEditorDarkModeControl from 'Components/PatternFly/CodeEditorDarkModeControl';
@@ -25,10 +25,14 @@ function NetworkPolicyModal({ networkPolicy, isOpen, onClose }: NetworkPolicyMod
             variant={ModalVariant.small}
             isOpen={isOpen}
             onClose={onClose}
+            actions={[
+                <Button className="pf-u-display-inline-block" onClick={exportYAMLHandler}>
+                    Export YAML
+                </Button>,
+            ]}
         >
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
                 <Title headingLevel="h3">{networkPolicy.name}</Title>
-
                 <CodeEditor
                     isDarkTheme={isDarkMode}
                     customControls={
@@ -44,11 +48,6 @@ function NetworkPolicyModal({ networkPolicy, isOpen, onClose }: NetworkPolicyMod
                     language={Language.yaml}
                     height="450px"
                 />
-                <FlexItem>
-                    <Button className="pf-u-display-inline-block" onClick={exportYAMLHandler}>
-                        Export YAML
-                    </Button>
-                </FlexItem>
             </Flex>
         </Modal>
     );

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicyModal.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicyModal.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { Button, Flex, FlexItem, Modal, ModalVariant, Title } from '@patternfly/react-core';
+import { CodeEditor, Language } from '@patternfly/react-code-editor';
+
+import CodeEditorDarkModeControl from 'Components/PatternFly/CodeEditorDarkModeControl';
+import { NetworkPolicy } from 'types/networkPolicy.proto';
+import download from 'utils/download';
+
+export type NetworkPolicyModalProps = {
+    networkPolicy: Pick<NetworkPolicy, 'name' | 'yaml'>;
+    isOpen: boolean;
+    onClose: () => void;
+};
+
+function NetworkPolicyModal({ networkPolicy, isOpen, onClose }: NetworkPolicyModalProps) {
+    const [isDarkMode, setIsDarkMode] = useState(false);
+
+    function exportYAMLHandler() {
+        download(`${networkPolicy.name}.yml`, networkPolicy.yaml, 'yml');
+    }
+
+    return (
+        <Modal
+            title="Network policy details"
+            variant={ModalVariant.small}
+            isOpen={isOpen}
+            onClose={onClose}
+        >
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+                <Title headingLevel="h3">{networkPolicy.name}</Title>
+
+                <CodeEditor
+                    isDarkTheme={isDarkMode}
+                    customControls={
+                        <CodeEditorDarkModeControl
+                            isDarkMode={isDarkMode}
+                            onToggleDarkMode={() => setIsDarkMode((wasDarkMode) => !wasDarkMode)}
+                        />
+                    }
+                    isCopyEnabled
+                    isLineNumbersVisible
+                    isReadOnly
+                    code={networkPolicy.yaml}
+                    language={Language.yaml}
+                    height="450px"
+                />
+                <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
+                    <Button className="pf-u-display-inline-block" onClick={exportYAMLHandler}>
+                        Export YAML
+                    </Button>
+                </FlexItem>
+            </Flex>
+        </Modal>
+    );
+}
+
+export default NetworkPolicyModal;

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicyModal.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicyModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, Flex, Modal, ModalVariant, Title } from '@patternfly/react-core';
+import { Button, Flex, Modal, ModalVariant } from '@patternfly/react-core';
 import { CodeEditor, Language } from '@patternfly/react-code-editor';
 
 import CodeEditorDarkModeControl from 'Components/PatternFly/CodeEditorDarkModeControl';
@@ -31,8 +31,8 @@ function NetworkPolicyModal({ networkPolicy, isOpen, onClose }: NetworkPolicyMod
                 </Button>,
             ]}
         >
-            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
-                <Title headingLevel="h3">{networkPolicy.name}</Title>
+            <Flex direction={{ default: 'column' }}>
+                <p>Policy name: {networkPolicy.name}</p>
                 <CodeEditor
                     isDarkTheme={isDarkMode}
                     customControls={


### PR DESCRIPTION
## Description

Updates the plain text for network policies in the "Deployment" tab of the Violations detail page to use a list of links instead. Clicking one of the links will open a modal that shows the yaml in the same code editor used in the Network Graph.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

View a violation that occurs on a deployment in a namespace with network policies. (Note that the specific deployment itself does not need to have network policies.)
![image](https://github.com/stackrox/stackrox/assets/1292638/6d209e01-2ae6-4c96-ad01-a27c4d602389)

Click on a network policy.
![image](https://github.com/stackrox/stackrox/assets/1292638/ab8668d1-ea4e-4291-a925-efa4fa4e90ac)
Dark mode:
![image](https://github.com/stackrox/stackrox/assets/1292638/1e238409-c984-4f01-891a-45d7a665fb1f)

Test that the copy control and export button work correctly (no screenshots).

Close the modal and open another.
![image](https://github.com/stackrox/stackrox/assets/1292638/6bced7e8-fb5a-4f66-adf4-272246cbbbce)

View a deployment in a namespace with no Network Policies:
![image](https://github.com/stackrox/stackrox/assets/1292638/6fcdbdfe-2294-41f8-8c38-2d894c370213)

