### PR TITLE
ROX-18474: Add listening endpoint link to sidebar nav

### DIFF
--- a/ui/apps/platform/cypress/integration/audit/listeningEndpoints/ListeningEndpoints.helpers.js
+++ b/ui/apps/platform/cypress/integration/audit/listeningEndpoints/ListeningEndpoints.helpers.js
@@ -1,6 +1,6 @@
 import { visit } from '../../../helpers/visit';
 
-const basePath = '/main/audit/listening-endpoints/';
+const basePath = '/main/listening-endpoints/';
 
 export function visitListeningEndpoints() {
     visit(basePath);

--- a/ui/apps/platform/cypress/integration/networkGraphPF/networkGraph.helpers.js
+++ b/ui/apps/platform/cypress/integration/networkGraphPF/networkGraph.helpers.js
@@ -1,4 +1,4 @@
-import { visitFromLeftNav } from '../../helpers/nav';
+import { visitFromLeftNavExpandable } from '../../helpers/nav';
 import { interactAndWaitForResponses } from '../../helpers/request';
 import { visit } from '../../helpers/visit';
 import selectSelectors from '../../selectors/select';
@@ -77,7 +77,7 @@ const routeMatcherMapToVisitNetworkGraph = {
 export const basePath = '/main/network-graph';
 
 export function visitNetworkGraphFromLeftNav() {
-    visitFromLeftNav('Network Graph', routeMatcherMapToVisitNetworkGraph);
+    visitFromLeftNavExpandable('Network', 'Network Graph', routeMatcherMapToVisitNetworkGraph);
 
     cy.location('pathname').should('eq', basePath);
 }

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -128,6 +128,7 @@ function ListeningEndpointsPage() {
             <PageTitle title="Listening Endpoints" />
             <PageSection variant="light">
                 <Title headingLevel="h1">Listening endpoints</Title>
+                <Text>Audit listening endpoints of deployments in your clusters</Text>
             </PageSection>
             <Divider component="div" />
             <PageSection

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -19,7 +19,7 @@ function EmbeddedTable({
         <TableComposable isNested>
             <Thead noWrap>
                 <Tr>
-                    <Th width={20}>Program name</Th>
+                    <Th width={20}>Process name</Th>
                     <Th width={10}>PID</Th>
                     <Th width={10}>Port</Th>
                     <Th width={10}>Protocol</Th>

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -26,6 +26,7 @@ import {
     vulnerabilitiesWorkloadCvesPath,
     networkBasePath,
     vulnerabilityReportsPath,
+    listeningEndpointsBasePath,
 } from 'routePaths';
 
 import LeftNavItem from './LeftNavItem';
@@ -85,6 +86,8 @@ function NavigationSidebar({
 
     const vulnerabilitiesPaths = [vulnerabilitiesWorkloadCvesPath, vulnerabilityReportsPath];
 
+    const networkSectionPaths = [networkBasePath, listeningEndpointsBasePath];
+
     const Navigation = (
         <Nav id="nav-primary-simple">
             <NavList id="nav-list-simple">
@@ -93,11 +96,25 @@ function NavigationSidebar({
                     path={dashboardPath}
                     title={basePathToLabelMap[dashboardPath]}
                 />
-                <LeftNavItem
-                    isActive={location.pathname.includes(networkBasePath)}
-                    path={networkBasePath}
-                    title="Network Graph"
-                />
+                <NavExpandable
+                    id="Network"
+                    title="Network"
+                    isActive={networkSectionPaths.some((path) => location.pathname.includes(path))}
+                    isExpanded={networkSectionPaths.some((path) =>
+                        location.pathname.includes(path)
+                    )}
+                >
+                    <LeftNavItem
+                        isActive={location.pathname.includes(networkBasePath)}
+                        path={networkBasePath}
+                        title={basePathToLabelMap[networkBasePath]}
+                    />
+                    <LeftNavItem
+                        isActive={location.pathname.includes(listeningEndpointsBasePath)}
+                        path={listeningEndpointsBasePath}
+                        title={basePathToLabelMap[listeningEndpointsBasePath]}
+                    />
+                </NavExpandable>
                 <LeftNavItem
                     isActive={location.pathname.includes(violationsBasePath)}
                     path={violationsBasePath}

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -47,7 +47,7 @@ export const dataRetentionPath = `${mainPath}/retention`;
 export const systemHealthPath = `${mainPath}/system-health`;
 export const collectionsBasePath = `${mainPath}/collections`;
 export const collectionsPath = `${mainPath}/collections/:collectionId?`;
-export const listeningEndpointsBasePath = `${mainPath}/audit/listening-endpoints`;
+export const listeningEndpointsBasePath = `${mainPath}/listening-endpoints`;
 
 // Configuration Management
 
@@ -164,7 +164,8 @@ const vulnerabilitiesPathToLabelMap = {
 
 export const basePathToLabelMap = {
     [dashboardPath]: 'Dashboard',
-    [networkBasePath]: 'Network Graph (2.0)',
+    [networkBasePath]: 'Network Graph',
+    [listeningEndpointsBasePath]: 'Listening Endpoints',
     [violationsBasePath]: 'Violations',
     [complianceBasePath]: 'Compliance',
     [complianceEnhancedBasePath]: 'Compliance (2.0)',


### PR DESCRIPTION
## Description

Expands the "Network Graph" link into a "Network" section and adds the "Listening Endpoints" page as a sublink of that section.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the app and view the sidebar:
![image](https://github.com/stackrox/stackrox/assets/1292638/ed16878b-bef2-48dc-ab8e-12bc9c9a5b76)

Test visiting the network graph and selecting a deployment:
![image](https://github.com/stackrox/stackrox/assets/1292638/888b58c6-1013-4dd5-8d67-0ebfd981216a)

Test visiting the listening endpoints page:
![image](https://github.com/stackrox/stackrox/assets/1292638/8a6f3ccb-92f3-4c8a-86df-9d7618b5c2a8)

