### PR TITLE
ROX-14975: Fix baseline setup

### DIFF
--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -313,6 +313,27 @@ func (m *manager) ProcessDeploymentCreate(deploymentID, _, clusterID, _ string) 
 	return m.processDeploymentCreate(deploymentID, clusterID)
 }
 
+func (m *manager) deleteDeploymentFromBaselines(deploymentID string) error {
+	modifiedDeployments := set.NewStringSet()
+	for id, baseline := range m.baselinesByDeploymentID {
+		if ok, peer := baseline.GetPeer(deploymentID); ok {
+			delete(baseline.BaselinePeers, peer)
+			modifiedDeployments.Add(id)
+		}
+
+		if ok, forbiddenPeer := baseline.GetForbiddenPeer(deploymentID); ok {
+			delete(baseline.ForbiddenPeers, forbiddenPeer)
+			modifiedDeployments.Add(id)
+		}
+	}
+
+	if err := m.persistNetworkBaselines(modifiedDeployments, nil); err != nil {
+		return errors.Wrapf(err, "deleting baseline of deployment ID %s", deploymentID)
+	}
+
+	return nil
+}
+
 func (m *manager) processDeploymentDelete(deploymentID string) error {
 	deletingBaseline, found := m.baselinesByDeploymentID[deploymentID]
 	if !found {
@@ -320,8 +341,8 @@ func (m *manager) processDeploymentDelete(deploymentID string) error {
 		return nil
 	}
 
-	// If the deployment is being tracked, but the baseline is not yet created, we cannot look at hte peers.  If we
-	// have a peer at all, then the peer will have been created
+	// If baseline for deleting deploynment exists, than we should look at all entries in the baseline
+	// in order to the delete this entry from other baselines.
 	if deletingBaseline != nil {
 		modifiedDeployments := set.NewStringSet()
 		for peer := range deletingBaseline.BaselinePeers {
@@ -352,6 +373,12 @@ func (m *manager) processDeploymentDelete(deploymentID string) error {
 		err := m.persistNetworkBaselines(modifiedDeployments, nil)
 		if err != nil {
 			return errors.Wrapf(err, "deleting baseline of deployment %q", deletingBaseline.DeploymentName)
+		}
+	} else {
+		// If baseline does not exist yet, it could still be that this deployment is already present in some other
+		// deployment's baseline. So we need to manually look through all the baselines
+		if err := m.deleteDeploymentFromBaselines(deploymentID); err != nil {
+			return err
 		}
 	}
 

--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -341,8 +341,8 @@ func (m *manager) processDeploymentDelete(deploymentID string) error {
 		return nil
 	}
 
-	// If baseline for deleting deploynment exists, than we should look at all entries in the baseline
-	// in order to the delete this entry from other baselines.
+	// If baseline for deleting deploynment exists, then we should look at all entries in its baseline
+	// in order to the delete its reference from peer baselines.
 	if deletingBaseline != nil {
 		modifiedDeployments := set.NewStringSet()
 		for peer := range deletingBaseline.BaselinePeers {

--- a/central/networkbaseline/manager/manager_impl_test.go
+++ b/central/networkbaseline/manager/manager_impl_test.go
@@ -564,6 +564,8 @@ func (suite *ManagerTestSuite) TestDeploymentDelete() {
 func (suite *ManagerTestSuite) TestDeploymentDelete_WithoutBaseline() {
 	suite.mustInitManager(
 		baselineWithPeers(1, depPeer(2, properties(false, 52))),
+		wrapWithForbidden(baselineWithPeers(3),
+			depPeer(2, properties(false, 52))),
 	)
 
 	// DeploymentID 2 should be in the internal map, but no baseline created yet.
@@ -571,8 +573,10 @@ func (suite *ManagerTestSuite) TestDeploymentDelete_WithoutBaseline() {
 
 	suite.Require().NoError(suite.m.ProcessDeploymentDelete(depID(2)))
 
+	// Should remove DeploymentID 2 from other baselines (BaselinedPeers and ForbiddenPeers) even if its baseline was never created
 	suite.assertBaselinesAre(
 		baselineWithPeers(1),
+		baselineWithPeers(3),
 	)
 }
 

--- a/central/networkbaseline/manager/manager_impl_test.go
+++ b/central/networkbaseline/manager/manager_impl_test.go
@@ -580,7 +580,6 @@ func (suite *ManagerTestSuite) TestDeploymentDelete_WithoutBaseline() {
 	)
 }
 
-
 func (suite *ManagerTestSuite) TestDeleteWithExtSrcPeer() {
 	suite.networkPolicyDS.EXPECT().GetNetworkPolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	suite.mustInitManager(

--- a/central/networkbaseline/manager/manager_impl_test.go
+++ b/central/networkbaseline/manager/manager_impl_test.go
@@ -561,6 +561,22 @@ func (suite *ManagerTestSuite) TestDeploymentDelete() {
 	)
 }
 
+func (suite *ManagerTestSuite) TestDeploymentDelete_WithoutBaseline() {
+	suite.mustInitManager(
+		baselineWithPeers(1, depPeer(2, properties(false, 52))),
+	)
+
+	// DeploymentID 2 should be in the internal map, but no baseline created yet.
+	suite.Require().NoError(suite.m.ProcessDeploymentCreate(depID(2), depName(2), clusterID(2), ns(2)))
+
+	suite.Require().NoError(suite.m.ProcessDeploymentDelete(depID(2)))
+
+	suite.assertBaselinesAre(
+		baselineWithPeers(1),
+	)
+}
+
+
 func (suite *ManagerTestSuite) TestDeleteWithExtSrcPeer() {
 	suite.networkPolicyDS.EXPECT().GetNetworkPolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	suite.mustInitManager(

--- a/pkg/networkgraph/networkbaseline/baseline_info.go
+++ b/pkg/networkgraph/networkbaseline/baseline_info.go
@@ -18,6 +18,33 @@ type BaselineInfo struct {
 	ForbiddenPeers       map[Peer]struct{}
 }
 
+// GetPeer returns the Peer struct if found in BaselinePeers.
+// Return first parameter (ok) false and empty peer if not found.
+func (i *BaselineInfo) GetPeer(id string) (bool, Peer) {
+	if i == nil {
+		return false, Peer{}
+	}
+	return i.getPeerFrom(id, i.BaselinePeers)
+}
+
+// GetForbiddenPeer returns the Peer struct if found in ForbiddenPeers.
+// Return first parameter (ok) false and empty peer if not found.
+func (i *BaselineInfo) GetForbiddenPeer(id string) (bool, Peer) {
+	if i == nil {
+		return false, Peer{}
+	}
+	return i.getPeerFrom(id, i.ForbiddenPeers)
+}
+
+func (i *BaselineInfo) getPeerFrom(id string, from map[Peer]struct{}) (bool, Peer) {
+	for peer := range from {
+		if peer.Entity.ID == id {
+			return true, peer
+		}
+	}
+	return false, Peer{}
+}
+
 // ConvertBaselineInfoFromProto converts proto NetworkBaseline to its in memory representation
 func ConvertBaselineInfoFromProto(protoBaseline *storage.NetworkBaseline) (*BaselineInfo, error) {
 	peers, err := ConvertPeersFromProto(protoBaseline.GetPeers())


### PR DESCRIPTION
## Description

This PR addresses a CI failure that happens due to a change that was made in the baseline creation.

Rather than reverting the change, and always create a baseline when a deployment is created, the proposal here is to search all baselines when deleting a deployment **only if that deployment does not have a baseline.**

The issue observed is that network flows are deleted from the table when the deployment gets deleted, making baseline inconsistent when a deployment is deleted. 

- Given we have two deployments: *server* and *client* which are created at the same time.
- Then *client* makes a request to *server* and shuts down.
- When this happens, ACS will remove the network flow between *client* and *server* from network_flows_v2.
There are two different paths the application could take, making the baseline creation behavior inconsistent:
1. Path one: if the baseline entry for *server* was already created (e.g. v1/networkbaseline/<server ID> was called or the observation period ended). Then the *client* ID *will be in the baseline*. Even if the client deployment was already deleted.
2. Path two: if the baseline entry for *server* was not yet created. Then the *client* ID *will not be in the baseline*. Because the network flows store no longer has an entry for the deleted deployment.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- [x] New unit tests added `central/networkbaseline/manager`
- [x] E2E Tests passed in CI
- [x] Manual test that baselines are updated when deployment without a baseline is deleted

Manual test:
1. Create `nginx` and `nginx-service`
2. Create baseline for nginx by opening the UI and going to basline tab in `nginx` deployment
3. Run pod that connects to `nginx`
```
kubectl -n test run my-netflow --rm -i --tty --image quay.io/rhacs-demo/netflow -- -connect <Service DNS>
```
4. Validate that `my-netflow` is in baseline
5. Delete `my-netflow`
6. Validate that `my-netflow` is *not* in the baseline

