### PR TITLE
ROX-18681: Add routeDescriptionMap and isRouteEnabled to routePaths

### DIFF
--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -215,7 +215,7 @@ export function isRouteEnabled(
         }
     }
 
-    return resourceAccessRequirements.every((resource) => hasReadAccess(resource));
+    return resourceAccessRequirements.every((resourceName) => hasReadAccess(resourceName));
 }
 
 /**

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -113,6 +113,7 @@ type RouteDescription = {
     resourceAccessRequirements: ResourceName[]; // assume READ_ACCESS
 };
 
+// Add path variables in alphabetical order to minimize merge conflicts when multiple people add routes.
 const routeDescriptionMap: Record<string, RouteDescription> = {
     [accessControlPath]: {
         resourceAccessRequirements: [],


### PR DESCRIPTION
## Description

Write route descriptions that correspond to conditional rendering in Body element.

After resource simplification, multiple resources imply only **and** never **or** as far as I am aware.

**Limitation**: We cannot have one route render either old component or new component according to feature flag. Even when Linda and I did completely replace classic policies with PatternFly policies, we used a temporary separate route during development.

### Procedure

Will add steps to a section following feature flags
https://github.com/stackrox/stackrox/tree/master/ui/apps/platform#feature-flags

1. Add path variable for new route.
2. Add route description with path as computed key for new route. Because we will stop adding title to `basePathToLabelMap` the net number of steps in routePaths remains the same.

### Residue

In the next step, I will move `vulnManagementReportsPath` and `vulnManagementRiskAcceptancePath` above `vulnManagementPath` and add a comment:

```ts
// Reporting and Risk Acceptance must precede generic Vulnerability Management. Keep paths independent in the future!
```

1. Body: add `routeComponentMap` and replace conditional rendering in React Router `Switch` element with:
    * `filter` method that calls `isRouteEnabled` for path
    * `map` method that renders `Route` element for path
4. NavigationSidebar: add description of 2-level navigation and replace with conditional rendering in 2 passes for second level first and first level second:
    * so expandable items know whether or not they have any links to render
    * so first level items which have conditional text know whether or not counterpart exists
5. Add missing resource requirements.
## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Visit pages via left navigation and explore 1 (or 2 for workflow) levels of descendant pages.