### PR TITLE
ROX-18563: byodb pgbouncer

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-08-external-db-configmap.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-08-external-db-configmap.yaml
@@ -13,7 +13,7 @@ data:
     centralDB:
       {{- if ._rox.central.db.external }}
       external: true
-      source: {{ ._rox.central.db.source.connectionString }} statement_timeout={{ ._rox.central.db.source.statementTimeoutMs }} pool_min_conns={{ ._rox.central.db.source.minConns }} pool_max_conns={{ ._rox.central.db.source.maxConns }}
+      source: {{ ._rox.central.db.source.connectionString }} pool_min_conns={{ ._rox.central.db.source.minConns }} pool_max_conns={{ ._rox.central.db.source.maxConns }}
       {{- else }}
       external: false
       source: >

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -271,6 +271,7 @@
 #       # ConnectionString should not be specified if the Central DB deployment is being managed by the helm chart
 #       # The connection string must be in the format described here https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
 #       # The only connection string format supported is as specified in "34.1.1.1. Keyword/Value Connection Strings"
+#       # If using a connection that supports "statement_timeout" it is recommended to include "statement_timeout=1200000"
 #       # Do NOT use a connection string with a password field. Instead specify the value below in the password section in values-private.yaml.
 #       connectionString: "host=central-db.stackrox port=5432 user=postgres sslmode=verify-full"
 #       minConns: 10

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -271,6 +271,7 @@
 #       # ConnectionString should not be specified if the Central DB deployment is being managed by the helm chart
 #       # The connection string must be in the format described here https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
 #       # The only connection string format supported is as specified in "34.1.1.1. Keyword/Value Connection Strings"
+#       # client_encoding=UTF8 is required in any connection string and the only supported encoding
 #       # statementTimeoutMs is ignored for external database connections
 #       # If using a connection that supports "statement_timeout" it is recommended to include "statement_timeout=1200000"
 #       # Do NOT use a connection string with a password field. Instead specify the value below in the password section in values-private.yaml.

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -271,6 +271,7 @@
 #       # ConnectionString should not be specified if the Central DB deployment is being managed by the helm chart
 #       # The connection string must be in the format described here https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
 #       # The only connection string format supported is as specified in "34.1.1.1. Keyword/Value Connection Strings"
+#       # statementTimeoutMs is ignored for external database connections
 #       # If using a connection that supports "statement_timeout" it is recommended to include "statement_timeout=1200000"
 #       # Do NOT use a connection string with a password field. Instead specify the value below in the password section in values-private.yaml.
 #       connectionString: "host=central-db.stackrox port=5432 user=postgres sslmode=verify-full"

--- a/image/templates/helm/stackrox-central/values.yaml.htpl
+++ b/image/templates/helm/stackrox-central/values.yaml.htpl
@@ -204,6 +204,7 @@ central:
 #    source:
 #      # ConnectionString should not be specified if the Central DB deployment is being managed by the helm chart
 #      # The connection string must be in the format described here https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
+#      # If using a connection that supports "statement_timeout" it is recommended to include "statement_timeout=1200000"
 #      # Do NOT use a connection string with a password field. Instead specify the value below in the password section/
 #      connectionString: null
 #      minConns: 10

--- a/image/templates/helm/stackrox-central/values.yaml.htpl
+++ b/image/templates/helm/stackrox-central/values.yaml.htpl
@@ -204,6 +204,7 @@ central:
 #    source:
 #      # ConnectionString should not be specified if the Central DB deployment is being managed by the helm chart
 #      # The connection string must be in the format described here https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
+#      # client_encoding=UTF8 is required in any connection string and the only supported encoding
 #      # statementTimeoutMs is ignored for external database connections
 #      # If using a connection that supports "statement_timeout" it is recommended to include "statement_timeout=1200000"
 #      # Do NOT use a connection string with a password field. Instead specify the value below in the password section/

--- a/image/templates/helm/stackrox-central/values.yaml.htpl
+++ b/image/templates/helm/stackrox-central/values.yaml.htpl
@@ -204,6 +204,7 @@ central:
 #    source:
 #      # ConnectionString should not be specified if the Central DB deployment is being managed by the helm chart
 #      # The connection string must be in the format described here https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
+#      # statementTimeoutMs is ignored for external database connections
 #      # If using a connection that supports "statement_timeout" it is recommended to include "statement_timeout=1200000"
 #      # Do NOT use a connection string with a password field. Instead specify the value below in the password section/
 #      connectionString: null

