### PR TITLE
chore(e2e): Add sensor scanner support to gke flavor of CI for ui-e2e

### DIFF
--- a/scripts/ci/jobs/gke_ui_e2e_tests.py
+++ b/scripts/ci/jobs/gke_ui_e2e_tests.py
@@ -17,6 +17,7 @@ os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 # Override test env defaults here:
 # (for defaults see: tests/e2e/lib.sh export_test_environment())
 os.environ["OUTPUT_FORMAT"] = "helm"
+os.environ["SENSOR_SCANNER_SUPPORT"] = "true"
 
 ClusterTestRunner(
     cluster=GKECluster("ui-e2e-test"),


### PR DESCRIPTION
## Description

What: Add sensor scanner support to gke flavor of CI for ui-e2e

Why: To allow the new tests for new delegated registries scanning UI to run the same on GKE envs, as well as OCP envs.


## Checklist
- [x] Investigated and inspected CI test results (failure of unrelated ocp-qa-e2e-test is flake)

## Testing Performed

CI