### PR TITLE
ROX-18467: Show scoped deployments in network policy simulator modal

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Button, Modal } from '@patternfly/react-core';
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import orderBy from 'lodash/orderBy';
+
+import useTableSort from 'hooks/patternfly/useTableSort';
+
+export type DeploymentScopeModalProps = {
+    deployments: {
+        namespace: string;
+        name: string;
+    }[];
+    isOpen: boolean;
+    onClose: () => void;
+};
+
+const sortFields = ['name', 'namespace'];
+const defaultSortOption = { field: 'name', direction: 'asc' } as const;
+
+function DeploymentScopeModal({ deployments, isOpen, onClose }: DeploymentScopeModalProps) {
+    const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
+
+    const sortedDeployments = orderBy(
+        deployments,
+        sortOption.field,
+        sortOption.reversed ? 'desc' : 'asc'
+    );
+
+    return (
+        <Modal
+            isOpen={isOpen}
+            title="Selected deployment scope"
+            variant="small"
+            onClose={onClose}
+            actions={[
+                <Button key="close" onClick={onClose}>
+                    Close
+                </Button>,
+            ]}
+        >
+            <TableComposable variant="compact">
+                <Thead noWrap>
+                    <Tr>
+                        <Th width={50} sort={getSortParams('name')}>
+                            Deployment
+                        </Th>
+                        <Th width={50} sort={getSortParams('namespace')}>
+                            Namespace
+                        </Th>
+                    </Tr>
+                </Thead>
+                <Tbody>
+                    {sortedDeployments.map(({ name, namespace }) => (
+                        <Tr key={`${namespace}/${name}`}>
+                            <Td dataLabel="Deployment">{name}</Td>
+                            <Td dataLabel="Namespace">{namespace}</Td>
+                        </Tr>
+                    ))}
+                </Tbody>
+            </TableComposable>
+        </Modal>
+    );
+}
+
+export default DeploymentScopeModal;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
@@ -44,15 +44,13 @@ function NetworkPoliciesGenerationScope({
             deploymentCount === 1 ? deployments[0].name : `${deploymentCount} deployments`;
 
         deploymentElement = (
-            <span>
-                <Button
-                    variant="link"
-                    isInline
-                    onClick={() => setModalDeployments(networkPolicyGenerationScope.deployments)}
-                >
-                    {deploymentText}
-                </Button>
-            </span>
+            <Button
+                variant="link"
+                isInline
+                onClick={() => setModalDeployments(networkPolicyGenerationScope.deployments)}
+            >
+                {deploymentText}
+            </Button>
         );
     }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Flex } from '@patternfly/react-core';
+import { Button, Flex } from '@patternfly/react-core';
 import uniq from 'lodash/uniq';
 
 import { ClusterIcon, DeploymentIcon, NamespaceIcon } from '../common/NetworkGraphIcons';
 
 import './NetworkPoliciesGenerationScope.css';
+import DeploymentScopeModal from './DeploymentScopeModal';
 
 export type EntityScope = {
     // `granularity` refers to the most specific entity type that has been selected by the user.
@@ -25,51 +26,71 @@ function NetworkPoliciesGenerationScope({
     networkPolicyGenerationScope,
 }: NetworkPoliciesGenerationScopeProps) {
     const { granularity, cluster, deployments } = networkPolicyGenerationScope;
+    const [modalDeployments, setModalDeployments] = React.useState<
+        { namespace: string; name: string }[] | null
+    >(null);
 
     let deploymentElement = <span>All deployments</span>;
     let namespaceElement = <span>All namespaces</span>;
 
-    if (granularity === 'NAMESPACE' || granularity === 'DEPLOYMENT') {
+    if (granularity !== 'CLUSTER') {
         const namespaces = uniq(deployments.map((deployment) => deployment.namespace));
         const namespaceCount = namespaces.length;
         const namespaceText = namespaceCount === 1 ? namespaces[0] : `${namespaceCount} namespaces`;
         namespaceElement = <span>{namespaceText}</span>;
-    }
 
-    if (granularity === 'DEPLOYMENT') {
         const deploymentCount = deployments.length;
         const deploymentText =
             deploymentCount === 1 ? deployments[0].name : `${deploymentCount} deployments`;
 
-        deploymentElement = <span>{deploymentText}</span>;
+        deploymentElement = (
+            <span>
+                <Button
+                    variant="link"
+                    isInline
+                    onClick={() => setModalDeployments(networkPolicyGenerationScope.deployments)}
+                >
+                    {deploymentText}
+                </Button>
+            </span>
+        );
     }
 
     return (
-        <div className="network-policies-generation-scope">
-            <Flex
-                alignItems={{ default: 'alignItemsCenter' }}
-                spaceItems={{ default: 'spaceItemsSm' }}
-            >
-                <DeploymentIcon aria-label="Deployment" />
-                {deploymentElement}
-            </Flex>
+        <>
+            {modalDeployments && (
+                <DeploymentScopeModal
+                    deployments={modalDeployments}
+                    isOpen={modalDeployments !== null}
+                    onClose={() => setModalDeployments(null)}
+                />
+            )}
+            <div className="network-policies-generation-scope">
+                <Flex
+                    alignItems={{ default: 'alignItemsCenter' }}
+                    spaceItems={{ default: 'spaceItemsSm' }}
+                >
+                    <DeploymentIcon aria-label="Deployment" />
+                    {deploymentElement}
+                </Flex>
 
-            <Flex
-                alignItems={{ default: 'alignItemsCenter' }}
-                spaceItems={{ default: 'spaceItemsSm' }}
-            >
-                <NamespaceIcon aria-label="Namespace" />
-                {namespaceElement}
-            </Flex>
+                <Flex
+                    alignItems={{ default: 'alignItemsCenter' }}
+                    spaceItems={{ default: 'spaceItemsSm' }}
+                >
+                    <NamespaceIcon aria-label="Namespace" />
+                    {namespaceElement}
+                </Flex>
 
-            <Flex
-                alignItems={{ default: 'alignItemsCenter' }}
-                spaceItems={{ default: 'spaceItemsSm' }}
-            >
-                <ClusterIcon aria-label="Cluster" />
-                <span>{cluster}</span>
-            </Flex>
-        </div>
+                <Flex
+                    alignItems={{ default: 'alignItemsCenter' }}
+                    spaceItems={{ default: 'spaceItemsSm' }}
+                >
+                    <ClusterIcon aria-label="Cluster" />
+                    <span>{cluster}</span>
+                </Flex>
+            </div>
+        </>
     );
 }
 


### PR DESCRIPTION
## Description

Makes the deployment section of the NG simulator sidebar scope clickable.

Clicking on this element opens a modal with a preview of all the deployments in the selected scope.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Select namespace and/or deployments and open the network policy simulator sidebar:
![image](https://github.com/stackrox/stackrox/assets/1292638/789b3ff0-9b9b-4da4-9d10-be4415cfedf5)

Click the deployment link to open the modal of currently selected deployments:
![image](https://github.com/stackrox/stackrox/assets/1292638/59b7be9f-f34e-4ad5-8fa5-50363515aa3a)

Sort by deployment or namespace:
![image](https://github.com/stackrox/stackrox/assets/1292638/c2073afe-fc80-4e86-9da6-e6c6797c55d8)
![image](https://github.com/stackrox/stackrox/assets/1292638/8961f51a-f4b9-4537-980c-d9009b024184)
![image](https://github.com/stackrox/stackrox/assets/1292638/802fbef4-52e2-40e5-b5c9-0d3d5dddac9b)

