### PR TITLE
chore(ui): Replace empty Th with Td to fix accessibility issues

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -225,7 +225,7 @@ function CollectionsTable({
                             Collection
                         </Th>
                         <Th modifier="wrap">Description</Th>
-                        <Th aria-label="Row actions" />
+                        <Td />
                     </Tr>
                 </Thead>
                 <Tbody>{tableContent}</Tbody>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -144,7 +144,7 @@ function IntegrationsTable({
                                         </Th>
                                     );
                                 })}
-                                <Th aria-label="Row actions" />
+                                <Td />
                             </Tr>
                         </Thead>
                         <Tbody>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
@@ -112,7 +112,7 @@ function TableModal({
                                                     </Th>
                                                 );
                                             })}
-                                            <Th aria-label="Row actions" />
+                                            <Td />
                                         </Tr>
                                     </Thead>
                                     <Tbody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -149,7 +149,7 @@ function VulnReportsPage() {
                                             <HelpIconTh tooltip="The report that was last run by a schedule or an on-demand action including 'send report now' and 'generate a downloadable report'">
                                                 Last run
                                             </HelpIconTh>
-                                            <Th />
+                                            <Td />
                                         </Tr>
                                     </Thead>
                                     {reports.length === 0 && (


### PR DESCRIPTION
## Description

### Problem

Minor issue from axe DevTools on 4 pages:

> Table header text should not be empty

Lighthouse does not report this as an accessibility issue.

### Analysis

Give axe DevTools benefit of the doubt that `Th` element without text, might be a problem for some screen readers even with `aria-label` attribute.

In case the benefit of the doubt is too generous, increase our empathy with customers not to inflict opinions about cloud security.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn start` in ui

### Manual testing

1. Visit /main/collections to see collections table

2. Visit /main/integrations, and then click a card to see integrations table

3. Visit /main/policy-management/policies, click **Create policy**, on step 3 drag **Image signature**, and then click **Select** and temporarily edit code to render table even though there are no signature integrations.

4. Visit /main/vulnerabilities/reports to see reports table