### PR TITLE
Refining Vulnerability Updater Workflow for Scanner V4 Based on Release Versions

### DIFF
--- a/.github/workflows/start-vulnerability-updater.yaml
+++ b/.github/workflows/start-vulnerability-updater.yaml
@@ -1,0 +1,65 @@
+name: Vulnerability Updater
+on:
+  push:
+    branches:
+      - "yli3/**"
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  read-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.output-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Generate matrix JSON
+        id: output-matrix
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "matrix<<$EOF" >> $GITHUB_OUTPUT
+          sed -n '/^\s*\(#.*\)\?$/!p' scanner/updater/version/RELEASE_VERSION | jq -Rs '{ versions: split("\n") }' | tee -a "$GITHUB_OUTPUT"
+          echo $EOF >> $GITHUB_OUTPUT
+
+  upload-vulnerabilities:
+    needs: read-versions
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ${{fromJson(needs.read-versions.outputs.matrix).versions}}
+    env:
+      ROX_PRODUCT_VERSION: ${{ matrix.version }}
+    steps:
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Update vulnerabilities
+        run: |
+          DOWNLOAD_URL="https://github.com/stackrox/stackrox/archive/refs/tags/${{ env.ROX_PRODUCT_VERSION }}.zip"
+          FILE_NAME=$(basename "$DOWNLOAD_URL")
+          wget "$DOWNLOAD_URL" -O "$FILE_NAME"
+          unzip "$FILE_NAME" -d unzipped-dir
+          cd unzipped-dir/stackrox-*
+          if [ ! -d "scanner" ]; then
+            echo "Scanner directory not found. Terminating current matrix step."
+            exit 0
+          fi
+          
+          cd scanner
+          go run cmd/updater/main.go -outputDir=${{ env.ROX_PRODUCT_VERSION }}
+          gsutil cp -r "${{ env.ROX_PRODUCT_VERSION }}" "gs://scanner-v4-test/"
+        
+  send-notification:
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+    - name: Send Slack notification on workflow failure
+      run: |
+        curl -X POST -H 'Content-type: application/json' --data '{"text":"<!subteam^S04S96AAVND|acs-scanner-primary> Failure in Scanner Updater Workflow: Failed to update vulnerabilities"}' ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}

--- a/scanner/cmd/scanner/scanner.go
+++ b/scanner/cmd/scanner/scanner.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"context"
+
+	"github.com/quay/zlog"
+	"github.com/stackrox/scanner/v4/version"
+)
+
+func main() {
+	// TODO: Log intro message with Scanner version.
+	zlog.Info(context.Background()).
+		Str("Version", version.Version).
+		Str("Mode", "TODO").
+		Msg("Running Scanner")
+
+	// Step 1. Read configuration file. This will determine how to contact DB and which mode to run in
+	// Step 2. Initialize API services and create ClairCore structs based on configuration settings
+}

--- a/scanner/cmd/updater/main.go
+++ b/scanner/cmd/updater/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/quay/zlog"
+	"github.com/stackrox/stackrox/scanner/v4/updater"
+)
+
+func main() {
+	// Parse command-line flags
+	outputDir := flag.String("outputDir", "", "Output directory")
+	flag.Parse()
+
+	// Check if outputDir flag is provided
+	if *outputDir == "" {
+		log.Fatal("Missing argument for the output directory.")
+	}
+
+	ctx := context.Background()
+	if err := updater.Export(ctx, *outputDir); err != nil {
+		zlog.Error(ctx).Err(err).Send()
+	}
+
+}

