### PR TITLE
ROX-18473: Add search input to listening endpoints table.

### DIFF
--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
     Bullseye,
     Button,
     Divider,
     PageSection,
     Pagination,
+    SearchInput,
     Spinner,
     Text,
     Title,
@@ -19,6 +20,7 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
+import useURLSearch from 'hooks/useURLSearch';
 import { useDeploymentListeningEndpoints } from './hooks/useDeploymentListeningEndpoints';
 import ListeningEndpointsTable from './ListeningEndpointsTable';
 
@@ -30,7 +32,22 @@ const sortOptions = {
 function ListeningEndpointsPage() {
     const { page, perPage, setPage, setPerPage } = useURLPagination(10);
     const { sortOption, getSortParams } = useURLSort(sortOptions);
-    const { data, error, loading } = useDeploymentListeningEndpoints(sortOption, page, perPage);
+    const { searchFilter, setSearchFilter } = useURLSearch();
+    const [searchValue, setSearchValue] = useState(() => {
+        const filter = searchFilter.Deployment;
+        return Array.isArray(filter) ? filter.join(',') : filter;
+    });
+
+    const { data, error, loading } = useDeploymentListeningEndpoints(
+        searchFilter,
+        sortOption,
+        page,
+        perPage
+    );
+
+    function onSearchInputChange(_event, value) {
+        setSearchValue(value);
+    }
 
     return (
         <>
@@ -42,6 +59,19 @@ function ListeningEndpointsPage() {
             <PageSection isFilled className="pf-u-display-flex pf-u-flex-direction-column">
                 <Toolbar>
                     <ToolbarContent>
+                        <ToolbarItem variant="search-filter" className="pf-u-flex-grow-1">
+                            <SearchInput
+                                aria-label="Search by deployment"
+                                placeholder="Search by deployment"
+                                value={searchValue}
+                                onChange={onSearchInputChange}
+                                onSearch={() => setSearchFilter({ Deployment: searchValue })}
+                                onClear={() => {
+                                    setSearchValue('');
+                                    setSearchFilter({});
+                                }}
+                            />
+                        </ToolbarItem>
                         <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
                             <Pagination
                                 toggleTemplate={({ firstIndex, lastIndex }) => (
@@ -90,7 +120,9 @@ function ListeningEndpointsPage() {
                                         <Button
                                             variant="link"
                                             onClick={() => {
-                                                /* TODO */
+                                                setPage(1);
+                                                setSearchValue('');
+                                                setSearchFilter({});
                                             }}
                                         >
                                             Clear search

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -19,12 +19,12 @@ function EmbeddedTable({
         <TableComposable isNested>
             <Thead noWrap>
                 <Tr>
-                    <Th>Program name</Th>
-                    <Th>PID</Th>
-                    <Th>Port</Th>
-                    <Th>Protocol</Th>
-                    <Th>Pod ID</Th>
-                    <Th>Container name</Th>
+                    <Th width={20}>Program name</Th>
+                    <Th width={10}>PID</Th>
+                    <Th width={10}>Port</Th>
+                    <Th width={10}>Protocol</Th>
+                    <Th width={30}>Pod ID</Th>
+                    <Th width={20}>Container name</Th>
                 </Tr>
             </Thead>
             <Tbody>
@@ -54,12 +54,16 @@ function ListeningEndpointsTable({ deployments, getSortParams }: ListeningEndpoi
         <TableComposable variant="compact">
             <Thead noWrap>
                 <Tr>
-                    <Th>{/* Header for expanded column */}</Th>
+                    <Td width={10}>{/* Header for expanded column */}</Td>
                     <Th width={30} sort={getSortParams('Deployment')}>
                         Deployment
                     </Th>
-                    <Th sort={getSortParams('Namespace')}>Namespace</Th>
-                    <Th sort={getSortParams('Cluster')}>Cluster</Th>
+                    <Th width={30} sort={getSortParams('Namespace')}>
+                        Namespace
+                    </Th>
+                    <Th width={30} sort={getSortParams('Cluster')}>
+                        Cluster
+                    </Th>
                 </Tr>
             </Thead>
             {deployments.map(({ id, name, namespace, cluster, listeningEndpoints }, rowIndex) => {

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/hooks/useDeploymentListeningEndpoints.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/hooks/useDeploymentListeningEndpoints.tsx
@@ -2,18 +2,19 @@ import { useCallback } from 'react';
 import { listDeployments } from 'services/DeploymentsService';
 import { getListeningEndpointsForDeployment } from 'services/ProcessListeningOnPortsService';
 import useRestQuery from 'hooks/useRestQuery';
-import { ApiSortOption } from 'types/search';
+import { ApiSortOption, SearchFilter } from 'types/search';
 
 /**
  * Returns a paginated list of deployments with their listening endpoints.
  */
 export function useDeploymentListeningEndpoints(
+    searchFilter: SearchFilter,
     sortOption: ApiSortOption,
     page: number,
     perPage: number
 ) {
     const queryFn = useCallback(() => {
-        return listDeployments({}, sortOption, page - 1, perPage).then((res) => {
+        return listDeployments(searchFilter, sortOption, page - 1, perPage).then((res) => {
             return Promise.all(
                 res.map((deployment) => {
                     const { request } = getListeningEndpointsForDeployment(deployment.id);
@@ -24,7 +25,7 @@ export function useDeploymentListeningEndpoints(
                 })
             );
         });
-    }, [sortOption, page, perPage]);
+    }, [searchFilter, sortOption, page, perPage]);
 
     return useRestQuery(queryFn);
 }


### PR DESCRIPTION
## Description

As titled again.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the listening endpoints page:
![image](https://github.com/stackrox/stackrox/assets/1292638/c9e778e5-9e8c-4634-8a8f-65e562d42fb2)

Enter a search value and press enter -or- click the `->` button:
![image](https://github.com/stackrox/stackrox/assets/1292638/60a86911-89d2-4645-a85b-46cee807167a)

Click the `X` button to clear the search:
![image](https://github.com/stackrox/stackrox/assets/1292638/9edf0c31-e311-4907-9aca-ae7f4de73569)

Open multiple deployments and view the alignment of the nested tables:
![image](https://github.com/stackrox/stackrox/assets/1292638/c55fc4dc-b8b6-4ce0-b37b-2ff8e8cb38e4)


