### PR TITLE
ROX-17643: Detector Cleanup

### DIFF
--- a/sensor/tests/connection/alerts/alert_test.go
+++ b/sensor/tests/connection/alerts/alert_test.go
@@ -1,0 +1,79 @@
+package alerts
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/tests/helper"
+	"github.com/stackrox/rox/sensor/testutils"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+)
+
+var (
+	DeploymentWithViolation = helper.K8sResourceInfo{Kind: "Deployment", YamlFile: "nginx.yaml", Name: "nginx-deployment"}
+)
+
+func Test_AlertsAreSentAfterConnectionRestart(t *testing.T) {
+	t.Setenv(features.PreventSensorRestartOnDisconnect.EnvVar(), "true")
+	if !features.PreventSensorRestartOnDisconnect.Enabled() {
+		t.Skip("Skip tests when ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT is disabled")
+		t.SkipNow()
+	}
+
+	t.Setenv("ROX_RESYNC_DISABLED", "true")
+	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", "1s")
+	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL", "2s")
+
+	config := helper.DefaultCentralConfig()
+	var err error
+	config.InitialSystemPolicies, err = testutils.GetPoliciesFromFile("./data/policies.json")
+	require.NoError(t, err)
+
+	c, err := helper.NewContextWithConfig(t, config)
+	require.NoError(t, err)
+
+	c.RunTest(helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {
+		ctx := context.Background()
+
+		testContext.WaitForSyncEvent(2 * time.Minute)
+
+		_, err = c.ApplyResourceAndWaitNoObject(ctx, helper.DefaultNamespace, DeploymentWithViolation, nil)
+		require.NoError(t, err)
+
+		// After first deployment, should see an alert for deployment
+		testContext.LastViolationState(DeploymentWithViolation.Name, hasRequiredLabelAlert, "Deployment should have alerts")
+
+		// We need to wait some virtual time until all the deployment updates happen before restarting. Otherwise,
+		// the deployment will continue to receive updates (e.g. image SHA update) and the test will pass even if
+		// the deduper is not reset
+		//time.Sleep(30 * time.Second)
+
+		// Simulate a blit in the Network connection
+		testContext.RestartFakeCentralConnection()
+
+		// Wait for reconciliation to finish
+		testContext.WaitForSyncEvent(2 * time.Minute)
+
+		// Should see the alert *again* on a connection restart
+		testContext.LastViolationState(DeploymentWithViolation.Name, hasRequiredLabelAlert, "Deployment should have alerts")
+	}))
+
+}
+
+func hasRequiredLabelAlert(alertResults *central.AlertResults) error {
+	alerts := alertResults.GetAlerts()
+	if len(alerts) != 1 {
+		return errors.Errorf("expected 1 alert to return but received: %d", len(alerts))
+	}
+
+	if alerts[0].Policy.Name != "Required Label: Owner/Team" {
+		return errors.Errorf("expected alert with name 'Required Label: Owner/Team' but is '%s' instead", alerts[0].Policy.Name)
+	}
+
+	return nil
+}

--- a/sensor/tests/connection/alerts/alert_test.go
+++ b/sensor/tests/connection/alerts/alert_test.go
@@ -53,7 +53,7 @@ func Test_AlertsAreSentAfterConnectionRestart(t *testing.T) {
 		// the deduper is not reset
 		time.Sleep(30 * time.Second)
 
-		// Simulate a blit in the Network connection
+		// Simulate a blip in the Network connection
 		testContext.RestartFakeCentralConnection()
 
 		// Wait for reconciliation to finish

--- a/sensor/tests/connection/alerts/alert_test.go
+++ b/sensor/tests/connection/alerts/alert_test.go
@@ -51,7 +51,7 @@ func Test_AlertsAreSentAfterConnectionRestart(t *testing.T) {
 		// We need to wait some virtual time until all the deployment updates happen before restarting. Otherwise,
 		// the deployment will continue to receive updates (e.g. image SHA update) and the test will pass even if
 		// the deduper is not reset
-		//time.Sleep(30 * time.Second)
+		time.Sleep(30 * time.Second)
 
 		// Simulate a blit in the Network connection
 		testContext.RestartFakeCentralConnection()

--- a/sensor/tests/connection/alerts/data/policies.json
+++ b/sensor/tests/connection/alerts/data/policies.json
@@ -1,0 +1,78 @@
+{
+  "policies": [
+    {
+      "id": "550081a1-ad3a-4eab-a874-8eb68fab2bbd",
+      "name": "Required Label: Owner/Team",
+      "description": "Alert on deployments missing the 'owner' or 'team' label",
+      "rationale": "The 'owner' or 'team' label should always be specified so that the deployment can quickly be associated with a specific user or team.",
+      "remediation": "Redeploy your service and set the 'owner' or 'team' label to yourself or your team respectively per organizational standards.",
+      "disabled": false,
+      "categories": [
+        "DevOps Best Practices",
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on istio-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "istio-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.580107859Z",
+      "SORTName": "Required Label: Owner/Team",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Required Label",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "owner|team=.+"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    }
+  ]
+}

--- a/sensor/tests/connection/alerts/yaml/nginx.yaml
+++ b/sensor/tests/connection/alerts/yaml/nginx.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+


### PR DESCRIPTION
## Description

This ticket became a no-op from the production code perspective. The detector is already being cleaned up when the connection is restarted since we do a full policy sync see [here](https://github.com/stackrox/stackrox/blob/6fae80c1358dbc1e9c828accd5d3135e61f2c6ba/sensor/common/detector/detector.go#L226).

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

- [x] Manual tests with local sensor
- [x] Added new integration test to make sure that alerts are sent after reconciliation