### PR TITLE
ROX-17856: Adding header, tabs, and actions for report details page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { useHistory, useParams, Link, generatePath } from 'react-router-dom';
 import {
     PageSection,
@@ -64,14 +64,11 @@ function ViewVulnReportPage() {
         isDeleting,
         onDelete,
         deleteError,
-        isDeleted,
-    } = useDeleteModal();
-
-    useEffect(() => {
-        if (isDeleted) {
+    } = useDeleteModal({
+        onCompleted: () => {
             history.push(vulnerabilityReportsPath);
-        }
-    }, [history, isDeleted]);
+        },
+    });
 
     function onToggleActionsDropdown() {
         setIsActionsDropdownOpen((prevValue) => !prevValue);
@@ -185,11 +182,7 @@ function ViewVulnReportPage() {
             </PageSection>
             <Divider component="div" />
             <PageSection variant="light" padding={{ default: 'noPadding' }} isCenterAligned>
-                <Tabs
-                    defaultActiveKey={0}
-                    aria-label="Tabs in the uncontrolled example"
-                    role="region"
-                >
+                <Tabs defaultActiveKey={0} aria-label="Report details tabs" role="region">
                     <Tab
                         eventKey={0}
                         title={<TabTitle icon={<HomeIcon />}>Configuration details</TabTitle>}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -1,7 +1,227 @@
-import React from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
+import { useHistory, useParams, Link, generatePath } from 'react-router-dom';
+import {
+    PageSection,
+    Title,
+    Divider,
+    Flex,
+    FlexItem,
+    Breadcrumb,
+    BreadcrumbItem,
+    Bullseye,
+    Spinner,
+    Dropdown,
+    DropdownToggle,
+    DropdownItem,
+    DropdownSeparator,
+    Tabs,
+    Tab,
+    TabTitleText,
+    TabTitleIcon,
+} from '@patternfly/react-core';
+import { CaretDownIcon, DownloadIcon, HistoryIcon, HomeIcon } from '@patternfly/react-icons';
+
+import { vulnerabilityReportPath, vulnerabilityReportsPath } from 'routePaths';
+import useFetchReport from 'Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReport';
+
+import PageTitle from 'Components/PageTitle';
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import NotFoundMessage from 'Components/NotFoundMessage/NotFoundMessage';
+import useDeleteModal from '../hooks/useDeleteModal';
+import DeleteReportModal from '../components/DeleteReportModal';
+
+export type TabTitleProps = {
+    icon?: ReactElement;
+    children: string;
+};
+
+function TabTitle({ icon, children }: TabTitleProps): ReactElement {
+    return (
+        <Flex alignItems={{ default: 'alignItemsCenter' }}>
+            {icon && (
+                <FlexItem>
+                    <TabTitleIcon>{icon}</TabTitleIcon>
+                </FlexItem>
+            )}
+            <FlexItem>
+                <TabTitleText>{children}</TabTitleText>
+            </FlexItem>
+        </Flex>
+    );
+}
 
 function ViewVulnReportPage() {
-    return <div />;
+    const history = useHistory();
+    const { reportId } = useParams();
+    const [isActionsDropdownOpen, setIsActionsDropdownOpen] = useState(false);
+
+    const { reportConfiguration, isLoading, error } = useFetchReport(reportId);
+
+    const {
+        openDeleteModal,
+        isDeleteModalOpen,
+        closeDeleteModal,
+        isDeleting,
+        onDelete,
+        deleteError,
+        isDeleted,
+    } = useDeleteModal();
+
+    useEffect(() => {
+        if (isDeleted) {
+            history.push(vulnerabilityReportsPath);
+        }
+    }, [history, isDeleted]);
+
+    function onToggleActionsDropdown() {
+        setIsActionsDropdownOpen((prevValue) => !prevValue);
+    }
+
+    function onSelectAction() {
+        setIsActionsDropdownOpen(false);
+    }
+
+    if (isLoading) {
+        return (
+            <Bullseye>
+                <Spinner isSVG />
+            </Bullseye>
+        );
+    }
+
+    if (error || !reportConfiguration) {
+        return (
+            <NotFoundMessage
+                title="Error fetching the report configuration"
+                message={error || 'No data available'}
+                actionText="Go to reports"
+                url={vulnerabilityReportsPath}
+            />
+        );
+    }
+
+    const vulnReportPageURL = generatePath(vulnerabilityReportPath, {
+        reportId: reportConfiguration.id,
+    }) as string;
+
+    return (
+        <>
+            <PageTitle title="View vulnerability report" />
+            <PageSection variant="light" className="pf-u-py-md">
+                <Breadcrumb>
+                    <BreadcrumbItemLink to={vulnerabilityReportsPath}>
+                        Vulnerability reporting
+                    </BreadcrumbItemLink>
+                    <BreadcrumbItem isActive>{reportConfiguration.name}</BreadcrumbItem>
+                </Breadcrumb>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                <Flex direction={{ default: 'row' }} className="pf-u-py-lg pf-u-px-lg">
+                    <FlexItem flex={{ default: 'flex_1' }}>
+                        <Title headingLevel="h1">{reportConfiguration.name}</Title>
+                    </FlexItem>
+                    <FlexItem>
+                        <Dropdown
+                            onSelect={onSelectAction}
+                            position="right"
+                            toggle={
+                                <DropdownToggle
+                                    isPrimary
+                                    onToggle={onToggleActionsDropdown}
+                                    toggleIndicator={CaretDownIcon}
+                                >
+                                    Actions
+                                </DropdownToggle>
+                            }
+                            isOpen={isActionsDropdownOpen}
+                            dropdownItems={[
+                                <DropdownItem
+                                    key="Edit report"
+                                    component={
+                                        <Link to={`${vulnReportPageURL}?action=edit`}>
+                                            Edit report
+                                        </Link>
+                                    }
+                                />,
+                                <DropdownSeparator key="separator" />,
+                                <DropdownItem
+                                    key="Send report now"
+                                    component="button"
+                                    onClick={() => {}}
+                                >
+                                    Send report now
+                                </DropdownItem>,
+                                <DropdownItem
+                                    key="Generate download"
+                                    component="button"
+                                    onClick={() => {}}
+                                >
+                                    Generate download
+                                </DropdownItem>,
+                                <DropdownItem
+                                    key="Clone report"
+                                    component={
+                                        <Link to={`${vulnReportPageURL}?action=clone`}>
+                                            Clone report
+                                        </Link>
+                                    }
+                                />,
+                                <DropdownSeparator key="Separator" />,
+                                <DropdownItem
+                                    key="Delete report"
+                                    className="pf-u-danger-color-100"
+                                    component="button"
+                                    onClick={() => {
+                                        openDeleteModal(reportConfiguration.id);
+                                    }}
+                                >
+                                    Delete report
+                                </DropdownItem>,
+                            ]}
+                        />
+                    </FlexItem>
+                </Flex>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection variant="light" padding={{ default: 'noPadding' }} isCenterAligned>
+                <Tabs
+                    defaultActiveKey={0}
+                    aria-label="Tabs in the uncontrolled example"
+                    role="region"
+                >
+                    <Tab
+                        eventKey={0}
+                        title={<TabTitle icon={<HomeIcon />}>Configuration details</TabTitle>}
+                        aria-label="Configuration details tab"
+                    >
+                        <div />
+                    </Tab>
+                    <Tab
+                        eventKey={1}
+                        title={<TabTitle icon={<HistoryIcon />}>Run history</TabTitle>}
+                        aria-label="Run history tab"
+                    >
+                        <div />
+                    </Tab>
+                    <Tab
+                        eventKey={2}
+                        title={<TabTitle icon={<DownloadIcon />}>Downloadable report</TabTitle>}
+                        aria-label="Downloadable report tab"
+                    >
+                        <div />
+                    </Tab>
+                </Tabs>
+            </PageSection>
+            <DeleteReportModal
+                isOpen={isDeleteModalOpen}
+                onClose={closeDeleteModal}
+                isDeleting={isDeleting}
+                onDelete={onDelete}
+                error={deleteError}
+            />
+        </>
+    );
 }
 
 export default ViewVulnReportPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
 import {
     PageSection,
     Title,
@@ -15,9 +15,6 @@ import {
     EmptyStateBody,
     EmptyStateVariant,
     Text,
-    Modal,
-    Alert,
-    AlertVariant,
 } from '@patternfly/react-core';
 import { ActionsColumn, TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { Link, generatePath } from 'react-router-dom';
@@ -29,12 +26,11 @@ import { vulnerabilityReportPath, vulnerabilityReportsPath } from 'routePaths';
 
 import PageTitle from 'Components/PageTitle';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate/EmptyStateTemplate';
-import { deleteReportConfiguration } from 'services/ReportsService';
-import useModal from 'hooks/useModal';
 import HelpIconTh from './HelpIconTh';
 import LastRunStatusState from './LastRunStatusState';
 import LastRunState from './LastRunState';
-import { getErrorMessage } from '../errorUtils';
+import useDeleteModal from '../hooks/useDeleteModal';
+import DeleteReportModal from '../components/DeleteReportModal';
 
 const CreateReportsButton = () => {
     return (
@@ -58,33 +54,21 @@ function VulnReportsPage() {
 
     const { reports, isLoading, error: fetchError, fetchReports } = useFetchReports();
 
-    const { isModalOpen, openModal, closeModal } = useModal();
-    const [reportIdToDelete, setReportIdToDelete] = useState<string>('');
-    const [isDeleting, setIsDeleting] = useState(false);
-    const [deleteError, setDeleteError] = useState<string>('');
+    const {
+        openDeleteModal,
+        isDeleteModalOpen,
+        closeDeleteModal,
+        isDeleting,
+        onDelete,
+        deleteError,
+        isDeleted,
+    } = useDeleteModal();
 
-    function openDeleteModal(reportId: string) {
-        openModal();
-        setReportIdToDelete(reportId);
-    }
-
-    function closeDeleteModal() {
-        closeModal();
-        setReportIdToDelete('');
-    }
-
-    async function deleteReport(reportId: string) {
-        setIsDeleting(true);
-        try {
-            await deleteReportConfiguration(reportId);
-            setIsDeleting(false);
-            closeDeleteModal();
+    useEffect(() => {
+        if (isDeleted) {
             fetchReports();
-        } catch (err) {
-            setIsDeleting(false);
-            setDeleteError(getErrorMessage(err));
         }
-    }
+    }, [fetchReports, isDeleted]);
 
     return (
         <>
@@ -186,20 +170,18 @@ function VulnReportsPage() {
                                         </Tbody>
                                     )}
                                     {reports.map((report) => {
-                                        const editVulnReportURL = `${
-                                            generatePath(vulnerabilityReportPath, {
+                                        const vulnReportURL = generatePath(
+                                            vulnerabilityReportPath,
+                                            {
                                                 reportId: report.id,
-                                            }) as string
-                                        }?action=edit`;
-                                        const cloneVulnReportURL = `${
-                                            generatePath(vulnerabilityReportPath, {
-                                                reportId: report.id,
-                                            }) as string
-                                        }?action=clone`;
+                                            }
+                                        ) as string;
                                         const rowActions = [
                                             {
                                                 title: (
-                                                    <Link to={editVulnReportURL}>Edit report</Link>
+                                                    <Link to={`${vulnReportURL}?action=edit`}>
+                                                        Edit report
+                                                    </Link>
                                                 ),
                                             },
                                             {
@@ -219,7 +201,7 @@ function VulnReportsPage() {
                                             },
                                             {
                                                 title: (
-                                                    <Link to={cloneVulnReportURL}>
+                                                    <Link to={`${vulnReportURL}?action=clone`}>
                                                         Clone report
                                                     </Link>
                                                 ),
@@ -248,7 +230,11 @@ function VulnReportsPage() {
                                                 }}
                                             >
                                                 <Tr>
-                                                    <Td>{report.name}</Td>
+                                                    <Td>
+                                                        <Link to={vulnReportURL}>
+                                                            {report.name}
+                                                        </Link>
+                                                    </Td>
                                                     <Td>
                                                         {
                                                             report.resourceScope.collectionScope
@@ -280,41 +266,13 @@ function VulnReportsPage() {
                     </Card>
                 </PageSection>
             </PageSection>
-            {reportIdToDelete !== '' && (
-                <Modal
-                    variant="small"
-                    title="Permanently delete report?"
-                    isOpen={isModalOpen}
-                    onClose={closeDeleteModal}
-                    actions={[
-                        <Button
-                            key="confirm"
-                            variant="danger"
-                            isLoading={isDeleting}
-                            isDisabled={isDeleting}
-                            onClick={() => deleteReport(reportIdToDelete)}
-                        >
-                            Delete
-                        </Button>,
-                        <Button key="cancel" variant="secondary" onClick={closeDeleteModal}>
-                            Cancel
-                        </Button>,
-                    ]}
-                >
-                    {deleteError && (
-                        <Alert
-                            isInline
-                            variant={AlertVariant.danger}
-                            title={deleteError}
-                            className="pf-u-mb-sm"
-                        />
-                    )}
-                    <p>
-                        This report and any attached downloadable reports will be permanently
-                        deleted. The action cannot be undone.
-                    </p>
-                </Modal>
-            )}
+            <DeleteReportModal
+                isOpen={isDeleteModalOpen}
+                onClose={closeDeleteModal}
+                isDeleting={isDeleting}
+                onDelete={onDelete}
+                error={deleteError}
+            />
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
     PageSection,
     Title,
@@ -61,14 +61,11 @@ function VulnReportsPage() {
         isDeleting,
         onDelete,
         deleteError,
-        isDeleted,
-    } = useDeleteModal();
-
-    useEffect(() => {
-        if (isDeleted) {
+    } = useDeleteModal({
+        onCompleted: () => {
             fetchReports();
-        }
-    }, [fetchReports, isDeleted]);
+        },
+    });
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/DeleteReportModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/DeleteReportModal.tsx
@@ -1,0 +1,56 @@
+import { Alert, AlertVariant, Button, Modal } from '@patternfly/react-core';
+import React, { ReactElement } from 'react';
+
+export type DeleteReportModalProps = {
+    isOpen: boolean;
+    onClose: () => void;
+    isDeleting: boolean;
+    onDelete: () => void;
+    error: string | null;
+};
+
+function DeleteReportModal({
+    isOpen,
+    onClose,
+    isDeleting,
+    onDelete,
+    error,
+}: DeleteReportModalProps): ReactElement {
+    return (
+        <Modal
+            variant="small"
+            title="Permanently delete report?"
+            isOpen={isOpen}
+            onClose={onClose}
+            actions={[
+                <Button
+                    key="confirm"
+                    variant="danger"
+                    isLoading={isDeleting}
+                    isDisabled={isDeleting}
+                    onClick={onDelete}
+                >
+                    Delete
+                </Button>,
+                <Button key="cancel" variant="secondary" onClick={onClose}>
+                    Cancel
+                </Button>,
+            ]}
+        >
+            {error && (
+                <Alert
+                    isInline
+                    variant={AlertVariant.danger}
+                    title={error}
+                    className="pf-u-mb-sm"
+                />
+            )}
+            <p>
+                This report and any attached downloadable reports will be permanently deleted. The
+                action cannot be undone.
+            </p>
+        </Modal>
+    );
+}
+
+export default DeleteReportModal;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/hooks/useDeleteModal.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/hooks/useDeleteModal.ts
@@ -3,6 +3,10 @@ import { useState } from 'react';
 import { deleteReportConfiguration } from 'services/ReportsService';
 import { getErrorMessage } from '../errorUtils';
 
+export type UseDeleteModalProps = {
+    onCompleted: () => void;
+};
+
 export type UseDeleteModalResult = {
     openDeleteModal: (reportId: string) => void;
     isDeleteModalOpen: boolean;
@@ -10,14 +14,12 @@ export type UseDeleteModalResult = {
     isDeleting: boolean;
     onDelete: () => void;
     deleteError: string | null;
-    isDeleted: boolean;
 };
 
-function useDeleteModal(): UseDeleteModalResult {
+function useDeleteModal({ onCompleted }: UseDeleteModalProps): UseDeleteModalResult {
     const { isModalOpen: isDeleteModalOpen, openModal, closeModal } = useModal();
     const [reportIdToDelete, setReportIdToDelete] = useState<string>('');
     const [isDeleting, setIsDeleting] = useState(false);
-    const [isDeleted, setIsDeleted] = useState(false);
     const [deleteError, setDeleteError] = useState<string | null>(null);
 
     function openDeleteModal(reportId: string) {
@@ -28,6 +30,8 @@ function useDeleteModal(): UseDeleteModalResult {
     function closeDeleteModal() {
         closeModal();
         setReportIdToDelete('');
+        setIsDeleting(false);
+        setDeleteError(null);
     }
 
     async function onDelete() {
@@ -35,8 +39,8 @@ function useDeleteModal(): UseDeleteModalResult {
         try {
             await deleteReportConfiguration(reportIdToDelete);
             setIsDeleting(false);
-            setIsDeleted(true);
             closeDeleteModal();
+            onCompleted();
         } catch (err) {
             setIsDeleting(false);
             setDeleteError(getErrorMessage(err));
@@ -50,7 +54,6 @@ function useDeleteModal(): UseDeleteModalResult {
         isDeleting,
         onDelete,
         deleteError,
-        isDeleted,
     };
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/hooks/useDeleteModal.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/hooks/useDeleteModal.ts
@@ -1,0 +1,57 @@
+import useModal from 'hooks/useModal';
+import { useState } from 'react';
+import { deleteReportConfiguration } from 'services/ReportsService';
+import { getErrorMessage } from '../errorUtils';
+
+export type UseDeleteModalResult = {
+    openDeleteModal: (reportId: string) => void;
+    isDeleteModalOpen: boolean;
+    closeDeleteModal: () => void;
+    isDeleting: boolean;
+    onDelete: () => void;
+    deleteError: string | null;
+    isDeleted: boolean;
+};
+
+function useDeleteModal(): UseDeleteModalResult {
+    const { isModalOpen: isDeleteModalOpen, openModal, closeModal } = useModal();
+    const [reportIdToDelete, setReportIdToDelete] = useState<string>('');
+    const [isDeleting, setIsDeleting] = useState(false);
+    const [isDeleted, setIsDeleted] = useState(false);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
+
+    function openDeleteModal(reportId: string) {
+        openModal();
+        setReportIdToDelete(reportId);
+    }
+
+    function closeDeleteModal() {
+        closeModal();
+        setReportIdToDelete('');
+    }
+
+    async function onDelete() {
+        setIsDeleting(true);
+        try {
+            await deleteReportConfiguration(reportIdToDelete);
+            setIsDeleting(false);
+            setIsDeleted(true);
+            closeDeleteModal();
+        } catch (err) {
+            setIsDeleting(false);
+            setDeleteError(getErrorMessage(err));
+        }
+    }
+
+    return {
+        openDeleteModal,
+        isDeleteModalOpen,
+        closeDeleteModal,
+        isDeleting,
+        onDelete,
+        deleteError,
+        isDeleted,
+    };
+}
+
+export default useDeleteModal;


### PR DESCRIPTION
## Description

This PR adds some content to the vuln report details page. You should see the breadcrumbs, the title, and an actions dropdown

<img width="1552" alt="Screenshot 2023-07-25 at 12 11 32 PM" src="https://github.com/stackrox/stackrox/assets/4805485/22b381b8-f9b8-4fda-9714-9b06490d7de4">
