### PR TITLE
chore(ui): Gate Workload CVE e2e tests behind feature flag

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveSingle.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
 import {
     applyLocalSeverityFilters,
     selectResourceFilterType,
@@ -9,6 +10,12 @@ import { selectors } from './WorkloadCves.selectors';
 
 describe('Workload CVE Image CVE Single page', () => {
     withAuth();
+
+    before(function () {
+        if (!hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES')) {
+            this.skip();
+        }
+    });
 
     it('should correctly handle ImageCVE single page specific behavior', () => {
         // Apply global default filters

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.js
@@ -1,6 +1,8 @@
 import upperFirst from 'lodash/upperFirst';
 
 import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
+
 import {
     applyLocalSeverityFilters,
     selectResourceFilterType,
@@ -12,6 +14,12 @@ import { selectors } from './WorkloadCves.selectors';
 
 describe('Workload CVE Image Single page', () => {
     withAuth();
+
+    before(function () {
+        if (!hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES')) {
+            this.skip();
+        }
+    });
 
     it('should correctly handle Image single page specific behavior', () => {
         visitWorkloadCveOverview();

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadTableToolbar.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadTableToolbar.test.js
@@ -1,9 +1,17 @@
 import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
 import { visitWorkloadCveOverview } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 
 describe('Workload table toolbar', () => {
     withAuth();
+
+    before(function () {
+        if (!hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES')) {
+            this.skip();
+        }
+    });
+
     it('should correctly handle applied filters', () => {
         visitWorkloadCveOverview();
 


### PR DESCRIPTION
## Description

Since the feature is still behind a feature flag until GA, put the tests behind the same flag.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local CI runs with `CYPRESS_ROX_VULN_MGMT_WORKLOAD_CVES` enabled and disabled to verify that tests run/don't run correctly.

Tests should be **enabled** in CI.
