### PR TITLE
ROX-18274: add `rox_sensor_info` metric

### DIFF
--- a/sensor/common/clusterid/cluster_id.go
+++ b/sensor/common/clusterid/cluster_id.go
@@ -14,7 +14,7 @@ var (
 
 	once           sync.Once
 	clusterID      string
-	clusterIDMutex sync.Mutex
+	clusterIDMutex sync.RWMutex
 
 	clusterIDAvailable = concurrency.NewSignal()
 )
@@ -41,13 +41,13 @@ func Get() string {
 			clusterIDAvailable.Signal()
 		}
 	})
-	return clusterID
+	return GetNoWait()
 }
 
 // GetNoWait returns the cluster id without waiting until it is available.
 func GetNoWait() string {
-	clusterIDMutex.Lock()
-	defer clusterIDMutex.Unlock()
+	clusterIDMutex.RLock()
+	defer clusterIDMutex.RUnlock()
 	return clusterID
 }
 

--- a/sensor/common/clusterid/cluster_id.go
+++ b/sensor/common/clusterid/cluster_id.go
@@ -44,6 +44,13 @@ func Get() string {
 	return clusterID
 }
 
+// GetNoWait returns the cluster id without waiting until it is available.
+func GetNoWait() string {
+	clusterIDMutex.Lock()
+	defer clusterIDMutex.Unlock()
+	return clusterID
+}
+
 // Set sets the global cluster ID value.
 func Set(value string) {
 	effectiveClusterID, err := centralsensor.GetClusterID(value, clusterIDFromCert())

--- a/sensor/common/metrics/info.go
+++ b/sensor/common/metrics/info.go
@@ -1,0 +1,12 @@
+package metrics
+
+import (
+	"github.com/stackrox/rox/sensor/common/managedcentral"
+)
+
+func getHosting() string {
+	if managedcentral.IsCentralManaged() {
+		return "cloud-service"
+	}
+	return "self-managed"
+}

--- a/sensor/common/metrics/init.go
+++ b/sensor/common/metrics/init.go
@@ -24,5 +24,6 @@ func init() {
 		k8sObjectIngestionToSendDuration,
 		resolverChannelSize,
 		outputChannelSize,
+		info,
 	)
 }

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -1,9 +1,14 @@
 package metrics
 
 import (
+	"strconv"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/metrics"
+	"github.com/stackrox/rox/pkg/version"
+	"github.com/stackrox/rox/sensor/common/clusterid"
 )
 
 var (
@@ -142,6 +147,21 @@ var (
 		Name:      "output_channel_size",
 		Help:      "A gauge to track the output channel size",
 	})
+
+	info = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metrics.PrometheusNamespace,
+			Subsystem: metrics.SensorSubsystem.String(),
+			Name:      "info",
+			Help:      "A metric with a constant '1' value labeled by information identifying the Central installation",
+			ConstLabels: prometheus.Labels{
+				"sensor_version": version.GetMainVersion(),
+				"hosting":        getHosting(),
+				"install_method": env.InstallMethod.Setting(),
+			},
+		},
+		[]string{"central_id", "sensor_id", "secured_nodes", "secured_vcpu"},
+	)
 )
 
 // IncrementPanicCounter increments the number of panic calls seen in a function
@@ -240,4 +260,16 @@ func IncOutputChannelSize() {
 // DecOutputChannelSize decreases the outputChannel by 1
 func DecOutputChannelSize() {
 	outputChannelSize.Dec()
+}
+
+// SetInfoMetric sets the cluster metrics for the info metric.
+func SetInfoMetric(cm *central.ClusterMetrics) {
+	info.Reset()
+	info.WithLabelValues(
+		// TODO: Get central ID
+		"",
+		clusterid.GetNoWait(),
+		strconv.FormatInt(cm.GetNodeCount(), 10),
+		strconv.FormatInt(cm.GetCpuCapacity(), 10),
+	).Set(1)
 }

--- a/sensor/kubernetes/clustermetrics/cluster_metrics.go
+++ b/sensor/kubernetes/clustermetrics/cluster_metrics.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
+	metricsPkg "github.com/stackrox/rox/sensor/common/metrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -92,6 +93,7 @@ func (cm *clusterMetricsImpl) Poll() {
 
 func (cm *clusterMetricsImpl) runPipeline() {
 	if metrics, err := cm.collectMetrics(); err == nil {
+		metricsPkg.SetInfoMetric(metrics)
 		cm.output <- message.New(&central.MsgFromSensor{
 			Msg: &central.MsgFromSensor_ClusterMetrics{
 				ClusterMetrics: metrics,

--- a/sensor/kubernetes/clustermetrics/cluster_metrics.go
+++ b/sensor/kubernetes/clustermetrics/cluster_metrics.go
@@ -93,12 +93,12 @@ func (cm *clusterMetricsImpl) Poll() {
 
 func (cm *clusterMetricsImpl) runPipeline() {
 	if metrics, err := cm.collectMetrics(); err == nil {
-		metricsPkg.SetInfoMetric(metrics)
 		cm.output <- message.New(&central.MsgFromSensor{
 			Msg: &central.MsgFromSensor_ClusterMetrics{
 				ClusterMetrics: metrics,
 			},
 		})
+		metricsPkg.SetInfoMetric(metrics)
 	} else {
 		log.Errorf("Collection of cluster metrics failed: %v", err.Error())
 	}


### PR DESCRIPTION
## Description

Add a rox_central_info metric, which is intended as a metric series sent to OpenShift Telemeter for telemetry purposes. It captures some basic information about the Central installation:

* `sensor_id`: this is the ACS cluster ID. Note that `cluster_id` already has a meaning within OpenShift telemetry as the ID of the OpenShift cluster. The label is renamed to make it unambiguous.
* `central_id`: the ID of the connected Central
* `sensor_version`: ACS version (e.g. 4.2.0)
* `hosting`: self-managed or cloud-service
* `install_method`: manifest, helm or rhacs-operator. Implemented via an env var, which we will need to set up (TODO).
* `secured_nodes`, `secured_vcpu`: sum of all nodes
* `value`: this is always 1 for easier counting in PromQL queries

<img width="1380" alt="Screenshot 2023-07-31 at 01 11 58" src="https://github.com/stackrox/stackrox/assets/55607356/ad881feb-a460-415c-8368-48f16d7ba353">


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

See screenshot.
