### PR TITLE
chore(ui): Delete unused export variables in routePaths

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReports.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReports.tsx
@@ -1,9 +1,11 @@
 import React, { ReactElement } from 'react';
 import { Route, Switch } from 'react-router-dom';
 
-import { vulnManagementReportsPath, vulnManagementReportsPathWithParam } from 'routePaths';
+import { vulnManagementReportsPath } from 'routePaths';
 import VulnMgmtReportsBasePage from './VulnMgmtReportsBasePage';
 import VulnMgmtReportSinglePage from './VulnMgmtReportSinglePage';
+
+export const vulnManagementReportsPathWithParam = `${vulnManagementReportsPath}/:reportId`;
 
 function VulnMgmtReports(): ReactElement {
     return (

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/PendingApprovalPopover.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ObservedCVEs/PendingApprovalPopover.tsx
@@ -3,7 +3,8 @@ import React, { ReactElement } from 'react';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 
 import { getQueryString } from 'utils/queryStringUtils';
-import { vulnManagementPendingApprovalsPath } from 'routePaths';
+
+import { vulnManagementPendingApprovalsPath } from '../pathsForRiskAcceptance';
 
 type PendingApprovalPopoverProps = {
     vulnRequestId: string;

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/RiskAcceptancePage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/RiskAcceptancePage.tsx
@@ -14,16 +14,16 @@ import {
 } from '@patternfly/react-core';
 import { Switch, Route, useHistory, useLocation, Redirect } from 'react-router-dom';
 
-import {
-    dashboardPath,
-    vulnManagementApprovedDeferralsPath,
-    vulnManagementApprovedFalsePositivesPath,
-    vulnManagementPath,
-    vulnManagementPendingApprovalsPath,
-} from 'routePaths';
+import { dashboardPath, vulnManagementPath } from 'routePaths';
 import usePermissions from 'hooks/usePermissions';
 import NotFoundMessage from 'Components/NotFoundMessage';
 import PageTitle from 'Components/PageTitle';
+
+import {
+    vulnManagementApprovedDeferralsPath,
+    vulnManagementApprovedFalsePositivesPath,
+    vulnManagementPendingApprovalsPath,
+} from './pathsForRiskAcceptance';
 import PendingApprovals from './PendingApprovals';
 import ApprovedDeferrals from './ApprovedDeferrals';
 import ApprovedFalsePositives from './ApprovedFalsePositives';

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/pathsForRiskAcceptance.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/pathsForRiskAcceptance.ts
@@ -1,0 +1,5 @@
+import { vulnManagementRiskAcceptancePath } from 'routePaths';
+
+export const vulnManagementPendingApprovalsPath = `${vulnManagementRiskAcceptancePath}/pending-approvals`;
+export const vulnManagementApprovedDeferralsPath = `${vulnManagementRiskAcceptancePath}/approved-deferrals`;
+export const vulnManagementApprovedFalsePositivesPath = `${vulnManagementRiskAcceptancePath}/approved-false-positives`;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -21,7 +21,7 @@ import {
 } from '@patternfly/react-core';
 import { CaretDownIcon, DownloadIcon, HistoryIcon, HomeIcon } from '@patternfly/react-icons';
 
-import { vulnerabilityReportPath, vulnerabilityReportsPath } from 'routePaths';
+import { vulnerabilityReportsPath } from 'routePaths';
 import { getReportFormValuesFromConfiguration } from 'Containers/Vulnerabilities/VulnerablityReporting/utils';
 import useFetchReport from 'Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReport';
 import useDeleteModal from 'Containers/Vulnerabilities/VulnerablityReporting/hooks/useDeleteModal';
@@ -29,6 +29,8 @@ import useDeleteModal from 'Containers/Vulnerabilities/VulnerablityReporting/hoo
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import NotFoundMessage from 'Components/NotFoundMessage/NotFoundMessage';
+
+import { vulnerabilityReportPath } from '../pathsForVulnerabilityReporting';
 import DeleteReportModal from '../components/DeleteReportModal';
 import ReportParametersDetails from '../components/ReportParametersDetails';
 import DeliveryDestinationsDetails from '../components/DeliveryDestinationsDetails';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -3,13 +3,15 @@ import { Route, Switch, Redirect } from 'react-router-dom';
 
 import usePageAction from 'Containers/Vulnerabilities/VulnerablityReporting/hooks/usePageAction';
 import usePermissions from 'hooks/usePermissions';
-import { vulnerabilityReportPath, vulnerabilityReportsPath } from 'routePaths';
+import { vulnerabilityReportsPath } from 'routePaths';
 
 import VulnReportsPage from './VulnReports/VulnReportsPage';
 import CreateVulnReportPage from './ModifyVulnReport/CreateVulnReportPage';
 import EditVulnReportPage from './ModifyVulnReport/EditVulnReportPage';
 import CloneVulnReportPage from './ModifyVulnReport/CloneVulnReportPage';
 import ViewVulnReportPage from './ViewVulnReport/ViewVulnReportPage';
+
+import { vulnerabilityReportPath } from './pathsForVulnerabilityReporting';
 
 import './VulnReportingPage.css';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -22,10 +22,12 @@ import { ExclamationCircleIcon, FileIcon } from '@patternfly/react-icons';
 
 import useFetchReports from 'Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReports';
 import usePermissions from 'hooks/usePermissions';
-import { vulnerabilityReportPath, vulnerabilityReportsPath } from 'routePaths';
+import { vulnerabilityReportsPath } from 'routePaths';
 
 import PageTitle from 'Components/PageTitle';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate/EmptyStateTemplate';
+
+import { vulnerabilityReportPath } from '../pathsForVulnerabilityReporting';
 import HelpIconTh from './HelpIconTh';
 import LastRunStatusState from './LastRunStatusState';
 import LastRunState from './LastRunState';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting.ts
@@ -1,0 +1,3 @@
+import { vulnerabilityReportsPath } from 'routePaths';
+
+export const vulnerabilityReportPath = `${vulnerabilityReportsPath}/:reportId`;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -5,19 +5,17 @@ import { Alert, PageSection } from '@patternfly/react-core';
 import PageNotFound from 'Components/PageNotFound';
 import PageTitle from 'Components/PageTitle';
 
-import {
-    vulnManagementPath,
-    vulnerabilitiesWorkloadCveDeploymentSinglePath,
-    vulnerabilitiesWorkloadCveImageSinglePath,
-    vulnerabilitiesWorkloadCveSinglePath,
-    vulnerabilitiesWorkloadCvesPath,
-} from 'routePaths';
+import { vulnManagementPath, vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import DeploymentPage from './Deployment/DeploymentPage';
 import ImagePage from './Image/ImagePage';
 import WorkloadCvesOverviewPage from './Overview/WorkloadCvesOverviewPage';
 import ImageCvePage from './ImageCve/ImageCvePage';
 
 import './WorkloadCvesPage.css';
+
+const vulnerabilitiesWorkloadCveSinglePath = `${vulnerabilitiesWorkloadCvesPath}/cves/:cveId`;
+const vulnerabilitiesWorkloadCveImageSinglePath = `${vulnerabilitiesWorkloadCvesPath}/images/:imageId`;
+const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesWorkloadCvesPath}/deployments/:deploymentId`;
 
 function WorkloadCvesPage() {
     return (

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -61,51 +61,17 @@ export const vulnerabilitiesBasePath = `${mainPath}/vulnerabilities`;
 export const vulnerabilitiesWorkloadCvesPath = `${vulnerabilitiesBasePath}/workload-cves`;
 export const vulnerabilityReportsPath = `${vulnerabilitiesBasePath}/reports`;
 
-// Configuration Management
+// Configuration Management paths for links from Search:
 
-export const configManagementClustersPath = `${configManagementPath}/clusters`;
-export const configManagementControlsPath = `${configManagementPath}/controls`;
-export const configManagementDeploymentsPath = `${configManagementPath}/deployments`;
-export const configManagementImagesPath = `${configManagementPath}/images`;
-export const configManagementNamespacesPath = `${configManagementPath}/namespaces`;
-export const configManagementNodesPath = `${configManagementPath}/nodes`;
-export const configManagementPoliciesPath = `${configManagementPath}/policies`;
 export const configManagementRolesPath = `${configManagementPath}/roles`;
 export const configManagementSecretsPath = `${configManagementPath}/secrets`;
 export const configManagementServiceAccountsPath = `${configManagementPath}/serviceaccounts`;
-export const configManagementSubjectsPath = `${configManagementPath}/subjects`;
 
-// Vuln Management Paths
+// Vulnerability Management 1.0 paths for links from Dashboard or Search:
 
-export const vulnManagementPoliciesPath = `${vulnManagementPath}/policies`;
-export const vulnManagementCVEsPath = `${vulnManagementPath}/cves`;
-export const vulnManagementImageCVEsPath = `${vulnManagementPath}/image-cves`;
-export const vulnManagementNodeCVEsPath = `${vulnManagementPath}/node-cves`;
-export const vulnManagementPlatformCVEsPath = `${vulnManagementPath}/cluster-cves`;
-export const vulnManagementClustersPath = `${vulnManagementPath}/clusters`;
-export const vulnManagementNamespacesPath = `${vulnManagementPath}/namespaces`;
-export const vulnManagementDeploymentsPath = `${vulnManagementPath}/deployments`;
 export const vulnManagementImagesPath = `${vulnManagementPath}/images`;
-// TODO: Remove the /components path once we completely split the components into node and image components
-export const vulnManagementComponentsPath = `${vulnManagementPath}/components`;
-export const vulnManagementNodeComponentsPath = `${vulnManagementPath}/node-components`;
-export const vulnManagementImageComponentsPath = `${vulnManagementPath}/image-components`;
+export const vulnManagementNamespacesPath = `${vulnManagementPath}/namespaces`;
 export const vulnManagementNodesPath = `${vulnManagementPath}/nodes`;
-
-// The following paths are not part of the infinite nesting Workflow in Vuln Management
-export const vulnManagementReportsPathWithParam = `${vulnManagementPath}/reports/:reportId`;
-
-export const vulnManagementPendingApprovalsPath = `${vulnManagementRiskAcceptancePath}/pending-approvals`;
-export const vulnManagementApprovedDeferralsPath = `${vulnManagementRiskAcceptancePath}/approved-deferrals`;
-export const vulnManagementApprovedFalsePositivesPath = `${vulnManagementRiskAcceptancePath}/approved-false-positives`;
-
-// VM 2.0 "Vulnerabilities" paths
-
-export const vulnerabilitiesWorkloadCveSinglePath = `${vulnerabilitiesBasePath}/workload-cves/cves/:cveId`;
-export const vulnerabilitiesWorkloadCveImageSinglePath = `${vulnerabilitiesBasePath}/workload-cves/images/:imageId`;
-export const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesBasePath}/workload-cves/deployments/:deploymentId`;
-
-export const vulnerabilityReportPath = `${vulnerabilitiesBasePath}/reports/:reportId`;
 
 // Source of truth for conditional rendering of Body route paths and NavigationSidebar links.
 
@@ -236,12 +202,12 @@ export const urlEntityListTypes = {
     [resourceTypes.DEPLOYMENT]: 'deployments',
     [resourceTypes.IMAGE]: 'images',
     [resourceTypes.SECRET]: 'secrets',
-    [resourceTypes.POLICY]: 'policies',
-    [resourceTypes.CVE]: 'cves',
+    [resourceTypes.POLICY]: 'policies', // TODO verify if used for Configuration Management
+    [resourceTypes.CVE]: 'cves', // TODO verify obsolete because non-postgres
     [resourceTypes.IMAGE_CVE]: 'image-cves',
     [resourceTypes.NODE_CVE]: 'node-cves',
     [resourceTypes.CLUSTER_CVE]: 'cluster-cves',
-    [resourceTypes.COMPONENT]: 'components',
+    [resourceTypes.COMPONENT]: 'components', // TODO verify obsolete because non-postgres
     [resourceTypes.NODE_COMPONENT]: 'node-components',
     [resourceTypes.IMAGE_COMPONENT]: 'image-components',
     [standardEntityTypes.CONTROL]: 'controls',
@@ -257,12 +223,12 @@ export const urlEntityTypes = {
     [resourceTypes.DEPLOYMENT]: 'deployment',
     [resourceTypes.IMAGE]: 'image',
     [resourceTypes.SECRET]: 'secret',
-    [resourceTypes.POLICY]: 'policy',
-    [resourceTypes.CVE]: 'cve',
+    [resourceTypes.POLICY]: 'policy', // TODO verify if used for Configuration Management
+    [resourceTypes.CVE]: 'cve', // TODO verify obsolete because non-postgres
     [resourceTypes.IMAGE_CVE]: 'image-cve',
     [resourceTypes.NODE_CVE]: 'node-cve',
     [resourceTypes.CLUSTER_CVE]: 'cluster-cve',
-    [resourceTypes.COMPONENT]: 'component',
+    [resourceTypes.COMPONENT]: 'component', // TODO verify obsolete because non-postgres
     [resourceTypes.NODE_COMPONENT]: 'node-component',
     [resourceTypes.IMAGE_COMPONENT]: 'image-component',
     [standardEntityTypes.CONTROL]: 'control',


### PR DESCRIPTION
## Description

Follow up comment by Dave https://github.com/stackrox/stackrox/pull/7128#pullrequestreview-1549738696

> Are the paths here and below that were not moved into the alphabetized list ones that are used only for routing inside the Container level? If so, I think it would be helpful noting that in comments that split the two sections so that new top level routes are sure to be added to the list above.

Set an example to **minimize** sub-route paths at global scope: only for inter-container links.

1. Delete obsolete.
2. Add to comments which containers import paths for links.
3. Move sub-route paths into containers.
    Forgive the somewhat verbose names, but even after all these years, my eyes sometimes rebel as camelCase for proper nouns like riskAcceptancePaths
4. Write `TODO` comments to verify properties in entity type to path segment maps.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

No change from unused, but slight change from move into containers.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: -354 = 3758208 - 3758562
        total: 22 = 9908521 - 9908499
    * `ls -al build/static/js/*.js | wc -l`
        0 = 80 - 80 files