### PR TITLE
ROX-0000: Fix mutex taking more than 5s to unlock

### DIFF
--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -30,7 +30,9 @@ func New(client client.Interface, configHandler config.Handler, nodeName string,
 		traceWriter:        traceWriter,
 		outputQueue:        queue,
 		storeProvider:      storeProvider,
+		mayCreateHandlers:  concurrency.NewSignal(),
 	}
+	k.mayCreateHandlers.Signal()
 	return k
 }
 

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -51,9 +51,7 @@ func managedFieldsTransformer(obj interface{}) (interface{}, error) {
 }
 
 func (k *listenerImpl) handleAllEvents() {
-	k.contextMtx.Lock()
-	defer k.contextMtx.Unlock()
-
+	defer k.mayCreateHandlers.Signal()
 	// TODO(ROX-14194): remove resyncingSif once all resources are adapted
 	var resyncingSif informers.SharedInformerFactory
 	if env.ResyncDisabled.BooleanSetting() {


### PR DESCRIPTION
## Description

This resulted from a PR that was merged recently: #7032

This might be a workaround for the moment, just to avoid using mutex. But perhaps a better approach would be to recreate the listeners entirely when going into offline mode.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- [x] Running tests
