### PR TITLE
ROX-17224: add client CA env vars

### DIFF
--- a/pkg/env/metrics.go
+++ b/pkg/env/metrics.go
@@ -32,6 +32,10 @@ var (
 	SecureMetricsClientCANamespace = RegisterSetting("ROX_SECURE_METRICS_CLIENT_CA_NS", WithDefault("kube-system"))
 	// SecureMetricsClientCAConfigMap has the config map that contains the client CA.
 	SecureMetricsClientCAConfigMap = RegisterSetting("ROX_SECURE_METRICS_CLIENT_CA_CFG", WithDefault("extension-apiserver-authentication"))
+	// SecureMetricsClientCAKey has the config map key that contains the client CA.
+	SecureMetricsClientCAKey = RegisterSetting("ROX_SECURE_METRICS_CLIENT_CA_KEY", WithDefault("client-ca-file"))
+	// SecureMetricsClientCertCN has the expected subject common name of the client cert.
+	SecureMetricsClientCertCN = RegisterSetting("ROX_SECURE_METRICS_CLIENT_CERT_CN", WithDefault("system:serviceaccount:openshift-monitoring:prometheus-k8s"))
 )
 
 func validatePort(setting Setting) error {

--- a/pkg/metrics/tls_test.go
+++ b/pkg/metrics/tls_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/k8scfgwatch"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,6 +49,7 @@ func TestTLSConfigurerClientCALoading(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, cfgrTLSConfig.ClientCAs)
 
+	clientCAKey := env.SecureMetricsClientCAKey.Setting()
 	watcher.Modify(&v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: clientCAName, Namespace: clientCANamespace},
 		Data:       map[string]string{clientCAKey: string(caFileRaw)},
@@ -73,6 +75,7 @@ func TestTLSConfigurerNoClientCAs(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, cfgrTLSConfig.ClientCAs)
 
+	clientCAKey := env.SecureMetricsClientCAKey.Setting()
 	watcher.Modify(&v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: clientCAName, Namespace: clientCANamespace},
 		Data:       map[string]string{clientCAKey: "invalid-PEM"},

--- a/pkg/metrics/verifier_test.go
+++ b/pkg/metrics/verifier_test.go
@@ -6,12 +6,14 @@ import (
 	"testing"
 
 	"github.com/cloudflare/cfssl/helpers"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestClientCertVerifier(t *testing.T) {
+	prometheusCertCN := env.SecureMetricsClientCertCN.Setting()
 	cases := map[string]struct {
 		certFilePath string
 		subjectCN    string


### PR DESCRIPTION
## Description

Expose all the client CA settings as env vars.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.