### PR TITLE
ROX-18642: Move and rewrite AsyncComponent in TypeScript

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/AsyncComponent.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/AsyncComponent.tsx
@@ -1,8 +1,15 @@
-import React, { Component } from 'react';
+import React, { Component, ElementType } from 'react';
 import Loader from 'Components/Loader';
 
+type Props = Record<string, never>;
+type State = {
+    component: ElementType | null;
+};
+
 export default function asyncComponent(importComponent) {
-    class AsyncComponent extends Component {
+    class AsyncComponent extends Component<Props, State> {
+        isComponentMounted: boolean;
+
         constructor(props) {
             super(props);
             this.state = {

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -34,13 +34,14 @@ import {
 } from 'routePaths';
 import { useTheme } from 'Containers/ThemeProvider';
 
-import asyncComponent from 'Components/AsyncComponent';
 import PageNotFound from 'Components/PageNotFound';
 import PageTitle from 'Components/PageTitle';
 import ErrorBoundary from 'Containers/ErrorBoundary';
 import { HasReadAccess } from 'hooks/usePermissions';
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import useAnalytics from 'hooks/useAnalytics';
+
+import asyncComponent from './AsyncComponent';
 
 function NotFoundPage(): ReactElement {
     return (


### PR DESCRIPTION
## Description

Verified that webpack needs to see `import('componentPath')` and so cannot replace component with component path in route configuration.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

It seems more likely that change to chunks is from move than from TypeScript.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 418 = 3757748 - 3757330
        total: 1043 = 9901516 - 9900473
    * `ls -al build/static/js/*.js | wc -l`
        1 = 79 - 78 files
3. `yarn start` in ui

### Manual testing

Visit pages via left navigation and explore 1 (or 2 for workflow) levels of descendant pages.