### PR TITLE
ROX-18684: Add routeComponentMap and call isRouteEnabled in Body

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/AsyncComponent.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/AsyncComponent.tsx
@@ -6,7 +6,7 @@ type State = {
     component: ElementType | null;
 };
 
-export default function asyncComponent(importComponent) {
+export default function asyncComponent(importComponent): ElementType {
     class AsyncComponent extends Component<Props, State> {
         isComponentMounted: boolean;
 

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -1,36 +1,37 @@
-import React, { ReactElement, useEffect } from 'react';
+import React, { ElementType, ReactElement, useEffect } from 'react';
 import { Redirect, Route, Switch, useLocation } from 'react-router-dom';
 import { PageSection } from '@patternfly/react-core';
 
+// Import path variables in alphabetical order to minimize merge conflicts when multiple people add routes.
 import {
-    mainPath,
-    dashboardPath,
-    networkPath,
-    violationsPath,
-    compliancePath,
-    complianceEnhancedBasePath,
-    clustersListPath,
+    isRouteEnabled, // predicate function
+    accessControlPath,
+    apidocsPath,
     clustersDelegateScanningPath,
     clustersPathWithParam,
+    collectionsPath,
+    complianceEnhancedBasePath,
+    compliancePath,
+    configManagementPath,
+    dashboardPath,
+    deprecatedPoliciesPath,
     integrationsPath,
+    listeningEndpointsBasePath,
+    mainPath,
+    networkPath,
     policiesPath,
     policyManagementBasePath,
-    deprecatedPoliciesPath,
     riskPath,
     searchPath,
-    apidocsPath,
-    accessControlPath,
-    userBasePath,
     systemConfigPath,
     systemHealthPath,
+    userBasePath,
+    violationsPath,
     vulnManagementPath,
     vulnManagementReportsPath,
-    configManagementPath,
     vulnManagementRiskAcceptancePath,
-    collectionsPath,
     vulnerabilitiesWorkloadCvesPath,
     vulnerabilityReportsPath,
-    listeningEndpointsBasePath,
 } from 'routePaths';
 import { useTheme } from 'Containers/ThemeProvider';
 
@@ -52,59 +53,51 @@ function NotFoundPage(): ReactElement {
     );
 }
 
-const AsyncSearchPage = asyncComponent(() => import('Containers/Search/SearchPage'));
-const AsyncApiDocsPage = asyncComponent(() => import('Containers/Docs/ApiPage'));
-const AsyncDashboardPage = asyncComponent(() => import('Containers/Dashboard/DashboardPage'));
-const AsyncNetworkGraphPage = asyncComponent(
-    () => import('Containers/NetworkGraph/NetworkGraphPage')
-);
-const AsyncDelegateScanningPage = asyncComponent(
-    () => import('Containers/Clusters/DelegateScanning/DelegateScanningPage')
-);
-const AsyncClustersPage = asyncComponent(() => import('Containers/Clusters/ClustersPage'));
-const AsyncPFClustersPage = asyncComponent(() => import('Containers/Clusters/PF/ClustersPage'));
-const AsyncIntegrationsPage = asyncComponent(
-    () => import('Containers/Integrations/IntegrationsPage')
-);
-const AsyncViolationsPage = asyncComponent(() => import('Containers/Violations/ViolationsPage'));
-
-const AsyncPolicyManagementPage = asyncComponent(
-    () => import('Containers/PolicyManagement/PolicyManagementPage')
-);
-
-const AsyncCollectionsPage = asyncComponent(() => import('Containers/Collections/CollectionsPage'));
-
-const AsyncCompliancePage = asyncComponent(() => import('Containers/Compliance/Page'));
-const AsyncComplianceEnhancedPage = asyncComponent(
-    () => import('Containers/ComplianceEnhanced/CompliancePage')
-);
-const AsyncRiskPage = asyncComponent(() => import('Containers/Risk/RiskPage'));
-const AsyncAccessControlPageV2 = asyncComponent(
-    () => import('Containers/AccessControl/AccessControl')
-);
-const AsyncUserPage = asyncComponent(() => import('Containers/User/UserPage'));
-const AsyncSystemConfigPage = asyncComponent(
-    () => import('Containers/SystemConfig/SystemConfigPage')
-);
-const AsyncConfigManagementPage = asyncComponent(() => import('Containers/ConfigManagement/Page'));
-const AsyncWorkloadCvesPage = asyncComponent(
-    () => import('Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage')
-);
-const AsyncVulnerabilityReportingPage = asyncComponent(
-    () => import('Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage')
-);
-const AsyncVulnMgmtReports = asyncComponent(
-    () => import('Containers/VulnMgmt/Reports/VulnMgmtReports')
-);
-const AsyncVulnMgmtRiskAcceptancePage = asyncComponent(
-    () => import('Containers/VulnMgmt/RiskAcceptance/RiskAcceptancePage')
-);
-const AsyncVulnMgmtPage = asyncComponent(() => import('Containers/VulnMgmt/WorkflowLayout'));
-const AsyncSystemHealthPage = asyncComponent(() => import('Containers/SystemHealth/DashboardPage'));
-
-const AsyncListeningEndpointsPage = asyncComponent(
-    () => import('Containers/Audit/ListeningEndpoints/ListeningEndpointsPage')
-);
+// routeComponentMap corresponds to routeDescriptionMap in src/routePaths.ts file.
+// Add path keys in alphabetical order to minimize merge conflicts when multiple people add routes.
+const routeComponentMap: Record<string, ElementType> = {
+    [accessControlPath]: asyncComponent(() => import('Containers/AccessControl/AccessControl')),
+    [apidocsPath]: asyncComponent(() => import('Containers/Docs/ApiPage')),
+    [clustersDelegateScanningPath]: asyncComponent(
+        () => import('Containers/Clusters/DelegateScanning/DelegateScanningPage')
+    ),
+    [clustersPathWithParam]: asyncComponent(() => import('Containers/Clusters/ClustersPage')),
+    [collectionsPath]: asyncComponent(() => import('Containers/Collections/CollectionsPage')),
+    [compliancePath]: asyncComponent(() => import('Containers/Compliance/Page')),
+    [complianceEnhancedBasePath]: asyncComponent(
+        () => import('Containers/ComplianceEnhanced/CompliancePage')
+    ),
+    [configManagementPath]: asyncComponent(() => import('Containers/ConfigManagement/Page')),
+    [dashboardPath]: asyncComponent(() => import('Containers/Dashboard/DashboardPage')),
+    [integrationsPath]: asyncComponent(() => import('Containers/Integrations/IntegrationsPage')),
+    [listeningEndpointsBasePath]: asyncComponent(
+        () => import('Containers/Audit/ListeningEndpoints/ListeningEndpointsPage')
+    ),
+    [networkPath]: asyncComponent(() => import('Containers/NetworkGraph/NetworkGraphPage')),
+    [policyManagementBasePath]: asyncComponent(
+        () => import('Containers/PolicyManagement/PolicyManagementPage')
+    ),
+    [riskPath]: asyncComponent(() => import('Containers/Risk/RiskPage')),
+    [searchPath]: asyncComponent(() => import('Containers/Search/SearchPage')),
+    [systemConfigPath]: asyncComponent(() => import('Containers/SystemConfig/SystemConfigPage')),
+    [systemHealthPath]: asyncComponent(() => import('Containers/SystemHealth/DashboardPage')),
+    [userBasePath]: asyncComponent(() => import('Containers/User/UserPage')),
+    [violationsPath]: asyncComponent(() => import('Containers/Violations/ViolationsPage')),
+    // Reporting and Risk Acceptance must precede generic Vulnerability Management. Keep paths independent in the future!
+    [vulnManagementReportsPath]: asyncComponent(
+        () => import('Containers/VulnMgmt/Reports/VulnMgmtReports')
+    ),
+    [vulnManagementRiskAcceptancePath]: asyncComponent(
+        () => import('Containers/VulnMgmt/RiskAcceptance/RiskAcceptancePage')
+    ),
+    [vulnManagementPath]: asyncComponent(() => import('Containers/VulnMgmt/WorkflowLayout')),
+    [vulnerabilitiesWorkloadCvesPath]: asyncComponent(
+        () => import('Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage')
+    ),
+    [vulnerabilityReportsPath]: asyncComponent(
+        () => import('Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage')
+    ),
+};
 
 type BodyProps = {
     hasReadAccess: HasReadAccess;
@@ -120,13 +113,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
 
     const { isDarkMode } = useTheme();
 
-    const isVulnMgmtWorkloadCvesEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_WORKLOAD_CVES');
-    const isVulnerabilityReportingEnhancementsEnabled = isFeatureFlagEnabled(
-        'ROX_VULN_MGMT_REPORTING_ENHANCEMENTS'
-    );
-
-    const hasVulnerabilityReportsPermission = hasReadAccess('WorkflowAdministration');
-    const hasCollectionsPermission = hasReadAccess('WorkflowAdministration');
+    const routePredicates = { hasReadAccess, isFeatureFlagEnabled };
 
     return (
         <div
@@ -138,66 +125,13 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                 <Switch>
                     <Route path="/" exact render={() => <Redirect to={dashboardPath} />} />
                     <Route path={mainPath} exact render={() => <Redirect to={dashboardPath} />} />
-                    <Route path={dashboardPath} component={AsyncDashboardPage} />
-                    <Route path={networkPath} component={AsyncNetworkGraphPage} />
-                    <Route path={violationsPath} component={AsyncViolationsPage} />
-                    <Route path={compliancePath} component={AsyncCompliancePage} />
-                    <Route
-                        path={complianceEnhancedBasePath}
-                        component={AsyncComplianceEnhancedPage}
-                    />
-                    <Route path={integrationsPath} component={AsyncIntegrationsPage} />
-                    <Route path={policyManagementBasePath} component={AsyncPolicyManagementPage} />
                     {/* Make sure the following Redirect element works after react-router-dom upgrade */}
                     <Redirect exact from={deprecatedPoliciesPath} to={policiesPath} />
-                    {hasCollectionsPermission && (
-                        <Route path={collectionsPath} component={AsyncCollectionsPage} />
-                    )}
-                    <Route path={riskPath} component={AsyncRiskPage} />
-                    <Route path={accessControlPath} component={AsyncAccessControlPageV2} />
-                    <Route path={searchPath} component={AsyncSearchPage} />
-                    <Route path={apidocsPath} component={AsyncApiDocsPage} />
-                    <Route path={userBasePath} component={AsyncUserPage} />
-                    <Route path={systemConfigPath} component={AsyncSystemConfigPage} />
-                    {isVulnMgmtWorkloadCvesEnabled && (
-                        <Route
-                            path={vulnerabilitiesWorkloadCvesPath}
-                            component={AsyncWorkloadCvesPage}
-                        />
-                    )}
-                    {hasVulnerabilityReportsPermission &&
-                        isVulnerabilityReportingEnhancementsEnabled && (
-                            <Route
-                                path={vulnerabilityReportsPath}
-                                component={AsyncVulnerabilityReportingPage}
-                            />
-                        )}
-                    {hasVulnerabilityReportsPermission && (
-                        <Route path={vulnManagementReportsPath} component={AsyncVulnMgmtReports} />
-                    )}
-                    <Route
-                        path={vulnManagementRiskAcceptancePath}
-                        component={AsyncVulnMgmtRiskAcceptancePage}
-                    />
-                    <Route path={vulnManagementPath} component={AsyncVulnMgmtPage} />
-                    <Route path={configManagementPath} component={AsyncConfigManagementPage} />
-                    <Route
-                        path={clustersDelegateScanningPath}
-                        component={AsyncDelegateScanningPage}
-                    />
-                    <Route path={clustersPathWithParam} component={AsyncClustersPage} />
-                    {process.env.NODE_ENV === 'development' && (
-                        <Route path={clustersListPath} component={AsyncPFClustersPage} />
-                    )}
-                    <Route path={systemHealthPath} component={AsyncSystemHealthPage} />
-                    {/* 
-                    TODO - Add any necessary permissions to the following route. The user will need read access to
-                          'Cluster' and 'Deployment' at the very least.
-                     */}
-                    <Route
-                        path={listeningEndpointsBasePath}
-                        component={AsyncListeningEndpointsPage}
-                    />
+                    {Object.entries(routeComponentMap)
+                        .filter(([path]) => isRouteEnabled(routePredicates, path))
+                        .map(([path, component]) => {
+                            return <Route key={path} path={path} component={component} />;
+                        })}
                     <Route component={NotFoundPage} />
                 </Switch>
             </ErrorBoundary>

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -110,8 +110,8 @@ export const vulnerabilityReportPath = `${vulnerabilitiesBasePath}/reports/:repo
 // Source of truth for conditional rendering of Body route paths and NavigationSidebar links.
 
 type RouteDescription = {
-    featureFlagDependency?: FeatureFlagEnvVar[]; // assume multiple feature flags imply all are enabled
-    resourceAccessRequirements: ResourceName[]; // assume READ_ACCESS and multiple resource names imply has access to all
+    featureFlagDependency?: FeatureFlagEnvVar[]; // assume multiple feature flags imply all must be enabled
+    resourceAccessRequirements: ResourceName[]; // assume READ_ACCESS and multiple resource names imply must have access to all
 };
 
 // Add path variables in alphabetical order to minimize merge conflicts when multiple people add routes.

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -14,20 +14,30 @@ export const testLoginResultsPath = '/test-login-results';
 export const authResponsePrefix = '/auth/response/';
 export const authorizeRoxctlPath = '/authorize-roxctl';
 
-export const dashboardPath = `${mainPath}/dashboard`;
-export const networkBasePath = `${mainPath}/network-graph`;
-export const networkPath = `${networkBasePath}/:detailType?/:detailId?`;
-export const violationsBasePath = `${mainPath}/violations`;
-export const violationsPath = `${violationsBasePath}/:alertId?`;
+// Add (related) path variables in alphabetical order to minimize merge conflicts when multiple people add routes.
+export const accessControlBasePath = `${mainPath}/access-control`;
+export const accessControlPath = `${accessControlBasePath}/:entitySegment?/:entityId?`;
+export const apidocsPath = `${mainPath}/apidocs`;
 export const clustersBasePath = `${mainPath}/clusters`;
-export const clustersDelegateScanningPath = `${clustersBasePath}/delegate-scanning`;
 export const clustersPathWithParam = `${clustersBasePath}/:clusterId?`;
 export const clustersListPath = `${mainPath}/clusters-pf`;
+export const clustersDelegateScanningPath = `${clustersBasePath}/delegate-scanning`;
+export const collectionsBasePath = `${mainPath}/collections`;
+export const collectionsPath = `${mainPath}/collections/:collectionId?`;
+export const complianceBasePath = `${mainPath}/compliance`;
+export const compliancePath = `${mainPath}/:context(compliance)`;
+export const complianceEnhancedBasePath = `${mainPath}/compliance-enhanced`;
+export const configManagementPath = `${mainPath}/configmanagement`;
+export const dashboardPath = `${mainPath}/dashboard`;
+export const dataRetentionPath = `${mainPath}/retention`;
 export const integrationsPath = `${mainPath}/integrations`;
-export const integrationsListPath = `${integrationsPath}/:source/:type`;
 export const integrationCreatePath = `${integrationsPath}/:source/:type/create`;
 export const integrationDetailsPath = `${integrationsPath}/:source/:type/view/:id`;
 export const integrationEditPath = `${integrationsPath}/:source/:type/edit/:id`;
+export const integrationsListPath = `${integrationsPath}/:source/:type`;
+export const listeningEndpointsBasePath = `${mainPath}/listening-endpoints`;
+export const networkBasePath = `${mainPath}/network-graph`;
+export const networkPath = `${networkBasePath}/:detailType?/:detailId?`;
 export const policyManagementBasePath = `${mainPath}/policy-management`;
 export const policiesBasePath = `${policyManagementBasePath}/policies`;
 export const policiesPath = `${policiesBasePath}/:policyId?/:command?`;
@@ -36,26 +46,23 @@ export const deprecatedPoliciesBasePath = `${mainPath}/policies`;
 export const deprecatedPoliciesPath = `${deprecatedPoliciesBasePath}/:policyId?/:command?`;
 export const riskBasePath = `${mainPath}/risk`;
 export const riskPath = `${riskBasePath}/:deploymentId?`;
-export const secretsPath = `${mainPath}/configmanagement/secrets/:secretId?`;
 export const searchPath = `${mainPath}/search`;
-export const apidocsPath = `${mainPath}/apidocs`;
-export const accessControlBasePath = `${mainPath}/access-control`;
-export const accessControlPath = `${accessControlBasePath}/:entitySegment?/:entityId?`;
+export const secretsPath = `${mainPath}/configmanagement/secrets/:secretId?`;
+export const systemConfigPath = `${mainPath}/systemconfig`;
+export const systemHealthPath = `${mainPath}/system-health`;
 export const userBasePath = `${mainPath}/user`;
 export const userRolePath = `${userBasePath}/roles/:roleName`;
-export const systemConfigPath = `${mainPath}/systemconfig`;
-export const complianceBasePath = `${mainPath}/compliance`;
-export const compliancePath = `${mainPath}/:context(compliance)`;
-export const complianceEnhancedBasePath = `${mainPath}/compliance-enhanced`;
-export const dataRetentionPath = `${mainPath}/retention`;
-export const systemHealthPath = `${mainPath}/system-health`;
-export const collectionsBasePath = `${mainPath}/collections`;
-export const collectionsPath = `${mainPath}/collections/:collectionId?`;
-export const listeningEndpointsBasePath = `${mainPath}/listening-endpoints`;
+export const violationsBasePath = `${mainPath}/violations`;
+export const violationsPath = `${violationsBasePath}/:alertId?`;
+export const vulnManagementPath = `${mainPath}/vulnerability-management`;
+export const vulnManagementReportsPath = `${vulnManagementPath}/reports`;
+export const vulnManagementRiskAcceptancePath = `${vulnManagementPath}/risk-acceptance`;
+export const vulnerabilitiesBasePath = `${mainPath}/vulnerabilities`;
+export const vulnerabilitiesWorkloadCvesPath = `${vulnerabilitiesBasePath}/workload-cves`;
+export const vulnerabilityReportsPath = `${vulnerabilitiesBasePath}/reports`;
 
 // Configuration Management
 
-export const configManagementPath = `${mainPath}/configmanagement`;
 export const configManagementClustersPath = `${configManagementPath}/clusters`;
 export const configManagementControlsPath = `${configManagementPath}/controls`;
 export const configManagementDeploymentsPath = `${configManagementPath}/deployments`;
@@ -70,7 +77,6 @@ export const configManagementSubjectsPath = `${configManagementPath}/subjects`;
 
 // Vuln Management Paths
 
-export const vulnManagementPath = `${mainPath}/vulnerability-management`;
 export const vulnManagementPoliciesPath = `${vulnManagementPath}/policies`;
 export const vulnManagementCVEsPath = `${vulnManagementPath}/cves`;
 export const vulnManagementImageCVEsPath = `${vulnManagementPath}/image-cves`;
@@ -87,30 +93,25 @@ export const vulnManagementImageComponentsPath = `${vulnManagementPath}/image-co
 export const vulnManagementNodesPath = `${vulnManagementPath}/nodes`;
 
 // The following paths are not part of the infinite nesting Workflow in Vuln Management
-export const vulnManagementReportsPath = `${vulnManagementPath}/reports`;
 export const vulnManagementReportsPathWithParam = `${vulnManagementPath}/reports/:reportId`;
 
-export const vulnManagementRiskAcceptancePath = `${vulnManagementPath}/risk-acceptance`;
 export const vulnManagementPendingApprovalsPath = `${vulnManagementRiskAcceptancePath}/pending-approvals`;
 export const vulnManagementApprovedDeferralsPath = `${vulnManagementRiskAcceptancePath}/approved-deferrals`;
 export const vulnManagementApprovedFalsePositivesPath = `${vulnManagementRiskAcceptancePath}/approved-false-positives`;
 
 // VM 2.0 "Vulnerabilities" paths
-export const vulnerabilitiesBasePath = `${mainPath}/vulnerabilities`;
 
-export const vulnerabilitiesWorkloadCvesPath = `${vulnerabilitiesBasePath}/workload-cves`;
 export const vulnerabilitiesWorkloadCveSinglePath = `${vulnerabilitiesBasePath}/workload-cves/cves/:cveId`;
 export const vulnerabilitiesWorkloadCveImageSinglePath = `${vulnerabilitiesBasePath}/workload-cves/images/:imageId`;
 export const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesBasePath}/workload-cves/deployments/:deploymentId`;
 
-export const vulnerabilityReportsPath = `${vulnerabilitiesBasePath}/reports`;
 export const vulnerabilityReportPath = `${vulnerabilitiesBasePath}/reports/:reportId`;
 
 // Source of truth for conditional rendering of Body route paths and NavigationSidebar links.
 
 type RouteDescription = {
-    featureFlagDependency?: FeatureFlagEnvVar; // can add array as alternative if needed in the future
-    resourceAccessRequirements: ResourceName[]; // assume READ_ACCESS
+    featureFlagDependency?: FeatureFlagEnvVar[]; // assume multiple feature flags imply all are enabled
+    resourceAccessRequirements: ResourceName[]; // assume READ_ACCESS and multiple resource names imply has access to all
 };
 
 // Add path variables in alphabetical order to minimize merge conflicts when multiple people add routes.
@@ -182,11 +183,11 @@ const routeDescriptionMap: Record<string, RouteDescription> = {
         resourceAccessRequirements: [],
     },
     [vulnerabilitiesWorkloadCvesPath]: {
-        featureFlagDependency: 'ROX_VULN_MGMT_WORKLOAD_CVES',
+        featureFlagDependency: ['ROX_VULN_MGMT_WORKLOAD_CVES'],
         resourceAccessRequirements: [],
     },
     [vulnerabilityReportsPath]: {
-        featureFlagDependency: 'ROX_VULN_MGMT_REPORTING_ENHANCEMENTS',
+        featureFlagDependency: ['ROX_VULN_MGMT_REPORTING_ENHANCEMENTS'],
         resourceAccessRequirements: ['WorkflowAdministration'],
     },
 };
@@ -210,8 +211,12 @@ export function isRouteEnabled(
 
     const { featureFlagDependency, resourceAccessRequirements } = routeDescription;
 
-    if (typeof featureFlagDependency === 'string') {
-        if (!isFeatureFlagEnabled(featureFlagDependency)) {
+    if (Array.isArray(featureFlagDependency)) {
+        if (
+            !featureFlagDependency.every((featureFlagEnvVar) =>
+                isFeatureFlagEnabled(featureFlagEnvVar)
+            )
+        ) {
             return false;
         }
     }


### PR DESCRIPTION
## Description

Follow up from #7118

* Also order path variable declarations to minimize merge conflicts when multiple people add routes.
* Move `vulnManagementReportsPath` and `vulnManagementRiskAcceptancePath` above `vulnManagementPath` and add a comment.
* Replace one feature flag with array of feature flags.

### Procedure

Will add steps to a section following feature flags
https://github.com/stackrox/stackrox/tree/master/ui/apps/platform#feature-flags

In src/routePaths.ts file:
1. Add path variable for new route.
2. Add property to `routeDescriptionMap` object.

Because we will stop adding title to `basePathToLabelMap` the net number of steps in routePaths remains the same.

In src/Containers/MainPage/Body.tsx file:
1. Import path variable for new route.
2. Add property to `routeComponentMap` object.

You save a step by including `asyncComponent(() => import('Containers/Whatever/WhateverPage'))` in step 2.

You might save more steps because `routeDescriptionMap` has feature flags and role resources.

In src/Containers/MainPage/Sidebar/NavigationSidebar.tsx file: stay tuned!

### Residue

1. Replace return of `true` with `false` for unknown route path.
2. See if negative match in pathname can remove need for order of classic Vulnerability Management route paths.
3. Delete src/Containers/Clusters/PF folder because incomplete PatternFly rewrite is outdated and risks backend developers making changes in the wrong places.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Delete `import('Containers/Clusters/PF/ClustersPage')` from Body might explain one fewer files.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 173 = 3758428 - 3758255
        total: -3100 = 9895392 - 9898492
    * `ls -al build/static/js/*.js | wc -l`
        -1 = 80 - 81 files
3. `yarn start` in ui

### Manual testing

Visit pages via left navigation and explore 1 (or 2 for workflow) levels of descendant pages.