### PR TITLE
ROX-18247: Add env var for registry mirroring support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Added Features
 
 - Telemetry collection enabled by default for self-managed installations. Opt-out is available on bundle generation, or at any time via the System Configuration UI.
-- A new environment variable `ROX_REGISTRY_MIRRORING_ENABLED` has been added that when set to `true` will enable processing registry mirrors during image enrichment.
+- A new environment variable `ROX_REGISTRY_MIRRORING_ENABLED` has been added that when set to `true` will enable processing registry mirrors during image enrichment. Mirror details are obtained via the `ImageContentSourcePolicy`, `ImageDigestMirrorSet`, and `ImageTagMirrorSet` CRs.
 
 ### Removed Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Added Features
 
 - Telemetry collection enabled by default for self-managed installations. Opt-out is available on bundle generation, or at any time via the System Configuration UI.
+- A new environment variable `ROX_REGISTRY_MIRRORING_ENABLED` has been added that when set to `true` will enable processing registry mirrors during image enrichment.
 
 ### Removed Features
 

--- a/pkg/env/registry_mirroring.go
+++ b/pkg/env/registry_mirroring.go
@@ -1,0 +1,6 @@
+package env
+
+var (
+	// RegistryMirroringEnabled enables processing registry mirrors during image enrichment.
+	RegistryMirroringEnabled = RegisterBooleanSetting("ROX_REGISTRY_MIRRORING_ENALBED", false)
+)

--- a/pkg/env/registry_mirroring.go
+++ b/pkg/env/registry_mirroring.go
@@ -2,5 +2,5 @@ package env
 
 var (
 	// RegistryMirroringEnabled enables processing registry mirrors during image enrichment.
-	RegistryMirroringEnabled = RegisterBooleanSetting("ROX_REGISTRY_MIRRORING_ENALBED", false)
+	RegistryMirroringEnabled = RegisterBooleanSetting("ROX_REGISTRY_MIRRORING_ENABLED", false)
 )


### PR DESCRIPTION
## Description

Adds an environment variable `ROX_REGISTRY_MIRRORING_ENABLED` that will be used to control enabling / disabling support for registry mirroring capabilities.

Is un-used as of this PR, will be consumed as the stories in ROX-11347 are implemented.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

Unit tests and docs will be added as part of stories mentioned in ROX-11347

## Testing Performed

N/A
