### PR TITLE
ROX-17327: Implement expiring message in Sensor

### DIFF
--- a/sensor/common/admissioncontroller/alert_handler.go
+++ b/sensor/common/admissioncontroller/alert_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
 )
 
 var (
@@ -22,7 +23,7 @@ type AlertHandler interface {
 }
 
 type alertHandlerImpl struct {
-	output       chan *central.MsgFromSensor
+	output       chan *message.ExpiringMessage
 	stopSig      concurrency.Signal
 	centralReady concurrency.Signal
 }
@@ -53,7 +54,7 @@ func (h *alertHandlerImpl) ProcessMessage(_ *central.MsgToSensor) error {
 	return nil
 }
 
-func (h *alertHandlerImpl) ResponsesC() <-chan *central.MsgFromSensor {
+func (h *alertHandlerImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return h.output
 }
 
@@ -80,8 +81,8 @@ func (h *alertHandlerImpl) processAlerts(alertMsg *sensor.AdmissionControlAlerts
 	}
 }
 
-func createAlertResultsMsg(alertResult *central.AlertResults) *central.MsgFromSensor {
-	return &central.MsgFromSensor{
+func createAlertResultsMsg(alertResult *central.AlertResults) *message.ExpiringMessage {
+	return message.New(&central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_Event{
 			Event: &central.SensorEvent{
 				Id: alertResult.GetDeploymentId(),
@@ -94,5 +95,5 @@ func createAlertResultsMsg(alertResult *central.AlertResults) *central.MsgFromSe
 				},
 			},
 		},
-	}
+	})
 }

--- a/sensor/common/admissioncontroller/mocks/alert_handler.go
+++ b/sensor/common/admissioncontroller/mocks/alert_handler.go
@@ -11,6 +11,7 @@ import (
 	sensor "github.com/stackrox/rox/generated/internalapi/sensor"
 	centralsensor "github.com/stackrox/rox/pkg/centralsensor"
 	common "github.com/stackrox/rox/sensor/common"
+	message "github.com/stackrox/rox/sensor/common/message"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -92,10 +93,10 @@ func (mr *MockAlertHandlerMockRecorder) ProcessMessage(msg interface{}) *gomock.
 }
 
 // ResponsesC mocks base method.
