### PR TITLE
ROX-18608: Add context to NetworFlows offline v1

### DIFF
--- a/sensor/common/detector/mocks/detector.go
+++ b/sensor/common/detector/mocks/detector.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	central "github.com/stackrox/rox/generated/internalapi/central"
@@ -104,15 +105,15 @@ func (mr *MockDetectorMockRecorder) ProcessMessage(msg interface{}) *gomock.Call
 }
 
 // ProcessNetworkFlow mocks base method.
-func (m *MockDetector) ProcessNetworkFlow(flow *storage.NetworkFlow) {
+func (m *MockDetector) ProcessNetworkFlow(ctx context.Context, flow *storage.NetworkFlow) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ProcessNetworkFlow", flow)
+	m.ctrl.Call(m, "ProcessNetworkFlow", ctx, flow)
 }
 
 // ProcessNetworkFlow indicates an expected call of ProcessNetworkFlow.
-func (mr *MockDetectorMockRecorder) ProcessNetworkFlow(flow interface{}) *gomock.Call {
+func (mr *MockDetectorMockRecorder) ProcessNetworkFlow(ctx, flow interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessNetworkFlow", reflect.TypeOf((*MockDetector)(nil).ProcessNetworkFlow), flow)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessNetworkFlow", reflect.TypeOf((*MockDetector)(nil).ProcessNetworkFlow), ctx, flow)
 }
 
 // ProcessPolicySync mocks base method.

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -232,7 +232,7 @@ type networkFlowManager struct {
 	centralReady  concurrency.Signal
 
 	ctxMutex    sync.Mutex
-	cancelCtx   func()
+	cancelCtx   context.CancelFunc
 	pipelineCtx context.Context
 
 	enricherTicker *time.Ticker

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -654,7 +654,6 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 		})
 	}
 	m.Stop(nil)
-	m.done.Wait()
 }
 
 func (s *NetworkFlowManagerTestSuite) TestExpireMessage() {
@@ -693,7 +692,6 @@ func (s *NetworkFlowManagerTestSuite) TestExpireMessage() {
 		s.Assert().True(msg.IsExpired(), "the message should be expired")
 	}
 	m.Stop(nil)
-	m.done.Wait()
 }
 
 // endregion

--- a/sensor/common/networkflow/manager/testing_test.go
+++ b/sensor/common/networkflow/manager/testing_test.go
@@ -70,7 +70,7 @@ func expectExternalLookupHelper(mockExternalStore *mocksExternalSrc.MockStore, t
 
 func expectDetectorHelper(mockDetector *mocksDetector.MockDetector, times int) expectFn {
 	return func() {
-		mockDetector.EXPECT().ProcessNetworkFlow(gomock.Any()).Times(times)
+		mockDetector.EXPECT().ProcessNetworkFlow(gomock.Any(), gomock.Any()).Times(times)
 	}
 }
 

--- a/sensor/common/networkflow/manager/testing_test.go
+++ b/sensor/common/networkflow/manager/testing_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/networkgraph"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	mocksDetector "github.com/stackrox/rox/sensor/common/detector/mocks"
@@ -32,6 +33,7 @@ func createManager(mockCtrl *gomock.Controller) (*networkFlowManager, *mocksMana
 		publicIPs:         newPublicIPsManager(),
 		centralReady:      concurrency.NewSignal(),
 		enricherTicker:    ticker,
+		finished:          &sync.WaitGroup{},
 	}
 	return mgr, mockEntityStore, mockExternalStore, mockDetector
 }


### PR DESCRIPTION
## Description

Add context to the `ExpiringMessage` as well as the detector calls. This allow us to cancel messages that shouldn't be sent upon disconnection with central.

- This is a followup of #6959

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- [x] Unit test
- [ ] CI
