### PR TITLE
fix(operator): fix openshift-monitoring tests

### DIFF
--- a/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
@@ -48,12 +48,12 @@ subjects:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: "central-monitor-{{ .Release.Name }}-{{ .Release.Namespace }}"
+  name: "central-monitor-{{ .Release.Namespace }}"
   namespace: openshift-monitoring
   labels:
-    {{- include "srox.labels" (list . "servicemonitor" (print "central-monitor-" .Release.Name "-" .Release.Namespace )) | nindent 4 }}
+    {{- include "srox.labels" (list . "servicemonitor" (print "central-monitor-" .Release.Namespace)) | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "servicemonitor" (print "central-monitor-" .Release.Name "-" .Release.Namespace )) | nindent 4 }}
+    {{- include "srox.annotations" (list . "servicemonitor" (print "central-monitor-" .Release.Namespace)) | nindent 4 }}
 spec:
   endpoints:
   - interval: 30s
@@ -77,12 +77,12 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: rhacs-central-auth-reader
+  name: "rhacs-central-auth-reader-{{ .Release.Namespace }}"
   namespace: kube-system
   labels:
-    {{- include "srox.labels" (list . "rolebinding" "rhacs-central-auth-reader") | nindent 4 }}
+    {{- include "srox.labels" (list . "rolebinding" (print "rhacs-central-auth-reader-" .Release.Namespace)) | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "rolebinding" "rhacs-central-auth-reader") | nindent 4 }}
+    {{- include "srox.annotations" (list . "rolebinding" (print "rhacs-central-auth-reader-" .Release.Namespace)) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
@@ -48,12 +48,12 @@ subjects:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: "sensor-monitor-{{ .Release.Name }}-{{ .Release.Namespace }}"
+  name: "sensor-monitor-{{ .Release.Namespace }}"
   namespace: openshift-monitoring
   labels:
-    {{- include "srox.labels" (list . "servicemonitor" (print "sensor-monitor-" .Release.Name "-" .Release.Namespace )) | nindent 4 }}
+    {{- include "srox.labels" (list . "servicemonitor" (print "sensor-monitor-" .Release.Namespace)) | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "servicemonitor" (print "sensor-monitor-" .Release.Name "-" .Release.Namespace )) | nindent 4 }}
+    {{- include "srox.annotations" (list . "servicemonitor" (print "sensor-monitor-" .Release.Namespace)) | nindent 4 }}
 spec:
   endpoints:
   - interval: 30s
@@ -101,12 +101,12 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: rhacs-sensor-auth-reader
+  name: "rhacs-sensor-auth-reader-{{ .Release.Namespace }}"
   namespace: kube-system
   labels:
-    {{- include "srox.labels" (list . "rolebinding" "rhacs-sensor-auth-reader") | nindent 4 }}
+    {{- include "srox.labels" (list . "rolebinding" (print "rhacs-sensor-auth-reader-" .Release.Namespace)) | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "rolebinding" "rhacs-sensor-auth-reader") | nindent 4 }}
+    {{- include "srox.annotations" (list . "rolebinding" (print "rhacs-sensor-auth-reader-" .Release.Namespace)) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/operator/tests/securedcluster/basic-sc/40-assert.yaml
+++ b/operator/tests/securedcluster/basic-sc/40-assert.yaml
@@ -10,8 +10,3 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: collector-monitor
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rhacs-sensor-auth-reader

--- a/operator/tests/securedcluster/basic-sc/40-enable-monitoring.yaml
+++ b/operator/tests/securedcluster/basic-sc/40-enable-monitoring.yaml
@@ -3,6 +3,7 @@ kind: SecuredCluster
 metadata:
   name: stackrox-secured-cluster-services
 spec:
+  clusterName: testing-cluster
   monitoring:
     openshift:
       enabled: true

--- a/operator/tests/securedcluster/basic-sc/41-disable-monitoring.yaml
+++ b/operator/tests/securedcluster/basic-sc/41-disable-monitoring.yaml
@@ -3,6 +3,7 @@ kind: SecuredCluster
 metadata:
   name: stackrox-secured-cluster-services
 spec:
+  clusterName: testing-cluster
   monitoring:
     openshift:
       enabled: false

--- a/operator/tests/securedcluster/basic-sc/41-errors.yaml
+++ b/operator/tests/securedcluster/basic-sc/41-errors.yaml
@@ -7,8 +7,3 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: collector-monitor
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rhacs-sensor-auth-reader


### PR DESCRIPTION
## Description

* `rhacs-central-auth-reader` and `rhacs-sensor-auth-reader` need to be created in the `kube-system` namespace. They therefore need unique names by adding the release namespace to avoid collisions. This issue is only hit if multiple Centrals / Sensors releases are installed into the same cluster.
* Similarly, the service monitors need unique names. However, adding the release namespace should be sufficient because no two Helm release may live in the same namespace.
* Removed the auth reader assert in the operator e2e tests because they now depend on the dynamically generated namespace name.
* Add `clusterName` to secured cluster CR as it seems to be required.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
