### PR TITLE
ROX-18360: Ensure API after preparing tests

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -431,6 +431,9 @@ patch_resources_for_test() {
     for target_port in 8080 8081 8082 8443 8444 8445 8446 8447 8448; do
         check_endpoint_availability "$target_port"
     done
+
+    # Ensure the API is available as well after patching the load balancer.
+    wait_for_api
 }
 
 check_endpoint_availability() {

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -40,9 +40,6 @@ test_e2e() {
 
     prepare_for_endpoints_test
 
-    # Give some time for the changes to the load balancer to be applied
-    wait_for_api
-
     run_roxctl_tests
     run_roxctl_bats_tests "roxctl-test-output" "cluster" || touch FAIL
     store_test_results "roxctl-test-output" "roxctl-test-output"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -40,6 +40,9 @@ test_e2e() {
 
     prepare_for_endpoints_test
 
+    # Give some time for the changes to the load balancer to be applied
+    wait_for_api
+
     run_roxctl_tests
     run_roxctl_bats_tests "roxctl-test-output" "cluster" || touch FAIL
     store_test_results "roxctl-test-output" "roxctl-test-output"


### PR DESCRIPTION
## Description

Currently, a flake exists within the roxctl tests when the `whoami` command is used.

Previously, the timeouts have been adjusted as well as retries have been implemented. 

However, the failure was observed now again.

Looking at the output of the logs:
```log
INFO: Tue Jul 11 05:32:19 UTC 2023: Patch the loadbalancer and netpol resources for endpoints test
service/central-loadbalancer patched
networkpolicy.networking.k8s.io/allow-ext-to-central-ports created
INFO: Tue Jul 11 05:33:30 UTC 2023: Run roxctl tests
Using API_ENDPOINT 34.135.119.201:443
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  1238  100  1205  100    33   8368    229 --:--:-- --:--:-- --:--:--  8597
Testing command: roxctl  central whoami
[FAIL] Specifying only --token-file fails
Captured output was:
ERROR:	rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: dial tcp 34.135.119.201:443: i/o timeout"
```

we can see that just before the roxctl tests are being run, the central loadbalancer service is patched in preparation for some later test that's been run.

The assumption is that the flake exists because the load balancer doesn't become ready in time when the endpoint is accessed. Hence, adding a `wait_for_api` before starting the roxctl tests to ensure that the API is available once roxctl tests are run.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI.
