### PR TITLE
fix(operator): fix openshift-monitoring tests

### DIFF
--- a/operator/tests/central/basic-central/10-assert.yaml
+++ b/operator/tests/central/basic-central/10-assert.yaml
@@ -94,12 +94,6 @@ kind: RoleBinding
 metadata:
   name: central-prometheus-k8s
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rhacs-central-auth-reader
-  namespace: kube-system
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/operator/tests/central/basic-central/10-assert.yaml
+++ b/operator/tests/central/basic-central/10-assert.yaml
@@ -94,6 +94,13 @@ kind: RoleBinding
 metadata:
   name: central-prometheus-k8s
 ---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: |
+    # Test that Central auth reader rolebinding exists in kube-system.
+    kubectl get rolebinding rhacs-central-auth-reader-${NAMESPACE} -n kube-system
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/operator/tests/common/delete-central-errors-cluster.envsubst.yaml
+++ b/operator/tests/common/delete-central-errors-cluster.envsubst.yaml
@@ -26,3 +26,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: stackrox-${NAMESPACE}-scanner-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rhacs-central-auth-reader-${NAMESPACE}
+  namespace: kube-system

--- a/operator/tests/common/delete-central-errors.yaml
+++ b/operator/tests/common/delete-central-errors.yaml
@@ -241,9 +241,3 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: central-prometheus-k8s
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rhacs-central-auth-reader
-  namespace: kube-system

--- a/operator/tests/securedcluster/basic-sc/40-assert.yaml
+++ b/operator/tests/securedcluster/basic-sc/40-assert.yaml
@@ -10,8 +10,3 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: collector-monitor
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rhacs-sensor-auth-reader

--- a/operator/tests/securedcluster/basic-sc/40-assert.yaml
+++ b/operator/tests/securedcluster/basic-sc/40-assert.yaml
@@ -10,3 +10,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: collector-monitor
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: |
+    # Test that Sensor auth reader rolebinding exists in kube-system.
+    kubectl get rolebinding rhacs-sensor-auth-reader-${NAMESPACE} -n kube-system

--- a/operator/tests/securedcluster/basic-sc/40-enable-monitoring.yaml
+++ b/operator/tests/securedcluster/basic-sc/40-enable-monitoring.yaml
@@ -3,6 +3,7 @@ kind: SecuredCluster
 metadata:
   name: stackrox-secured-cluster-services
 spec:
+  clusterName: testing-cluster
   monitoring:
     openshift:
       enabled: true

--- a/operator/tests/securedcluster/basic-sc/41-disable-monitoring.yaml
+++ b/operator/tests/securedcluster/basic-sc/41-disable-monitoring.yaml
@@ -3,6 +3,7 @@ kind: SecuredCluster
 metadata:
   name: stackrox-secured-cluster-services
 spec:
+  clusterName: testing-cluster
   monitoring:
     openshift:
       enabled: false

--- a/operator/tests/securedcluster/basic-sc/41-errors.yaml
+++ b/operator/tests/securedcluster/basic-sc/41-errors.yaml
@@ -7,8 +7,3 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: collector-monitor
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rhacs-sensor-auth-reader

--- a/operator/tests/securedcluster/basic-sc/41-errors.yaml
+++ b/operator/tests/securedcluster/basic-sc/41-errors.yaml
@@ -7,10 +7,3 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: collector-monitor
----
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-commands:
-- script: |
-    # Test that Sensor auth reader rolebinding does not exist in kube-system.
-    ! kubectl get rolebinding rhacs-sensor-auth-reader-${NAMESPACE} -n kube-system

--- a/operator/tests/securedcluster/basic-sc/41-errors.yaml
+++ b/operator/tests/securedcluster/basic-sc/41-errors.yaml
@@ -7,3 +7,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: collector-monitor
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: |
+    # Test that Sensor auth reader rolebinding does not exist in kube-system.
+    ! kubectl get rolebinding rhacs-sensor-auth-reader-${NAMESPACE} -n kube-system


### PR DESCRIPTION
## Description

* Removed the auth reader assert in the operator e2e tests because they now depend on the dynamically generated namespace name.
* Added `clusterName` to secured cluster CR as it seems to be required.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
