### PR TITLE
ROX-18276: Drop unneeded labels from telemeter metric

### DIFF
--- a/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
@@ -92,4 +92,37 @@ subjects:
     name: central
     namespace: "{{ .Release.Namespace }}"
 
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: "central-telemeter-{{ .Release.Namespace }}"
+  namespace: openshift-monitoring
+  labels:
+    {{- include "srox.labels" (list . "prometheusrule" (print "central-telemeter-" .Release.Namespace )) | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "prometheusrule" (print "central-telemeter-" .Release.Namespace )) | nindent 4 }}
+spec:
+  groups:
+    - name: rhacs.telemeter
+      rules:
+        - expr: |
+            max by (branding, build, central_id, central_version, hosting, install_method) (
+              rox_central_secured_clusters
+            )
+          record: rhacs:telemetry:rox_central_secured_clusters
+
+        - expr: |
+            max by (branding, build, central_id, central_version, hosting, install_method) (
+              rox_central_secured_nodes
+            )
+          record: rhacs:telemetry:rox_central_secured_nodes
+
+        - expr: |
+            max by (branding, build, central_id, central_version, hosting, install_method) (
+              rox_central_secured_vcpu
+            )
+          record: rhacs:telemetry:rox_central_secured_vcpu
+
 {{- end -}}

--- a/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
@@ -116,4 +116,31 @@ subjects:
     name: sensor
     namespace: "{{ .Release.Namespace }}"
 
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: "sensor-telemeter-{{ .Release.Namespace }}"
+  namespace: openshift-monitoring
+  labels:
+    {{- include "srox.labels" (list . "prometheusrule" (print "sensor-telemeter-" .Release.Namespace )) | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "prometheusrule" (print "sensor-telemeter-" .Release.Namespace )) | nindent 4 }}
+spec:
+  groups:
+    - name: rhacs.telemeter
+      rules:
+        - expr: |
+            max by (branding, build, central_id, hosting, install_method, sensor_id, sensor_version) (
+              rox_sensor_secured_nodes
+            )
+          record: rhacs:telemetry:rox_sensor_secured_nodes
+
+        - expr: |
+            max by (branding, build, central_id, hosting, install_method, sensor_id, sensor_version) (
+              rox_sensor_secured_vcpu
+            )
+          record: rhacs:telemetry:rox_sensor_secured_vcpu
+
 {{- end -}}


### PR DESCRIPTION
## Description

Deploy a recording rule for the Telemeter metric. This is just to remove some unnecessary labels to reduce the load for the Telemeter service.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
