### PR TITLE
test(netpol): check netpol generated output

### DIFF
--- a/roxctl/connectivity-map/testdata/minimal/output.json
+++ b/roxctl/connectivity-map/testdata/minimal/output.json
@@ -1,0 +1,27 @@
+[
+  {
+    "src": "0.0.0.0-255.255.255.255",
+    "dst": "default/frontend[Deployment]",
+    "conn": "TCP 8080"
+  },
+  {
+    "src": "default/backend[Deployment]",
+    "dst": "default/backend[Deployment]",
+    "conn": "All Connections"
+  },
+  {
+    "src": "default/frontend[Deployment]",
+    "dst": "0.0.0.0-255.255.255.255",
+    "conn": "UDP 53"
+  },
+  {
+    "src": "default/frontend[Deployment]",
+    "dst": "default/backend[Deployment]",
+    "conn": "TCP 9090"
+  },
+  {
+    "src": "default/frontend[Deployment]",
+    "dst": "default/frontend[Deployment]",
+    "conn": "All Connections"
+  }
+]

--- a/roxctl/connectivity-map/testdata/minimal/output.txt
+++ b/roxctl/connectivity-map/testdata/minimal/output.txt
@@ -1,0 +1,5 @@
+0.0.0.0-255.255.255.255 => default/frontend[Deployment] : TCP 8080
+default/backend[Deployment] => default/backend[Deployment] : All Connections
+default/frontend[Deployment] => 0.0.0.0-255.255.255.255 : UDP 53
+default/frontend[Deployment] => default/backend[Deployment] : TCP 9090
+default/frontend[Deployment] => default/frontend[Deployment] : All Connections


### PR DESCRIPTION
## Description

Add check for generated output of netpol generate so we fail in unit tests not only in bats.

Refs:
- https://github.com/stackrox/stackrox/pull/7139

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
