### PR TITLE
chore(e2e): Unskip openshift in tests that call verifyConditionalCVEs

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasOrchestratorFlavor } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -78,19 +77,11 @@ describe('Vulnerability Management Clusters', () => {
         verifyConditionalCVEs(entitiesKey, 'image-cves', 3, 'imageVulnerabilityCounter');
     });
 
-    it('should display either links for node CVEs or text for No CVEs', function () {
-        if (hasOrchestratorFlavor('openshift')) {
-            this.skip(); // TODO verify and remove
-        }
-
+    it('should display either links for node CVEs or text for No CVEs', () => {
         verifyConditionalCVEs(entitiesKey, 'node-cves', 4, 'nodeVulnerabilityCounter');
     });
 
-    it('should display either links for cluster CVEs or text for No CVEs', function () {
-        if (hasOrchestratorFlavor('openshift')) {
-            this.skip(); // TODO verify and remove
-        }
-
+    it('should display either links for cluster CVEs or text for No CVEs', () => {
         verifyConditionalCVEs(entitiesKey, 'cluster-cves', 5, 'clusterVulnerabilityCounter');
     });
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
@@ -1,4 +1,3 @@
-import { hasOrchestratorFlavor } from '../../helpers/features';
 import withAuth from '../../helpers/basicAuth';
 import {
     assertSortedItems,
@@ -73,11 +72,7 @@ describe('Vulnerability Management Deployments', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    it('should display either links for image CVEs or text for No CVEs', function () {
-        if (hasOrchestratorFlavor('openshift')) {
-            this.skip(); // TODO verify and remove
-        }
-
+    it('should display either links for image CVEs or text for No CVEs', () => {
         verifyConditionalCVEs(entitiesKey, 'image-cves', 3, 'imageVulnerabilityCounter');
     });
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasOrchestratorFlavor } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -115,11 +114,7 @@ describe('Vulnerability Management Image Components', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    it('should display either links for image CVEs or text for No CVEs', function () {
-        if (hasOrchestratorFlavor('openshift')) {
-            this.skip(); // TODO verify and remove
-        }
-
+    it('should display either links for image CVEs or text for No CVEs', () => {
         verifyConditionalCVEs(entitiesKey, 'image-cves', 4, 'vulnCounter');
     });
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasOrchestratorFlavor } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -73,11 +72,7 @@ describe('Vulnerability Management Namespaces', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    it('should display either links for image CVEs or text for No CVEs', function () {
-        if (hasOrchestratorFlavor('openshift')) {
-            this.skip(); // TODO verify and remove
-        }
-
+    it('should display either links for image CVEs or text for No CVEs', () => {
         verifyConditionalCVEs(entitiesKey, 'image-cves', 3, 'imageVulnerabilityCounter');
     });
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
@@ -117,11 +117,7 @@ describe('Vulnerability Management Node Components', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    it('should display either links for node CVEs or text for No CVEs', function () {
-        if (hasOrchestratorFlavor('openshift')) {
-            this.skip(); // TODO verify and remove
-        }
-
+    it('should display either links for node CVEs or text for No CVEs', () => {
         verifyConditionalCVEs(entitiesKey, 'node-cves', 4, 'vulnCounter');
     });
 


### PR DESCRIPTION
## Description

Because `verifyConditionalCVEs` supports **absence of CVEs** remove `skip` from 6 tests:
* for node CVEs and cluster CVEs in clusters.test.js
* for image CVEs in deployments.test.js
* for image CVEs in imageComponents.test.js
* for image CVEs in namespaces.test.js
* for node CVEs in nodeComponents.test.js

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed