### PR TITLE
feat(helm): enable OpenShift monitoring by default

### DIFF
--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -22,7 +22,7 @@ defaults:
         preferredDuringSchedulingIgnoredDuringExecution:
         # Central is single-homed, so avoid preemptible nodes.
         - weight: 100
-          preference: 
+          preference:
             matchExpressions:
             - key: cloud.google.com/gke-preemptible
               operator: NotIn
@@ -39,7 +39,7 @@ defaults:
             - key: node-role.kubernetes.io/compute
               operator: Exists
         # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
-        # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.    
+        # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
         - weight: 100
           preference:
             matchExpressions:
@@ -169,10 +169,6 @@ defaults:
     [<- if not .AutoSensePodSecurityPolicies >]
     enablePodSecurityPolicies: [< .EnablePodSecurityPolicies >]
     [<- end >]
-
-  monitoring:
-    openshift:
-      enabled: false
 
 pvcDefaults:
   claimName: "stackrox-db"

--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -108,6 +108,10 @@
   {{ include "srox.warn" (list . "enableOpenShiftMonitoring option was replaced with monitoring.openshift.enabled") }}
   {{ $_ := set $._rox "monitoring" (dict "openshift" (dict "enabled" true)) }}
 {{ end }}
+{{/* Default `monitoring.openshift.enabled = true` unless `env.openshift != 4`. */}}
+{{ if kindIs "invalid" $._rox.monitoring.openshift.enabled }}
+{{ $_ := set $._rox "monitoring" (dict "openshift" (dict "enabled" (eq $._rox.env.openshift 4))) }}
+{{ end }}
 {{ if and $._rox.monitoring.openshift.enabled (ne $._rox.env.openshift 4) }}
   {{ include "srox.warn" (list . "'monitoring.openshift.enabled' is set to true, but the chart is not being deployed in an OpenShift 4 cluster. Proceeding with 'monitoring.openshift.enabled=false'.") }}
   {{ $_ := set $._rox "monitoring" (dict "openshift" (dict "enabled" false)) }}

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -133,7 +133,7 @@
 #     - effect: NoExecute
 #       key: infra
 #       value: reserved
-#   
+#
 #   If scheduling needs specific affinities, you can specify the corresponding affinities here.
 #   affinity:
 #     nodeAffinity:
@@ -531,3 +531,8 @@
 # # the default "stackrox-central-services". This has been observed to work in some cases,
 # # but is not generally supported.
 # allowNonstandardReleaseName: false
+
+# monitoring:
+#   # Enables integration with OpenShift platform monitoring.
+#   openshift:
+#     enabled: true

--- a/image/templates/helm/stackrox-central/values.yaml.htpl
+++ b/image/templates/helm/stackrox-central/values.yaml.htpl
@@ -369,3 +369,7 @@ central:
 #    # via `overrideAPIResources`.
 #    extraAPIResources: []
 #
+#monitoring:
+#  # Enables integration with OpenShift platform monitoring.
+#  openshift:
+#    enabled: true

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -76,7 +76,7 @@ admissionControl:
     timeout: 20
     enforceOnUpdates: false
   replicas: 3
-  
+
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -90,6 +90,10 @@
   {{ include "srox.warn" (list . "enableOpenShiftMonitoring option was replaced with monitoring.openshift.enabled") }}
   {{ $_ := set $._rox "monitoring" (dict "openshift" (dict "enabled" true)) }}
 {{ end }}
+{{/* Default `monitoring.openshift.enabled = true` unless `env.openshift != 4`. */}}
+{{ if kindIs "invalid" $._rox.monitoring.openshift.enabled }}
+{{ $_ := set $._rox "monitoring" (dict "openshift" (dict "enabled" (eq $._rox.env.openshift 4))) }}
+{{ end }}
 {{ if and $._rox.monitoring.openshift.enabled (ne $._rox.env.openshift 4) }}
   {{ include "srox.warn" (list . "'monitoring.openshift.enabled' is set to true, but the chart is not being deployed in an OpenShift 4 cluster. Proceeding with 'monitoring.openshift.enabled=false'.") }}
   {{ $_ := set $._rox "monitoring" (dict "openshift" (dict "enabled" false)) }}

--- a/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
@@ -460,3 +460,8 @@
 #    # can be used in conjunction with both data obtained from the API server, or data set
 #    # via `overrideAPIResources`.
 #    extraAPIResources: []
+#
+#monitoring:
+#  # Enables integration with OpenShift platform monitoring.
+#  openshift:
+#    enabled: true

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
@@ -17,6 +17,9 @@ values:
     dbServiceTLS:
       cert: ""
       key: ""
