### PR TITLE
ROX-0000: Fix node inventory resend edge case

### DIFF
--- a/compliance/collection/compliance/compliance.go
+++ b/compliance/collection/compliance/compliance.go
@@ -109,7 +109,10 @@ func (c *Compliance) manageNodeScanLoop(ctx context.Context) <-chan *sensor.MsgF
 			case <-ctx.Done():
 				return
 			case _, ok := <-c.umh.RetryCommand():
-				if ok && c.cache != nil {
+				if c.cache == nil {
+					log.Debug("Requested to retry but cache is empty. Resetting scan timer.")
+					t.Reset(time.Second)
+				} else if ok {
 					nodeInventoriesC <- c.cache
 				}
 			case <-t.C:


### PR DESCRIPTION
## Description

I was able to trigger* a situation where a nodeInventory is not ACK-ed but the cache in Compliance is empty. This will result in Compliance retrying and not getting an ACK until the next scheduled scan happens.

This PR provides a fix where we recognize such situation and schedule the next scan immediately (in 1s).  

*) I am still not sure how to reproduce this reliably. What I did was simply a restart of sensor. I think it may be a time coincidence. 

The root cause seem to be the inability of Compliance to receive the ACK from Sensor AND empty nodeInventory cache in Compliance.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

### N/A
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Manual test on a cluster (see the `*` note about reproducing this) 


## Full collector pod log from the run where it occurs

