### PR TITLE
fix(restore): Fix Postgres restore database name

### DIFF
--- a/central/globaldb/v2backuprestore/restore/postgres.go
+++ b/central/globaldb/v2backuprestore/restore/postgres.go
@@ -1,12 +1,10 @@
 package restore
 
 import (
-	"fmt"
 	"io"
 	"os/exec"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/pkg/config"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgadmin"
@@ -14,8 +12,7 @@ import (
 )
 
 const (
-	// restoreSuffix - suffix for the restore database
-	restoreSuffix = "_restore"
+	restoreDB = "central_restore"
 )
 
 var (
@@ -85,6 +82,5 @@ func runRestoreStream(fileReader io.Reader, sourceMap map[string]string, config 
 }
 
 func getRestoreDBName() string {
-	// Build the active database name for the connection
-	return fmt.Sprintf("%s%s", config.GetConfig().CentralDB.DatabaseName, restoreSuffix)
+	return restoreDB
 }


### PR DESCRIPTION
## Description

The restore database name was central_active_restore instead of central_restore. This means that restore is broken. I will follow up with a PR for a test that ensures restore works

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manually