### PR TITLE
ROX-18605: Initial conversion functions for Create Indexer Report 

### DIFF
--- a/scanner/services/converters.go
+++ b/scanner/services/converters.go
@@ -1,0 +1,132 @@
+package services
+
+import (
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/pkg/cpe"
+	"github.com/stackrox/rox/generated/internalapi/scanner/v4"
+)
+
+func convertToIndexReport(r *claircore.IndexReport) *v4.IndexReport {
+	if r == nil {
+		return nil
+	}
+	var environments map[string]*v4.Environment_List
+	if len(r.Environments) > 0 {
+		environments = make(map[string]*v4.Environment_List, len(r.Environments))
+	}
+	for k, v := range r.Environments {
+		for _, e := range v {
+			l, ok := environments[k]
+			if !ok {
+				l = &v4.Environment_List{}
+				environments[k] = l
+			}
+			l.Environments = append(l.Environments, convertToEnvironment(e))
+		}
+	}
+	return &v4.IndexReport{
+		State:         r.State,
+		Success:       r.Success,
+		Err:           r.Err,
+		Packages:      convertMapToSlice(convertToPackage, r.Packages),
+		Distributions: convertMapToSlice(convertToDistribution, r.Distributions),
+		Repositories:  convertMapToSlice(convertToRepository, r.Repositories),
+		Environments:  environments,
+	}
+}
+
+func convertToPackage(p *claircore.Package) *v4.Package {
+	if p == nil {
+		return nil
+	}
+	// Conversion functions.
+	toNormalizedVersion := func(version claircore.Version) *v4.NormalizedVersion {
+		return &v4.NormalizedVersion{
+			Kind: version.Kind,
+			V:    version.V[:],
+		}
+	}
+	toSourcePackage := func(p *claircore.Package) (source *v4.Package) {
+		if p == nil {
+			return nil
+		}
+		// Sanitize and avoid recursion.
+		if p.Source != nil {
+			p.Source.Source = nil
+			source = convertToPackage(p.Source)
+		}
+		return source
+	}
+	return &v4.Package{
+		Id:                p.ID,
+		Name:              p.Name,
+		Version:           p.Version,
+		NormalizedVersion: toNormalizedVersion(p.NormalizedVersion),
+		Kind:              p.Kind,
+		Source:            toSourcePackage(p.Source),
+		PackageDb:         p.PackageDB,
+		RepositoryHint:    p.RepositoryHint,
+		Module:            p.Module,
+		Arch:              p.Arch,
+		Cpe:               convertToCPEString(p.CPE),
+	}
+}
+
+func convertToDistribution(d *claircore.Distribution) *v4.Distribution {
+	if d == nil {
+		return nil
+	}
+	return &v4.Distribution{
+		Id:              d.ID,
+		Did:             d.DID,
+		Name:            d.Name,
+		Version:         d.Version,
+		VersionCodeName: d.VersionCodeName,
+		VersionId:       d.VersionID,
+		Arch:            d.Arch,
+		Cpe:             convertToCPEString(d.CPE),
+		PrettyName:      d.PrettyName,
+	}
+}
+
+func convertToRepository(r *claircore.Repository) *v4.Repository {
+	if r == nil {
+		return nil
+	}
+	return &v4.Repository{
+		Id:   r.ID,
+		Name: r.Name,
+		Key:  r.Key,
+		Uri:  r.URI,
+		Cpe:  convertToCPEString(r.CPE),
+	}
+}
+
+func convertToEnvironment(e *claircore.Environment) *v4.Environment {
+	if e == nil {
+		return nil
+	}
+	return &v4.Environment{
+		PackageDb:      e.PackageDB,
+		IntroducedIn:   convertToDigestString(e.IntroducedIn),
+		DistributionId: e.DistributionID,
+		RepositoryIds:  append([]string(nil), e.RepositoryIDs...),
+	}
+}
+
+func convertToCPEString(c cpe.WFN) string {
+	return c.String()
+}
+
+func convertToDigestString(digest claircore.Digest) string {
+	return digest.String()
+}
+
+// convertMapToSlice converts generic maps keyed by strings to a slice using a
+// provided conversion function.
+func convertMapToSlice[IN any, OUT any](convF func(*IN) *OUT, in map[string]*IN) (out []*OUT) {
+	for _, i := range in {
+		out = append(out, convF(i))
+	}
+	return out
+}

