### PR TITLE
refactor(image): Copy UI and notices directly to Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -615,11 +615,11 @@ endif
 
 .PHONY: copy-binaries-to-image-dir
 copy-binaries-to-image-dir: copy-go-binaries-to-image-dir
-	cp -r ui/build image/ui/
+	cp -r ui/build image/rhel/ui/
 ifdef CI
-	$(SILENT)[ -d image/THIRD_PARTY_NOTICES ] || { echo "image/THIRD_PARTY_NOTICES dir not found! It is required for CI-built images."; exit 1; }
+	$(SILENT)[ -d image/rhel/THIRD_PARTY_NOTICES ] || { echo "image/rhel/THIRD_PARTY_NOTICES dir not found! It is required for CI-built images."; exit 1; }
 else
-	$(SILENT)[ -f image/THIRD_PARTY_NOTICES ] || mkdir -p image/THIRD_PARTY_NOTICES
+	$(SILENT)[ -f image/rhel/THIRD_PARTY_NOTICES ] || mkdir -p image/rhel/THIRD_PARTY_NOTICES
 endif
 	$(SILENT)[ -d image/rhel/docs ] || { echo "Generated docs not found in image/rhel/docs. They are required for build."; exit 1; }
 
@@ -679,7 +679,7 @@ clean: clean-image
 clean-image:
 	@echo "+ $@"
 	git clean -xf image/bin image/rhel/bin
-	git clean -xdf image/ui image/rhel/docs
+	git clean -xdf image/ui image/rhel/ui image/rhel/docs
 	git clean -xf integration-tests/mock-grpc-server/image/bin/mock-grpc-server
 	rm -f $(CURDIR)/image/rhel/bundle.tar.gz $(CURDIR)/image/postgres/bundle.tar.gz
 	rm -rf $(CURDIR)/image/rhel/scripts
@@ -716,7 +716,7 @@ ossls-audit: deps
 .PHONY: ossls-notice
 ossls-notice: deps
 	ossls version
-	ossls audit --export image/THIRD_PARTY_NOTICES
+	ossls audit --export image/rhel/THIRD_PARTY_NOTICES
 
 .PHONY: collector-tag
 collector-tag:

--- a/image/rhel/.gitignore
+++ b/image/rhel/.gitignore
@@ -2,3 +2,5 @@ bundle.tar.gz
 bundle.tar.gz.sha512
 scripts
 Dockerfile.gen
+ui
+THIRD_PARTY_NOTICES

--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -51,8 +51,9 @@ COPY bin/sensor-upgrader    /stackrox/bin/sensor-upgrader
 COPY bin/admission-control  /stackrox/bin/admission-control
 COPY bin/roxctl*            /assets/downloads/cli/
 
-COPY --from=extracted_bundle /bundle/THIRD_PARTY_NOTICES/ /THIRD_PARTY_NOTICES/
-COPY --from=extracted_bundle /bundle/ui/ /ui/
+COPY THIRD_PARTY_NOTICES /THIRD_PARTY_NOTICES/
+COPY ui /ui
+
 COPY --from=extracted_bundle /bundle/snappy.rpm /tmp/
 COPY --from=extracted_bundle /bundle/postgres-libs.rpm /tmp/
 COPY --from=extracted_bundle /bundle/postgres.rpm /tmp/

--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -33,9 +33,6 @@ chmod -R 755 "${bundle_root}"
 # includes artifacts that would be otherwise downloaded or included via a COPY
 # command in the Dockerfile.
 
-cp -pr "${INPUT_ROOT}/THIRD_PARTY_NOTICES"  "${bundle_root}/"
-cp -pr "${INPUT_ROOT}/ui/build/"*           "${bundle_root}/ui/"
-
 arch="x86_64"
 goarch="amd64"
 if [[ $(uname -m) == "arm64" ]]; then


### PR DESCRIPTION
## Description

Removes the UI copy and third party notices copy from the bundler

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI