### PR TITLE
ROX-18613: sensor's context provider

### DIFF
--- a/sensor/common/context/context_provider.go
+++ b/sensor/common/context/context_provider.go
@@ -2,10 +2,11 @@ package contextprovider
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
-	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
 )
@@ -21,45 +22,61 @@ var _ ContextProvider = (*contextProviderImpl)(nil)
 
 // NewContextProvider Initializes a new ContextProvider
 func NewContextProvider() ContextProvider {
-	return &contextProviderImpl{
-		centralReachable: concurrency.NewSignal(),
-		stopper:          concurrency.NewStopper(),
+	ret := &contextProviderImpl{
+		firstCentralConnection: &atomic.Bool{},
 	}
+	// We initialize here and not in Start to avoid races with other sensor components
+	// that might call GetContext on their respective Start functions.
+	ret.init(func() (context.Context, func()) {
+		return context.WithCancel(context.Background())
+	})
+	return ret
 }
 
 type contextProviderImpl struct {
-	cancelContextFn  func()
-	sensorContext    context.Context
-	centralReachable concurrency.Signal
-	stopper          concurrency.Stopper
+	mu              sync.RWMutex
+	cancelContextFn func()
+	sensorContext   context.Context
+	// newContextFn defines the function that creates a new context/cancelFunction.
+	// This is needed for testing purposes.
+	newContextFn func() (context.Context, func())
+	// firstCentralConnection indicates whether is the first time Central is reachable or not.
+	// This is needed to make sure any SensorComponent that calls GetContext on Start gets a
+	// valid context that won't be overriden on receiving the CentralReachable notification.
+	firstCentralConnection *atomic.Bool
 }
 
-// GetContext returns the sensor context. This call will block until central is reachable.
-// This blocking in behavior is needed to ensure unset or old contexts are not passed to other component.
+// GetContext returns the sensor context.
 func (c *contextProviderImpl) GetContext() context.Context {
-	select {
-	case <-c.centralReachable.Done():
-		return c.sensorContext
-	case <-c.stopper.Flow().StopRequested():
-		return nil
-	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.sensorContext
+}
+
+// init sets the newContextFn and initializes the sensorContext and the cancelContextFn
+func (c *contextProviderImpl) init(ctxFn func() (context.Context, func())) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.newContextFn = ctxFn
+	c.sensorContext, c.cancelContextFn = c.newContextFn()
 }
 
 func (c *contextProviderImpl) Start() error {
 	return nil
 }
 
-func (c *contextProviderImpl) Stop(_ error) {
-	c.stopper.Client().Stop()
-}
+func (c *contextProviderImpl) Stop(_ error) {}
 
 func (c *contextProviderImpl) Notify(event common.SensorComponentEvent) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	switch event {
 	case common.SensorComponentEventCentralReachable:
-		c.sensorContext, c.cancelContextFn = context.WithCancel(context.Background())
-		c.centralReachable.Signal()
+		// We only re-create the context if it's not the first time central is reachable.
+		if !c.firstCentralConnection.CompareAndSwap(false, true) {
+			c.sensorContext, c.cancelContextFn = c.newContextFn()
+		}
 	case common.SensorComponentEventOfflineMode:
-		c.centralReachable.Reset()
 		c.cancelContextFn()
 	}
 }

--- a/sensor/common/context/context_provider.go
+++ b/sensor/common/context/context_provider.go
@@ -1,0 +1,54 @@
+package contextprovider
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
+)
+
+type ContextProvider interface {
+	common.SensorComponent
+	GetContext() context.Context
+}
+
+var _ ContextProvider = (*contextProviderImpl)(nil)
+
+func NewContextProvider() ContextProvider {
+	return &contextProviderImpl{}
+}
+
+type contextProviderImpl struct {
+	centralReachable concurrency.Signal
+	sensorContext    context.Context
+	cancelContextFn  func()
+}
+
+// GetContext returns the sensor context. This call will block until central is reachable.
+// This blocking in behavior is needed to ensure unset or old contexts are not passed to other component.
+func (c *contextProviderImpl) GetContext() context.Context {
+	return nil
+}
+
+func (c *contextProviderImpl) Start() error {
+	return nil
+}
+
+func (c *contextProviderImpl) Stop(_ error) {}
+
+func (c *contextProviderImpl) Notify(_ common.SensorComponentEvent) {}
+
+func (c *contextProviderImpl) Capabilities() []centralsensor.SensorCapability {
+	return nil
+}
+
+func (c *contextProviderImpl) ProcessMessage(_ *central.MsgToSensor) error {
+	return nil
+}
+
+func (c *contextProviderImpl) ResponsesC() <-chan *message.ExpiringMessage {
+	return nil
+}

