### PR TITLE
ROX-18312: Mark GetAll as deprecated in GenericStore

### DIFF
--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -199,6 +199,8 @@ func (s *GenericStore[T, PT]) Walk(ctx context.Context, fn func(obj PT) error) e
 }
 
 // GetAll retrieves all objects from the store.
+//
+// Deprecated: This can be dangerous on high cardinality stores consider Walk instead.
 func (s *GenericStore[T, PT]) GetAll(ctx context.Context) ([]PT, error) {
 	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetAll)
 


### PR DESCRIPTION
## Description

`GetAll` is enabled only for certain stores and the option to enable it has following comment:
https://github.com/stackrox/stackrox/blob/286a94051140da4ef181478a61aed7ed11da339f/tools/generate-helpers/pg-table-bindings/main.go#L103-L104

To prevent usage outside of an interface that exposes this method only for [certain stores](https://github.com/search?q=repo%3Astackrox%2Fstackrox+--get-all-func&type=code) we will mark it as deprecated with a comment to prefer using `Walk` that could be more efficient if we need to just do some operation on all values but not need them all at once.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI