### PR TITLE
ROX-18133: Add permission checks to listening endpoints route

### DIFF
--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -113,7 +113,7 @@ const routeDescriptionMap: Record<string, RouteDescription> = {
         resourceAccessRequirements: [],
     },
     [listeningEndpointsBasePath]: {
-        resourceAccessRequirements: [],
+        resourceAccessRequirements: ['Deployment', 'DeploymentExtension'],
     },
     [networkPath]: {
         resourceAccessRequirements: [],


### PR DESCRIPTION
## Description

As titled.

Required permissions are derived from the two endpoints this page hits, [here](https://github.com/stackrox/stackrox/blob/master/central/deployment/service/service_impl.go#L39) for Deployment and [here](https://github.com/stackrox/stackrox/blob/master/central/processlisteningonport/service/service_impl.go#L19) for DeploymentExtension.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manually set 'DeploymentExtension' to `NO_ACCESS` from a breakpoint in the UI. Do the same with `Deployment`.
- The route returns a 404 page
- The link is not visible in the lefthand navigation
<img width="1677" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/fdb83492-f536-42ea-b9c9-4a045c787edc">

Load the UI with a user that has permissions for both resources:
![image](https://github.com/stackrox/stackrox/assets/1292638/0c972c89-9d7f-4f38-83c7-6fde77a44b88)