--- a/scanner/services/converters_test.go
+++ b/scanner/services/converters_test.go
@@ -1,0 +1,286 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/pkg/cpe"
+	"github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_convertToIndexReport(t *testing.T) {
+	sampleDigest := claircore.MustParseDigest("sha256:aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f")
+	tests := []struct {
+		name string
+		arg  *claircore.IndexReport
+		want *v4.IndexReport
+	}{
+		{
+			name: "when nil then nil",
+		},
+		{
+			name: "when default values",
+			arg:  &claircore.IndexReport{},
+			want: &v4.IndexReport{},
+		},
+		{
+			name: "when happy sample values",
+			arg: &claircore.IndexReport{
+				Hash:  sampleDigest,
+				State: "sample_state",
+				Packages: map[string]*claircore.Package{
+					"sample_package_key": {
+						Name: "sample_package",
+					}},
+				Distributions: map[string]*claircore.Distribution{
+					"sample_distribution_key": {
+						Name: "sample_distribution",
+					}},
+				Repositories: map[string]*claircore.Repository{
+					"sample_repository_key": {
+						Name: "sample_repository",
+					}},
+				Environments: map[string][]*claircore.Environment{"sample_env_key": {
+					{
+						PackageDB:    "sample_db",
+						IntroducedIn: sampleDigest,
+					},
+				}},
+				Success: true,
+				Err:     "",
+			},
+			want: &v4.IndexReport{
+				State: "sample_state",
+				Packages: []*v4.Package{
+					{
+						Name: "sample_package",
+						NormalizedVersion: &v4.NormalizedVersion{
+							Kind: "",
+							V:    make([]int32, 10),
+						},
+						Cpe: "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*",
+					},
+				},
+				Distributions: []*v4.Distribution{
+					{
+						Name: "sample_distribution",
+						Cpe:  "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*",
+					},
+				},
+				Repositories: []*v4.Repository{
+					{
+						Name: "sample_repository",
+						Cpe:  "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*",
+					},
+				},
+				Environments: map[string]*v4.Environment_List{"sample_env_key": {Environments: []*v4.Environment{
+					{
+						PackageDb:    "sample_db",
+						IntroducedIn: sampleDigest.String(),
+					},
+				}}},
+				Success: true,
+				Err:     "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, convertToIndexReport(tt.arg))
+		})
+	}
+}
+
+func Test_convertToPackage(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  *claircore.Package
+		want *v4.Package
+	}{
+		{
+			name: "when nil then nil",
+		},
+		{
+			name: "when sample values then no error",
+			arg: &claircore.Package{
+				ID:             "sample id",
+				Name:           "sample name",
+				Version:        "sample version",
+				Kind:           "sample kind",
+				Source:         nil,
+				PackageDB:      "sample package db",
+				Filepath:       "sample file path",
+				RepositoryHint: "sample hint",
+				NormalizedVersion: claircore.Version{
+					Kind: "test",
+					V:    [...]int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
+				},
+				Module: "sample module",
+				Arch:   "sample arch",
+				CPE:    cpe.WFN{},
+			},
+			want: &v4.Package{
+				Id:      "sample id",
+				Name:    "sample name",
+				Version: "sample version",
+				NormalizedVersion: &v4.NormalizedVersion{
+					Kind: "test",
+					V:    []int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
+				},
+				Kind:           "sample kind",
+				Source:         nil,
+				PackageDb:      "sample package db",
+				RepositoryHint: "sample hint",
+				Module:         "sample module",
+				Arch:           "sample arch",
+				Cpe:            "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertToPackage(tt.arg)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+	// Test source with another source (prevents recursion).
+	t.Run("when source has source no convertion", func(t *testing.T) {
+		arg := &claircore.Package{
+			Name: "Package",
+			Source: &claircore.Package{
+				Name: "source",
+				Source: &claircore.Package{
+					Name: "another source",
+				},
+			},
+		}
+		got := convertToPackage(arg)
+		assert.Nil(t, got.GetSource().GetSource())
+	})
+}
+
+func Test_convertToDistribution(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     *claircore.Distribution
+		want    *v4.Distribution
+		wantErr bool
+	}{
+		{
+			name: "when nil then nil",
+		},
+		{
+			name: "when default then no errors",
+			arg:  &claircore.Distribution{},
+			want: &v4.Distribution{Cpe: "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*"},
+		},
+		{
+			name: "when default then no errors",
+			arg: &claircore.Distribution{
+				ID:              "sample id",
+				DID:             "sample did",
+				Name:            "sample name",
+				Version:         "sample version",
+				VersionCodeName: "sample version codename",
+				VersionID:       "sample version id",
+				Arch:            "sample arch",
+				CPE:             cpe.MustUnbind("cpe:/a:redhat:openshift:4.12::el8"),
+				PrettyName:      "sample pretty name",
+			},
+			want: &v4.Distribution{
+				Id:              "sample id",
+				Did:             "sample did",
+				Name:            "sample name",
+				Version:         "sample version",
+				VersionCodeName: "sample version codename",
+				VersionId:       "sample version id",
+				Arch:            "sample arch",
+				Cpe:             "cpe:2.3:a:redhat:openshift:4.12:*:el8:*:*:*:*:*",
+				PrettyName:      "sample pretty name",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertToDistribution(tt.arg)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_convertToRepository(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  *claircore.Repository
+		want *v4.Repository
+	}{
+		{
+			name: "when nil then nil",
+		},
+		{
+			name: "when sample then no error",
+			arg: &claircore.Repository{
+				ID:   "sample id",
+				Name: "sample name",
+				Key:  "sample key",
+				URI:  "sample URI",
+				CPE:  cpe.MustUnbind("cpe:/a:redhat:openshift:4.12::el8"),
+			},
+			want: &v4.Repository{
+				Id:   "sample id",
+				Name: "sample name",
+				Key:  "sample key",
+				Uri:  "sample URI",
+				Cpe:  "cpe:2.3:a:redhat:openshift:4.12:*:el8:*:*:*:*:*",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertToRepository(tt.arg)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_convertToEnvironment(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  *claircore.Environment
+		want *v4.Environment
+	}{
+		{
+			name: "when nil then nil",
+		},
+		{
+			name: "when default then no errors",
+			arg:  &claircore.Environment{},
+			want: &v4.Environment{},
+		},
+		{
+			name: "when sample values then no errors",
+			arg: &claircore.Environment{
+				PackageDB:      "sample package db",
+				IntroducedIn:   claircore.Digest{},
+				DistributionID: "sample distribution",
+				RepositoryIDs:  nil,
+			},
+			want: &v4.Environment{
+				PackageDb:      "sample package db",
+				IntroducedIn:   "",
+				DistributionId: "sample distribution",
+				RepositoryIds:  nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertToEnvironment(tt.arg)
+			assert.Equal(t, tt.want, got)
+			if tt.want != nil && tt.want.RepositoryIds != nil {
+				assert.NotEqual(t, &tt.want.RepositoryIds, &got.RepositoryIds)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

The conversion functions from Clair to Scanner types related to creating index reports have been included in this patch. The Scanner V4 APIs use protobuf types that require translation from the underlying Clair Core types.

🌳 master
├─ :arrow_up_small: **ROX-18605: Initial conversion functions for Create Indexer Report #7043** :point_left: 
├─── :arrow_up_small: ROX-18605: Implement create index report #7077
├───── :arrow_up_small: ROX-18605: Implement Indexer Get and Has endpoints #7099


## Checklist
- [x] Investigated and inspected CI test results
- [X] Unit test and regression tests added

### N/A
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

- UTs.
