### PR TITLE
ROX-17702: make use of the cmpmap in the pipeline

### DIFF
--- a/central/sensor/service/pipeline/clustermetrics/pipeline.go
+++ b/central/sensor/service/pipeline/clustermetrics/pipeline.go
@@ -66,6 +66,9 @@ func (p *pipelineImpl) Run(
 	p.metricsStore.Set(clusterID, msg.GetClusterMetrics())
 
 	clusterTelemetry.UpdateSecuredClusterIdentity(ctx, clusterID, msg.GetClusterMetrics())
+
+	updateMaxima(clusterID, msg.GetClusterMetrics())
+
 	return nil
 }
 

--- a/central/sensor/service/pipeline/clustermetrics/update_maxima.go
+++ b/central/sensor/service/pipeline/clustermetrics/update_maxima.go
@@ -9,18 +9,18 @@ import (
 // BillingMetrics are the metrics we collect and show to the customers to help
 // them report their usage.
 type BillingMetrics struct {
-	TotalNodes      int64
-	TotalMilliCores int64
+	TotalNodes int64
+	TotalCores int64
 }
 
 var (
-	nodesMap      = maputil.NewMaxMap[string, int64]()
-	millicoresMap = maputil.NewMaxMap[string, int64]()
+	nodesMap = maputil.NewMaxMap[string, int64]()
+	coresMap = maputil.NewMaxMap[string, int64]()
 )
 
 func updateMaxima(clusterID string, cm *central.ClusterMetrics) {
 	nodesMap.Add(clusterID, cm.GetNodeCount())
-	millicoresMap.Add(clusterID, cm.GetCpuCapacity())
+	coresMap.Add(clusterID, cm.GetCpuCapacity())
 }
 
 // CutMetrics resets the metrics and returns the collected values since last
@@ -32,9 +32,9 @@ func CutMetrics(ids set.StringSet) *BillingMetrics {
 			m.TotalNodes += v
 		}
 	}
-	for id, v := range millicoresMap.Reset() {
+	for id, v := range coresMap.Reset() {
 		if ids.Contains(id) {
-			m.TotalMilliCores += v
+			m.TotalCores += v
 		}
 	}
 	return &m

--- a/central/sensor/service/pipeline/clustermetrics/update_maxima.go
+++ b/central/sensor/service/pipeline/clustermetrics/update_maxima.go
@@ -1,0 +1,41 @@
+package clustermetrics
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/maputil"
+	"github.com/stackrox/rox/pkg/set"
+)
+
+// BillingMetrics are the metrics we collect and show to the customers to help
+// them report their usage.
+type BillingMetrics struct {
+	TotalNodes      int64
+	TotalMilliCores int64
+}
+
+var (
+	nodesMap      = maputil.NewMaxMap[string, int64]()
+	millicoresMap = maputil.NewMaxMap[string, int64]()
+)
+
+func updateMaxima(clusterID string, cm *central.ClusterMetrics) {
+	nodesMap.Add(clusterID, cm.GetNodeCount())
+	millicoresMap.Add(clusterID, cm.GetCpuCapacity())
+}
+
+// CutMetrics resets the metrics and returns the collected values since last
+// invocation.
+func CutMetrics(ids set.StringSet) *BillingMetrics {
+	var m BillingMetrics
+	for id, v := range nodesMap.Reset() {
+		if ids.Contains(id) {
+			m.TotalNodes += v
+		}
+	}
+	for id, v := range millicoresMap.Reset() {
+		if ids.Contains(id) {
+			m.TotalMilliCores += v
+		}
+	}
+	return &m
+}


### PR DESCRIPTION
## Description

Update the in-memory map with the maximum values of nodes and cores per secured cluster.

The data in the map will be periodically stored, and reset for the next collection period.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~


## Testing Performed

Unit tests.