--- a/sensor/common/context/context_provider.go
+++ b/sensor/common/context/context_provider.go
@@ -58,11 +58,9 @@ func (c *contextProviderImpl) Notify(event common.SensorComponentEvent) {
 	case common.SensorComponentEventCentralReachable:
 		c.sensorContext, c.cancelContextFn = context.WithCancel(context.Background())
 		c.centralReachable.Signal()
-		break
 	case common.SensorComponentEventOfflineMode:
 		c.centralReachable.Reset()
 		c.cancelContextFn()
-		break
 	}
 }
 

--- a/sensor/common/context/context_provider.go
+++ b/sensor/common/context/context_provider.go
@@ -20,7 +20,7 @@ type ContextProvider interface {
 
 var _ ContextProvider = (*contextProviderImpl)(nil)
 
-// NewContextProvider Initializes a new ContextProvider
+// NewContextProvider initializes a new ContextProvider
 func NewContextProvider() ContextProvider {
 	ret := &contextProviderImpl{
 		firstCentralConnection: &atomic.Bool{},
@@ -40,7 +40,7 @@ type contextProviderImpl struct {
 	// newContextFn defines the function that creates a new context/cancelFunction.
 	// This is needed for testing purposes.
 	newContextFn func() (context.Context, func())
-	// firstCentralConnection indicates whether is the first time Central is reachable or not.
+	// firstCentralConnection indicates whether it is the first time Central is reachable or not.
 	// This is needed to make sure any SensorComponent that calls GetContext on Start gets a
 	// valid context that won't be overriden on receiving the CentralReachable notification.
 	firstCentralConnection *atomic.Bool

--- a/sensor/common/context/context_provider.go
+++ b/sensor/common/context/context_provider.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stackrox/rox/sensor/common/message"
 )
 
+// ContextProvider Sensor component that provides a common context.
+// This context will be cancelled and reset if Sensor enters Offline mode.
 type ContextProvider interface {
 	common.SensorComponent
 	GetContext() context.Context
@@ -17,6 +19,7 @@ type ContextProvider interface {
 
 var _ ContextProvider = (*contextProviderImpl)(nil)
 
+// NewContextProvider Initializes a new ContextProvider
 func NewContextProvider() ContextProvider {
 	return &contextProviderImpl{
 		centralReachable: concurrency.NewSignal(),

--- a/sensor/common/context/context_provider_test.go
+++ b/sensor/common/context/context_provider_test.go
@@ -1,12 +1,20 @@
 package contextprovider
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+)
+
+const (
+	contextKey         = "context-key"
+	contextValuePrefix = "context-value"
 )
 
 type contextProviderSuite struct {
@@ -17,79 +25,180 @@ func TestContextProvider(t *testing.T) {
 	suite.Run(t, new(contextProviderSuite))
 }
 
-func (s *contextProviderSuite) TestGetContextBlockUntilCentralReachable() {
-	provider := s.createContextProvider()
+func (s *contextProviderSuite) TestGetContextBeforeCentralReachable() {
+	provider := s.createContextProvider(newTestContextFnHelper(contextValuePrefix).contextWithValue())
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		s.Assert().NotNil(provider.GetContext())
-		s.Assert().True(provider.centralReachable.IsDone(), "the context should not be returned until central is reachable")
-		wg.Done()
-	}()
+	ctx := provider.GetContext()
+	s.Assert().Equal(fmt.Sprintf("%s-%d", contextValuePrefix, 1), ctx.Value(contextKey))
+}
+
+func (s *contextProviderSuite) TestGetContextAfterCentralReachable() {
+	provider := s.createContextProvider(newTestContextFnHelper(contextValuePrefix).contextWithValue())
+
+	s.Assert().Equal(fmt.Sprintf("%s-%d", contextValuePrefix, 1), provider.GetContext().Value(contextKey))
+	provider.Notify(common.SensorComponentEventCentralReachable)
+	// After central is reachable the context should be the same
+	s.Assert().Equal(fmt.Sprintf("%s-%d", contextValuePrefix, 1), provider.GetContext().Value(contextKey))
+}
+
+func (s *contextProviderSuite) TestGetContextDifferentContextAfterReconnect() {
+	provider := s.createContextProvider(newTestContextFnHelper(contextValuePrefix).contextWithValue())
 
 	provider.Notify(common.SensorComponentEventCentralReachable)
+	s.Assert().Equal(fmt.Sprintf("%s-%d", contextValuePrefix, 1), provider.GetContext().Value(contextKey))
+	provider.Notify(common.SensorComponentEventOfflineMode)
+	provider.Notify(common.SensorComponentEventCentralReachable)
+	// After central is reachable again the context should be the different
+	s.Assert().Equal(fmt.Sprintf("%s-%d", contextValuePrefix, 2), provider.GetContext().Value(contextKey))
+}
+
+func (s *contextProviderSuite) TestGetContextCancelInOfflineMode() {
+	provider := s.createContextProvider(newTestContextFnHelper(contextValuePrefix).contextWithValue())
+
+	ctx := provider.GetContext()
+	provider.Notify(common.SensorComponentEventCentralReachable)
+	s.Assert().Equal(fmt.Sprintf("%s-%d", contextValuePrefix, 1), ctx.Value(contextKey))
+	select {
+	case <-ctx.Done():
+		s.Fail("the context should not be cancelled")
+	case <-time.After(10 * time.Millisecond):
+		break
+	}
+	provider.Notify(common.SensorComponentEventOfflineMode)
+	select {
+	case <-ctx.Done():
+		break
+	case <-time.After(5 * time.Second):
+		s.Fail("the context should be cancelled")
+	}
+}
+
+func (s *contextProviderSuite) TestGetContextCallFromMultipleGoroutines() {
+	provider := s.createContextProvider(newTestContextFnHelper(contextValuePrefix).contextWithValue())
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		s.Assert().Equal(fmt.Sprintf("%s-%d", contextValuePrefix, 1), provider.GetContext().Value(contextKey))
+	}()
+	go func() {
+		defer wg.Done()
+		s.Assert().Equal(fmt.Sprintf("%s-%d", contextValuePrefix, 1), provider.GetContext().Value(contextKey))
+	}()
 	wg.Wait()
 }
 
-func (s *contextProviderSuite) TestGetContextBlocksUntilStopped() {
-	provider := s.createContextProvider()
-
-	provider.Notify(common.SensorComponentEventCentralReachable)
-	provider.Notify(common.SensorComponentEventOfflineMode)
-	ch := make(chan struct{})
-	defer close(ch)
-	go func() {
-		s.Assert().Nil(provider.GetContext())
-		s.Assert().False(provider.centralReachable.IsDone())
-		ch <- struct{}{}
-	}()
-	select {
-	case <-time.After(time.Millisecond):
-		break
-	case <-ch:
-		s.Fail("context should not returned if central is not reachable")
-		break
+func (s *contextProviderSuite) TestOrderOfComponentsMatter() {
+	provider := s.createContextProvider(newTestContextFnHelper(contextValuePrefix).contextWithValue())
+	components := []notifiableComponent{
+		// The provider needs to be the first in getting notify.
+		// Otherwise, other components would get and old context on CentralReachable.
+		provider,
+		&fakeComponent{
+			provider: provider,
+		},
+		&fakeComponent{
+			provider: provider,
+		},
 	}
-	provider.Stop(nil)
-	select {
-	case <-time.After(5 * time.Second):
-		s.Fail("timeout waiting for the component to be stopped")
-	case <-ch:
-		break
+	states := []struct {
+		event common.SensorComponentEvent
+		value int
+	}{
+		{
+			event: common.SensorComponentEventCentralReachable,
+			value: 1,
+		},
+		{
+			event: common.SensorComponentEventOfflineMode,
+			value: 1,
+		},
+		{
+			event: common.SensorComponentEventCentralReachable,
+			value: 2,
+		},
 	}
-}
-
-func (s *contextProviderSuite) TestOfflineMode() {
-	provider := s.createContextProvider()
-
-	s.Assert().Nil(provider.sensorContext)
-	s.Assert().Nil(provider.cancelContextFn)
-	provider.Notify(common.SensorComponentEventCentralReachable)
-	oldCtx := provider.sensorContext
-	s.Assert().NotNil(oldCtx)
-	s.Assert().NotNil(provider.cancelContextFn)
-	provider.Notify(common.SensorComponentEventOfflineMode)
-	select {
-	case <-oldCtx.Done():
-		break
-	case <-time.After(5 * time.Second):
-		s.Fail("timeout waiting for the context to be canceled")
-	}
-	provider.Notify(common.SensorComponentEventCentralReachable)
-	s.Assert().NotEqual(oldCtx, provider.sensorContext)
-	s.Assert().NotNil(provider.cancelContextFn)
-	select {
-	case <-provider.sensorContext.Done():
-		s.Fail("the context should not be canceled when central is reachable")
-	case <-time.After(time.Millisecond):
-		break
+	for _, state := range states {
+		for _, component := range components {
+			component.Notify(state.event)
+		}
+		for _, component := range components {
+			if testable, ok := component.(*fakeComponent); ok {
+				testable.assertContextValue(s.T(), contextKey, fmt.Sprintf("%s-%d", contextValuePrefix, state.value))
+				testable.assertCancelContext(s.T(), state.event)
+			}
+		}
 	}
 }
 
-func (s *contextProviderSuite) createContextProvider() *contextProviderImpl {
+type notifiableComponent interface {
+	Notify(common.SensorComponentEvent)
+}
+
+type fakeComponent struct {
+	provider ContextProvider
+	ctx      context.Context
+}
+
+func (f *fakeComponent) Notify(event common.SensorComponentEvent) {
+	switch event {
+	case common.SensorComponentEventCentralReachable:
+		f.ctx = f.provider.GetContext()
+	case common.SensorComponentEventOfflineMode:
+	}
+}
+
+func (f *fakeComponent) assertContextValue(t *testing.T, key, value string) {
+	assert.Equal(t, value, f.ctx.Value(key))
+}
+
+func (f *fakeComponent) assertCancelContext(t *testing.T, event common.SensorComponentEvent) {
+	switch event {
+	case common.SensorComponentEventCentralReachable:
+		select {
+		case <-f.ctx.Done():
+			t.Error("the context should not be cancelled")
+			return
+		case <-time.After(10 * time.Millisecond):
+			return
+		}
+	case common.SensorComponentEventOfflineMode:
+		select {
+		case <-f.ctx.Done():
+			return
+		case <-time.After(5 * time.Second):
+			t.Error("the context should be cancelled")
+			return
+		}
+	}
+	if event == common.SensorComponentEventOfflineMode {
+	}
+}
+
+type testContextFnHelper struct {
+	value         string
+	contextNumber int
+}
+
+func newTestContextFnHelper(value string) *testContextFnHelper {
+	return &testContextFnHelper{
+		value:         value,
+		contextNumber: 0,
+	}
+}
+
+func (h *testContextFnHelper) contextWithValue() func() (context.Context, func()) {
+	return func() (context.Context, func()) {
+		h.contextNumber++
+		return context.WithCancel(context.WithValue(context.Background(), contextKey, fmt.Sprintf("%s-%d", h.value, h.contextNumber)))
+	}
+}
+
+func (s *contextProviderSuite) createContextProvider(contextFn func() (context.Context, func())) *contextProviderImpl {
 	provider, ok := NewContextProvider().(*contextProviderImpl)
 	s.Assert().True(ok)
+	provider.init(contextFn)
 	s.Assert().NoError(provider.Start())
+	provider.newContextFn = contextFn
 	return provider
 }

--- a/sensor/common/context/context_provider_test.go
+++ b/sensor/common/context/context_provider_test.go
@@ -1,0 +1,95 @@
+package contextprovider
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stretchr/testify/suite"
+)
+
+type contextProviderSuite struct {
+	suite.Suite
+}
+
+func TestContextProvider(t *testing.T) {
+	suite.Run(t, new(contextProviderSuite))
+}
+
+func (s *contextProviderSuite) TestGetContextBlockUntilCentralReachable() {
+	provider := s.createContextProvider()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		s.Assert().NotNil(provider.GetContext())
+		s.Assert().True(provider.centralReachable.IsDone(), "the context should not be returned until central is reachable")
+		wg.Done()
+	}()
+
+	provider.Notify(common.SensorComponentEventCentralReachable)
+	wg.Wait()
+}
+
+func (s *contextProviderSuite) TestGetContextBlocksUntilStopped() {
+	provider := s.createContextProvider()
+
+	provider.Notify(common.SensorComponentEventCentralReachable)
+	provider.Notify(common.SensorComponentEventOfflineMode)
+	ch := make(chan struct{})
+	defer close(ch)
+	go func() {
+		s.Assert().Nil(provider.GetContext())
+		s.Assert().False(provider.centralReachable.IsDone())
+		ch <- struct{}{}
+	}()
+	select {
+	case <-time.After(time.Millisecond):
+		break
+	case <-ch:
+		s.Fail("context should not returned if central is not reachable")
+		break
+	}
+	provider.Stop(nil)
+	select {
+	case <-time.After(5 * time.Second):
+		s.Fail("timeout waiting for the component to be stopped")
+	case <-ch:
+		break
+	}
+}
+
+func (s *contextProviderSuite) TestOfflineMode() {
+	provider := s.createContextProvider()
+
+	s.Assert().Nil(provider.sensorContext)
+	s.Assert().Nil(provider.cancelContextFn)
+	provider.Notify(common.SensorComponentEventCentralReachable)
+	oldCtx := provider.sensorContext
+	s.Assert().NotNil(oldCtx)
+	s.Assert().NotNil(provider.cancelContextFn)
+	provider.Notify(common.SensorComponentEventOfflineMode)
+	select {
+	case <-oldCtx.Done():
+		break
+	case <-time.After(5 * time.Second):
+		s.Fail("timeout waiting for the context to be canceled")
+	}
+	provider.Notify(common.SensorComponentEventCentralReachable)
+	s.Assert().NotEqual(oldCtx, provider.sensorContext)
+	s.Assert().NotNil(provider.cancelContextFn)
+	select {
+	case <-provider.sensorContext.Done():
+		s.Fail("the context should not be canceled when central is reachable")
+	case <-time.After(time.Millisecond):
+		break
+	}
+}
+
+func (s *contextProviderSuite) createContextProvider() *contextProviderImpl {
+	provider, ok := NewContextProvider().(*contextProviderImpl)
+	s.Assert().True(ok)
+	s.Assert().NoError(provider.Start())
+	return provider
+}

--- a/sensor/common/context/context_provider_test.go
+++ b/sensor/common/context/context_provider_test.go
@@ -91,8 +91,8 @@ func (s *contextProviderSuite) TestGetContextCallFromMultipleGoroutines() {
 func (s *contextProviderSuite) TestOrderOfComponentsMatter() {
 	provider := s.createContextProvider(newTestContextFnHelper(contextValuePrefix).contextWithValue())
 	components := []notifiableComponent{
-		// The provider needs to be the first in getting notify.
-		// Otherwise, other components would get and old context on CentralReachable.
+		// The provider needs to be the first to get notified.
+		// Otherwise, other components would get an old context on CentralReachable.
 		provider,
 		&fakeComponent{
 			provider: provider,

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/certdistribution"
 	"github.com/stackrox/rox/sensor/common/compliance"
 	"github.com/stackrox/rox/sensor/common/config"
+	contextprovider "github.com/stackrox/rox/sensor/common/context"
 	"github.com/stackrox/rox/sensor/common/delegatedregistry"
 	"github.com/stackrox/rox/sensor/common/deployment"
 	"github.com/stackrox/rox/sensor/common/detector"
@@ -65,6 +66,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		log.Infof("Running sensor with Kubernetes re-sync enabled. Re-sync time: %s", cfg.resyncPeriod.String())
 	}
 
+	contextProvider := contextprovider.NewContextProvider()
 	storeProvider := resources.InitializeStore()
 
 	admCtrlSettingsMgr := admissioncontroller.NewSettingsManager(storeProvider.Deployments(), storeProvider.Pods())
@@ -133,6 +135,8 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	networkFlowManager :=
 		manager.NewManager(storeProvider.Entities(), externalsrcs.StoreInstance(), policyDetector)
 	components := []common.SensorComponent{
+		// The contextProvider needs to be first in this slice to ensure it is the first component that gets called on Notify
+		contextProvider,
 		admCtrlMsgForwarder,
 		enforcer,
 		networkFlowManager,


### PR DESCRIPTION
## Description

This PR aims to add a context provider component to enable other sensor components to have a unique context that will be canceled if sensor enters offline mode. This context cancellation logic can be use to expire messages that might still be in sensor's pipelines when we enter offline mode.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- [x] Only unit tests
