### PR TITLE
fix: Secure cluster-internal port with HTTPS

### DIFF
--- a/central/internal/server.go
+++ b/central/internal/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NYTimes/gziphandler"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/grpc/metrics"
+	"github.com/stackrox/rox/pkg/mtls"
 )
 
 // HTTPServer is a HTTP server to serve functionality available only within the cluster.
@@ -49,7 +50,12 @@ func (s *HTTPServer) RunForever() {
 }
 
 func runForever(server *http.Server) {
-	err := server.ListenAndServe()
+	// The reason we reuse mTLS certificate here is
+	// we only use TLS certificate here for encryption and thus
+	// do not care about which identity this certificate presents.
+	// Alternative solution discussed included issuing separate certificate for this endpoint
+	// which we decided not to pursue due to much bigger complexity.
+	err := server.ListenAndServeTLS(mtls.CertFilePath(), mtls.KeyFilePath())
 	// The HTTP server should never terminate.
 	log.Panicf("Unexpected termination of private HTTP server: %v", err)
 }


### PR DESCRIPTION
## Description

The goal of this PR is to protect cluster-internal port(used to get central diagnostic data in ACSCS) with HTTPS. This is due to the fact that central diagnostic data is sensitive and shouldn't be unencrypted.

We reuse mTLS certificate here as we don't care if caller trusts our certificate or not - we only use it for encryption. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Deployed stackrox locally
2. Adjusted `ROX_MANAGED_CENTRAL` to `true`
3. `port-forward` to Central
4. `curl https://localhost:9095/diagnostics` does not work, while `curl --insecure https://localhost:9095/diagnostics` returns diagnostic data
