### PR TITLE
fix(ui): Fix inconsistent case on Vulnerability Management dashboard

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
@@ -22,7 +22,7 @@ function verifyVulnerabilityManagementDashboardApplicationAndInfrastructure(
 }
 
 function getViewAllSelectorForWidget(widgetHeading) {
-    return `${selectors.getWidget(widgetHeading)} a:contains("View All")`;
+    return `${selectors.getWidget(widgetHeading)} a:contains("View all")`;
 }
 
 function selectTopRiskyOption(optionText) {
@@ -73,7 +73,7 @@ describe('Vulnerability Management Dashboard', () => {
         cy.get('[data-testid="panel"]').contains('[data-testid="panel-header"]', /^\d+ images?/);
     });
 
-    it('should properly navigate to the clusters list', () => {
+    it('should navigate to the clusters list', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'clusters';
@@ -85,7 +85,7 @@ describe('Vulnerability Management Dashboard', () => {
         );
     });
 
-    it('should properly navigate to the namespaces list', () => {
+    it('should navigate to the namespaces list', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'namespaces';
@@ -97,7 +97,7 @@ describe('Vulnerability Management Dashboard', () => {
         );
     });
 
-    it('should properly navigate to the deployments list', () => {
+    it('should navigate to the deployments list', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'deployments';
@@ -133,11 +133,11 @@ describe('Vulnerability Management Dashboard', () => {
         );
     });
 
-    it('clicking the "Top Riskiest Images" widget\'s "View All" button should take you to the images list', () => {
+    it('should go to images list from View all link of Top riskiest images', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'images';
-        const widgetHeading = 'Top Riskiest Images';
+        const widgetHeading = 'Top riskiest images';
 
         interactAndWaitForVulnerabilityManagementEntities(() => {
             cy.get(getViewAllSelectorForWidget(widgetHeading)).click();
@@ -149,11 +149,11 @@ describe('Vulnerability Management Dashboard', () => {
         );
     });
 
-    it('clicking the "Recently Detected Image Vulnerabilities" widget\'s "View All" button should take you to the CVEs list', () => {
+    it('should go to image-cves list from View all link of Recently detected image vulnerabilities', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'image-cves';
-        const widgetHeading = 'Recently Detected Image Vulnerabilities';
+        const widgetHeading = 'Recently detected image vulnerabilities';
 
         interactAndWaitForVulnerabilityManagementEntities(() => {
             cy.get(getViewAllSelectorForWidget(widgetHeading)).click();
@@ -162,11 +162,11 @@ describe('Vulnerability Management Dashboard', () => {
         cy.location('search').should('eq', '?sort[0][id]=CVE%20Created%20Time&sort[0][desc]=true');
     });
 
-    it('clicking the "Most Common Image Vulnerabilities" widget\'s "View All" button should take you to the CVEs list', () => {
+    it('should to to image-cves list from View all link of Most common image vulnerabilities', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'image-cves';
-        const widgetHeading = 'Most Common Image Vulnerabilities';
+        const widgetHeading = 'Most common image vulnerabilities';
 
         interactAndWaitForVulnerabilityManagementEntities(() => {
             cy.get(getViewAllSelectorForWidget(widgetHeading)).click();
@@ -178,11 +178,11 @@ describe('Vulnerability Management Dashboard', () => {
         );
     });
 
-    it('clicking the "Clusters With Most Orchestrator & Istio Vulnerabilities" widget\'s "View All" button should take you to the clusters list', () => {
+    it('should go to clusters list from View all link of Clusters with most orchestrator and Istio vulnerabilities', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'clusters';
-        const widgetHeading = 'Clusters With Most Orchestrator & Istio Vulnerabilities';
+        const widgetHeading = 'Clusters with most orchestrator and Istio vulnerabilities';
 
         interactAndWaitForVulnerabilityManagementEntities(() => {
             cy.get(getViewAllSelectorForWidget(widgetHeading)).click();
@@ -191,22 +191,22 @@ describe('Vulnerability Management Dashboard', () => {
         cy.location('search').should('eq', '');
     });
 
-    it('clicking the "Top risky deployments by CVE count & CVSS score" widget\'s "View All" button should take you to the deployments list', () => {
+    it('should to to deployments list from View all link of Top risky deployments by CVE count and CVSS score', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'deployments';
-        const widgetHeading = 'Top risky deployments by CVE count & CVSS score';
+        const widgetHeading = 'Top risky deployments by CVE count and CVSS score';
 
         interactAndWaitForVulnerabilityManagementEntities(() => {
             cy.get(getViewAllSelectorForWidget(widgetHeading)).click();
         }, entitiesKey);
     });
 
-    it('clicking the "Top risky namespaces by CVE count & CVSS score" widget\'s "View All" button should take you to the namespaces list', () => {
+    it('should go to namespaces list from View all link of Top risky namespaces by CVE count and CVSS score', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'namespaces';
-        const widgetHeading = 'Top risky namespaces by CVE count & CVSS score';
+        const widgetHeading = 'Top risky namespaces by CVE count and CVSS score';
 
         selectTopRiskyOption(widgetHeading);
         interactAndWaitForVulnerabilityManagementEntities(() => {
@@ -214,11 +214,11 @@ describe('Vulnerability Management Dashboard', () => {
         }, entitiesKey);
     });
 
-    it('clicking the "Top risky images by CVE count & CVSS score" widget\'s "View All" button should take you to the images list', () => {
+    it('should go to images list from View all link of Top risky images by CVE count and CVSS score', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'images';
-        const widgetHeading = 'Top risky images by CVE count & CVSS score';
+        const widgetHeading = 'Top risky images by CVE count and CVSS score';
 
         selectTopRiskyOption(widgetHeading);
         interactAndWaitForVulnerabilityManagementEntities(() => {
@@ -226,11 +226,11 @@ describe('Vulnerability Management Dashboard', () => {
         }, entitiesKey);
     });
 
-    it('clicking the "Top risky images by CVE count & CVSS score" widget\'s "View All" button should take you to the nodes list', () => {
+    it('should go to nodes list from View all link of Top risky images by CVE count and CVSS score', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'nodes';
-        const widgetHeading = 'Top risky nodes by CVE count & CVSS score';
+        const widgetHeading = 'Top risky nodes by CVE count and CVSS score';
 
         selectTopRiskyOption(widgetHeading);
         interactAndWaitForVulnerabilityManagementEntities(() => {

--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboardToEntityPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboardToEntityPage.test.js
@@ -43,7 +43,7 @@ function getHeaderTextFromItemTextWithoutSeparators(itemText) {
 }
 
 function selectTopRiskiestOption(optionText) {
-    const widgetSelector = selectors.getWidget('Top Riskiest');
+    const widgetSelector = selectors.getWidget('Top riskiest');
     cy.get(`${widgetSelector} .react-select__control`).click();
     cy.get(`${widgetSelector} .react-select__option:contains("${optionText}")`).click();
 }
@@ -53,11 +53,11 @@ describe('Vulnerability Management Dashboard', () => {
 
     // Some tests might fail in local deployment.
 
-    it('has link from Top Riskiest Images widget to image page', () => {
+    it('has item link to image page from Top riskiest images', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'images';
-        const widgetHeading = 'Top Riskiest Images';
+        const widgetHeading = 'Top riskiest images';
 
         verifyItemLinkToEntityPage(
             entitiesKey,
@@ -66,11 +66,11 @@ describe('Vulnerability Management Dashboard', () => {
         );
     });
 
-    it('has link from Top Riskiest Node Components widget to node component page', () => {
+    it('has item link to node component page from Top riskiest node components', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'node-components';
-        const widgetHeading = 'Top Riskiest Node Components';
+        const widgetHeading = 'Top riskiest node components';
 
         selectTopRiskiestOption(widgetHeading);
         verifyItemLinkToEntityPage(
@@ -80,11 +80,11 @@ describe('Vulnerability Management Dashboard', () => {
         );
     });
 
-    it('has link from Top Riskiest Image Components widget to image component page', () => {
+    it('has item link to image component page from Top riskiest image components', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'image-components';
-        const widgetHeading = 'Top Riskiest Image Components';
+        const widgetHeading = 'Top riskiest image components';
 
         selectTopRiskiestOption(widgetHeading);
         verifyItemLinkToEntityPage(
@@ -94,11 +94,11 @@ describe('Vulnerability Management Dashboard', () => {
         );
     });
 
-    it('has link from Top Riskiest Nodes widget to node page', () => {
+    it('has item link to node page from Top riskiest nodes', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'nodes';
-        const widgetHeading = 'Top Riskiest Nodes';
+        const widgetHeading = 'Top riskiest nodes';
 
         selectTopRiskiestOption(widgetHeading);
         verifyItemLinkToEntityPage(
@@ -108,11 +108,12 @@ describe('Vulnerability Management Dashboard', () => {
         );
     });
 
-    it.skip('has link from Recently Detected Image Vulnerabilities widget to vulnerability page', () => {
+    // TODO test fails because of product problem that page does not render the CVE id.
+    it.skip('has item link to image CVE page from Recently detected image vulnerabilities', () => {
         visitVulnerabilityManagementDashboard();
 
-        const entitiesKey = 'cves'; // TODO enable test when we decide whether request will be getCve or getImageCve
-        const widgetHeading = 'Recently Detected Image Vulnerabilities';
+        const entitiesKey = 'image-cves';
+        const widgetHeading = 'Recently detected image vulnerabilities';
 
         verifyItemLinkToEntityPage(
             entitiesKey,
@@ -121,12 +122,12 @@ describe('Vulnerability Management Dashboard', () => {
         );
     });
 
-    // Vulnerability graphQL resolver is not support on postgres. Use Image/Node/ClusterVulnerability resolver.
-    it.skip('has link from Most Common Image Vulnerabilities widget to vulnerability page', () => {
+    // TODO test fails because of product problem that page does not render the CVE id.
+    it.skip('has item link to image CVE page from Most common image vulnerabilities widget', () => {
         visitVulnerabilityManagementDashboard();
 
-        const entitiesKey = 'image-cves'; // TODO enable test when we decide whether request will be getCve or getImageCve
-        const widgetHeading = 'Most Common Image Vulnerabilities';
+        const entitiesKey = 'image-cves';
+        const widgetHeading = 'Most common image vulnerabilities';
 
         verifyItemLinkToEntityPage(
             entitiesKey,
@@ -135,11 +136,11 @@ describe('Vulnerability Management Dashboard', () => {
         );
     });
 
-    it('has link from Clusters With Most Orchestrator & Istio Vulnerabilities to cluster page', () => {
+    it('has item link to cluster single page from Clusters with most orchestrator and Istio vulnerabilities', () => {
         visitVulnerabilityManagementDashboard();
 
         const entitiesKey = 'clusters';
-        const widgetHeading = 'Clusters With Most Orchestrator & Istio Vulnerabilities';
+        const widgetHeading = 'Clusters with most orchestrator and Istio vulnerabilities';
 
         verifyItemLinkToEntityPage(
             entitiesKey,

--- a/ui/apps/platform/src/Components/ViewAllButton/index.ts
+++ b/ui/apps/platform/src/Components/ViewAllButton/index.ts
@@ -1,1 +1,0 @@
-export { default } from './ViewAllButton';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.js
@@ -102,7 +102,7 @@ function VulnMgmtComponentOverview({ data, entityContext }) {
                                 className="h-full min-w-48 bg-base-100 pdf-page"
                                 keyValuePairs={metadataKeyValuePairs}
                                 statTiles={componentStats}
-                                title="Details & Metadata"
+                                title="Details and metadata"
                             />
                         </div>
                         <div className="s-1">

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtDeploymentOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtDeploymentOverview.js
@@ -89,7 +89,7 @@ const VulnMgmtDeploymentOverview = ({ data, entityContext }) => {
                                 className="h-full min-w-48 bg-base-100 pdf-page"
                                 keyValuePairs={metadataKeyValuePairs}
                                 statTiles={deploymentStats}
-                                title="Details & Metadata"
+                                title="Details and metadata"
                                 labels={labels}
                                 annotations={annotations}
                             />

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
@@ -171,7 +171,7 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
                                 className="h-full sm:min-h-64 min-w-48 bg-base-100 pdf-page"
                                 keyValuePairs={metadataKeyValuePairs}
                                 statTiles={imageStats}
-                                title="Details & Metadata"
+                                title="Details and metadata"
                             />
                         </div>
                         <div className="s-1">

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.js
@@ -71,7 +71,7 @@ const VulnMgmtNamespaceOverview = ({ data, entityContext }) => {
                                 keyValuePairs={metadataKeyValuePairs}
                                 statTiles={namespaceStats}
                                 labels={labels}
-                                title="Details & Metadata"
+                                title="Details and metadata"
                             />
                         </div>
                         <div className="sx-1 lg:sx-2 sy-1 min-h-55 h-full">

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Node/VulnMgmtNodeOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Node/VulnMgmtNodeOverview.js
@@ -123,7 +123,7 @@ const VulnMgmtNodeOverview = ({ data, entityContext }) => {
                                 className="h-full min-w-48 bg-base-100 pdf-page"
                                 keyValuePairs={metadataKeyValuePairs}
                                 statTiles={nodeStats}
-                                title="Details & Metadata"
+                                title="Details and metadata"
                                 labels={labels}
                                 annotations={annotations}
                             />

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/ClustersWithMostClusterVulnerabilities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/ClustersWithMostClusterVulnerabilities.js
@@ -9,7 +9,6 @@ import { checkForPermissionErrorMessage } from 'utils/permissionUtils';
 import queryService from 'utils/queryService';
 import entityTypes from 'constants/entityTypes';
 import workflowStateContext from 'Containers/workflowStateContext';
-import ViewAllButton from 'Components/ViewAllButton';
 import Loader from 'Components/Loader';
 import Widget from 'Components/Widget';
 import NoResultsMessage from 'Components/NoResultsMessage';
@@ -18,6 +17,8 @@ import FixableCVECount from 'Components/FixableCVECount';
 import kubeSVG from 'images/kube.svg';
 import istioSVG from 'images/istio.svg';
 import openShiftSVG from 'images/openShift.svg';
+
+import ViewAllButton from './ViewAllButton';
 
 const CLUSTER_WITH_MOST_CLUSTER_VULNERABILTIES = gql`
     query clustersWithMostClusterVulnerabilities {
@@ -116,7 +117,7 @@ const processData = (data, workflowState, limit) => {
 
             const orchestratorContent = isOpenShiftCluster ? (
                 <div className="flex items-center justify-left mr-8">
-                    <Tooltip content="OpenShift Vulnerabilities">
+                    <Tooltip content="OpenShift vulnerabilities">
                         <div className="flex">
                             <img src={openShiftSVG} alt="openshift" className="pr-2" />
                             <FixableCVECount
@@ -132,7 +133,7 @@ const processData = (data, workflowState, limit) => {
                 </div>
             ) : (
                 <div className="flex flex-1 items-center justify-left mr-8">
-                    <Tooltip content="Kubernetes Vulnerabilities">
+                    <Tooltip content="Kubernetes vulnerabilities">
                         <div className="flex">
                             <img src={kubeSVG} alt="kube" className="pr-2" />
                             <FixableCVECount
@@ -152,7 +153,7 @@ const processData = (data, workflowState, limit) => {
             const orchestratorIstioContent = (
                 <div className="flex">
                     {orchestratorContent}
-                    <Tooltip content="Istio Vulnerabilities">
+                    <Tooltip content="Istio vulnerabilities">
                         <div className="flex items-center justify-left pr-2">
                             <img src={istioSVG} alt="istio" className="pr-2" />
                             <FixableCVECount
@@ -227,7 +228,7 @@ const ClustersWithMostClusterVulnerabilities = ({ entityContext, limit }) => {
     return (
         <Widget
             className="h-full pdf-page"
-            header="Clusters With Most Orchestrator & Istio Vulnerabilities"
+            header="Clusters with most orchestrator and Istio vulnerabilities"
             headerComponents={<ViewAllButton url={viewAllURL} />}
         >
             {content}

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/CvesByCvssScore.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/CvesByCvssScore.js
@@ -6,13 +6,14 @@ import queryService from 'utils/queryService';
 
 import Loader from 'Components/Loader';
 import Widget from 'Components/Widget';
-import ViewAllButton from 'Components/ViewAllButton';
 import Sunburst from 'Components/visuals/Sunburst';
 import NoComponentVulnMessage from 'Components/NoComponentVulnMessage';
 import workflowStateContext from 'Containers/workflowStateContext';
 import { vulnSeverityIconColors } from 'constants/visuals/colors';
 import { vulnerabilitySeverityLabels } from 'messages/common';
 import { getScopeQuery } from 'Containers/VulnMgmt/Entity/VulnMgmtPolicyQueryUtil';
+
+import ViewAllButton from './ViewAllButton';
 
 const IMAGE_CVES_QUERY = gql`
     query getImageCvesByCVSS($query: String, $scopeQuery: String) {
@@ -149,7 +150,7 @@ const CvesByCvssScore = ({ entityContext, parentContext }) => {
     }
 
     return (
-        <Widget className="h-full pdf-page" header="CVEs by CVSS Score" headerComponents={header}>
+        <Widget className="h-full pdf-page" header="CVEs by CVSS score" headerComponents={header}>
             {content}
         </Widget>
     );

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabilities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabilities.js
@@ -4,7 +4,6 @@ import { gql, useQuery } from '@apollo/client';
 import sortBy from 'lodash/sortBy';
 
 import workflowStateContext from 'Containers/workflowStateContext';
-import ViewAllButton from 'Components/ViewAllButton';
 import Loader from 'Components/Loader';
 import Widget from 'Components/Widget';
 import LabeledBarGraph from 'Components/visuals/LabeledBarGraph';
@@ -15,6 +14,8 @@ import entityTypes from 'constants/entityTypes';
 import { cveSortFields } from 'constants/sortFields';
 import { WIDGET_PAGINATION_START_OFFSET } from 'constants/workflowPages.constants';
 import { getTooltip } from 'utils/vulnerabilityUtils';
+
+import ViewAllButton from './ViewAllButton';
 
 const MOST_COMMON_IMAGE_VULNERABILITIES = gql`
     query mostCommonImageVulnerabilities($query: String, $vulnPagination: Pagination) {
@@ -113,7 +114,7 @@ const MostCommonVulnerabilities = ({ entityContext, search, limit }) => {
     return (
         <Widget
             className="h-full pdf-page"
-            header="Most Common Image Vulnerabilities"
+            header="Most common image vulnerabilities"
             headerComponents={<ViewAllButton url={viewAllURL} />}
         >
             {content}

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabiltiesInDeployment.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabiltiesInDeployment.js
@@ -9,11 +9,12 @@ import workflowStateContext from 'Containers/workflowStateContext';
 import { getVulnerabilityChips } from 'utils/vulnerabilityUtils';
 import { cveSortFields } from 'constants/sortFields';
 import { WIDGET_PAGINATION_START_OFFSET } from 'constants/workflowPages.constants';
-import ViewAllButton from 'Components/ViewAllButton';
 import Loader from 'Components/Loader';
 import NumberedList from 'Components/NumberedList';
 import Widget from 'Components/Widget';
 import NoResultsMessage from 'Components/NoResultsMessage';
+
+import ViewAllButton from './ViewAllButton';
 
 const MOST_COMMON_IMAGE_VULNERABILITIES = gql`
     query mostCommonImageVulnerabilities($query: String, $vulnPagination: Pagination) {
@@ -88,7 +89,7 @@ const MostCommonVulnerabiltiesInDeployment = ({ deploymentId, limit }) => {
     return (
         <Widget
             className="h-full pdf-page"
-            header="Most Common Image Vulnerabilities"
+            header="Most common image vulnerabilities"
             headerComponents={<ViewAllButton url={viewAllURL} />}
         >
             {content}

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/RecentlyDetectedImageVulnerabilities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/RecentlyDetectedImageVulnerabilities.js
@@ -6,7 +6,6 @@ import sortBy from 'lodash/sortBy';
 import entityTypes from 'constants/entityTypes';
 import queryService from 'utils/queryService';
 import workflowStateContext from 'Containers/workflowStateContext';
-import ViewAllButton from 'Components/ViewAllButton';
 import Loader from 'Components/Loader';
 import Widget from 'Components/Widget';
 import NumberedList from 'Components/NumberedList';
@@ -14,6 +13,8 @@ import { checkForPermissionErrorMessage } from 'utils/permissionUtils';
 import { getVulnerabilityChips } from 'utils/vulnerabilityUtils';
 import NoResultsMessage from 'Components/NoResultsMessage';
 import { cveSortFields } from 'constants/sortFields';
+
+import ViewAllButton from './ViewAllButton';
 
 const RECENTLY_DETECTED_IMAGE_VULNERABILITIES = gql`
     query recentlyDetectedImageVulnerabilities(
@@ -113,7 +114,7 @@ const RecentlyDetectedImageVulnerabilities = ({ entityContext, search, limit }) 
     return (
         <Widget
             className="h-full pdf-page"
-            header="Recently Detected Image Vulnerabilities"
+            header="Recently detected image vulnerabilities"
             headerComponents={<ViewAllButton url={viewAllURL} />}
         >
             {content}

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
@@ -4,7 +4,6 @@ import { gql, useQuery } from '@apollo/client';
 import { format } from 'date-fns';
 
 import workflowStateContext from 'Containers/workflowStateContext';
-import ViewAllButton from 'Components/ViewAllButton';
 import Loader from 'Components/Loader';
 import NoResultsMessage from 'Components/NoResultsMessage';
 import TextSelect from 'Components/TextSelect';
@@ -23,6 +22,8 @@ import {
     entityNounOrdinaryCasePlural,
     entityNounSentenceCaseSingular,
 } from '../entitiesForVulnerabilityManagement';
+
+import ViewAllButton from './ViewAllButton';
 
 const TOP_RISKIEST_IMAGE_VULNS = gql`
     query topRiskiestImageVulns($query: String, $pagination: Pagination) {
@@ -198,13 +199,13 @@ const getEntitiesByContext = (entityContext) => {
     const entities = [];
     if (!entityContext[entityTypes.NODE_COMPONENT] && !entityContext[entityTypes.IMAGE]) {
         entities.push({
-            label: 'Top Riskiest Node Components',
+            label: 'Top riskiest node components',
             value: entityTypes.NODE_COMPONENT,
         });
     }
     if (!entityContext[entityTypes.IMAGE_COMPONENT] && !entityContext[entityTypes.NODE]) {
         entities.push({
-            label: 'Top Riskiest Image Components',
+            label: 'Top riskiest image components',
             value: entityTypes.IMAGE_COMPONENT,
         });
     }
@@ -214,13 +215,13 @@ const getEntitiesByContext = (entityContext) => {
     ) {
         // unshift so it sits at the front of the list (in case both entity types are added, image should come first)
         entities.unshift({
-            label: 'Top Riskiest Images',
+            label: 'Top riskiest images',
             value: entityTypes.IMAGE,
         });
     }
     if (!entityContext[entityTypes.NODE] && !entityContext[entityTypes.IMAGE]) {
         entities.push({
-            label: 'Top Riskiest Nodes',
+            label: 'Top riskiest nodes',
             value: entityTypes.NODE,
         });
     }

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.js
@@ -7,7 +7,6 @@ import queryService from 'utils/queryService';
 import workflowStateContext from 'Containers/workflowStateContext';
 import Loader from 'Components/Loader';
 import NoResultsMessage from 'Components/NoResultsMessage';
-import ViewAllButton from 'Components/ViewAllButton';
 import Widget from 'Components/Widget';
 import Scatterplot from 'Components/visuals/Scatterplot';
 import HoverHintListItem from 'Components/visuals/HoverHintListItem';
@@ -22,6 +21,8 @@ import { entitySortFieldsMap, cveSortFields } from 'constants/sortFields';
 import { WIDGET_PAGINATION_START_OFFSET } from 'constants/workflowPages.constants';
 import { entityPriorityField } from '../VulnMgmt.constants';
 import { entityNounOrdinaryCasePlural } from '../entitiesForVulnerabilityManagement';
+
+import ViewAllButton from './ViewAllButton';
 
 // Beware, policy instead of vulnerability severities because of getSeverityByCvss function!
 
@@ -179,7 +180,7 @@ const TopRiskyEntitiesByVulnerabilities = ({
     // Entity Type selection
     const [selectedEntityType, setEntityType] = useState(defaultSelection);
     const entityOptions = riskEntityTypes.map((entityType) => ({
-        label: `Top risky ${entityNounOrdinaryCasePlural[entityType]} by CVE count & CVSS score`,
+        label: `Top risky ${entityNounOrdinaryCasePlural[entityType]} by CVE count and CVSS score`,
         value: entityType,
     }));
     function onChange(datum) {

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/ViewAllButton.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/ViewAllButton.tsx
@@ -1,11 +1,11 @@
 import React, { ReactElement } from 'react';
-import { HashLink } from 'react-router-hash-link';
+import { Link } from 'react-router-dom';
 
 const ViewAllButton = ({ url }: { url: string }): ReactElement => {
     return (
-        <HashLink to={url} className="btn-sm btn-base whitespace-nowrap no-underline">
+        <Link to={url} className="btn-sm btn-base whitespace-nowrap no-underline">
             View all
-        </HashLink>
+        </Link>
     );
 };
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/ViewAllButton.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/ViewAllButton.tsx
@@ -4,7 +4,7 @@ import { HashLink } from 'react-router-hash-link';
 const ViewAllButton = ({ url }: { url: string }): ReactElement => {
     return (
         <HashLink to={url} className="btn-sm btn-base whitespace-nowrap no-underline">
-            View All
+            View all
         </HashLink>
     );
 };


### PR DESCRIPTION
## Description

Although several classic pages still have title case, this high profile page has inconsistent case.

### Solution

1. During update to **View all** text, I noticed that it rendered `HashLink` element to support former links from System Health to anchors in Integrations, but after updates of other containers to PatternFly elements, the only uses of `ViewAllButton` are in Vulnerability Management widgets, therefore:
    * Render `Link` element.
    * Move to same folder as components that import it, so obvious to delete it whenever we delete them.

### Residue

1. Vulnerability single page does not render CVE id.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### Manual testing

1. Visit /main/vulnerability-management
    * See **View all** buttons
    * See **Top riskiest images** and so on
    * See **Recently detected image vulnerabilitites**
    * See **Most common image vulnerabilities**
    * See **Clusters with most orchestrator and Istio vulnerabilities**
        ![dashboard](https://github.com/stackrox/stackrox/assets/11862657/c90ec7fe-056d-4907-bd20-cd9ff9203c33)

### Integration testing

* vulnmanagement/dashboard.test.js
* vulnmanagement/dashboardToEntityPage.test.js
