### PR TITLE
fix(ci): Allow time for log gathering in splunk test

### DIFF
--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -10,6 +10,7 @@ import io.restassured.response.Response
 
 import io.stackrox.proto.api.v1.AlertServiceOuterClass
 
+import common.Constants
 import objects.Deployment
 import services.AlertService
 import services.ApiTokenService
@@ -30,7 +31,7 @@ import spock.lang.Tag
 class IntegrationsSplunkViolationsTest extends BaseSpecification {
     @Rule
     @SuppressWarnings(["JUnitPublicProperty"])
-    Timeout globalTimeout = new Timeout(1000, TimeUnit.SECONDS)
+    Timeout globalTimeout = new Timeout(1000 + Constants.TEST_FEATURE_TIMEOUT_PAD, TimeUnit.SECONDS)
 
     private static final String ASSETS_DIR = Paths.get(
             System.getProperty("user.dir"), "artifacts", "splunk-violations-test")


### PR DESCRIPTION
## Description

On failure, the IntegrationsSplunkViolationsTest can reach JUnits globalTimeout which results in a failure report that hides the original root cause. This change extends the timeout to include time for debug & log gathering.

e.g. in this failure: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-qa-e2e-tests/1680930296364535808
The test errors after 14 minutes due to:
```
    14:58:19 | INFO  | IntegrationsSplunkViolationsTest | Attempt 14 to get violations from Splunk
    14:58:19 | DEBUG | SplunkUtil                | {"sid":"1689605899.22"}
    14:58:19 | DEBUG | SplunkUtil                | New Search created: 1689605899.22
    14:58:36 | ERROR | Helpers                   | An exception occurred in test
    org.spockframework.runtime.ConditionNotSatisfiedError: Condition not satisfied:

    hasProcessViolation
    |
    false
```

The timeout kicks during debug gathering:
```
IntegrationsSplunkViolationsTest > Verify Splunk violations: StackRox violations reach Splunk TA FAILED
    org.junit.runners.model.TestTimedOutException: test timed out after 1000 seconds
        at java.base@17.0.6-ea/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:252)
```

Note the timeout does not cause the debug thread to quit and it blindly continues while the tests move on.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient