### PR TITLE
fix(k8scfgwatch): remove watch timeout

### DIFF
--- a/pkg/k8scfgwatch/cfg_watcher.go
+++ b/pkg/k8scfgwatch/cfg_watcher.go
@@ -69,11 +69,10 @@ func (w *ConfigMapWatcher) run(ctx concurrency.Waitable, namespace string, name 
 }
 
 func (w *ConfigMapWatcher) startWatcher(ctx concurrency.Waitable, namespace string, name string) {
-	watchCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(concurrency.AsContext(ctx), timeout)
-	defer cancel()
 	watcher, err := w.k8sClient.CoreV1().ConfigMaps(namespace).Watch(
-		watchCtx,
-		metav1.SingleObject(metav1.ObjectMeta{Name: name, Namespace: namespace}))
+		concurrency.AsContext(ctx),
+		metav1.SingleObject(metav1.ObjectMeta{Name: name, Namespace: namespace}),
+	)
 	if err != nil {
 		log.Errorw(fmt.Sprintf("Unable to start watching config map %s/%s", name, namespace), zap.Error(err))
 		return


### PR DESCRIPTION
## Description

The watch context timeout was intended to deal with connection timeouts during the initial server response, however it also includes the event stream that comes after. This leads to unintended early disconnect of the watcher, which is then re-created. However, connection problems should already be covered by the default transport, which includes timeouts. So the context timeout is not needed here, and just leads to log spam and added load on the k8s API.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested on OpenShift cluster.