### PR TITLE
ROX-17157: Fix reconciliation for offline mode for Kubernetes Listener

### DIFF
--- a/sensor/kubernetes/eventpipeline/component/component.go
+++ b/sensor/kubernetes/eventpipeline/component/component.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"context"
+
 	"github.com/stackrox/rox/sensor/common/message"
 )
 
@@ -25,4 +27,10 @@ type OutputQueue interface {
 	PipelineComponent
 	Send(event *ResourceEvent)
 	ResponsesC() <-chan *message.ExpiringMessage
+}
+
+// ContextListener is a component that listens but has a context in the messages
+type ContextListener interface {
+	PipelineComponent
+	StartWithContext(context.Context) error
 }

--- a/sensor/kubernetes/eventpipeline/component/mocks/component.go
+++ b/sensor/kubernetes/eventpipeline/component/mocks/component.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	message "github.com/stackrox/rox/sensor/common/message"
@@ -195,4 +196,67 @@ func (m *MockOutputQueue) Stop(arg0 error) {
 func (mr *MockOutputQueueMockRecorder) Stop(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockOutputQueue)(nil).Stop), arg0)
+}
+
+// MockContextListener is a mock of ContextListener interface.
+type MockContextListener struct {
+	ctrl     *gomock.Controller
+	recorder *MockContextListenerMockRecorder
+}
+
+// MockContextListenerMockRecorder is the mock recorder for MockContextListener.
+type MockContextListenerMockRecorder struct {
+	mock *MockContextListener
+}
+
+// NewMockContextListener creates a new mock instance.
+func NewMockContextListener(ctrl *gomock.Controller) *MockContextListener {
+	mock := &MockContextListener{ctrl: ctrl}
+	mock.recorder = &MockContextListenerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockContextListener) EXPECT() *MockContextListenerMockRecorder {
+	return m.recorder
+}
+
+// Start mocks base method.
+func (m *MockContextListener) Start() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Start")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Start indicates an expected call of Start.
+func (mr *MockContextListenerMockRecorder) Start() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockContextListener)(nil).Start))
+}
+
+// StartWithContext mocks base method.
+func (m *MockContextListener) StartWithContext(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartWithContext", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StartWithContext indicates an expected call of StartWithContext.
+func (mr *MockContextListenerMockRecorder) StartWithContext(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWithContext", reflect.TypeOf((*MockContextListener)(nil).StartWithContext), arg0)
+}
+
+// Stop mocks base method.
+func (m *MockContextListener) Stop(arg0 error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Stop", arg0)
+}
+
+// Stop indicates an expected call of Stop.
+func (mr *MockContextListenerMockRecorder) Stop(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockContextListener)(nil).Stop), arg0)
 }

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -25,12 +25,12 @@ import (
 func New(client client.Interface, configHandler config.Handler, detector detector.Detector, reprocessor reprocessor.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, storeProvider *resources.InMemoryStoreProvider, queueSize int) common.SensorComponent {
 	outputQueue := output.New(detector, queueSize)
 	var depResolver component.Resolver
-	var resourceListener component.PipelineComponent
+	var resourceListener component.ContextListener
 	if env.ResyncDisabled.BooleanSetting() {
 		depResolver = resolver.New(outputQueue, storeProvider, queueSize)
-		resourceListener = listener.New(context.TODO(), client, configHandler, nodeName, resyncPeriod, traceWriter, depResolver, storeProvider)
+		resourceListener = listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, depResolver, storeProvider)
 	} else {
-		resourceListener = listener.New(context.TODO(), client, configHandler, nodeName, resyncPeriod, traceWriter, outputQueue, storeProvider)
+		resourceListener = listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, outputQueue, storeProvider)
 	}
 
 	offlineMode := &atomic.Bool{}

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -1,6 +1,7 @@
 package eventpipeline
 
 import (
+	"context"
 	"io"
 	"sync/atomic"
 	"time"
@@ -27,9 +28,9 @@ func New(client client.Interface, configHandler config.Handler, detector detecto
 	var resourceListener component.PipelineComponent
 	if env.ResyncDisabled.BooleanSetting() {
 		depResolver = resolver.New(outputQueue, storeProvider, queueSize)
-		resourceListener = listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, depResolver, storeProvider)
+		resourceListener = listener.New(context.TODO(), client, configHandler, nodeName, resyncPeriod, traceWriter, depResolver, storeProvider)
 	} else {
-		resourceListener = listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, outputQueue, storeProvider)
+		resourceListener = listener.New(context.TODO(), client, configHandler, nodeName, resyncPeriod, traceWriter, outputQueue, storeProvider)
 	}
 
 	offlineMode := &atomic.Bool{}

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -1,7 +1,6 @@
 package eventpipeline
 
 import (
-	"context"
 	"io"
 	"sync/atomic"
 	"time"

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -73,7 +73,7 @@ func (p *eventPipeline) ResponsesC() <-chan *message.ExpiringMessage {
 func (p *eventPipeline) stopCurrentContext() {
 	p.contextMtx.Lock()
 	defer p.contextMtx.Unlock()
-	if p.context != nil {
+	if p.cancelContext != nil {
 		p.cancelContext()
 	}
 }

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -122,6 +122,7 @@ func (p *eventPipeline) Notify(event common.SensorComponentEvent) {
 		// Start listening to events if not yet listening
 		if p.offlineMode.CompareAndSwap(true, false) {
 			log.Infof("Connection established: Starting Kubernetes listener")
+			// TODO(ROX-18613): use contextProvider to provide context for listener
 			p.createNewContext()
 			if err := p.listener.StartWithContext(p.context); err != nil {
 				log.Fatalf("Failed to start listener component. Sensor cannot run without listening to Kubernetes events: %s", err)

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -1,6 +1,7 @@
 package eventpipeline
 
 import (
+	"context"
 	"sync/atomic"
 
 	"github.com/pkg/errors"
@@ -10,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/message"
@@ -25,7 +27,7 @@ var (
 type eventPipeline struct {
 	output      component.OutputQueue
 	resolver    component.Resolver
-	listener    component.PipelineComponent
+	listener    component.ContextListener
 	detector    detector.Detector
 	reprocessor reprocessor.Handler
 
@@ -33,6 +35,10 @@ type eventPipeline struct {
 
 	eventsC chan *message.ExpiringMessage
 	stopSig concurrency.Signal
+
+	contextMtx    sync.Mutex
+	context       context.Context
+	cancelContext context.CancelFunc
 }
 
 // Capabilities implements common.SensorComponent
@@ -62,6 +68,20 @@ func (p *eventPipeline) ProcessMessage(msg *central.MsgToSensor) error {
 // ResponsesC implements common.SensorComponent
 func (p *eventPipeline) ResponsesC() <-chan *message.ExpiringMessage {
 	return p.eventsC
+}
+
+func (p *eventPipeline) stopCurrentContext() {
+	p.contextMtx.Lock()
+	defer p.contextMtx.Unlock()
+	if p.context != nil {
+		p.cancelContext()
+	}
+}
+
+func (p *eventPipeline) createNewContext() {
+	p.contextMtx.Lock()
+	defer p.contextMtx.Unlock()
+	p.context, p.cancelContext = context.WithCancel(context.Background())
 }
 
 // Start implements common.SensorComponent
@@ -102,13 +122,15 @@ func (p *eventPipeline) Notify(event common.SensorComponentEvent) {
 		// Start listening to events if not yet listening
 		if p.offlineMode.CompareAndSwap(true, false) {
 			log.Infof("Connection established: Starting Kubernetes listener")
-			if err := p.listener.Start(); err != nil {
+			p.createNewContext()
+			if err := p.listener.StartWithContext(p.context); err != nil {
 				log.Fatalf("Failed to start listener component. Sensor cannot run without listening to Kubernetes events: %s", err)
 			}
 		}
 	case common.SensorComponentEventOfflineMode:
 		// Stop listening to events
 		if p.offlineMode.CompareAndSwap(false, true) {
+			p.stopCurrentContext()
 			p.listener.Stop(errors.New("gRPC connection stopped"))
 		}
 	}

--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -69,10 +69,6 @@ func (s *eventPipelineSuite) SetupTest() {
 	}
 }
 
-// 1. Making sure that k8s listeners will stop when we go into offline mode
-// 2. Context from the messages received in ResponsesC will be cancelled when
-//    going into offline mode
-
 func (s *eventPipelineSuite) write() {
 	s.outputC <- message.NewExpiring(s.pipeline.context, nil)
 }
@@ -131,8 +127,6 @@ func (s *eventPipelineSuite) Test_OfflineModeCases() {
 	}
 
 	for i, orderedFunctions := range testCases {
-		// Expect listener to be reset (i.e. started twice and stopped once)
-
 		s.Run(fmt.Sprintf("case %d", i), func() {
 			for _, fn := range orderedFunctions {
 				fn()

--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -1,7 +1,6 @@
 package eventpipeline
 
 import (
-	"fmt"
 	"sync/atomic"
 	"testing"
 
@@ -109,25 +108,18 @@ func (s *eventPipelineSuite) Test_OfflineModeCases() {
 	s.Require().NoError(s.pipeline.Start())
 	s.pipeline.Notify(common.SensorComponentEventCentralReachable)
 
-	testCases := [][]func(){
-		// Base case: Start, WA, WB, RA, RB, Disconnect
-		{s.online, s.write, s.write, s.readSuccess, s.readSuccess, s.offline},
-		// Case: Start, WA, WB, Disconnect, RA, RB, Reconnect
-		{s.write, s.write, s.offline, s.readExpired, s.readExpired, s.online},
-		// Case: Start, WA, Disconnect, WB, Reconnect, RA, RB
-		{s.write, s.write, s.offline, s.online, s.readExpired, s.readExpired},
-		// Case: Start, WA, Disconnect, Reconnect, WB, RA, RB
-		{s.write, s.offline, s.write, s.online, s.readExpired, s.readExpired},
-		// Case: Start, WA, Disconnect, Reconnect, WB, RA, RB
-		{s.write, s.offline, s.online, s.write, s.readExpired, s.readSuccess},
-		// Case: Start, Disconnect, WA, Reconnect, WB, RA, RB
-		{s.offline, s.write, s.online, s.write, s.readExpired, s.readSuccess},
-		// Case: Start, Disconnect, Reconnect, WA, WB, RA, RB
-		{s.offline, s.online, s.write, s.write, s.readSuccess, s.readSuccess},
+	testCases := map[string][]func(){
+		"Base case: Start, WA, WB, RA, RB, Disconnect":       {s.online, s.write, s.write, s.readSuccess, s.readSuccess, s.offline},
+		"Case: Start, WA, WB, Disconnect, RA, RB, Reconnect": {s.write, s.write, s.offline, s.readExpired, s.readExpired, s.online},
+		"Case: Start, WA, WB, Disconnect, Reconnect, RA, RB": {s.write, s.write, s.offline, s.online, s.readExpired, s.readExpired},
+		"Case: Start, WA, Disconnect, WB, Reconnect, RA, RB": {s.write, s.offline, s.write, s.online, s.readExpired, s.readExpired},
+		"Case: Start, WA, Disconnect, Reconnect, WB, RA, RB": {s.write, s.offline, s.online, s.write, s.readExpired, s.readSuccess},
+		"Case: Start, Disconnect, WA, Reconnect, WB, RA, RB": {s.offline, s.write, s.online, s.write, s.readExpired, s.readSuccess},
+		"Case: Start, Disconnect, Reconnect, WA, WB, RA, RB": {s.offline, s.online, s.write, s.write, s.readSuccess, s.readSuccess},
 	}
 
-	for i, orderedFunctions := range testCases {
-		s.Run(fmt.Sprintf("case %d", i), func() {
+	for caseName, orderedFunctions := range testCases {
+		s.Run(caseName, func() {
 			for _, fn := range orderedFunctions {
 				fn()
 			}

--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -110,7 +110,7 @@ func (s *eventPipelineSuite) Test_OfflineModeCases() {
 	s.listener.EXPECT().StartWithContext(gomock.Any()).AnyTimes()
 	s.listener.EXPECT().Stop(gomock.Any()).AnyTimes()
 
-	s.pipeline.Start()
+	s.Require().NoError(s.pipeline.Start())
 	s.pipeline.Notify(common.SensorComponentEventCentralReachable)
 
 	testCases := [][]func(){
@@ -155,7 +155,7 @@ func (s *eventPipelineSuite) Test_OfflineMode() {
 	s.listener.EXPECT().StartWithContext(gomock.Any()).Times(2)
 	s.listener.EXPECT().Stop(gomock.Any()).Times(1)
 
-	s.pipeline.Start()
+	s.Require().NoError(s.pipeline.Start())
 	s.pipeline.Notify(common.SensorComponentEventCentralReachable)
 
 	outputC <- message.NewExpiring(s.pipeline.context, nil)

--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -1,12 +1,15 @@
 package eventpipeline
 
 import (
+	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common"
 	mockDetector "github.com/stackrox/rox/sensor/common/detector/mocks"
 	"github.com/stackrox/rox/sensor/common/message"
 	mockReprocessor "github.com/stackrox/rox/sensor/common/reprocessor/mocks"
@@ -24,7 +27,11 @@ type eventPipelineSuite struct {
 	resolver    *mockComponent.MockResolver
 	detector    *mockDetector.MockDetector
 	reprocessor *mockReprocessor.MockHandler
+	listener    *mockComponent.MockContextListener
+	outputQueue *mockComponent.MockOutputQueue
 	pipeline    *eventPipeline
+
+	outputC chan *message.ExpiringMessage
 }
 
 var _ suite.SetupTestSuite = &eventPipelineSuite{}
@@ -38,26 +45,134 @@ func (s *eventPipelineSuite) TearDownTest() {
 	s.T().Cleanup(s.mockCtrl.Finish)
 }
 
-type mockListener struct{}
-
-func (m *mockListener) Start() error { return nil }
-func (m *mockListener) Stop(_ error) {}
-
 func (s *eventPipelineSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
 
 	s.resolver = mockComponent.NewMockResolver(s.mockCtrl)
 	s.detector = mockDetector.NewMockDetector(s.mockCtrl)
 	s.reprocessor = mockReprocessor.NewMockHandler(s.mockCtrl)
+	s.listener = mockComponent.NewMockContextListener(s.mockCtrl)
+	s.outputQueue = mockComponent.NewMockOutputQueue(s.mockCtrl)
+
+	offlineMode := atomic.Bool{}
+	offlineMode.Store(true)
+
 	s.pipeline = &eventPipeline{
 		eventsC:     make(chan *message.ExpiringMessage),
 		stopSig:     concurrency.NewSignal(),
-		output:      mockComponent.NewMockOutputQueue(s.mockCtrl),
+		output:      s.outputQueue,
 		resolver:    s.resolver,
 		detector:    s.detector,
 		reprocessor: s.reprocessor,
-		listener:    &mockListener{},
+		listener:    s.listener,
+		offlineMode: &offlineMode,
 	}
+}
+
+// 1. Making sure that k8s listeners will stop when we go into offline mode
+// 2. Context from the messages received in ResponsesC will be cancelled when
+//    going into offline mode
+
+func (s *eventPipelineSuite) write() {
+	s.outputC <- message.NewExpiring(s.pipeline.context, nil)
+}
+
+func (s *eventPipelineSuite) online() {
+	s.pipeline.Notify(common.SensorComponentEventCentralReachable)
+}
+
+func (s *eventPipelineSuite) offline() {
+	s.pipeline.Notify(common.SensorComponentEventOfflineMode)
+}
+
+func (s *eventPipelineSuite) readSuccess() {
+	msg, more := <-s.pipeline.ResponsesC()
+	s.Assert().True(more, "channel should be open")
+	s.Assert().False(msg.IsExpired(), "message should not be expired")
+}
+
+func (s *eventPipelineSuite) readExpired() {
+	msg, more := <-s.pipeline.ResponsesC()
+	s.Assert().True(more, "channel should be open")
+	s.Assert().True(msg.IsExpired(), "message should be expired")
+}
+
+func (s *eventPipelineSuite) Test_OfflineModeCases() {
+	s.T().Setenv("ROX_RESYNC_DISABLED", "true")
+
+	outputC := make(chan *message.ExpiringMessage, 10)
+	s.outputQueue.EXPECT().ResponsesC().
+		AnyTimes().Return(outputC)
+	s.outputC = outputC
+
+	s.outputQueue.EXPECT().Start().Times(1)
+	s.resolver.EXPECT().Start().Times(1)
+	s.listener.EXPECT().StartWithContext(gomock.Any()).AnyTimes()
+		s.listener.EXPECT().Stop(gomock.Any()).AnyTimes()
+
+	s.pipeline.Start()
+	s.pipeline.Notify(common.SensorComponentEventCentralReachable)
+
+	testCases := [][]func(){
+		// Base case: Start, WA, WB, RA, RB, Disconnect
+		{s.online, s.write, s.write, s.readSuccess, s.readSuccess, s.offline},
+		// Case: Start, WA, WB, Disconnect, RA, RB, Reconnect
+		{s.write, s.write, s.offline, s.readExpired, s.readExpired, s.online},
+		// Case: Start, WA, Disconnect, WB, Reconnect, RA, RB
+		{s.write, s.write, s.offline, s.online, s.readExpired, s.readExpired},
+		// Case: Start, WA, Disconnect, Reconnect, WB, RA, RB
+		{s.write, s.offline, s.write, s.online, s.readExpired, s.readExpired},
+		// Case: Start, WA, Disconnect, Reconnect, WB, RA, RB
+		{s.write, s.offline, s.online, s.write, s.readExpired, s.readSuccess},
+		// Case: Start, Disconnect, WA, Reconnect, WB, RA, RB
+		{s.offline, s.write, s.online, s.write, s.readExpired, s.readSuccess},
+		// Case: Start, Disconnect, Reconnect, WA, WB, RA, RB
+		{s.offline, s.online, s.write, s.write, s.readSuccess, s.readSuccess},
+	}
+
+	for i, orderedFunctions := range testCases {
+		// Expect listener to be reset (i.e. started twice and stopped once)
+
+		s.Run(fmt.Sprintf("case %d", i), func() {
+			for _, fn := range orderedFunctions {
+				fn()
+			}
+		})
+	}
+}
+
+func (s *eventPipelineSuite) Test_OfflineMode() {
+	s.T().Setenv("ROX_RESYNC_DISABLED", "true")
+
+	outputC := make(chan *message.ExpiringMessage, 10)
+	s.outputQueue.EXPECT().ResponsesC().
+		AnyTimes().Return(outputC)
+
+	s.outputQueue.EXPECT().Start().Times(1)
+	s.resolver.EXPECT().Start().Times(1)
+
+	// Expect listener to be reset (i.e. started twice and stopped once)
+	s.listener.EXPECT().StartWithContext(gomock.Any()).Times(2)
+	s.listener.EXPECT().Stop(gomock.Any()).Times(1)
+
+	s.pipeline.Start()
+	s.pipeline.Notify(common.SensorComponentEventCentralReachable)
+
+	outputC <- message.NewExpiring(s.pipeline.context, nil)
+	outputC <- message.NewExpiring(s.pipeline.context, nil)
+
+	// Read message A
+	msgA, more := <-s.pipeline.ResponsesC()
+	s.Require().True(more, "should have more messages in ResponsesC")
+	s.Assert().False(msgA.IsExpired(), "context should not be expired")
+
+	s.pipeline.Notify(common.SensorComponentEventOfflineMode)
+	s.pipeline.Notify(common.SensorComponentEventCentralReachable)
+
+	// Read message B
+	msgB, more := <-s.pipeline.ResponsesC()
+	s.Require().True(more, "should have more messages in ResponsesC")
+	s.Assert().True(msgB.IsExpired(), "context should be expired")
 }
 
 func (s *eventPipelineSuite) Test_ReprocessDeployments() {

--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -108,7 +108,7 @@ func (s *eventPipelineSuite) Test_OfflineModeCases() {
 	s.outputQueue.EXPECT().Start().Times(1)
 	s.resolver.EXPECT().Start().Times(1)
 	s.listener.EXPECT().StartWithContext(gomock.Any()).AnyTimes()
-		s.listener.EXPECT().Stop(gomock.Any()).AnyTimes()
+	s.listener.EXPECT().Stop(gomock.Any()).AnyTimes()
 
 	s.pipeline.Start()
 	s.pipeline.Notify(common.SensorComponentEventCentralReachable)

--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -20,7 +20,7 @@ var (
 )
 
 // New returns a new kubernetes listener.
-func New(ctx context.Context, client client.Interface, configHandler config.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, queue component.Resolver, storeProvider *resources.InMemoryStoreProvider) component.PipelineComponent {
+func New(client client.Interface, configHandler config.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, queue component.Resolver, storeProvider *resources.InMemoryStoreProvider) component.ContextListener {
 	k := &listenerImpl{
 		client:             client,
 		stopSig:            concurrency.NewSignal(),
@@ -30,7 +30,6 @@ func New(ctx context.Context, client client.Interface, configHandler config.Hand
 		traceWriter:        traceWriter,
 		outputQueue:        queue,
 		storeProvider:      storeProvider,
-		context: ctx,
 	}
 	return k
 }

--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -20,7 +20,7 @@ var (
 )
 
 // New returns a new kubernetes listener.
-func New(client client.Interface, configHandler config.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, queue component.Resolver, storeProvider *resources.InMemoryStoreProvider) component.PipelineComponent {
+func New(ctx context.Context, client client.Interface, configHandler config.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, queue component.Resolver, storeProvider *resources.InMemoryStoreProvider) component.PipelineComponent {
 	k := &listenerImpl{
 		client:             client,
 		stopSig:            concurrency.NewSignal(),
@@ -30,6 +30,7 @@ func New(client client.Interface, configHandler config.Handler, nodeName string,
 		traceWriter:        traceWriter,
 		outputQueue:        queue,
 		storeProvider:      storeProvider,
+		context: ctx,
 	}
 	return k
 }

--- a/sensor/kubernetes/listener/listener_impl.go
+++ b/sensor/kubernetes/listener/listener_impl.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/awscredentials"
@@ -45,6 +46,9 @@ func (k *listenerImpl) StartWithContext(ctx context.Context) error {
 
 func (k *listenerImpl) Start() error {
 	if k.context == nil {
+		if !buildinfo.ReleaseBuild {
+			panic("Something went very wrong: starting Kubernetes Listener with nil context")
+		}
 		return errors.New("cannot start listener without a context")
 	}
 

--- a/sensor/kubernetes/listener/listener_impl.go
+++ b/sensor/kubernetes/listener/listener_impl.go
@@ -1,6 +1,7 @@
 package listener
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -29,6 +30,7 @@ type listenerImpl struct {
 	traceWriter        io.Writer
 	outputQueue        component.Resolver
 	storeProvider      *resources.InMemoryStoreProvider
+	context            context.Context
 }
 
 func (k *listenerImpl) Start() error {

--- a/sensor/kubernetes/listener/listener_impl.go
+++ b/sensor/kubernetes/listener/listener_impl.go
@@ -70,6 +70,7 @@ func (k *listenerImpl) Stop(_ error) {
 		k.credentialsManager.Stop()
 	}
 	k.stopSig.Signal()
+	k.storeProvider.CleanupStores()
 }
 
 func clusterOperatorCRDExists(client client.Interface) (bool, error) {

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -1,6 +1,8 @@
 package listener
 
 import (
+	"context"
+
 	osAppsExtVersions "github.com/openshift/client-go/apps/informers/externalversions"
 	osConfigExtVersions "github.com/openshift/client-go/config/informers/externalversions"
 	osRouteExtVersions "github.com/openshift/client-go/route/informers/externalversions"
@@ -125,13 +127,13 @@ func (k *listenerImpl) handleAllEvents() {
 	stopSignal := &k.stopSig
 
 	// Informers that need to be synced initially
-	handle(namespaceInformer, dispatchers.ForNamespaces(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
-	handle(secretInformer, dispatchers.ForSecrets(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
-	handle(saInformer, dispatchers.ForServiceAccounts(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+	handle(k.context, namespaceInformer, dispatchers.ForNamespaces(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+	handle(k.context, secretInformer, dispatchers.ForSecrets(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+	handle(k.context, saInformer, dispatchers.ForServiceAccounts(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
 
 	// Roles need to be synced before role bindings because role bindings have a reference
-	handle(roleInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
-	handle(clusterRoleInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+	handle(k.context, roleInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+	handle(k.context, clusterRoleInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
 
 	var osConfigFactory osConfigExtVersions.SharedInformerFactory
 	if k.client.OpenshiftConfig() != nil {
@@ -145,17 +147,17 @@ func (k *listenerImpl) handleAllEvents() {
 	}
 	// For openshift clusters only
 	if osConfigFactory != nil {
-		handle(osConfigFactory.Config().V1().ClusterOperators().Informer(), dispatchers.ForClusterOperators(),
+		handle(k.context, osConfigFactory.Config().V1().ClusterOperators().Informer(), dispatchers.ForClusterOperators(),
 			k.outputQueue, nil, noDependencyWaitGroup, stopSignal, &eventLock)
 	}
 
 	if crdSharedInformerFactory != nil {
 		log.Info("syncing compliance operator resources")
 		// Handle results, rules, and scan setting bindings first
-		handle(complianceResultInformer, dispatchers.ForComplianceOperatorResults(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
-		handle(complianceRuleInformer, dispatchers.ForComplianceOperatorRules(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
-		handle(complianceScanSettingBindingsInformer, dispatchers.ForComplianceOperatorScanSettingBindings(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
-		handle(complianceScanInformer, dispatchers.ForComplianceOperatorScans(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+		handle(k.context, complianceResultInformer, dispatchers.ForComplianceOperatorResults(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+		handle(k.context, complianceRuleInformer, dispatchers.ForComplianceOperatorRules(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+		handle(k.context, complianceScanSettingBindingsInformer, dispatchers.ForComplianceOperatorScanSettingBindings(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+		handle(k.context, complianceScanInformer, dispatchers.ForComplianceOperatorScans(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
 	}
 
 	if !startAndWait(stopSignal, noDependencyWaitGroup, sif, resyncingSif, osConfigFactory, crdSharedInformerFactory) {
@@ -169,8 +171,8 @@ func (k *listenerImpl) handleAllEvents() {
 	roleBindingInformer := resyncingSif.Rbac().V1().RoleBindings().Informer()
 	clusterRoleBindingInformer := resyncingSif.Rbac().V1().ClusterRoleBindings().Informer()
 
-	handle(roleBindingInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-	handle(clusterRoleBindingInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+	handle(k.context, roleBindingInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+	handle(k.context, clusterRoleBindingInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
 
 	if !startAndWait(stopSignal, prePodWaitGroup, resyncingSif) {
 		return
@@ -180,7 +182,7 @@ func (k *listenerImpl) handleAllEvents() {
 
 	// Wait for the pod informer to sync before processing other types.
 	// This is required because the PodLister is used to populate the image ids of deployments.
-	// However, do not ACTUALLY handle pod events yet -- those need to wait for deployments to be
+	// However, do not ACTUALLY handle, pod events yet -- those need to wait for deployments to be
 	// synced, since we need to enrich pods with the deployment ids, and for that we need the entire
 	// hierarchy to be populated.
 	if !cache.WaitForCacheSync(stopSignal.Done(), podInformer.Informer().HasSynced) {
@@ -191,25 +193,25 @@ func (k *listenerImpl) handleAllEvents() {
 	preTopLevelDeploymentWaitGroup := &concurrency.WaitGroup{}
 
 	// Non-deployment types.
-	handle(sif.Networking().V1().NetworkPolicies().Informer(), dispatchers.ForNetworkPolicies(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
-	handle(sif.Core().V1().Nodes().Informer(), dispatchers.ForNodes(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
-	handle(sif.Core().V1().Services().Informer(), dispatchers.ForServices(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+	handle(k.context, sif.Networking().V1().NetworkPolicies().Informer(), dispatchers.ForNetworkPolicies(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+	handle(k.context, sif.Core().V1().Nodes().Informer(), dispatchers.ForNodes(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+	handle(k.context, sif.Core().V1().Services().Informer(), dispatchers.ForServices(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
 
 	if osRouteFactory != nil {
-		handle(osRouteFactory.Route().V1().Routes().Informer(), dispatchers.ForOpenshiftRoutes(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+		handle(k.context, osRouteFactory.Route().V1().Routes().Informer(), dispatchers.ForOpenshiftRoutes(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
 	}
 
 	// Deployment subtypes (this ensures that the hierarchy maps are generated correctly)
-	handle(resyncingSif.Batch().V1().Jobs().Informer(), dispatchers.ForJobs(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
-	handle(resyncingSif.Apps().V1().ReplicaSets().Informer(), dispatchers.ForDeployments(kubernetesPkg.ReplicaSet), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
-	handle(resyncingSif.Core().V1().ReplicationControllers().Informer(), dispatchers.ForDeployments(kubernetesPkg.ReplicationController), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+	handle(k.context, resyncingSif.Batch().V1().Jobs().Informer(), dispatchers.ForJobs(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+	handle(k.context, resyncingSif.Apps().V1().ReplicaSets().Informer(), dispatchers.ForDeployments(kubernetesPkg.ReplicaSet), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+	handle(k.context, resyncingSif.Core().V1().ReplicationControllers().Informer(), dispatchers.ForDeployments(kubernetesPkg.ReplicationController), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
 
 	// Compliance operator profiles are handled AFTER results, rules, and scan setting bindings have been synced
 	if complianceProfileInformer != nil {
-		handle(complianceProfileInformer, dispatchers.ForComplianceOperatorProfiles(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+		handle(k.context, complianceProfileInformer, dispatchers.ForComplianceOperatorProfiles(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
 	}
 	if complianceTailoredProfileInformer != nil {
-		handle(complianceTailoredProfileInformer, dispatchers.ForComplianceOperatorTailoredProfiles(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+		handle(k.context, complianceTailoredProfileInformer, dispatchers.ForComplianceOperatorTailoredProfiles(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
 	}
 
 	if !startAndWait(stopSignal, preTopLevelDeploymentWaitGroup, sif, resyncingSif, crdSharedInformerFactory, osRouteFactory) {
@@ -221,19 +223,19 @@ func (k *listenerImpl) handleAllEvents() {
 	wg := &concurrency.WaitGroup{}
 
 	// Deployment types.
-	handle(resyncingSif.Apps().V1().DaemonSets().Informer(), dispatchers.ForDeployments(kubernetesPkg.DaemonSet), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
-	handle(resyncingSif.Apps().V1().Deployments().Informer(), dispatchers.ForDeployments(kubernetesPkg.Deployment), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
-	handle(resyncingSif.Apps().V1().StatefulSets().Informer(), dispatchers.ForDeployments(kubernetesPkg.StatefulSet), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
+	handle(k.context, resyncingSif.Apps().V1().DaemonSets().Informer(), dispatchers.ForDeployments(kubernetesPkg.DaemonSet), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
+	handle(k.context, resyncingSif.Apps().V1().Deployments().Informer(), dispatchers.ForDeployments(kubernetesPkg.Deployment), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
+	handle(k.context, resyncingSif.Apps().V1().StatefulSets().Informer(), dispatchers.ForDeployments(kubernetesPkg.StatefulSet), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
 
 	if ok, err := sensorUtils.HasAPI(k.client.Kubernetes(), "batch/v1", kubernetesPkg.CronJob); err != nil {
 		log.Errorf("error determining API version to use for CronJobs: %v", err)
 	} else if ok {
-		handle(resyncingSif.Batch().V1().CronJobs().Informer(), dispatchers.ForDeployments(kubernetesPkg.CronJob), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
+		handle(k.context, resyncingSif.Batch().V1().CronJobs().Informer(), dispatchers.ForDeployments(kubernetesPkg.CronJob), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
 	} else {
-		handle(resyncingSif.Batch().V1beta1().CronJobs().Informer(), dispatchers.ForDeployments(kubernetesPkg.CronJob), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
+		handle(k.context, resyncingSif.Batch().V1beta1().CronJobs().Informer(), dispatchers.ForDeployments(kubernetesPkg.CronJob), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
 	}
 	if osAppsFactory != nil {
-		handle(osAppsFactory.Apps().V1().DeploymentConfigs().Informer(), dispatchers.ForDeployments(kubernetesPkg.DeploymentConfig), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
+		handle(k.context, osAppsFactory.Apps().V1().DeploymentConfigs().Informer(), dispatchers.ForDeployments(kubernetesPkg.DeploymentConfig), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
 	}
 
 	// SharedInformerFactories can have Start called multiple times which will start the rest of the handlers
@@ -245,7 +247,7 @@ func (k *listenerImpl) handleAllEvents() {
 
 	// Finally, run the pod informer, and process pod events.
 	podWaitGroup := &concurrency.WaitGroup{}
-	handle(podInformer.Informer(), dispatchers.ForDeployments(kubernetesPkg.Pod), k.outputQueue, &syncingResources, podWaitGroup, stopSignal, &eventLock)
+	handle(k.context, podInformer.Informer(), dispatchers.ForDeployments(kubernetesPkg.Pod), k.outputQueue, &syncingResources, podWaitGroup, stopSignal, &eventLock)
 	if !startAndWait(stopSignal, podWaitGroup, resyncingSif) {
 		return
 	}
@@ -269,6 +271,7 @@ func (k *listenerImpl) handleAllEvents() {
 // Helper function that creates and adds a handler to an informer.
 // ////////////////////////////////////////////////////////////////
 func handle(
+	ctx context.Context,
 	informer cache.SharedIndexInformer,
 	dispatcher resources.Dispatcher,
 	resolver component.Resolver,
@@ -278,6 +281,7 @@ func handle(
 	eventLock *sync.Mutex,
 ) {
 	handlerImpl := &resourceEventHandlerImpl{
+		context:          ctx,
 		eventLock:        eventLock,
 		dispatcher:       dispatcher,
 		resolver:         resolver,

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -51,6 +51,9 @@ func managedFieldsTransformer(obj interface{}) (interface{}, error) {
 }
 
 func (k *listenerImpl) handleAllEvents() {
+	k.contextMtx.Lock()
+	defer k.contextMtx.Unlock()
+
 	// TODO(ROX-14194): remove resyncingSif once all resources are adapted
 	var resyncingSif informers.SharedInformerFactory
 	if env.ResyncDisabled.BooleanSetting() {

--- a/sensor/kubernetes/listener/resource_event_handler_impl.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl.go
@@ -19,7 +19,7 @@ import (
 // resourceEventHandlerImpl processes OnAdd, OnUpdate, and OnDelete events, and joins the results to an output
 // channel
 type resourceEventHandlerImpl struct {
-	context context.Context
+	context    context.Context
 	eventLock  *sync.Mutex
 	dispatcher resources.Dispatcher
 

--- a/sensor/kubernetes/listener/resource_event_handler_impl.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl.go
@@ -1,6 +1,8 @@
 package listener
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -17,6 +19,7 @@ import (
 // resourceEventHandlerImpl processes OnAdd, OnUpdate, and OnDelete events, and joins the results to an output
 // channel
 type resourceEventHandlerImpl struct {
+	context context.Context
 	eventLock  *sync.Mutex
 	dispatcher resources.Dispatcher
 

--- a/sensor/kubernetes/listener/resource_event_handler_impl.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl.go
@@ -109,8 +109,7 @@ func (h *resourceEventHandlerImpl) sendResourceEvent(obj, oldObj interface{}, ac
 	}
 
 	message := h.dispatcher.ProcessEvent(obj, oldObj, action)
-	// TODO(ROX-17157) Add context here
-	message.Context = nil
+	message.Context = h.context
 	h.resolver.Send(message)
 }
 

--- a/sensor/kubernetes/listener/resource_event_handler_impl_test.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl_test.go
@@ -99,7 +99,6 @@ func (suite *ResourceEventHandlerImplTestSuite) newHandlerImplWithContext(ctx co
 		seenIDs:                    make(map[types.UID]struct{}),
 		missingInitialIDs:          nil,
 	}
-
 }
 
 // Test that when a message is handled by an unsynced resourceEventHandlerImpl it's ID is added to the seedIDs set

--- a/sensor/kubernetes/listener/resource_event_handler_impl_test.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl_test.go
@@ -17,6 +17,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+type contextKey int
+
+const (
+	ctxKeyTest contextKey = iota
+)
+
 func TestResourceEventHandlerImpl(t *testing.T) {
 	suite.Run(t, new(ResourceEventHandlerImplTestSuite))
 }
@@ -112,7 +118,7 @@ func (suite *ResourceEventHandlerImplTestSuite) TestIDsAddedToSyncSet() {
 }
 
 func (suite *ResourceEventHandlerImplTestSuite) TestContextIsPassed() {
-	ctx := context.WithValue(context.Background(), "test", "abc")
+	ctx := context.WithValue(context.Background(), ctxKeyTest, "abc")
 	handler := suite.newHandlerImplWithContext(ctx)
 
 	obj := randomID()
@@ -225,7 +231,7 @@ func matchContextValue(value string) gomock.Matcher {
 	return &contextMatcher{value}
 }
 
-type contextMatcher struct{
+type contextMatcher struct {
 	value string
 }
 
@@ -235,7 +241,7 @@ func (m *contextMatcher) Matches(x interface{}) bool {
 	if !ok {
 		return false
 	}
-	return event.Context.Value("test") == m.value
+	return event.Context.Value(ctxKeyTest) == m.value
 }
 
 // String implements gomock.Matcher
@@ -244,4 +250,3 @@ func (m *contextMatcher) String() string {
 }
 
 var _ gomock.Matcher = &contextMatcher{}
-

--- a/sensor/kubernetes/listener/resource_event_handler_impl_test.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl_test.go
@@ -122,8 +122,6 @@ func (suite *ResourceEventHandlerImplTestSuite) TestContextIsPassed() {
 	handler.OnAdd(obj)
 }
 
-
-
 func (suite *ResourceEventHandlerImplTestSuite) TestIDsAddedToMissingSet() {
 	handler := suite.newHandlerImpl()
 

--- a/sensor/tests/connection/k8sreconciliation/reconcile_test.go
+++ b/sensor/tests/connection/k8sreconciliation/reconcile_test.go
@@ -34,7 +34,6 @@ func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
 	c, err := helper.NewContext(t)
 	require.NoError(t, err)
 
-	
 	// Timeline of the events in this test:
 	// 1) Create deployment Nginx1
 	// 2) Create deployment Nginx2
@@ -56,9 +55,12 @@ func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
 
 		testContext.WaitForSyncEvent(2 * time.Minute)
 		_, err = c.ApplyResourceAndWaitNoObject(ctx, helper.DefaultNamespace, NginxDeployment1, nil)
+		require.NoError(t, err)
 		deleteDeployment2, err := c.ApplyResourceAndWaitNoObject(ctx, helper.DefaultNamespace, NginxDeployment2, nil)
+		require.NoError(t, err)
 
-		_, _ = c.ApplyResourceAndWaitNoObject(ctx, helper.DefaultNamespace, NetpolBlockEgress, nil)
+		_, err = c.ApplyResourceAndWaitNoObject(ctx, helper.DefaultNamespace, NetpolBlockEgress, nil)
+		require.NoError(t, err)
 
 		testContext.StopCentralGRPC()
 

--- a/sensor/tests/connection/k8sreconciliation/reconcile_test.go
+++ b/sensor/tests/connection/k8sreconciliation/reconcile_test.go
@@ -48,8 +48,7 @@ func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
 	//  NetworkPolicy 	block-all-egress
 	//
 	// Using a NetworkPolicy here will make sure that no deployments that were removed while the connection
-	// was down will be used for
-	//
+	// was down will be reprocessed and sent when the NetworkPolicy event gets resynced.
 	c.RunTest(helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {
 		ctx := context.Background()
 

--- a/sensor/tests/connection/k8sreconciliation/reconcile_test.go
+++ b/sensor/tests/connection/k8sreconciliation/reconcile_test.go
@@ -16,6 +16,9 @@ import (
 var (
 	NginxDeployment1 = helper.K8sResourceInfo{Kind: "Deployment", YamlFile: "nginx.yaml", Name: "nginx-deployment"}
 	NginxDeployment2 = helper.K8sResourceInfo{Kind: "Deployment", YamlFile: "nginx2.yaml", Name: "nginx-deployment-2"}
+	NginxDeployment3 = helper.K8sResourceInfo{Kind: "Deployment", YamlFile: "nginx3.yaml", Name: "nginx-deployment-3"}
+
+	NetpolBlockEgress = helper.K8sResourceInfo{Kind: "NetworkPolicy", YamlFile: "netpol-block-egress.yaml", Name: "block-all-egress"}
 )
 
 func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
@@ -31,17 +34,39 @@ func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
 	c, err := helper.NewContext(t)
 	require.NoError(t, err)
 
+	
+	// Timeline of the events in this test:
+	// 1) Create deployment Nginx1
+	// 2) Create deployment Nginx2
+	// 3) Create NetworkPolicy block-all-egress
+	// 4) gRPC Connection interrupted
+	// 5) Delete deployment Nginx2
+	// 6) Create deployment Nginx3
+	// 7) gRPC Connection re-established
+	// 8) Sensor transmits current state with SYNC event type:
+	//  Deployment 		Nginx1
+	//  Deployment 		Nginx3
+	//  NetworkPolicy 	block-all-egress
+	//
+	// Using a NetworkPolicy here will make sure that no deployments that were removed while the connection
+	// was down will be used for
+	//
 	c.RunTest(helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {
 		ctx := context.Background()
 
 		testContext.WaitForSyncEvent(2 * time.Minute)
 		_, err = c.ApplyResourceAndWaitNoObject(ctx, helper.DefaultNamespace, NginxDeployment1, nil)
+		deleteDeployment2, err := c.ApplyResourceAndWaitNoObject(ctx, helper.DefaultNamespace, NginxDeployment2, nil)
+
+		_, _ = c.ApplyResourceAndWaitNoObject(ctx, helper.DefaultNamespace, NetpolBlockEgress, nil)
 
 		testContext.StopCentralGRPC()
 
 		obj := &appsV1.Deployment{}
-		_, err = c.ApplyResource(ctx, helper.DefaultNamespace, &NginxDeployment2, obj, nil)
+		_, err = c.ApplyResource(ctx, helper.DefaultNamespace, &NginxDeployment3, obj, nil)
 		require.NoError(t, err)
+
+		require.NoError(t, deleteDeployment2())
 
 		testContext.StartFakeGRPC()
 
@@ -49,9 +74,17 @@ func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
 		require.Len(t, archived, 1)
 		deploymentMessageInArchive(t, archived[0], helper.DefaultNamespace, NginxDeployment1.Name)
 
+		// Wait for sync event to be sent, then expect the following state to be transmitted:
+		//   SYNC nginx-deployment-1
+		//   SYNC nginx-deployment-3
+		//   No event for nginx-deployment-2 (was deleted while connection was down)
+		// This reconciliation state will make Central delete Nginx2, keep Nginx1 and create Nginx3
 		testContext.WaitForSyncEvent(2 * time.Minute)
-		testContext.DeploymentActionReceived(NginxDeployment1.Name, central.ResourceAction_SYNC_RESOURCE)
-		testContext.DeploymentActionReceived(NginxDeployment2.Name, central.ResourceAction_SYNC_RESOURCE)
+		testContext.FirstDeploymentReceivedWithAction(NginxDeployment1.Name, central.ResourceAction_SYNC_RESOURCE)
+		testContext.FirstDeploymentReceivedWithAction(NginxDeployment3.Name, central.ResourceAction_SYNC_RESOURCE)
+
+		// This assertion will fail if events are not properly cleared from the internal queues and in-memory stores
+		testContext.DeploymentNotReceived(NginxDeployment2.Name)
 	}))
 
 }

--- a/sensor/tests/connection/k8sreconciliation/yaml/netpol-block-egress.yaml
+++ b/sensor/tests/connection/k8sreconciliation/yaml/netpol-block-egress.yaml
@@ -1,0 +1,11 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: block-all-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: nginx-2
+  policyTypes:
+     - Egress
+

--- a/sensor/tests/connection/k8sreconciliation/yaml/nginx.yaml
+++ b/sensor/tests/connection/k8sreconciliation/yaml/nginx.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: nginx
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: nginx
@@ -19,3 +19,4 @@ spec:
         image: nginx:1.14.2
         ports:
         - containerPort: 80
+

--- a/sensor/tests/connection/k8sreconciliation/yaml/nginx3.yaml
+++ b/sensor/tests/connection/k8sreconciliation/yaml/nginx3.yaml
@@ -1,18 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment-2
+  name: nginx-deployment-3
   labels:
-    app: nginx-2
+    app: nginx-3
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nginx-2
+      app: nginx-3
   template:
     metadata:
       labels:
-        app: nginx-2
+        app: nginx-3
     spec:
       containers:
       - name: nginx

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/sensor"
 	"github.com/stackrox/rox/sensor/testutils"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -477,6 +478,31 @@ func (c *TestContext) WaitForDeploymentEventWithTimeout(name string, timeout tim
 
 }
 
+// FirstDeploymentStateMatchesWithTimeout checks that the first deployment received with name matches the assertion function.
+func (c *TestContext) FirstDeploymentStateMatchesWithTimeout(name string, assertion AssertFunc, message string, timeout time.Duration) {
+	timer := time.NewTimer(timeout)
+	ticker := time.NewTicker(defaultTicker)
+	lastErr := errors.New("no deployment found")
+	for {
+		select {
+		case <-timer.C:
+			c.t.Errorf("timeout reached waiting for state: (%s): %s", message, lastErr)
+			return
+		case <-ticker.C:
+			messages := c.GetFakeCentral().GetAllMessages()
+			deploymentMessage := GetFirstMessageWithDeploymentName(messages, DefaultNamespace, name)
+			deployment := deploymentMessage.GetEvent().GetDeployment()
+			action := deploymentMessage.GetEvent().GetAction()
+			if deployment != nil {
+				// Always return when deployment is found. As soon as deployment != nil it should be the deployment
+				// that matches assertion. If it isn't, the test should fail immediately. There's no point in waiting.
+				lastErr = assertion(deployment, action)
+				return
+			}
+		}
+	}
+}
+
 // LastDeploymentState checks the deployment state similarly to `LastDeploymentStateWithTimeout` with a default 3 seconds timeout.
 func (c *TestContext) LastDeploymentState(name string, assertion AssertFunc, message string) {
 	c.LastDeploymentStateWithTimeout(name, assertion, message, defaultWaitTimeout)
@@ -509,17 +535,24 @@ func (c *TestContext) LastDeploymentStateWithTimeout(name string, assertion Asse
 
 // DeploymentCreateReceived checks if a deployment object was received with CREATE action.
 func (c *TestContext) DeploymentCreateReceived(name string) {
-	c.DeploymentActionReceived(name, central.ResourceAction_CREATE_RESOURCE)
+	c.FirstDeploymentReceivedWithAction(name, central.ResourceAction_CREATE_RESOURCE)
 }
 
-// DeploymentActionReceived checks if a deployment object was received with specific action type.
-func (c *TestContext) DeploymentActionReceived(name string, expectedAction central.ResourceAction) {
-	c.LastDeploymentState(name, func(_ *storage.Deployment, action central.ResourceAction) error {
+// FirstDeploymentReceivedWithAction checks if a deployment object was received with specific action type.
+func (c *TestContext) FirstDeploymentReceivedWithAction(name string, expectedAction central.ResourceAction) {
+	c.FirstDeploymentStateMatchesWithTimeout(name, func(_ *storage.Deployment, action central.ResourceAction) error {
 		if action != expectedAction {
 			return errors.Errorf("event action is %s, but expected %s", action, expectedAction)
 		}
 		return nil
-	}, fmt.Sprintf("Deployment %s should be received with action %s", name, expectedAction))
+	}, fmt.Sprintf("Deployment %s should be received with action %s", name, expectedAction), defaultWaitTimeout)
+}
+
+// DeploymentNotReceived checks that a deployment event for deployment with name should not have been received by fake central.
+func (c *TestContext) DeploymentNotReceived(name string) {
+	messages := c.GetFakeCentral().GetAllMessages()
+	lastDeploymentUpdate := GetLastMessageWithDeploymentName(messages, DefaultNamespace, name)
+	assert.Nilf(c.t, lastDeploymentUpdate, "should not have found deployment with name %s: %+v", name, lastDeploymentUpdate)
 }
 
 // GetLastMessageMatching finds last element in slice matching `matchFn`.
@@ -795,6 +828,17 @@ func (c *TestContext) waitForResource(timeout time.Duration, fn condition) error
 			}
 		}
 	}
+}
+
+// GetFirstMessageWithDeploymentName find the first sensor message by namespace and deployment name
+func GetFirstMessageWithDeploymentName(messages []*central.MsgFromSensor, ns, name string) *central.MsgFromSensor {
+	for _, msg := range messages {
+		deployment := msg.GetEvent().GetDeployment()
+		if deployment.GetName() == name && deployment.GetNamespace() == ns {
+			return msg
+		}
+	}
+	return nil
 }
 
 // GetLastMessageWithDeploymentName find most recent sensor messages by namespace and deployment name


### PR DESCRIPTION
## Description

This PR relies on a few past PRs to make kubernetes reconciliation work when flipping between offline and online mode.
- #6958: Add context to every messages in the pipeline. This prevents messages to linger in the queue and mess up the reconciliation.
- #6692: Adds interface for cleaning up the in-memory stores. This is called when going into offline mode. This is required because during the reconciliation, we might pick up old deployments that were deleted while sensor wasn't listening to events.
- #6376: Adds offline mode for Kubernetes listeners. This triggers the reconciliation once the listeners are re-created.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- [x] E2E Tests
- [x] Implement new integration test for k8s reconciliation 