### PR TITLE
ROX-18456: upgrade test rollback to 4 1

### DIFF
--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -83,7 +83,8 @@ test_upgrade_paths() {
 
     EARLIER_SHA="fe924fce30bbec4dbd37d731ccd505837a2c2575"
     EARLIER_TAG="3.74.0-1-gfe924fce30"
-    FORCE_ROLLBACK_VERSION="$INITIAL_POSTGRES_TAG"
+    # To test we remain backwards compatible rollback to 4.1.1
+    FORCE_ROLLBACK_VERSION="4.1.1"
 
     cd "$REPO_FOR_TIME_TRAVEL"
     git checkout "$EARLIER_SHA"


### PR DESCRIPTION
## Description

All changes must now be backwards compatible to 4.1.  So update the test to rollback to 4.1 instead of back to the original 3.74.X.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

It is a CI test so CI is sufficient.