+  monitoring:
+    openshift:
+      enabled: false
 tests:
 - name: "central with default settings"
   expect: |

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/injected-cabundle-cm.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/injected-cabundle-cm.test.yaml
@@ -2,6 +2,9 @@ values:
   central:
     persistence:
       none: true
+  monitoring:
+    openshift:
+      enabled: false
 tests:
 - server:
     visibleSchemas:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-auth.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-auth.test.yaml
@@ -8,6 +8,9 @@ values:
   central:
     persistence:
       none: true
+  monitoring:
+    openshift:
+      enabled: false
 
 server:
   availableSchemas:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-autosense.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-autosense.test.yaml
@@ -2,6 +2,9 @@ values:
   central:
     persistence:
       none: true
+  monitoring:
+    openshift:
+      enabled: false
 tests:
 - name: "Detect OpenShift 3 if no openshift server resources are not visible"
   set:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -42,6 +42,11 @@ tests:
     env.openshift: 4
   tests: *enabled-test
 
+- name: "When enabled via default value"
+  set:
+    env.openshift: 4
+  tests: *enabled-test
+
 - name: "When disabled"
   set:
     monitoring.openshift.enabled: false
@@ -67,6 +72,11 @@ tests:
 - name: "Disable override when on explicit OpenShift 3 environment"
   set:
     monitoring.openshift.enabled: true
+    env.openshift: 3
+  tests: *disabled-test
+
+- name: "Disable override with default value when on explicit OpenShift 3 environment"
+  set:
     env.openshift: 3
   tests: *disabled-test
 

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
@@ -12,6 +12,9 @@ values:
     dbServiceTLS:
       cert: ""
       key: ""
+  monitoring:
+    openshift:
+      enabled: false
 tests:
 - name: "scanner with default settings"
   expect: |

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/sccs.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/sccs.test.yaml
@@ -5,6 +5,9 @@ values:
   central:
     persistence:
       none: true
+  monitoring:
+    openshift:
+      enabled: false
 tests:
 - name: Should create SCCs
   expect: |

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/suite.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/suite.yaml
@@ -28,3 +28,6 @@ values:
   createSecrets: false
   ca:
     cert: "DUMMY CA CERTIFICATE"
+  monitoring:
+    openshift:
+      enabled: false

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -1,3 +1,7 @@
+values:
+  monitoring:
+    openshift:
+      enabled: false
 server:
   availableSchemas:
   - openshift-4.1.0

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/audit-logs.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/audit-logs.test.yaml
@@ -1,3 +1,7 @@
+values:
+  monitoring:
+    openshift:
+      enabled: false
 server:
   availableSchemas:
   - openshift-4.1.0

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/env.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/env.test.yaml
@@ -1,3 +1,7 @@
+values:
+  monitoring:
+    openshift:
+      enabled: false
 server:
   availableSchemas:
   - openshift-4.1.0

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/injected-cabundle-cm.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/injected-cabundle-cm.test.yaml
@@ -1,3 +1,7 @@
+values:
+  monitoring:
+    openshift:
+      enabled: false
 tests:
 - server:
     visibleSchemas:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/legacy-settings.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/legacy-settings.test.yaml
@@ -1,3 +1,7 @@
+values:
+  monitoring:
+    openshift:
+      enabled: false
 tests:
 - name: Basic legacy settings
   values:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -38,6 +38,11 @@ tests:
     env.openshift: 4
   tests: *enabled-test
 
+- name: "When enabled via default value"
+  set:
+    env.openshift: 4
+  tests: *enabled-test
+
 - name: "When disabled"
   set:
     monitoring.openshift.enabled: false
@@ -63,6 +68,11 @@ tests:
 - name: "Disable override when on explicit OpenShift 3 environment"
   set:
     monitoring.openshift.enabled: true
+    env.openshift: 3
+  tests: *disabled-test
+
+- name: "Disable override with default value when on explicit OpenShift 3 environment"
+  set:
     env.openshift: 3
   tests: *disabled-test
 

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-slim.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-slim.test.yaml
@@ -1,3 +1,7 @@
+values:
+  monitoring:
+    openshift:
+      enabled: false
 server:
   visibleSchemas:
   - openshift-4.1.0

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/sccs.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/sccs.test.yaml
@@ -1,3 +1,7 @@
+values:
+  monitoring:
+    openshift:
+      enabled: false
 server:
   visibleSchemas:
   - openshift-4.1.0


### PR DESCRIPTION
## Description

Enable OpenShift platform monitoring integration via `monitoring.openshift.enabled: true` by default. On OpenShift 3 clusters we default back to `monitoring.openshift.enabled: false`.

Note that changes to the Helm test code such as

```
values:
  monitoring:
    openshift:
      enabled: false
```

are required in some cases because the Prometheus related CRDs are not known to the tests. Because they are not related to the actual test intend, I opted to disable the feature for these tests.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Deployed on OCP test cluster.