### PR TITLE
ROX-17318: Don't return scanner definitions when in offline mode

### DIFF
--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -20,12 +20,17 @@ const (
 	SensorComponentEventOfflineMode SensorComponentEvent = "offline-mode"
 )
 
+// Notifiable is the interface used by Sensor to notify components of state changes in Central<->Sensor connectivity.
+type Notifiable interface {
+	Notify(e SensorComponentEvent)
+}
+
 // SensorComponent is one of the components that constitute sensor. It supports for receiving messages from central,
 // as well as sending messages back to central.
 type SensorComponent interface {
+	Notifiable
 	Start() error
 	Stop(err error) // TODO: get rid of err argument as it always seems to be effectively nil.
-	Notify(e SensorComponentEvent)
 	Capabilities() []centralsensor.SensorCapability
 
 	ProcessMessage(msg *central.MsgToSensor) error

--- a/sensor/common/scannerdefinitions/http_handler.go
+++ b/sensor/common/scannerdefinitions/http_handler.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync/atomic"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/clientconn"
@@ -11,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/sensor/common"
 	"google.golang.org/grpc/codes"
 )
 
@@ -20,29 +22,48 @@ var (
 	headersToProxy = set.NewFrozenStringSet("If-Modified-Since", "Accept-Encoding")
 )
 
-// scannerDefinitionsHandler handles requests to retrieve scanner definitions
+// ScannerDefinitionHandler handles requests to retrieve scanner definitions
 // from Central.
