### PR TITLE
chore(ui): Replace ui-components Avatar with inline code

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -41,6 +41,7 @@
         "graphql": "^15.5.0",
         "history": "^4.9.0",
         "html2canvas": "1.0.0-rc.7",
+        "initials": "^3.1.2",
         "js-base64": "^3.7.2",
         "jspdf": "^2.3.1",
         "jspdf-autotable": "^3.5.14",

--- a/ui/apps/platform/src/Containers/MainPage/Header/UserMenu.js
+++ b/ui/apps/platform/src/Containers/MainPage/Header/UserMenu.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
+import initials from 'initials';
 import {
     Dropdown,
     DropdownItem,
@@ -10,7 +11,6 @@ import {
     DropdownToggle,
     Flex,
 } from '@patternfly/react-core';
-import { Avatar } from '@stackrox/ui-components';
 
 import { selectors } from 'reducers';
 import { actions as authActions } from 'reducers/auth';
@@ -91,10 +91,9 @@ function UserMenu({ logout, userData }) {
 
     const toggle = (
         <DropdownToggle aria-label="User menu" onToggle={setIsOpen} toggleIndicator={null}>
-            <Avatar
-                name={name}
-                extraClassName="h-10 w-10 flex items-center justify-center leading-none"
-            />
+            <span className="h-10 w-10 flex items-center justify-center leading-none text-xl border border-base-400 rounded-full">
+                {name ? initials(name) : '--'}
+            </span>
         </DropdownToggle>
     );
 


### PR DESCRIPTION
## Description

Prerequisite to remove ui-components as a dependency.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

TL;DR Slight increase: to know, you measure.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 111 = 4231518 - 4231407
        total: 111 = 10248033 - 10247922
    * `ls -al build/static/js/*.js | wc -l`
        0 = 80 - 80 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/dashboard
    ![UserMenu](https://github.com/stackrox/stackrox/assets/11862657/bbd5299a-cce5-4c5e-8619-49ccc73cec42)

### Integration testing

* logout.test.js
* userInfo.test.js