### PR TITLE
chore(ui): Purge unused Tailwind style rules

### DIFF
--- a/ui/apps/platform/tailwind.config.js
+++ b/ui/apps/platform/tailwind.config.js
@@ -20,4 +20,5 @@ module.exports = {
             '6xl': '2.5rem', // 40px
         },
     },
+    purge: ['./src/**/*.{js,ts,tsx}'],
 };


### PR DESCRIPTION
## Description

### Problem

> Tailwind is not purging unused styles because no template paths have been provided.

> The bundle size is significantly larger than recommended.

### Solution

After having removed partial class names via template literal and removed many obsolete classes, turn on purge option which consists of pattern for any source files which might contain Tailwind classes.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

TL;DR Additional 4.5 minutes corresponds to 14 Kb/sec savings: remember when that was a reasonable modem speed?

1. `yarn build` in ui and then compute branch - master for the following
    * time 270 = 390 - 120 plus or minus seconds or so
    * `wc build/static/css/*.css`
        main.css: -3940869 = 801862 - 4742731
        total: -3940869 = 1663033 - 5603902
    * `ls -al build/static/css/*.css | wc`
        0 = 29 - 29 files
2. `yarn start` in ui (did not notice a corresponding change in time, but was also multi tasking at the time :)

### Rebase after delete ui-components dependency

1. `yarn build` in ui and then compute branch - master for the following
    * time 363s
    * `wc build/static/css/*.css`
        main.css: -3941103 = 797984 - 4739087
        total: -3941103 = 1675732 - 5616835
    * `ls -al build/static/css/*.css | wc -l`
        0 = 29 - 29 files
2. `yarn start` in ui

### Manual testing

Visit pages via left navigation and explore 1 (or 2 for workflow) levels of descendant pages.