### PR TITLE
chore(test): Enabling constraints in postgres tests

### DIFF
--- a/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission/migration_test.go
+++ b/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission/migration_test.go
@@ -88,7 +88,7 @@ func TestMigration(t *testing.T) {
 }
 
 func (s *psMigrationTestSuite) SetupTest() {
-	s.db = pghelper.ForT(s.T(), true)
+	s.db = pghelper.ForT(s.T(), false)
 	s.store = permissionSetPostgresStore.New(s.db.DB)
 	pgutils.CreateTableFromModel(context.Background(), s.db.GetGormDB(), frozenSchema.CreateTablePermissionSetsStmt)
 }

--- a/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/migration_test.go
+++ b/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/migration_test.go
@@ -91,7 +91,7 @@ func TestMigration(t *testing.T) {
 }
 
 func (s *psMigrationTestSuite) SetupTest() {
-	s.db = pghelper.ForT(s.T(), true)
+	s.db = pghelper.ForT(s.T(), false)
 	s.store = permissionSetPostgresStore.New(s.db.DB)
 	pgutils.CreateTableFromModel(context.Background(), s.db.GetGormDB(), frozenSchema.CreateTablePermissionSetsStmt)
 }

--- a/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/migration_test.go
+++ b/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/migration_test.go
@@ -387,7 +387,7 @@ func TestMigration(t *testing.T) {
 }
 
 func (s *reportConfigsMigrationTestSuite) SetupTest() {
-	s.db = pghelper.ForT(s.T(), true)
+	s.db = pghelper.ForT(s.T(), false)
 	s.reportConfigStore = reportConfigurationPostgres.New(s.db.DB)
 	s.accessScopeStore = accessScopePostgres.New(s.db.DB)
 	s.collectionStore = collectionPostgres.New(s.db.DB)

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/migration_test.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/migration_test.go
@@ -42,7 +42,7 @@ func TestMigration(t *testing.T) {
 }
 
 func (s *networkFlowsMigrationTestSuite) SetupTest() {
-	s.db = pghelper.ForT(s.T(), true)
+	s.db = pghelper.ForT(s.T(), false)
 	pgutils.CreateTableFromModel(context.Background(), s.db.GetGormDB(), oldSchema.CreateTableNetworkFlowsStmt)
 	pgutils.CreateTableFromModel(context.Background(), s.db.GetGormDB(), oldSchema.CreateTableClustersStmt)
 

--- a/migrator/migrations/m_173_to_m_174_group_unique_constraint/migration_test.go
+++ b/migrator/migrations/m_173_to_m_174_group_unique_constraint/migration_test.go
@@ -119,7 +119,7 @@ func TestGroupUniqueConstraintMigration(t *testing.T) {
 }
 
 func (s *groupUniqueConstraintMigrationTestSuite) SetupSuite() {
-	s.db = pghelper.ForT(s.T(), true)
+	s.db = pghelper.ForT(s.T(), false)
 	pgutils.CreateTableFromModel(ctx, s.db.GetGormDB(), frozenSchemav73.CreateTableGroupsStmt)
 }
 

--- a/migrator/migrations/m_177_to_m_178_group_permissions/migration_test.go
+++ b/migrator/migrations/m_177_to_m_178_group_permissions/migration_test.go
@@ -427,7 +427,7 @@ func TestMigration(t *testing.T) {
 }
 
 func (s *psMigrationTestSuite) SetupSuite() {
-	s.db = pghelper.ForT(s.T(), true)
+	s.db = pghelper.ForT(s.T(), false)
 	pgutils.CreateTableFromModel(ctx, s.db.GetGormDB(), frozenSchema.CreateTablePermissionSetsStmt)
 }
 

--- a/migrator/migrations/m_179_to_m_180_openshift_policy_exclusions/migration_test.go
+++ b/migrator/migrations/m_179_to_m_180_openshift_policy_exclusions/migration_test.go
@@ -32,7 +32,7 @@ func TestMigration(t *testing.T) {
 }
 
 func (s *categoriesMigrationTestSuite) SetupTest() {
-	s.db = pghelper.ForT(s.T(), true)
+	s.db = pghelper.ForT(s.T(), false)
 	s.policyStore = policyPostgresStore.New(s.db.DB)
 	pgutils.CreateTableFromModel(context.Background(), s.db.GetGormDB(), frozenSchema.CreateTablePoliciesStmt)
 

--- a/migrator/migrations/m_180_to_m_181_move_to_blobstore/migration_test.go
+++ b/migrator/migrations/m_180_to_m_181_move_to_blobstore/migration_test.go
@@ -36,7 +36,7 @@ func TestMigration(t *testing.T) {
 }
 
 func (s *blobMigrationTestSuite) SetupTest() {
-	s.db = pghelper.ForT(s.T(), true)
+	s.db = pghelper.ForT(s.T(), false)
 }
 
 func (s *blobMigrationTestSuite) TearDownTest() {

--- a/migrator/migrations/m_181_to_m_182_group_role_permission_with_access_one/migration_test.go
+++ b/migrator/migrations/m_181_to_m_182_group_role_permission_with_access_one/migration_test.go
@@ -344,7 +344,7 @@ func TestMigration(t *testing.T) {
 }
 
 func (s *psMigrationTestSuite) SetupSuite() {
-	s.db = pghelper.ForT(s.T(), true)
+	s.db = pghelper.ForT(s.T(), false)
 	pgutils.CreateTableFromModel(ctx, s.db.GetGormDB(), frozenSchema.CreateTablePermissionSetsStmt)
 }
 

--- a/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/migration_test.go
+++ b/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/migration_test.go
@@ -37,7 +37,7 @@ func TestMigration(t *testing.T) {
 }
 
 func (s *migrationTestSuite) SetupTest() {
-	s.db = pghelper.ForT(s.T(), true)
+	s.db = pghelper.ForT(s.T(), false)
 
 	pgutils.CreateTableFromModel(ctx, s.db.GetGormDB(), frozenSchema.CreateTableAPITokensStmt)
 	pgutils.CreateTableFromModel(ctx, s.db.GetGormDB(), frozenSchema.CreateTableGroupsStmt)

--- a/migrator/migrations/m_184_to_m_185_remove_policy_vulnerability_report_resources/migration_test.go
+++ b/migrator/migrations/m_184_to_m_185_remove_policy_vulnerability_report_resources/migration_test.go
@@ -175,7 +175,7 @@ func TestMigration(t *testing.T) {
 }
 
 func (s *psMigrationTestSuite) SetupSuite() {
-	s.db = pghelper.ForT(s.T(), true)
+	s.db = pghelper.ForT(s.T(), false)
 	pgutils.CreateTableFromModel(ctx, s.db.GetGormDB(), frozenSchema.CreateTablePermissionSetsStmt)
 }
 

--- a/migrator/migrations/m_185_to_m_186_more_policy_migrations/migration_test.go
+++ b/migrator/migrations/m_185_to_m_186_more_policy_migrations/migration_test.go
@@ -40,7 +40,7 @@ func simplePolicy(policyID string) *storage.Policy {
 }
 
 func (s *policyMigrationTestSuite) SetupTest() {
-	s.db = pghelper.ForT(s.T(), true)
+	s.db = pghelper.ForT(s.T(), false)
 	s.policyStore = policyPostgresStore.New(s.db.DB)
 	pgutils.CreateTableFromModel(context.Background(), s.db.GetGormDB(), frozenSchema.CreateTablePoliciesStmt)
 

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/migration_test.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/migration_test.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/migration_test.go
@@ -41,7 +41,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/migration_test.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/migration_test.go
@@ -43,7 +43,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_04_to_n_05_postgres_images/migration_test.go
+++ b/migrator/migrations/n_04_to_n_05_postgres_images/migration_test.go
@@ -41,7 +41,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_05_to_n_06_postgres_active_components/migration_test.go
+++ b/migrator/migrations/n_05_to_n_06_postgres_active_components/migration_test.go
@@ -47,7 +47,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/migration_test.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/migration_test.go
@@ -41,7 +41,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/migration_test.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/migration_test.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/migration_test.go
@@ -45,7 +45,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_09_to_n_10_postgres_cluster_cves/migration_test.go
+++ b/migrator/migrations/n_09_to_n_10_postgres_cluster_cves/migration_test.go
@@ -43,7 +43,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/migration_test.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/migration_test.go
@@ -43,7 +43,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/migration_test.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/migration_test.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/migration_test.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/migration_test.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/migration_test.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/migration_test.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/migration_test.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/migration_test.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/migration_test.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/migration_test.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_21_to_n_22_postgres_configs/migration_test.go
+++ b/migrator/migrations/n_21_to_n_22_postgres_configs/migration_test.go
@@ -45,7 +45,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/migration_test.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/migration_test.go
@@ -45,7 +45,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/migration_test.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/migration_test.go
@@ -41,7 +41,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_24_to_n_25_postgres_installation_infos/migration_test.go
+++ b/migrator/migrations/n_24_to_n_25_postgres_installation_infos/migration_test.go
@@ -45,7 +45,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/migration_test.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/migration_test.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/migration_test.go
@@ -41,7 +41,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_27_to_n_28_postgres_log_imbues/migration_test.go
+++ b/migrator/migrations/n_27_to_n_28_postgres_log_imbues/migration_test.go
@@ -44,7 +44,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/migration_test.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/migration_test.go
@@ -41,7 +41,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/migration_test.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_30_to_n_31_postgres_network_flows/migration_test.go
+++ b/migrator/migrations/n_30_to_n_31_postgres_network_flows/migration_test.go
@@ -46,7 +46,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/migration_test.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/migration_test.go
@@ -40,7 +40,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/migration_test.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/migration_test.go
@@ -45,7 +45,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/migration_test.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/migration_test.go
@@ -41,7 +41,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/migration_test.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/migration_test.go
@@ -45,7 +45,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_35_to_n_36_postgres_nodes/migration_test.go
+++ b/migrator/migrations/n_35_to_n_36_postgres_nodes/migration_test.go
@@ -41,7 +41,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/migration_test.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/migration_test.go
@@ -45,7 +45,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/migration_test.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/migration_test.go
@@ -38,7 +38,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/migration_test.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/migration_test.go
@@ -41,7 +41,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/migration_test.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/migration_test.go
@@ -45,7 +45,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/migration_test.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/migration_test.go
@@ -41,7 +41,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/migration_test.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/migration_test.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/migration_test.go
@@ -41,7 +41,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/migration_test.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/migration_test.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/migration_test.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/migration_test.go
@@ -41,7 +41,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/migration_test.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/migration_test.go
@@ -38,7 +38,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/migration_test.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/migration_test.go
@@ -41,7 +41,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_48_to_n_49_postgres_sensor_upgrade_configs/migration_test.go
+++ b/migrator/migrations/n_48_to_n_49_postgres_sensor_upgrade_configs/migration_test.go
@@ -45,7 +45,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/migration_test.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/migration_test.go
@@ -41,7 +41,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_50_to_n_51_postgres_service_identities/migration_test.go
+++ b/migrator/migrations/n_50_to_n_51_postgres_service_identities/migration_test.go
@@ -45,7 +45,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/migration_test.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/migration_test.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/migration_test.go
@@ -93,7 +93,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 	s.gormDB = s.postgresDB.GetGormDB()
 	pgutils.CreateTableFromModel(s.ctx, s.gormDB, frozenSchema.CreateTableReportConfigurationsStmt)
 }

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/migration_test.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/migration_test.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/migration_test.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/migration_test.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/migration_test.go
@@ -42,7 +42,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {

--- a/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
+++ b/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
@@ -30,7 +30,7 @@ type postgresPolicyMigratorTestSuite struct {
 }
 
 func (s *postgresPolicyMigratorTestSuite) SetupTest() {
-	s.db = pghelper.ForT(s.T(), true)
+	s.db = pghelper.ForT(s.T(), false)
 	s.ctx = context.Background()
 	pgutils.CreateTableFromModel(s.ctx, s.db.GetGormDB(), schema.CreateTablePoliciesStmt)
 	s.store = policypostgresstore.New(s.db, s.T())

--- a/tools/generate-helpers/bootstrap-migration/migration_test.go.tpl
+++ b/tools/generate-helpers/bootstrap-migration/migration_test.go.tpl
@@ -29,7 +29,7 @@ func TestMigration(t *testing.T) {
 
 
 func (s *migrationTestSuite) SetupSuite() {
-	s.db = pghelper.ForT(s.T(), true)
+	s.db = pghelper.ForT(s.T(), false)
 	// {{template "TODO"}}: Create the schemas and tables required for the pre-migration dataset push to DB
 }
 

--- a/tools/generate-helpers/pg-table-bindings/migration_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/migration_test.go.tpl
@@ -56,7 +56,7 @@ func (s *postgresMigrationSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.ctx = sac.WithAllAccess(context.Background())
-	s.postgresDB = pghelper.ForT(s.T(), true)
+	s.postgresDB = pghelper.ForT(s.T(), false)
 }
 
 func (s *postgresMigrationSuite) TearDownTest() {


### PR DESCRIPTION
## Description

Enabled constraints (fk relationships, etc) when creating a DB for test. Makes the test closer to production.

NOTE: This PR only changes tests and code generator for tests. It seems to only have been used for migration tests.

## Checklist
- [x] Investigated and inspected CI test results
~[ ] Unit test and regression tests added
[ ] Evaluated and added CHANGELOG entry if required
[ ] Determined and documented upgrade steps
[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

These are all tests. 

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
