### PR TITLE
ROX-18472: Add sorting to listening endpoint columns

### DIFF
--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -18,12 +18,19 @@ import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate/EmptySt
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useURLPagination from 'hooks/useURLPagination';
+import useURLSort from 'hooks/useURLSort';
 import { useDeploymentListeningEndpoints } from './hooks/useDeploymentListeningEndpoints';
 import ListeningEndpointsTable from './ListeningEndpointsTable';
 
+const sortOptions = {
+    sortFields: ['Deployment', 'Namespace', 'Cluster'],
+    defaultSortOption: { field: 'Deployment', direction: 'asc' } as const,
+};
+
 function ListeningEndpointsPage() {
     const { page, perPage, setPage, setPerPage } = useURLPagination(10);
-    const { data, error, loading } = useDeploymentListeningEndpoints(page, perPage);
+    const { sortOption, getSortParams } = useURLSort(sortOptions);
+    const { data, error, loading } = useDeploymentListeningEndpoints(sortOption, page, perPage);
 
     return (
         <>
@@ -91,7 +98,10 @@ function ListeningEndpointsPage() {
                                     </EmptyStateTemplate>
                                 </Bullseye>
                             ) : (
-                                <ListeningEndpointsTable deployments={data} />
+                                <ListeningEndpointsTable
+                                    deployments={data}
+                                    getSortParams={getSortParams}
+                                />
                             )}
                         </>
                     )}

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -6,6 +6,7 @@ import { ProcessListeningOnPort } from 'services/ProcessListeningOnPortsService'
 import { l4ProtocolLabels } from 'constants/networkFlow';
 import { ListDeployment } from 'types/deployment.proto';
 import useSet from 'hooks/useSet';
+import { GetSortParams } from 'hooks/useURLSort';
 
 function EmbeddedTable({
     deploymentId,
@@ -44,18 +45,21 @@ function EmbeddedTable({
 
 export type ListeningEndpointsTableProps = {
     deployments: (ListDeployment & { listeningEndpoints: ProcessListeningOnPort[] })[];
+    getSortParams: GetSortParams;
 };
 
-function ListeningEndpointsTable({ deployments }: ListeningEndpointsTableProps) {
+function ListeningEndpointsTable({ deployments, getSortParams }: ListeningEndpointsTableProps) {
     const expandedRowSet = useSet<string>();
     return (
         <TableComposable variant="compact">
             <Thead noWrap>
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>
-                    <Th width={30}>Deployment</Th>
-                    <Th>Namespace</Th>
-                    <Th>Cluster</Th>
+                    <Th width={30} sort={getSortParams('Deployment')}>
+                        Deployment
+                    </Th>
+                    <Th sort={getSortParams('Namespace')}>Namespace</Th>
+                    <Th sort={getSortParams('Cluster')}>Cluster</Th>
                 </Tr>
             </Thead>
             {deployments.map(({ id, name, namespace, cluster, listeningEndpoints }, rowIndex) => {

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/hooks/useDeploymentListeningEndpoints.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/hooks/useDeploymentListeningEndpoints.tsx
@@ -2,15 +2,18 @@ import { useCallback } from 'react';
 import { listDeployments } from 'services/DeploymentsService';
 import { getListeningEndpointsForDeployment } from 'services/ProcessListeningOnPortsService';
 import useRestQuery from 'hooks/useRestQuery';
-
-const sortOptions = { field: 'Deployment', reversed: 'false' };
+import { ApiSortOption } from 'types/search';
 
 /**
  * Returns a paginated list of deployments with their listening endpoints.
  */
-export function useDeploymentListeningEndpoints(page, perPage) {
+export function useDeploymentListeningEndpoints(
+    sortOption: ApiSortOption,
+    page: number,
+    perPage: number
+) {
     const queryFn = useCallback(() => {
-        return listDeployments({}, sortOptions, page - 1, perPage).then((res) => {
+        return listDeployments({}, sortOption, page - 1, perPage).then((res) => {
             return Promise.all(
                 res.map((deployment) => {
                     const { request } = getListeningEndpointsForDeployment(deployment.id);
@@ -21,7 +24,7 @@ export function useDeploymentListeningEndpoints(page, perPage) {
                 })
             );
         });
-    }, [page, perPage]);
+    }, [sortOption, page, perPage]);
 
     return useRestQuery(queryFn);
 }

--- a/ui/apps/platform/src/services/DeploymentsService.ts
+++ b/ui/apps/platform/src/services/DeploymentsService.ts
@@ -4,7 +4,7 @@ import searchOptionsToQuery, { RestSearchOption } from 'services/searchOptionsTo
 import { Deployment, ListDeployment } from 'types/deployment.proto';
 import { ContainerNameAndBaselineStatus } from 'types/processBaseline.proto';
 import { Risk } from 'types/risk.proto';
-import { SearchFilter } from 'types/search';
+import { ApiSortOption, SearchFilter } from 'types/search';
 import {
     ORCHESTRATOR_COMPONENTS_KEY,
     orchestratorComponentsOption,
@@ -25,7 +25,7 @@ function shouldHideOrchestratorComponents() {
 
 function fillDeploymentSearchQuery(
     searchFilter: SearchFilter,
-    sortOption: Record<string, string>,
+    sortOption: Record<string, string> | ApiSortOption,
     page: number,
     pageSize: number
 ): string {
@@ -33,7 +33,7 @@ function fillDeploymentSearchQuery(
     const query = getRequestQueryStringForSearchFilter(searchFilter);
     const queryObject: Record<
         string,
-        string | Record<string, number | string | Record<string, string>>
+        string | Record<string, number | string | Record<string, string> | ApiSortOption>
     > = {
         pagination: {
             offset,
@@ -56,7 +56,7 @@ function fillDeploymentSearchQuery(
  */
 export function listDeployments(
     searchFilter: SearchFilter,
-    sortOption: Record<string, string>,
+    sortOption: Record<string, string> | ApiSortOption,
     page: number,
     pageSize: number
 ): Promise<ListDeployment[]> {
@@ -76,7 +76,7 @@ export function listDeployments(
  */
 export function fetchDeploymentsWithProcessInfo(
     searchFilter: SearchFilter,
-    sortOption: Record<string, string>,
+    sortOption: Record<string, string> | ApiSortOption,
     page: number,
     pageSize: number
 ): CancellableRequest<ListDeploymentWithProcessInfo[]> {


### PR DESCRIPTION
## Description

As titled.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the listening endpoints page, default sort should be by Deployment, ascending.
![image](https://github.com/stackrox/stackrox/assets/1292638/83892201-0037-4892-a4e8-3bd9f6b77c30)

Check deployment descending:
![image](https://github.com/stackrox/stackrox/assets/1292638/75ada4d2-6fa1-4c0f-b302-ce2c7ace1023)

Sorting by Namespace:
![image](https://github.com/stackrox/stackrox/assets/1292638/e4445ccc-9f72-4561-af2f-8ab050d0d4f9)
![image](https://github.com/stackrox/stackrox/assets/1292638/f9e07df6-2cb8-48d5-b7e8-de8f93721c0d)

Sorting by Cluster (tested against staging):
![image](https://github.com/stackrox/stackrox/assets/1292638/ba855bf2-9d20-4c46-8a32-661e1eb7096a)
![image](https://github.com/stackrox/stackrox/assets/1292638/5d39e7fe-77f7-4441-99ab-f548bd198461)

## Follow ups
- Stagingdb seems to never return listening endpoint data. Why?


