### PR TITLE
ROX-18468: Add existing network policies YAML to simulator side panel

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import * as networkService from 'services/NetworkService';
 import { ensureExhaustive } from 'utils/type.utils';
-import { NetworkPolicy, NetworkPolicyModification } from 'types/networkPolicy.proto';
+import { NetworkPolicyModification } from 'types/networkPolicy.proto';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { Simulation } from '../utils/getSimulation';
@@ -12,7 +12,6 @@ import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 export type NetworkPolicySimulator =
     | {
           state: 'ACTIVE';
-          networkPolicies: NetworkPolicy[];
           isLoading: boolean;
           error: string;
       }
@@ -87,7 +86,6 @@ function useNetworkPolicySimulator({
         if (state === 'ACTIVE') {
             setSimulator({
                 state: 'ACTIVE',
-                networkPolicies: [],
                 error: '',
                 isLoading: true,
             });
@@ -101,36 +99,11 @@ function useNetworkPolicySimulator({
         }
         switch (state) {
             case 'ACTIVE':
-                networkService
-                    .fetchNetworkPoliciesByClusterId(
-                        options.scopeHierarchy.cluster.id,
-                        getRequestQueryStringForSearchFilter({
-                            Namespace: options.scopeHierarchy.namespaces,
-                            Deployment: options.scopeHierarchy.deployments,
-                            ...options.scopeHierarchy.remainingQuery,
-                        })
-                    )
-                    .then((data) => {
-                        setSimulator({
-                            state,
-                            networkPolicies: data,
-                            error: '',
-                            isLoading: false,
-                        });
-                    })
-                    .catch((error) => {
-                        const message = getAxiosErrorMessage(error);
-                        const errorMessage =
-                            message ||
-                            'An unknown error occurred while getting the list of clusters';
-
-                        setSimulator({
-                            state,
-                            networkPolicies: [],
-                            error: errorMessage,
-                            isLoading: false,
-                        });
-                    });
+                setSimulator({
+                    state,
+                    error: '',
+                    isLoading: false,
+                });
                 break;
             case 'GENERATED':
                 networkService

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/CodeCompareIcon.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/CodeCompareIcon.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+function CodeCompareIcon() {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="currentColor"
+            height="1em"
+            width="1em"
+            viewBox="0 0 512 512"
+            role="img"
+            style={{ verticalAlign: '-0.125em' }}
+        >
+            {/* <!--! Font Awesome Free 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --> */}
+            <path d="M320 488c0 9.5-5.6 18.1-14.2 21.9s-18.8 2.3-25.8-4.1l-80-72c-5.1-4.6-7.9-11-7.9-17.8s2.9-13.3 7.9-17.8l80-72c7-6.3 17.2-7.9 25.8-4.1s14.2 12.4 14.2 21.9v40h16c35.3 0 64-28.7 64-64V153.3C371.7 141 352 112.8 352 80c0-44.2 35.8-80 80-80s80 35.8 80 80c0 32.8-19.7 61-48 73.3V320c0 70.7-57.3 128-128 128H320v40zM456 80a24 24 0 1 0 -48 0 24 24 0 1 0 48 0zM192 24c0-9.5 5.6-18.1 14.2-21.9s18.8-2.3 25.8 4.1l80 72c5.1 4.6 7.9 11 7.9 17.8s-2.9 13.3-7.9 17.8l-80 72c-7 6.3-17.2 7.9-25.8 4.1s-14.2-12.4-14.2-21.9V128H176c-35.3 0-64 28.7-64 64V358.7c28.3 12.3 48 40.5 48 73.3c0 44.2-35.8 80-80 80s-80-35.8-80-80c0-32.8 19.7-61 48-73.3V192c0-70.7 57.3-128 128-128h16V24zM56 432a24 24 0 1 0 48 0 24 24 0 1 0 -48 0z" />
+        </svg>
+    );
+}
+
+export default CodeCompareIcon;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/CompareYAMLModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/CompareYAMLModal.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Button, Flex, Modal, Text, Title } from '@patternfly/react-core';
+import NetworkPoliciesYAML from './NetworkPoliciesYAML';
+
+export type CompareYAMLModalProps = {
+    current: string;
+    generated: string;
+    isOpen: boolean;
+    onClose: () => void;
+};
+
+function CompareYAMLModal({ current, generated, isOpen, onClose }: CompareYAMLModalProps) {
+    return (
+        <Modal
+            className="compare-yaml-modal"
+            isOpen={isOpen}
+            header={
+                <>
+                    <Title headingLevel="h2">Compare with existing network policies</Title>
+                    <Text>
+                        Compare changes in the generated network policies to the existing network
+                        policies.
+                    </Text>
+                </>
+            }
+            onClose={onClose}
+            actions={[
+                <Button key="close" onClick={onClose}>
+                    Close
+                </Button>,
+            ]}
+        >
+            <Flex
+                className="pf-u-mt-md"
+                direction={{ default: 'column', md: 'row' }}
+                flexWrap={{ default: 'nowrap' }}
+            >
+                <Flex direction={{ default: 'column' }} style={{ flex: '1' }}>
+                    <Text className="pf-u-font-weight-bold">Generated network policies</Text>
+                    <NetworkPoliciesYAML yaml={generated} height="400px" />
+                </Flex>
+                <Flex direction={{ default: 'column' }} style={{ flex: '1' }}>
+                    <Text className="pf-u-font-weight-bold">Existing network policies</Text>
+                    <NetworkPoliciesYAML yaml={current} height="400px" />
+                </Flex>
+            </Flex>
+        </Modal>
+    );
+}
+
+export default CompareYAMLModal;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/CompareYAMLModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/CompareYAMLModal.tsx
@@ -18,8 +18,7 @@ function CompareYAMLModal({ current, generated, isOpen, onClose }: CompareYAMLMo
                 <>
                     <Title headingLevel="h2">Compare with existing network policies</Title>
                     <Text>
-                        Compare changes in the generated network policies to the existing network
-                        policies.
+                        Compare the generated network policies to the existing network policies.
                     </Text>
                 </>
             }
@@ -36,12 +35,12 @@ function CompareYAMLModal({ current, generated, isOpen, onClose }: CompareYAMLMo
                 flexWrap={{ default: 'nowrap' }}
             >
                 <Flex direction={{ default: 'column' }} style={{ flex: '1' }}>
-                    <Text className="pf-u-font-weight-bold">Generated network policies</Text>
-                    <NetworkPoliciesYAML yaml={generated} height="400px" />
-                </Flex>
-                <Flex direction={{ default: 'column' }} style={{ flex: '1' }}>
                     <Text className="pf-u-font-weight-bold">Existing network policies</Text>
                     <NetworkPoliciesYAML yaml={current} height="400px" />
+                </Flex>
+                <Flex direction={{ default: 'column' }} style={{ flex: '1' }}>
+                    <Text className="pf-u-font-weight-bold">Generated network policies</Text>
+                    <NetworkPoliciesYAML yaml={generated} height="400px" />
                 </Flex>
             </Flex>
         </Modal>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.css
@@ -1,0 +1,8 @@
+.network-policies-yaml .pf-c-code-editor__controls {
+  width: 100%;
+}
+
+
+.compare-yaml-modal {
+  --pf-c-modal-box--MaxWidth: 1200px;
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
@@ -6,8 +6,12 @@ import { useTheme } from 'Containers/ThemeProvider';
 import download from 'utils/download';
 import CodeEditorDarkModeControl from 'Components/PatternFly/CodeEditorDarkModeControl';
 
+import './NetworkPoliciesYAML.css';
+
 type NetworkPoliciesYAMLProp = {
     yaml: string;
+    height?: string;
+    additionalControls?: React.ReactNode[];
 };
 
 const labels = {
@@ -18,7 +22,11 @@ const downloadYAMLHandler = (fileName: string, fileContent: string) => () => {
     download(`${fileName}.yml`, fileContent, 'yml');
 };
 
-function NetworkPoliciesYAML({ yaml }: NetworkPoliciesYAMLProp) {
+function NetworkPoliciesYAML({
+    yaml,
+    height = '300px',
+    additionalControls = [],
+}: NetworkPoliciesYAMLProp) {
     const { isDarkMode } = useTheme();
     const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
 
@@ -37,7 +45,7 @@ function NetworkPoliciesYAML({ yaml }: NetworkPoliciesYAMLProp) {
     );
 
     return (
-        <div className="pf-u-h-100">
+        <div className="network-policies-yaml pf-u-h-100">
             <CodeEditor
                 isDarkTheme={customDarkMode}
                 customControls={[
@@ -46,13 +54,14 @@ function NetworkPoliciesYAML({ yaml }: NetworkPoliciesYAMLProp) {
                         onToggleDarkMode={onToggleDarkMode}
                     />,
                     downloadYAMLControl,
+                    ...additionalControls,
                 ]}
                 isCopyEnabled
                 isLineNumbersVisible
                 isReadOnly
                 code={yaml}
                 language={Language.yaml}
-                height="300px"
+                height={height}
             />
         </div>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -220,8 +220,8 @@ function NetworkPolicySimulatorSidePanel({
                                             <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                                                 <Title headingLevel="h3">Compare changes</Title>
                                                 <Text>
-                                                    Compare changes in the generated network
-                                                    policies to the existing network policies.
+                                                    Compare the generated network policies to the
+                                                    existing network policies.
                                                 </Text>
                                             </Flex>
                                         }

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -195,7 +195,7 @@ function NetworkPolicySimulatorSidePanel({
                     </StackItem>
                     <StackItem isFilled style={{ overflow: 'auto' }}>
                         <NetworkPoliciesYAML
-                            yaml={currentYaml}
+                            yaml={generatedYaml}
                             additionalControls={[
                                 <Flex
                                     justifyContent={{ default: 'justifyContentFlexEnd' }}

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -213,12 +213,12 @@ function NetworkPolicySimulatorSidePanel({
                                         }
                                         icon={<CodeCompareIcon />}
                                     >
-                                        Compare changes
+                                        Compare
                                     </Button>
                                     <Popover
                                         bodyContent={
                                             <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-                                                <Title headingLevel="h3">Compare changes</Title>
+                                                <Title headingLevel="h3">Compare</Title>
                                                 <Text>
                                                     Compare the generated network policies to the
                                                     existing network policies.

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
     Alert,
     Bullseye,
@@ -18,10 +18,16 @@ import {
     Text,
     TextContent,
     TextVariants,
+    Title,
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
+import sortBy from 'lodash/sortBy';
 
+import useRestQuery from 'hooks/useRestQuery';
 import useTabs from 'hooks/patternfly/useTabs';
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { fetchNetworkPoliciesByClusterId } from 'services/NetworkService';
+
 import ViewActiveYAMLs from './ViewActiveYAMLs';
 import {
     NetworkPolicySimulator,
@@ -33,6 +39,8 @@ import UploadYAMLButton from './UploadYAMLButton';
 import NetworkSimulatorActions from './NetworkSimulatorActions';
 import NotifyYAMLModal from './NotifyYAMLModal';
 import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
+import CompareYAMLModal from './CompareYAMLModal';
+import CodeCompareIcon from './CodeCompareIcon';
 
 type NetworkPolicySimulatorSidePanelProps = {
     simulator: NetworkPolicySimulator;
@@ -56,6 +64,26 @@ function NetworkPolicySimulatorSidePanel({
     const [isExcludingPortsAndProtocols, setIsExcludingPortsAndProtocols] =
         React.useState<boolean>(false);
     const [isNotifyModalOpen, setIsNotifyModalOpen] = React.useState(false);
+    const [compareModalYAMLs, setCompareModalYAMLs] = React.useState<{
+        generated: string;
+        current: string;
+    } | null>(null);
+
+    const clusterId = scopeHierarchy.cluster.id;
+    const deploymentQuery = getRequestQueryStringForSearchFilter({
+        Namespace: scopeHierarchy.namespaces,
+        Deployment: scopeHierarchy.deployments,
+        ...scopeHierarchy.remainingQuery,
+    });
+
+    const fetchNetworkPolicies = useCallback(
+        () =>
+            fetchNetworkPoliciesByClusterId(clusterId, deploymentQuery).then((policies) =>
+                sortBy(policies, 'name')
+            ),
+        [clusterId, deploymentQuery]
+    );
+    const { data: currentNetworkPolicies } = useRestQuery(fetchNetworkPolicies);
 
     function handleFileInputChange(
         _event: React.ChangeEvent<HTMLInputElement> | React.DragEvent<HTMLElement>,
@@ -130,7 +158,12 @@ function NetworkPolicySimulatorSidePanel({
     }
 
     if (simulator.state === 'GENERATED') {
-        const yaml = getDisplayYAMLFromNetworkPolicyModification(simulator.modification);
+        const currentPolicies = currentNetworkPolicies ?? [];
+        const currentYaml =
+            currentPolicies.length === 0
+                ? 'No network policies exist in the current scope'
+                : currentPolicies.map((policy) => policy.yaml).join('\n---\n');
+        const generatedYaml = getDisplayYAMLFromNetworkPolicyModification(simulator.modification);
         return (
             <div>
                 <Flex
@@ -161,7 +194,49 @@ function NetworkPolicySimulatorSidePanel({
                         />
                     </StackItem>
                     <StackItem isFilled style={{ overflow: 'auto' }}>
-                        <NetworkPoliciesYAML yaml={yaml} />
+                        <NetworkPoliciesYAML
+                            yaml={currentYaml}
+                            additionalControls={[
+                                <Flex
+                                    justifyContent={{ default: 'justifyContentFlexEnd' }}
+                                    alignItems={{ default: 'alignItemsCenter' }}
+                                    spaceItems={{ default: 'spaceItemsNone' }}
+                                    className="pf-u-flex-1"
+                                >
+                                    <Button
+                                        variant="link"
+                                        onClick={() =>
+                                            setCompareModalYAMLs({
+                                                generated: generatedYaml,
+                                                current: currentYaml,
+                                            })
+                                        }
+                                        icon={<CodeCompareIcon />}
+                                    >
+                                        Compare changes
+                                    </Button>
+                                    <Popover
+                                        bodyContent={
+                                            <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+                                                <Title headingLevel="h3">Compare changes</Title>
+                                                <Text>
+                                                    Compare changes in the generated network
+                                                    policies to the existing network policies.
+                                                </Text>
+                                            </Flex>
+                                        }
+                                    >
+                                        <button
+                                            className="pf-u-color-200"
+                                            type="button"
+                                            aria-label="More info on comparing changes"
+                                        >
+                                            <HelpIcon />
+                                        </button>
+                                    </Popover>
+                                </Flex>,
+                            ]}
+                        />
                     </StackItem>
                     <StackItem>
                         <NetworkSimulatorActions
@@ -178,11 +253,19 @@ function NetworkPolicySimulatorSidePanel({
                     clusterId={scopeHierarchy.cluster.id}
                     modification={simulator.modification}
                 />
+                {compareModalYAMLs && (
+                    <CompareYAMLModal
+                        generated={compareModalYAMLs.generated}
+                        current={compareModalYAMLs.current}
+                        isOpen={!!compareModalYAMLs}
+                        onClose={() => setCompareModalYAMLs(null)}
+                    />
+                )}
             </div>
         );
     }
 
-    // @TODO: Consider how to reuse parts of this that are similiar between states
+    // @TODO: Consider how to reuse parts of this that are similar between states
     if (simulator.state === 'UNDO') {
         const yaml = getDisplayYAMLFromNetworkPolicyModification(simulator.modification);
         return (
@@ -376,8 +459,8 @@ function NetworkPolicySimulatorSidePanel({
                                             <Text component={TextVariants.p}>
                                                 Generate a set of recommended network policies based
                                                 on your cluster baseline. Cluster baseline is the
-                                                aggregatation of the baselines of the deployments
-                                                that belong to the cluster.
+                                                aggregation of the baselines of the deployments that
+                                                belong to the cluster.
                                             </Text>
                                         </TextContent>
                                     </StackItem>
@@ -441,9 +524,7 @@ function NetworkPolicySimulatorSidePanel({
                     hidden={activeKeyTab !== tabs.VIEW_ACTIVE_YAMLS}
                 >
                     <ViewActiveYAMLs
-                        networkPolicies={
-                            simulator.state === 'ACTIVE' ? simulator.networkPolicies : []
-                        }
+                        networkPolicies={currentNetworkPolicies ?? []}
                         generateNetworkPolicies={generateNetworkPolicies}
                         undoNetworkPolicies={undoNetworkPolicies}
                         onFileInputChange={handleFileInputChange}

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulateNetworkPolicyButton.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulateNetworkPolicyButton.tsx
@@ -27,7 +27,7 @@ function SimulateNetworkPolicyButton({ simulation, isDisabled }: SimulateNetwork
             isDisabled={isDisabled || simulation.isOn}
             onClick={enableNetworkPolicySimulation}
         >
-            Simulate network policy
+            Network policy generator
         </Button>
     );
 }

--- a/ui/apps/platform/src/services/NetworkService.js
+++ b/ui/apps/platform/src/services/NetworkService.js
@@ -1,5 +1,4 @@
 import queryString from 'qs';
-import sortBy from 'lodash/sortBy';
 
 import { ORCHESTRATOR_COMPONENTS_KEY } from 'utils/orchestratorComponents';
 
@@ -355,7 +354,7 @@ export function getActiveNetworkModification(clusterId, deploymentQuery) {
  */
 export function fetchNetworkPoliciesByClusterId(clusterId, deploymentQuery) {
     if (clusterId === '') {
-        return Promise.resolve([]);
+        return Promise.reject(new Error('A cluster ID must be provided to fetch network policies'));
     }
     // The `deploymentQuery` param functions identically to the general `query` param used in
     // other API calls and accepts the same search filter syntax.
@@ -364,9 +363,7 @@ export function fetchNetworkPoliciesByClusterId(clusterId, deploymentQuery) {
         method: 'GET',
         url: `${networkPoliciesBaseUrl}?${params}`,
     };
-    return axios(options).then((response) => {
-        return sortBy(response?.data?.networkPolicies, 'name') ?? [];
-    });
+    return axios(options).then((response) => response.data.networkPolicies ?? []);
 }
 
 /**


### PR DESCRIPTION
## Description

This adds a button to the network policy simulation that allows the user to view the generated policies side-by-side with the existing network policies.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

View the network graph page and enable the simulator. Verify that the "View active YAMLs" tab works correctly, and identically to how it did before this change, showing all existing network policies for deployments in the current scope.
![image](https://github.com/stackrox/stackrox/assets/1292638/359cbfc8-fc29-4c3c-a6b6-b47e8f5e37a9)
![image](https://github.com/stackrox/stackrox/assets/1292638/e1b376bc-21f1-4ba7-8adb-e3d61d6f9cd7)

Return to the "Simulate network policies" tab and generate network policies:
![image](https://github.com/stackrox/stackrox/assets/1292638/a1c9514e-a696-4289-858c-290c7f1725fc)
![image](https://github.com/stackrox/stackrox/assets/1292638/755ec6f3-feb2-4d30-b1fe-183dc3389249)

Click the "Compare changes" button to view the generated policies side by side with the existing network policies:
![image](https://github.com/stackrox/stackrox/assets/1292638/8e0229c4-0e18-4b36-a6ae-3108a3f32d61)

Close the modal and change the network graph scope - ensure that the updated policies are reflected in the modal when generated again.
![image](https://github.com/stackrox/stackrox/assets/1292638/23a58ff4-9ff8-43ae-b5cb-f06ec9936b65)

## Follow up

The code editor theme button gets out of sync when multiple code editors are visible on the page at once. This is because this state is tracked locally in our components, but the underlying monaco editor uses a single global state for the theme. Additionally this theme cannot be different across multiple editors on the same page. This also has the side effect of changing all visible editors to the light mode whenever a new editor is initialized on the page.

https://github.com/stackrox/stackrox/assets/1292638/1b58f9ce-025e-4b43-99b3-13ce23f2cec8



