### PR TITLE
ROX-9981: Refactor AllowFixedScopeCheckerCore

### DIFF
--- a/central/role/sachelper/sachelper.go
+++ b/central/role/sachelper/sachelper.go
@@ -75,6 +75,9 @@ func (h *clusterSACHelperImpl) GetClustersForPermissions(
 	if err != nil {
 		return nil, err
 	}
+	if len(clusterIDsInScope) == 0 && !hasFullAccess {
+		return nil, nil
+	}
 
 	// Use an elevated context to fetch cluster names associated with the listed IDs.
 	// This context must not be propagated.
@@ -157,6 +160,9 @@ func (h *clusterNamespaceSACHelperImpl) GetNamespacesForClusterAndPermissions(
 	namespacesInScope, hasFullAccess, err := listNamespaceNamesInScope(ctx, clusterID, resourcesWithAccess)
 	if err != nil {
 		return nil, err
+	}
+	if len(namespacesInScope) == 0 && !hasFullAccess {
+		return nil, nil
 	}
 
 	// Use an elevated context to fetch namespace IDs and names associated with the listed namespace names.

--- a/pkg/sac/allow_fixed_scopes_checker_core.go
+++ b/pkg/sac/allow_fixed_scopes_checker_core.go
@@ -20,6 +20,225 @@ type allowedFixedScopesCheckerCore struct {
 	targetNamespace NamespaceScopeKey
 }
 
+// region ScopeCheckerCore interface functions
+
+func (c *allowedFixedScopesCheckerCore) SubScopeChecker(scopeKey ScopeKey) ScopeCheckerCore {
+	switch key := scopeKey.(type) {
+	case AccessModeScopeKey:
+		if c.checkerLevel != GlobalScopeKind ||
+			(!c.allowsGlobalAccess() && !c.accessKeys.Contains(key)) {
+			return denyAllScopeCheckerCore
+		}
+		return c.subScopeCheckerBuilder().withAccessMode(key)
+		if c.checkerLevel != GlobalScopeKind {
+			return denyAllScopeCheckerCore
+		}
+		if c.allowsGlobalAccess() {
+			return c.subScopeCheckerBuilder().withAccessMode(key)
+		}
+		if !c.accessKeys.Contains(key) {
+			return denyAllScopeCheckerCore
+		}
+		return c.subScopeCheckerBuilder().withAccessMode(key)
+	case ResourceScopeKey:
+		if c.checkerLevel != AccessModeScopeKind {
+			return denyAllScopeCheckerCore
+		}
+		if c.allowsAccessModeLevelAccess() {
+			return c.subScopeCheckerBuilder().withResource(key)
+		}
+		if !c.resourceKeys.Contains(key) {
+			return denyAllScopeCheckerCore
+		}
+		return c.subScopeCheckerBuilder().withResource(key)
+	case ClusterScopeKey:
+		if c.checkerLevel != ResourceScopeKind {
+			return denyAllScopeCheckerCore
+		}
+		if c.allowsResourceLevelAccess() {
+			return c.subScopeCheckerBuilder().withCluster(key)
+		}
+		if !c.clusterKeys.Contains(key) {
+			return denyAllScopeCheckerCore
+		}
+		return c.subScopeCheckerBuilder().withCluster(key)
+	case NamespaceScopeKey:
+		if c.checkerLevel != ClusterScopeKind {
+			return denyAllScopeCheckerCore
+		}
+		if c.allowsClusterLevelAccess() {
+			return c.subScopeCheckerBuilder().withNamespace(key)
+		}
+		if c.namespaceKeys.Cardinality() > 0 && !c.namespaceKeys.Contains(key) {
+			return denyAllScopeCheckerCore
+		}
+		return c.subScopeCheckerBuilder().withNamespace(key)
+	}
+	return denyAllScopeCheckerCore
+}
+
+func (c *allowedFixedScopesCheckerCore) Allowed() bool {
+	switch c.checkerLevel {
+	case GlobalScopeKind:
+		return c.allowsGlobalAccess()
+	case AccessModeScopeKind:
+		return c.allowsAccessModeLevelAccess()
+	case ResourceScopeKind:
+		return c.allowsResourceLevelAccess()
+	case ClusterScopeKind:
+		return c.allowsClusterLevelAccess()
+	case NamespaceScopeKind:
+		return true
+	}
+	return false
+}
+
+func (c *allowedFixedScopesCheckerCore) EffectiveAccessScope(
+	resource permissions.ResourceWithAccess,
+) (*effectiveaccessscope.ScopeTree, error) {
+	// Global access granted
+	if c.allowsGlobalAccess() {
+		return effectiveaccessscope.UnrestrictedEffectiveAccessScope(), nil
+	}
+
+	// Drill down to AccessMode level
+	if !c.accessKeys.Contains(AccessModeScopeKey(resource.Access)) {
+		return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
+	}
+	if c.allowsAccessModeLevelAccess() {
+		return effectiveaccessscope.UnrestrictedEffectiveAccessScope(), nil
+	}
+
+	// Drill down to Resource level
+	targetResource := resource.Resource.GetResource()
+	targetReplacingResource := resource.Resource.GetReplacingResource()
+	if !c.resourceKeys.Contains(ResourceScopeKey(targetResource)) &&
+		(targetReplacingResource == nil || !c.resourceKeys.Contains(ResourceScopeKey(*targetReplacingResource))) {
+		return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
+	}
+	if c.allowsResourceLevelAccess() {
+		return effectiveaccessscope.UnrestrictedEffectiveAccessScope(), nil
+	}
+
+	// Cluster and Namespace level
+	clusterIDs := make([]string, 0, c.clusterKeys.Cardinality())
+	for clusterKey := range c.clusterKeys {
+		clusterIDs = append(clusterIDs, clusterKey.String())
+	}
+	if c.allowsClusterLevelAccess() {
+		return effectiveaccessscope.FromClustersAndNamespacesMap(clusterIDs, nil), nil
+	}
+	namespaces := make([]string, 0, c.namespaceKeys.Cardinality())
+	for namespaceKey := range c.namespaceKeys {
+		namespaces = append(namespaces, namespaceKey.String())
+	}
+	clusterNamespaceMap := make(map[string][]string, len(clusterIDs))
+	for clusterIx := range clusterIDs {
+		clusterID := clusterIDs[clusterIx]
+		clusterNamespaceMap[clusterID] = namespaces
+	}
+	return effectiveaccessscope.FromClustersAndNamespacesMap(nil, clusterNamespaceMap), nil
+}
+
+// endregion ScopeCheckerCore interface functions
+
+// region Public constructors
+
+// AllowFixedScopes returns a scope checker core that allows those scopes that
+// are in the cross product of all individual scope key lists. I.e.,
+//
+//	AllowFixedScopes(
+//		AccessModeScopeKeys(storage.Access_READ, storage.Access_READ_WRITE),
+//		ResourceScopeKeys(resources.CLUSTER),
+//	)
+//
+// returns a scope checker core that allows read and write access to all cluster resources.
+func AllowFixedScopes(keyLists ...[]ScopeKey) ScopeCheckerCore {
+	switch len(keyLists) {
+	case 0:
+		return allowFixedGlobalLevelScopes()
+	case 1:
+		return allowFixedAccessModeLevelScopes(keyLists[0])
+	case 2:
+		return allowFixedResourceLevelScopes(keyLists[0], keyLists[1])
+	case 3:
+		return allowFixedClusterLevelScopes(keyLists[0], keyLists[1], keyLists[2])
+	case 4:
+		return allowFixedNamespaceLevelScopes(keyLists[0], keyLists[1], keyLists[2], keyLists[3])
+	}
+	return denyAllScopeCheckerCore
+}
+
+// endregion Public constructors
+
+// region helpers for Interface functions
+
+type subScopeCheckerBuilder struct {
+	core *allowedFixedScopesCheckerCore
+}
+
+func (c *allowedFixedScopesCheckerCore) subScopeCheckerBuilder() *subScopeCheckerBuilder {
+	return &subScopeCheckerBuilder{
+		core: &allowedFixedScopesCheckerCore{
+			checkerLevel:    c.checkerLevel + 1,
+			accessKeys:      c.accessKeys,
+			resourceKeys:    c.resourceKeys,
+			clusterKeys:     c.clusterKeys,
+			namespaceKeys:   c.namespaceKeys,
+			accessLevel:     c.accessLevel,
+			targetResource:  c.targetResource,
+			targetCluster:   c.targetCluster,
+			targetNamespace: c.targetNamespace,
+		},
+	}
+}
+
+func (b *subScopeCheckerBuilder) withAccessMode(key AccessModeScopeKey) ScopeCheckerCore {
+	b.core.accessLevel = key
+	return b.core
+}
+
+func (b *subScopeCheckerBuilder) withResource(key ResourceScopeKey) ScopeCheckerCore {
+	b.core.targetResource = key
+	return b.core
+}
+
+func (b *subScopeCheckerBuilder) withCluster(key ClusterScopeKey) ScopeCheckerCore {
+	b.core.targetCluster = key
+	return b.core
+}
+
+func (b *subScopeCheckerBuilder) withNamespace(key NamespaceScopeKey) ScopeCheckerCore {
+	b.core.targetNamespace = key
+	return b.core
+}
+
+func (c *allowedFixedScopesCheckerCore) allowsGlobalAccess() bool {
+	return c.accessKeys.Cardinality() == 0 &&
+		c.resourceKeys.Cardinality() == 0 &&
+		c.clusterKeys.Cardinality() == 0 &&
+		c.namespaceKeys.Cardinality() == 0
+}
+
+func (c *allowedFixedScopesCheckerCore) allowsAccessModeLevelAccess() bool {
+	return c.resourceKeys.Cardinality() == 0 &&
+		c.clusterKeys.Cardinality() == 0 &&
+		c.namespaceKeys.Cardinality() == 0
+}
+
+func (c *allowedFixedScopesCheckerCore) allowsResourceLevelAccess() bool {
+	return c.clusterKeys.Cardinality() == 0 &&
+		c.namespaceKeys.Cardinality() == 0
+}
+
+func (c *allowedFixedScopesCheckerCore) allowsClusterLevelAccess() bool {
+	return c.namespaceKeys.Cardinality() == 0
+}
+
+// endregion helpers for Interface functions
+
+// region helpers for constructors
+
 func typedKeySet[T comparable](scopeKeys []ScopeKey) set.Set[T] {
 	typedKeys := make([]T, 0, len(scopeKeys))
 	for _, scopeKey := range scopeKeys {
@@ -94,197 +313,4 @@ func allowFixedNamespaceLevelScopes(
 	}
 }
 
-type subScopeCheckerBuilder struct {
-	core *allowedFixedScopesCheckerCore
-}
-
-func (c *allowedFixedScopesCheckerCore) subScopeCheckerBuilder() *subScopeCheckerBuilder {
-	return &subScopeCheckerBuilder{
-		core: &allowedFixedScopesCheckerCore{
-			checkerLevel:    c.checkerLevel + 1,
-			accessKeys:      c.accessKeys,
-			resourceKeys:    c.resourceKeys,
-			clusterKeys:     c.clusterKeys,
-			namespaceKeys:   c.namespaceKeys,
-			accessLevel:     c.accessLevel,
-			targetResource:  c.targetResource,
-			targetCluster:   c.targetCluster,
-			targetNamespace: c.targetNamespace,
-		},
-	}
-}
-
-func (b *subScopeCheckerBuilder) withAccessMode(key AccessModeScopeKey) ScopeCheckerCore {
-	b.core.accessLevel = key
-	return b.core
-}
-
-func (b *subScopeCheckerBuilder) withResource(key ResourceScopeKey) ScopeCheckerCore {
-	b.core.targetResource = key
-	return b.core
-}
-
-func (b *subScopeCheckerBuilder) withCluster(key ClusterScopeKey) ScopeCheckerCore {
-	b.core.targetCluster = key
-	return b.core
-}
-
-func (b *subScopeCheckerBuilder) withNamespace(key NamespaceScopeKey) ScopeCheckerCore {
-	b.core.targetNamespace = key
-	return b.core
-}
-
-func (c *allowedFixedScopesCheckerCore) SubScopeChecker(scopeKey ScopeKey) ScopeCheckerCore {
-	switch key := scopeKey.(type) {
-	case AccessModeScopeKey:
-		if c.checkerLevel != GlobalScopeKind {
-			return denyAllScopeCheckerCore
-		}
-		if c.accessKeys.Cardinality() == 0 &&
-			c.resourceKeys.Cardinality() == 0 &&
-			c.clusterKeys.Cardinality() == 0 &&
-			c.namespaceKeys.Cardinality() == 0 {
-			return c.subScopeCheckerBuilder().withAccessMode(key)
-		}
-		if !c.accessKeys.Contains(key) {
-			return denyAllScopeCheckerCore
-		}
-		return c.subScopeCheckerBuilder().withAccessMode(key)
-	case ResourceScopeKey:
-		if c.checkerLevel != AccessModeScopeKind {
-			return denyAllScopeCheckerCore
-		}
-		if c.resourceKeys.Cardinality() == 0 &&
-			c.clusterKeys.Cardinality() == 0 &&
-			c.namespaceKeys.Cardinality() == 0 {
-			return c.subScopeCheckerBuilder().withResource(key)
-		}
-		if c.resourceKeys.Cardinality() > 0 && !c.resourceKeys.Contains(key) {
-			return denyAllScopeCheckerCore
-		}
-		return c.subScopeCheckerBuilder().withResource(key)
-	case ClusterScopeKey:
-		if c.checkerLevel != ResourceScopeKind {
-			return denyAllScopeCheckerCore
-		}
-		if c.clusterKeys.Cardinality() == 0 && c.namespaceKeys.Cardinality() == 0 {
-			return c.subScopeCheckerBuilder().withCluster(key)
-		}
-		if !c.clusterKeys.Contains(key) {
-			return denyAllScopeCheckerCore
-		}
-		return c.subScopeCheckerBuilder().withCluster(key)
-	case NamespaceScopeKey:
-		if c.checkerLevel != ClusterScopeKind {
-			return denyAllScopeCheckerCore
-		}
-		if c.namespaceKeys.Cardinality() == 0 {
-			return c.subScopeCheckerBuilder().withNamespace(key)
-		}
-		if c.namespaceKeys.Cardinality() > 0 && !c.namespaceKeys.Contains(key) {
-			return denyAllScopeCheckerCore
-		}
-		return c.subScopeCheckerBuilder().withNamespace(key)
-	}
-	return denyAllScopeCheckerCore
-}
-
-func (c *allowedFixedScopesCheckerCore) Allowed() bool {
-	switch c.checkerLevel {
-	case GlobalScopeKind:
-		return c.accessKeys.Cardinality() == 0 &&
-			c.resourceKeys.Cardinality() == 0 &&
-			c.clusterKeys.Cardinality() == 0 &&
-			c.namespaceKeys.Cardinality() == 0
-	case AccessModeScopeKind:
-		return c.resourceKeys.Cardinality() == 0 &&
-			c.clusterKeys.Cardinality() == 0 &&
-			c.namespaceKeys.Cardinality() == 0
-	case ResourceScopeKind:
-		return c.clusterKeys.Cardinality() == 0 &&
-			c.namespaceKeys.Cardinality() == 0
-	case ClusterScopeKind:
-		return c.namespaceKeys.Cardinality() == 0
-	case NamespaceScopeKind:
-		return true
-	}
-	return false
-}
-
-func (c *allowedFixedScopesCheckerCore) EffectiveAccessScope(
-	resource permissions.ResourceWithAccess,
-) (*effectiveaccessscope.ScopeTree, error) {
-	// Global access granted
-	if c.accessKeys.Cardinality() == 0 &&
-		c.resourceKeys.Cardinality() == 0 &&
-		c.clusterKeys.Cardinality() == 0 &&
-		c.resourceKeys.Cardinality() == 0 {
-		return effectiveaccessscope.UnrestrictedEffectiveAccessScope(), nil
-	}
-
-	// Drill down to AccessMode level
-	if !c.accessKeys.Contains(AccessModeScopeKey(resource.Access)) {
-		return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
-	}
-	if c.resourceKeys.Cardinality() == 0 &&
-		c.clusterKeys.Cardinality() == 0 &&
-		c.resourceKeys.Cardinality() == 0 {
-		return effectiveaccessscope.UnrestrictedEffectiveAccessScope(), nil
-	}
-
-	// Drill down to Resource level
-	targetResource := resource.Resource.GetResource()
-	targetReplacingResource := resource.Resource.GetReplacingResource()
-	if !c.resourceKeys.Contains(ResourceScopeKey(targetResource)) &&
-		(targetReplacingResource == nil || !c.resourceKeys.Contains(ResourceScopeKey(*targetReplacingResource))) {
-		return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
-	}
-	if c.clusterKeys.Cardinality() == 0 &&
-		c.namespaceKeys.Cardinality() == 0 {
-		return effectiveaccessscope.UnrestrictedEffectiveAccessScope(), nil
-	}
-
-	// Cluster and Namespace level
-	clusterIDs := make([]string, 0, c.clusterKeys.Cardinality())
-	for clusterKey := range c.clusterKeys {
-		clusterIDs = append(clusterIDs, clusterKey.String())
-	}
-	if c.namespaceKeys.Cardinality() == 0 {
-		return effectiveaccessscope.FromClustersAndNamespacesMap(clusterIDs, nil), nil
-	}
-	namespaces := make([]string, 0, c.namespaceKeys.Cardinality())
-	for namespaceKey := range c.namespaceKeys {
-		namespaces = append(namespaces, namespaceKey.String())
-	}
-	clusterNamespaceMap := make(map[string][]string, len(clusterIDs))
-	for clusterIx := range clusterIDs {
-		clusterID := clusterIDs[clusterIx]
-		clusterNamespaceMap[clusterID] = namespaces
-	}
-	return effectiveaccessscope.FromClustersAndNamespacesMap(nil, clusterNamespaceMap), nil
-}
-
-// AllowFixedScopes returns a scope checker core that allows those scopes that
-// are in the cross product of all individual scope key lists. I.e.,
-//
-//	AllowFixedScopes(
-//		AccessModeScopeKeys(storage.Access_READ, storage.Access_READ_WRITE),
-//		ResourceScopeKeys(resources.CLUSTER),
-//	)
-//
-// returns a scope checker core that allows read and write access to all cluster resources.
-func AllowFixedScopes(keyLists ...[]ScopeKey) ScopeCheckerCore {
-	switch len(keyLists) {
-	case 0:
-		return allowFixedGlobalLevelScopes()
-	case 1:
-		return allowFixedAccessModeLevelScopes(keyLists[0])
-	case 2:
-		return allowFixedResourceLevelScopes(keyLists[0], keyLists[1])
-	case 3:
-		return allowFixedClusterLevelScopes(keyLists[0], keyLists[1], keyLists[2])
-	case 4:
-		return allowFixedNamespaceLevelScopes(keyLists[0], keyLists[1], keyLists[2], keyLists[3])
-	}
-	return denyAllScopeCheckerCore
-}
+// endregion helpers for constructors

--- a/pkg/sac/allow_fixed_scopes_checker_core.go
+++ b/pkg/sac/allow_fixed_scopes_checker_core.go
@@ -25,11 +25,6 @@ type allowedFixedScopesCheckerCore struct {
 func (c *allowedFixedScopesCheckerCore) SubScopeChecker(scopeKey ScopeKey) ScopeCheckerCore {
 	switch key := scopeKey.(type) {
 	case AccessModeScopeKey:
-		if c.checkerLevel != GlobalScopeKind ||
-			(!c.allowsGlobalAccess() && !c.accessKeys.Contains(key)) {
-			return denyAllScopeCheckerCore
-		}
-		return c.subScopeCheckerBuilder().withAccessMode(key)
 		if c.checkerLevel != GlobalScopeKind {
 			return denyAllScopeCheckerCore
 		}
@@ -69,7 +64,7 @@ func (c *allowedFixedScopesCheckerCore) SubScopeChecker(scopeKey ScopeKey) Scope
 		if c.allowsClusterLevelAccess() {
 			return c.subScopeCheckerBuilder().withNamespace(key)
 		}
-		if c.namespaceKeys.Cardinality() > 0 && !c.namespaceKeys.Contains(key) {
+		if !c.namespaceKeys.Contains(key) {
 			return denyAllScopeCheckerCore
 		}
 		return c.subScopeCheckerBuilder().withNamespace(key)

--- a/pkg/sac/allow_fixed_scopes_checker_core.go
+++ b/pkg/sac/allow_fixed_scopes_checker_core.go
@@ -73,8 +73,9 @@ func (c *allowedFixedScopesCheckerCore) SubScopeChecker(scopeKey ScopeKey) Scope
 			return denyAllScopeCheckerCore
 		}
 		return c.subScopeCheckerBuilder().withNamespace(key)
+	default:
+		return denyAllScopeCheckerCore
 	}
-	return denyAllScopeCheckerCore
 }
 
 func (c *allowedFixedScopesCheckerCore) Allowed() bool {
@@ -89,8 +90,9 @@ func (c *allowedFixedScopesCheckerCore) Allowed() bool {
 		return c.allowsClusterLevelAccess()
 	case NamespaceScopeKind:
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 func (c *allowedFixedScopesCheckerCore) EffectiveAccessScope(
@@ -165,8 +167,9 @@ func AllowFixedScopes(keyLists ...[]ScopeKey) ScopeCheckerCore {
 		return allowFixedClusterLevelScopes(keyLists[0], keyLists[1], keyLists[2])
 	case 4:
 		return allowFixedNamespaceLevelScopes(keyLists[0], keyLists[1], keyLists[2], keyLists[3])
+	default:
+		return denyAllScopeCheckerCore
 	}
-	return denyAllScopeCheckerCore
 }
 
 // endregion Public constructors
@@ -214,21 +217,15 @@ func (b *subScopeCheckerBuilder) withNamespace(key NamespaceScopeKey) ScopeCheck
 }
 
 func (c *allowedFixedScopesCheckerCore) allowsGlobalAccess() bool {
-	return c.accessKeys.Cardinality() == 0 &&
-		c.resourceKeys.Cardinality() == 0 &&
-		c.clusterKeys.Cardinality() == 0 &&
-		c.namespaceKeys.Cardinality() == 0
+	return c.accessKeys.Cardinality() == 0 && c.allowsAccessModeLevelAccess()
 }
 
 func (c *allowedFixedScopesCheckerCore) allowsAccessModeLevelAccess() bool {
-	return c.resourceKeys.Cardinality() == 0 &&
-		c.clusterKeys.Cardinality() == 0 &&
-		c.namespaceKeys.Cardinality() == 0
+	return c.resourceKeys.Cardinality() == 0 && c.allowsResourceLevelAccess()
 }
 
 func (c *allowedFixedScopesCheckerCore) allowsResourceLevelAccess() bool {
-	return c.clusterKeys.Cardinality() == 0 &&
-		c.namespaceKeys.Cardinality() == 0
+	return c.clusterKeys.Cardinality() == 0 && c.allowsClusterLevelAccess()
 }
 
 func (c *allowedFixedScopesCheckerCore) allowsClusterLevelAccess() bool {

--- a/pkg/sac/allow_fixed_scopes_checker_core.go
+++ b/pkg/sac/allow_fixed_scopes_checker_core.go
@@ -130,8 +130,7 @@ func (c *allowedFixedScopesCheckerCore) EffectiveAccessScope(
 		namespaces = append(namespaces, namespaceKey.String())
 	}
 	clusterNamespaceMap := make(map[string][]string, len(clusterIDs))
-	for clusterIx := range clusterIDs {
-		clusterID := clusterIDs[clusterIx]
+	for _, clusterID := range clusterIDs {
 		clusterNamespaceMap[clusterID] = namespaces
 	}
 	return effectiveaccessscope.FromClustersAndNamespacesMap(nil, clusterNamespaceMap), nil

--- a/pkg/sac/allow_fixed_scopes_checker_core.go
+++ b/pkg/sac/allow_fixed_scopes_checker_core.go
@@ -3,11 +3,234 @@ package sac
 import (
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
+	"github.com/stackrox/rox/pkg/set"
 )
 
-type scopeKeySet map[ScopeKey]struct{}
+type allowedFixedScopesCheckerCore struct {
+	checkerLevel ScopeKind
 
-type allowFixedScopesCheckerCore []scopeKeySet
+	accessKeys    set.Set[AccessModeScopeKey]
+	resourceKeys  set.Set[ResourceScopeKey]
+	clusterKeys   set.Set[ClusterScopeKey]
+	namespaceKeys set.Set[NamespaceScopeKey]
+
+	accessLevel     AccessModeScopeKey
+	targetResource  ResourceScopeKey
+	targetCluster   ClusterScopeKey
+	targetNamespace NamespaceScopeKey
+}
+
+func typedKeySet[T comparable](scopeKeys []ScopeKey) set.Set[T] {
+	typedKeys := make([]T, 0, len(scopeKeys))
+	for _, scopeKey := range scopeKeys {
+		if key, ok := scopeKey.(T); ok {
+			typedKeys = append(typedKeys, key)
+		}
+	}
+	return set.NewSet[T](typedKeys...)
+}
+
+func allowFixedGlobalLevelScopes() ScopeCheckerCore {
+	return &allowedFixedScopesCheckerCore{
+		checkerLevel:  GlobalScopeKind,
+		accessKeys:    typedKeySet[AccessModeScopeKey]([]ScopeKey{}),
+		resourceKeys:  typedKeySet[ResourceScopeKey]([]ScopeKey{}),
+		clusterKeys:   typedKeySet[ClusterScopeKey]([]ScopeKey{}),
+		namespaceKeys: typedKeySet[NamespaceScopeKey]([]ScopeKey{}),
+	}
+}
+
+func allowFixedAccessModeLevelScopes(
+	accessLevelKeys []ScopeKey,
+) ScopeCheckerCore {
+	return &allowedFixedScopesCheckerCore{
+		checkerLevel:  GlobalScopeKind,
+		accessKeys:    typedKeySet[AccessModeScopeKey](accessLevelKeys),
+		resourceKeys:  typedKeySet[ResourceScopeKey]([]ScopeKey{}),
+		clusterKeys:   typedKeySet[ClusterScopeKey]([]ScopeKey{}),
+		namespaceKeys: typedKeySet[NamespaceScopeKey]([]ScopeKey{}),
+	}
+}
+
+func allowFixedResourceLevelScopes(
+	accessLevelKeys []ScopeKey,
+	resourceLevelKeys []ScopeKey,
+) ScopeCheckerCore {
+	return &allowedFixedScopesCheckerCore{
+		checkerLevel:  GlobalScopeKind,
+		accessKeys:    typedKeySet[AccessModeScopeKey](accessLevelKeys),
+		resourceKeys:  typedKeySet[ResourceScopeKey](resourceLevelKeys),
+		clusterKeys:   typedKeySet[ClusterScopeKey]([]ScopeKey{}),
+		namespaceKeys: typedKeySet[NamespaceScopeKey]([]ScopeKey{}),
+	}
+}
+
+func allowFixedClusterLevelScopes(
+	accessLevelKeys []ScopeKey,
+	resourceLevelKeys []ScopeKey,
+	clusterLevelKeys []ScopeKey,
+) ScopeCheckerCore {
+	return &allowedFixedScopesCheckerCore{
+		checkerLevel:  GlobalScopeKind,
+		accessKeys:    typedKeySet[AccessModeScopeKey](accessLevelKeys),
+		resourceKeys:  typedKeySet[ResourceScopeKey](resourceLevelKeys),
+		clusterKeys:   typedKeySet[ClusterScopeKey](clusterLevelKeys),
+		namespaceKeys: typedKeySet[NamespaceScopeKey]([]ScopeKey{}),
+	}
+}
+
+func allowFixedNamespaceLevelScopes(
+	accessLevelKeys []ScopeKey,
+	resourceLevelKeys []ScopeKey,
+	clusterLevelKeys []ScopeKey,
+	namespaceLevelKeys []ScopeKey,
+) ScopeCheckerCore {
+	return &allowedFixedScopesCheckerCore{
+		checkerLevel:  GlobalScopeKind,
+		accessKeys:    typedKeySet[AccessModeScopeKey](accessLevelKeys),
+		resourceKeys:  typedKeySet[ResourceScopeKey](resourceLevelKeys),
+		clusterKeys:   typedKeySet[ClusterScopeKey](clusterLevelKeys),
+		namespaceKeys: typedKeySet[NamespaceScopeKey](namespaceLevelKeys),
+	}
+}
+
+func (c *allowedFixedScopesCheckerCore) SubScopeChecker(scopeKey ScopeKey) ScopeCheckerCore {
+	switch key := scopeKey.(type) {
+	case AccessModeScopeKey:
+		if c.checkerLevel != GlobalScopeKind {
+			return denyAllScopeCheckerCore
+		}
+		if c.accessKeys.Cardinality() > 0 && !c.accessKeys.Contains(key) {
+			return denyAllScopeCheckerCore
+		}
+		return &allowedFixedScopesCheckerCore{
+			checkerLevel:  AccessModeScopeKind,
+			accessKeys:    c.accessKeys,
+			resourceKeys:  c.resourceKeys,
+			clusterKeys:   c.clusterKeys,
+			namespaceKeys: c.namespaceKeys,
+			accessLevel:   key,
+		}
+	case ResourceScopeKey:
+		if c.checkerLevel != AccessModeScopeKind {
+			return denyAllScopeCheckerCore
+		}
+		if c.resourceKeys.Cardinality() > 0 && !c.resourceKeys.Contains(key) {
+			return denyAllScopeCheckerCore
+		}
+		return &allowedFixedScopesCheckerCore{
+			checkerLevel:   ResourceScopeKind,
+			accessKeys:     c.accessKeys,
+			resourceKeys:   c.resourceKeys,
+			clusterKeys:    c.clusterKeys,
+			namespaceKeys:  c.namespaceKeys,
+			accessLevel:    c.accessLevel,
+			targetResource: key,
+		}
+	case ClusterScopeKey:
+		if c.checkerLevel != ResourceScopeKind {
+			return denyAllScopeCheckerCore
+		}
+		if c.clusterKeys.Cardinality() > 0 && !c.clusterKeys.Contains(key) {
+			return denyAllScopeCheckerCore
+		}
+		return &allowedFixedScopesCheckerCore{
+			checkerLevel:   ClusterScopeKind,
+			accessKeys:     c.accessKeys,
+			resourceKeys:   c.resourceKeys,
+			clusterKeys:    c.clusterKeys,
+			namespaceKeys:  c.namespaceKeys,
+			accessLevel:    c.accessLevel,
+			targetResource: c.targetResource,
+			targetCluster:  key,
+		}
+	case NamespaceScopeKey:
+		if c.checkerLevel != ClusterScopeKind {
+			return denyAllScopeCheckerCore
+		}
+		if c.namespaceKeys.Cardinality() > 0 && !c.namespaceKeys.Contains(key) {
+			return denyAllScopeCheckerCore
+		}
+		return &allowedFixedScopesCheckerCore{
+			checkerLevel:    NamespaceScopeKind,
+			accessKeys:      c.accessKeys,
+			resourceKeys:    c.resourceKeys,
+			clusterKeys:     c.clusterKeys,
+			namespaceKeys:   c.namespaceKeys,
+			accessLevel:     c.accessLevel,
+			targetResource:  c.targetResource,
+			targetCluster:   c.targetCluster,
+			targetNamespace: key,
+		}
+	}
+	return denyAllScopeCheckerCore
+}
+
+func (c *allowedFixedScopesCheckerCore) Allowed() bool {
+	switch c.checkerLevel {
+	case GlobalScopeKind:
+		return c.accessKeys.Cardinality() == 0
+	case AccessModeScopeKind:
+		return c.resourceKeys.Cardinality() == 0
+	case ResourceScopeKind:
+		return c.clusterKeys.Cardinality() == 0
+	case ClusterScopeKind:
+		// resourceScope := resources.GetScopeForResource(permissions.Resource(c.targetResource))
+		// if resourceScope == permissions.ClusterScope {
+		// 	return true
+		// }
+		return c.namespaceKeys.Cardinality() == 0
+	case NamespaceScopeKind:
+		return true
+	}
+	return false
+}
+
+func (c *allowedFixedScopesCheckerCore) EffectiveAccessScope(
+	resource permissions.ResourceWithAccess,
+) (*effectiveaccessscope.ScopeTree, error) {
+	if c.accessKeys.Cardinality() == 0 &&
+		c.resourceKeys.Cardinality() == 0 &&
+		c.clusterKeys.Cardinality() == 0 &&
+		c.resourceKeys.Cardinality() == 0 {
+		return effectiveaccessscope.UnrestrictedEffectiveAccessScope(), nil
+	}
+	if !c.accessKeys.Contains(AccessModeScopeKey(resource.Access)) {
+		return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
+	}
+	if c.resourceKeys.Cardinality() == 0 &&
+		c.clusterKeys.Cardinality() == 0 &&
+		c.resourceKeys.Cardinality() == 0 {
+		return effectiveaccessscope.UnrestrictedEffectiveAccessScope(), nil
+	}
+	targetResource := resource.Resource.GetResource()
+	targetReplacingResource := resource.Resource.GetReplacingResource()
+	if !c.resourceKeys.Contains(ResourceScopeKey(targetResource)) &&
+		(targetReplacingResource == nil || !c.resourceKeys.Contains(ResourceScopeKey(*targetReplacingResource))) {
+		return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
+	}
+	if c.clusterKeys.Cardinality() == 0 &&
+		c.namespaceKeys.Cardinality() == 0 {
+		return effectiveaccessscope.UnrestrictedEffectiveAccessScope(), nil
+	}
+	clusterIDs := make([]string, 0, c.clusterKeys.Cardinality())
+	for _, clusterKey := range c.clusterKeys.AsSlice() {
+		clusterIDs = append(clusterIDs, clusterKey.String())
+	}
+	if c.namespaceKeys.Cardinality() == 0 {
+		return effectiveaccessscope.FromClustersAndNamespacesMap(clusterIDs, nil), nil
+	}
+	namespaces := make([]string, 0, c.namespaceKeys.Cardinality())
+	for _, namespaceKey := range c.namespaceKeys.AsSlice() {
+		namespaces = append(namespaces, namespaceKey.String())
+	}
+	namespaceMap := make(map[string][]string, len(clusterIDs))
+	for clusterIx := range clusterIDs {
+		clusterID := clusterIDs[clusterIx]
+		namespaceMap[clusterID] = namespaces
+	}
+	return effectiveaccessscope.FromClustersAndNamespacesMap(nil, namespaceMap), nil
+}
 
 // AllowFixedScopes returns a scope checker core that allows those scopes that
 // are in the cross product of all individual scope key lists. I.e.,
@@ -19,105 +242,17 @@ type allowFixedScopesCheckerCore []scopeKeySet
 //
 // returns a scope checker core that allows read and write access to all cluster resources.
 func AllowFixedScopes(keyLists ...[]ScopeKey) ScopeCheckerCore {
-	sets := make(allowFixedScopesCheckerCore, len(keyLists))
-	for i, keyList := range keyLists {
-		set := make(map[ScopeKey]struct{}, len(keyList))
-		for _, key := range keyList {
-			set[key] = struct{}{}
-		}
-		sets[i] = set
-	}
-	return sets
-}
-
-func (c allowFixedScopesCheckerCore) Allowed() bool {
-	return len(c) == 0
-}
-
-func (c allowFixedScopesCheckerCore) SubScopeChecker(key ScopeKey) ScopeCheckerCore {
-	if len(c) == 0 {
-		return c
-	}
-	if _, ok := c.topLevelKeys()[key]; ok {
-		return c.next()
+	switch len(keyLists) {
+	case 0:
+		return allowFixedGlobalLevelScopes()
+	case 1:
+		return allowFixedAccessModeLevelScopes(keyLists[0])
+	case 2:
+		return allowFixedResourceLevelScopes(keyLists[0], keyLists[1])
+	case 3:
+		return allowFixedClusterLevelScopes(keyLists[0], keyLists[1], keyLists[2])
+	case 4:
+		return allowFixedNamespaceLevelScopes(keyLists[0], keyLists[1], keyLists[2], keyLists[3])
 	}
 	return denyAllScopeCheckerCore
-}
-
-func (c allowFixedScopesCheckerCore) EffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
-	if len(c) == 0 {
-		return effectiveaccessscope.UnrestrictedEffectiveAccessScope(), nil
-	}
-	// TODO (ROX-9981): Change the structure of allowFixedScopesCheckerCore to have explicit scope level semantic
-	for key := range c.topLevelKeys() {
-		switch key.(type) {
-		case AccessModeScopeKey:
-			return c.getAccessModeEffectiveAccessScope(resource)
-		case ResourceScopeKey:
-			return c.getResourceEffectiveAccessScope(resource)
-		case ClusterScopeKey:
-			return c.getClusterEffectiveAccessScope()
-		}
-		break
-	}
-	return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
-}
-
-func (c allowFixedScopesCheckerCore) getAccessModeEffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
-	if len(c) == 0 {
-		return effectiveaccessscope.UnrestrictedEffectiveAccessScope(), nil
-	}
-	_, accessAllowed := c.topLevelKeys()[AccessModeScopeKey(resource.Access)]
-	if !accessAllowed {
-		return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
-	}
-	return c.next().getResourceEffectiveAccessScope(resource)
-}
-
-func (c allowFixedScopesCheckerCore) getResourceEffectiveAccessScope(resource permissions.ResourceWithAccess) (*effectiveaccessscope.ScopeTree, error) {
-	if len(c) == 0 {
-		return effectiveaccessscope.UnrestrictedEffectiveAccessScope(), nil
-	}
-	_, resourceAllowed := c.topLevelKeys()[ResourceScopeKey(resource.Resource.GetResource())]
-	if !resourceAllowed {
-		if resource.Resource.GetReplacingResource() == nil {
-			return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
-		}
-		_, replacingResourceAllowed := c.topLevelKeys()[ResourceScopeKey(*resource.Resource.GetReplacingResource())]
-		if !replacingResourceAllowed {
-			return effectiveaccessscope.DenyAllEffectiveAccessScope(), nil
-		}
-	}
-	return c.next().getClusterEffectiveAccessScope()
-}
-
-func (c allowFixedScopesCheckerCore) getClusterEffectiveAccessScope() (*effectiveaccessscope.ScopeTree, error) {
-	if len(c) == 0 {
-		return effectiveaccessscope.UnrestrictedEffectiveAccessScope(), nil
-	}
-	clusterIDs := make([]string, 0, len(c[0]))
-	for clusterID := range c.topLevelKeys() {
-		clusterIDs = append(clusterIDs, clusterID.String())
-	}
-	if len(c) == 1 {
-		return effectiveaccessscope.FromClustersAndNamespacesMap(clusterIDs, nil), nil
-	}
-	namespaces := make([]string, 0, len(c[1]))
-	for namespace := range c.next().topLevelKeys() {
-		namespaces = append(namespaces, namespace.String())
-	}
-	clusterNamespaceMap := make(map[string][]string, 0)
-	for clusterIx := range clusterIDs {
-		clusterID := clusterIDs[clusterIx]
-		clusterNamespaceMap[clusterID] = namespaces
-	}
-	return effectiveaccessscope.FromClustersAndNamespacesMap(nil, clusterNamespaceMap), nil
-}
-
-func (c allowFixedScopesCheckerCore) topLevelKeys() scopeKeySet {
-	return c[0]
-}
-
-func (c allowFixedScopesCheckerCore) next() allowFixedScopesCheckerCore {
-	return c[1:]
 }

--- a/pkg/sac/resources/list.go
+++ b/pkg/sac/resources/list.go
@@ -153,6 +153,23 @@ func newInternalResourceMetadata(name permissions.Resource, scope permissions.Re
 	return md
 }
 
+// GetScopeForResource gives the scope associated with the target resource.
+func GetScopeForResource(resource permissions.Resource) permissions.ResourceScope {
+	md, found := resourceToMetadata[resource]
+	if found {
+		return md.GetScope()
+	}
+	md, found = disabledResourceToMetadata[resource]
+	if found {
+		return md.GetScope()
+	}
+	md, found = internalResourceToMetadata[resource]
+	if found {
+		return md.GetScope()
+	}
+	return permissions.GlobalScope
+}
+
 // ListAll returns a list of all resources.
 func ListAll() []permissions.Resource {
 	resources := make([]permissions.Resource, 0, len(resourceToMetadata))


### PR DESCRIPTION
## Description

**_Summary_**:
The AllowFixedScope checker core has a simplistic behaviour that is not consistent with the built-in scope checker core for cluster scoped resources.
In order to align the behaviour, a first step is taken in order to re-structure the AllowFixedScope checker core to later be able to align the behaviour.

**_Details_**:
Scoped access control basically checks whether the requested is granted access to a given action (accessMode) on a given resource, potentially for a given object. Objects being granted access to are tied to a scope level (global, tied to a cluster or tied to a namespace). Access checks to a given object are performed against an action on a resource, and potentially (depending on the resource scope level) a set of allowed clusters or namespaces in clusters.

The expected behaviour of scoped access control depends on the scope level being considered.
- For resources of global scope level, only the permissions (accessMode and target resource) should be considered.
- For resources of cluster scope level, accessMode and target resource are relevant, as well as whether the allowed scope includes at least part of the cluster where the target object resides.
- For resources of namespace scope level, all accessMode, target resource, cluster and namespace have to be considered.

There are essentially four strategies to define the set of action/resource/cluster/namespaces that are allowed for data access. These are enforced by specific ScopeCheckerCore classes:
- 1 - The built-in authorizer
- 2 - all-or-nothing access (allow-all or deny-all)
- 3 - allow specific ScopeKey hierarchies
- 4 - ad-hoc hierarchies for test purposes

The current refactor focuses on the third ScopeCheckerCore class.

This class is not necessarily aware of the scope level of the object being targeted, and does not properly enforces the expected behaviour for globally-scoped and cluster-scoped objects. This refactor aims at structuring the AllowFixedScopes ScopeCheckerCore to be aware of the allowed hierarchy as well as what action/resource/cluster/namespace is being considered for access check.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI should be sufficient
