### PR TITLE
fix(ui): Fix inconsistent severity colors and icons on dashboard

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/SeverityIcons.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/SeverityIcons.tsx
@@ -8,42 +8,57 @@ import {
 } from '@patternfly/react-icons';
 import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 
+import {
+    CRITICAL_SEVERITY_COLOR,
+    LOW_SEVERITY_COLOR,
+    IMPORTANT_HIGH_SEVERITY_COLOR,
+    MODERATE_MEDIUM_SEVERITY_COLOR,
+    UNKNOWN_SEVERITY_COLOR,
+} from 'constants/visuals/colors';
 import { VulnerabilitySeverity } from 'types/cve.proto';
-import { vulnSeverityIconColors } from 'constants/visuals/colors';
+import { PolicySeverity } from 'types/policy.proto';
 
 // Defines the default PF icons that represent a CVE severity, and sets the default colors for the icons.
 // Color can be overridden by passing the standard `color` prop to the icon component.
+// For example, colors={count === 0 ? noViolationsColor: undefined} prop.
+
+export const CriticalSeverityIcon = (props) => (
+    <CriticalRiskIcon {...props} color={props.color ?? CRITICAL_SEVERITY_COLOR} />
+);
+
+export const ImportantSeverityIcon = (props) => (
+    <AngleDoubleUpIcon {...props} color={props.color ?? IMPORTANT_HIGH_SEVERITY_COLOR} />
+);
+
+export const HighSeverityIcon = ImportantSeverityIcon; // High is for policy severity
+
+export const ModerateSeverityIcon = (props) => (
+    <EqualsIcon {...props} color={props.color ?? MODERATE_MEDIUM_SEVERITY_COLOR} />
+);
+
+export const MediumSeverityIcon = ModerateSeverityIcon; // Medium is for policy severity
+
+export const LowSeverityIcon = (props) => (
+    <AngleDoubleDownIcon {...props} color={props.color ?? LOW_SEVERITY_COLOR} />
+);
+
+export const UnknownSeverityIcon = (props) => (
+    <UnknownIcon {...props} color={props.color ?? UNKNOWN_SEVERITY_COLOR} />
+);
+
 const SeverityIcons: Record<VulnerabilitySeverity, React.FC<SVGIconProps>> = {
-    CRITICAL_VULNERABILITY_SEVERITY: (props) => (
-        <CriticalRiskIcon
-            {...props}
-            color={props.color ?? vulnSeverityIconColors.CRITICAL_VULNERABILITY_SEVERITY}
-        />
-    ),
-    IMPORTANT_VULNERABILITY_SEVERITY: (props) => (
-        <AngleDoubleUpIcon
-            {...props}
-            color={props.color ?? vulnSeverityIconColors.IMPORTANT_VULNERABILITY_SEVERITY}
-        />
-    ),
-    MODERATE_VULNERABILITY_SEVERITY: (props) => (
-        <EqualsIcon
-            {...props}
-            color={props.color ?? vulnSeverityIconColors.MODERATE_VULNERABILITY_SEVERITY}
-        />
-    ),
-    LOW_VULNERABILITY_SEVERITY: (props) => (
-        <AngleDoubleDownIcon
-            {...props}
-            color={props.color ?? vulnSeverityIconColors.LOW_VULNERABILITY_SEVERITY}
-        />
-    ),
-    UNKNOWN_VULNERABILITY_SEVERITY: (props) => (
-        <UnknownIcon
-            {...props}
-            color={props.color ?? vulnSeverityIconColors.UNKNOWN_VULNERABILITY_SEVERITY}
-        />
-    ),
+    CRITICAL_VULNERABILITY_SEVERITY: CriticalSeverityIcon,
+    IMPORTANT_VULNERABILITY_SEVERITY: ImportantSeverityIcon,
+    MODERATE_VULNERABILITY_SEVERITY: ModerateSeverityIcon,
+    LOW_VULNERABILITY_SEVERITY: LowSeverityIcon,
+    UNKNOWN_VULNERABILITY_SEVERITY: UnknownSeverityIcon,
+};
+
+export const policySeverityIconMap: Record<PolicySeverity, React.FC<SVGIconProps>> = {
+    CRITICAL_SEVERITY: CriticalSeverityIcon,
+    HIGH_SEVERITY: HighSeverityIcon,
+    MEDIUM_SEVERITY: MediumSeverityIcon,
+    LOW_SEVERITY: LowSeverityIcon,
 };
 
 export default SeverityIcons;

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRiskTable.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { HashLink as Link } from 'react-router-hash-link';
 import { Tooltip, Truncate } from '@patternfly/react-core';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
-import { SecurityIcon } from '@patternfly/react-icons';
 
