### PR TITLE
refactor(pg): remove unused context arg

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoActiveComponents(ctx context.Context, batch *pgx.Batch, obj *storage.ActiveComponent) error {
+func insertIntoActiveComponents(batch *pgx.Batch, obj *storage.ActiveComponent) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {
@@ -107,7 +107,7 @@ func insertIntoActiveComponents(ctx context.Context, batch *pgx.Batch, obj *stor
 	var query string
 
 	for childIndex, child := range obj.GetActiveContextsSlice() {
-		if err := insertIntoActiveComponentsActiveContextsSlices(ctx, batch, child, obj.GetId(), childIndex); err != nil {
+		if err := insertIntoActiveComponentsActiveContextsSlices(batch, child, obj.GetId(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -117,7 +117,7 @@ func insertIntoActiveComponents(ctx context.Context, batch *pgx.Batch, obj *stor
 	return nil
 }
 
-func insertIntoActiveComponentsActiveContextsSlices(_ context.Context, batch *pgx.Batch, obj *storage.ActiveComponent_ActiveContext, activeComponentID string, idx int) error {
+func insertIntoActiveComponentsActiveContextsSlices(batch *pgx.Batch, obj *storage.ActiveComponent_ActiveContext, activeComponentID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoAlerts(_ context.Context, batch *pgx.Batch, obj *storage.Alert) error {
+func insertIntoAlerts(batch *pgx.Batch, obj *storage.Alert) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoAPITokens(_ context.Context, batch *pgx.Batch, obj *storage.TokenMetadata) error {
+func insertIntoAPITokens(batch *pgx.Batch, obj *storage.TokenMetadata) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoAuthProviders(_ context.Context, batch *pgx.Batch, obj *storage.AuthProvider) error {
+func insertIntoAuthProviders(batch *pgx.Batch, obj *storage.AuthProvider) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/blob/datastore/store/postgres/store.go
+++ b/central/blob/datastore/store/postgres/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoBlobs(_ context.Context, batch *pgx.Batch, obj *storage.Blob) error {
+func insertIntoBlobs(batch *pgx.Batch, obj *storage.Blob) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoClusters(_ context.Context, batch *pgx.Batch, obj *storage.Cluster) error {
+func insertIntoClusters(batch *pgx.Batch, obj *storage.Cluster) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoClusterHealthStatuses(_ context.Context, batch *pgx.Batch, obj *storage.ClusterHealthStatus) error {
+func insertIntoClusterHealthStatuses(batch *pgx.Batch, obj *storage.ClusterHealthStatus) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -81,7 +81,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoClusterInitBundles(_ context.Context, batch *pgx.Batch, obj *storage.InitBundleMeta) error {
+func insertIntoClusterInitBundles(batch *pgx.Batch, obj *storage.InitBundleMeta) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
+++ b/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoComplianceConfigs(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceConfig) error {
+func insertIntoComplianceConfigs(batch *pgx.Batch, obj *storage.ComplianceConfig) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoComplianceDomains(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceDomain) error {
+func insertIntoComplianceDomains(batch *pgx.Batch, obj *storage.ComplianceDomain) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoComplianceRunMetadata(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceRunMetadata) error {
+func insertIntoComplianceRunMetadata(batch *pgx.Batch, obj *storage.ComplianceRunMetadata) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoComplianceRunResults(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceRunResults) error {
+func insertIntoComplianceRunResults(batch *pgx.Batch, obj *storage.ComplianceRunResults) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoComplianceStrings(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceStrings) error {
+func insertIntoComplianceStrings(batch *pgx.Batch, obj *storage.ComplianceStrings) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoComplianceOperatorCheckResults(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorCheckResult) error {
+func insertIntoComplianceOperatorCheckResults(batch *pgx.Batch, obj *storage.ComplianceOperatorCheckResult) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoComplianceOperatorProfiles(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorProfile) error {
+func insertIntoComplianceOperatorProfiles(batch *pgx.Batch, obj *storage.ComplianceOperatorProfile) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoComplianceOperatorRules(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorRule) error {
+func insertIntoComplianceOperatorRules(batch *pgx.Batch, obj *storage.ComplianceOperatorRule) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoComplianceOperatorScans(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorScan) error {
+func insertIntoComplianceOperatorScans(batch *pgx.Batch, obj *storage.ComplianceOperatorScan) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoComplianceOperatorScanSettingBindings(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorScanSettingBinding) error {
+func insertIntoComplianceOperatorScanSettingBindings(batch *pgx.Batch, obj *storage.ComplianceOperatorScanSettingBinding) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/complianceoperator/v2/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/v2/checkresults/store/postgres/store.go
@@ -87,7 +87,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoComplianceOperatorCheckResultV2(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorCheckResultV2) error {
+func insertIntoComplianceOperatorCheckResultV2(batch *pgx.Batch, obj *storage.ComplianceOperatorCheckResultV2) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/complianceoperator/v2/profiles/store/postgres/store.go
+++ b/central/complianceoperator/v2/profiles/store/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoComplianceOperatorProfileV2(ctx context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorProfileV2) error {
+func insertIntoComplianceOperatorProfileV2(batch *pgx.Batch, obj *storage.ComplianceOperatorProfileV2) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {
@@ -109,7 +109,7 @@ func insertIntoComplianceOperatorProfileV2(ctx context.Context, batch *pgx.Batch
 	var query string
 
 	for childIndex, child := range obj.GetRules() {
-		if err := insertIntoComplianceOperatorProfileV2Rules(ctx, batch, child, obj.GetId(), childIndex); err != nil {
+		if err := insertIntoComplianceOperatorProfileV2Rules(batch, child, obj.GetId(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -119,7 +119,7 @@ func insertIntoComplianceOperatorProfileV2(ctx context.Context, batch *pgx.Batch
 	return nil
 }
 
-func insertIntoComplianceOperatorProfileV2Rules(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorProfileV2_Rule, complianceOperatorProfileV2ID string, idx int) error {
+func insertIntoComplianceOperatorProfileV2Rules(batch *pgx.Batch, obj *storage.ComplianceOperatorProfileV2_Rule, complianceOperatorProfileV2ID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start

--- a/central/complianceoperator/v2/rules/store/postgres/store.go
+++ b/central/complianceoperator/v2/rules/store/postgres/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoComplianceOperatorRuleV2(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorRuleV2) error {
+func insertIntoComplianceOperatorRuleV2(batch *pgx.Batch, obj *storage.ComplianceOperatorRuleV2) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/complianceoperator/v2/scans/store/postgres/store.go
+++ b/central/complianceoperator/v2/scans/store/postgres/store.go
@@ -87,7 +87,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoComplianceOperatorScanV2(ctx context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorScanV2) error {
+func insertIntoComplianceOperatorScanV2(batch *pgx.Batch, obj *storage.ComplianceOperatorScanV2) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {
@@ -108,7 +108,7 @@ func insertIntoComplianceOperatorScanV2(ctx context.Context, batch *pgx.Batch, o
 	var query string
 
 	for childIndex, child := range obj.GetProfile() {
-		if err := insertIntoComplianceOperatorScanV2Profiles(ctx, batch, child, obj.GetId(), childIndex); err != nil {
+		if err := insertIntoComplianceOperatorScanV2Profiles(batch, child, obj.GetId(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -118,7 +118,7 @@ func insertIntoComplianceOperatorScanV2(ctx context.Context, batch *pgx.Batch, o
 	return nil
 }
 
-func insertIntoComplianceOperatorScanV2Profiles(_ context.Context, batch *pgx.Batch, obj *storage.ProfileShim, complianceOperatorScanV2ID string, idx int) error {
+func insertIntoComplianceOperatorScanV2Profiles(batch *pgx.Batch, obj *storage.ProfileShim, complianceOperatorScanV2ID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start

--- a/central/complianceoperator/v2/scansettings/store/postgres/store.go
+++ b/central/complianceoperator/v2/scansettings/store/postgres/store.go
@@ -87,7 +87,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoComplianceOperatorScanSettingV2(ctx context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorScanSettingV2) error {
+func insertIntoComplianceOperatorScanSettingV2(batch *pgx.Batch, obj *storage.ComplianceOperatorScanSettingV2) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {
@@ -107,7 +107,7 @@ func insertIntoComplianceOperatorScanSettingV2(ctx context.Context, batch *pgx.B
 	var query string
 
 	for childIndex, child := range obj.GetProfiles() {
-		if err := insertIntoComplianceOperatorScanSettingV2Profiles(ctx, batch, child, obj.GetScanName(), childIndex); err != nil {
+		if err := insertIntoComplianceOperatorScanSettingV2Profiles(batch, child, obj.GetScanName(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -115,7 +115,7 @@ func insertIntoComplianceOperatorScanSettingV2(ctx context.Context, batch *pgx.B
 	query = "delete from compliance_operator_scan_setting_v2_profiles where compliance_operator_scan_setting_v2_ScanName = $1 AND idx >= $2"
 	batch.Queue(query, obj.GetScanName(), len(obj.GetProfiles()))
 	for childIndex, child := range obj.GetClusters() {
-		if err := insertIntoComplianceOperatorScanSettingV2Clusters(ctx, batch, child, obj.GetScanName(), childIndex); err != nil {
+		if err := insertIntoComplianceOperatorScanSettingV2Clusters(batch, child, obj.GetScanName(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -125,7 +125,7 @@ func insertIntoComplianceOperatorScanSettingV2(ctx context.Context, batch *pgx.B
 	return nil
 }
 
-func insertIntoComplianceOperatorScanSettingV2Profiles(_ context.Context, batch *pgx.Batch, obj *storage.ProfileShim, complianceOperatorScanSettingV2ScanName string, idx int) error {
+func insertIntoComplianceOperatorScanSettingV2Profiles(batch *pgx.Batch, obj *storage.ProfileShim, complianceOperatorScanSettingV2ScanName string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
@@ -140,7 +140,7 @@ func insertIntoComplianceOperatorScanSettingV2Profiles(_ context.Context, batch 
 	return nil
 }
 
-func insertIntoComplianceOperatorScanSettingV2Clusters(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceOperatorScanSettingV2_ClusterScanStatus, complianceOperatorScanSettingV2ScanName string, idx int) error {
+func insertIntoComplianceOperatorScanSettingV2Clusters(batch *pgx.Batch, obj *storage.ComplianceOperatorScanSettingV2_ClusterScanStatus, complianceOperatorScanSettingV2ScanName string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start

--- a/central/complianceoperatorintegration/store/postgres/store.go
+++ b/central/complianceoperatorintegration/store/postgres/store.go
@@ -87,7 +87,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoComplianceIntegrations(_ context.Context, batch *pgx.Batch, obj *storage.ComplianceIntegration) error {
+func insertIntoComplianceIntegrations(batch *pgx.Batch, obj *storage.ComplianceIntegration) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoClusterCves(_ context.Context, batch *pgx.Batch, obj *storage.ClusterCVE) error {
+func insertIntoClusterCves(batch *pgx.Batch, obj *storage.ClusterCVE) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoImageCves(_ context.Context, batch *pgx.Batch, obj *storage.ImageCVE) error {
+func insertIntoImageCves(batch *pgx.Batch, obj *storage.ImageCVE) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoNodeCves(_ context.Context, batch *pgx.Batch, obj *storage.NodeCVE) error {
+func insertIntoNodeCves(batch *pgx.Batch, obj *storage.NodeCVE) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/declarativeconfig/health/datastore/store/postgres/store.go
+++ b/central/declarativeconfig/health/datastore/store/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoDeclarativeConfigHealths(_ context.Context, batch *pgx.Batch, obj *storage.DeclarativeConfigHealth) error {
+func insertIntoDeclarativeConfigHealths(batch *pgx.Batch, obj *storage.DeclarativeConfigHealth) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoDeployments(ctx context.Context, batch *pgx.Batch, obj *storage.Deployment) error {
+func insertIntoDeployments(batch *pgx.Batch, obj *storage.Deployment) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {
@@ -141,7 +141,7 @@ func insertIntoDeployments(ctx context.Context, batch *pgx.Batch, obj *storage.D
 	var query string
 
 	for childIndex, child := range obj.GetContainers() {
-		if err := insertIntoDeploymentsContainers(ctx, batch, child, obj.GetId(), childIndex); err != nil {
+		if err := insertIntoDeploymentsContainers(batch, child, obj.GetId(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -149,7 +149,7 @@ func insertIntoDeployments(ctx context.Context, batch *pgx.Batch, obj *storage.D
 	query = "delete from deployments_containers where deployments_Id = $1 AND idx >= $2"
 	batch.Queue(query, pgutils.NilOrUUID(obj.GetId()), len(obj.GetContainers()))
 	for childIndex, child := range obj.GetPorts() {
-		if err := insertIntoDeploymentsPorts(ctx, batch, child, obj.GetId(), childIndex); err != nil {
+		if err := insertIntoDeploymentsPorts(batch, child, obj.GetId(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -159,7 +159,7 @@ func insertIntoDeployments(ctx context.Context, batch *pgx.Batch, obj *storage.D
 	return nil
 }
 
-func insertIntoDeploymentsContainers(ctx context.Context, batch *pgx.Batch, obj *storage.Container, deploymentID string, idx int) error {
+func insertIntoDeploymentsContainers(batch *pgx.Batch, obj *storage.Container, deploymentID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
@@ -186,7 +186,7 @@ func insertIntoDeploymentsContainers(ctx context.Context, batch *pgx.Batch, obj 
 	var query string
 
 	for childIndex, child := range obj.GetConfig().GetEnv() {
-		if err := insertIntoDeploymentsContainersEnvs(ctx, batch, child, deploymentID, idx, childIndex); err != nil {
+		if err := insertIntoDeploymentsContainersEnvs(batch, child, deploymentID, idx, childIndex); err != nil {
 			return err
 		}
 	}
@@ -194,7 +194,7 @@ func insertIntoDeploymentsContainers(ctx context.Context, batch *pgx.Batch, obj 
 	query = "delete from deployments_containers_envs where deployments_Id = $1 AND deployments_containers_idx = $2 AND idx >= $3"
 	batch.Queue(query, pgutils.NilOrUUID(deploymentID), idx, len(obj.GetConfig().GetEnv()))
 	for childIndex, child := range obj.GetVolumes() {
-		if err := insertIntoDeploymentsContainersVolumes(ctx, batch, child, deploymentID, idx, childIndex); err != nil {
+		if err := insertIntoDeploymentsContainersVolumes(batch, child, deploymentID, idx, childIndex); err != nil {
 			return err
 		}
 	}
@@ -202,7 +202,7 @@ func insertIntoDeploymentsContainers(ctx context.Context, batch *pgx.Batch, obj 
 	query = "delete from deployments_containers_volumes where deployments_Id = $1 AND deployments_containers_idx = $2 AND idx >= $3"
 	batch.Queue(query, pgutils.NilOrUUID(deploymentID), idx, len(obj.GetVolumes()))
 	for childIndex, child := range obj.GetSecrets() {
-		if err := insertIntoDeploymentsContainersSecrets(ctx, batch, child, deploymentID, idx, childIndex); err != nil {
+		if err := insertIntoDeploymentsContainersSecrets(batch, child, deploymentID, idx, childIndex); err != nil {
 			return err
 		}
 	}
@@ -212,7 +212,7 @@ func insertIntoDeploymentsContainers(ctx context.Context, batch *pgx.Batch, obj 
 	return nil
 }
 
-func insertIntoDeploymentsContainersEnvs(_ context.Context, batch *pgx.Batch, obj *storage.ContainerConfig_EnvironmentConfig, deploymentID string, deploymentContainerIdx int, idx int) error {
+func insertIntoDeploymentsContainersEnvs(batch *pgx.Batch, obj *storage.ContainerConfig_EnvironmentConfig, deploymentID string, deploymentContainerIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
@@ -230,7 +230,7 @@ func insertIntoDeploymentsContainersEnvs(_ context.Context, batch *pgx.Batch, ob
 	return nil
 }
 
-func insertIntoDeploymentsContainersVolumes(_ context.Context, batch *pgx.Batch, obj *storage.Volume, deploymentID string, deploymentContainerIdx int, idx int) error {
+func insertIntoDeploymentsContainersVolumes(batch *pgx.Batch, obj *storage.Volume, deploymentID string, deploymentContainerIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
@@ -250,7 +250,7 @@ func insertIntoDeploymentsContainersVolumes(_ context.Context, batch *pgx.Batch,
 	return nil
 }
 
-func insertIntoDeploymentsContainersSecrets(_ context.Context, batch *pgx.Batch, obj *storage.EmbeddedSecret, deploymentID string, deploymentContainerIdx int, idx int) error {
+func insertIntoDeploymentsContainersSecrets(batch *pgx.Batch, obj *storage.EmbeddedSecret, deploymentID string, deploymentContainerIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
@@ -267,7 +267,7 @@ func insertIntoDeploymentsContainersSecrets(_ context.Context, batch *pgx.Batch,
 	return nil
 }
 
-func insertIntoDeploymentsPorts(ctx context.Context, batch *pgx.Batch, obj *storage.PortConfig, deploymentID string, idx int) error {
+func insertIntoDeploymentsPorts(batch *pgx.Batch, obj *storage.PortConfig, deploymentID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
@@ -284,7 +284,7 @@ func insertIntoDeploymentsPorts(ctx context.Context, batch *pgx.Batch, obj *stor
 	var query string
 
 	for childIndex, child := range obj.GetExposureInfos() {
-		if err := insertIntoDeploymentsPortsExposureInfos(ctx, batch, child, deploymentID, idx, childIndex); err != nil {
+		if err := insertIntoDeploymentsPortsExposureInfos(batch, child, deploymentID, idx, childIndex); err != nil {
 			return err
 		}
 	}
@@ -294,7 +294,7 @@ func insertIntoDeploymentsPorts(ctx context.Context, batch *pgx.Batch, obj *stor
 	return nil
 }
 
-func insertIntoDeploymentsPortsExposureInfos(_ context.Context, batch *pgx.Batch, obj *storage.PortConfig_ExposureInfo, deploymentID string, deploymentPortIdx int, idx int) error {
+func insertIntoDeploymentsPortsExposureInfos(batch *pgx.Batch, obj *storage.PortConfig_ExposureInfo, deploymentID string, deploymentPortIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoExternalBackups(_ context.Context, batch *pgx.Batch, obj *storage.ExternalBackup) error {
+func insertIntoExternalBackups(batch *pgx.Batch, obj *storage.ExternalBackup) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoGroups(_ context.Context, batch *pgx.Batch, obj *storage.Group) error {
+func insertIntoGroups(batch *pgx.Batch, obj *storage.Group) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/hash/datastore/store/postgres/store.go
+++ b/central/hash/datastore/store/postgres/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoHashes(_ context.Context, batch *pgx.Batch, obj *storage.Hash) error {
+func insertIntoHashes(batch *pgx.Batch, obj *storage.Hash) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoImageComponents(_ context.Context, batch *pgx.Batch, obj *storage.ImageComponent) error {
+func insertIntoImageComponents(batch *pgx.Batch, obj *storage.ImageComponent) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -87,7 +87,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoImageIntegrations(_ context.Context, batch *pgx.Batch, obj *storage.ImageIntegration) error {
+func insertIntoImageIntegrations(batch *pgx.Batch, obj *storage.ImageIntegration) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoIntegrationHealths(_ context.Context, batch *pgx.Batch, obj *storage.IntegrationHealth) error {
+func insertIntoIntegrationHealths(batch *pgx.Batch, obj *storage.IntegrationHealth) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoLogImbues(_ context.Context, batch *pgx.Batch, obj *storage.LogImbue) error {
+func insertIntoLogImbues(batch *pgx.Batch, obj *storage.LogImbue) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoNamespaces(_ context.Context, batch *pgx.Batch, obj *storage.NamespaceMetadata) error {
+func insertIntoNamespaces(batch *pgx.Batch, obj *storage.NamespaceMetadata) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoNetworkBaselines(_ context.Context, batch *pgx.Batch, obj *storage.NetworkBaseline) error {
+func insertIntoNetworkBaselines(batch *pgx.Batch, obj *storage.NetworkBaseline) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoNetworkGraphConfigs(_ context.Context, batch *pgx.Batch, obj *storage.NetworkGraphConfig) error {
+func insertIntoNetworkGraphConfigs(batch *pgx.Batch, obj *storage.NetworkGraphConfig) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -82,7 +82,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoNetworkEntities(_ context.Context, batch *pgx.Batch, obj *storage.NetworkEntity) error {
+func insertIntoNetworkEntities(batch *pgx.Batch, obj *storage.NetworkEntity) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoNetworkpolicies(_ context.Context, batch *pgx.Batch, obj *storage.NetworkPolicy) error {
+func insertIntoNetworkpolicies(batch *pgx.Batch, obj *storage.NetworkPolicy) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoNetworkpoliciesundodeployments(_ context.Context, batch *pgx.Batch, obj *storage.NetworkPolicyApplicationUndoDeploymentRecord) error {
+func insertIntoNetworkpoliciesundodeployments(batch *pgx.Batch, obj *storage.NetworkPolicyApplicationUndoDeploymentRecord) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoNetworkpolicyapplicationundorecords(_ context.Context, batch *pgx.Batch, obj *storage.NetworkPolicyApplicationUndoRecord) error {
+func insertIntoNetworkpolicyapplicationundorecords(batch *pgx.Batch, obj *storage.NetworkPolicyApplicationUndoRecord) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoNodeComponents(_ context.Context, batch *pgx.Batch, obj *storage.NodeComponent) error {
+func insertIntoNodeComponents(batch *pgx.Batch, obj *storage.NodeComponent) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoNotifiers(_ context.Context, batch *pgx.Batch, obj *storage.Notifier) error {
+func insertIntoNotifiers(batch *pgx.Batch, obj *storage.Notifier) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoPods(ctx context.Context, batch *pgx.Batch, obj *storage.Pod) error {
+func insertIntoPods(batch *pgx.Batch, obj *storage.Pod) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {
@@ -129,7 +129,7 @@ func insertIntoPods(ctx context.Context, batch *pgx.Batch, obj *storage.Pod) err
 	var query string
 
 	for childIndex, child := range obj.GetLiveInstances() {
-		if err := insertIntoPodsLiveInstances(ctx, batch, child, obj.GetId(), childIndex); err != nil {
+		if err := insertIntoPodsLiveInstances(batch, child, obj.GetId(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -139,7 +139,7 @@ func insertIntoPods(ctx context.Context, batch *pgx.Batch, obj *storage.Pod) err
 	return nil
 }
 
-func insertIntoPodsLiveInstances(_ context.Context, batch *pgx.Batch, obj *storage.ContainerInstance, podID string, idx int) error {
+func insertIntoPodsLiveInstances(batch *pgx.Batch, obj *storage.ContainerInstance, podID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -87,7 +87,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoPolicies(_ context.Context, batch *pgx.Batch, obj *storage.Policy) error {
+func insertIntoPolicies(batch *pgx.Batch, obj *storage.Policy) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoPolicyCategories(_ context.Context, batch *pgx.Batch, obj *storage.PolicyCategory) error {
+func insertIntoPolicyCategories(batch *pgx.Batch, obj *storage.PolicyCategory) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/policycategoryedge/store/postgres/store.go
+++ b/central/policycategoryedge/store/postgres/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoPolicyCategoryEdges(_ context.Context, batch *pgx.Batch, obj *storage.PolicyCategoryEdge) error {
+func insertIntoPolicyCategoryEdges(batch *pgx.Batch, obj *storage.PolicyCategoryEdge) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoProcessBaselines(_ context.Context, batch *pgx.Batch, obj *storage.ProcessBaseline) error {
+func insertIntoProcessBaselines(batch *pgx.Batch, obj *storage.ProcessBaseline) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoProcessBaselineResults(_ context.Context, batch *pgx.Batch, obj *storage.ProcessBaselineResults) error {
+func insertIntoProcessBaselineResults(batch *pgx.Batch, obj *storage.ProcessBaselineResults) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoProcessIndicators(_ context.Context, batch *pgx.Batch, obj *storage.ProcessIndicator) error {
+func insertIntoProcessIndicators(batch *pgx.Batch, obj *storage.ProcessIndicator) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/processlisteningonport/store/postgres/store.go
+++ b/central/processlisteningonport/store/postgres/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoListeningEndpoints(_ context.Context, batch *pgx.Batch, obj *storage.ProcessListeningOnPortStorage) error {
+func insertIntoListeningEndpoints(batch *pgx.Batch, obj *storage.ProcessListeningOnPortStorage) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoK8sRoles(_ context.Context, batch *pgx.Batch, obj *storage.K8SRole) error {
+func insertIntoK8sRoles(batch *pgx.Batch, obj *storage.K8SRole) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoRoleBindings(ctx context.Context, batch *pgx.Batch, obj *storage.K8SRoleBinding) error {
+func insertIntoRoleBindings(batch *pgx.Batch, obj *storage.K8SRoleBinding) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {
@@ -133,7 +133,7 @@ func insertIntoRoleBindings(ctx context.Context, batch *pgx.Batch, obj *storage.
 	var query string
 
 	for childIndex, child := range obj.GetSubjects() {
-		if err := insertIntoRoleBindingsSubjects(ctx, batch, child, obj.GetId(), childIndex); err != nil {
+		if err := insertIntoRoleBindingsSubjects(batch, child, obj.GetId(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -143,7 +143,7 @@ func insertIntoRoleBindings(ctx context.Context, batch *pgx.Batch, obj *storage.
 	return nil
 }
 
-func insertIntoRoleBindingsSubjects(_ context.Context, batch *pgx.Batch, obj *storage.Subject, roleBindingID string, idx int) error {
+func insertIntoRoleBindingsSubjects(batch *pgx.Batch, obj *storage.Subject, roleBindingID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoReportConfigurations(_ context.Context, batch *pgx.Batch, obj *storage.ReportConfiguration) error {
+func insertIntoReportConfigurations(batch *pgx.Batch, obj *storage.ReportConfiguration) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/reports/metadata/datastore/store/postgres/store.go
+++ b/central/reports/metadata/datastore/store/postgres/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoReportMetadata(_ context.Context, batch *pgx.Batch, obj *storage.ReportMetadata) error {
+func insertIntoReportMetadata(batch *pgx.Batch, obj *storage.ReportMetadata) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/reports/snapshot/datastore/store/postgres/store.go
+++ b/central/reports/snapshot/datastore/store/postgres/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoReportSnapshots(_ context.Context, batch *pgx.Batch, obj *storage.ReportSnapshot) error {
+func insertIntoReportSnapshots(batch *pgx.Batch, obj *storage.ReportSnapshot) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoCollections(ctx context.Context, batch *pgx.Batch, obj *storage.ResourceCollection) error {
+func insertIntoCollections(batch *pgx.Batch, obj *storage.ResourceCollection) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {
@@ -107,7 +107,7 @@ func insertIntoCollections(ctx context.Context, batch *pgx.Batch, obj *storage.R
 	var query string
 
 	for childIndex, child := range obj.GetEmbeddedCollections() {
-		if err := insertIntoCollectionsEmbeddedCollections(ctx, batch, child, obj.GetId(), childIndex); err != nil {
+		if err := insertIntoCollectionsEmbeddedCollections(batch, child, obj.GetId(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -117,7 +117,7 @@ func insertIntoCollections(ctx context.Context, batch *pgx.Batch, obj *storage.R
 	return nil
 }
 
-func insertIntoCollectionsEmbeddedCollections(_ context.Context, batch *pgx.Batch, obj *storage.ResourceCollection_EmbeddedResourceCollection, collectionID string, idx int) error {
+func insertIntoCollectionsEmbeddedCollections(batch *pgx.Batch, obj *storage.ResourceCollection_EmbeddedResourceCollection, collectionID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoRisks(_ context.Context, batch *pgx.Batch, obj *storage.Risk) error {
+func insertIntoRisks(batch *pgx.Batch, obj *storage.Risk) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoPermissionSets(_ context.Context, batch *pgx.Batch, obj *storage.PermissionSet) error {
+func insertIntoPermissionSets(batch *pgx.Batch, obj *storage.PermissionSet) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoRoles(_ context.Context, batch *pgx.Batch, obj *storage.Role) error {
+func insertIntoRoles(batch *pgx.Batch, obj *storage.Role) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoSimpleAccessScopes(_ context.Context, batch *pgx.Batch, obj *storage.SimpleAccessScope) error {
+func insertIntoSimpleAccessScopes(batch *pgx.Batch, obj *storage.SimpleAccessScope) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoSecrets(ctx context.Context, batch *pgx.Batch, obj *storage.Secret) error {
+func insertIntoSecrets(batch *pgx.Batch, obj *storage.Secret) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {
@@ -130,7 +130,7 @@ func insertIntoSecrets(ctx context.Context, batch *pgx.Batch, obj *storage.Secre
 	var query string
 
 	for childIndex, child := range obj.GetFiles() {
-		if err := insertIntoSecretsFiles(ctx, batch, child, obj.GetId(), childIndex); err != nil {
+		if err := insertIntoSecretsFiles(batch, child, obj.GetId(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -140,7 +140,7 @@ func insertIntoSecrets(ctx context.Context, batch *pgx.Batch, obj *storage.Secre
 	return nil
 }
 
-func insertIntoSecretsFiles(ctx context.Context, batch *pgx.Batch, obj *storage.SecretDataFile, secretID string, idx int) error {
+func insertIntoSecretsFiles(batch *pgx.Batch, obj *storage.SecretDataFile, secretID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
@@ -156,7 +156,7 @@ func insertIntoSecretsFiles(ctx context.Context, batch *pgx.Batch, obj *storage.
 	var query string
 
 	for childIndex, child := range obj.GetImagePullSecret().GetRegistries() {
-		if err := insertIntoSecretsFilesRegistries(ctx, batch, child, secretID, idx, childIndex); err != nil {
+		if err := insertIntoSecretsFilesRegistries(batch, child, secretID, idx, childIndex); err != nil {
 			return err
 		}
 	}
@@ -166,7 +166,7 @@ func insertIntoSecretsFiles(ctx context.Context, batch *pgx.Batch, obj *storage.
 	return nil
 }
 
-func insertIntoSecretsFilesRegistries(_ context.Context, batch *pgx.Batch, obj *storage.ImagePullSecret_Registry, secretID string, secretFileIdx int, idx int) error {
+func insertIntoSecretsFilesRegistries(batch *pgx.Batch, obj *storage.ImagePullSecret_Registry, secretID string, secretFileIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -106,7 +106,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 	return nil
 }
 
-func insertIntoServiceAccounts(_ context.Context, batch *pgx.Batch, obj *storage.ServiceAccount) error {
+func insertIntoServiceAccounts(batch *pgx.Batch, obj *storage.ServiceAccount) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoServiceIdentities(_ context.Context, batch *pgx.Batch, obj *storage.ServiceIdentity) error {
+func insertIntoServiceIdentities(batch *pgx.Batch, obj *storage.ServiceIdentity) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoSignatureIntegrations(_ context.Context, batch *pgx.Batch, obj *storage.SignatureIntegration) error {
+func insertIntoSignatureIntegrations(batch *pgx.Batch, obj *storage.SignatureIntegration) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -83,7 +83,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoVulnerabilityRequests(ctx context.Context, batch *pgx.Batch, obj *storage.VulnerabilityRequest) error {
+func insertIntoVulnerabilityRequests(batch *pgx.Batch, obj *storage.VulnerabilityRequest) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {
@@ -111,7 +111,7 @@ func insertIntoVulnerabilityRequests(ctx context.Context, batch *pgx.Batch, obj 
 	var query string
 
 	for childIndex, child := range obj.GetApprovers() {
-		if err := insertIntoVulnerabilityRequestsApprovers(ctx, batch, child, obj.GetId(), childIndex); err != nil {
+		if err := insertIntoVulnerabilityRequestsApprovers(batch, child, obj.GetId(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -119,7 +119,7 @@ func insertIntoVulnerabilityRequests(ctx context.Context, batch *pgx.Batch, obj 
 	query = "delete from vulnerability_requests_approvers where vulnerability_requests_Id = $1 AND idx >= $2"
 	batch.Queue(query, obj.GetId(), len(obj.GetApprovers()))
 	for childIndex, child := range obj.GetComments() {
-		if err := insertIntoVulnerabilityRequestsComments(ctx, batch, child, obj.GetId(), childIndex); err != nil {
+		if err := insertIntoVulnerabilityRequestsComments(batch, child, obj.GetId(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -129,7 +129,7 @@ func insertIntoVulnerabilityRequests(ctx context.Context, batch *pgx.Batch, obj 
 	return nil
 }
 
-func insertIntoVulnerabilityRequestsApprovers(_ context.Context, batch *pgx.Batch, obj *storage.SlimUser, vulnerabilityRequestID string, idx int) error {
+func insertIntoVulnerabilityRequestsApprovers(batch *pgx.Batch, obj *storage.SlimUser, vulnerabilityRequestID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
@@ -144,7 +144,7 @@ func insertIntoVulnerabilityRequestsApprovers(_ context.Context, batch *pgx.Batc
 	return nil
 }
 
-func insertIntoVulnerabilityRequestsComments(_ context.Context, batch *pgx.Batch, obj *storage.RequestComment, vulnerabilityRequestID string, idx int) error {
+func insertIntoVulnerabilityRequestsComments(batch *pgx.Batch, obj *storage.RequestComment, vulnerabilityRequestID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -84,7 +84,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoWatchedImages(_ context.Context, batch *pgx.Batch, obj *storage.WatchedImage) error {
+func insertIntoWatchedImages(batch *pgx.Batch, obj *storage.WatchedImage) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -43,7 +43,7 @@ type PermissionChecker interface {
 
 type primaryKeyGetter[T any, PT unmarshaler[T]] func(obj PT) string
 type durationTimeSetter func(start time.Time, op ops.Op)
-type inserter[T any, PT unmarshaler[T]] func(ctx context.Context, batch *pgx.Batch, obj PT) error
+type inserter[T any, PT unmarshaler[T]] func(batch *pgx.Batch, obj PT) error
 type copier[T any, PT unmarshaler[T]] func(ctx context.Context, s Deleter, tx *postgres.Tx, objs ...PT) error
 type upsertChecker[T any, PT unmarshaler[T]] func(ctx context.Context, objs ...PT) error
 
@@ -530,7 +530,7 @@ func (s *GenericStore[T, PT]) upsert(ctx context.Context, objs ...PT) error {
 
 	for _, obj := range objs {
 		batch := &pgx.Batch{}
-		if err := s.insertInto(ctx, batch, obj); err != nil {
+		if err := s.insertInto(batch, obj); err != nil {
 			return err
 		}
 		batchResults := conn.SendBatch(ctx, batch)

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestStructs(ctx context.Context, batch *pgx.Batch, obj *storage.TestStruct) error {
+func insertIntoTestStructs(batch *pgx.Batch, obj *storage.TestStruct) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {
@@ -118,7 +118,7 @@ func insertIntoTestStructs(ctx context.Context, batch *pgx.Batch, obj *storage.T
 	var query string
 
 	for childIndex, child := range obj.GetNested() {
-		if err := insertIntoTestStructsNesteds(ctx, batch, child, obj.GetKey1(), childIndex); err != nil {
+		if err := insertIntoTestStructsNesteds(batch, child, obj.GetKey1(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -128,7 +128,7 @@ func insertIntoTestStructs(ctx context.Context, batch *pgx.Batch, obj *storage.T
 	return nil
 }
 
-func insertIntoTestStructsNesteds(_ context.Context, batch *pgx.Batch, obj *storage.TestStruct_Nested, testStructKey1 string, idx int) error {
+func insertIntoTestStructsNesteds(batch *pgx.Batch, obj *storage.TestStruct_Nested, testStructKey1 string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -195,7 +195,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 
 {{- define "insertObject"}}
 {{- $schema := .schema }}
-func {{ template "insertFunctionName" $schema }}({{ if eq (len $schema.Children) 0 }}_{{ else }}ctx{{ end }} context.Context, batch *pgx.Batch, obj {{$schema.Type}}{{ range $field := $schema.FieldsDeterminedByParent }}, {{$field.Name}} {{$field.Type}}{{end}}) error {
+func {{ template "insertFunctionName" $schema }}(batch *pgx.Batch, obj {{$schema.Type}}{{ range $field := $schema.FieldsDeterminedByParent }}, {{$field.Name}} {{$field.Type}}{{end}}) error {
     {{if not $schema.Parent }}
     serialized, marshalErr := obj.Marshal()
     if marshalErr != nil {
@@ -217,7 +217,7 @@ func {{ template "insertFunctionName" $schema }}({{ if eq (len $schema.Children)
 
     {{range $index, $child := $schema.Children }}
     for childIndex, child := range obj.{{$child.ObjectGetter}} {
-        if err := {{ template "insertFunctionName" $child }}(ctx, batch, child{{ range $field := $schema.PrimaryKeys }}, {{$field.Getter "obj"}}{{end}}, childIndex); err != nil {
+        if err := {{ template "insertFunctionName" $child }}(batch, child{{ range $field := $schema.PrimaryKeys }}, {{$field.Getter "obj"}}{{end}}, childIndex); err != nil {
             return err
         }
     }

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -87,7 +87,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestSingleKeyStructs(_ context.Context, batch *pgx.Batch, obj *storage.TestSingleKeyStruct) error {
+func insertIntoTestSingleKeyStructs(batch *pgx.Batch, obj *storage.TestSingleKeyStruct) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestChild1(_ context.Context, batch *pgx.Batch, obj *storage.TestChild1) error {
+func insertIntoTestChild1(batch *pgx.Batch, obj *storage.TestChild1) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestChild1P4(_ context.Context, batch *pgx.Batch, obj *storage.TestChild1P4) error {
+func insertIntoTestChild1P4(batch *pgx.Batch, obj *storage.TestChild1P4) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestChild2(_ context.Context, batch *pgx.Batch, obj *storage.TestChild2) error {
+func insertIntoTestChild2(batch *pgx.Batch, obj *storage.TestChild2) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestG2GrandChild1(_ context.Context, batch *pgx.Batch, obj *storage.TestG2GrandChild1) error {
+func insertIntoTestG2GrandChild1(batch *pgx.Batch, obj *storage.TestG2GrandChild1) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestG3GrandChild1(_ context.Context, batch *pgx.Batch, obj *storage.TestG3GrandChild1) error {
+func insertIntoTestG3GrandChild1(batch *pgx.Batch, obj *storage.TestG3GrandChild1) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestGGrandChild1(_ context.Context, batch *pgx.Batch, obj *storage.TestGGrandChild1) error {
+func insertIntoTestGGrandChild1(batch *pgx.Batch, obj *storage.TestGGrandChild1) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestGrandChild1(_ context.Context, batch *pgx.Batch, obj *storage.TestGrandChild1) error {
+func insertIntoTestGrandChild1(batch *pgx.Batch, obj *storage.TestGrandChild1) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestGrandparents(ctx context.Context, batch *pgx.Batch, obj *storage.TestGrandparent) error {
+func insertIntoTestGrandparents(batch *pgx.Batch, obj *storage.TestGrandparent) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {
@@ -107,7 +107,7 @@ func insertIntoTestGrandparents(ctx context.Context, batch *pgx.Batch, obj *stor
 	var query string
 
 	for childIndex, child := range obj.GetEmbedded() {
-		if err := insertIntoTestGrandparentsEmbeddeds(ctx, batch, child, obj.GetId(), childIndex); err != nil {
+		if err := insertIntoTestGrandparentsEmbeddeds(batch, child, obj.GetId(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -117,7 +117,7 @@ func insertIntoTestGrandparents(ctx context.Context, batch *pgx.Batch, obj *stor
 	return nil
 }
 
-func insertIntoTestGrandparentsEmbeddeds(ctx context.Context, batch *pgx.Batch, obj *storage.TestGrandparent_Embedded, testGrandparentID string, idx int) error {
+func insertIntoTestGrandparentsEmbeddeds(batch *pgx.Batch, obj *storage.TestGrandparent_Embedded, testGrandparentID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
@@ -132,7 +132,7 @@ func insertIntoTestGrandparentsEmbeddeds(ctx context.Context, batch *pgx.Batch, 
 	var query string
 
 	for childIndex, child := range obj.GetEmbedded2() {
-		if err := insertIntoTestGrandparentsEmbeddedsEmbedded2(ctx, batch, child, testGrandparentID, idx, childIndex); err != nil {
+		if err := insertIntoTestGrandparentsEmbeddedsEmbedded2(batch, child, testGrandparentID, idx, childIndex); err != nil {
 			return err
 		}
 	}
@@ -142,7 +142,7 @@ func insertIntoTestGrandparentsEmbeddeds(ctx context.Context, batch *pgx.Batch, 
 	return nil
 }
 
-func insertIntoTestGrandparentsEmbeddedsEmbedded2(_ context.Context, batch *pgx.Batch, obj *storage.TestGrandparent_Embedded_Embedded2, testGrandparentID string, testGrandparentEmbeddedIdx int, idx int) error {
+func insertIntoTestGrandparentsEmbeddedsEmbedded2(batch *pgx.Batch, obj *storage.TestGrandparent_Embedded_Embedded2, testGrandparentID string, testGrandparentEmbeddedIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestParent1(ctx context.Context, batch *pgx.Batch, obj *storage.TestParent1) error {
+func insertIntoTestParent1(batch *pgx.Batch, obj *storage.TestParent1) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {
@@ -106,7 +106,7 @@ func insertIntoTestParent1(ctx context.Context, batch *pgx.Batch, obj *storage.T
 	var query string
 
 	for childIndex, child := range obj.GetChildren() {
-		if err := insertIntoTestParent1Childrens(ctx, batch, child, obj.GetId(), childIndex); err != nil {
+		if err := insertIntoTestParent1Childrens(batch, child, obj.GetId(), childIndex); err != nil {
 			return err
 		}
 	}
@@ -116,7 +116,7 @@ func insertIntoTestParent1(ctx context.Context, batch *pgx.Batch, obj *storage.T
 	return nil
 }
 
-func insertIntoTestParent1Childrens(_ context.Context, batch *pgx.Batch, obj *storage.TestParent1_Child1Ref, testParent1ID string, idx int) error {
+func insertIntoTestParent1Childrens(batch *pgx.Batch, obj *storage.TestParent1_Child1Ref, testParent1ID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestParent2(_ context.Context, batch *pgx.Batch, obj *storage.TestParent2) error {
+func insertIntoTestParent2(batch *pgx.Batch, obj *storage.TestParent2) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestParent3(_ context.Context, batch *pgx.Batch, obj *storage.TestParent3) error {
+func insertIntoTestParent3(batch *pgx.Batch, obj *storage.TestParent3) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -86,7 +86,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestParent4(_ context.Context, batch *pgx.Batch, obj *storage.TestParent4) error {
+func insertIntoTestParent4(batch *pgx.Batch, obj *storage.TestParent4) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -85,7 +85,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestShortCircuits(_ context.Context, batch *pgx.Batch, obj *storage.TestShortCircuit) error {
+func insertIntoTestShortCircuits(batch *pgx.Batch, obj *storage.TestShortCircuit) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
@@ -87,7 +87,7 @@ func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
 }
 
-func insertIntoTestSingleUUIDKeyStructs(_ context.Context, batch *pgx.Batch, obj *storage.TestSingleUUIDKeyStruct) error {
+func insertIntoTestSingleUUIDKeyStructs(batch *pgx.Batch, obj *storage.TestSingleUUIDKeyStruct) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {


### PR DESCRIPTION
## Description

`insertInto` has context param that is not used. This PR removes it. 

## Checklist
- [x] Investigated and inspected CI test results

If any of these don't apply, please comment below.

## Testing Performed

CI