### PR TITLE
fix(log):  simply log source before we append sensitive things to it

### DIFF
--- a/migrator/postgres/gorm/config.go
+++ b/migrator/postgres/gorm/config.go
@@ -3,7 +3,6 @@ package gorm
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/migrator/log"
@@ -54,6 +53,9 @@ func getConfig() (*gormConfig, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "pgsql: could not load password file %q", pgconfig.DBPasswordFile)
 	}
+
+	log.WriteToStderrf("connect to gorm: %q", centralConfig.CentralDB.Source)
+
 	// Add the password to the source to pass to get the pool config
 	source := fmt.Sprintf("%s password=%s", centralConfig.CentralDB.Source, password)
 	source = pgutils.PgxpoolDsnToPgxDsn(source)
@@ -68,7 +70,6 @@ func (gc *gormConfig) Connect(dbName string) (*gorm.DB, error) {
 	if !pgconfig.IsExternalDatabase() && dbName != "" {
 		source = fmt.Sprintf("%s database=%s", gc.source, dbName)
 	}
-	log.WriteToStderrf("connect to gorm: %v", strings.Replace(source, strings.TrimSpace(gc.password), "<REDACTED>", -1))
 
 	db, err := gorm.Open(postgres.Open(source), &gorm.Config{
 		NamingStrategy:    pgutils.NamingStrategy,
@@ -105,7 +106,6 @@ func (gc *gormConfig) ConnectWithRetries(dbName string) (db *gorm.DB, err error)
 // ConnectDatabase connects to the configured database within the Postgres instance and returns a Gorm DB instance with error if applicable.
 func (gc *gormConfig) ConnectDatabase() (*gorm.DB, error) {
 	source := gc.source
-	log.WriteToStderrf("connect to gorm: %v", strings.Replace(source, strings.TrimSpace(gc.password), "<REDACTED>", -1))
 
 	db, err := gorm.Open(postgres.Open(source), &gorm.Config{
 		NamingStrategy:    pgutils.NamingStrategy,


### PR DESCRIPTION
## Description

Move the logging of source before the password is appended.  We could argue that we could just not log the source, but at this time there is some value there to be able to see what we are connecting to.

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

spin up cluster locally and verify connection has no password in it
