### PR TITLE
test(ui): Temporarily disable flaky workload cve toolbar test

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadTableToolbar.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadTableToolbar.test.js
@@ -12,7 +12,8 @@ describe('Workload table toolbar', () => {
         }
     });
 
-    it('should correctly handle applied filters', () => {
+    // TODO Fix the flake and re-enable this test https://issues.redhat.com/browse/ROX-17959
+    it.skip('should correctly handle applied filters', () => {
         visitWorkloadCveOverview();
 
         // Set the entity type to 'Namespace'


### PR DESCRIPTION
## Description

This flake seems to gradually be happening more frequently as time goes on, so I'll disable it for now until a proper fix can be worked.

https://issues.redhat.com/browse/ROX-17959

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

N/A