-type scannerDefinitionsHandler struct {
-	centralClient *http.Client
+type ScannerDefinitionHandler struct {
+	centralClient    *http.Client
+	centralReachable atomic.Bool
 }
 
 // NewDefinitionsHandler creates a new scanner definitions handler.
-func NewDefinitionsHandler(centralEndpoint string) (http.Handler, error) {
+func NewDefinitionsHandler(centralEndpoint string) (*ScannerDefinitionHandler, error) {
 	client, err := clientconn.NewHTTPClient(mtls.CentralSubject, centralEndpoint, 0)
 	if err != nil {
 		return nil, errors.Wrap(err, "instantiating central HTTP transport")
 	}
-	return &scannerDefinitionsHandler{
-		centralClient: client,
+	return &ScannerDefinitionHandler{
+		centralClient:    client,
+		centralReachable: atomic.Bool{},
 	}, nil
 }
 
-func (h *scannerDefinitionsHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+// Notify reacts to sensor going into online/offline mode.
+func (h *ScannerDefinitionHandler) Notify(e common.SensorComponentEvent) {
+	switch e {
+	case common.SensorComponentEventCentralReachable:
+		h.centralReachable.Store(true)
+	case common.SensorComponentEventOfflineMode:
+		h.centralReachable.Store(false)
+	}
+}
+
+func (h *ScannerDefinitionHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	// Validate request.
 	if request.Method != http.MethodGet {
 		writer.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
+
+	// If central is not reachable, then the request should return an error to Scanner.
+	if !h.centralReachable.Load() {
+		httputil.WriteGRPCStyleErrorf(writer, codes.Internal, "central not reachable")
+		return
+	}
+
 	// Prepare the Central's request, proxy relevant headers and all parameters.
 	// No need to set Scheme nor Host, as the client will already do that for us.
 	centralURL := url.URL{

--- a/sensor/common/scannerdefinitions/http_handler.go
+++ b/sensor/common/scannerdefinitions/http_handler.go
@@ -26,7 +26,7 @@ var (
 // from Central.
 type ScannerDefinitionHandler struct {
 	centralClient    *http.Client
-	centralReachable atomic.Bool
+	centralReachable *atomic.Bool
 }
 
 // NewDefinitionsHandler creates a new scanner definitions handler.
@@ -37,7 +37,7 @@ func NewDefinitionsHandler(centralEndpoint string) (*ScannerDefinitionHandler, e
 	}
 	return &ScannerDefinitionHandler{
 		centralClient:    client,
-		centralReachable: atomic.Bool{},
+		centralReachable: &atomic.Bool{},
 	}, nil
 }
 

--- a/sensor/common/scannerdefinitions/http_handler.go
+++ b/sensor/common/scannerdefinitions/http_handler.go
@@ -50,7 +50,7 @@ func (h *Handler) Notify(e common.SensorComponentEvent) {
 	case common.SensorComponentEventOfflineMode:
 		h.centralReachable.Store(false)
 	default:
-		log.Infof("Notified with unknown event: %s", e)
+		log.Warnf("Notified with unknown event: %s", e)
 	}
 }
 

--- a/sensor/common/scannerdefinitions/http_handler_test.go
+++ b/sensor/common/scannerdefinitions/http_handler_test.go
@@ -27,7 +27,7 @@ func TestServeHTTP_Responses(t *testing.T) {
 	}{
 		{
 			name:             "when central is not reachable then return internal error",
-			statusCode:       http.StatusInternalServerError,
+			statusCode:       http.StatusServiceUnavailable,
 			responseBody:     "{\"code\":14,\"message\":\"central not reachable\"}",
 			centralReachable: false,
 		},

--- a/sensor/common/scannerdefinitions/http_handler_test.go
+++ b/sensor/common/scannerdefinitions/http_handler_test.go
@@ -82,7 +82,7 @@ func TestServeHTTP_Responses(t *testing.T) {
 				} else {
 					tt.args.request.Method = method
 				}
-				h := &scannerDefinitionsHandler{
+				h := &ScannerDefinitionHandler{
 					centralClient: &http.Client{
 						Transport: httputil.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 							assert.Equal(t, tt.args.request.URL.RawQuery, req.URL.RawQuery)

--- a/sensor/common/scannerdefinitions/http_handler_test.go
+++ b/sensor/common/scannerdefinitions/http_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stackrox/rox/pkg/httputil"
@@ -19,19 +20,28 @@ func TestServeHTTP_Responses(t *testing.T) {
 		methods []string
 	}
 	tests := []struct {
-		name         string
-		args         args
-		responseBody string
-		statusCode   int
+		name             string
+		args             args
+		responseBody     string
+		statusCode       int
+		centralReachable bool
 	}{
 		{
-			name:         "when central replies 200 with content then writer matches",
-			statusCode:   http.StatusOK,
-			responseBody: "the foobar body.",
+			name:             "when central is not reachable then return internal error",
+			statusCode:       http.StatusInternalServerError,
+			responseBody:     "{\"code\":13,\"message\":\"central not reachable\"}",
+			centralReachable: false,
 		},
 		{
-			name:       "when central replies 304 then writer matches",
-			statusCode: http.StatusNotModified,
+			name:             "when central replies 200 with content then writer matches",
+			statusCode:       http.StatusOK,
+			responseBody:     "the foobar body.",
+			centralReachable: true,
+		},
+		{
+			name:             "when central replies 304 then writer matches",
+			statusCode:       http.StatusNotModified,
+			centralReachable: true,
 		},
 		{
 			name:       "when method is not GET then 405",
@@ -49,6 +59,7 @@ func TestServeHTTP_Responses(t *testing.T) {
 				},
 				request: &http.Request{},
 			},
+			centralReachable: true,
 		},
 		{
 			name:       "when request contains multiple headers then proxy all of them",
@@ -59,6 +70,7 @@ func TestServeHTTP_Responses(t *testing.T) {
 					Header: map[string][]string{"Accept-Encoding": {"foo", "bar"}},
 				},
 			},
+			centralReachable: true,
 		},
 	}
 	for _, tt := range tests {
@@ -82,7 +94,10 @@ func TestServeHTTP_Responses(t *testing.T) {
 				} else {
 					tt.args.request.Method = method
 				}
+				reachable := atomic.Bool{}
+				reachable.Store(tt.centralReachable)
 				h := &ScannerDefinitionHandler{
+					centralReachable: &reachable,
 					centralClient: &http.Client{
 						Transport: httputil.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 							assert.Equal(t, tt.args.request.URL.RawQuery, req.URL.RawQuery)

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -91,8 +91,6 @@ func NewSensor(configHandler config.Handler, detector detector.Detector, imageSe
 		currentStateMtx: &sync.Mutex{},
 
 		stoppedSig: concurrency.NewErrorSignal(),
-
-		notifyList: []common.Notifiable{},
 	}
 }
 


### PR DESCRIPTION
## Description

This PR is part of the effort of making Sensor resilient to Central disconnects.

When the connection with central stops, local scanner might still request scanner definitions from Sensor. In this case, avoid making a call to Central and return an error directly to Scanner. 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- [x] New unit tests
- [x] CI  