### PR TITLE
ROX-18477: operator delete valuesFrom in proxy config if values is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-18173: A few previously public endpoints now require authentication: `/v1/metadata`,
   `/v1/database/status`, `/v1/mitreattackvectors`. This reduces the surface for DoS attacks and
   prevents an attacker from taking advantage of the information served by these endpoints.
+- ROX-18477: Fixed an issue that breaks operator installations if a `Central` or `SecuredCluster` CR configures egress proxy environment variables while openshift cluster-wide proxy is enabled.
 
 ## [4.1.0]
 

--- a/operator/pkg/central/reconciler/reconciler.go
+++ b/operator/pkg/central/reconciler/reconciler.go
@@ -55,7 +55,7 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 
 	return reconciler.SetupReconcilerWithManager(
 		mgr, platform.CentralGVK, image.CentralServicesChartPrefix,
-		proxy.InjectProxyEnvVars(translation.New(mgr.GetClient()), proxyEnv),
+		proxy.InjectProxyEnvVars(translation.New(mgr.GetClient()), proxyEnv, mgr.GetLogger()),
 		opts...,
 	)
 }

--- a/operator/pkg/proxy/translation.go
+++ b/operator/pkg/proxy/translation.go
@@ -63,6 +63,7 @@ func InjectProxyEnvVars(translator values.Translator, proxyEnv map[string]string
 
 // delValueFromIfValueExists deletes the valueFrom key from customize.envVars entries
 // if both value and valueFrom key exist. Returns the unmodified values in case of error in accessing values.
+// This function was introduced to fix the bug documented in ROX-18477
 func delValueFromIfValueExists(values chartutil.Values) chartutil.Values {
 	envVarsMap, err := values.Table("customize.envVars")
 	if err != nil {

--- a/operator/pkg/proxy/translation.go
+++ b/operator/pkg/proxy/translation.go
@@ -61,8 +61,8 @@ func InjectProxyEnvVars(translator values.Translator, proxyEnv map[string]string
 	})
 }
 
-// delValueFromIfValueExists deletes the valueFrom key from customize.envVars entries if both value and valueFrom key exists
-// returns the unmodified values in case of error
+// delValueFromIfValueExists deletes the valueFrom key from customize.envVars entries
+// if both value and valueFrom key exist. Returns the unmodified values in case of error in accessing values.
 func delValueFromIfValueExists(values chartutil.Values) chartutil.Values {
 	envVarsMap, err := values.Table("customize.envVars")
 	if err != nil {

--- a/operator/pkg/proxy/translation_test.go
+++ b/operator/pkg/proxy/translation_test.go
@@ -98,16 +98,3 @@ func TestInjectProxyNoValueConflict(t *testing.T) {
 		}
 	}
 }
-
-func customizeProxyVarsTranslator(ctx context.Context, u *unstructured.Unstructured) (chartutil.Values, error) {
-	customizeValue := translation.GetCustomize(&platform.CustomizeSpec{
-		EnvVars: []corev1.EnvVar{
-			{Name: "HTTP_PROXY", Value: "cr.proxy.value"},
-		},
-	})
-
-	vb := translation.ValuesBuilder{}
-	vb.AddChild("customize", customizeValue)
-
-	return vb.Build()
-}

--- a/operator/pkg/proxy/translation_test.go
+++ b/operator/pkg/proxy/translation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/operator-framework/helm-operator-plugins/pkg/values"
 	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"github.com/stackrox/rox/operator/pkg/values/translation"
@@ -77,7 +78,7 @@ func TestInjectProxyNoValueConflict(t *testing.T) {
 		return vb.Build()
 	}
 
-	injectTranslator := InjectProxyEnvVars(values.TranslatorFunc(proxyCustomizeTranslator), proxyEnvVars)
+	injectTranslator := InjectProxyEnvVars(values.TranslatorFunc(proxyCustomizeTranslator), proxyEnvVars, logr.New(nil))
 	values, err := injectTranslator.Translate(context.Background(), &unstructured.Unstructured{})
 	require.NoError(t, err, "translating values")
 

--- a/operator/pkg/proxy/translation_test.go
+++ b/operator/pkg/proxy/translation_test.go
@@ -1,13 +1,18 @@
 package proxy
 
 import (
+	"context"
 	"testing"
 
+	"github.com/operator-framework/helm-operator-plugins/pkg/values"
 	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	"github.com/stackrox/rox/operator/pkg/values/translation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/chartutil"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var (
@@ -53,4 +58,56 @@ customize:
 
 	require.NoError(t, err)
 	assert.Equal(t, expectedVals, vals)
+}
+
+func TestInjectProxyNoValueConflict(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "some.proxy.dns:443")
+
+	proxyEnvVars := GetProxyEnvVars()
+	proxyCustomizeTranslator := func(ctx context.Context, u *unstructured.Unstructured) (chartutil.Values, error) {
+		customizeValue := translation.GetCustomize(&platform.CustomizeSpec{
+			EnvVars: []corev1.EnvVar{
+				{Name: "HTTP_PROXY", Value: "cr.proxy.value"},
+			},
+		})
+
+		vb := translation.ValuesBuilder{}
+		vb.AddChild("customize", customizeValue)
+
+		return vb.Build()
+	}
+
+	injectTranslator := InjectProxyEnvVars(values.TranslatorFunc(proxyCustomizeTranslator), proxyEnvVars)
+	values, err := injectTranslator.Translate(context.Background(), &unstructured.Unstructured{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envVars, err := values.Table("customize.envVars")
+	require.NoError(t, err, "getting customize.envVars as YAML table")
+
+	for envVarName := range envVars {
+		envVar, err := envVars.Table(envVarName)
+		require.NoErrorf(t, err, "getting %s as YAML table", envVarName)
+
+		_, hasValue := envVar["value"]
+		_, hasValueFrom := envVar["valueFrom"]
+
+		if hasValue && hasValueFrom {
+			t.Fatalf("env var: %s has value conflict. Both value and value from set: %v", envVarName, envVars[envVarName])
+		}
+	}
+}
+
+func customizeProxyVarsTranslator(ctx context.Context, u *unstructured.Unstructured) (chartutil.Values, error) {
+	customizeValue := translation.GetCustomize(&platform.CustomizeSpec{
+		EnvVars: []corev1.EnvVar{
+			{Name: "HTTP_PROXY", Value: "cr.proxy.value"},
+		},
+	})
+
+	vb := translation.ValuesBuilder{}
+	vb.AddChild("customize", customizeValue)
+
+	return vb.Build()
 }

--- a/operator/pkg/proxy/translation_test.go
+++ b/operator/pkg/proxy/translation_test.go
@@ -79,13 +79,12 @@ func TestInjectProxyNoValueConflict(t *testing.T) {
 
 	injectTranslator := InjectProxyEnvVars(values.TranslatorFunc(proxyCustomizeTranslator), proxyEnvVars)
 	values, err := injectTranslator.Translate(context.Background(), &unstructured.Unstructured{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "translating values")
 
 	envVars, err := values.Table("customize.envVars")
 	require.NoError(t, err, "getting customize.envVars as YAML table")
 
+	require.Len(t, envVars, 1)
 	for envVarName := range envVars {
 		envVar, err := envVars.Table(envVarName)
 		require.NoErrorf(t, err, "getting %s as YAML table", envVarName)

--- a/operator/pkg/securedcluster/reconciler/reconciler.go
+++ b/operator/pkg/securedcluster/reconciler/reconciler.go
@@ -38,7 +38,7 @@ func RegisterNewReconciler(mgr ctrl.Manager) error {
 	return reconciler.SetupReconcilerWithManager(
 		mgr, platform.SecuredClusterGVK,
 		image.SecuredClusterServicesChartPrefix,
-		proxy.InjectProxyEnvVars(translation.NewTranslator(mgr.GetClient()), proxyEnv),
+		proxy.InjectProxyEnvVars(translation.NewTranslator(mgr.GetClient()), proxyEnv, mgr.GetLogger()),
 		opts...,
 	)
 }


### PR DESCRIPTION
## Description

If the operator runs with proxy environment (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) variables set for its deployment and the CR also configures the same proxy environment variables in its `customize` field. The operator merges both configuration to an invalid state for env variables like this:

```yaml
spec:
  customize:
    envVars:
    - name: HTTP_PROXY
      value: http://10.68.248.34:80
      valueFrom:
        secretKeyRef:
          key: "HTTP_PROXY"
          name: central-stackrox-central-services-proxy-env
```

Having a conflict like this lead to a helm releases that can't be applied. In ROX-18477 this lead to an endless reconciliation retry that was responsible for the creation of secrets in the stackrox namespace.

This happens due to a conflict when merging environment variable proxy configuration with CR proxy configuration. This PR adds a filter to drop the valueFrom key from the helm values if a value key is specified after the merge happened.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Added a unit test to reproduce the error, fixed the unit test.

CI is sufficient to test against regression.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
