### PR TITLE
fix(ui): Fix accessibility issues for id and active tab in Compliance

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/Entity/Cluster.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Cluster.js
@@ -12,11 +12,12 @@ import ComplianceList from 'Containers/Compliance/List/List';
 import ComplianceByStandards from 'Containers/Compliance/widgets/ComplianceByStandards';
 import Loader from 'Components/Loader';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';
-import ResourceTabs from 'Components/ResourceTabs';
 import { entityPagePropTypes, entityPageDefaultProps } from 'constants/entityPageProps';
 import searchContext from 'Containers/searchContext';
 import isGQLLoading from 'utils/gqlLoading';
+
 import Header from './Header';
+import ResourceTabs from './ResourceTabs';
 
 function processData(data) {
     if (!data || !data.results) {

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Control.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Control.js
@@ -13,11 +13,12 @@ import useCases from 'constants/useCaseTypes';
 import ComplianceList from 'Containers/Compliance/List/List';
 import Loader from 'Components/Loader';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';
-import ResourceTabs from 'Components/ResourceTabs';
 import PageNotFound from 'Components/PageNotFound';
 import searchContext from 'Containers/searchContext';
 import isGQLLoading from 'utils/gqlLoading';
+
 import Header from './Header';
+import ResourceTabs from './ResourceTabs';
 
 const ControlPage = ({
     entityId,

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.js
@@ -10,7 +10,6 @@ import Loader from 'Components/Loader';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import { entityPagePropTypes, entityPageDefaultProps } from 'constants/entityPageProps';
 import URLService from 'utils/URLService';
-import ResourceTabs from 'Components/ResourceTabs';
 // TODO: this exception will be unnecessary once Compliance pages are re-structured like Config Management
 /* eslint-disable-next-line import/no-cycle */
 import ComplianceList from 'Containers/Compliance/List/List';
@@ -24,6 +23,7 @@ import isGQLLoading from 'utils/gqlLoading';
 import searchContext from 'Containers/searchContext';
 
 import Header from './Header';
+import ResourceTabs from './ResourceTabs';
 
 function processData(data) {
     if (!data || !data.deployment) {

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.js
@@ -11,7 +11,6 @@ import Widget from 'Components/Widget';
 // TODO: this exception will be unnecessary once Compliance pages are re-structured like Config Management
 /* eslint-disable-next-line import/no-cycle */
 import ComplianceList from 'Containers/Compliance/List/List';
-import ResourceTabs from 'Components/ResourceTabs';
 import ResourceCount from 'Containers/Compliance/widgets/ResourceCount';
 import PageNotFound from 'Components/PageNotFound';
 import isGQLLoading from 'utils/gqlLoading';
@@ -23,7 +22,9 @@ import entityTypes from 'constants/entityTypes';
 import useCases from 'constants/useCaseTypes';
 import { entityPagePropTypes, entityPageDefaultProps } from 'constants/entityPageProps';
 import searchContext from 'Containers/searchContext';
+
 import Header from './Header';
+import ResourceTabs from './ResourceTabs';
 
 function processData(data, entityId) {
     const defaultValue = {

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Node.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Node.js
@@ -17,7 +17,6 @@ import Labels from 'Containers/Compliance/widgets/Labels';
 import EntityCompliance from 'Containers/Compliance/widgets/EntityCompliance';
 import Loader from 'Components/Loader';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';
-import ResourceTabs from 'Components/ResourceTabs';
 // TODO: this exception will be unnecessary once Compliance pages are re-structured like Config Management
 /* eslint-disable-next-line import/no-cycle */
 import ComplianceList from 'Containers/Compliance/List/List';
@@ -26,7 +25,9 @@ import { entityPagePropTypes, entityPageDefaultProps } from 'constants/entityPag
 import useCases from 'constants/useCaseTypes';
 import isGQLLoading from 'utils/gqlLoading';
 import searchContext from 'Containers/searchContext';
+
 import Header from './Header';
+import ResourceTabs from './ResourceTabs';
 
 function processData(data) {
     if (!data || !data.node) {

--- a/ui/apps/platform/src/Containers/Compliance/Entity/ResourceTabs.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/ResourceTabs.js
@@ -59,26 +59,19 @@ const ResourceTabs = ({ entityType, entityId, resourceTabs, selectedType, match,
                 }
                 const tabData = processData(data);
                 return (
-                    <ul className="border-b border-base-400 bg-base-200 pl-3">
+                    <ul className="border-b border-base-400 bg-base-100 pl-3">
                         {tabData.map((datum, i) => {
                             const borderLeft = !i ? 'border-l' : '';
-                            let bgColor = 'bg-base-200';
-                            let textColor = 'text-base-600';
-                            const style = {
-                                borderColor: 'hsla(225, 44%, 87%, 1)',
-                            };
-                            if (datum.type === selectedType || (!selectedType && !datum.type)) {
-                                bgColor = 'bg-base-100';
-                                textColor = 'text-primary-600';
-                                style.borderTopColor = 'hsla(225, 90%, 67%, 1)';
-                                style.borderTopWidth = '1px';
-                            }
+                            const bgColor =
+                                datum.type === selectedType || (!selectedType && !datum.type)
+                                    ? 'bg-primary-200'
+                                    : 'bg-base-100';
+                            const textColor = 'text-base-600';
 
                             return (
                                 <li key={datum.title} className="inline-block">
                                     <Link
-                                        style={style}
-                                        className={`no-underline ${textColor} ${borderLeft} ${bgColor} border-r min-w-32 px-3 text-center pt-3 pb-3 font-700 inline-block`}
+                                        className={`no-underline ${textColor} ${borderLeft} ${bgColor} border-r border-base-400 min-w-32 px-3 text-center pt-3 pb-3 font-700 inline-block`}
                                         to={datum.link}
                                     >
                                         {datum.title}

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandard.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandard.js
@@ -14,43 +14,25 @@ import {
     CRITICAL_SEVERITY_COLOR,
     IMPORTANT_HIGH_SEVERITY_COLOR,
     MODERATE_MEDIUM_SEVERITY_COLOR,
+    noViolationsColor,
 } from 'constants/visuals/colors';
 import { COMPLIANCE_STANDARDS } from 'queries/standard';
 import queryService from 'utils/queryService';
 import searchContext from 'Containers/searchContext';
 import isGQLLoading from 'utils/gqlLoading';
 
-const passColor = COMPLIANCE_PASS_COLOR;
-const warningColor = MODERATE_MEDIUM_SEVERITY_COLOR;
-const cautionColor = IMPORTANT_HIGH_SEVERITY_COLOR;
-const skippedColor = 'var(--base-400)'; // same as NAColor in ComplianceByControls
-const alertColor = CRITICAL_SEVERITY_COLOR;
+import { getColor } from './colorsForCompliance';
 
 const linkColor = 'var(--base-600)';
 const textColor = 'var(--base-600)';
 
-const getColor = (value) => {
-    if (value === 100) {
-        return passColor;
-    }
-    if (value >= 70) {
-        return warningColor;
-    }
-    if (value >= 50) {
-        return cautionColor;
-    }
-    if (Number.isNaN(value)) {
-        return skippedColor;
-    }
-    return alertColor;
-};
-
+// Consistent with getColor helper function.
 const sunburstLegendData = [
-    { title: '100%', color: passColor },
-    { title: '> 70%', color: warningColor },
-    { title: '> 50%', color: cautionColor },
-    { title: '< 50%', color: alertColor },
-    { title: 'Skipped', color: skippedColor },
+    { title: '100%', color: COMPLIANCE_PASS_COLOR },
+    { title: '> 70%', color: MODERATE_MEDIUM_SEVERITY_COLOR },
+    { title: '> 50%', color: IMPORTANT_HIGH_SEVERITY_COLOR },
+    { title: '< 50%', color: CRITICAL_SEVERITY_COLOR },
+    { title: 'Skipped', color: noViolationsColor },
 ];
 
 const processSunburstData = (match, location, data, standard) => {

--- a/ui/apps/platform/src/Containers/Compliance/widgets/HorizontalBarChart.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/HorizontalBarChart.js
@@ -5,7 +5,6 @@ import {
     YAxis,
     VerticalGridLines,
     HorizontalBarSeries,
-    GradientDefs,
     LabelSeries,
 } from 'react-vis';
 import { withRouter, Link } from 'react-router-dom';
@@ -13,7 +12,7 @@ import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import merge from 'deepmerge';
 
-import BarGradient from 'Components/visuals/BarGradient';
+import { getColor } from './colorsForCompliance';
 
 const minimalMargin = { top: -15, bottom: 0, left: 0, right: 0 };
 
@@ -110,7 +109,6 @@ class HorizontalBarChart extends Component {
     getSeriesProps = () => {
         const { minimal } = this.props;
         const defaultSeriesProps = {
-            color: 'url(#horizontalGradient)',
             style: {
                 height: minimal ? 15 : 20,
                 rx: '2px',
@@ -158,36 +156,7 @@ class HorizontalBarChart extends Component {
 
         return (
             <div {...containerProps}>
-                {/* Bar Background  */}
-                <svg
-                    className="absolute"
-                    height="0"
-                    width="10"
-                    xmlns="http://www.w3.org/2000/svg"
-                    version="1.1"
-                >
-                    <defs>
-                        <pattern
-                            id="bar-background"
-                            patternUnits="userSpaceOnUse"
-                            width="6"
-                            height="6"
-                        >
-                            background-color: #ffffff;
-                            <image
-                                xlinkHref="data:image/svg+xml,%3Csvg width='6' height='6' viewBox='0 0 6 6' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23ccc9d2' fill-opacity='0.4' fill-rule='evenodd'%3E%3Cpath d='M5 0h1L0 6V5zM6 5v1H5z'/%3E%3C/g%3E%3C/svg%3E"
-                                x="0"
-                                y="0"
-                                width="6"
-                                height="6"
-                            />
-                        </pattern>
-                    </defs>
-                </svg>
                 <FlexibleWidthXYPlot {...plotProps}>
-                    <GradientDefs>
-                        <BarGradient />
-                    </GradientDefs>
                     {/* Empty area bar background */}
 
                     {!minimal && <VerticalGridLines tickValues={tickValues} />}
@@ -209,10 +178,9 @@ class HorizontalBarChart extends Component {
                             y: item.y,
                             link: item.link,
                         }))}
+                        color="var(--pf-global--palette--black-200)"
                         style={{
                             height: seriesProps.style.height,
-                            stroke: 'var(--base-300)',
-                            fill: `url(#bar-background)`,
                             rx: '2',
                             ry: '2',
                             cursor: `${minimal ? '' : 'pointer'}`,
@@ -221,14 +189,18 @@ class HorizontalBarChart extends Component {
                     />
 
                     {/* Values */}
-                    <HorizontalBarSeries data={sortedData} {...seriesProps} />
+                    <HorizontalBarSeries
+                        data={sortedData.map((item) => ({ ...item, color: getColor(item.x) }))}
+                        {...seriesProps}
+                        colorType="literal"
+                    />
                     <LabelSeries
                         data={this.getLabelData()}
                         className="text-xs pointer-events-none theme-light"
                         labelAnchorY="no-change"
                         labelAnchorX="end-alignment"
                         style={{
-                            fill: 'var(--primary-800)',
+                            fill: '#ffffff',
                             cursor: `${minimal ? '' : 'pointer'}`,
                         }}
                     />

--- a/ui/apps/platform/src/Containers/Compliance/widgets/colorsForCompliance.ts
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/colorsForCompliance.ts
@@ -1,0 +1,23 @@
+import {
+    COMPLIANCE_PASS_COLOR,
+    CRITICAL_SEVERITY_COLOR,
+    IMPORTANT_HIGH_SEVERITY_COLOR,
+    MODERATE_MEDIUM_SEVERITY_COLOR,
+    noViolationsColor,
+} from 'constants/visuals/colors';
+
+export function getColor(value: number) {
+    if (value === 100) {
+        return COMPLIANCE_PASS_COLOR;
+    }
+    if (value >= 70) {
+        return MODERATE_MEDIUM_SEVERITY_COLOR;
+    }
+    if (value >= 50) {
+        return IMPORTANT_HIGH_SEVERITY_COLOR;
+    }
+    if (Number.isNaN(value)) {
+        return noViolationsColor; // skipped
+    }
+    return CRITICAL_SEVERITY_COLOR;
+}


### PR DESCRIPTION
## Description

### Problems

1. Compliance dashboard with scan results: 2 minor issues

    > id value must be unique

    ```svg
    <pattern id="bar-background" patternUnits="userSpaceOnUse" width="6" height="6">
    ```

2. Compliance entity single page: 1 serious issue

    > Elements must meet minimum color contrast ratio thresholds

    > Element has insufficient color contrast of 2.28 (foreground color: #5fb2f7, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1

### Analysis and solutions

1. HorizontalBarChart defines `pattern` element with same `id` for each instance.

    Factor out `getColor` function for consistency with ComplianceByStandard sunburst graph.

2. Replace text color with background color for active tab as in grouped tabs (the corresponding tabs in Configuration Management and Vulnerability Management single pages)

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Components/GroupedTabs.js#L11

### Residue

1. Move 6 colors for **vertical** bar charts from global scope to container scope and replace classic with PatternFly.
2. Compliance entities list: 1 serious issue: Scrollable region must have keyboard access

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Decrease might include elements no longer imported from react-viz dependency.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3758562 - 3758562
        total: -790 = 9910768 - 9911558
    * `ls -al build/static/js/*.js | wc -l`
        0 = 80 - 80 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/compliance to see red, orange, yellow, blue bars similar to sunburst graphs.
    ![HorizontalBarChart](https://github.com/stackrox/stackrox/assets/11862657/aebd9a03-ff5e-48fa-99c0-ac88b24a77f6)

2. Visit /main/compliance/deployement, click **admission-control** to open side panel, click link to single page to see active **Overview** tab has blue **background** color instead of text color.
    ![single_tabs](https://github.com/stackrox/stackrox/assets/11862657/be5efe9a-e49b-4ab9-85e3-8c673e83c697)
