### PR TITLE
ROX-16267: Clarify token's provenance

### DIFF
--- a/pkg/grpc/authn/tokenbased/extractor.go
+++ b/pkg/grpc/authn/tokenbased/extractor.go
@@ -115,6 +115,7 @@ func (e *extractor) withRoleNames(ctx context.Context, token *tokens.TokenInfo, 
 		authProvider:  authProvider,
 	}
 	if id.friendlyName == "" {
+		// Note we use roles as seen in the token, without filtering.
 		id.friendlyName = fmt.Sprintf("anonymous bearer token %q with roles [%s] (jti: %s, expires: %s)",
 			token.Name,
 			strings.Join(roleNames, ","),

--- a/pkg/grpc/authn/tokenbased/extractor.go
+++ b/pkg/grpc/authn/tokenbased/extractor.go
@@ -115,7 +115,11 @@ func (e *extractor) withRoleNames(ctx context.Context, token *tokens.TokenInfo, 
 		authProvider:  authProvider,
 	}
 	if id.friendlyName == "" {
-		id.friendlyName = fmt.Sprintf("anonymous bearer token with roles %s (expires %v)", strings.Join(roleNames, ","), token.Expiry())
+		id.friendlyName = fmt.Sprintf("anonymous bearer token %q with roles [%s] (jti: %s, expires: %s)",
+			token.Name,
+			strings.Join(roleNames, ","),
+			token.ID,
+			token.Expiry().Format(time.RFC3339))
 	}
 	return id, nil
 }


### PR DESCRIPTION
## Description

When a modifying operation is performed, [audit log captures user identity](https://github.com/stackrox/stackrox/blob/bcf64d26fa015b91731d2febaa0ae238951f8b23/central/audit/audit.go#L95) associated with the operation. In case anonymous API token is presented, the only identifiable information is [identity's `FriendlyName`](https://github.com/stackrox/stackrox/blob/a6c70b876d86872a0f32ac5f0bef43412866b4c4/pkg/grpc/authn/tokenbased/identity.go#L50-L57), which currently captures associated roles and token expiration.

This PR adds token ID (`jti`) and name to identity's `FriendlyName`. It also ensures expiration is printed in RFC3339 time format instead of debug string.

`FriendlyName` before: `anonymous bearer token with roles Admin,Continous Delivery (expires 2023-07-28 21:55:20.775166 +0200 CEST m=+0.000106390)`

`FriendlyName` after: `anonymous bearer token "alexr test token" with roles [Admin,Continous Delivery] (jti: 8955ec1f-8aef-4200-a4df-d4f919444ba7, expires: 2023-07-28T21:27:02+02:00)`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
  - I don't think we need to worry about backward compatibility of string fields in audit log messages
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
  - No need to document this either.

## Testing Performed

CI run. 