### PR TITLE
fix(ci): add missing path for merge logs

### DIFF
--- a/qa-tests-backend/scripts/lib.sh
+++ b/qa-tests-backend/scripts/lib.sh
@@ -103,6 +103,8 @@ get_spec_log_url() {
     url="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test"
     if is_in_PR_context; then
         url="${url}/pr-logs/pull/stackrox_stackrox/${PULL_NUMBER}"
+    else
+        url="${url}/logs"
     fi
     url="${url}/${JOB_NAME}/${BUILD_ID}/artifacts/${JOB_NAME_SAFE}/stackrox-e2e/artifacts"
     url="${url}/${log##"${ARTIFACT_DIR}"/}"


### PR DESCRIPTION
## Description

Per title, the URLs for merge CI logs are incorrect.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient - will check again after merge 