-func (m *MockAlertHandler) ResponsesC() <-chan *central.MsgFromSensor {
+func (m *MockAlertHandler) ResponsesC() <-chan *message.ExpiringMessage {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResponsesC")
-	ret0, _ := ret[0].(<-chan *central.MsgFromSensor)
+	ret0, _ := ret[0].(<-chan *message.ExpiringMessage)
 	return ret0
 }
 

--- a/sensor/common/admissioncontroller/singleton.go
+++ b/sensor/common/admissioncontroller/singleton.go
@@ -1,9 +1,9 @@
 package admissioncontroller
 
 import (
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/message"
 )
 
 var (
@@ -14,7 +14,7 @@ var (
 func newAlertHandler() *alertHandlerImpl {
 	return &alertHandlerImpl{
 		stopSig:      concurrency.NewSignal(),
-		output:       make(chan *central.MsgFromSensor),
+		output:       make(chan *message.ExpiringMessage),
 		centralReady: concurrency.NewSignal(),
 	}
 }

--- a/sensor/common/compliance/auditlog_manager.go
+++ b/sensor/common/compliance/auditlog_manager.go
@@ -1,12 +1,12 @@
 package compliance
 
 import (
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/clusterid"
+	"github.com/stackrox/rox/sensor/common/message"
 )
 
 //go:generate mockgen-wrapper AuditLogCollectionManager
@@ -49,7 +49,7 @@ func NewAuditLogCollectionManager() AuditLogCollectionManager {
 		eligibleComplianceNodes: make(map[string]sensor.ComplianceService_CommunicateServer),
 		fileStates:              make(map[string]*storage.AuditLogFileState),
 		auditEventMsgs:          make(chan *sensor.MsgFromCompliance),
-		fileStateUpdates:        make(chan *central.MsgFromSensor),
+		fileStateUpdates:        make(chan *message.ExpiringMessage),
 		stopSig:                 concurrency.NewSignal(),
 		forceUpdateSig:          concurrency.NewSignal(),
 		centralReady:            concurrency.NewSignal(),

--- a/sensor/common/compliance/auditlog_manager_impl.go
+++ b/sensor/common/compliance/auditlog_manager_impl.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
 )
 
 const (
@@ -28,7 +29,7 @@ type auditLogCollectionManagerImpl struct {
 	eligibleComplianceNodes         map[string]sensor.ComplianceService_CommunicateServer
 
 	auditEventMsgs   chan *sensor.MsgFromCompliance
-	fileStateUpdates chan *central.MsgFromSensor
+	fileStateUpdates chan *message.ExpiringMessage
 
 	stopSig        concurrency.Signal
 	forceUpdateSig concurrency.Signal
@@ -71,7 +72,7 @@ func (a *auditLogCollectionManagerImpl) ProcessMessage(_ *central.MsgToSensor) e
 	return nil
 }
 
-func (a *auditLogCollectionManagerImpl) ResponsesC() <-chan *central.MsgFromSensor {
+func (a *auditLogCollectionManagerImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return a.fileStateUpdates
 }
 
@@ -163,14 +164,14 @@ func (a *auditLogCollectionManagerImpl) getLatestFileStates() map[string]*storag
 	return nodeStates
 }
 
-func (a *auditLogCollectionManagerImpl) getCentralUpdateMsg(fileStates map[string]*storage.AuditLogFileState) *central.MsgFromSensor {
-	return &central.MsgFromSensor{
+func (a *auditLogCollectionManagerImpl) getCentralUpdateMsg(fileStates map[string]*storage.AuditLogFileState) *message.ExpiringMessage {
+	return message.New(&central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_AuditLogStatusInfo{
 			AuditLogStatusInfo: &central.AuditLogStatusInfo{
 				NodeAuditLogFileStates: fileStates,
 			},
 		},
-	}
+	})
 }
 
 // AddEligibleComplianceNode adds the specified node and it's connection to the list of nodes whose audit log collection lifecycle will be managed

--- a/sensor/common/compliance/auditlog_manager_test.go
+++ b/sensor/common/compliance/auditlog_manager_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/updater"
 	"github.com/stretchr/testify/suite"
 )
@@ -90,7 +91,7 @@ func (s *AuditLogCollectionManagerTestSuite) getManager(
 		forceUpdateSig:          concurrency.NewSignal(),
 		centralReady:            concurrency.NewSignal(),
 		auditEventMsgs:          make(chan *sensor.MsgFromCompliance, 5), // Buffered for the test only
-		fileStateUpdates:        make(chan *central.MsgFromSensor),
+		fileStateUpdates:        make(chan *message.ExpiringMessage),
 	}
 }
 

--- a/sensor/common/compliance/command_handler.go
+++ b/sensor/common/compliance/command_handler.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
 )
 
 // CommandHandler executes the input scrape commands, and reconciles scrapes with input ComplianceReturns,
@@ -20,7 +21,7 @@ func NewCommandHandler(complianceService Service) CommandHandler {
 		service: complianceService,
 
 		commands: make(chan *central.ScrapeCommand),
-		updates:  make(chan *central.MsgFromSensor),
+		updates:  make(chan *message.ExpiringMessage),
 
 		scrapeIDToState: make(map[string]*scrapeState),
 

--- a/sensor/common/compliance/mocks/auditlog_manager.go
+++ b/sensor/common/compliance/mocks/auditlog_manager.go
@@ -12,6 +12,7 @@ import (
 	storage "github.com/stackrox/rox/generated/storage"
 	centralsensor "github.com/stackrox/rox/pkg/centralsensor"
 	common "github.com/stackrox/rox/sensor/common"
+	message "github.com/stackrox/rox/sensor/common/message"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -153,10 +154,10 @@ func (mr *MockAuditLogCollectionManagerMockRecorder) RemoveEligibleComplianceNod
 }
 
 // ResponsesC mocks base method.
-func (m *MockAuditLogCollectionManager) ResponsesC() <-chan *central.MsgFromSensor {
+func (m *MockAuditLogCollectionManager) ResponsesC() <-chan *message.ExpiringMessage {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResponsesC")
-	ret0, _ := ret[0].(<-chan *central.MsgFromSensor)
+	ret0, _ := ret[0].(<-chan *message.ExpiringMessage)
 	return ret0
 }
 

--- a/sensor/common/compliance/multiplexer.go
+++ b/sensor/common/compliance/multiplexer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/pkg/channelmultiplexer"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
 )
 
 var _ common.ComplianceComponent = (*Multiplexer)(nil)
@@ -68,7 +69,7 @@ func (c *Multiplexer) ProcessMessage(_ *central.MsgToSensor) error {
 }
 
 // ResponsesC is unimplemented, part of the component interface
-func (c *Multiplexer) ResponsesC() <-chan *central.MsgFromSensor {
+func (c *Multiplexer) ResponsesC() <-chan *message.ExpiringMessage {
 	return nil
 }
 

--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/common/message"
 	"google.golang.org/grpc"
 )
 
@@ -28,7 +29,7 @@ type SensorComponent interface {
 	Capabilities() []centralsensor.SensorCapability
 
 	ProcessMessage(msg *central.MsgToSensor) error
-	ResponsesC() <-chan *central.MsgFromSensor
+	ResponsesC() <-chan *message.ExpiringMessage
 }
 
 // MessageToComplianceWithAddress adds the Hostname to sensor.MsgToCompliance so we know where to send it to.

--- a/sensor/common/config/handler.go
+++ b/sensor/common/config/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/admissioncontroller"
 	"github.com/stackrox/rox/sensor/common/compliance"
+	"github.com/stackrox/rox/sensor/common/message"
 )
 
 var (
@@ -65,7 +66,7 @@ func (c *configHandlerImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
-func (c *configHandlerImpl) ResponsesC() <-chan *central.MsgFromSensor {
+func (c *configHandlerImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return nil
 }
 

--- a/sensor/common/delegatedregistry/delegated_registry_handler.go
+++ b/sensor/common/delegatedregistry/delegated_registry_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/common/scan"
 	"google.golang.org/grpc"
@@ -76,7 +77,7 @@ func (d *delegatedRegistryImpl) ProcessMessage(msg *central.MsgToSensor) error {
 	return nil
 }
 
-func (d *delegatedRegistryImpl) ResponsesC() <-chan *central.MsgFromSensor {
+func (d *delegatedRegistryImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return nil
 }
 

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -388,10 +388,7 @@ func (d *detectorImpl) runAuditLogEventDetector() {
 			}
 
 			// TODO(ROX-17326): Add context to detector message
-			expiringMessage := &message.ExpiringMessage{
-				MsgFromSensor: msg,
-				Context:       context.TODO(),
-			}
+			expiringMessage := message.NewExpiring(msg, context.TODO())
 
 			select {
 			case <-d.auditStopper.Flow().StopRequested():
@@ -493,10 +490,7 @@ func createAlertResultsMsg(action central.ResourceAction, alertResults *central.
 	}
 
 	// TODO(ROX-17326): Add context to detector messages
-	return &message.ExpiringMessage{
-		MsgFromSensor: msgFromSensor,
-		Context:       context.TODO(),
-	}
+	return message.NewExpiring(msgFromSensor, context.TODO())
 }
 
 func (d *detectorImpl) processIndicator(pi *storage.ProcessIndicator) {

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -387,7 +387,7 @@ func (d *detectorImpl) runAuditLogEventDetector() {
 				},
 			}
 
-			// TODO: Add context to detector message
+			// TODO(ROX-17326): Add context to detector message
 			expiringMessage := &message.ExpiringMessage{
 				MsgFromSensor: msg,
 				Context:       context.TODO(),
@@ -492,7 +492,7 @@ func createAlertResultsMsg(action central.ResourceAction, alertResults *central.
 		},
 	}
 
-	// TODO: Add context to detector messages
+	// TODO(ROX-17326): Add context to detector messages
 	return &message.ExpiringMessage{
 		MsgFromSensor: msgFromSensor,
 		Context:       context.TODO(),

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -1,6 +1,7 @@
 package detector
 
 import (
+	"context"
 	"sort"
 
 	"github.com/gogo/protobuf/types"
@@ -29,6 +30,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/enforcer"
 	"github.com/stackrox/rox/sensor/common/externalsrcs"
 	"github.com/stackrox/rox/sensor/common/imagecacheutils"
+	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/common/scan"
 	"github.com/stackrox/rox/sensor/common/store"
@@ -65,7 +67,7 @@ func New(enforcer enforcer.Enforcer, admCtrlSettingsMgr admissioncontroller.Sett
 	return &detectorImpl{
 		unifiedDetector: unified.NewDetector(),
 
-		output:                    make(chan *central.MsgFromSensor),
+		output:                    make(chan *message.ExpiringMessage),
 		auditEventsChan:           auditLogEvents,
 		deploymentAlertOutputChan: make(chan outputResult),
 		deploymentProcessingMap:   make(map[string]int64),
@@ -94,7 +96,7 @@ func New(enforcer enforcer.Enforcer, admCtrlSettingsMgr admissioncontroller.Sett
 type detectorImpl struct {
 	unifiedDetector unified.Detector
 
-	output                    chan *central.MsgFromSensor
+	output                    chan *message.ExpiringMessage
 	auditEventsChan           chan *sensor.AuditEvents
 	deploymentAlertOutputChan chan outputResult
 
@@ -306,7 +308,7 @@ func (d *detectorImpl) ProcessMessage(msg *central.MsgToSensor) error {
 	return nil
 }
 
-func (d *detectorImpl) ResponsesC() <-chan *central.MsgFromSensor {
+func (d *detectorImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return d.output
 }
 
@@ -369,12 +371,8 @@ func (d *detectorImpl) runAuditLogEventDetector() {
 			sort.Slice(alerts, func(i, j int) bool {
 				return alerts[i].GetPolicy().GetId() < alerts[j].GetPolicy().GetId()
 			})
-			select {
-			case <-d.auditStopper.Flow().StopRequested():
-				return
-			case <-d.serializerStopper.Flow().StopRequested():
-				return
-			case d.output <- &central.MsgFromSensor{
+
+			msg := &central.MsgFromSensor{
 				Msg: &central.MsgFromSensor_Event{
 					Event: &central.SensorEvent{
 						Action: central.ResourceAction_CREATE_RESOURCE,
@@ -387,7 +385,20 @@ func (d *detectorImpl) runAuditLogEventDetector() {
 						},
 					},
 				},
-			}:
+			}
+
+			// TODO: Add context to detector message
+			expiringMessage := &message.ExpiringMessage{
+				MsgFromSensor: msg,
+				Context:       context.TODO(),
+			}
+
+			select {
+			case <-d.auditStopper.Flow().StopRequested():
+				return
+			case <-d.serializerStopper.Flow().StopRequested():
+				return
+			case d.output <- expiringMessage:
 			}
 		}
 	}
@@ -464,8 +475,8 @@ func (d *detectorImpl) ProcessIndicator(pi *storage.ProcessIndicator) {
 	go d.processIndicator(pi)
 }
 
-func createAlertResultsMsg(action central.ResourceAction, alertResults *central.AlertResults) *central.MsgFromSensor {
-	return &central.MsgFromSensor{
+func createAlertResultsMsg(action central.ResourceAction, alertResults *central.AlertResults) *message.ExpiringMessage {
+	msgFromSensor := &central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_Event{
 			Event: &central.SensorEvent{
 				Id:     alertResults.GetDeploymentId(),
@@ -479,6 +490,12 @@ func createAlertResultsMsg(action central.ResourceAction, alertResults *central.
 				},
 			},
 		},
+	}
+
+	// TODO: Add context to detector messages
+	return &message.ExpiringMessage{
+		MsgFromSensor: msgFromSensor,
+		Context:       context.TODO(),
 	}
 }
 

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -388,7 +388,7 @@ func (d *detectorImpl) runAuditLogEventDetector() {
 			}
 
 			// TODO(ROX-17326): Add context to detector message
-			expiringMessage := message.NewExpiring(msg, context.TODO())
+			expiringMessage := message.NewExpiring(context.TODO(), msg)
 
 			select {
 			case <-d.auditStopper.Flow().StopRequested():
@@ -490,7 +490,7 @@ func createAlertResultsMsg(action central.ResourceAction, alertResults *central.
 	}
 
 	// TODO(ROX-17326): Add context to detector messages
-	return message.NewExpiring(msgFromSensor, context.TODO())
+	return message.NewExpiring(context.TODO(), msgFromSensor)
 }
 
 func (d *detectorImpl) processIndicator(pi *storage.ProcessIndicator) {

--- a/sensor/common/detector/mocks/detector.go
+++ b/sensor/common/detector/mocks/detector.go
@@ -11,6 +11,7 @@ import (
 	storage "github.com/stackrox/rox/generated/storage"
 	centralsensor "github.com/stackrox/rox/pkg/centralsensor"
 	common "github.com/stackrox/rox/sensor/common"
+	message "github.com/stackrox/rox/sensor/common/message"
 	gomock "go.uber.org/mock/gomock"
 	grpc "google.golang.org/grpc"
 )
@@ -187,10 +188,10 @@ func (mr *MockDetectorMockRecorder) ReprocessDeployments(deploymentIDs ...interf
 }
 
 // ResponsesC mocks base method.
-func (m *MockDetector) ResponsesC() <-chan *central.MsgFromSensor {
+func (m *MockDetector) ResponsesC() <-chan *message.ExpiringMessage {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResponsesC")
-	ret0, _ := ret[0].(<-chan *central.MsgFromSensor)
+	ret0, _ := ret[0].(<-chan *message.ExpiringMessage)
 	return ret0
 }
 

--- a/sensor/common/enforcer/enforcer.go
+++ b/sensor/common/enforcer/enforcer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/enforcers"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
 )
 
 var (
@@ -46,7 +47,7 @@ func (e *enforcer) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
-func (e *enforcer) ResponsesC() <-chan *central.MsgFromSensor {
+func (e *enforcer) ResponsesC() <-chan *message.ExpiringMessage {
 	return nil
 }
 

--- a/sensor/common/externalsrcs/handler.go
+++ b/sensor/common/externalsrcs/handler.go
@@ -15,6 +15,7 @@ import (
 	pkgNet "github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
 )
 
 var (
@@ -90,7 +91,7 @@ func (h *handlerImpl) ProcessMessage(msg *central.MsgToSensor) error {
 	}
 }
 
-func (h *handlerImpl) ResponsesC() <-chan *central.MsgFromSensor {
+func (h *handlerImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return nil
 }
 

--- a/sensor/common/image/service_impl.go
+++ b/sensor/common/image/service_impl.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/imagecacheutils"
+	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/scan"
 	"google.golang.org/grpc"
 )
@@ -154,6 +155,6 @@ func (s *serviceImpl) ProcessMessage(_ *central.MsgToSensor) error {
 	return nil
 }
 
-func (s *serviceImpl) ResponsesC() <-chan *central.MsgFromSensor {
+func (s *serviceImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return nil
 }

--- a/sensor/common/message/message.go
+++ b/sensor/common/message/message.go
@@ -16,11 +16,11 @@ type ExpiringMessage struct {
 
 // New creates an ExpiringMessage with msg and context.Background.
 func New(msg *central.MsgFromSensor) *ExpiringMessage {
-	return NewExpiring(msg, context.Background())
+	return NewExpiring(context.Background(), msg)
 }
 
 // NewExpiring creates a message with a specific context.
-func NewExpiring(msg *central.MsgFromSensor, ctx context.Context) *ExpiringMessage {
+func NewExpiring(ctx context.Context, msg *central.MsgFromSensor) *ExpiringMessage {
 	return &ExpiringMessage{
 		MsgFromSensor: msg,
 		Context:       ctx,

--- a/sensor/common/message/message.go
+++ b/sensor/common/message/message.go
@@ -6,23 +6,26 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 )
 
+// ExpiringMessage is a wrapper on central.MsgFromSensor with the addition of a Context.
+// The context will be cancelled when the message is expired and should no longer be sent
+// to Central.
 type ExpiringMessage struct {
 	*central.MsgFromSensor
 	Context context.Context
 }
 
+// New creates an ExpiringMessage with msg and context.Background.
 func New(msg *central.MsgFromSensor) *ExpiringMessage {
-	return NewWithContext(msg, context.Background())
-}
-
-func NewWithContext(msg *central.MsgFromSensor, ctx context.Context) *ExpiringMessage {
-	expiringMessage := &ExpiringMessage{
+	return &ExpiringMessage{
 		MsgFromSensor: msg,
-		Context:       ctx,
+		Context:       context.Background(),
 	}
-	return expiringMessage
 }
 
+// Wait is a helper function that will wait until the context on the message is Done.
+// This should be used when sending on blocking channels to abort the process the message
+// expired in the meantime. If the context is not set, this function blocks forever (i.e. wait on
+// context.Background() channel).
 func (m *ExpiringMessage) Wait() <-chan struct{} {
 	if m.Context == nil {
 		return context.Background().Done()
@@ -30,6 +33,8 @@ func (m *ExpiringMessage) Wait() <-chan struct{} {
 	return m.Context.Done()
 }
 
+// IsExpired is a helper function that checks if the context already expired without blocking.
+// If the context isn't set this function will always return false.
 func (m *ExpiringMessage) IsExpired() bool {
 	if m.Context == nil {
 		return false

--- a/sensor/common/message/message.go
+++ b/sensor/common/message/message.go
@@ -1,0 +1,44 @@
+package message
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+)
+
+type ExpiringMessage struct {
+	*central.MsgFromSensor
+	Context context.Context
+}
+
+func New(msg *central.MsgFromSensor) *ExpiringMessage {
+	return NewWithContext(msg, context.Background())
+}
+
+func NewWithContext(msg *central.MsgFromSensor, ctx context.Context) *ExpiringMessage {
+	expiringMessage := &ExpiringMessage{
+		MsgFromSensor: msg,
+		Context:       ctx,
+	}
+	return expiringMessage
+}
+
+func (m *ExpiringMessage) Wait() <-chan struct{} {
+	if m.Context == nil {
+		return context.Background().Done()
+	}
+	return m.Context.Done()
+}
+
+func (m *ExpiringMessage) IsExpired() bool {
+	if m.Context == nil {
+		return false
+	}
+
+	select {
+	case <-m.Context.Done():
+		return true
+	default:
+		return false
+	}
+}

--- a/sensor/common/message/message.go
+++ b/sensor/common/message/message.go
@@ -16,9 +16,14 @@ type ExpiringMessage struct {
 
 // New creates an ExpiringMessage with msg and context.Background.
 func New(msg *central.MsgFromSensor) *ExpiringMessage {
+	return NewExpiring(msg, context.Background())
+}
+
+// NewExpiring creates a message with a specific context.
+func NewExpiring(msg *central.MsgFromSensor, ctx context.Context) *ExpiringMessage {
 	return &ExpiringMessage{
 		MsgFromSensor: msg,
-		Context:       context.Background(),
+		Context:       ctx,
 	}
 }
 

--- a/sensor/common/processsignal/pipeline_test.go
+++ b/sensor/common/processsignal/pipeline_test.go
@@ -4,18 +4,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/process/filter"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	"github.com/stackrox/rox/sensor/common/detector/mocks"
+	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
 
 func TestProcessPipeline(t *testing.T) {
-	sensorEvents := make(chan *central.MsgFromSensor)
-	actualEvents := make(chan *central.MsgFromSensor)
+	sensorEvents := make(chan *message.ExpiringMessage)
+	actualEvents := make(chan *message.ExpiringMessage)
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -89,7 +89,7 @@ func TestProcessPipeline(t *testing.T) {
 	closeChan <- true
 }
 
-func consumeEnrichedSignals(sensorEvents chan *central.MsgFromSensor, results chan *central.MsgFromSensor, closeChan chan bool) {
+func consumeEnrichedSignals(sensorEvents chan *message.ExpiringMessage, results chan *message.ExpiringMessage, closeChan chan bool) {
 	for {
 		select {
 		case event := <-sensorEvents:

--- a/sensor/common/reprocessor/handler.go
+++ b/sensor/common/reprocessor/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/admissioncontroller"
 	"github.com/stackrox/rox/sensor/common/detector"
+	"github.com/stackrox/rox/sensor/common/message"
 )
 
 var (
@@ -96,6 +97,6 @@ func (h *handlerImpl) ProcessInvalidateImageCache(req *central.InvalidateImageCa
 	return nil
 }
 
-func (h *handlerImpl) ResponsesC() <-chan *central.MsgFromSensor {
+func (h *handlerImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return nil
 }

--- a/sensor/common/reprocessor/mocks/handler.go
+++ b/sensor/common/reprocessor/mocks/handler.go
@@ -10,6 +10,7 @@ import (
 	central "github.com/stackrox/rox/generated/internalapi/central"
 	centralsensor "github.com/stackrox/rox/pkg/centralsensor"
 	common "github.com/stackrox/rox/sensor/common"
+	message "github.com/stackrox/rox/sensor/common/message"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -105,10 +106,10 @@ func (mr *MockHandlerMockRecorder) ProcessReprocessDeployments(arg0 interface{})
 }
 
 // ResponsesC mocks base method.
-func (m *MockHandler) ResponsesC() <-chan *central.MsgFromSensor {
+func (m *MockHandler) ResponsesC() <-chan *message.ExpiringMessage {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResponsesC")
-	ret0, _ := ret[0].(<-chan *central.MsgFromSensor)
+	ret0, _ := ret[0].(<-chan *message.ExpiringMessage)
 	return ret0
 }
 

--- a/sensor/common/signal/signal_service.go
+++ b/sensor/common/signal/signal_service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
 	"google.golang.org/grpc"
 )
 
@@ -36,7 +37,7 @@ type serviceImpl struct {
 	sensorAPI.UnimplementedSignalServiceServer
 
 	queue      chan *v1.Signal
-	indicators chan *central.MsgFromSensor
+	indicators chan *message.ExpiringMessage
 
 	processPipeline Pipeline
 }
@@ -57,7 +58,7 @@ func (s *serviceImpl) ProcessMessage(_ *central.MsgToSensor) error {
 	return nil
 }
 
-func (s *serviceImpl) ResponsesC() <-chan *central.MsgFromSensor {
+func (s *serviceImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return s.indicators
 }
 
@@ -66,7 +67,7 @@ func (s *serviceImpl) RegisterServiceServer(grpcServer *grpc.Server) {
 	sensorAPI.RegisterSignalServiceServer(grpcServer, s)
 }
 
-// RegisterServiceHandlerFromEndpoint registers this service with the given gRPC Gateway endpoint.
+// RegisterServiceHandler registers this service with the given gRPC Gateway endpoint.
 func (s *serviceImpl) RegisterServiceHandler(_ context.Context, _ *runtime.ServeMux, _ *grpc.ClientConn) error {
 	// There is no grpc gateway handler for signal service
 	return nil

--- a/sensor/common/signal/singleton.go
+++ b/sensor/common/signal/singleton.go
@@ -2,11 +2,11 @@ package signal
 
 import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/sensor/common/message"
 )
 
 // New creates a new signal service
-func New(pipeline Pipeline, indicators chan *central.MsgFromSensor) Service {
+func New(pipeline Pipeline, indicators chan *message.ExpiringMessage) Service {
 	return &serviceImpl{
 		queue:           make(chan *v1.Signal, maxBufferSize),
 		indicators:      indicators,

--- a/sensor/kubernetes/admissioncontroller/config_map_persister.go
+++ b/sensor/kubernetes/admissioncontroller/config_map_persister.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/admissioncontroller"
+	"github.com/stackrox/rox/sensor/common/message"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,7 +71,7 @@ func (p *configMapPersister) ProcessMessage(_ *central.MsgToSensor) error {
 	return nil
 }
 
-func (p *configMapPersister) ResponsesC() <-chan *central.MsgFromSensor {
+func (p *configMapPersister) ResponsesC() <-chan *message.ExpiringMessage {
 	return nil
 }
 

--- a/sensor/kubernetes/complianceoperator/mocks/types.go
+++ b/sensor/kubernetes/complianceoperator/mocks/types.go
@@ -10,6 +10,7 @@ import (
 	central "github.com/stackrox/rox/generated/internalapi/central"
 	centralsensor "github.com/stackrox/rox/pkg/centralsensor"
 	common "github.com/stackrox/rox/sensor/common"
+	message "github.com/stackrox/rox/sensor/common/message"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -128,10 +129,10 @@ func (mr *MockInfoUpdaterMockRecorder) ProcessMessage(msg interface{}) *gomock.C
 }
 
 // ResponsesC mocks base method.
-func (m *MockInfoUpdater) ResponsesC() <-chan *central.MsgFromSensor {
+func (m *MockInfoUpdater) ResponsesC() <-chan *message.ExpiringMessage {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResponsesC")
-	ret0, _ := ret[0].(<-chan *central.MsgFromSensor)
+	ret0, _ := ret[0].(<-chan *message.ExpiringMessage)
 	return ret0
 }
 

--- a/sensor/kubernetes/complianceoperator/updater.go
+++ b/sensor/kubernetes/complianceoperator/updater.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
 	appsv1 "k8s.io/api/apps/v1"
 	kubeAPIErr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +39,7 @@ func NewInfoUpdater(client kubernetes.Interface, updateInterval time.Duration) I
 	return &updaterImpl{
 		client:         client,
 		updateInterval: updateInterval,
-		response:       make(chan *central.MsgFromSensor),
+		response:       make(chan *message.ExpiringMessage),
 		stopSig:        concurrency.NewSignal(),
 	}
 }
@@ -46,7 +47,7 @@ func NewInfoUpdater(client kubernetes.Interface, updateInterval time.Duration) I
 type updaterImpl struct {
 	client               kubernetes.Interface
 	updateInterval       time.Duration
-	response             chan *central.MsgFromSensor
+	response             chan *message.ExpiringMessage
 	stopSig              concurrency.Signal
 	complianceOperatorNS string
 }
@@ -73,7 +74,7 @@ func (u *updaterImpl) ProcessMessage(_ *central.MsgToSensor) error {
 	return nil
 }
 
-func (u *updaterImpl) ResponsesC() <-chan *central.MsgFromSensor {
+func (u *updaterImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return u.response
 }
 
@@ -114,7 +115,7 @@ func (u *updaterImpl) collectInfoAndSendResponse() bool {
 	log.Debugf("Compliance Operator Info: %v", protoutils.NewWrapper(msg.GetComplianceOperatorInfo()))
 
 	select {
-	case u.response <- msg:
+	case u.response <- message.New(msg):
 		return true
 	case <-u.stopSig.Done():
 		return false

--- a/sensor/kubernetes/eventpipeline/component/component.go
+++ b/sensor/kubernetes/eventpipeline/component/component.go
@@ -1,6 +1,8 @@
 package component
 
-import "github.com/stackrox/rox/generated/internalapi/central"
+import (
+	"github.com/stackrox/rox/sensor/common/message"
+)
 
 // PipelineComponent components that constitute the eventPipeline
 type PipelineComponent interface {
@@ -22,5 +24,5 @@ type Resolver interface {
 type OutputQueue interface {
 	PipelineComponent
 	Send(event *ResourceEvent)
-	ResponsesC() <-chan *central.MsgFromSensor
+	ResponsesC() <-chan *message.ExpiringMessage
 }

--- a/sensor/kubernetes/eventpipeline/component/message.go
+++ b/sensor/kubernetes/eventpipeline/component/message.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"context"
+
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/sensor/common/store/resolver"
@@ -52,11 +54,14 @@ type ResourceEvent struct {
 
 	// DeploymentReferences returns a list of deployment references generated from a Kubernetes Event
 	DeploymentReferences []DeploymentReference
+
+	// Context contains a context that determines if the message is still valid.
+	Context context.Context
 }
 
 // NewEvent creates a resource event with preset sensor event messages.
 func NewEvent(msg ...*central.SensorEvent) *ResourceEvent {
-	return &ResourceEvent{ForwardMessages: msg}
+	return &ResourceEvent{ForwardMessages: msg, Context: context.Background()}
 }
 
 // AddSensorEvent appends central sensor events to be bundled with this resource event.

--- a/sensor/kubernetes/eventpipeline/component/mocks/component.go
+++ b/sensor/kubernetes/eventpipeline/component/mocks/component.go
@@ -7,7 +7,7 @@ package mocks
 import (
 	reflect "reflect"
 
-	central "github.com/stackrox/rox/generated/internalapi/central"
+	message "github.com/stackrox/rox/sensor/common/message"
 	component "github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -146,10 +146,10 @@ func (m *MockOutputQueue) EXPECT() *MockOutputQueueMockRecorder {
 }
 
 // ResponsesC mocks base method.
-func (m *MockOutputQueue) ResponsesC() <-chan *central.MsgFromSensor {
+func (m *MockOutputQueue) ResponsesC() <-chan *message.ExpiringMessage {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResponsesC")
-	ret0, _ := ret[0].(<-chan *central.MsgFromSensor)
+	ret0, _ := ret[0].(<-chan *message.ExpiringMessage)
 	return ret0
 }
 

--- a/sensor/kubernetes/eventpipeline/output/output.go
+++ b/sensor/kubernetes/eventpipeline/output/output.go
@@ -3,15 +3,15 @@ package output
 import (
 	"sync/atomic"
 
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/sensor/common/detector"
+	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
 
 // New instantiates a an output Queue component
 func New(detector detector.Detector, queueSize int) component.OutputQueue {
 	ch := make(chan *component.ResourceEvent, queueSize)
-	forwardQueue := make(chan *central.MsgFromSensor)
+	forwardQueue := make(chan *message.ExpiringMessage)
 	outputQueue := &outputQueueImpl{
 		detector:     detector,
 		innerQueue:   ch,

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -77,7 +77,7 @@ func (q *outputQueueImpl) runOutputQueue() {
 			}
 		}
 
-		// TODO: Don't process message in the detector if message expired
+		// TODO(ROX-17326): Don't process message in the detector if message expired
 		// The order here is important. We rely on the ReprocessDeployment being called before ProcessDeployment to remove the deployments from the deduper.
 		q.detector.ReprocessDeployments(msg.ReprocessDeployments...)
 		for _, detectorRequest := range msg.DetectorMessages {

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -71,7 +71,7 @@ func (q *outputQueueImpl) runOutputQueue() {
 		}
 
 		for _, resourceUpdates := range msg.ForwardMessages {
-			expiringMessage := message.NewExpiring(wrapSensorEvent(resourceUpdates), msg.Context)
+			expiringMessage := message.NewExpiring(msg.Context, wrapSensorEvent(resourceUpdates))
 			if !expiringMessage.IsExpired() {
 				q.forwardQueue <- expiringMessage
 			}

--- a/sensor/kubernetes/eventpipeline/output/output_test.go
+++ b/sensor/kubernetes/eventpipeline/output/output_test.go
@@ -1,0 +1,81 @@
+package output
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/sensor/common/detector/mocks"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+const (
+	waitTimeout = 100 * time.Millisecond
+)
+
+func shouldForwardMessage(t *testing.T, ch <-chan *message.ExpiringMessage) {
+	select {
+	case <-ch:
+	case <-time.After(waitTimeout):
+		t.Error("expecting event to have arrived")
+	}
+}
+
+func shouldNotForwardMessage(t *testing.T, ch <-chan *message.ExpiringMessage) {
+	select {
+	case <-ch:
+		t.Error("expecting event to not have arrived")
+	case <-time.After(waitTimeout):
+	}
+}
+
+func Test_OutputQueue_ExpiringMessages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	detector := mocks.NewMockDetector(ctrl)
+	q := New(detector, 10)
+
+	assert.NoError(t, q.Start())
+	defer q.Stop(nil)
+
+	expiredContext, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	testCases := map[string]struct {
+		message   *component.ResourceEvent
+		assertion func(*testing.T, <-chan *message.ExpiringMessage)
+	}{
+		"Empty context are treated as Background": {
+			message: &component.ResourceEvent{
+				ForwardMessages: []*central.SensorEvent{{Id: "a"}},
+				Context:         nil,
+			},
+			assertion: shouldForwardMessage,
+		},
+		"Not expired message is sent": {
+			message: &component.ResourceEvent{
+				ForwardMessages: []*central.SensorEvent{{Id: "a"}},
+				Context:         context.Background(),
+			},
+			assertion: shouldForwardMessage,
+		},
+		"Expired message is not sent": {
+			message: &component.ResourceEvent{
+				ForwardMessages: []*central.SensorEvent{{Id: "a"}},
+				Context:         expiredContext,
+			},
+			assertion: shouldNotForwardMessage,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			detector.EXPECT().ReprocessDeployments(gomock.Eq([]string{}))
+			q.Send(tc.message)
+			tc.assertion(t, q.ResponsesC())
+		})
+	}
+}

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -5,12 +5,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/detector"
+	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/reprocessor"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
@@ -35,7 +35,7 @@ func New(client client.Interface, configHandler config.Handler, detector detecto
 	offlineMode := &atomic.Bool{}
 	offlineMode.Store(true)
 
-	pipelineResponses := make(chan *central.MsgFromSensor)
+	pipelineResponses := make(chan *message.ExpiringMessage)
 	return &eventPipeline{
 		eventsC:     pipelineResponses,
 		stopSig:     concurrency.NewSignal(),

--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
 	mockDetector "github.com/stackrox/rox/sensor/common/detector/mocks"
+	"github.com/stackrox/rox/sensor/common/message"
 	mockReprocessor "github.com/stackrox/rox/sensor/common/reprocessor/mocks"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	mockComponent "github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component/mocks"
@@ -49,7 +50,7 @@ func (s *eventPipelineSuite) SetupTest() {
 	s.detector = mockDetector.NewMockDetector(s.mockCtrl)
 	s.reprocessor = mockReprocessor.NewMockHandler(s.mockCtrl)
 	s.pipeline = &eventPipeline{
-		eventsC:     make(chan *central.MsgFromSensor),
+		eventsC:     make(chan *message.ExpiringMessage),
 		stopSig:     concurrency.NewSignal(),
 		output:      mockComponent.NewMockOutputQueue(s.mockCtrl),
 		resolver:    s.resolver,

--- a/sensor/kubernetes/listener/resource_event_handler_impl.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl.go
@@ -106,7 +106,7 @@ func (h *resourceEventHandlerImpl) sendResourceEvent(obj, oldObj interface{}, ac
 	}
 
 	message := h.dispatcher.ProcessEvent(obj, oldObj, action)
-	// TODO Add context here
+	// TODO(ROX-17157) Add context here
 	message.Context = nil
 	h.resolver.Send(message)
 }

--- a/sensor/kubernetes/listener/resource_event_handler_impl.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl.go
@@ -106,6 +106,8 @@ func (h *resourceEventHandlerImpl) sendResourceEvent(obj, oldObj interface{}, ac
 	}
 
 	message := h.dispatcher.ProcessEvent(obj, oldObj, action)
+	// TODO Add context here
+	message.Context = nil
 	h.resolver.Send(message)
 }
 

--- a/sensor/kubernetes/listener/resource_event_handler_impl_test.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	mocks2 "github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component/mocks"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/mocks"
 	"github.com/stretchr/testify/suite"
@@ -58,7 +59,8 @@ func makeExpectedMap(expectedIDs ...*hasAnID) *map[types.UID]struct{} {
 }
 
 func (suite *ResourceEventHandlerImplTestSuite) addObj(handler *resourceEventHandlerImpl, obj *hasAnID, expectedMap *map[types.UID]struct{}) {
-	suite.dispatcher.EXPECT().ProcessEvent(obj, nil, central.ResourceAction_SYNC_RESOURCE)
+	suite.dispatcher.EXPECT().ProcessEvent(obj, nil, central.ResourceAction_SYNC_RESOURCE).
+		Return(&component.ResourceEvent{})
 	suite.resolver.EXPECT().Send(gomock.Any())
 	handler.OnAdd(obj)
 	suite.Equal(*expectedMap, handler.seenIDs)
@@ -169,7 +171,8 @@ func (suite *ResourceEventHandlerImplTestSuite) TestCompleteSync() {
 	handler.PopulateInitialObjects([]interface{}{testMsgOne, testMsgTwo})
 	suite.Equal(*expectedMap, handler.missingInitialIDs)
 
-	suite.dispatcher.EXPECT().ProcessEvent(testMsgTwo, nil, central.ResourceAction_SYNC_RESOURCE)
+	suite.dispatcher.EXPECT().ProcessEvent(testMsgTwo, nil, central.ResourceAction_SYNC_RESOURCE).
+		Return(&component.ResourceEvent{})
 	suite.resolver.EXPECT().Send(gomock.Any())
 	handler.OnAdd(testMsgTwo)
 	suite.assertFinished(handler)

--- a/sensor/kubernetes/localscanner/certificate_requester_test.go
+++ b/sensor/kubernetes/localscanner/certificate_requester_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -117,7 +118,7 @@ func TestCertificateRequesterRequestConcurrentRequestDoNotInterfere(t *testing.T
 }
 
 type certificateRequesterFixture struct {
-	sendC                chan *central.MsgFromSensor
+	sendC                chan *message.ExpiringMessage
 	receiveC             chan *central.IssueLocalScannerCertsResponse
 	requester            CertificateRequester
 	interceptedRequestID *atomic.Value
@@ -128,7 +129,7 @@ type certificateRequesterFixture struct {
 // newFixture creates a new test fixture that uses `timeout` as context timeout if `timeout` is
 // not 0, and `testTimeout` otherwise.
 func newFixture(timeout time.Duration) *certificateRequesterFixture {
-	sendC := make(chan *central.MsgFromSensor)
+	sendC := make(chan *message.ExpiringMessage)
 	receiveC := make(chan *central.IssueLocalScannerCertsResponse)
 	requester := NewCertificateRequester(sendC, receiveC)
 	var interceptedRequestID atomic.Value

--- a/sensor/kubernetes/localscanner/tls_issuer.go
+++ b/sensor/kubernetes/localscanner/tls_issuer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -48,7 +49,7 @@ func NewLocalScannerTLSIssuer(
 	sensorNamespace string,
 	sensorPodName string,
 ) common.SensorComponent {
-	msgToCentralC := make(chan *central.MsgFromSensor)
+	msgToCentralC := make(chan *message.ExpiringMessage)
 	msgFromCentralC := make(chan *central.IssueLocalScannerCertsResponse)
 	return &localScannerTLSIssuerImpl{
 		sensorNamespace:              sensorNamespace,
@@ -67,7 +68,7 @@ type localScannerTLSIssuerImpl struct {
 	sensorNamespace              string
 	sensorPodName                string
 	k8sClient                    kubernetes.Interface
-	msgToCentralC                chan *central.MsgFromSensor
+	msgToCentralC                chan *message.ExpiringMessage
 	msgFromCentralC              chan *central.IssueLocalScannerCertsResponse
 	certRefreshBackoff           wait.Backoff
 	getCertificateRefresherFn    certificateRefresherGetter
@@ -145,7 +146,7 @@ func (i *localScannerTLSIssuerImpl) Capabilities() []centralsensor.SensorCapabil
 
 // ResponsesC is called "responses" because for other SensorComponent it is central that
 // initiates the interaction. However, here it is sensor which sends a request to central.
-func (i *localScannerTLSIssuerImpl) ResponsesC() <-chan *central.MsgFromSensor {
+func (i *localScannerTLSIssuerImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return i.msgToCentralC
 }
 

--- a/sensor/kubernetes/localscanner/tls_issuer_test.go
+++ b/sensor/kubernetes/localscanner/tls_issuer_test.go
@@ -13,6 +13,7 @@ import (
 	testutilsMTLS "github.com/stackrox/rox/pkg/mtls/testutils"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -53,7 +54,7 @@ func newLocalScannerTLSIssuerFixture(k8sClientConfig fakeK8sClientConfig) *local
 		componentGetter: &componentGetterMock{},
 		k8sClient:       getFakeK8sClient(k8sClientConfig),
 	}
-	msgToCentralC := make(chan *central.MsgFromSensor)
+	msgToCentralC := make(chan *message.ExpiringMessage)
 	msgFromCentralC := make(chan *central.IssueLocalScannerCertsResponse)
 	fixture.tlsIssuer = &localScannerTLSIssuerImpl{
 		sensorNamespace:              sensorNamespace,
@@ -360,7 +361,7 @@ func (s *localScannerTLSIssueIntegrationTests) getCertificate(serviceType storag
 }
 
 func (s *localScannerTLSIssueIntegrationTests) waitForRequest(ctx context.Context, tlsIssuer common.SensorComponent) *central.IssueLocalScannerCertsRequest {
-	var request *central.MsgFromSensor
+	var request *message.ExpiringMessage
 	select {
 	case request = <-tlsIssuer.ResponsesC():
 	case <-ctx.Done():

--- a/sensor/kubernetes/networkpolicies/command_handler.go
+++ b/sensor/kubernetes/networkpolicies/command_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
 	"k8s.io/client-go/kubernetes"
 	networkingV1Client "k8s.io/client-go/kubernetes/typed/networking/v1"
 )
@@ -23,7 +24,7 @@ type commandHandler struct {
 	networkingV1Client networkingV1Client.NetworkingV1Interface
 
 	commandsC  chan *central.NetworkPoliciesCommand
-	responsesC chan *central.MsgFromSensor
+	responsesC chan *message.ExpiringMessage
 
 	stopSig concurrency.Signal
 }
@@ -37,7 +38,7 @@ func newCommandHandler(networkingV1Client networkingV1Client.NetworkingV1Interfa
 	return &commandHandler{
 		networkingV1Client: networkingV1Client,
 		commandsC:          make(chan *central.NetworkPoliciesCommand),
-		responsesC:         make(chan *central.MsgFromSensor),
+		responsesC:         make(chan *message.ExpiringMessage),
 		stopSig:            concurrency.NewSignal(),
 	}
 }
@@ -57,7 +58,7 @@ func (h *commandHandler) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
-func (h *commandHandler) ResponsesC() <-chan *central.MsgFromSensor {
+func (h *commandHandler) ResponsesC() <-chan *message.ExpiringMessage {
 	return h.responsesC
 }
 
@@ -95,9 +96,9 @@ func (h *commandHandler) ProcessMessage(msg *central.MsgToSensor) error {
 
 func (h *commandHandler) sendResponse(resp *central.NetworkPoliciesResponse) bool {
 	select {
-	case h.responsesC <- &central.MsgFromSensor{
+	case h.responsesC <- message.New(&central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_NetworkPoliciesResponse{NetworkPoliciesResponse: resp},
-	}:
+	}):
 		return true
 	case <-h.stopSig.Done():
 		return false

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/externalsrcs"
 	"github.com/stackrox/rox/sensor/common/image"
+	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/networkflow/manager"
 	"github.com/stackrox/rox/sensor/common/networkflow/service"
 	"github.com/stackrox/rox/sensor/common/processfilter"
@@ -126,7 +127,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	complianceCommandHandler := compliance.NewCommandHandler(complianceService)
 
 	// Create Process Pipeline
-	indicators := make(chan *central.MsgFromSensor)
+	indicators := make(chan *message.ExpiringMessage)
 	processPipeline := processsignal.NewProcessPipeline(indicators, storeProvider.Entities(), processfilter.Singleton(), policyDetector)
 	processSignals := signalService.New(processPipeline, indicators)
 	networkFlowManager :=

--- a/sensor/kubernetes/upgrade/command_handler_impl.go
+++ b/sensor/kubernetes/upgrade/command_handler_impl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/clusterid"
 	"github.com/stackrox/rox/sensor/common/config"
+	"github.com/stackrox/rox/sensor/common/message"
 	"google.golang.org/grpc"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -78,7 +79,7 @@ func (h *commandHandler) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
-func (h *commandHandler) ResponsesC() <-chan *central.MsgFromSensor {
+func (h *commandHandler) ResponsesC() <-chan *message.ExpiringMessage {
 	return nil
 }
 


### PR DESCRIPTION
## Description

This is a large refactor in Sensor that introduces the possibility of identifying if messages should be dropped at any point in the pipeline. 

It changes the type of `RepsonsesC` from `MsgFromSensor` to a wrapping struct called `ExpiringMessage`, which is the same as `MsgFromSensor` but it also contains a `Context`, which can be cancelled in case this message is no longer valid. 

This will help to make sure that the Kubernetes reconciliation still works when restarting sensor and some message is stuck waiting in a channel in Sensor. Any messages that have a cancelled context shall not be sent in the gRPC connection. 

This PR still doesn't make use of this mechanism, it's a prefactor to introduce it so it can be leveraged when implementing [ROX-17157](https://issues.redhat.com/browse/ROX-17157) (which was already attempted here #6889, hence the prefactor) 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~


## Testing Performed

- [ ] CI run
- [x] output_tests for sensor output component