### PR TITLE
ROX-18537: switch e2e tests in stackrox to core bpf

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -87,7 +87,7 @@ deploy_stackrox_with_custom_sensor() {
 export_test_environment() {
     ci_export ADMISSION_CONTROLLER_UPDATES "${ADMISSION_CONTROLLER_UPDATES:-true}"
     ci_export ADMISSION_CONTROLLER "${ADMISSION_CONTROLLER:-true}"
-    ci_export COLLECTION_METHOD "${COLLECTION_METHOD:-ebpf}"
+    ci_export COLLECTION_METHOD "${COLLECTION_METHOD:-core_bpf}"
     ci_export DEPLOY_STACKROX_VIA_OPERATOR "${DEPLOY_STACKROX_VIA_OPERATOR:-false}"
     ci_export INSTALL_COMPLIANCE_OPERATOR "${INSTALL_COMPLIANCE_OPERATOR:-false}"
     ci_export LOAD_BALANCER "${LOAD_BALANCER:-lb}"


### PR DESCRIPTION
## Description

The core_bpf collection method was recently released as a technical preview. In the next release it will be GA. In order to do that we need more confidence that it is working. E2e tests will be switched over to using core_bpf as the collection method. Some e2e tests will be kept as ebpf and the nightly CI runs will use both core_bpf and ebpf.

See the original issue in stackrox/collector

https://github.com/stackrox/collector/issues/1231

See the corresponding PR in openshift/release https://github.com/openshift/release/pull/41392

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Ran CI with ebpf as the default collection method

If any of these don't apply, please comment below.

Unit tests don't apply as no code is being added or changed.
CHANGELOG is not needed as there is no customer impact
No upgrade steps are needed as there are no code changes.
There are no user facing changes to document

## Testing Performed

### Ran CI with ebpf as the default collection method

See [this](https://github.com/stackrox/stackrox/pull/7000/commits/48e32db53a7e2b126b3562815a309424865afec1) commit

There were only four OSCI jobs that ran 

- gke-nongroovy-e2e-tests (Passed used ebpf)
- gke-qa-e2e-tests (Passed used ebpf)
- gke-sensor-integration-tests (Passed)
- shell-unit-tests (Passed. Doesn't use collector. So it is not relevant)
