### PR TITLE
fix(ui): Fix accessibility issue about TextSelect input form label

### DIFF
--- a/ui/apps/platform/src/Components/TextSelect/TextSelect.js
+++ b/ui/apps/platform/src/Components/TextSelect/TextSelect.js
@@ -31,7 +31,18 @@ const TextSelect = ({ ...rest }) => {
     const components = {
         DropdownIndicator,
     };
-    return <Select styles={selectStyles} isSearchable={false} {...rest} components={components} />;
+    // Because React Select renders a dummy input element,
+    // axe DevTools reports a theoretical issue: Form elements must have labels.
+    // One of its suggestions is to enclose the form element in a label element.
+    // Thankfully that does not affect the layout.
+    // However, jsx-a11y rule only accepts label as sibling, not enclosing.
+    /* eslint-disable jsx-a11y/label-has-associated-control */
+    return (
+        <label>
+            <Select styles={selectStyles} isSearchable={false} {...rest} components={components} />
+        </label>
+    );
+    /* eslint-enable jsx-a11y/label-has-associated-control */
 };
 
 export default TextSelect;


### PR DESCRIPTION
## Description

### Problem

> Form elements must have labels

### Analysis

TextSelect based on React Select renders a dummy `input` element:

* src/Containers/ConfigManagement/Dashboard/widgets/ComplianceByControls.js
* src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
* src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.js

### Solution

Comment from code:

```js
// Because React Select renders a dummy input element,
// axe DevTools reports a theoretical issue: Form elements must have labels.
// One of its suggestions is to enclose the form element in a label element.
// Thankfully that does not affect the layout.
// However, jsx-a11y rule only accepts label as sibling, not enclosing.
/* eslint-disable jsx-a11y/label-has-associated-control */
return (
    <label>
        <Select styles={selectStyles} isSearchable={false} {...rest} components={components} />
    </label>
);
/* eslint-enable jsx-a11y/label-has-associated-control */
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Visit /main/configmanagement: see absence of issue from axe DevTools
    ![configmanagement](https://github.com/stackrox/stackrox/assets/11862657/7f7e0c08-a01f-429c-a531-730a5c2e0885)

2. Visit /main/vulnerability-management: see absence of issue from axe DevTools
    ![vulnerability-management](https://github.com/stackrox/stackrox/assets/11862657/327ea782-50c2-412e-acff-ed7007a435c6)

### Integration testing

* configmanagement/dashboard.test.js
* vulnmanagement/dashboard.test.js
* vulnmanagement/dashboardToEntityPage.test.js
