### PR TITLE
ROX-18471: Update listening endpoints to use expandable table

### DIFF
--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.test.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.test.tsx
@@ -40,73 +40,12 @@ function mockDeploymentsWithListeningEndpoints(deployments) {
 
 describe('ListeningEndpointsPage', () => {
     it('should render a default message when no deployments are found', async () => {
-        setup();
-
         mockDeploymentsWithListeningEndpoints([]);
+
+        setup();
 
         expect(
             await screen.findByText('No deployments with listening endpoints found')
         ).toBeInTheDocument();
-    });
-
-    it('should not render deployments without listening endpoints', async () => {
-        setup();
-
-        mockDeploymentsWithListeningEndpoints([
-            {
-                id: 'd-1',
-                name: 'deployment-1',
-                listeningEndpoints: [],
-            },
-            {
-                id: 'd-2',
-                name: 'deployment-2',
-                listeningEndpoints: [
-                    { id: '1', endpoint: { port: 80, protocol: 'TCP' }, signal: {} },
-                ],
-            },
-        ]);
-
-        expect(await screen.findByText('deployment-2')).toBeInTheDocument();
-        expect(screen.queryByText('deployment-1')).not.toBeInTheDocument();
-    });
-
-    it('should render a view more button to allow loading more deployments', async () => {
-        const { user } = setup();
-
-        // Generate 15 mock deployments with names `deployment-1` through `deployment-15`
-        mockDeploymentsWithListeningEndpoints(
-            Array.from({ length: 15 }).map((_, i) => ({
-                id: `d-${i + 1}`,
-                name: `deployment-${i + 1}`,
-                listeningEndpoints: [
-                    { id: `${i + 1}`, endpoint: { port: 80, protocol: 'TCP' }, signal: {} },
-                ],
-            }))
-        );
-
-        // Check that only 1-10 are loaded
-        expect(await screen.findByText('deployment-1')).toBeInTheDocument();
-        expect(screen.getByText('deployment-10')).toBeInTheDocument();
-        expect(screen.queryByText('deployment-11')).not.toBeInTheDocument();
-
-        // Check that view more button is present
-        const viewMoreButton = screen.getByRole('button', { name: 'View more' });
-        expect(viewMoreButton).toBeInTheDocument();
-        // Click it
-        await user.click(viewMoreButton);
-
-        // Expect the button to be disabled during loading
-        expect(viewMoreButton).toBeDisabled();
-
-        // Check that 11-15 are loaded
-        expect(await screen.findByText('deployment-11')).toBeInTheDocument();
-        expect(screen.getByText('deployment-15')).toBeInTheDocument();
-        // Check that the originals are still there too
-        expect(screen.getByText('deployment-1')).toBeInTheDocument();
-        expect(screen.getByText('deployment-10')).toBeInTheDocument();
-
-        // Since all results are loaded, the button should be gone
-        expect(screen.queryByRole('button', { name: 'View more' })).not.toBeInTheDocument();
     });
 });

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -4,25 +4,26 @@ import {
     Button,
     Divider,
     PageSection,
+    Pagination,
     Spinner,
-    Stack,
+    Text,
     Title,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
 } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate/EmptyStateTemplate';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import useURLPagination from 'hooks/useURLPagination';
 import { useDeploymentListeningEndpoints } from './hooks/useDeploymentListeningEndpoints';
 import ListeningEndpointsTable from './ListeningEndpointsTable';
 
 function ListeningEndpointsPage() {
-    const { data, lastFetchError, isFetchingNextPage, isEndOfResults, fetchNextPage } =
-        useDeploymentListeningEndpoints();
-    const isInitialLoad =
-        data.length === 0 && !lastFetchError && isFetchingNextPage && !isEndOfResults;
-    const deployments = data
-        .flat()
-        .filter((deployment) => deployment.listeningEndpoints.length > 0);
+    const { page, perPage, setPage, setPerPage } = useURLPagination(10);
+    const { data, error, loading } = useDeploymentListeningEndpoints(page, perPage);
 
     return (
         <>
@@ -31,46 +32,70 @@ function ListeningEndpointsPage() {
                 <Title headingLevel="h1">Listening endpoints</Title>
             </PageSection>
             <Divider component="div" />
-            <PageSection isFilled>
-                {lastFetchError && (
-                    <div className="pf-u-background-color-100">
-                        <EmptyStateTemplate
-                            title="Error loading deployments with listening endpoints"
-                            headingLevel="h2"
-                            icon={ExclamationCircleIcon}
-                            iconClassName="pf-u-danger-color-100"
-                        >
-                            {lastFetchError.message}
-                        </EmptyStateTemplate>
-                    </div>
-                )}
-                {isInitialLoad && (
-                    <Bullseye>
-                        <Spinner aria-label="Loading listening endpoints for deployments" />
-                    </Bullseye>
-                )}
-                {!lastFetchError && !isInitialLoad && (
-                    <>
-                        {deployments.length === 0 ? (
-                            <Title headingLevel="h2">
-                                No deployments with listening endpoints found
-                            </Title>
-                        ) : (
-                            <Stack>
-                                <ListeningEndpointsTable deployments={deployments} />
-                                {!isEndOfResults && (
-                                    <Button
-                                        onClick={() => fetchNextPage(true)}
-                                        isLoading={isFetchingNextPage}
-                                        isDisabled={isFetchingNextPage}
-                                    >
-                                        View more
-                                    </Button>
+            <PageSection isFilled className="pf-u-display-flex pf-u-flex-direction-column">
+                <Toolbar>
+                    <ToolbarContent>
+                        <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
+                            <Pagination
+                                toggleTemplate={({ firstIndex, lastIndex }) => (
+                                    <span>
+                                        <b>
+                                            {firstIndex} - {lastIndex}
+                                        </b>{' '}
+                                        of <b>many</b>
+                                    </span>
                                 )}
-                            </Stack>
-                        )}
-                    </>
-                )}
+                                page={page}
+                                perPage={perPage}
+                                onSetPage={(_, newPage) => setPage(newPage)}
+                                onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                            />
+                        </ToolbarItem>
+                    </ToolbarContent>
+                </Toolbar>
+                <div className="pf-u-background-color-100">
+                    {error && (
+                        <Bullseye>
+                            <EmptyStateTemplate
+                                title="Error loading deployments with listening endpoints"
+                                headingLevel="h2"
+                                icon={ExclamationCircleIcon}
+                                iconClassName="pf-u-danger-color-100"
+                            >
+                                {getAxiosErrorMessage(error.message)}
+                            </EmptyStateTemplate>
+                        </Bullseye>
+                    )}
+                    {loading && (
+                        <Bullseye>
+                            <Spinner aria-label="Loading listening endpoints for deployments" />
+                        </Bullseye>
+                    )}
+                    {!error && !loading && data && (
+                        <>
+                            {data.length === 0 ? (
+                                <Bullseye>
+                                    <EmptyStateTemplate
+                                        title="No deployments with listening endpoints found"
+                                        headingLevel="h2"
+                                    >
+                                        <Text>Clear any search value and try again</Text>
+                                        <Button
+                                            variant="link"
+                                            onClick={() => {
+                                                /* TODO */
+                                            }}
+                                        >
+                                            Clear search
+                                        </Button>
+                                    </EmptyStateTemplate>
+                                </Bullseye>
+                            ) : (
+                                <ListeningEndpointsTable deployments={data} />
+                            )}
+                        </>
+                    )}
+                </div>
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -1,58 +1,98 @@
 import React from 'react';
-import { Bullseye } from '@patternfly/react-core';
+import { Card } from '@patternfly/react-core';
 import { Tbody, Tr, Td, TableComposable, Th, Thead } from '@patternfly/react-table';
 
 import { ProcessListeningOnPort } from 'services/ProcessListeningOnPortsService';
-import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { l4ProtocolLabels } from 'constants/networkFlow';
 import { ListDeployment } from 'types/deployment.proto';
+import useSet from 'hooks/useSet';
 
-export type ListeningEndpointsTableProps = {
-    deployments: (ListDeployment & { listeningEndpoints: ProcessListeningOnPort[] })[];
-};
-
-function ListeningEndpointsTable({ deployments }: ListeningEndpointsTableProps) {
+function EmbeddedTable({
+    deploymentId,
+    listeningEndpoints,
+}: {
+    deploymentId: string;
+    listeningEndpoints: ProcessListeningOnPort[];
+}) {
     return (
-        <TableComposable borders={false} variant="compact">
+        <TableComposable isNested>
             <Thead noWrap>
                 <Tr>
                     <Th>Program name</Th>
                     <Th>PID</Th>
                     <Th>Port</Th>
                     <Th>Protocol</Th>
-                    <Th>Deployment</Th>
-                    <Th>Namespace</Th>
-                    <Th>Cluster</Th>
                     <Th>Pod ID</Th>
                     <Th>Container name</Th>
                 </Tr>
             </Thead>
             <Tbody>
-                {deployments.length === 0 && (
-                    <Tr>
-                        <Td colSpan={8}>
-                            <Bullseye>
-                                <EmptyStateTemplate title="No results found" headingLevel="h2" />
-                            </Bullseye>
-                        </Td>
+                {listeningEndpoints.map(({ podId, endpoint, signal, containerName }) => (
+                    <Tr key={`${deploymentId}/${podId}/${endpoint.port}`}>
+                        <Td dataLabel="Program name">{signal.name}</Td>
+                        <Td dataLabel="PID">{signal.pid}</Td>
+                        <Td dataLabel="Port">{endpoint.port}</Td>
+                        <Td dataLabel="Protocol">{l4ProtocolLabels[endpoint.protocol]}</Td>
+                        <Td dataLabel="Pod ID">{podId}</Td>
+                        <Td dataLabel="Container name">{containerName}</Td>
                     </Tr>
-                )}
-                {deployments.flatMap(({ id, name, namespace, cluster, listeningEndpoints }) =>
-                    listeningEndpoints.map(({ podId, endpoint, signal, containerName }) => (
-                        <Tr key={`${id}/${podId}/${endpoint.port}`}>
-                            <Td dataLabel="Program name">{signal.name}</Td>
-                            <Td dataLabel="PID">{signal.pid}</Td>
-                            <Td dataLabel="Port">{endpoint.port}</Td>
-                            <Td dataLabel="Protocol">{l4ProtocolLabels[endpoint.protocol]}</Td>
+                ))}
+            </Tbody>
+        </TableComposable>
+    );
+}
+
+export type ListeningEndpointsTableProps = {
+    deployments: (ListDeployment & { listeningEndpoints: ProcessListeningOnPort[] })[];
+};
+
+function ListeningEndpointsTable({ deployments }: ListeningEndpointsTableProps) {
+    const expandedRowSet = useSet<string>();
+    return (
+        <TableComposable variant="compact">
+            <Thead noWrap>
+                <Tr>
+                    <Th>{/* Header for expanded column */}</Th>
+                    <Th width={30}>Deployment</Th>
+                    <Th>Namespace</Th>
+                    <Th>Cluster</Th>
+                </Tr>
+            </Thead>
+            {deployments.map(({ id, name, namespace, cluster, listeningEndpoints }, rowIndex) => {
+                const isExpanded = expandedRowSet.has(id);
+                return (
+                    <Tbody key={id} isExpanded={isExpanded}>
+                        <Tr>
+                            {listeningEndpoints.length > 0 ? (
+                                <Td
+                                    expand={{
+                                        rowIndex,
+                                        isExpanded,
+                                        onToggle: () => expandedRowSet.toggle(id),
+                                    }}
+                                />
+                            ) : (
+                                <Td />
+                            )}
                             <Td dataLabel="Deployment">{name}</Td>
                             <Td dataLabel="Namespace">{namespace}</Td>
                             <Td dataLabel="Cluster">{cluster}</Td>
-                            <Td dataLabel="Pod ID">{podId}</Td>
-                            <Td dataLabel="Container name">{containerName}</Td>
                         </Tr>
-                    ))
-                )}
-            </Tbody>
+                        {listeningEndpoints.length > 0 && (
+                            <Tr isExpanded={isExpanded}>
+                                <Td colSpan={4}>
+                                    <Card className="pf-u-m-md" isFlat>
+                                        <EmbeddedTable
+                                            deploymentId={id}
+                                            listeningEndpoints={listeningEndpoints}
+                                        />
+                                    </Card>
+                                </Td>
+                            </Tr>
+                        )}
+                    </Tbody>
+                );
+            })}
         </TableComposable>
     );
 }

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/hooks/useDeploymentListeningEndpoints.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/hooks/useDeploymentListeningEndpoints.tsx
@@ -1,23 +1,16 @@
 import { useCallback } from 'react';
-import { UsePaginatedQueryReturn, usePaginatedQuery } from 'hooks/usePaginatedQuery';
 import { listDeployments } from 'services/DeploymentsService';
-import {
-    ProcessListeningOnPort,
-    getListeningEndpointsForDeployment,
-} from 'services/ProcessListeningOnPortsService';
-import { ListDeployment } from 'types/deployment.proto';
+import { getListeningEndpointsForDeployment } from 'services/ProcessListeningOnPortsService';
+import useRestQuery from 'hooks/useRestQuery';
 
 const sortOptions = { field: 'Deployment', reversed: 'false' };
-const pageSize = 10;
 
 /**
  * Returns a paginated list of deployments with their listening endpoints.
  */
-export function useDeploymentListeningEndpoints(): UsePaginatedQueryReturn<
-    ListDeployment & { listeningEndpoints: ProcessListeningOnPort[] }
-> {
-    const queryFn = useCallback((page: number) => {
-        return listDeployments({}, sortOptions, page, pageSize).then((res) => {
+export function useDeploymentListeningEndpoints(page, perPage) {
+    const queryFn = useCallback(() => {
+        return listDeployments({}, sortOptions, page - 1, perPage).then((res) => {
             return Promise.all(
                 res.map((deployment) => {
                     const { request } = getListeningEndpointsForDeployment(deployment.id);
@@ -28,7 +21,7 @@ export function useDeploymentListeningEndpoints(): UsePaginatedQueryReturn<
                 })
             );
         });
-    }, []);
+    }, [page, perPage]);
 
-    return usePaginatedQuery(queryFn, pageSize);
+    return useRestQuery(queryFn);
 }


### PR DESCRIPTION
## Description

Replaces the infinite, flat table on the listening endpoints page with a traditionally paginated table and expandable rows.

Deployments with no listening endpoints will be present in the table, but will not be expandable.

This also uses the _# of many_ pagination pattern that was suggested in the past to avoid additional expensive network requests.

## Follow ups

- Add column sorting
- Add a search by deployment input

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the listening endpoints page:
![image](https://github.com/stackrox/stackrox/assets/1292638/c3fea38c-fe50-4a37-bb9c-5c244d2175a4)

Test pagination controls:
![image](https://github.com/stackrox/stackrox/assets/1292638/44aac5e7-5577-48ef-a5fd-18b24014c946)

Test expanding and closing multiple rows:
![image](https://github.com/stackrox/stackrox/assets/1292638/77c62d55-6d53-4048-8986-60efc2732d2f)

Page beyond the max number of items (TBD - need to follow up with UX on ideal patterns for this case):
![image](https://github.com/stackrox/stackrox/assets/1292638/4cacea75-14fe-4a59-a9ef-22ba2c6f8788)

