### PR TITLE
ROX-17716: Delete ui-components and tippy.js from dependencies

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -20,7 +20,6 @@
         "@patternfly/react-table": "4.112.39",
         "@patternfly/react-topology": "4.93.5",
         "@patternfly/react-user-feedback": "^1.1.2",
-        "@stackrox/ui-components": "*",
         "axios": "^0.25.0",
         "classnames": "^2.3.2",
         "computed-style-to-inline-style": "^3.0.0",
@@ -91,7 +90,6 @@
         "reselect": "^4.1.2",
         "store": "^2.0.12",
         "styled-components": "^5.3.1",
-        "tippy.js": "^6.3.7",
         "use-deep-compare-effect": "^1.8.1",
         "yup": "^1.2.0"
     },

--- a/ui/apps/platform/src/Containers/MainPage/Header/CLIDownloadMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/CLIDownloadMenu.tsx
@@ -77,13 +77,8 @@ function CLIDownloadMenu({ addToast, removeToast }: CLIDownloadMenuProps): React
         setIsCLIMenuOpen(!isCLIMenuOpen);
     }
 
-    // The className prop overrides `font-weight: 600` for button in ui-components.css file.
     const CLIDownloadIcon = (
-        <Flex
-            alignItems={{ default: 'alignItemsCenter' }}
-            spaceItems={{ default: 'spaceItemsSm' }}
-            className="pf-u-font-weight-normal"
-        >
+        <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsSm' }}>
             <FlexItem>
                 <DownloadIcon alt="" />
             </FlexItem>

--- a/ui/apps/platform/src/app.tw.css
+++ b/ui/apps/platform/src/app.tw.css
@@ -13,12 +13,9 @@
 @tailwind components;
 @tailwind utilities;
 
-@import '~@stackrox/ui-components/lib/ui-components.css';
-
 /* reset the unthinking hardcoded resets of Tailwind Forms in v2 plugin,
    https://github.com/tailwindlabs/tailwindcss-forms/blob/master/src/index.js
-   This has to be done in both ui-components CSS and apps/platform CSS,
-   otherwise, the Tailwind reset will win if it's only done in one or the other. */
+*/
 [type='text'],
 [type='email'],
 [type='url'],

--- a/ui/apps/platform/src/constants/form.constants.ts
+++ b/ui/apps/platform/src/constants/form.constants.ts
@@ -15,8 +15,7 @@ export const divToggleOuterClassName =
 export const justifyBetweenClassName = 'flex items-center justify-between';
 
 // The select element base style includes: pr-8 w-full
-// Add font-400 to override `font-weight: 600` for select element from ui-components.css file.
 export const selectElementClassName =
-    'bg-base-100 block border-base-300 focus:border-base-500 p-2 text-base-600 font-400 z-1';
+    'bg-base-100 block border-base-300 focus:border-base-500 p-2 text-base-600 z-1';
 export const selectWrapperClassName =
     'bg-base-100 border-2 border-base-300 hover:border-base-400 leading-normal rounded text-base-600 w-full';

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -10,10 +10,6 @@
   color: var(--base-600);
 }
 
-#main-page-container > div > :not(.pf-c-page__main-section) button {
-    font-weight: inherit; /* override font-weight: 600 in ui-components.css file */
-}
-
 /* Universal selector increases specificity of these override style rules */
 
 * .theme-dark {
@@ -76,9 +72,10 @@
     border-color: var(--pf-c-form-control--disabled--BorderColor) !important;
 }
 
-/* Override classic opacity: 0.5 for disabled buttons so they match disabled input elements. */
-.pf-c-page__main-section button:disabled {
-    opacity: inherit;
+/* Replace override for PatternFly with rule from ui-components.css file for classic disabled buttons. */
+:not(.pf-c-page__main-section) button:disabled {
+    opacity: 0.5;
+    pointer-events: none;
 }
 
 /* SimpleListItem in policy categories: specify color instead of depending on opacity. */
@@ -152,10 +149,6 @@
 /* override width of thead checkbox so that it's not cut off when table is empty */
 .pf-c-table thead tr > .pf-c-table__check {
     min-width: 44px;
-}
-
-button.pf-c-tree-view__node {
-    font-weight: inherit; /* override 600 from ui-components */
 }
 
 /* Global Search modal */


### PR DESCRIPTION
## Description

This is the caboose of the train to delete Network Graph 1.0 code and so on.

### Analysis

Investigate how the follwing style rules relate to PatternFly and Tailwind:

1. `html`
    * `line-height: 1.15` is redundant with a PatternFly base.css

2. `body`
    * non-standard property that is not in app.tw.css and only in PatternFly for a very specific selector

    ```css
    body {
        -webkit-font-smoothing: antialiased;
        -moz-osx-font-smoothing: grayscale;
    }
    ```

    https://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/

    > Feel free to use it on light text on dark backgrounds

    > but for main portions of text where readability is paramount please leave the default setting alone and let the operating system handle the smoothing.

    Therefore, more good than harm to omit global override.

3. various elements
    * Tailwind `break-words` means `overflow-wrap: break-word` redundant with same rule in app.tw.css

4. `input[type='number']`
    * There are no occurrences of `onMinus` or `onPlus` props for PatternFly `NumberInput` element to have spin buttons.
    * The only `input` elements with `type="number"` attribute are pagination which do not have spin buttons.

5. `button:focus`
    * `@apply outline-none` does not seem to prevent outline, although I did not find override rules.

    https://tailwindcss.com/docs/outline-style#removing-outlines

    > It is highly recommended to apply your own focus styling for accessibility when using this utility.

6. `button, select`
    * Other rules override all of the following:

    ```css
    @apply text-base-600 text-base font-600 appearance-none;
    line-height: 14px; /*weird render bug fix where select text gets clipped at bottom */
    ```

7. `button[disabled]`
    * Replace override for PatternFly in trumps.css file with the rule for classic buttons.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

No change to yarn.lock file because multi-repo still includes ui-components.

No change in js now, but whole might be greater than the sum of the parts from recent deletions of imports from ui-components

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/css/*.css`
        main.css: -3644 = 4739087 - 4742731
        total: -3644 = 5616835 - 5620479
    * `ls -al build/static/css/*.css | wc -l`
        0 = 29 - 29 files
    * `wc build/static/js/*.js`
        main.css: -36 = 3757330 - 3757366 but 0.888 of recent 4231488
        total: -54 = 9896289 - 9896343 but 0.965 of recent 10246230
    * `ls -al build/static/js/*.js | wc -l`
        0 = 78 - 78 files
3. `yarn start` in ui

### Manual testing

Visit pages via left navigation and explore 1 (or 2 for workflow) levels of descendant pages.