### PR TITLE
ROX-17702: schedule periodic data insertion

### DIFF
--- a/central/telemetry/billingmetrics/data.go
+++ b/central/telemetry/billingmetrics/data.go
@@ -1,0 +1,69 @@
+package billingmetrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	bmetrics "github.com/stackrox/rox/central/billingmetrics/store"
+	cluStore "github.com/stackrox/rox/central/cluster/datastore"
+	"github.com/stackrox/rox/central/sensor/service/pipeline/clustermetrics"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/set"
+)
+
+var (
+	clusterReader = sac.AllowFixedScopes(
+		sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+		sac.ResourceScopeKeys(resources.Cluster))
+
+	metricsWriter = sac.AllowFixedScopes(
+		sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+		sac.ResourceScopeKeys(resources.Administration))
+
+	previousMetrics = &clustermetrics.BillingMetrics{}
+)
+
+func average(metrics ...*clustermetrics.BillingMetrics) clustermetrics.BillingMetrics {
+	n := int64(len(metrics))
+	a := clustermetrics.BillingMetrics{}
+	if n == 0 {
+		return a
+	}
+	for _, m := range metrics {
+		a.TotalNodes += m.TotalNodes
+		a.TotalMilliCores += m.TotalMilliCores
+	}
+	a.TotalNodes /= n
+	a.TotalMilliCores /= n
+	return a
+}
+
+func getClusterIDs() (set.StringSet, error) {
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), clusterReader)
+
+	clusters, err := cluStore.Singleton().GetClusters(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "cluster datastore failure")
+	}
+	ids := set.NewStringSet()
+	for _, cluster := range clusters {
+		ids.Add(cluster.GetId())
+	}
+	return ids, nil
+}
+
+func checkIn(metrics clustermetrics.BillingMetrics) error {
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), metricsWriter)
+
+	err := bmetrics.Singleton().Insert(ctx, &storage.BillingMetrics{
+		Ts: protoconv.ConvertTimeToTimestamp(time.Now()),
+		Sr: &storage.BillingMetrics_SecuredResources{
+			Nodes:      int32(metrics.TotalNodes),
+			Millicores: int32(metrics.TotalMilliCores)},
+	})
+	return errors.Wrap(err, "billing metrics datastore failure")
+}

--- a/central/telemetry/billingmetrics/data.go
+++ b/central/telemetry/billingmetrics/data.go
@@ -35,10 +35,10 @@ func average(metrics ...*clustermetrics.BillingMetrics) clustermetrics.BillingMe
 	}
 	for _, m := range metrics {
 		a.TotalNodes += m.TotalNodes
-		a.TotalMilliCores += m.TotalMilliCores
+		a.TotalCores += m.TotalCores
 	}
 	a.TotalNodes /= n
-	a.TotalMilliCores /= n
+	a.TotalCores /= n
 	return a
 }
 
@@ -62,8 +62,8 @@ func checkIn(metrics clustermetrics.BillingMetrics) error {
 	err := bmetrics.Singleton().Insert(ctx, &storage.BillingMetrics{
 		Ts: protoconv.ConvertTimeToTimestamp(time.Now()),
 		Sr: &storage.BillingMetrics_SecuredResources{
-			Nodes:      int32(metrics.TotalNodes),
-			Millicores: int32(metrics.TotalMilliCores)},
+			Nodes: int32(metrics.TotalNodes),
+			Cores: int32(metrics.TotalCores)},
 	})
 	return errors.Wrap(err, "billing metrics datastore failure")
 }

--- a/central/telemetry/billingmetrics/data_test.go
+++ b/central/telemetry/billingmetrics/data_test.go
@@ -10,16 +10,16 @@ import (
 func Test_average(t *testing.T) {
 	a := average()
 	assert.Equal(t, int64(0), a.TotalNodes)
-	assert.Equal(t, int64(0), a.TotalMilliCores)
+	assert.Equal(t, int64(0), a.TotalCores)
 
 	metrics := []*clustermetrics.BillingMetrics{{
-		TotalNodes:      0,
-		TotalMilliCores: 100,
+		TotalNodes: 0,
+		TotalCores: 100,
 	}, {
-		TotalNodes:      10,
-		TotalMilliCores: 0,
+		TotalNodes: 10,
+		TotalCores: 0,
 	}}
 	a = average(metrics...)
 	assert.Equal(t, int64(5), a.TotalNodes)
-	assert.Equal(t, int64(50), a.TotalMilliCores)
+	assert.Equal(t, int64(50), a.TotalCores)
 }

--- a/central/telemetry/billingmetrics/data_test.go
+++ b/central/telemetry/billingmetrics/data_test.go
@@ -1,0 +1,25 @@
+package billingmetrics
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/central/sensor/service/pipeline/clustermetrics"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_average(t *testing.T) {
+	a := average()
+	assert.Equal(t, int64(0), a.TotalNodes)
+	assert.Equal(t, int64(0), a.TotalMilliCores)
+
+	metrics := []*clustermetrics.BillingMetrics{{
+		TotalNodes:      0,
+		TotalMilliCores: 100,
+	}, {
+		TotalNodes:      10,
+		TotalMilliCores: 0,
+	}}
+	a = average(metrics...)
+	assert.Equal(t, int64(5), a.TotalNodes)
+	assert.Equal(t, int64(50), a.TotalMilliCores)
+}

--- a/central/telemetry/billingmetrics/scheduler.go
+++ b/central/telemetry/billingmetrics/scheduler.go
@@ -1,0 +1,58 @@
+package billingmetrics
+
+import (
+	"time"
+
+	"github.com/stackrox/rox/central/sensor/service/pipeline/clustermetrics"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+const period = 1 * time.Hour
+
+var (
+	log  = logging.LoggerForModule()
+	stop = concurrency.NewSignal()
+)
+
+func gather() {
+	ids, err := getClusterIDs()
+	if err != nil {
+		log.Debug("Failed to get cluster IDs for billing metrics snapshot: ", err)
+		return
+	}
+	log.Debugf("Cutting billing metrics for %d clusters: %v", len(ids), ids)
+	newMetrics := clustermetrics.CutMetrics(ids)
+	// Store the average values to smooth short (< 2 periods) peaks and drops.
+	if err := checkIn(average(previousMetrics, newMetrics)); err != nil {
+		log.Debug("Failed to store a billing metrics snapshot: ", err)
+	}
+	previousMetrics = newMetrics
+}
+
+func run() {
+	ticker := time.NewTicker(period)
+	defer ticker.Stop()
+	gather()
+	for {
+		select {
+		case <-ticker.C:
+			gather()
+		case <-stop.Done():
+			log.Debug("Billing metrics reporting stopped")
+			stop.Reset()
+			return
+		}
+	}
+}
+
+// Schedule initiates periodic data injections to the database with the
+// collected billing metrics.
+func Schedule() {
+	go run()
+}
+
+// Stop stops the scheduled timer
+func Stop() {
+	stop.Signal()
+}


### PR DESCRIPTION
## Description

Schedule a periodic store of the collected billing metrics. The values are taken from the max-map, where they're collected since the last invocation.

Stored are the average (between the current and previous invocations) total numbers of secured cores and nodes. This removes short peaks and drops in the numbers.

Only the values of known clusters, which exist in the database at the moment of invocation, are taken into account.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Unit tests.