--- a/migrator/postgres/gorm/config.go
+++ b/migrator/postgres/gorm/config.go
@@ -55,7 +55,7 @@ func getConfig() (*gormConfig, error) {
 		return nil, errors.Wrapf(err, "pgsql: could not load password file %q", pgconfig.DBPasswordFile)
 	}
 	// Add the password to the source to pass to get the pool config
-	source := fmt.Sprintf("%s password=%s client_encoding=UTF8", centralConfig.CentralDB.Source, password)
+	source := fmt.Sprintf("%s password=%s", centralConfig.CentralDB.Source, password)
 	source = pgutils.PgxpoolDsnToPgxDsn(source)
 	gConfig = &gormConfig{source: source, password: string(password)}
 	return gConfig, nil

--- a/migrator/postgreshelper/load.go
+++ b/migrator/postgreshelper/load.go
@@ -30,10 +30,13 @@ func GetConnections() (postgres.DB, *gorm.DB, error) {
 		return nil, nil, err
 	}
 
-	// For migrations we may have long running jobs.  Here we explicitly turn
-	// off the statement timeout for the connection and will rely on the context
-	// timeouts to control this.
-	//dbConfig.ConnConfig.RuntimeParams["statement_timeout"] = "0"
+	if !pgconfig.IsExternalDatabase() {
+		// For migrations we may have long running jobs.  Here we explicitly turn
+		// off the statement timeout for the connection and will rely on the context
+		// timeouts to control this.
+		dbConfig.ConnConfig.RuntimeParams["statement_timeout"] = "0"
+	}
+
 	postgresDB, err = pgadmin.GetPool(dbConfig)
 	if err != nil {
 		log.WriteToStderrf("timed out connecting to database: %v", err)
@@ -75,12 +78,13 @@ func Load(databaseName string) (postgres.DB, *gorm.DB, error) {
 				return nil, nil, err
 			}
 		}
+
+		// For migrations we may have long running jobs.  Here we explicitly turn
+		// off the statement timeout for the connection and will rely on the context
+		// timeouts to control this.
+		adminConfig.ConnConfig.RuntimeParams["statement_timeout"] = "0"
 	}
 
-	// For migrations we may have long running jobs.  Here we explicitly turn
-	// off the statement timeout for the connection and will rely on the context
-	// timeouts to control this.
-	//adminConfig.ConnConfig.RuntimeParams["statement_timeout"] = "0"
 	postgresDB, err = pgadmin.GetClonePool(adminConfig, databaseName)
 	if err != nil {
 		log.WriteToStderrf("timed out connecting to database: %v", err)

--- a/migrator/postgreshelper/load.go
+++ b/migrator/postgreshelper/load.go
@@ -33,7 +33,7 @@ func GetConnections() (postgres.DB, *gorm.DB, error) {
 	// For migrations we may have long running jobs.  Here we explicitly turn
 	// off the statement timeout for the connection and will rely on the context
 	// timeouts to control this.
-	dbConfig.ConnConfig.RuntimeParams["statement_timeout"] = "0"
+	//dbConfig.ConnConfig.RuntimeParams["statement_timeout"] = "0"
 	postgresDB, err = pgadmin.GetPool(dbConfig)
 	if err != nil {
 		log.WriteToStderrf("timed out connecting to database: %v", err)
@@ -80,7 +80,7 @@ func Load(databaseName string) (postgres.DB, *gorm.DB, error) {
 	// For migrations we may have long running jobs.  Here we explicitly turn
 	// off the statement timeout for the connection and will rely on the context
 	// timeouts to control this.
-	adminConfig.ConnConfig.RuntimeParams["statement_timeout"] = "0"
+	//adminConfig.ConnConfig.RuntimeParams["statement_timeout"] = "0"
 	postgresDB, err = pgadmin.GetClonePool(adminConfig, databaseName)
 	if err != nil {
 		log.WriteToStderrf("timed out connecting to database: %v", err)


### PR DESCRIPTION
## Description

pgbouncer is a connection pooler that does not accept the `statement_timeout` parameter.  So we have to not append that parameter to the connection string of external databases in order to support pgbouncer backed databases.  The changes here remove that from the external connection.  Also adjusted `client_encoding`.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

spun up a pgbouncer following this:
https://github.com/edoburu/docker-pgbouncer/blob/master/examples/kubernetes/README.md

Then tested it with external and pgbouncer connected to an external database.
