### PR TITLE
CI: Fix PolicyConfigurationTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
@@ -25,7 +25,6 @@ import services.ClusterService
 import services.ImageService
 import services.NodeService
 import services.PolicyService
-import util.Timer
 
 import org.junit.Assume
 import spock.lang.Shared

--- a/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
@@ -159,13 +159,11 @@ class PolicyConfigurationTest extends BaseSpecification {
         orchestrator.createDeployment(NGINX_WITH_DIGEST)
 
         when:
-        Timer t = new Timer(60, 1)
-        def image
-        while (image == null && t.IsValid()) {
-            image = ImageService.getImage(
+        withRetry(30, 2) {
+            def image = ImageService.getImage(
                     "sha256:86ae264c3f4acb99b2dee4d0098c40cb8c46dcf9e1148f05d3a51c4df6758c12")
+            assert image != null
         }
-        assert image != null
 
         and:
         "Run busybox latest with same digest as previous image"


### PR DESCRIPTION
## Description

This test was failing because `ImageService.getImage` throws an exception when it cannot find an image. This PR turns the loop into a standard withRetry() loop.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient + OCP tests where this fails most often + 50x run against an infra cluster.