--- a/scanner/updater/export.go
+++ b/scanner/updater/export.go
@@ -1,0 +1,106 @@
+package updater
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/claircore/libvuln/jsonblob"
+	"github.com/quay/claircore/libvuln/updates"
+	_ "github.com/quay/claircore/updater/defaults"
+	"github.com/quay/zlog"
+	"github.com/stackrox/stackrox/scanner/v4/updater/manual"
+	"golang.org/x/time/rate"
+)
+
+// Export is responsible for triggering the updaters to download Common Vulnerabilities and Exposures (CVEs) data
+// and then outputting the result as a zstd-compressed file with .ztd extension
+func Export(ctx context.Context, outputDir string) error {
+	var outOfTree []driver.Updater
+
+	// Append updater sets directly to the outOfTree
+	appendUpdaterSet := func(updaterSet driver.UpdaterSet, err error) {
+		if err != nil {
+			zlog.Error(ctx).Err(err).Send()
+			return
+		}
+		outOfTree = append(outOfTree, updaterSet.Updaters()...)
+	}
+
+	appendUpdaterSet(manual.UpdaterSet(ctx, nil))
+
+	// create temp folder
+	err := os.Mkdir(outputDir, 0700)
+	if err != nil {
+		return err
+	}
+
+	// create temp file
+	outputFile, err := os.Create(filepath.Join(outputDir, "output.json.ztd"))
+	if err != nil {
+		return err
+	}
+	defer outputFile.Close()
+
+	limiter := rate.NewLimiter(rate.Every(time.Second), 5)
+	httpClient := &http.Client{
+		Transport: &rateLimitedTransport{
+			limiter:   limiter,
+			transport: http.DefaultTransport,
+		},
+	}
+
+	zstdWriter, err := zstd.NewWriter(outputFile)
+	if err != nil {
+		return err
+	}
+	defer zstdWriter.Close()
+
+	updaterStore, err := jsonblob.New()
+	updaterSetMgr, err := updates.NewManager(ctx, updaterStore, updates.NewLocalLockSource(), httpClient,
+		updates.WithEnabled([]string{"oracle", "photon", "suse", "aws", "rhcc"}),
+		updates.WithOutOfTree(outOfTree),
+	)
+	if err != nil {
+		return err
+	}
+	if err := updaterSetMgr.Run(ctx); err != nil {
+		return err
+	}
+
+	err = updaterStore.Store(zstdWriter)
+	if err != nil {
+		return err
+	}
+
+	configStore, err := jsonblob.New()
+	configMgr, err := updates.NewManager(ctx, configStore, updates.NewLocalLockSource(), http.DefaultClient,
+		updates.WithEnabled([]string{"debian", "alpine", "rhel", "ubuntu", "osv"}),
+	)
+	if err := configMgr.Run(ctx); err != nil {
+		return err
+	}
+
+	err = configStore.Store(zstdWriter)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type rateLimitedTransport struct {
+	limiter   *rate.Limiter
+	transport http.RoundTripper
+}
+
+func (t *rateLimitedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := t.limiter.Wait(req.Context()); err != nil {
+		return nil, err
+	}
+	return t.transport.RoundTrip(req)
+}

--- a/scanner/updater/manual/data.go
+++ b/scanner/updater/manual/data.go
@@ -1,0 +1,7 @@
+package manual
+
+import (
+	"github.com/quay/claircore"
+)
+
+var manuallyEnrichedVulns = []*claircore.Vulnerability{}

--- a/scanner/updater/manual/manual.go
+++ b/scanner/updater/manual/manual.go
@@ -1,0 +1,40 @@
+package manual
+
+import (
+	"context"
+	"io"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/libvuln/driver"
+)
+
+// Factory is the UpdaterSetFactory exposed by this package.
+//
+// All configuration is done on the returned updaters.
+type Factory struct {
+}
+
+func UpdaterSet(_ context.Context, vulns []*claircore.Vulnerability) (driver.UpdaterSet, error) {
+	res := driver.NewUpdaterSet()
+	res.Add(&updater{data: vulns})
+	return res, nil
+}
+
+type updater struct {
+	data []*claircore.Vulnerability
+}
+
+var _ driver.Updater = (*updater)(nil)
+
+func (u *updater) Name() string { return `manual updater` }
+
+func (u *updater) Fetch(_ context.Context, _ driver.Fingerprint) (io.ReadCloser, driver.Fingerprint, error) {
+	return nil, "", nil
+}
+
+func (u *updater) Parse(_ context.Context, _ io.ReadCloser) ([]*claircore.Vulnerability, error) {
+	if u.data == nil || len(u.data) == 0 {
+		return manuallyEnrichedVulns, nil
+	}
+	return u.data, nil
+}

--- a/scanner/updater/manual/manual_example_test.go
+++ b/scanner/updater/manual/manual_example_test.go
@@ -1,0 +1,69 @@
+package manual
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/datastore/postgres"
+	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/claircore/libvuln/updates"
+	"github.com/quay/claircore/test/integration"
+	pgtest "github.com/quay/claircore/test/postgres"
+	"github.com/quay/zlog"
+)
+
+var manuallyTestVulns = []*claircore.Vulnerability{
+	{
+		Updater:     "manual",
+		Name:        "GHSA-cj7v-27pg-wf7q",
+		Description: "URI use within Jetty's HttpURI class can parse invalid URIs such as http://localhost;/path as having an authority with a host of localhost;A URIs of the type http://localhost;/path should be interpreted to be either invalid or as localhost; to be the userinfo and no host. However, HttpURI.host returns localhost; which is definitely wrong.",
+		//Issued:             time.Parse("2006-01-02 15:04", "2022-07-07T20:55:34Z"),
+		Links:              "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2022/07/GHSA-cj7v-27pg-wf7q/GHSA-cj7v-27pg-wf7q.json",
+		Severity:           "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:L/A:N",
+		NormalizedSeverity: claircore.Low,
+		Package: &claircore.Package{
+			Name: "org.eclipse.jetty:jetty-http",
+			Kind: claircore.BINARY,
+		},
+		FixedInVersion: "fixed=9.4.47&introduced=0",
+		Repo: &claircore.Repository{
+			Name: "maven",
+		},
+	}}
+
+func ManualUpdater(t *testing.T) {
+	ctx := context.Background()
+	var updaters []driver.Updater
+
+	// Append updater sets directly to the updaters
+	appendUpdaterSet := func(updaterSet driver.UpdaterSet, err error) {
+		if err != nil {
+			zlog.Error(ctx).Msg(err.Error())
+			return
+		}
+		updaters = append(updaters, updaterSet.Updaters()...)
+	}
+	integration.NeedDB(t)
+	pool := pgtest.TestMatcherDB(ctx, t)
+	store := postgres.NewMatcherStore(pool)
+	appendUpdaterSet(UpdaterSet(ctx, manuallyTestVulns))
+	updaterSetMgr, err := updates.NewManager(ctx, store, updates.NewLocalLockSource(), http.DefaultClient,
+		updates.WithOutOfTree(updaters),
+	)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	if err = updaterSetMgr.Run(ctx); err != nil {
+		fmt.Println(err)
+		return
+	}
+}
+
+// TestExampleManualUpdater: go test -run ExampleManualUpdater
+func TestExampleManualUpdater(t *testing.T) {
+	ManualUpdater(t)
+}

