### PR TITLE
CI: Fix ImageScanningTest flakes

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -810,8 +810,11 @@ class ImageScanningTest extends BaseSpecification {
             imageDigest = images.find { it.name == imageName }
             assert imageDigest?.id, "image ${imageName} not found among ${images*.name}"
         }
-        ImageOuterClass.Image imageDetail = ImageService.getImage(imageDigest?.id)
-        validateImageMetadata(imageDetail, source)
+        ImageOuterClass.Image imageDetail
+        withRetry(10, 20) {
+            imageDetail = ImageService.getImage(imageDigest?.id)
+            validateImageMetadata(imageDetail, source)
+        }
         return imageDetail
     }
 


### PR DESCRIPTION
## Description

Since @Retry() was removed this test fails more often. One particular culprit is `Image metadata from registry test` when the Azure container registry times out:

```
pkg/images/enricher: 2023/07/07 09:09:58.403784 enricher_impl.go:348: Info: Getting metadata for image stackroxci.azurecr.io/stackroxci/registry-image:0.3
image/service: 2023/07/07 09:10:03.492909 service_impl.go:289: Error: error enriching image "stackroxci.azurecr.io/stackroxci/registry-image:0.3": image enrichment error: error getting metadata for image: stackroxci.azurecr.io/stackroxci/registry-image:0.3 error: getting metadata from registry: "acr": Get "https://eusmanaged51.blob.core.windows.net/1783c77074a44bedb6bc08eb5ab66324-z69mm6zphh//docker/registry/v2/blobs/sha256/e0/e03ee8c409b34496c09c261194dd3d0d825f0a67350d49c8812d7dd65a95dfdc/data?se=2023-07-07T09%3A25%3A26Z&sig=zJtrccN4K1fBQGLXeXnI74J%2Fc%2BlUNjwzid%2FlCcxThb8%3D&sp=r&spr=https&sr=b&sv=2018-03-28&regid=1783c77074a44bedb6bc08eb5ab66324": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

This PR gives central time to retry.

It also adds a configurable wait to the standalone test runner.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient