### PR TITLE
feat(operator): enable OpenShift monitoring by default in CRD

### DIFF
--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -66,25 +66,6 @@ type CentralSpec struct {
 	Monitoring *GlobalMonitoring `json:"monitoring,omitempty"`
 }
 
-// GlobalMonitoring defines settings related to monitoring.
-type GlobalMonitoring struct {
-	OpenShiftMonitoring *OpenShiftMonitoring `json:"openshift,omitempty"`
-}
-
-// OpenShiftMonitoring defines settings related to OpenShift Monitoring
-type OpenShiftMonitoring struct {
-	//+kubebuilder:validation:Default=true
-	//+kubebuilder:default=false
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	Enabled bool `json:"enabled"`
-}
-
-// IsOpenShiftMonitoringEnabled returns true if OpenShiftMonitoring is enabled.
-// This function is nil safe.
-func (m *GlobalMonitoring) IsOpenShiftMonitoringEnabled() bool {
-	return m != nil && m.OpenShiftMonitoring != nil && m.OpenShiftMonitoring.Enabled
-}
-
 // Egress defines settings related to outgoing network traffic.
 type Egress struct {
 	// Configures whether Red Hat Advanced Cluster Security should run in online or offline (disconnected) mode.

--- a/operator/apis/platform/v1alpha1/common_types.go
+++ b/operator/apis/platform/v1alpha1/common_types.go
@@ -199,3 +199,23 @@ const (
 	// ExposeEndpointDisabled means that component should not expose monitoring port.
 	ExposeEndpointDisabled ExposeEndpoint = "Disabled"
 )
+
+// GlobalMonitoring defines settings related to global monitoring. Contrary to
+// `Monitoring`, the corresponding Helm flag lives in the global scope `.monitoring`.
+type GlobalMonitoring struct {
+	OpenShiftMonitoring *OpenShiftMonitoring `json:"openshift,omitempty"`
+}
+
+// OpenShiftMonitoring defines settings related to OpenShift Monitoring
+type OpenShiftMonitoring struct {
+	//+kubebuilder:validation:Default=true
+	//+kubebuilder:default=true
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	Enabled bool `json:"enabled"`
+}
+
+// IsOpenShiftMonitoringEnabled returns true if OpenShiftMonitoring is enabled.
+// This function is nil safe.
+func (m *GlobalMonitoring) IsOpenShiftMonitoringEnabled() bool {
+	return m != nil && m.OpenShiftMonitoring != nil && m.OpenShiftMonitoring.Enabled
+}

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -688,7 +688,7 @@ spec:
                       Monitoring
                     properties:
                       enabled:
-                        default: false
+                        default: true
                         type: boolean
                     required:
                     - enabled

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -391,7 +391,7 @@ spec:
                       Monitoring
                     properties:
                       enabled:
-                        default: false
+                        default: true
                         type: boolean
                     required:
                     - enabled

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -689,7 +689,7 @@ spec:
                       Monitoring
                     properties:
                       enabled:
-                        default: false
+                        default: true
                         type: boolean
                     required:
                     - enabled

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -392,7 +392,7 @@ spec:
                       Monitoring
                     properties:
                       enabled:
-                        default: false
+                        default: true
                         type: boolean
                     required:
                     - enabled


### PR DESCRIPTION
## Description

* Move `GlobalMonitoring` into common types.
* Flip default to `true`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
