### PR TITLE
fix(ui): Delete Enabled column in Configuration Management Policies

### DIFF
--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Policies.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Policies.js
@@ -36,22 +36,11 @@ const tableColumns = [
     },
     {
         Header: `Policy`,
-        headerClassName: `w-1/8 ${defaultHeaderClassName}`,
-        className: `w-1/8 ${defaultColumnClassName}`,
+        headerClassName: `w-1/4 ${defaultHeaderClassName}`,
+        className: `w-1/4 ${defaultColumnClassName}`,
         accessor: 'name',
         id: policySortFields.POLICY,
         sortField: policySortFields.POLICY,
-    },
-    {
-        Header: `Enabled`,
-        headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
-        className: `w-1/8 ${defaultColumnClassName}`,
-        Cell: ({ original }) => {
-            const { disabled, pdf } = original;
-            return <PolicyDisabledIconText isDisabled={disabled} isTextOnly={pdf} />;
-        },
-        accessor: 'disabled',
-        sortable: false, // not performant as of 2020-06-11
     },
     {
         Header: `Enforced`,
@@ -98,8 +87,8 @@ const tableColumns = [
     },
     {
         Header: `Categories`,
-        headerClassName: `w-1/8 ${defaultHeaderClassName}`,
-        className: `w-1/8 ${defaultColumnClassName}`,
+        headerClassName: `w-1/4 ${defaultHeaderClassName}`,
+        className: `w-1/4 ${defaultColumnClassName}`,
         Cell: ({ original }) => {
             const { categories } = original;
             return categories.join(', ');


### PR DESCRIPTION
## Description

Recommended by Mandar and confirmed by ACS UX team on 2023-07-12

Follow up after changes suggested in PatternFly Design Share and reviewed by ACS UX team:
* Replace icons **without** text for enabled state with icon **with** text
* Replace hyphen **without** explanation for status of disabled policies with icon **with** text

Enabled column is redundant because Policy Status has either:
* Disabled is explicit
* Fail implies Enabled
* Pass implies Enabled

### Residue

UI/UX meeting discussed but did not yet converge on specific improvement for default sort on this page.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

## Manual testing

1. Visit /main/configmanagement/policies

    * 1920px panel width
        ![policies_1920](https://github.com/stackrox/stackrox/assets/11862657/17963e5d-ba74-425a-8ff0-047a01f466da)

    * 1440px newer laptop width
        ![policies_1440](https://github.com/stackrox/stackrox/assets/11862657/896e396e-d0b8-4f1e-b16d-e63026eb29ad)

    * 1280px older laptop width
        ![policies_1280](https://github.com/stackrox/stackrox/assets/11862657/6d32a482-8ca9-4081-9439-c7fee204d435)

### Integration testing

* configmanagement/policies.test.js