### PR TITLE
chore(ui): Cleanup data-testid in Violations container

### DIFF
--- a/ui/apps/platform/cypress/integration/violations/Violations.selectors.js
+++ b/ui/apps/platform/cypress/integration/violations/Violations.selectors.js
@@ -6,7 +6,6 @@ export const selectors = {
         resolveAndAddToBaselineBtn: 'button:contains("Resolve and add to process baseline")',
     },
     details: {
-        page: '[data-testid="violation-details-page"]',
         title: 'h1.pf-c-title',
         subtitle: 'h2.pf-c-title',
         tabs: 'li.pf-c-tabs__item',
@@ -16,17 +15,17 @@ export const selectors = {
         policyTab: 'li.pf-c-tabs__item:contains("Policy")',
     },
     enforcement: {
-        detailMessage: '[data-testid="enforcement-detail-message"]',
-        explanationMessage: '[data-testid="enforcement-explanation-message"]',
+        detailMessage: '[aria-label="Enforcement detail message"]',
+        explanationMessage: '[aria-label="Enforcement explanation message"]',
     },
     deployment: {
-        overview: '[data-testid="deployment-details"] [data-testid="deployment-overview"]',
+        overview: '[aria-label="Deployment details"] [aria-label="Deployment overview"]',
         containerConfiguration:
-            '[data-testid="deployment-details"] [data-testid="container-configuration"]',
-        securityContext: '[data-testid="deployment-details"] [data-testid="security-context"]',
-        portConfiguration: '[data-testid="deployment-details"] [data-testid="port-configuration"]',
+            '[aria-label="Deployment details"] [aria-label="Container configuration"]',
+        securityContext: '[aria-label="Deployment details"] [aria-label="Security context"]',
+        portConfiguration: '[aria-label="Deployment details"] [aria-label="Port configuration"]',
         networkPolicy:
-            '[data-testid="deployment-details"] [aria-label="Network policies in namespace"]',
+            '[aria-label="Deployment details"] [aria-label="Network policies in namespace"]',
         networkPolicyModal: "[role='dialog']:contains('Network policy details')",
     },
 };

--- a/ui/apps/platform/cypress/integration/violations/violations.test.js
+++ b/ui/apps/platform/cypress/integration/violations/violations.test.js
@@ -57,7 +57,6 @@ describe('Violations', () => {
         visitViolationsWithFixture('alerts/alerts.json');
         visitViolationFromTableWithFixture('alerts/alertFirstInAlerts.json');
 
-        cy.get(selectors.details.page);
         cy.get(selectors.details.title).should('have.text', 'Misuse of iptables');
         cy.get(selectors.details.subtitle).should('have.text', 'in "ip-masq-agent" deployment');
     });
