### PR TITLE
fix(ui): Fix accessibility issues in Configuration Management Secrets

### DIFF
--- a/ui/apps/platform/cypress/integration/configmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/dashboard.test.js
@@ -197,13 +197,13 @@ describe('Configuration Management Dashboard', () => {
         }, entitiesKey);
     });
 
-    it('clicking the "Policy Violations By Severity" widget\'s "View All" button should take you to the policies list', () => {
+    it('should go to policies list from View All button in Policies widget', () => {
         const entitiesKey = 'policies';
 
         visitConfigurationManagementDashboard();
 
         interactAndWaitForConfigurationManagementEntities(() => {
-            cy.get(selectors.getWidget('Policy Violations by Severity'))
+            cy.get(selectors.getWidget('Policy violations by severity'))
                 .find('button:contains("View All")')
                 .click();
         }, entitiesKey);
@@ -221,44 +221,44 @@ describe('Configuration Management Dashboard', () => {
         }, entitiesKey);
     });
 
-    it('clicking the "Users with most Cluster Admin Roles" widget\'s "View All" button should take you to the users & groups list', () => {
+    it('should go to subjects (users and groups) list from View All button in Users widget', () => {
         const entitiesKey = 'subjects';
 
         visitConfigurationManagementDashboard();
 
         interactAndWaitForConfigurationManagementEntities(() => {
-            cy.get(selectors.getWidget('Users with most Cluster Admin Roles'))
+            cy.get(selectors.getWidget('Users with most cluster admin roles'))
                 .find('button:contains("View All")')
                 .click();
         }, entitiesKey);
     });
 
-    it('clicking a specific user in the "Users with most Cluster Admin Roles" widget should take you to a single subject page', () => {
+    it('should open side panel from link in Users widget', () => {
         const entitiesKey = 'subjects';
 
         visitConfigurationManagementDashboard();
 
         interactAndWaitForConfigurationManagementEntityInSidePanel(() => {
-            cy.get(selectors.getWidget('Users with most Cluster Admin Roles'))
+            cy.get(selectors.getWidget('Users with most cluster admin roles'))
                 .find(selectors.horizontalBars)
                 .eq(0)
                 .click();
         }, entitiesKey);
     });
 
-    it('clicking the "Secrets Most Used Across Deployments" widget\'s "View All" button should take you to the secrets list', () => {
+    it('should go to secrets list from View All button in Secrets widget', () => {
         const entitiesKey = 'secrets';
 
         visitConfigurationManagementDashboard();
 
         interactAndWaitForConfigurationManagementEntities(() => {
-            cy.get(selectors.getWidget('Secrets Most Used Across Deployments'))
+            cy.get(selectors.getWidget('Secrets most used across deployments'))
                 .find('button:contains("View All")')
                 .click();
         }, entitiesKey);
     });
 
-    it('should show the same number of policies in the "Policy Violations By Severity" widget as it does in the Policies list', () => {
+    it('should go to filtered policies list from link in Policy violations widget', () => {
         const entitiesKey = 'policies';
 
         visitConfigurationManagementDashboard();
@@ -266,7 +266,7 @@ describe('Configuration Management Dashboard', () => {
         // Click the first bullet list link.
         // All bases are covered, because policies without violations is a possible link.
         policyViolationsBySeverityLinkShouldMatchList(
-            `${selectors.getWidget('Policy Violations by Severity')} .widget-detail-bullet:eq(0) a`,
+            `${selectors.getWidget('Policy violations by severity')} .widget-detail-bullet:eq(0) a`,
             /^(\d+) /,
             entitiesKey
         );
@@ -316,13 +316,13 @@ describe('Configuration Management Dashboard', () => {
         cy.location('search').should('contain', '[Compliance%20State]=Fail');
     });
 
-    it('clicking the "Secrets Most Used Across Deployments" widget\'s individual list items should take you to the secret\'s single page', () => {
+    it('should open side panel from link in Secrets widget', () => {
         const entitiesKey = 'secrets';
 
         visitConfigurationManagementDashboard();
 
         interactAndWaitForConfigurationManagementEntityInSidePanel(() => {
-            cy.get(selectors.getWidget('Secrets Most Used Across Deployments'))
+            cy.get(selectors.getWidget('Secrets most used across deployments'))
                 .find('ul li')
                 .eq(0)
                 .click();

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.js
@@ -289,7 +289,7 @@ const PolicyViolationsBySeverity = ({ match, location }) => {
                 return (
                     <Widget
                         className="s-2 pdf-page"
-                        header="Policy Violations by Severity"
+                        header="Policy violations by severity"
                         headerComponents={viewAllLink}
                     >
                         {contents}

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.js
@@ -4,7 +4,6 @@ import ReactRouterPropTypes from 'react-router-prop-types';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 import dateFns from 'date-fns';
-import { Tooltip } from '@patternfly/react-core';
 
 import Loader from 'Components/Loader';
 import URLService from 'utils/URLService';
@@ -108,52 +107,33 @@ const SecretsMostUsedAcrossDeployments = ({ match, location }) => {
                                     .push(item.id)
                                     .url();
                                 return (
-                                    <Link
+                                    <li
                                         key={item.id}
-                                        to={linkTo}
-                                        className={`no-underline text-base-600 hover:bg-base-200 inline-block border-base-300 w-full ${
+                                        className={`text-base-600 inline-block flex flex-row border-base-300 w-full ${
                                             index !== 4 || index !== 9 ? 'border-b' : ''
                                         }`}
                                     >
-                                        <li>
-                                            <div className="flex flex-row">
-                                                <div className="self-center text-2xl pl-4 pr-4">
-                                                    {index + 1}
-                                                </div>
-                                                <div className="flex flex-col truncate pr-4 pb-4 pt-4 text-sm">
-                                                    <span className="text-xs pb-1 text-base-500">
-                                                        {item.clusterName}/{item.namespace}
-                                                    </span>
-                                                    <span className="pb-2">{item.name}</span>
-                                                    <Tooltip
-                                                        content={
-                                                            <div>
-                                                                {`${
-                                                                    item.deploymentCount
-                                                                } ${pluralize(
-                                                                    'Deployment',
-                                                                    item.deploymentCount
-                                                                )}, `}
-                                                                {getCertificateStatus(item.files)}
-                                                            </div>
-                                                        }
-                                                    >
-                                                        {item.deploymentCount > 0 && (
-                                                            <div className="truncate">
-                                                                {`${
-                                                                    item.deploymentCount
-                                                                } ${pluralize(
-                                                                    'Deployment',
-                                                                    item.deploymentCount
-                                                                )}, `}
-                                                                {getCertificateStatus(item.files)}
-                                                            </div>
-                                                        )}
-                                                    </Tooltip>
-                                                </div>
-                                            </div>
-                                        </li>
-                                    </Link>
+                                        <div className="self-center text-2xl pl-4 pr-4">
+                                            {index + 1}
+                                        </div>
+                                        <div className="flex flex-col truncate pr-4 pb-4 pt-4 text-sm">
+                                            <span className="text-base-500">
+                                                {item.clusterName}/{item.namespace}
+                                            </span>
+                                            <Link className="text-base-600 underline" to={linkTo}>
+                                                {item.name}
+                                            </Link>
+                                            {item.deploymentCount > 0 && (
+                                                <span className="mt-1 truncate">
+                                                    {`${item.deploymentCount} ${pluralize(
+                                                        'deployment',
+                                                        item.deploymentCount
+                                                    )}, `}
+                                                    {getCertificateStatus(item.files)}
+                                                </span>
+                                            )}
+                                        </div>
+                                    </li>
                                 );
                             })}
                         </ul>
@@ -162,7 +142,7 @@ const SecretsMostUsedAcrossDeployments = ({ match, location }) => {
                 return (
                     <Widget
                         className="s-2 overflow-hidden pdf-page"
-                        header="Secrets Most Used Across Deployments"
+                        header="Secrets most used across deployments"
                         headerComponents={viewAllLink}
                     >
                         {contents}

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/UsersWithMostClusterAdminRoles.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/UsersWithMostClusterAdminRoles.js
@@ -105,7 +105,7 @@ const UsersWithMostClusterAdminRoles = ({ match, location }) => {
                 return (
                     <Widget
                         className="s-2 overflow-hidden pdf-page"
-                        header="Users with most Cluster Admin Roles"
+                        header="Users with most cluster admin roles"
                         headerComponents={viewAllLink}
                     >
                         {contents}


### PR DESCRIPTION
## Description

### Problem

1 and 10 serious issues, respectively

> `ul` and `ol` must only directly contain `li` and so on elements

> `li` elements must be contained in a `ul` or `ol`

### Analysis

SecretsMostUsedAcrossDeployment renders `li` inside `a` element, instead of `a` inside `li` element.

### Solution

1. Replace invisible block link with visible link for secret name.
2. Delete redundant tooltip for deployment count and certificate status.
3. Adjust margins.
4. While we are at it, replace title case with sentence case for 3 widgets.

### Observation

A lot of custom alignment to render a unique list when data cries out for a table:

| Secret             |      Status | Cluster | Namespace | Deployments |
| :---               |        ---: | :---    | :--       |        ---: |
| proxy-config       |    no certs | remote  | stackrox  |           2 |
| monitoring         | valid certs | remote  | stackrox  |           1 |
| central-htpassword |    no certs | remote  | stackrox  |           1 |

and so on

And did you notice irony of explict numbers in unordered list?

### Residue

1. React select `input` element in widget titles on Configuration Management and Vulnerability Management have critical issue:

    > Form elements must have labels.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### Manual testing

1. Visit /main/configmanagement
    * See sentence case in widget titles (except for standard name).
    * See link for secret.
    * See absence of tooltip for deployments and certificate status.
        ![Secrets_most_used_across_deployments](https://github.com/stackrox/stackrox/assets/11862657/1bc720d8-478c-4d63-af62-6f4abf8a7563)

2. Click a secret to open it in the side panel.

### Integration testing

* configmanagement/dashboard.test.js