### PR TITLE
ROX-18645: Handle events with missing resource

### DIFF
--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -105,7 +105,7 @@ func newConnection(ctx context.Context,
 	deduper := hashMgr.GetDeduper(ctx, cluster.GetId())
 	deduper.StartSync()
 
-	conn.sensorEventHandler = newSensorEventHandler(eventPipeline, conn, &conn.stopSig, deduper)
+	conn.sensorEventHandler = newSensorEventHandler(cluster, sensorHello.GetSensorVersion(), eventPipeline, conn, &conn.stopSig, deduper)
 	conn.scrapeCtrl = scrape.NewController(conn, &conn.stopSig)
 	conn.networkPoliciesCtrl = networkpolicies.NewController(conn, &conn.stopSig)
 	conn.networkEntitiesCtrl = networkentities.NewController(cluster.GetId(), networkEntityMgr, graph.Singleton(), conn, &conn.stopSig)

--- a/central/sensor/service/connection/sensorevents.go
+++ b/central/sensor/service/connection/sensorevents.go
@@ -72,6 +72,10 @@ func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.Ms
 	var workerType string
 	switch evt := msg.Msg.(type) {
 	case *central.MsgFromSensor_Event:
+		if msg.GetEvent() == nil {
+			log.Errorf("Received unknown event from cluster %s (%s). May be due to Sensor (%s) version mismatch with Central (%s)", s.cluster.GetName(), s.cluster.GetId(), s.sensorVersion, version.GetMainVersion())
+			return
+		}
 		switch evt.Event.Resource.(type) {
 		case *central.SensorEvent_Synced:
 			// Call the reconcile functions
@@ -92,7 +96,7 @@ func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.Ms
 			msg.DedupeKey = fmt.Sprintf("NodeInventory:%s", msg.GetDedupeKey())
 		default:
 			if evt.Event.GetResource() == nil {
-				log.Errorf("Received unknown event from cluster %s (%s). May be due to Sensor (%s) version mismatch with Central (%s)", s.cluster.GetName(), s.cluster.GetId(), s.sensorVersion, version.GetMainVersion())
+				log.Errorf("Received event with unknown resource from cluster %s (%s). May be due to Sensor (%s) version mismatch with Central (%s)", s.cluster.GetName(), s.cluster.GetId(), s.sensorVersion, version.GetMainVersion())
 				return
 			}
 			// Default worker type is the event type.


### PR DESCRIPTION
## Description

Fix panic in Central when resource is nil

sensor/service/connection: 2023/07/26 18:53:21.480780 sensorevents.go:97: Error: Received event with unknown resource from cluster remote (3eb5fe5a-c30c-40c3-aee2-24cd2c1ec4ab). May be due to Sensor (4.1.x-511-g11a58138f9-dirty) version mismatch with Central (4.1.x-511-g11a58138f9-dirty)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Will add an event and send from Sensor