@@ -126,7 +125,7 @@ describe('Violations', () => {
 
         cy.get(selectors.deployment.overview);
         cy.get(selectors.deployment.containerConfiguration);
-        cy.get(`${selectors.deployment.containerConfiguration} [data-testid="commands"]`).should(
+        cy.get(`${selectors.deployment.containerConfiguration} *[aria-label="Commands"]`).should(
             'not.exist'
         );
         cy.get(selectors.deployment.securityContext);
@@ -139,7 +138,7 @@ describe('Violations', () => {
 
         cy.get(selectors.deployment.containerConfiguration);
         // TODO need more positive and negative assertions to contrast deployments in this and the previous test.
-        cy.get(`${selectors.deployment.containerConfiguration} [data-testid="commands"]`).should(
+        cy.get(`${selectors.deployment.containerConfiguration} *[aria-label="Commands"]`).should(
             'not.exist'
         );
     });

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
@@ -29,7 +29,7 @@ function ContainerConfiguration({ container }: ContainerConfigurationProps): Rea
     const { resources, volumes, secrets, config, image } = container;
     const { command, args } = config || {};
     return (
-        <DescriptionList data-testid="container-configuration" isHorizontal>
+        <DescriptionList isHorizontal>
             <ContainerImage image={image} />
             <Divider component="div" />
             {(command?.length > 0 || args?.length > 0) && (
@@ -38,14 +38,14 @@ function ContainerConfiguration({ container }: ContainerConfigurationProps): Rea
                         <DescriptionListItem
                             term="Commands"
                             desc={<MultilineDescription descArr={command} />}
-                            data-testid="commands"
+                            aria-label="Commands"
                         />
                     )}
                     {args?.length > 0 && (
                         <DescriptionListItem
                             term="Arguments"
                             desc={<MultilineDescription descArr={args} />}
-                            data-testid="arguments"
+                            aria-label="Arguments"
                         />
                     )}
                     <Divider component="div" />
@@ -86,7 +86,7 @@ export type ContainerConfigurationsProps = {
 function ContainerConfigurations({ deployment }: ContainerConfigurationsProps): ReactElement {
     const containers = deployment?.containers || [];
     return (
-        <Card isFlat>
+        <Card isFlat aria-label="Container configuration">
             <CardBody>
                 {containers.length > 0
                     ? containers.map((container, idx) => (

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/SecurityContext.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/SecurityContext.tsx
@@ -2,18 +2,24 @@ import React, { ReactElement } from 'react';
 import { Card, CardBody, DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
+import { Deployment } from 'types/deployment.proto';
 
-function SecurityContext({ deployment }): ReactElement {
-    const securityContextContainers = deployment?.containers?.filter(
-        (container) =>
-            !!(
-                container?.securityContext?.privileged ||
-                container?.securityContext?.addCapabilities.length > 0 ||
-                container?.securityContext?.dropCapabilities.length > 0
-            )
-    );
+export type SecurityContextProps = {
+    deployment: Deployment | null;
+};
+
+function SecurityContext({ deployment }: SecurityContextProps): ReactElement {
+    const securityContextContainers =
+        deployment?.containers?.filter(
+            (container) =>
+                !!(
+                    container?.securityContext?.privileged ||
+                    container?.securityContext?.addCapabilities.length > 0 ||
+                    container?.securityContext?.dropCapabilities.length > 0
+                )
+        ) ?? [];
     return (
-        <Card isFlat data-testid="security-context">
+        <Card isFlat aria-label="Security context">
             <CardBody>
                 {securityContextContainers?.length > 0
                     ? securityContextContainers.map((container, idx) => {

--- a/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/DeploymentDetails.tsx
@@ -107,14 +107,13 @@ const DeploymentDetails = ({ alertDeployment }: DeploymentDetailsProps) => {
         <Flex
             direction={{ default: 'column' }}
             flex={{ default: 'flex_1' }}
-            data-testid="deployment-details"
+            aria-label="Deployment details"
         >
             {!relatedDeployment && relatedDeploymentFetchError && (
                 <Alert
                     variant="warning"
                     isInline
                     title="There was an error fetching the deployment details. This deployment may no longer exist."
-                    data-testid="deployment-snapshot-warning"
                 >
                     {getAxiosErrorMessage(relatedDeploymentFetchError)}
                 </Alert>
@@ -128,7 +127,7 @@ const DeploymentDetails = ({ alertDeployment }: DeploymentDetailsProps) => {
                         <Divider component="div" />
                     </FlexItem>
                     <FlexItem>
-                        <Card isFlat data-testid="deployment-overview">
+                        <Card isFlat aria-label="Deployment overview">
                             <CardBody>
                                 {relatedDeployment && (
                                     <DeploymentOverview deployment={relatedDeployment} />
@@ -143,7 +142,7 @@ const DeploymentDetails = ({ alertDeployment }: DeploymentDetailsProps) => {
                         <Divider component="div" />
                     </FlexItem>
                     <FlexItem>
-                        <Card isFlat data-testid="port-configuration">
+                        <Card isFlat aria-label="Port configuration">
                             <CardBody>
                                 {relatedDeploymentPorts.length > 0
                                     ? formatDeploymentPorts(relatedDeploymentPorts).map(

--- a/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Explanation.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Explanation.tsx
@@ -29,7 +29,7 @@ function Explanation({ lifecycleStage, enforcement, policyId }: ExplanationProps
     const linkAddr = `../policies/${policyId}`;
 
     return (
-        <div className="pf-u-p-md" data-testid="enforcement-explanation-message">
+        <div className="pf-u-p-md" aria-label="Enforcement explanation message">
             <div className="pf-u-pb-md">
                 {getEnforcementExplanation(lifecycleStage, enforcement.message)}
             </div>

--- a/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Header.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Header.tsx
@@ -54,7 +54,7 @@ function Header({
     }
 
     return (
-        <div className="pf-u-p-md" data-testid="enforcement-detail-message">
+        <div className="pf-u-p-md" aria-label="Enforcement detail message">
             Enforcement {countMessage}
         </div>
     );

--- a/ui/apps/platform/src/Containers/Violations/Details/K8sCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/K8sCard.tsx
@@ -33,7 +33,7 @@ function K8sCard({ message, keyValueAttrs = { attrs: [] }, time }: K8sCardProps)
     }
 
     return (
-        <div className="pf-u-pb-md" key={message} data-testid="runtime-processes">
+        <div className="pf-u-pb-md" key={message}>
             <Card isExpanded={isExpanded} id={message} isFlat>
                 <CardHeader onExpand={onExpand}>
                     <CardTitle>{message}</CardTitle>

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkFlowCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkFlowCard.tsx
@@ -27,7 +27,7 @@ function NetworkFlowCard({ networkFlowInfo, message, time }: NetworkFlowCardProp
     }
 
     return (
-        <div className="pf-u-mb-md" key={message} data-testid="networkFlow">
+        <div className="pf-u-mb-md" key={message}>
             <Card isExpanded={isExpanded} id={message} isFlat>
                 <CardHeader onExpand={onExpand}>
                     <CardTitle>{message}</CardTitle>

--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
@@ -70,11 +70,7 @@ function ViolationDetailsPage(): ReactElement {
                 <Title headingLevel="h1">{title}</Title>
                 <Title headingLevel="h2">{`in "${entityName as string}" ${resourceType}`}</Title>
             </PageSection>
-            <PageSection
-                variant="default"
-                padding={{ default: 'noPadding' }}
-                data-testid="violation-details-page"
-            >
+            <PageSection variant="default" padding={{ default: 'noPadding' }}>
                 <Tabs
                     mountOnEnter
                     activeKey={activeTabKey}

--- a/ui/apps/platform/src/Containers/Violations/Modals/ExcludeConfirmation.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Modals/ExcludeConfirmation.tsx
@@ -61,7 +61,6 @@ function ExcludeConfirmation({
                 </Button>,
             ]}
             onClose={cancelModal}
-            data-testid="exclude-confirmation-modal"
             aria-label="Confirm excluding violations"
         >
             {`Are you sure you want to exclude ${numSelectedRows} ${pluralize(

--- a/ui/apps/platform/src/Containers/Violations/Modals/ResolveConfirmation.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Modals/ResolveConfirmation.tsx
@@ -42,7 +42,6 @@ function ResolveConfirmation({
                 </Button>,
             ]}
             onClose={cancelModal}
-            data-testid="resolve-confirmation-modal"
             aria-label="Confirm resolving violations"
         >
             {`Are you sure you want to resolve ${numSelectedRows} ${pluralize(

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -140,7 +140,7 @@ function ViolationsTablePanel({
                         {pluralize(violationsCount, 'result')} found
                     </Title>
                 </FlexItem>
-                <FlexItem data-testid="violations-bulk-actions-dropdown">
+                <FlexItem>
                     <Select
                         onToggle={onToggleSelect}
                         isOpen={isSelectOpen}

--- a/ui/apps/platform/src/Containers/Violations/types/violationTypes.ts
+++ b/ui/apps/platform/src/Containers/Violations/types/violationTypes.ts
@@ -79,36 +79,6 @@ export type ProcessViolation = {
     }[];
 };
 
-export type Deployment = {
-    annotations: {
-        email: string;
-        owner: string;
-    };
-    clusterId: string;
-    clusterName: string;
-    containers: {
-        image: {
-            id: string;
-            name: {
-                fullName: string;
-                registry: string;
-                remote: string;
-                tag: string;
-            };
-            notPullable: boolean;
-        };
-    }[];
-    id: string;
-    inactive: boolean;
-    labels: {
-        app: string;
-    };
-    name: string;
-    namespace: string;
-    namespaceId: string;
-    type: string;
-};
-
 export type Alert = {
     id: string;
     deployment?: {


### PR DESCRIPTION
## Description

Follow up to #6908, this removes almost all instances of `data-testid` in the Violations detail page in favor of using accessible `aria-label` attributes.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
