### PR TITLE
ROX-18374: Autodetect PSP in delete-sensor.sh

### DIFF
--- a/image/templates/sensor/kubernetes/delete-sensor.sh
+++ b/image/templates/sensor/kubernetes/delete-sensor.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-kubectl -n stackrox delete cm,secret,sa,svc,validatingwebhookconfigurations,ds,deploy,netpol,psp,clusterrole,clusterrolebinding,role,rolebinding -l auto-upgrade.stackrox.io/component=sensor --wait
+kubectl -n stackrox delete cm,secret,sa,svc,validatingwebhookconfigurations,ds,deploy,netpol,clusterrole,clusterrolebinding,role,rolebinding -l auto-upgrade.stackrox.io/component=sensor --wait
+
+SUPPORTS_PSP=$(kubectl api-resources | grep "podsecuritypolicies" -c || true)
+
+if [[ ! "${SUPPORTS_PSP}" -ne 0 ]]; then
+    kubectl -n stackrox delete psp -l auto-upgrade.stackrox.io/component=sensor --wait
+fi
 
 if ! kubectl get -n stackrox deploy/central; then
     kubectl delete -n stackrox secret stackrox

--- a/image/templates/sensor/kubernetes/delete-sensor.sh
+++ b/image/templates/sensor/kubernetes/delete-sensor.sh
@@ -4,10 +4,10 @@ kubectl -n stackrox delete cm,secret,sa,svc,validatingwebhookconfigurations,ds,d
 
 SUPPORTS_PSP=$(kubectl api-resources | grep "podsecuritypolicies" -c || true)
 
-if [[ ! "${SUPPORTS_PSP}" -ne 0 ]]; then
+if [[ "${SUPPORTS_PSP}" -ne 0 ]]; then
     kubectl -n stackrox delete psp -l auto-upgrade.stackrox.io/component=sensor --wait
 fi
 
-if ! kubectl get -n stackrox deploy/central; then
+if ! kubectl get -n stackrox deploy/central 2>&1; then
     kubectl delete -n stackrox secret stackrox
 fi

--- a/image/templates/sensor/openshift/delete-sensor.sh
+++ b/image/templates/sensor/openshift/delete-sensor.sh
@@ -4,12 +4,12 @@ oc -n stackrox delete cm,secret,sa,svc,validatingwebhookconfigurations,ds,deploy
 
 SUPPORTS_PSP=$(oc api-resources | grep "podsecuritypolicies" -c || true)
 
-if [[ ! "${SUPPORTS_PSP}" -ne 0 ]]; then
+if [[ "${SUPPORTS_PSP}" -ne 0 ]]; then
     oc -n stackrox delete psp -l auto-upgrade.stackrox.io/component=sensor --wait
 fi
 
 oc delete scc -l auto-upgrade.stackrox.io/component=sensor --wait
 
-if ! oc get -n stackrox deploy/central > /dev/null; then
+if ! oc get -n stackrox deploy/central > /dev/null 2>&1; then
     oc delete -n stackrox secret stackrox
 fi

--- a/image/templates/sensor/openshift/delete-sensor.sh
+++ b/image/templates/sensor/openshift/delete-sensor.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-oc -n stackrox delete cm,secret,sa,svc,validatingwebhookconfigurations,ds,deploy,netpol,psp,clusterrole,clusterrolebinding,role,rolebinding -l auto-upgrade.stackrox.io/component=sensor --wait
+oc -n stackrox delete cm,secret,sa,svc,validatingwebhookconfigurations,ds,deploy,netpol,clusterrole,clusterrolebinding,role,rolebinding -l auto-upgrade.stackrox.io/component=sensor --wait
+
+SUPPORTS_PSP=$(oc api-resources | grep "podsecuritypolicies" -c || true)
+
+if [[ ! "${SUPPORTS_PSP}" -ne 0 ]]; then
+    oc -n stackrox delete psp -l auto-upgrade.stackrox.io/component=sensor --wait
+fi
 
 oc delete scc -l auto-upgrade.stackrox.io/component=sensor --wait
 

--- a/scripts/style/shellcheck_skip.txt
+++ b/scripts/style/shellcheck_skip.txt
@@ -23,9 +23,7 @@ image/templates/common/port-forward.sh
 image/templates/common/setup-central.sh
 image/templates/common/setup-scanner.sh
 image/templates/common/setup.sh
-image/templates/sensor/kubernetes/delete-sensor.sh
 image/templates/sensor/kubernetes/sensor.sh
-image/templates/sensor/openshift/delete-sensor.sh
 image/templates/sensor/openshift/sensor.sh
 licenses/generate-license-wrapper.sh
 operator/hack/common.sh


### PR DESCRIPTION
## Description

Skip PSPs for clusters where PSPs were removed (K8S v1.25 and above)

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~~Unit test and regression tests added~~
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~


## Testing Performed
Manually tested on the following platforms:
1. Vanilla K8S v1.27.3+k3s1
2. Vanilla K8S v1.23.6+k3s1
3. Openshift 4.11.44 (Infra)
4. Openshift 4.13.4 (Infra)

### Test steps:
1. Install Central
2. Create a cluster from the UI, download a sensor bundle.
5. Install Secured Cluster with `./sensor.sh`
6. Uninstall with `./delete-sensor.sh` 
