### PR TITLE
ROX-18639: Added changes for report history pruning task

### DIFF
--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -164,7 +164,7 @@ func (g *garbageCollectorImpl) pruneBasedOnConfig() {
 	g.removeExpiredVulnRequests()
 	g.collectClusters(pvtConfig)
 	if features.VulnMgmtReportingEnhancements.Enabled() {
-		g.collectReportHistory(pvtConfig)
+		g.removeOldReportHistory(pvtConfig)
 	}
 	postgres.PruneActiveComponents(pruningCtx, g.postgres)
 	postgres.PruneClusterHealthStatuses(pruningCtx, g.postgres)
@@ -557,7 +557,7 @@ func (g *garbageCollectorImpl) collectImages(config *storage.PrivateConfig) {
 	}
 }
 
-func (g *garbageCollectorImpl) collectReportHistory(config *storage.PrivateConfig) {
+func (g *garbageCollectorImpl) removeOldReportHistory(config *storage.PrivateConfig) {
 	reportHistoryRetentionConfig := config.GetReportRetentionConfig().GetHistoryRetentionDurationDays()
 	query := search.NewQueryBuilder().AddDays(search.ReportCompletionTime, int64(reportHistoryRetentionConfig)).ProtoQuery()
 	err := pgSearch.RunDeleteRequestForSchema(pruningCtx, pkgSchema.ReportSnapshotsSchema, query, g.postgres)

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -539,8 +539,7 @@ func (s *PruningTestSuite) TestImagePruning() {
 			alerts, config, images, deployments, pods := s.generateImageDataStructures(ctx)
 			nodes := s.generateNodeDataStructures()
 
-			gc := newGarbageCollector(alerts, nodes, images, nil, deployments, pods, nil, nil, nil, nil, config, nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
-
+			gc := newGarbageCollector(alerts, nodes, images, nil, deployments, pods, nil, nil, nil, nil, config, nil, nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
 			// Add images, deployments, and pods into the datastores
 			if c.deployment != nil {
 				require.NoError(t, deployments.UpsertDeployment(ctx, c.deployment))
@@ -798,7 +797,7 @@ func (s *PruningTestSuite) TestClusterPruning() {
 				lastClusterPruneTime = time.Now().Add(-24 * time.Hour)
 			}
 
-			gc := newGarbageCollector(nil, nil, nil, clusterDS, deploymentsDS, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
+			gc := newGarbageCollector(nil, nil, nil, clusterDS, deploymentsDS, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
 			gc.collectClusters(c.config)
 
 			// Now get all clusters and compare the names to ensure only the expected ones exist
@@ -921,7 +920,7 @@ func (s *PruningTestSuite) TestClusterPruningCentralCheck() {
 
 			// Run GC
 			lastClusterPruneTime = time.Now().Add(-24 * time.Hour)
-			gc := newGarbageCollector(nil, nil, nil, clusterDS, deploymentsDS, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
+			gc := newGarbageCollector(nil, nil, nil, clusterDS, deploymentsDS, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
 			gc.collectClusters(getCluserRetentionConfig(60, 90, 72))
 
 			// Now get all clusters and compare the names to ensure only the expected ones exist
@@ -1094,7 +1093,7 @@ func (s *PruningTestSuite) TestAlertPruning() {
 			alerts, config, images, deployments := s.generateAlertDataStructures(ctx)
 			nodes := s.generateNodeDataStructures()
 
-			gc := newGarbageCollector(alerts, nodes, images, nil, deployments, nil, nil, nil, nil, nil, config, nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
+			gc := newGarbageCollector(alerts, nodes, images, nil, deployments, nil, nil, nil, nil, nil, config, nil, nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
 
 			// Add alerts into the datastores
 			for _, alert := range c.alerts {

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -661,7 +661,7 @@ func (s *PruningTestSuite) TestReportHistoryPruning() {
 		}
 		repBeforePruning, _, _ := reportds.Get(s.ctx, test.reportSnapshot.ReportId)
 		assert.NotEmpty(s.T(), repBeforePruning)
-		gci.collectReportHistory(config)
+		gci.removeOldReportHistory(config)
 		repsPruning, _, _ := reportds.Get(s.ctx, test.reportSnapshot.ReportId)
 		if test.repExpected {
 			assert.NotEmpty(s.T(), repsPruning)

--- a/central/pruning/singleton.go
+++ b/central/pruning/singleton.go
@@ -16,6 +16,7 @@ import (
 	plopDatastore "github.com/stackrox/rox/central/processlisteningonport/datastore"
 	k8sRoleDataStore "github.com/stackrox/rox/central/rbac/k8srole/datastore"
 	k8srolebindingStore "github.com/stackrox/rox/central/rbac/k8srolebinding/datastore"
+	snapshotDataStore "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	riskDataStore "github.com/stackrox/rox/central/risk/datastore"
 	serviceAccountDataStore "github.com/stackrox/rox/central/serviceaccount/datastore"
 	vulnReqDataStore "github.com/stackrox/rox/central/vulnerabilityrequest/datastore"
@@ -47,7 +48,8 @@ func Singleton() GarbageCollector {
 			serviceAccountDataStore.Singleton(),
 			k8sRoleDataStore.Singleton(),
 			k8srolebindingStore.Singleton(),
-			logimbueStore.Singleton())
+			logimbueStore.Singleton(),
+			snapshotDataStore.Singleton())
 	})
 	return gc
 }


### PR DESCRIPTION
This PR adds pruning task for report history(snapshots). Report history is pruned based on value of report history config. 
Will add another PR for unit tests

Test Done:
Unit tests passed
e2e tests passed
