### PR TITLE
ROX-17702: comparing map

### DIFF
--- a/pkg/maputil/cmpmap.go
+++ b/pkg/maputil/cmpmap.go
@@ -25,7 +25,7 @@ type orderable interface {
 }
 
 // Max returns true if b is greater than a. May be used as a predicate to a
-// comparing map to hold maximum values of the keys.
+// comparing map to hold maximum values.
 func Max[V orderable](a, b V) bool {
 	return a < b
 }

--- a/pkg/maputil/cmpmap.go
+++ b/pkg/maputil/cmpmap.go
@@ -1,0 +1,67 @@
+package maputil
+
+import "github.com/stackrox/rox/pkg/sync"
+
+type cmpmap[K comparable, V any, C func(a, b V) bool] struct {
+	data map[K]V
+	cmp  C
+	mux  sync.RWMutex
+}
+
+// NewCmpMap creates a new comparing map, which only updates the stored values if the
+// cmp predicate returns true when provided with the existing and new values.
+// Example:
+//
+//	NewCmpMap[string](Max[int])
+func NewCmpMap[K comparable, V any, Cmp func(a, b V) bool](cmp Cmp) *cmpmap[K, V, Cmp] {
+	return &cmpmap[K, V, Cmp]{cmp: cmp}
+}
+
+type orderable interface {
+	~int | ~int64 | ~string | ~float32 | ~float64 | ~byte
+}
+
+// Max returns true if b is greater than a. May be used as a predicate to a
+// comparing map to hold maximum values of the keys.
+func Max[V orderable](a, b V) bool {
+	return a < b
+}
+
+// NewMaxMap is a shortcut to create a comparing map[string]int64.
+func NewMaxMap[K comparable, V orderable]() *cmpmap[K, V, func(a, b V) bool] {
+	return NewCmpMap[K](Max[V])
+}
+
+// Reset cleans the map and returns the previously stored one.
+func (m *cmpmap[K, V, _]) Reset() map[K]V {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	prev := m.data
+	m.data = nil
+	return prev
+}
+
+// Get returns the stored value by key.
+func (m *cmpmap[K, V, _]) Get(k K) (V, bool) {
+	m.mux.RLock()
+	defer m.mux.RUnlock()
+	v, ok := m.data[k]
+	return v, ok
+}
+
+// Add inserts the value v to the map at the key k, or updates the value if the
+// comparison predicate returns true.
+func (m *cmpmap[K, V, C]) Add(k K, v V) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	if existing, ok := m.data[k]; ok {
+		if m.cmp(existing, v) {
+			m.data[k] = v
+		}
+	} else {
+		if m.data == nil {
+			m.data = make(map[K]V, 1)
+		}
+		m.data[k] = v
+	}
+}

--- a/pkg/maputil/cmpmap_test.go
+++ b/pkg/maputil/cmpmap_test.go
@@ -20,7 +20,9 @@ func TestMaximap_Get(t *testing.T) {
 
 func TestMaximap_Add(t *testing.T) {
 	m := NewMaxMap[string, int]()
-	m.Add("a", 1)
+
+	m.Add("a", -1)
+	assert.Equal(t, -1, m.data["a"])
 
 	m.Add("a", 5)
 	assert.Equal(t, 5, m.data["a"])

--- a/pkg/maputil/cmpmap_test.go
+++ b/pkg/maputil/cmpmap_test.go
@@ -1,0 +1,40 @@
+package maputil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaximap_Get(t *testing.T) {
+	m := NewMaxMap[string, int]()
+	v, ok := m.Get("a")
+	assert.Equal(t, 0, v)
+	assert.False(t, ok)
+
+	m.Add("a", 1)
+	v, ok = m.Get("a")
+	assert.Equal(t, 1, v)
+	assert.True(t, ok)
+}
+
+func TestMaximap_Add(t *testing.T) {
+	m := NewMaxMap[string, int]()
+	m.Add("a", 1)
+
+	m.Add("a", 5)
+	assert.Equal(t, 5, m.data["a"])
+
+	m.Add("a", 4)
+	assert.Equal(t, 5, m.data["a"])
+	m.Add("b", 3)
+	assert.Equal(t, 3, m.data["b"])
+}
+
+func TestMaximap_Reset(t *testing.T) {
+	m := NewMaxMap[string, int]()
+	m.Add("a", 1)
+	prev := m.Reset()
+	assert.Equal(t, 1, prev["a"])
+	assert.Nil(t, m.data)
+}


### PR DESCRIPTION
## Description

A map which executes a predicate on updating an existing value.

Allows for implementing a map which stores, e.g. maximum values, ignoring attempts to update values less than the stored ones.

This utility will be used by the billing metrics service.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Unit tests.