```
collector Collector Version: 3.15.x-65-ga5ab4b809e
collector OS: Red Hat Enterprise Linux CoreOS 413.92.202306141213-0 (Plow)
collector Kernel Version: 5.14.0-284.18.1.el9_2.x86_64
collector Starting StackRox Collector...
collector [INFO    2023/07/21 11:20:34] Hostname: 'collector-ch8fr'
collector [INFO    2023/07/21 11:20:34] User configured collection-method=ebpf
collector [INFO    2023/07/21 11:20:34] Afterglow is enabled
collector [INFO    2023/07/21 11:20:34] Sensor configured at address: sensor.stackrox.svc:443
collector [INFO    2023/07/21 11:20:34] Attempting to connect to Sensor
collector [INFO    2023/07/21 11:20:39] Successfully connected to Sensor.
collector [INFO    2023/07/21 11:20:39] Module version: 2.5.0
collector [INFO    2023/07/21 11:20:39] Config: collection_method:ebpf, useChiselCache:1, scrape_interval:30, turn_off_scrape:0, hostname:collector-ch8fr, processesListeningOnPorts:1, logLevel:INFO, set_import_users:0
collector [INFO    2023/07/21 11:20:39] Candidate drivers: 
collector [INFO    2023/07/21 11:20:39] collector-ebpf-5.14.0-284.18.1.el9_2.x86_64.o
collector [INFO    2023/07/21 11:20:39] Attempting to download collector-ebpf-5.14.0-284.18.1.el9_2.x86_64.o
collector [INFO    2023/07/21 11:20:39] Attempting to download kernel object from https://sensor.stackrox.svc:443/kernel-objects/2.5.0/collector-ebpf-5.14.0-284.18.1.el9_2.x86_64.o.gz
collector [INFO    2023/07/21 11:20:40] Successfully downloaded and decompressed /module/collector-ebpf.o
collector [INFO    2023/07/21 11:20:41] 
collector [INFO    2023/07/21 11:20:41] This product uses ebpf subcomponents licensed under the GNU
collector [INFO    2023/07/21 11:20:41] GENERAL PURPOSE LICENSE Version 2 outlined in the /kernel-modules/LICENSE file.
collector [INFO    2023/07/21 11:20:41] Source code for the ebpf subcomponents is available at
collector [INFO    2023/07/21 11:20:41] https://github.com/stackrox/falcosecurity-libs/
collector [INFO    2023/07/21 11:20:41] 
collector [INFO    2023/07/21 11:20:41] 
collector [INFO    2023/07/21 11:20:41] == Collector Startup Diagnostics: ==
compliance No certificates found in /usr/local/share/ca-certificates
compliance No certificates found in /etc/pki/injected-ca-trust
compliance pkg/metrics: 2023/07/21 11:20:38.346953 server.go:143: Warn: Secure metrics server is disabled
compliance pkg/metrics: 2023/07/21 11:20:38.347114 server.go:126: Warn: Metrics server is disabled
compliance pkg/metrics: 2023/07/21 11:20:38.347170 server.go:143: Warn: Secure metrics server is disabled
compliance pkg/metrics: 2023/07/21 11:20:38.348013 server.go:126: Warn: Metrics server is disabled
compliance pkg/metrics: 2023/07/21 11:20:38.348099 server.go:143: Warn: Secure metrics server is disabled
compliance collection/compliance: 2023/07/21 11:20:38.350873 node_scanner.go:49: Info: Initialized gRPC connection to node-inventory container
compliance collection/compliance: 2023/07/21 11:20:38.350921 compliance.go:49: Info: Running StackRox Version: 4.1.x-464-g48dec1ef77
compliance collection/compliance: 2023/07/21 11:20:38.352425 compliance.go:60: Info: Initialized gRPC stream connection to Sensor
compliance collection/intervals: 2023/07/21 11:20:38.352616 intervals.go:64: Info: Scanning intervals: base interval: 4h0m0s, maximum absolute deviation from base: 24m0s, first scan starts not later than in: 5m0s
compliance collection/intervals: 2023/07/21 11:20:38.352641 intervals.go:72: Info: Initial scanning in 30.083051531s
compliance collection/compliance: 2023/07/21 11:20:38.623329 compliance.go:271: Info: Successfully connected to Sensor at sensor.stackrox.svc:443
compliance collection/compliance: 2023/07/21 11:21:08.436152 compliance.go:116: Info: Scanning node "piotr-07-21-ltkxm-worker-c-799tn.c.srox-temp-dev-test.internal"
compliance collection/intervals: 2023/07/21 11:21:11.460842 intervals.go:82: Info: Next node scan in 4h8m56.732870692s
compliance pkg/retry: 2023/07/21 11:21:41.462701 unconfirmed_message_handler.go:64: Info: Suggesting to resend, retry 1 (next retry in 1m0s)
compliance 2023/07/21 11:21:41 ERROR: [transport] Client received GoAway with error code ENHANCE_YOUR_CALM and debug data equal to ASCII "too_many_pings".
compliance pkg/retry: 2023/07/21 11:22:41.466725 unconfirmed_message_handler.go:64: Info: Suggesting to resend, retry 2 (next retry in 1m30s)
compliance pkg/retry: 2023/07/21 11:24:11.468956 unconfirmed_message_handler.go:64: Info: Suggesting to resend, retry 3 (next retry in 2m0s)
compliance pkg/retry: 2023/07/21 11:26:11.470692 unconfirmed_message_handler.go:64: Info: Suggesting to resend, retry 4 (next retry in 2m30s)
compliance collection/compliance: 2023/07/21 11:27:16.762214 compliance.go:159: Error: Error running recv: error receiving msg from sensor: rpc error: code = Unavailable desc = error reading from server: EOF
compliance collection/compliance: 2023/07/21 11:27:16.769984 compliance.go:266: Info: Sleeping for 0.69 seconds between attempts to connect to Sensor, err: error communicating with sensor: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 172.30.218.19:443: connect: connection refused"
collector [INFO    2023/07/21 11:20:41]  Connected to Sensor?       true
collector [INFO    2023/07/21 11:20:41]  Kernel driver candidates:
collector [INFO    2023/07/21 11:20:41]    collector-ebpf-5.14.0-284.18.1.el9_2.x86_64.o (available)
collector [INFO    2023/07/21 11:20:41]  Driver loaded into kernel: collector-ebpf-5.14.0-284.18.1.el9_2.x86_64.o
collector [INFO    2023/07/21 11:20:41] ====================================
collector [INFO    2023/07/21 11:20:41] 
node-inventory {"Event":"Max extractable file size set to 200 MB","Level":"info","Location":"main.go:261","Time":"2023-07-21 11:20:43.957118"}
node-inventory {"Event":"Max ELF executable file size set to 800 MB","Level":"info","Location":"main.go:267","Time":"2023-07-21 11:20:43.957322"}
node-inventory {"Event":"Max image file reader buffer size set to 100 MB","Level":"info","Location":"main.go:273","Time":"2023-07-21 11:20:43.957357"}
node-inventory {"Event":"Running Scanner version 2.30.x-21-g8a51cffa91 in Node Inventory mode","Level":"info","Location":"main.go:280","Time":"2023-07-21 11:20:43.957437"}
node-inventory {"Event":"Launching backend GRPC listener on 127.0.0.1:8444","Level":"info","Location":"grpc.go:47","Time":"2023-07-21 11:20:43.960102"}
node-inventory {"Event":"Loading repo-to-cpe map into mem","Level":"info","Location":"singleton.go:22","Time":"2023-07-21 11:21:11.428529"}
node-inventory {"Event":"Done loading repo-to-cpe map into mem","Level":"info","Location":"singleton.go:24","Time":"2023-07-21 11:21:11.455234"}
node-inventory {"Event":"Finished node scan: node \"piotr-07-21-ltkxm-worker-c-799tn.c.srox-temp-dev-test.internal\" with 511 rhel-components and notes: [LANGUAGE_CVES_UNAVAILABLE]","Level":"info","Location":"service.go:58","Time":"2023-07-21 11:21:11.458865"}
compliance collection/compliance: 2023/07/21 11:27:17.459932 compliance.go:266: Info: Sleeping for 0.60 seconds between attempts to connect to Sensor, err: error communicating with sensor: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 172.30.218.19:443: connect: connection refused"
compliance collection/compliance: 2023/07/21 11:27:18.056462 compliance.go:266: Info: Sleeping for 1.08 seconds between attempts to connect to Sensor, err: error communicating with sensor: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 172.30.218.19:443: connect: connection refused"
compliance collection/compliance: 2023/07/21 11:27:19.132201 compliance.go:266: Info: Sleeping for 1.62 seconds between attempts to connect to Sensor, err: error communicating with sensor: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 172.30.218.19:443: connect: connection refused"
compliance collection/compliance: 2023/07/21 11:27:20.754642 compliance.go:266: Info: Sleeping for 1.36 seconds between attempts to connect to Sensor, err: error communicating with sensor: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 172.30.218.19:443: connect: connection refused"
compliance collection/compliance: 2023/07/21 11:27:22.111745 compliance.go:266: Info: Sleeping for 3.37 seconds between attempts to connect to Sensor, err: error communicating with sensor: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 172.30.218.19:443: connect: connection refused"
compliance collection/compliance: 2023/07/21 11:27:25.484765 compliance.go:271: Info: Successfully connected to Sensor at sensor.stackrox.svc:443
compliance pkg/retry: 2023/07/21 11:28:41.471792 unconfirmed_message_handler.go:64: Info: Suggesting to resend, retry 5 (next retry in 3m0s)
compliance pkg/retry: 2023/07/21 11:31:41.474168 unconfirmed_message_handler.go:64: Info: Suggesting to resend, retry 6 (next retry in 3m30s)
compliance pkg/retry: 2023/07/21 11:35:11.474347 unconfirmed_message_handler.go:64: Info: Suggesting to resend, retry 7 (next retry in 4m0s)
compliance pkg/retry: 2023/07/21 11:39:11.476632 unconfirmed_message_handler.go:64: Info: Suggesting to resend, retry 8 (next retry in 4m30s)
compliance pkg/retry: 2023/07/21 11:43:41.478988 unconfirmed_message_handler.go:64: Info: Suggesting to resend, retry 9 (next retry in 5m0s)
compliance pkg/retry: 2023/07/21 11:48:41.482125 unconfirmed_message_handler.go:64: Info: Suggesting to resend, retry 10 (next retry in 5m30s)
compliance pkg/retry: 2023/07/21 11:54:11.484935 unconfirmed_message_handler.go:64: Info: Suggesting to resend, retry 11 (next retry in 6m0s)
collector [INFO    2023/07/21 11:20:41] Network scrape interval set to 30 seconds
collector [INFO    2023/07/21 11:20:41] Waiting for Sensor to become ready ...
collector [INFO    2023/07/21 11:20:41] Sensor connectivity is successful
collector [INFO    2023/07/21 11:20:41] Started network status notifier.
collector [INFO    2023/07/21 11:20:41] Established network connection info stream.
collector [INFO    2023/07/21 11:20:41] Trying to establish GRPC stream for signals ...
collector [INFO    2023/07/21 11:20:41] Successfully established GRPC stream for signals.
collector [INFO    2023/07/21 11:20:42] Found self-check process event.
collector [INFO    2023/07/21 11:20:42] Found self-check connection event.
collector [INFO    2023/07/21 11:20:51] self-check (pid=78) exitted with status: 0
collector [ERROR   2023/07/21 11:27:16] Error streaming network connection info: Socket closed
collector [ERROR   2023/07/21 11:27:17] GRPC writes failed: Socket closed
collector [ERROR   2023/07/21 11:27:17] GRPC stream interrupted
collector [INFO    2023/07/21 11:27:17] Trying to establish GRPC stream for signals ...
collector [ERROR   2023/07/21 11:27:17] [Throttled] GRPC stream is not established
collector [INFO    2023/07/21 11:27:22] Successfully established GRPC stream for signals.
collector [INFO    2023/07/21 11:27:26] Established network connection info stream.

```
