### PR TITLE
[ROX-18804] : Remove usages of report service's context from scheduler and report generator; Prevent v1 scheduler from running when v2 reporting is enabled

### DIFF
--- a/central/reports/common/query_builder.go
+++ b/central/reports/common/query_builder.go
@@ -41,6 +41,7 @@ func NewVulnReportQueryBuilder(collection *storage.ResourceCollection, vulnFilte
 
 // BuildQuery builds scope and cve filtering queries for vuln reporting
 func (q *queryBuilder) BuildQuery(ctx context.Context) (*ReportQuery, error) {
+	// TODO ROX-18773 : Add SAC query filter on deploymentsQuery to scope the results by report requester.
 	deploymentsQuery, err := q.collectionQueryResolver.ResolveCollectionQuery(ctx, q.collection)
 	if err != nil {
 		return nil, err

--- a/central/reports/manager/manager_impl.go
+++ b/central/reports/manager/manager_impl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/contextutil"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 )
@@ -23,6 +24,9 @@ type managerImpl struct {
 }
 
 func (m *managerImpl) Remove(ctx context.Context, id string) error {
+	if features.VulnMgmtReportingEnhancements.Enabled() {
+		return nil
+	}
 	if ok, err := reportsSAC.WriteAllowed(ctx); err != nil {
 		return err
 	} else if !ok {
@@ -33,6 +37,9 @@ func (m *managerImpl) Remove(ctx context.Context, id string) error {
 }
 
 func (m *managerImpl) Upsert(ctx context.Context, reportConfig *storage.ReportConfiguration) error {
+	if features.VulnMgmtReportingEnhancements.Enabled() {
+		return nil
+	}
 	if ok, err := reportsSAC.WriteAllowed(ctx); err != nil {
 		return err
 	} else if !ok {
@@ -45,6 +52,9 @@ func (m *managerImpl) Upsert(ctx context.Context, reportConfig *storage.ReportCo
 }
 
 func (m *managerImpl) RunReport(ctx context.Context, reportConfig *storage.ReportConfiguration) error {
+	if features.VulnMgmtReportingEnhancements.Enabled() {
+		return nil
+	}
 	/*
 	 * Multiple on demand reports cannot be executed concurrently.
 	 * An on demand report may be submitted while other scheduled reports are being run and will be
@@ -64,9 +74,15 @@ func (m *managerImpl) RunReport(ctx context.Context, reportConfig *storage.Repor
 }
 
 func (m *managerImpl) Start() {
+	if features.VulnMgmtReportingEnhancements.Enabled() {
+		return
+	}
 	m.scheduler.Start()
 }
 
 func (m *managerImpl) Stop() {
+	if features.VulnMgmtReportingEnhancements.Enabled() {
+		return
+	}
 	m.scheduler.Stop()
 }

--- a/central/reports/manager/manager_impl.go
+++ b/central/reports/manager/manager_impl.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/contextutil"
-	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 )
@@ -24,7 +24,7 @@ type managerImpl struct {
 }
 
 func (m *managerImpl) Remove(ctx context.Context, id string) error {
-	if features.VulnMgmtReportingEnhancements.Enabled() {
+	if env.VulnReportingEnhancements.BooleanSetting() {
 		return nil
 	}
 	if ok, err := reportsSAC.WriteAllowed(ctx); err != nil {
@@ -37,7 +37,7 @@ func (m *managerImpl) Remove(ctx context.Context, id string) error {
 }
 
 func (m *managerImpl) Upsert(ctx context.Context, reportConfig *storage.ReportConfiguration) error {
-	if features.VulnMgmtReportingEnhancements.Enabled() {
+	if env.VulnReportingEnhancements.BooleanSetting() {
 		return nil
 	}
 	if ok, err := reportsSAC.WriteAllowed(ctx); err != nil {
@@ -52,7 +52,7 @@ func (m *managerImpl) Upsert(ctx context.Context, reportConfig *storage.ReportCo
 }
 
 func (m *managerImpl) RunReport(ctx context.Context, reportConfig *storage.ReportConfiguration) error {
-	if features.VulnMgmtReportingEnhancements.Enabled() {
+	if env.VulnReportingEnhancements.BooleanSetting() {
 		return nil
 	}
 	/*
@@ -74,14 +74,14 @@ func (m *managerImpl) RunReport(ctx context.Context, reportConfig *storage.Repor
 }
 
 func (m *managerImpl) Start() {
-	if features.VulnMgmtReportingEnhancements.Enabled() {
+	if env.VulnReportingEnhancements.BooleanSetting() {
 		return
 	}
 	m.scheduler.Start()
 }
 
 func (m *managerImpl) Stop() {
-	if features.VulnMgmtReportingEnhancements.Enabled() {
+	if env.VulnReportingEnhancements.BooleanSetting() {
 		return
 	}
 	m.scheduler.Stop()

--- a/central/reports/scheduler/v2/mocks/scheduler.go
+++ b/central/reports/scheduler/v2/mocks/scheduler.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	reportgenerator "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
@@ -51,18 +52,18 @@ func (mr *MockSchedulerMockRecorder) CanSubmitReportRequest(user, reportConfig i
 }
 
 // CancelReportRequest mocks base method.
-func (m *MockScheduler) CancelReportRequest(reportID string) (bool, error) {
+func (m *MockScheduler) CancelReportRequest(ctx context.Context, reportID string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CancelReportRequest", reportID)
+	ret := m.ctrl.Call(m, "CancelReportRequest", ctx, reportID)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CancelReportRequest indicates an expected call of CancelReportRequest.
-func (mr *MockSchedulerMockRecorder) CancelReportRequest(reportID interface{}) *gomock.Call {
+func (mr *MockSchedulerMockRecorder) CancelReportRequest(ctx, reportID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelReportRequest", reflect.TypeOf((*MockScheduler)(nil).CancelReportRequest), reportID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelReportRequest", reflect.TypeOf((*MockScheduler)(nil).CancelReportRequest), ctx, reportID)
 }
 
 // RemoveReportSchedule mocks base method.
@@ -102,18 +103,18 @@ func (mr *MockSchedulerMockRecorder) Stop() *gomock.Call {
 }
 
 // SubmitReportRequest mocks base method.
-func (m *MockScheduler) SubmitReportRequest(request *reportgenerator.ReportRequest, reSubmission bool) (string, error) {
+func (m *MockScheduler) SubmitReportRequest(ctx context.Context, request *reportgenerator.ReportRequest, reSubmission bool) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubmitReportRequest", request, reSubmission)
+	ret := m.ctrl.Call(m, "SubmitReportRequest", ctx, request, reSubmission)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SubmitReportRequest indicates an expected call of SubmitReportRequest.
-func (mr *MockSchedulerMockRecorder) SubmitReportRequest(request, reSubmission interface{}) *gomock.Call {
+func (mr *MockSchedulerMockRecorder) SubmitReportRequest(ctx, request, reSubmission interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitReportRequest", reflect.TypeOf((*MockScheduler)(nil).SubmitReportRequest), request, reSubmission)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitReportRequest", reflect.TypeOf((*MockScheduler)(nil).SubmitReportRequest), ctx, request, reSubmission)
 }
 
 // UpsertReportSchedule mocks base method.

--- a/central/reports/scheduler/v2/mocks/scheduler.go
+++ b/central/reports/scheduler/v2/mocks/scheduler.go
@@ -5,7 +5,6 @@
 package mocks
 
 import (
-	context "context"
 	reflect "reflect"
 
 	reportgenerator "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
@@ -52,18 +51,18 @@ func (mr *MockSchedulerMockRecorder) CanSubmitReportRequest(user, reportConfig i
 }
 
 // CancelReportRequest mocks base method.
-func (m *MockScheduler) CancelReportRequest(ctx context.Context, reportID string) (bool, error) {
+func (m *MockScheduler) CancelReportRequest(reportID string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CancelReportRequest", ctx, reportID)
+	ret := m.ctrl.Call(m, "CancelReportRequest", reportID)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CancelReportRequest indicates an expected call of CancelReportRequest.
-func (mr *MockSchedulerMockRecorder) CancelReportRequest(ctx, reportID interface{}) *gomock.Call {
+func (mr *MockSchedulerMockRecorder) CancelReportRequest(reportID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelReportRequest", reflect.TypeOf((*MockScheduler)(nil).CancelReportRequest), ctx, reportID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelReportRequest", reflect.TypeOf((*MockScheduler)(nil).CancelReportRequest), reportID)
 }
 
 // RemoveReportSchedule mocks base method.

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -15,6 +15,8 @@ import (
 	"github.com/pkg/errors"
 	blobDS "github.com/stackrox/rox/central/blob/datastore"
 	deploymentDS "github.com/stackrox/rox/central/deployment/datastore"
+	"github.com/stackrox/rox/central/graphql/resolvers"
+	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
 	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/reports/common"
 	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
@@ -25,13 +27,13 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/branding"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/grpc/authz/allow"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mathutil"
 	"github.com/stackrox/rox/pkg/notifier"
 	"github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stackrox/rox/pkg/sac"
-	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/templates"
 	"github.com/stackrox/rox/pkg/timestamp"
@@ -40,6 +42,8 @@ import (
 
 var (
 	log = logging.LoggerForModule()
+
+	reportGenCtx = resolvers.SetAuthorizerOverride(loaders.WithLoaderContext(sac.WithAllAccess(context.Background())), allow.Anonymous())
 )
 
 type reportGeneratorImpl struct {
@@ -63,13 +67,9 @@ func (rg *reportGeneratorImpl) ProcessReportRequest(req *ReportRequest) {
 		rg.logAndUpsertError(errors.Wrap(err, "Invalid report request"), req)
 		return
 	}
-	if req.Ctx == nil {
-		log.Error("Request does not have valid non-nil context")
-		return
-	}
 
 	if req.ReportConfig.GetVulnReportFilters().GetSinceLastSentScheduledReport() {
-		req.DataStartTime, err = rg.lastSuccessfulScheduledReportTime(req.Ctx, req.ReportConfig)
+		req.DataStartTime, err = rg.lastSuccessfulScheduledReportTime(req.ReportConfig)
 		if err != nil {
 			rg.logAndUpsertError(errors.Wrap(err, "Error finding last successful scheduled report time"), req)
 			return
@@ -79,7 +79,7 @@ func (rg *reportGeneratorImpl) ProcessReportRequest(req *ReportRequest) {
 	}
 
 	// Change report status to PREPARING
-	err = rg.updateReportStatus(req.Ctx, req.ReportSnapshot, storage.ReportStatus_PREPARING)
+	err = rg.updateReportStatus(req.ReportSnapshot, storage.ReportStatus_PREPARING)
 	if err != nil {
 		rg.logAndUpsertError(errors.Wrap(err, "Error changing report status to PREPARING"), req)
 		return
@@ -93,7 +93,7 @@ func (rg *reportGeneratorImpl) ProcessReportRequest(req *ReportRequest) {
 
 	// Change report status to SUCCESS
 	req.ReportSnapshot.ReportStatus.CompletedAt = types.TimestampNow()
-	err = rg.updateReportStatus(req.Ctx, req.ReportSnapshot, storage.ReportStatus_SUCCESS)
+	err = rg.updateReportStatus(req.ReportSnapshot, storage.ReportStatus_SUCCESS)
 	if err != nil {
 		rg.logAndUpsertError(errors.Wrap(err, "Error changing report status to SUCCESS"), req)
 		return
@@ -103,7 +103,7 @@ func (rg *reportGeneratorImpl) ProcessReportRequest(req *ReportRequest) {
 /* Report generation helper functions */
 func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error {
 	// Get the results of running the report query
-	deployedImgData, watchedImgData, err := rg.getReportData(req.Ctx, req.ReportConfig, req.Collection, req.DataStartTime)
+	deployedImgData, watchedImgData, err := rg.getReportData(req.ReportConfig, req.Collection, req.DataStartTime)
 	if err != nil {
 		return err
 	}
@@ -129,20 +129,20 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 
 	switch req.ReportSnapshot.ReportStatus.ReportNotificationMethod {
 	case storage.ReportStatus_DOWNLOAD:
-		if err = rg.saveReportData(req.Ctx, req.ReportSnapshot.GetReportConfigurationId(),
+		if err = rg.saveReportData(req.ReportSnapshot.GetReportConfigurationId(),
 			req.ReportSnapshot.GetReportId(), zippedCSVData); err != nil {
 			return errors.Wrap(err, "error persisting blob")
 		}
 	case storage.ReportStatus_EMAIL:
 		errorList := errorhelpers.NewErrorList("Error sending email notifications: ")
 		for _, notifierConfig := range req.ReportConfig.GetNotifiers() {
-			nf := rg.notificationProcessor.GetNotifier(req.Ctx, notifierConfig.GetEmailConfig().GetNotifierId())
+			nf := rg.notificationProcessor.GetNotifier(reportGenCtx, notifierConfig.GetEmailConfig().GetNotifierId())
 			reportNotifier, ok := nf.(notifiers.ReportNotifier)
 			if !ok {
 				errorList.AddError(errors.Errorf("incorrect type of notifier '%s'", notifierConfig.GetEmailConfig().GetNotifierId()))
 				continue
 			}
-			err := rg.retryableSendReportResults(req.Ctx, reportNotifier, notifierConfig.GetEmailConfig().GetMailingLists(),
+			err := rg.retryableSendReportResults(reportNotifier, notifierConfig.GetEmailConfig().GetMailingLists(),
 				zippedCSVData, messageText)
 			if err != nil {
 				errorList.AddError(errors.Errorf("Error sending email for notifier '%s': %s",
@@ -156,16 +156,10 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 	return nil
 }
 
-func (rg *reportGeneratorImpl) saveReportData(ctx context.Context, configID, reportID string, data *bytes.Buffer) error {
+func (rg *reportGeneratorImpl) saveReportData(configID, reportID string, data *bytes.Buffer) error {
 	if data == nil {
 		data = bytes.NewBuffer([]byte{})
 	}
-
-	// Augment ctx with write access to Administration for Upsert.
-	ctx = sac.WithGlobalAccessScopeChecker(ctx,
-		sac.AllowFixedScopes(
-			sac.AccessModeScopeKeys(storage.Access_READ_WRITE_ACCESS),
-			sac.ResourceScopeKeys(resources.Administration)))
 
 	// Store downloadable report in blob storage
 	b := &storage.Blob{
@@ -174,14 +168,14 @@ func (rg *reportGeneratorImpl) saveReportData(ctx context.Context, configID, rep
 		ModifiedTime: types.TimestampNow(),
 		Length:       int64(data.Len()),
 	}
-	return rg.blobStore.Upsert(ctx, b, data)
+	return rg.blobStore.Upsert(reportGenCtx, b, data)
 }
 
-func (rg *reportGeneratorImpl) getReportData(ctx context.Context, rc *storage.ReportConfiguration, collection *storage.ResourceCollection,
+func (rg *reportGeneratorImpl) getReportData(rc *storage.ReportConfiguration, collection *storage.ResourceCollection,
 	dataStartTime *types.Timestamp) ([]common.DeployedImagesResult, []common.WatchedImagesResult, error) {
 	var deployedImgResults []common.DeployedImagesResult
 	var watchedImgResults []common.WatchedImagesResult
-	rQuery, err := rg.buildReportQuery(ctx, rc, collection, dataStartTime)
+	rQuery, err := rg.buildReportQuery(rc, collection, dataStartTime)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -195,11 +189,11 @@ func (rg *reportGeneratorImpl) getReportData(ctx context.Context, rc *storage.Re
 		// This query is a 'disjunction of conjunctions' where all conjunctions involve same fields.
 		// Current query language for graphQL does not have semantics to define such a query. Due to this we need to fetch deploymentIDs first
 		// and then pass them to graphQL.
-		deploymentIds, err := rg.getDeploymentIDs(ctx, rQuery.DeploymentsQuery)
+		deploymentIds, err := rg.getDeploymentIDs(rQuery.DeploymentsQuery)
 		if err != nil {
 			return nil, nil, err
 		}
-		result, err := rg.runPaginatedDeploymentsQuery(ctx, rQuery.CveFieldsQuery, deploymentIds)
+		result, err := rg.runPaginatedDeploymentsQuery(rQuery.CveFieldsQuery, deploymentIds)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -208,11 +202,11 @@ func (rg *reportGeneratorImpl) getReportData(ctx context.Context, rc *storage.Re
 	}
 
 	if filterOnImageType(rc.GetVulnReportFilters().GetImageTypes(), storage.VulnerabilityReportFilters_WATCHED) {
-		watchedImages, err := rg.getWatchedImages(ctx)
+		watchedImages, err := rg.getWatchedImages()
 		if err != nil {
 			return nil, nil, err
 		}
-		result, err := rg.runPaginatedImagesQuery(ctx, rQuery.CveFieldsQuery, watchedImages)
+		result, err := rg.runPaginatedImagesQuery(rQuery.CveFieldsQuery, watchedImages)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -222,11 +216,11 @@ func (rg *reportGeneratorImpl) getReportData(ctx context.Context, rc *storage.Re
 	return deployedImgResults, watchedImgResults, nil
 }
 
-func (rg *reportGeneratorImpl) buildReportQuery(ctx context.Context, rc *storage.ReportConfiguration,
+func (rg *reportGeneratorImpl) buildReportQuery(rc *storage.ReportConfiguration,
 	collection *storage.ResourceCollection, dataStartTime *types.Timestamp) (*common.ReportQuery, error) {
 	qb := common.NewVulnReportQueryBuilder(collection, rc.GetVulnReportFilters(), rg.collectionQueryResolver,
 		timestamp.FromProtobuf(dataStartTime).GoTime())
-	rQuery, err := qb.BuildQuery(ctx)
+	rQuery, err := qb.BuildQuery(reportGenCtx)
 	if err != nil {
 		return nil, errors.Wrap(err, "error building report query")
 	}
@@ -234,7 +228,7 @@ func (rg *reportGeneratorImpl) buildReportQuery(ctx context.Context, rc *storage
 }
 
 // Returns vuln report data from deployments matched by the collection.
-func (rg *reportGeneratorImpl) runPaginatedDeploymentsQuery(ctx context.Context, cveQuery string, deploymentIds []string) (common.DeployedImagesResult, error) {
+func (rg *reportGeneratorImpl) runPaginatedDeploymentsQuery(cveQuery string, deploymentIds []string) (common.DeployedImagesResult, error) {
 	offset := paginatedQueryStartOffset
 	var resultData common.DeployedImagesResult
 	for {
@@ -243,7 +237,7 @@ func (rg *reportGeneratorImpl) runPaginatedDeploymentsQuery(ctx context.Context,
 		}
 		scopeQuery := fmt.Sprintf("%s:%s", search.DeploymentID.String(),
 			strings.Join(deploymentIds[offset:mathutil.MinInt(offset+paginationLimit, len(deploymentIds))], ","))
-		r, err := execQuery[common.DeployedImagesResult](ctx, rg, deployedImagesReportQuery, deployedImagesReportQueryOpName,
+		r, err := execQuery[common.DeployedImagesResult](rg, deployedImagesReportQuery, deployedImagesReportQueryOpName,
 			scopeQuery, cveQuery, nil)
 		if err != nil {
 			return r, err
@@ -255,7 +249,7 @@ func (rg *reportGeneratorImpl) runPaginatedDeploymentsQuery(ctx context.Context,
 }
 
 // Returns vuln report data for watched images
-func (rg *reportGeneratorImpl) runPaginatedImagesQuery(ctx context.Context, cveQuery string, watchedImages []string) (common.WatchedImagesResult, error) {
+func (rg *reportGeneratorImpl) runPaginatedImagesQuery(cveQuery string, watchedImages []string) (common.WatchedImagesResult, error) {
 	offset := paginatedQueryStartOffset
 	var resultData common.WatchedImagesResult
 	for {
@@ -271,7 +265,7 @@ func (rg *reportGeneratorImpl) runPaginatedImagesQuery(ctx context.Context, cveQ
 				"distinct":      true,
 			},
 		}
-		r, err := execQuery[common.WatchedImagesResult](ctx, rg, watchedImagesReportQuery, watchedImagesReportQueryOpName,
+		r, err := execQuery[common.WatchedImagesResult](rg, watchedImagesReportQuery, watchedImagesReportQueryOpName,
 			scopeQuery, cveQuery, sortOpt)
 		if err != nil {
 			return r, err
@@ -282,7 +276,7 @@ func (rg *reportGeneratorImpl) runPaginatedImagesQuery(ctx context.Context, cveQ
 	return resultData, nil
 }
 
-func execQuery[T any](ctx context.Context, rg *reportGeneratorImpl, gqlQuery, opName, scopeQuery, cveQuery string,
+func execQuery[T any](rg *reportGeneratorImpl, gqlQuery, opName, scopeQuery, cveQuery string,
 	sortOpt map[string]interface{}) (T, error) {
 	pagination := map[string]interface{}{
 		"offset": paginatedQueryStartOffset,
@@ -294,7 +288,7 @@ func execQuery[T any](ctx context.Context, rg *reportGeneratorImpl, gqlQuery, op
 		}
 	}
 
-	response := rg.Schema.Exec(ctx,
+	response := rg.Schema.Exec(reportGenCtx,
 		gqlQuery, opName, map[string]interface{}{
 			"scopequery": scopeQuery,
 			"cvequery":   cveQuery,
@@ -313,10 +307,10 @@ func execQuery[T any](ctx context.Context, rg *reportGeneratorImpl, gqlQuery, op
 
 /* Utility Functions */
 
-func (rg *reportGeneratorImpl) retryableSendReportResults(ctx context.Context, reportNotifier notifiers.ReportNotifier, mailingList []string,
+func (rg *reportGeneratorImpl) retryableSendReportResults(reportNotifier notifiers.ReportNotifier, mailingList []string,
 	zippedCSVData *bytes.Buffer, messageText string) error {
 	return retry.WithRetry(func() error {
-		return reportNotifier.ReportNotify(ctx, zippedCSVData, mailingList, messageText)
+		return reportNotifier.ReportNotify(reportGenCtx, zippedCSVData, mailingList, messageText)
 	},
 		retry.OnlyRetryableErrors(),
 		retry.Tries(3),
@@ -327,7 +321,7 @@ func (rg *reportGeneratorImpl) retryableSendReportResults(ctx context.Context, r
 	)
 }
 
-func (rg *reportGeneratorImpl) lastSuccessfulScheduledReportTime(ctx context.Context, config *storage.ReportConfiguration) (*types.Timestamp, error) {
+func (rg *reportGeneratorImpl) lastSuccessfulScheduledReportTime(config *storage.ReportConfiguration) (*types.Timestamp, error) {
 	query := search.NewQueryBuilder().
 		AddExactMatches(search.ReportConfigID, config.GetId()).
 		AddExactMatches(search.ReportRequestType, storage.ReportStatus_SCHEDULED.String()).
@@ -336,7 +330,7 @@ func (rg *reportGeneratorImpl) lastSuccessfulScheduledReportTime(ctx context.Con
 			AddSortOption(search.NewSortOption(search.ReportCompletionTime).Reversed(true)).
 			Limit(1)).
 		ProtoQuery()
-	results, err := rg.reportSnapshotStore.SearchReportSnapshots(ctx, query)
+	results, err := rg.reportSnapshotStore.SearchReportSnapshots(reportGenCtx, query)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error finding last successful scheduled report time")
 	}
@@ -349,16 +343,16 @@ func (rg *reportGeneratorImpl) lastSuccessfulScheduledReportTime(ctx context.Con
 	return results[0].GetReportStatus().GetCompletedAt(), nil
 }
 
-func (rg *reportGeneratorImpl) getDeploymentIDs(ctx context.Context, deploymentsQuery *v1.Query) ([]string, error) {
-	results, err := rg.deploymentDatastore.Search(ctx, deploymentsQuery)
+func (rg *reportGeneratorImpl) getDeploymentIDs(deploymentsQuery *v1.Query) ([]string, error) {
+	results, err := rg.deploymentDatastore.Search(reportGenCtx, deploymentsQuery)
 	if err != nil {
 		return nil, err
 	}
 	return search.ResultsToIDs(results), nil
 }
 
-func (rg *reportGeneratorImpl) getWatchedImages(ctx context.Context) ([]string, error) {
-	watched, err := rg.watchedImageDatastore.GetAllWatchedImages(ctx)
+func (rg *reportGeneratorImpl) getWatchedImages() ([]string, error) {
+	watched, err := rg.watchedImageDatastore.GetAllWatchedImages(reportGenCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -369,18 +363,14 @@ func (rg *reportGeneratorImpl) getWatchedImages(ctx context.Context) ([]string, 
 	return results, nil
 }
 
-func (rg *reportGeneratorImpl) updateReportStatus(ctx context.Context, snapshot *storage.ReportSnapshot, status storage.ReportStatus_RunState) error {
+func (rg *reportGeneratorImpl) updateReportStatus(snapshot *storage.ReportSnapshot, status storage.ReportStatus_RunState) error {
 	snapshot.ReportStatus.RunState = status
-	return rg.reportSnapshotStore.UpdateReportSnapshot(ctx, snapshot)
+	return rg.reportSnapshotStore.UpdateReportSnapshot(reportGenCtx, snapshot)
 }
 
 func (rg *reportGeneratorImpl) logAndUpsertError(reportErr error, req *ReportRequest) {
 	if req == nil || req.ReportConfig == nil {
 		utils.Should(errors.New("Request does not have non-nil report configuration"))
-		return
-	}
-	if req.Ctx == nil {
-		utils.Should(errors.New("Request does not have valid non-nil context"))
 		return
 	}
 	if req.ReportSnapshot == nil || req.ReportSnapshot.ReportStatus == nil {
@@ -392,7 +382,8 @@ func (rg *reportGeneratorImpl) logAndUpsertError(reportErr error, req *ReportReq
 		req.ReportSnapshot.ReportStatus.ErrorMsg = reportErr.Error()
 	}
 	req.ReportSnapshot.ReportStatus.CompletedAt = types.TimestampNow()
-	err := rg.updateReportStatus(req.Ctx, req.ReportSnapshot, storage.ReportStatus_FAILURE)
+	err := rg.updateReportStatus(req.ReportSnapshot, storage.ReportStatus_FAILURE)
+
 	if err != nil {
 		log.Errorf("Error changing report status to FAILURE for report config '%s', report ID '%s': %s",
 			req.ReportConfig.GetName(), req.ReportSnapshot.GetReportId(), err)

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/fixtures"
-	"github.com/stackrox/rox/pkg/grpc/authz/allow"
 	types2 "github.com/stackrox/rox/pkg/images/types"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	postgresSchema "github.com/stackrox/rox/pkg/postgres/schema"
@@ -113,7 +112,7 @@ func (s *EnhancedReportingTestSuite) TestSaveReportData() {
 
 	// Save report
 	reportID := "reportid"
-	s.Require().NoError(s.reportGenerator.saveReportData(s.ctx, configID, reportID, buf))
+	s.Require().NoError(s.reportGenerator.saveReportData(configID, reportID, buf))
 	newBuf, _, exists, err := s.blobStore.GetBlobWithDataInBuffer(s.ctx, common.GetReportBlobPath(configID, reportID))
 	s.Require().NoError(err)
 	s.Require().True(exists)
@@ -121,7 +120,7 @@ func (s *EnhancedReportingTestSuite) TestSaveReportData() {
 
 	// Save empty report
 	reportID = "anotherid"
-	s.Require().NoError(s.reportGenerator.saveReportData(s.ctx, configID, reportID, nil))
+	s.Require().NoError(s.reportGenerator.saveReportData(configID, reportID, nil))
 	newBuf, _, exists, err = s.blobStore.GetBlobWithDataInBuffer(s.ctx, common.GetReportBlobPath(configID, reportID))
 	s.Require().NoError(err)
 	s.Require().True(exists)
@@ -129,7 +128,6 @@ func (s *EnhancedReportingTestSuite) TestSaveReportData() {
 }
 
 func (s *EnhancedReportingTestSuite) TestGetReportData() {
-	ctx := resolvers.SetAuthorizerOverride(s.ctx, allow.Anonymous())
 	clusters := []string{"c1", "c2"}
 	namespaces := []string{"ns1", "ns2"}
 	deployments, images := testDeploymentsWithImages(clusters, namespaces, 1)
@@ -266,7 +264,7 @@ func (s *EnhancedReportingTestSuite) TestGetReportData() {
 			s.NoError(err)
 
 			reportConfig := testReportConfig(tc.collection.GetId(), tc.fixability, tc.severities, tc.imageTypes)
-			deployedImgResults, watchedImgResults, err := s.reportGenerator.getReportData(ctx, reportConfig, tc.collection, nil)
+			deployedImgResults, watchedImgResults, err := s.reportGenerator.getReportData(reportConfig, tc.collection, nil)
 			s.NoError(err)
 			reportData := extractVulnReportData(deployedImgResults, watchedImgResults)
 			s.ElementsMatch(tc.expected.deploymentNames, reportData.deploymentNames)

--- a/central/reports/scheduler/v2/reportgenerator/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/types.go
@@ -1,8 +1,6 @@
 package reportgenerator
 
 import (
-	"context"
-
 	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/generated/storage"
 )
@@ -13,7 +11,6 @@ type ReportRequest struct {
 	ReportSnapshot *storage.ReportSnapshot
 	Collection     *storage.ResourceCollection
 	DataStartTime  *types.Timestamp
-	Ctx            context.Context
 }
 
 type reportEmailFormat struct {

--- a/central/reports/scheduler/v2/scheduler.go
+++ b/central/reports/scheduler/v2/scheduler.go
@@ -1,6 +1,8 @@
 package v2
 
 import (
+	"context"
+
 	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
 	"github.com/stackrox/rox/generated/storage"
 )
@@ -20,11 +22,11 @@ type Scheduler interface {
 	// SubmitReportRequest submits a report execution request. The report request can be either for an on demand report or a scheduled report.
 	// If there is already a pending report request submitted by the same user for the same report config, this request will be denied.
 	// However, there can be multiple pending report requests for same configuration by different users.
-	SubmitReportRequest(request *reportGen.ReportRequest, reSubmission bool) (string, error)
+	SubmitReportRequest(ctx context.Context, request *reportGen.ReportRequest, reSubmission bool) (string, error)
 
 	// CancelReportRequest cancels a report request that is still waiting in queue.
 	// If the report is already being prepared or has completed execution, it cannot be cancelled.
-	CancelReportRequest(reportID string) (bool, error)
+	CancelReportRequest(ctx context.Context, reportID string) (bool, error)
 
 	// Start scheduler. A scheduler instance can only be started once. It cannot be re-started once stopped.
 	// This func will log errors if the scheduler fails to start.

--- a/central/reports/scheduler/v2/scheduler.go
+++ b/central/reports/scheduler/v2/scheduler.go
@@ -1,8 +1,6 @@
 package v2
 
 import (
-	"context"
-
 	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
 	"github.com/stackrox/rox/generated/storage"
 )
@@ -26,7 +24,7 @@ type Scheduler interface {
 
 	// CancelReportRequest cancels a report request that is still waiting in queue.
 	// If the report is already being prepared or has completed execution, it cannot be cancelled.
-	CancelReportRequest(ctx context.Context, reportID string) (bool, error)
+	CancelReportRequest(reportID string) (bool, error)
 
 	// Start scheduler. A scheduler instance can only be started once. It cannot be re-started once stopped.
 	// This func will log errors if the scheduler fails to start.

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -343,6 +343,7 @@ func (s *scheduler) queueScheduledReports() {
 	reportConfigs, err := s.reportConfigDatastore.GetReportConfigurations(scheduledCtx, query)
 	if err != nil {
 		log.Errorf("Error finding scheduled reports: %s", err)
+		return
 	}
 	for _, rc := range reportConfigs {
 		if rc.GetSchedule() != nil {

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -10,7 +10,6 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/graphql/resolvers"
-	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
 	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
 	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
 	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
@@ -21,7 +20,6 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
-	"github.com/stackrox/rox/pkg/grpc/authz/allow"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/protoconv/schedule"
 	"github.com/stackrox/rox/pkg/sac"
@@ -35,7 +33,7 @@ import (
 var (
 	log = logging.LoggerForModule()
 
-	scheduledCtx = resolvers.SetAuthorizerOverride(loaders.WithLoaderContext(sac.WithAllAccess(context.Background())), allow.Anonymous())
+	scheduledCtx = sac.WithAllAccess(context.Background())
 )
 
 type scheduler struct {
@@ -130,8 +128,8 @@ func (s *scheduler) Start() {
 		log.Error("Scheduler already running")
 		return
 	}
-	s.queuePendingReports(scheduledCtx)
-	s.queueScheduledReports(scheduledCtx)
+	s.queuePendingReports()
+	s.queueScheduledReports()
 	go s.runReports()
 }
 
@@ -242,12 +240,12 @@ func (s *scheduler) RemoveReportSchedule(reportConfigID string) {
 
 // CancelReportRequest cancels a report request that is still waiting in queue. A user can only cancel a report requested by them.
 // If the report is already being prepared or has completed execution, it cannot be cancelled.
-func (s *scheduler) CancelReportRequest(ctx context.Context, reportID string) (bool, error) {
+func (s *scheduler) CancelReportRequest(reportID string) (bool, error) {
 	removed := s.tryRemoveFromRequestQueue(reportID)
 	if !removed {
 		return false, nil
 	}
-	err := s.reportSnapshotStore.DeleteReportSnapshot(ctx, reportID)
+	err := s.reportSnapshotStore.DeleteReportSnapshot(scheduledCtx, reportID)
 	if err != nil {
 		return false, errors.Wrapf(err, "Error deleting report ID '%s' from storage", reportID)
 	}
@@ -266,7 +264,7 @@ func (s *scheduler) tryRemoveFromRequestQueue(reportID string) bool {
 }
 
 func (s *scheduler) CanSubmitReportRequest(user *storage.SlimUser, reportConfig *storage.ReportConfiguration) (bool, error) {
-	return s.doesUserHavePendingReport(scheduledCtx, reportConfig.GetId(), user.GetId())
+	return s.doesUserHavePendingReport(reportConfig.GetId(), user.GetId())
 }
 
 // SubmitReportRequest submits a report execution request. The report request can be either for an on demand report or a scheduled report.
@@ -277,11 +275,10 @@ func (s *scheduler) SubmitReportRequest(request *reportGen.ReportRequest, reSubm
 	if err != nil {
 		return "", err
 	}
-	request.Ctx = selectContext(request)
 
 	request.ReportSnapshot.ReportStatus.RunState = storage.ReportStatus_WAITING
 	request.ReportSnapshot.ReportStatus.QueuedAt = types.TimestampNow()
-	request.ReportSnapshot.ReportId, err = s.validateAndPersistSnapshot(request.Ctx, request.ReportSnapshot, reSubmission)
+	request.ReportSnapshot.ReportId, err = s.validateAndPersistSnapshot(request.ReportSnapshot, reSubmission)
 	if err != nil {
 		return "", err
 	}
@@ -313,43 +310,37 @@ func (s *scheduler) reportClosure(reportConfig *storage.ReportConfiguration) fun
 	}
 }
 
-func (s *scheduler) queuePendingReports(ctx context.Context) {
+func (s *scheduler) queuePendingReports() {
 	pendingReportsQuery := search.NewQueryBuilder().
 		AddExactMatches(search.ReportState, storage.ReportStatus_WAITING.String(), storage.ReportStatus_PREPARING.String()).
 		WithPagination(search.NewPagination().AddSortOption(search.NewSortOption(search.ReportQueuedTime))).
 		ProtoQuery()
-	pendingReports, err := s.reportSnapshotStore.SearchReportSnapshots(ctx, pendingReportsQuery)
+	pendingReports, err := s.reportSnapshotStore.SearchReportSnapshots(scheduledCtx, pendingReportsQuery)
 	if err != nil {
 		log.Errorf("Error finding pending reports: %s", err)
 		return
 	}
 
 	for _, snap := range pendingReports {
-		reportConfig, found, err := s.reportConfigDatastore.GetReportConfiguration(ctx, snap.GetReportConfigurationId())
+		reportReq, err := validation.ValidateAndGenerateReportRequest(s.reportConfigDatastore, s.collectionDatastore, s.notifierDatastore,
+			snap.GetReportConfigurationId(), snap.GetRequester(), snap.GetReportStatus().GetReportNotificationMethod(),
+			snap.GetReportStatus().GetReportRequestType())
 		if err != nil {
-			log.Errorf("Error rescheduling pending report for report config ID '%s': %s", snap.GetReportConfigurationId(), err)
+			log.Errorf("Error rescheduling pending report job for report config ID '%s': %s", snap.GetReportConfigurationId(), err)
 			continue
 		}
-		if !found {
-			log.Warnf("Report configuration with ID %s had pending reports but the configuration no longer exists",
-				snap.GetReportConfigurationId())
-			continue
-		}
-		_, err = s.SubmitReportRequest(&reportGen.ReportRequest{
-			ReportConfig:   reportConfig,
-			ReportSnapshot: snap,
-		}, true)
+		_, err = s.SubmitReportRequest(reportReq, true)
 		if err != nil {
-			log.Errorf("Error rescheduling pending report job for report config '%s': %s", snap.GetReportConfigurationId(), err)
+			log.Errorf("Error rescheduling pending report job for report config ID '%s': %s", snap.GetReportConfigurationId(), err)
 		}
 	}
 }
 
-func (s *scheduler) queueScheduledReports(ctx context.Context) {
+func (s *scheduler) queueScheduledReports() {
 	query := search.NewQueryBuilder().
 		AddExactMatches(search.ReportType, storage.ReportConfiguration_VULNERABILITY.String()).
 		ProtoQuery()
-	reportConfigs, err := s.reportConfigDatastore.GetReportConfigurations(ctx, query)
+	reportConfigs, err := s.reportConfigDatastore.GetReportConfigurations(scheduledCtx, query)
 	if err != nil {
 		log.Errorf("Error finding scheduled reports: %s", err)
 	}
@@ -387,12 +378,12 @@ func findAndRemoveFromQueue(reportRequestsQueue *list.List, pred func(req *repor
 // Validate report snapshot and store it to db if validation succeeds.
 // Will return report_id if successful.
 // Validation will check if the user requesting the report doesn't already have a pending report for the same config
-func (s *scheduler) validateAndPersistSnapshot(ctx context.Context, snapshot *storage.ReportSnapshot, reSubmission bool) (string, error) {
+func (s *scheduler) validateAndPersistSnapshot(snapshot *storage.ReportSnapshot, reSubmission bool) (string, error) {
 	s.dbLock.Lock()
 	defer s.dbLock.Unlock()
 
 	if snapshot.GetReportStatus().GetReportRequestType() == storage.ReportStatus_ON_DEMAND {
-		userHasAnotherReport, err := s.doesUserHavePendingReport(ctx, snapshot.GetReportConfigurationId(), snapshot.GetRequester().GetId())
+		userHasAnotherReport, err := s.doesUserHavePendingReport(snapshot.GetReportConfigurationId(), snapshot.GetRequester().GetId())
 		if err != nil {
 			return "", err
 		}
@@ -404,9 +395,9 @@ func (s *scheduler) validateAndPersistSnapshot(ctx context.Context, snapshot *st
 
 	var err error
 	if !reSubmission {
-		snapshot.ReportId, err = s.reportSnapshotStore.AddReportSnapshot(ctx, snapshot)
+		snapshot.ReportId, err = s.reportSnapshotStore.AddReportSnapshot(scheduledCtx, snapshot)
 	} else {
-		err = s.reportSnapshotStore.UpdateReportSnapshot(ctx, snapshot)
+		err = s.reportSnapshotStore.UpdateReportSnapshot(scheduledCtx, snapshot)
 	}
 
 	if err != nil {
@@ -415,13 +406,13 @@ func (s *scheduler) validateAndPersistSnapshot(ctx context.Context, snapshot *st
 	return snapshot.GetReportId(), nil
 }
 
-func (s *scheduler) doesUserHavePendingReport(ctx context.Context, configID string, userID string) (bool, error) {
+func (s *scheduler) doesUserHavePendingReport(configID string, userID string) (bool, error) {
 	query := search.NewQueryBuilder().
 		AddExactMatches(search.ReportConfigID, configID).
 		AddExactMatches(search.ReportState, storage.ReportStatus_WAITING.String(), storage.ReportStatus_PREPARING.String()).
 		AddExactMatches(search.ReportRequestType, storage.ReportStatus_ON_DEMAND.String()).
 		ProtoQuery()
-	runningReports, err := s.reportSnapshotStore.SearchReportSnapshots(ctx, query)
+	runningReports, err := s.reportSnapshotStore.SearchReportSnapshots(scheduledCtx, query)
 	if err != nil {
 		return false, err
 	}
@@ -431,11 +422,4 @@ func (s *scheduler) doesUserHavePendingReport(ctx context.Context, configID stri
 		}
 	}
 	return false, nil
-}
-
-func selectContext(req *reportGen.ReportRequest) context.Context {
-	if req.Ctx == nil {
-		return scheduledCtx
-	}
-	return req.Ctx
 }

--- a/central/reports/service/singleton.go
+++ b/central/reports/service/singleton.go
@@ -32,10 +32,12 @@ func initializeManager() manager.Manager {
 
 	query := search.NewQueryBuilder().AddExactMatches(search.ReportType, storage.ReportConfiguration_VULNERABILITY.String()).ProtoQuery()
 	reportConfigs, err := datastore.Singleton().GetReportConfigurations(ctx, query)
-	if err != nil {
-		panic(err)
-	}
 	mgr := manager.Singleton()
+	if err != nil {
+		log.Errorf("Error finding scheduled reports: %s", err)
+		return mgr
+	}
+
 	for _, rc := range reportConfigs {
 		if err := mgr.Upsert(ctx, rc); err != nil {
 			log.Errorf("error upserting report config: %v", err)

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -293,7 +293,7 @@ func (s *serviceImpl) RunReport(ctx context.Context, req *apiV2.RunReportRequest
 		return nil, err
 	}
 
-	reportID, err := s.scheduler.SubmitReportRequest(reportReq, false)
+	reportID, err := s.scheduler.SubmitReportRequest(ctx, reportReq, false)
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +321,7 @@ func (s *serviceImpl) CancelReport(ctx context.Context, req *apiV2.ResourceByID)
 		return nil, err
 	}
 
-	cancelled, err := s.scheduler.CancelReportRequest(req.GetId())
+	cancelled, err := s.scheduler.CancelReportRequest(ctx, req.GetId())
 	if err != nil {
 		return nil, err
 	}

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -321,7 +321,7 @@ func (s *serviceImpl) CancelReport(ctx context.Context, req *apiV2.ResourceByID)
 		return nil, err
 	}
 
-	cancelled, err := s.scheduler.CancelReportRequest(ctx, req.GetId())
+	cancelled, err := s.scheduler.CancelReportRequest(req.GetId())
 	if err != nil {
 		return nil, err
 	}

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -759,7 +759,7 @@ func (s *ReportServiceTestSuite) TestRunReport() {
 					Return(collection, true, nil).Times(1)
 				s.notifierDataStore.EXPECT().GetManyNotifiers(gomock.Any(), notifierIDs).
 					Return(notifiers, nil).Times(1)
-				s.scheduler.EXPECT().SubmitReportRequest(gomock.Any(), false).
+				s.scheduler.EXPECT().SubmitReportRequest(gomock.Any(), gomock.Any(), false).
 					Return("reportID", nil).Times(1)
 			},
 			isError: false,
@@ -782,7 +782,7 @@ func (s *ReportServiceTestSuite) TestRunReport() {
 					Return(collection, true, nil).Times(1)
 				s.notifierDataStore.EXPECT().GetManyNotifiers(gomock.Any(), notifierIDs).
 					Return(notifiers, nil).Times(1)
-				s.scheduler.EXPECT().SubmitReportRequest(gomock.Any(), false).
+				s.scheduler.EXPECT().SubmitReportRequest(gomock.Any(), gomock.Any(), false).
 					Return("reportID", nil).Times(1)
 			},
 			isError: false,
@@ -910,7 +910,7 @@ func (s *ReportServiceTestSuite) TestCancelReport() {
 			mockGen: func() {
 				s.reportSnapshotDataStore.EXPECT().Get(gomock.Any(), reportSnapshot.GetReportId()).
 					Return(reportSnapshot, true, nil).Times(1)
-				s.scheduler.EXPECT().CancelReportRequest(gomock.Any()).
+				s.scheduler.EXPECT().CancelReportRequest(gomock.Any(), gomock.Any()).
 					Return(false, errors.New("Datastore error")).Times(1)
 			},
 			isError: true,
@@ -924,7 +924,7 @@ func (s *ReportServiceTestSuite) TestCancelReport() {
 			mockGen: func() {
 				s.reportSnapshotDataStore.EXPECT().Get(gomock.Any(), reportSnapshot.GetReportId()).
 					Return(reportSnapshot, true, nil).Times(1)
-				s.scheduler.EXPECT().CancelReportRequest(gomock.Any()).
+				s.scheduler.EXPECT().CancelReportRequest(gomock.Any(), gomock.Any()).
 					Return(false, nil).Times(1)
 			},
 			isError: true,
@@ -938,7 +938,7 @@ func (s *ReportServiceTestSuite) TestCancelReport() {
 			mockGen: func() {
 				s.reportSnapshotDataStore.EXPECT().Get(gomock.Any(), reportSnapshot.GetReportId()).
 					Return(reportSnapshot, true, nil).Times(1)
-				s.scheduler.EXPECT().CancelReportRequest(gomock.Any()).
+				s.scheduler.EXPECT().CancelReportRequest(gomock.Any(), gomock.Any()).
 					Return(true, nil).Times(1)
 			},
 			isError: false,

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -910,9 +910,8 @@ func (s *ReportServiceTestSuite) TestCancelReport() {
 			mockGen: func() {
 				s.reportSnapshotDataStore.EXPECT().Get(gomock.Any(), reportSnapshot.GetReportId()).
 					Return(reportSnapshot, true, nil).Times(1)
-				s.scheduler.EXPECT().CancelReportRequest(gomock.Any(), gomock.Any()).
-					Return(false, errors.New("Datastore error")).
-					Times(1)
+				s.scheduler.EXPECT().CancelReportRequest(gomock.Any()).
+					Return(false, errors.New("Datastore error")).Times(1)
 			},
 			isError: true,
 		},
@@ -925,9 +924,8 @@ func (s *ReportServiceTestSuite) TestCancelReport() {
 			mockGen: func() {
 				s.reportSnapshotDataStore.EXPECT().Get(gomock.Any(), reportSnapshot.GetReportId()).
 					Return(reportSnapshot, true, nil).Times(1)
-				s.scheduler.EXPECT().CancelReportRequest(gomock.Any(), gomock.Any()).
-					Return(false, nil).
-					Times(1)
+				s.scheduler.EXPECT().CancelReportRequest(gomock.Any()).
+					Return(false, nil).Times(1)
 			},
 			isError: true,
 		},
@@ -940,9 +938,8 @@ func (s *ReportServiceTestSuite) TestCancelReport() {
 			mockGen: func() {
 				s.reportSnapshotDataStore.EXPECT().Get(gomock.Any(), reportSnapshot.GetReportId()).
 					Return(reportSnapshot, true, nil).Times(1)
-				s.scheduler.EXPECT().CancelReportRequest(gomock.Any(), gomock.Any()).
-					Return(true, nil).
-					Times(1)
+				s.scheduler.EXPECT().CancelReportRequest(gomock.Any()).
+					Return(true, nil).Times(1)
 			},
 			isError: false,
 		},


### PR DESCRIPTION
## Description

`RunReport(...)` in report service queues the report request by calling `SubmitReportRequest(...)` on the scheduler. When submitting report request, the service used to pass its own context to the `SubmitReportRequest(...)`. Scheduler and report generator used this context to store snapshot, making graphQL queries etc. However, once the service `RunReport(...)`, its context gets cancelled and its usages in scheduler and report generator which happen in a separate routine become invalid.
To prevent this, this PR removes the code passing service's context to scheduler and report generator. Scheduler and generator use their own `allAccessContext` which will not get cancelled. 

For scoping the report results, I will add `SimpleAccessScope` field to `ReportRequest` in ROX-18773 and use that scope to build a scope query in report generation.

This PR also adds changes to prevent v1 scheduler from running when v2 reporting is enabled.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Manual testing by triggering on demand and downloadable reports.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
