### PR TITLE
ROX-18185: Add scope of netpol generation to simulator side panel

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -33,61 +33,8 @@ import {
 } from './hooks/useNetworkPolicySimulator';
 import { EdgeState } from './components/EdgeStateSelect';
 import { deploymentTabs } from './utils/deploymentUtils';
+import { getInScopeEntities } from './utils/simulatorUtils';
 import { NetworkScopeHierarchy } from './types/networkScopeHierarchy';
-import { EntityScope } from './simulation/NetworkPoliciesGenerationScope';
-
-/**
- * Given the array of nodeModels returned by the network graph API and the user's
- * current scope hierarchy, return the scope of entities that should be included
- * in the network policy simulation.
- */
-function getInScopeEntities(
-    nodeModels: CustomNodeModel[],
-    scopeHierarchy: NetworkScopeHierarchy
-): EntityScope {
-    let granularity: EntityScope['granularity'] = 'CLUSTER';
-
-    if (scopeHierarchy.namespaces.length === 0 && scopeHierarchy.deployments.length === 0) {
-        // Only a cluster is selected
-        granularity = 'CLUSTER';
-    } else if (scopeHierarchy.namespaces.length > 0 && scopeHierarchy.deployments.length === 0) {
-        // A cluster and at least one namespace is selected
-        granularity = 'NAMESPACE';
-    } else {
-        // A cluster, at least one namespace, and at least one deployment is selected
-        granularity = 'DEPLOYMENT';
-    }
-
-    // A cluster, at least one namespace, and at least one deployment is selected. We
-    // include all deployments from the model that match a selected namespace and
-    // selected deployment name from the scope hierarchy.
-    const namespaceNameSet = new Set(scopeHierarchy.namespaces);
-    const deploymentNameSet = new Set(scopeHierarchy.deployments);
-
-    const deploymentScope: EntityScope = {
-        granularity,
-        cluster: scopeHierarchy.cluster.name,
-        namespaces: scopeHierarchy.namespaces,
-        deployments: [],
-    };
-
-    nodeModels.forEach((node) => {
-        if (node.data.type !== 'DEPLOYMENT') {
-            return;
-        }
-
-        const inSelectedNamespaces = namespaceNameSet.has(node.data.deployment.namespace);
-        const inSelectedDeployments = deploymentNameSet.has(node.data.deployment.name);
-        if (
-            (granularity === 'NAMESPACE' && inSelectedNamespaces) ||
-            (granularity === 'DEPLOYMENT' && inSelectedNamespaces && inSelectedDeployments)
-        ) {
-            deploymentScope.deployments.push(node.data.deployment);
-        }
-    });
-
-    return deploymentScope;
-}
 
 // TODO: move these type defs to a central location
 export const UrlDetailType = {

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.css
@@ -1,0 +1,39 @@
+.network-policies-generation-scope {
+  --badge-width: 2rem;
+}
+
+.network-policies-generation-scope > *:nth-child(2)  {
+  --tree-depth: 1;
+}
+
+.network-policies-generation-scope > *:nth-child(3)  {
+  --tree-depth: 2;
+}
+
+.network-policies-generation-scope > * {
+  position: relative;
+  padding-left: calc(var(--tree-depth) * var(--badge-width));
+  padding-bottom: var(--pf-global--spacer--xs);
+}
+
+.network-policies-generation-scope > *:not(:first-child):before, 
+.network-policies-generation-scope > *:not(:first-child):after  {
+  position: absolute;
+  content: "";
+  background-color: var(--pf-global--BorderColor--100);
+}
+
+.network-policies-generation-scope > *:not(:first-child):before  {
+  height: 40%;
+  width: 1px;
+  top: 0;
+  left: calc((var(--tree-depth) * var(--badge-width)) - (var(--badge-width) / 2));
+}
+
+.network-policies-generation-scope > *:not(:first-child):after  {
+  height: 1px;
+  width: calc(var(--badge-width) / 2.5);
+  left: 0;
+  bottom: calc(var(--badge-width) / 2);
+  margin-left: calc((var(--tree-depth) * var(--badge-width)) - (var(--badge-width) / 2));
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
@@ -25,35 +25,27 @@ export type NetworkPoliciesGenerationScopeProps = {
 function NetworkPoliciesGenerationScope({
     networkPolicyGenerationScope,
 }: NetworkPoliciesGenerationScopeProps) {
-    const { granularity, cluster } = networkPolicyGenerationScope;
+    const { granularity, cluster, deployments } = networkPolicyGenerationScope;
 
     let deploymentElement = <span>All deployments</span>;
     let namespaceElement = <span>All namespaces</span>;
 
-    if (granularity === 'NAMESPACE') {
-        const namespaceCount = networkPolicyGenerationScope.namespaces.length;
-        namespaceElement = (
-            <span>
-                {namespaceCount} {pluralize('namespace', namespaceCount)}
-            </span>
-        );
-    } else if (granularity === 'DEPLOYMENT') {
-        // Only count namespaces that have a deployment in scope, even if the namespace is selected
-        // otherwise
-        const namespaceCount = uniq(
-            networkPolicyGenerationScope.deployments.map((deployment) => deployment.namespace)
-        ).length;
-        namespaceElement = (
-            <span>
-                {namespaceCount} {pluralize('namespace', namespaceCount)}
-            </span>
-        );
-        const deploymentCount = networkPolicyGenerationScope.deployments.length;
-        deploymentElement = (
-            <span>
-                {deploymentCount} {pluralize('deployment', deploymentCount)}
-            </span>
-        );
+    if (granularity === 'NAMESPACE' || granularity === 'DEPLOYMENT') {
+        const namespaces = uniq(deployments.map((deployment) => deployment.namespace));
+        const namespaceCount = namespaces.length;
+        const namespaceText =
+            namespaceCount === 1 ? `namespace "${namespaces[0]}"` : `${namespaceCount} namespaces`;
+        namespaceElement = <span>{namespaceText}</span>;
+    }
+
+    if (granularity === 'DEPLOYMENT') {
+        const deploymentCount = deployments.length;
+        const deploymentText =
+            deploymentCount === 1
+                ? `deployment "${deployments[0].name}"`
+                : `${deploymentCount} deployments`;
+
+        deploymentElement = <span>{deploymentText}</span>;
     }
 
     return (

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
@@ -32,17 +32,14 @@ function NetworkPoliciesGenerationScope({
     if (granularity === 'NAMESPACE' || granularity === 'DEPLOYMENT') {
         const namespaces = uniq(deployments.map((deployment) => deployment.namespace));
         const namespaceCount = namespaces.length;
-        const namespaceText =
-            namespaceCount === 1 ? `namespace "${namespaces[0]}"` : `${namespaceCount} namespaces`;
+        const namespaceText = namespaceCount === 1 ? namespaces[0] : `${namespaceCount} namespaces`;
         namespaceElement = <span>{namespaceText}</span>;
     }
 
     if (granularity === 'DEPLOYMENT') {
         const deploymentCount = deployments.length;
         const deploymentText =
-            deploymentCount === 1
-                ? `deployment "${deployments[0].name}"`
-                : `${deploymentCount} deployments`;
+            deploymentCount === 1 ? deployments[0].name : `${deploymentCount} deployments`;
 
         deploymentElement = <span>{deploymentText}</span>;
     }
@@ -53,7 +50,7 @@ function NetworkPoliciesGenerationScope({
                 alignItems={{ default: 'alignItemsCenter' }}
                 spaceItems={{ default: 'spaceItemsSm' }}
             >
-                <DeploymentIcon />
+                <DeploymentIcon title="Deployment" />
                 {deploymentElement}
             </Flex>
 
@@ -61,7 +58,7 @@ function NetworkPoliciesGenerationScope({
                 alignItems={{ default: 'alignItemsCenter' }}
                 spaceItems={{ default: 'spaceItemsSm' }}
             >
-                <NamespaceIcon />
+                <NamespaceIcon title="Namespace" />
                 {namespaceElement}
             </Flex>
 
@@ -69,8 +66,8 @@ function NetworkPoliciesGenerationScope({
                 alignItems={{ default: 'alignItemsCenter' }}
                 spaceItems={{ default: 'spaceItemsSm' }}
             >
-                <ClusterIcon />
-                <span>cluster &quot;{cluster}&quot;</span>
+                <ClusterIcon title="Cluster" />
+                <span>{cluster}</span>
             </Flex>
         </div>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Flex } from '@patternfly/react-core';
-import pluralize from 'pluralize';
 import uniq from 'lodash/uniq';
 
 import { ClusterIcon, DeploymentIcon, NamespaceIcon } from '../common/NetworkGraphIcons';

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
@@ -50,7 +50,7 @@ function NetworkPoliciesGenerationScope({
                 alignItems={{ default: 'alignItemsCenter' }}
                 spaceItems={{ default: 'spaceItemsSm' }}
             >
-                <DeploymentIcon title="Deployment" />
+                <DeploymentIcon aria-label="Deployment" />
                 {deploymentElement}
             </Flex>
 
@@ -58,7 +58,7 @@ function NetworkPoliciesGenerationScope({
                 alignItems={{ default: 'alignItemsCenter' }}
                 spaceItems={{ default: 'spaceItemsSm' }}
             >
-                <NamespaceIcon title="Namespace" />
+                <NamespaceIcon aria-label="Namespace" />
                 {namespaceElement}
             </Flex>
 
@@ -66,7 +66,7 @@ function NetworkPoliciesGenerationScope({
                 alignItems={{ default: 'alignItemsCenter' }}
                 spaceItems={{ default: 'spaceItemsSm' }}
             >
-                <ClusterIcon title="Cluster" />
+                <ClusterIcon aria-label="Cluster" />
                 <span>{cluster}</span>
             </Flex>
         </div>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Flex } from '@patternfly/react-core';
+import pluralize from 'pluralize';
+import uniq from 'lodash/uniq';
+
+import { ClusterIcon, DeploymentIcon, NamespaceIcon } from '../common/NetworkGraphIcons';
+
+import './NetworkPoliciesGenerationScope.css';
+
+export type EntityScope = {
+    // `granularity` refers to the most specific entity type that has been selected by the user.
+    granularity: 'CLUSTER' | 'NAMESPACE' | 'DEPLOYMENT';
+    cluster: string;
+    namespaces: string[];
+    deployments: {
+        namespace: string;
+        name: string;
+    }[];
+};
+
+export type NetworkPoliciesGenerationScopeProps = {
+    networkPolicyGenerationScope: EntityScope;
+};
+
+function NetworkPoliciesGenerationScope({
+    networkPolicyGenerationScope,
+}: NetworkPoliciesGenerationScopeProps) {
+    const { granularity, cluster } = networkPolicyGenerationScope;
+
+    let deploymentElement = <span>All deployments</span>;
+    let namespaceElement = <span>All namespaces</span>;
+
+    if (granularity === 'NAMESPACE') {
+        const namespaceCount = networkPolicyGenerationScope.namespaces.length;
+        namespaceElement = (
+            <span>
+                {namespaceCount} {pluralize('namespace', namespaceCount)}
+            </span>
+        );
+    } else if (granularity === 'DEPLOYMENT') {
+        // Only count namespaces that have a deployment in scope, even if the namespace is selected
+        // otherwise
+        const namespaceCount = uniq(
+            networkPolicyGenerationScope.deployments.map((deployment) => deployment.namespace)
+        ).length;
+        namespaceElement = (
+            <span>
+                {namespaceCount} {pluralize('namespace', namespaceCount)}
+            </span>
+        );
+        const deploymentCount = networkPolicyGenerationScope.deployments.length;
+        deploymentElement = (
+            <span>
+                {deploymentCount} {pluralize('deployment', deploymentCount)}
+            </span>
+        );
+    }
+
+    return (
+        <div className="network-policies-generation-scope">
+            <Flex
+                alignItems={{ default: 'alignItemsCenter' }}
+                spaceItems={{ default: 'spaceItemsSm' }}
+            >
+                <DeploymentIcon />
+                {deploymentElement}
+            </Flex>
+
+            <Flex
+                alignItems={{ default: 'alignItemsCenter' }}
+                spaceItems={{ default: 'spaceItemsSm' }}
+            >
+                <NamespaceIcon />
+                {namespaceElement}
+            </Flex>
+
+            <Flex
+                alignItems={{ default: 'alignItemsCenter' }}
+                spaceItems={{ default: 'spaceItemsSm' }}
+            >
+                <ClusterIcon />
+                <span>cluster &quot;{cluster}&quot;</span>
+            </Flex>
+        </div>
+    );
+}
+
+export default NetworkPoliciesGenerationScope;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -181,11 +181,9 @@ function NetworkPolicySimulatorSidePanel({
                 >
                     <FlexItem>
                         <TextContent>
-                            <Text
-                                component={TextVariants.h2}
-                                className="pf-u-font-size-xl pf-u-mr-2xl"
-                            >
-                                Generated network policies from the baselines of
+                            <Text component={TextVariants.h2}>Generated network policies</Text>
+                            <Text component={TextVariants.h3} className="pf-u-m-0">
+                                Scope of baseline:
                             </Text>
                         </TextContent>
                     </FlexItem>
@@ -380,8 +378,9 @@ function NetworkPolicySimulatorSidePanel({
                     className="pf-u-p-md pf-u-pb-sm pf-u-mb-0"
                 >
                     <TextContent>
-                        <Text component={TextVariants.h2} className="pf-u-font-size-xl pf-u-mr-2xl">
-                            Generate network policies from the baselines of
+                        <Text component={TextVariants.h2}>Generate network policies</Text>
+                        <Text component={TextVariants.h3} className="pf-u-m-0">
+                            Scope of baseline:
                         </Text>
                     </TextContent>
                     <NetworkPoliciesGenerationScope

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -41,11 +41,18 @@ import NotifyYAMLModal from './NotifyYAMLModal';
 import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import CompareYAMLModal from './CompareYAMLModal';
 import CodeCompareIcon from './CodeCompareIcon';
+import NetworkPoliciesGenerationScope, { EntityScope } from './NetworkPoliciesGenerationScope';
 
-type NetworkPolicySimulatorSidePanelProps = {
+export type NetworkPolicySimulatorSidePanelProps = {
     simulator: NetworkPolicySimulator;
     setNetworkPolicyModification: SetNetworkPolicyModification;
+    /** scopeHierarchy is the user's selected scope for the network graph */
     scopeHierarchy: NetworkScopeHierarchy;
+    /**
+     *  `networkPolicyGenerationScope` is the set of entities selected by the `scopeHierarchy`
+     *  that can have network policies generated for them
+     */
+    networkPolicyGenerationScope: EntityScope;
 };
 
 const tabs = {
@@ -57,6 +64,7 @@ function NetworkPolicySimulatorSidePanel({
     simulator,
     setNetworkPolicyModification,
     scopeHierarchy,
+    networkPolicyGenerationScope,
 }: NetworkPolicySimulatorSidePanelProps) {
     const { activeKeyTab, onSelectTab } = useTabs({
         defaultTab: tabs.SIMULATE_NETWORK_POLICIES,
@@ -167,32 +175,25 @@ function NetworkPolicySimulatorSidePanel({
         return (
             <div>
                 <Flex
-                    direction={{ default: 'row' }}
-                    alignItems={{ default: 'alignItemsFlexEnd' }}
-                    className="pf-u-p-lg pf-u-mb-0"
+                    direction={{ default: 'column' }}
+                    spaceItems={{ default: 'spaceItemsSm' }}
+                    className="pf-u-p-md pf-u-pb-sm pf-u-mb-0"
                 >
                     <FlexItem>
                         <TextContent>
-                            <Text component={TextVariants.h2} className="pf-u-font-size-xl">
-                                Network Policy Simulator
+                            <Text
+                                component={TextVariants.h2}
+                                className="pf-u-font-size-xl pf-u-mr-2xl"
+                            >
+                                Generated network policies from the baselines of
                             </Text>
                         </TextContent>
                     </FlexItem>
+                    <NetworkPoliciesGenerationScope
+                        networkPolicyGenerationScope={networkPolicyGenerationScope}
+                    />
                 </Flex>
-                <Divider component="div" />
                 <Stack hasGutter>
-                    <StackItem className="pf-u-p-md">
-                        <Alert
-                            variant={simulator.error ? 'danger' : 'success'}
-                            isInline
-                            isPlain
-                            title={
-                                simulator.error
-                                    ? simulator.error
-                                    : `Policies generated from the baseline for cluster “${scopeHierarchy.cluster.name}”`
-                            }
-                        />
-                    </StackItem>
                     <StackItem isFilled style={{ overflow: 'auto' }}>
                         <NetworkPoliciesYAML
                             yaml={generatedYaml}
@@ -373,17 +374,19 @@ function NetworkPolicySimulatorSidePanel({
     return (
         <Stack>
             <StackItem>
-                <Flex direction={{ default: 'row' }} className="pf-u-p-lg pf-u-mb-0">
-                    <FlexItem>
-                        <TextContent>
-                            <Text
-                                component={TextVariants.h2}
-                                className="pf-u-font-size-xl pf-u-mr-xl"
-                            >
-                                Simulate network policy for cluster “{scopeHierarchy.cluster.name}”
-                            </Text>
-                        </TextContent>
-                    </FlexItem>
+                <Flex
+                    direction={{ default: 'column' }}
+                    spaceItems={{ default: 'spaceItemsSm' }}
+                    className="pf-u-p-md pf-u-pb-sm pf-u-mb-0"
+                >
+                    <TextContent>
+                        <Text component={TextVariants.h2} className="pf-u-font-size-xl pf-u-mr-2xl">
+                            Generate network policies from the baselines of
+                        </Text>
+                    </TextContent>
+                    <NetworkPoliciesGenerationScope
+                        networkPolicyGenerationScope={networkPolicyGenerationScope}
+                    />
                 </Flex>
             </StackItem>
             <StackItem>
@@ -416,7 +419,7 @@ function NetworkPolicySimulatorSidePanel({
                                                 component={TextVariants.h2}
                                                 className="pf-u-font-size-lg"
                                             >
-                                                Generate network policies based on the baseline
+                                                Generate network policies from the baseline
                                                 <Popover
                                                     showClose={false}
                                                     bodyContent={
@@ -460,7 +463,9 @@ function NetworkPolicySimulatorSidePanel({
                                                 Generate a set of recommended network policies based
                                                 on your cluster baseline. Cluster baseline is the
                                                 aggregation of the baselines of the deployments that
-                                                belong to the cluster.
+                                                belong to the cluster. Only deployments that are
+                                                part of the current scope will be included in
+                                                generated policies.
                                             </Text>
                                         </TextContent>
                                     </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
@@ -57,9 +57,10 @@ export function getInScopeEntities(
 ): EntityScope {
     const granularity = getGranularityFromScopeHierarchy(scopeHierarchy);
 
-    // A cluster, at least one namespace, and at least one deployment is selected. We
-    // include all deployments from the model that match a selected namespace and
-    // selected deployment name from the scope hierarchy.
+    // Include all deployments from the model that match a selected namespace and
+    // selected deployment name from the scope hierarchy. This prevents the inclusion
+    // of namespaces and deployments that are visible due to active connections between nodes
+    // and not due to the user's selection.
     const namespaceNameSet = new Set(scopeHierarchy.namespaces);
     const deploymentNameSet = new Set(scopeHierarchy.deployments);
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
@@ -1,4 +1,7 @@
 import { NetworkPolicyModification } from 'types/networkPolicy.proto';
+import { EntityScope } from '../simulation/NetworkPoliciesGenerationScope';
+import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
+import { CustomNodeModel } from '../types/topology.type';
 
 export function getDisplayYAMLFromNetworkPolicyModification(
     modification: NetworkPolicyModification | null
@@ -26,4 +29,61 @@ export function getDisplayYAMLFromNetworkPolicyModification(
     }
 
     return displayYaml;
+}
+
+function getGranularityFromScopeHierarchy(
+    scopeHierarchy: NetworkScopeHierarchy
+): EntityScope['granularity'] {
+    if (scopeHierarchy.namespaces.length === 0 && scopeHierarchy.deployments.length === 0) {
+        // Only a cluster is selected
+        return 'CLUSTER';
+    }
+    if (scopeHierarchy.namespaces.length > 0 && scopeHierarchy.deployments.length === 0) {
+        // A cluster and at least one namespace is selected
+        return 'NAMESPACE';
+    }
+    // A cluster, at least one namespace, and at least one deployment is selected
+    return 'DEPLOYMENT';
+}
+
+/**
+ * Given the array of nodeModels returned by the network graph API and the user's
+ * current scope hierarchy, return the scope of entities that should be included
+ * in the network policy simulation.
+ */
+export function getInScopeEntities(
+    nodeModels: CustomNodeModel[],
+    scopeHierarchy: NetworkScopeHierarchy
+): EntityScope {
+    const granularity = getGranularityFromScopeHierarchy(scopeHierarchy);
+
+    // A cluster, at least one namespace, and at least one deployment is selected. We
+    // include all deployments from the model that match a selected namespace and
+    // selected deployment name from the scope hierarchy.
+    const namespaceNameSet = new Set(scopeHierarchy.namespaces);
+    const deploymentNameSet = new Set(scopeHierarchy.deployments);
+
+    const deploymentScope: EntityScope = {
+        granularity,
+        cluster: scopeHierarchy.cluster.name,
+        namespaces: scopeHierarchy.namespaces,
+        deployments: [],
+    };
+
+    nodeModels.forEach((node) => {
+        if (node.data.type !== 'DEPLOYMENT') {
+            return;
+        }
+
+        const inSelectedNamespaces = namespaceNameSet.has(node.data.deployment.namespace);
+        const inSelectedDeployments = deploymentNameSet.has(node.data.deployment.name);
+        if (
+            (granularity === 'NAMESPACE' && inSelectedNamespaces) ||
+            (granularity === 'DEPLOYMENT' && inSelectedNamespaces && inSelectedDeployments)
+        ) {
+            deploymentScope.deployments.push(node.data.deployment);
+        }
+    });
+
+    return deploymentScope;
 }


### PR DESCRIPTION
## Description

Shows the current scope of selected deployments/namespaces/cluster in the network simulator side panel in order to give users a clear idea of what entities will be used to generated the network policies.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Open the network simulator panel, and verify the displayed text against the selected scope and the data in the graph.

One namespace selected:
![image](https://github.com/stackrox/stackrox/assets/1292638/415d2b1b-142a-4380-86e1-c00880d0eea4)

Two namespaces selected:
![image](https://github.com/stackrox/stackrox/assets/1292638/ae004e12-9b45-400a-9618-1e484d54226d)

Multiple namespaces selected, multiple deployments selected from **one** of those namespaces:
![image](https://github.com/stackrox/stackrox/assets/1292638/5a030ab1-d97a-4526-82b1-da5c260e5d64)

Multiple namespaces selected with deployments selected from each:
![image](https://github.com/stackrox/stackrox/assets/1292638/25b75804-9890-4dbb-b4cd-fb2f0304e37a)

The scope view is also visible after policies have been generated:
![image](https://github.com/stackrox/stackrox/assets/1292638/75e51a0e-3585-496b-9ef2-7f91e48f81b2)