--- a/scanner/updater/version/RELEASE_VERSION
+++ b/scanner/updater/version/RELEASE_VERSION
@@ -1,0 +1,9 @@
+# This file lists the ACS versions supported by Scanner V4 and Scanner V4 Updater.
+# Since Scanner V4 shares the same version as ACS,
+# Scanner V4 Updater updates vulnerability data for all versions of Scanner V4 listed in this file
+# and uploads that data to Google Storage.
+# Various versions of Scanner V4 matchers will import vulnerability data based on their respective versions from Google Storage.
+4.0.0
+3.74.4
+4.1.x-475-g08897c063a
+4.1.x-470-g7f0dea0e37


### PR DESCRIPTION
## Description
Implementation of a workflow for iterating through the supported versions of ACS and retrieve vulnerability data for each version. This workflow allows us to periodically pull the necessary vulnerability information, ensuring that we cover all supported ACS versions

export.go module calls collection of Claircore updaters, is responsible for downloading vulnerability data. Once the updaters have completed their execution, a JSON blob containing the vulnerability data is generated as a result. This process ensures the retrieval and consolidation of up-to-date vulnerability information through the utilization of the Claircore updaters.

The vuln data json will be uploaded to google storage, currently the bucket is stackrox-dev

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Determined and documented upgrade steps

## Testing Performed

Run workflow in the CI
Updated vulns by release version: https://console.cloud.google.com/storage/browser/scanner-v4-test?project=stackrox-dev&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&prefix=&forceOnObjectsSortingFiltering=false
