### PR TITLE
fix(ui): Fix accessibility problem with side panel BackButton

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.selectors.js
@@ -23,7 +23,7 @@ export const dashboardSelectors = {
 
 const sidePanelSelectors = {
     sidePanel: '[data-testid="side-panel"]',
-    backButton: '[data-testid="sidepanelBackButton"]',
+    backButton: '[aria-label="Go to preceding breadcrumb"]',
     entityIcon: '[data-testid="entity-icon"]',
     sidePanelExternalLinkButton: '[aria-label="External link"]',
     scanDataMessage: '[data-testid="message"].error-message:contains("CVE Data May Be Inaccurate")',

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BackButton.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BackButton.js
@@ -14,7 +14,7 @@ const BackButton = ({ match, location, entityType1, entityListType2, entityId2 }
             <Link
                 className="flex items-center justify-center text-base-600 border-r border-base-300 px-4 mr-4 h-full hover:bg-primary-200 w-16"
                 to={link}
-                data-testid="sidepanelBackButton"
+                aria-label="Go to preceding breadcrumb"
             >
                 <ArrowLeft className="h-6 w-6 text-600" />
             </Link>

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
@@ -6,10 +6,11 @@ import upperFirst from 'lodash/upperFirst';
 import { ChevronRight } from 'react-feather';
 import { Link, withRouter } from 'react-router-dom';
 
-import BackButton from 'Containers/ConfigManagement/SidePanel/buttons/BackButton';
 import useEntityName from 'hooks/useEntityName';
 import entityLabels from 'messages/entity';
 import URLService from 'utils/URLService';
+
+import BackButton from './BackButton';
 
 const Icon = (
     <ChevronRight className="bg-base-200 border border-base-400 mx-4 rounded-full" size="14" />

--- a/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumbs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumbs.tsx
@@ -25,7 +25,7 @@ const BackLink = ({ workflowState, enabled }) => {
         <Link
             className="flex items-center justify-center text-base-600 border-r border-base-300 px-4 mr-4 h-full hover:bg-primary-200 w-16"
             to={url}
-            data-testid="sidepanelBackButton"
+            aria-label="Go to preceding breadcrumb"
         >
             <ArrowLeft className="h-6 w-6 text-600" />
         </Link>


### PR DESCRIPTION
## Description

### Problem

> Links must have discernable text

### Solution

1. Replace `data-testid` prop with `aria-label` prop:
    * Solve accessibility problem for image link.
    * Prefer visible text or accessibility attributes instead of `data-testid` attributes in test selectors.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### Manual testing

1. Visit /main/configmanagement/deployments, click a row, and then click a related entities link.
    ![configmanagement_aria-label](https://github.com/stackrox/stackrox/assets/11862657/7db3789c-ebc7-453f-a56d-0de67b6ea292)

2. Visit /main/vulnerability-management/deployments, click a row, and then click a related entities link.
    ![vulnerability-management_aria-label](https://github.com/stackrox/stackrox/assets/11862657/6fe28bc4-73b2-4dba-b9f7-ec61ddc2e73b)

### Integration testing

* vulnmanagement/clusterCVEs.test.js
* vulnmanagement/clusters.test.js
* vulnmanagement/deployments.test.js
* vulnmanagement/imageComponents.test.js
* vulnmanagement/imageCves.test.js
* vulnmanagement/images.test.js
* vulnmanagement/namespaces.test.js
* vulnmanagement/nodeComponents.test.js
* vulnmanagement/nodeCves.test.js
* vulnmanagement/nodes.test.js