+import { CriticalSeverityIcon, ImportantSeverityIcon } from 'Components/PatternFly/SeverityIcons';
+import { noViolationsColor } from 'constants/visuals/colors';
 import { ImageName } from 'types/image.proto';
-import { severityColors } from 'constants/visuals/colors';
 import { vulnManagementPath } from 'routePaths';
 
 type VulnCounts = {
@@ -13,19 +13,39 @@ type VulnCounts = {
     fixable: number;
 };
 
+type ImageVulnerabilityCounter = {
+    important: VulnCounts;
+    critical: VulnCounts;
+};
+
 export type ImageData = {
     images: {
         id: string;
         name: Partial<ImageName>;
         priority: number;
-        imageVulnerabilityCounter: {
-            important: VulnCounts;
-            critical: VulnCounts;
-        };
+        imageVulnerabilityCounter: ImageVulnerabilityCounter;
     }[];
 };
 
 export type CveStatusOption = 'Fixable' | 'All';
+
+function countCritical(
+    imageVulnerabilityCounter: ImageVulnerabilityCounter,
+    cveStatusOption: CveStatusOption
+) {
+    return cveStatusOption === 'Fixable'
+        ? imageVulnerabilityCounter.critical.fixable
+        : imageVulnerabilityCounter.critical.total;
+}
+
+function countImportant(
+    imageVulnerabilityCounter: ImageVulnerabilityCounter,
+    cveStatusOption: CveStatusOption
+) {
+    return cveStatusOption === 'Fixable'
+        ? imageVulnerabilityCounter.important.fixable
+        : imageVulnerabilityCounter.important.total;
+}
 
 export type ImagesAtMostRiskProps = {
     imageData: ImageData;
@@ -85,9 +105,13 @@ function ImagesAtMostRiskTable({ imageData: { images }, cveStatusOption }: Image
                             {priority}
                         </Td>
                         <Td dataLabel={columnNames.criticalCves}>
-                            <SecurityIcon
+                            <CriticalSeverityIcon
                                 className="pf-u-display-inline pf-u-mr-xs"
-                                color={severityColors.CRITICAL_SEVERITY}
+                                color={
+                                    countCritical(imageVulnerabilityCounter, cveStatusOption) === 0
+                                        ? noViolationsColor
+                                        : undefined
+                                }
                             />
                             <span>
                                 {cveStatusOption === 'Fixable'
@@ -96,9 +120,13 @@ function ImagesAtMostRiskTable({ imageData: { images }, cveStatusOption }: Image
                             </span>
                         </Td>
                         <Td className="pf-u-pr-0" dataLabel={columnNames.importantCves}>
-                            <SecurityIcon
+                            <ImportantSeverityIcon
                                 className="pf-u-display-inline pf-u-mr-xs"
-                                color={severityColors.HIGH_SEVERITY}
+                                color={
+                                    countImportant(imageVulnerabilityCounter, cveStatusOption) === 0
+                                        ? noViolationsColor
+                                        : undefined
+                                }
                             />
                             {cveStatusOption === 'Fixable'
                                 ? `${imageVulnerabilityCounter.important.fixable} fixable`

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/MostRecentViolations.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/MostRecentViolations.tsx
@@ -2,13 +2,12 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Flex, Title, Truncate } from '@patternfly/react-core';
 import { TableComposable, Tbody, Tr, Td } from '@patternfly/react-table';
-import { SecurityIcon } from '@patternfly/react-icons';
 
 import ResourceIcon from 'Components/PatternFly/ResourceIcon';
+import { policySeverityIconMap } from 'Components/PatternFly/SeverityIcons';
 import { Alert, isDeploymentAlert, isResourceAlert } from 'types/alert.proto';
-import { violationsBasePath } from 'routePaths';
-import { severityColors } from 'constants/visuals/colors';
 import { getDateTime } from 'utils/dateUtils';
+import { violationsBasePath } from 'routePaths';
 import NoDataEmptyState from './NoDataEmptyState';
 
 export type MostRecentViolationsProps = {
@@ -45,13 +44,11 @@ function MostRecentViolations({ alerts }: MostRecentViolationsProps) {
                                 name = <Truncate content={alert.resource.name} />;
                             }
 
+                            const PolicySeverityIcon = policySeverityIconMap[policy.severity];
                             return (
                                 <Tr key={id}>
                                     <Td className="pf-u-p-0" dataLabel="Severity icon">
-                                        <SecurityIcon
-                                            className="pf-u-display-inline"
-                                            color={severityColors[policy.severity]}
-                                        />
+                                        <PolicySeverityIcon className="pf-u-display-inline" />
                                     </Td>
                                     <Td dataLabel="Violation name">
                                         <Link to={`${violationsBasePath}/${id}`}>

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/PolicyViolationTiles.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/PolicyViolationTiles.tsx
@@ -5,7 +5,7 @@ import { violationsBasePath } from 'routePaths';
 import { SearchFilter } from 'types/search';
 import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 import { severityLabels } from 'messages/common';
-import { severityColors } from 'constants/visuals/colors';
+import { policySeverityColorMap } from 'constants/visuals/colors';
 import { policySeverities, PolicySeverity } from 'types/policy.proto';
 import LinkShim from 'Components/PatternFly/LinkShim';
 
@@ -20,7 +20,9 @@ type SeverityTileProps = {
 function SeverityTile({ severity, violationCount, link }: SeverityTileProps) {
     return (
         <Button
-            style={{ '--pf-severity-tile-color': severityColors[severity] } as CSSProperties}
+            style={
+                { '--pf-severity-tile-color': policySeverityColorMap[severity] } as CSSProperties
+            }
             className="pf-severity-tile pf-u-w-100 pf-u-px-md pf-u-py-sm pf-u-align-items-center"
             key={severity}
             variant={ButtonVariant.link}

--- a/ui/apps/platform/src/constants/visuals/colors.ts
+++ b/ui/apps/platform/src/constants/visuals/colors.ts
@@ -11,22 +11,7 @@ const colors = [
     'var(--secondary-400)',
 ];
 
-export const colorTypes = ['alert', 'caution', 'warning', 'success', 'tertiary', 'primary', 'base'];
-
-export const fileUploadColors = {
-    BACKGROUND_COLOR: 'var(--warning-300)', // close to original upload background '#faecd2'
-    ICON_COLOR: 'var(--warning-700)', // close to original upload icon '#b39357
-};
-
-export const defaultColorType = 'base';
-
-// TODO supersede with policySeverityColors below.
-export const severityColors: Record<PolicySeverity, string> = {
-    LOW_SEVERITY: 'var(--color-severity-low)',
-    MEDIUM_SEVERITY: 'var(--color-severity-medium)',
-    HIGH_SEVERITY: 'var(--color-severity-important)',
-    CRITICAL_SEVERITY: 'var(--color-severity-critical)',
-};
+export const noViolationsColor = 'var(--pf-global--Color--200)';
 
 /*
  * Export individual constants for consistency in pseudo-severity use cases like compliance.
@@ -45,7 +30,7 @@ export const policySeverityColorMap: Record<PolicySeverity, string> = {
     LOW_SEVERITY: LOW_SEVERITY_COLOR,
     MEDIUM_SEVERITY: MODERATE_MEDIUM_SEVERITY_COLOR,
     HIGH_SEVERITY: IMPORTANT_HIGH_SEVERITY_COLOR,
-    CRITICAL_SEVERITY: UNKNOWN_SEVERITY_COLOR,
+    CRITICAL_SEVERITY: CRITICAL_SEVERITY_COLOR,
 };
 
 // TODO rename as vulnerabilitySeverityColorMap.

--- a/ui/apps/platform/src/css/acs.css
+++ b/ui/apps/platform/src/css/acs.css
@@ -14,11 +14,6 @@
     --color-resource-configmap: var(--pf-global--palette--purple-600);
     /* unknown has no openshift equivalent */
     --color-resource-unknown: var(--pf-global--palette--black-500);
-
-    --color-severity-low: var(--pf-global--palette--black-500);
-    --color-severity-medium: var(--pf-global--palette--gold-300);
-    --color-severity-important: var(--pf-global--palette--orange-300);
-    --color-severity-critical: var(--pf-global--palette--red-100);
 }
 
 /*

--- a/ui/apps/platform/src/utils/chartUtils.ts
+++ b/ui/apps/platform/src/utils/chartUtils.ts
@@ -2,12 +2,12 @@ import { History } from 'react-router-dom';
 import { getTheme, ChartThemeColor, ChartBarProps } from '@patternfly/react-charts';
 import merge from 'lodash/merge';
 
-import { severityColors } from 'constants/visuals/colors';
+import { policySeverityColorMap } from 'constants/visuals/colors';
 import { ValueOf } from './type.utils';
 
 export const solidBlueChartColor = 'var(--pf-global--palette--blue-400)';
 
-export const severityColorScale = Object.values(severityColors);
+export const severityColorScale = Object.values(policySeverityColorMap);
 
 // Clone default PatternFly chart themes
 const defaultTheme = getTheme(ChartThemeColor.multi);


### PR DESCRIPTION
## Description

### Problems

1. Low severity is gray on main dashboard but blue everywhere else
2. High/important severity is orange-300 on dashboard but orange-200 everywhere else.
3. SecurityIcon for critical and important on dashboard but CriticalRiskIcon and AngleDoubleUpIcon everywhere else. 

### Analysis

Find in Files `severityColors` has 10 results in 5 files

1. src/constants/visuals/colors.ts

    ```ts
    export const severityColors: Record<PolicySeverity, string> = {
        LOW_SEVERITY: 'var(--color-severity-low)',
        MEDIUM_SEVERITY: 'var(--color-severity-medium)',
        HIGH_SEVERITY: 'var(--color-severity-important)',
        CRITICAL_SEVERITY: 'var(--color-severity-critical)',
    };
    ```

2. src/Containers/Dashboard/Widgets/ImagesAtMostRiskTable.tsx vulnerability severity

    ```tsx
    <SecurityIcon
        className="pf-u-display-inline pf-u-mr-xs"
        color={severityColors.CRITICAL_SEVERITY}
    />
    ```

    ```tsx
    <SecurityIcon
        className="pf-u-display-inline pf-u-mr-xs"
        color={severityColors.HIGH_SEVERITY}
    />
    ```

3. src/Containers/Dashboard/Widgets/MostRecentViolations.tsx policy severity

    ```tsx
    <SecurityIcon
        className="pf-u-display-inline"
        color={severityColors[policy.severity]}
    />
    ```

4. src/Containers/Dashboard/Widgets/PolicyViolationTiles.tsx policy severity

    ```tsx
    <Button
        style={{ '--pf-severity-tile-color': severityColors[severity] } as CSSProperties}
        className="pf-severity-tile pf-u-w-100 pf-u-px-md pf-u-py-sm pf-u-align-items-center"
        key={severity}
        variant={ButtonVariant.link}
        component={LinkShim}
        href={link}
    >
        <Stack>
            <StackItem className="pf-u-font-weight-bold pf-u-font-size-xl">
                {violationCount}
            </StackItem>
            <StackItem>{severityLabels[severity]}</StackItem>
        </Stack>
    </Button>
    ```

5. src/utils/chartUtils.ts

    ```ts
    export const severityColorScale = Object.values(severityColors);
    ```

### Solution

1. src/constants/visuals/colors.ts
    * Delete unused variables.

2. src/Containers/Dashboard/Widgets/ImagesAtMostRiskTable.tsx vulnerability severity
    * Replace `SecurityIcon` and `CRITICAL_SEVERITY` with `CriticalSeverityIcon`
    * Replace `SecurityIcon` and `HIGH_SEVERITY` with `ImportantSeverityIcon`

3. src/Containers/Dashboard/Widgets/MostRecentViolations.tsx policy severity
    * Replace `SecurityIcon` and `severityColors` with `policySeverityIconMap`

4. src/Containers/Dashboard/Widgets/PolicyViolationTiles.tsx policy severity
    * Replace `severityColors` with `policySeverityColorMap`

5. src/utils/chartUtils.ts
    * Replace `severityColors` with `policySeverityColorMap`

6. src/Components/PatternFly/SeverityIcons.tsx
    * Export `noViolationsColor` from `fadedTextColor` in WorkflowCVEs container
    * Export individual icons
    * Export `policySeverityIconMap`

7. src/css/acs.css
    * Delete variables for `severityColors`

### Residue

1. Move `colors` that are used only in `VerticalBarChart` and `VerticalClusterBar` into Compliance container.
2. Move colors.ts from visuals subfolder to src/constants folder.
3. Rename some export variables for clarity and consistency.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/css/*.css`
        main.css: -244 = 797740 - 797984
        total: -244 = 1641178 - 1641422
    * `ls -al build/static/css/*.css | wc -l`
        0 = 29 - 29 files
    * `wc build/static/js/*.js`
        main.css: 0 = 3758534 - 3758534
        total: 3059 = 9904953 - 9901894
    * `ls -al build/static/js/*.js | wc -l`
        0 = 80 - 80 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/dashboard
    * See blue for low severity.
    * Images at most risk: see severity icons (in gray because no fixable vulnerabilities).
        Apart from the objective to be consistent, unlike icons to distinguish different severities in a **Severity** column, icons seem redundant here in **Critical CVEs** and **Important CVEs** columns.

![dashboard_1](https://github.com/stackrox/stackrox/assets/11862657/9d9335a5-9b62-45fe-8064-91358a26d123)
![dashboard_2](https://github.com/stackrox/stackrox/assets/11862657/338e1cc8-60c1-459a-9630-7a8e7f03bcb6)

Although I forget the reason why dashboard renders as `Gallery` instead of grid layout, I am reminded that it does not expand responsively to fit more items in 1920px panel width:
![dashboard_1920](https://github.com/stackrox/stackrox/assets/11862657/fd46e4fc-a6e7-47a0-a69f-5f14c222b798)
