### PR TITLE
fix(ui): Don't render network graph when no namespace is selected

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -351,7 +351,8 @@ function NetworkGraphPage() {
                 {!hasClusterNamespaceSelected && <EmptyUnscopedState />}
                 {models.activeModel.nodes.length > 0 &&
                     models.extraneousModel.nodes.length > 0 &&
-                    !isLoading && (
+                    !isLoading &&
+                    hasClusterNamespaceSelected && (
                         <NetworkGraphContainer
                             models={models}
                             edgeState={edgeState}


### PR DESCRIPTION
## Description

Found an issue where if you select a namespace in the network graph, then clear the selection so that only "cluster" is selected, the graph and sidebar will continue to render.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the NG
Select a namespace
De-select the namespace
The empty section should not scroll down to show the stale graph visualization.
![image](https://github.com/stackrox/stackrox/assets/1292638/20f0c223-e4fb-4b2f-a4ad-e56daf9ec6e4)

Previous behavior:

https://github.com/stackrox/stackrox/assets/1292638/372f16c7-c6e3-4f9f-ab87-b66f1da0eaca


