### PR TITLE
ROX-17326: Add context to detector

### DIFF
--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -50,11 +50,11 @@ type Detector interface {
 	common.SensorComponent
 	common.CentralGRPCConnAware
 
-	ProcessDeployment(deployment *storage.Deployment, action central.ResourceAction)
+	ProcessDeployment(ctx context.Context, deployment *storage.Deployment, action central.ResourceAction)
 	ReprocessDeployments(deploymentIDs ...string)
 	ProcessIndicator(indicator *storage.ProcessIndicator)
 	ProcessNetworkFlow(ctx context.Context, flow *storage.NetworkFlow)
-	ProcessPolicySync(sync *central.PolicySync) error
+	ProcessPolicySync(ctx context.Context, sync *central.PolicySync) error
 	ProcessReassessPolicies() error
 	ProcessReprocessDeployments() error
 	ProcessUpdatedImage(image *storage.Image) error
@@ -140,6 +140,7 @@ type outputResult struct {
 	results   *central.AlertResults
 	timestamp int64
 	action    central.ResourceAction
+	context   context.Context
 }
 
 // serializeDeployTimeOutput serializes all messages that are going to be output. This allows us to guarantee the ordering
@@ -194,8 +195,7 @@ func (d *detectorImpl) serializeDeployTimeOutput() {
 			select {
 			case <-d.serializerStopper.Flow().StopRequested():
 				return
-				// TODO(ROX-17326): Add context to detector messages
-			case d.output <- createAlertResultsMsg(context.TODO(), result.action, alertResults):
+			case d.output <- createAlertResultsMsg(result.context, result.action, alertResults):
 			}
 		}
 	}
@@ -223,7 +223,7 @@ func (d *detectorImpl) Capabilities() []centralsensor.SensorCapability {
 }
 
 // ProcessPolicySync reconciles policies and flush all deployments through the detector
-func (d *detectorImpl) ProcessPolicySync(sync *central.PolicySync) error {
+func (d *detectorImpl) ProcessPolicySync(ctx context.Context, sync *central.PolicySync) error {
 	// Note: Assume the version of the policies received from central is never
 	// older than sensor's version. Convert to latest if this proves wrong.
 	d.unifiedDetector.ReconcilePolicies(sync.GetPolicies())
@@ -232,7 +232,7 @@ func (d *detectorImpl) ProcessPolicySync(sync *central.PolicySync) error {
 	// Take deployment lock and flush
 	concurrency.WithLock(&d.deploymentDetectionLock, func() {
 		for _, deployment := range d.deploymentStore.GetAll() {
-			d.processDeploymentNoLock(deployment, central.ResourceAction_UPDATE_RESOURCE)
+			d.processDeploymentNoLock(ctx, deployment, central.ResourceAction_UPDATE_RESOURCE)
 		}
 	})
 
@@ -343,6 +343,7 @@ func (d *detectorImpl) runDetector() {
 				},
 				timestamp: scanOutput.deployment.GetStateTimestamp(),
 				action:    scanOutput.action,
+				context:   scanOutput.context,
 			}:
 			}
 		}
@@ -388,8 +389,9 @@ func (d *detectorImpl) runAuditLogEventDetector() {
 				},
 			}
 
-			// TODO(ROX-17326): Add context to detector message
-			expiringMessage := message.NewExpiring(context.TODO(), msg)
+			// These messages are coming from compliance, and since compliance supports offline mode as well
+			// it should be ok to leave these messages without expiration.
+			expiringMessage := message.New(msg)
 
 			select {
 			case <-d.auditStopper.Flow().StopRequested():
@@ -411,11 +413,11 @@ func (d *detectorImpl) markDeploymentForProcessing(id string) {
 	}
 }
 
-func (d *detectorImpl) ProcessDeployment(deployment *storage.Deployment, action central.ResourceAction) {
+func (d *detectorImpl) ProcessDeployment(ctx context.Context, deployment *storage.Deployment, action central.ResourceAction) {
 	d.deploymentDetectionLock.Lock()
 	defer d.deploymentDetectionLock.Unlock()
 
-	d.processDeploymentNoLock(deployment, action)
+	d.processDeploymentNoLock(ctx, deployment, action)
 }
 
 func (d *detectorImpl) ReprocessDeployments(deploymentIDs ...string) {
@@ -432,7 +434,7 @@ func (d *detectorImpl) getNetworkPoliciesApplied(deployment *storage.Deployment)
 	return networkpolicy.GenerateNetworkPoliciesAppliedObj(networkPolicies)
 }
 
-func (d *detectorImpl) processDeploymentNoLock(deployment *storage.Deployment, action central.ResourceAction) {
+func (d *detectorImpl) processDeploymentNoLock(ctx context.Context, deployment *storage.Deployment, action central.ResourceAction) {
 	switch action {
 	case central.ResourceAction_REMOVE_RESOURCE:
 		d.baselineEval.RemoveDeployment(deployment.GetId())
@@ -445,6 +447,7 @@ func (d *detectorImpl) processDeploymentNoLock(deployment *storage.Deployment, a
 			case <-d.alertStopSig.Done():
 				return
 			case d.deploymentAlertOutputChan <- outputResult{
+				context: ctx,
 				results: &central.AlertResults{DeploymentId: deployment.GetId()},
 				action:  action,
 			}:
@@ -453,7 +456,7 @@ func (d *detectorImpl) processDeploymentNoLock(deployment *storage.Deployment, a
 	case central.ResourceAction_CREATE_RESOURCE:
 		d.deduper.addDeployment(deployment)
 		d.markDeploymentForProcessing(deployment.GetId())
-		go d.enricher.blockingScan(deployment, d.getNetworkPoliciesApplied(deployment), action)
+		go d.enricher.blockingScan(ctx, deployment, d.getNetworkPoliciesApplied(deployment), action)
 	case central.ResourceAction_UPDATE_RESOURCE, central.ResourceAction_SYNC_RESOURCE:
 		// Check if the deployment has changes that require detection, which is more expensive than hashing
 		// If not, then just return
@@ -461,7 +464,7 @@ func (d *detectorImpl) processDeploymentNoLock(deployment *storage.Deployment, a
 			return
 		}
 		d.markDeploymentForProcessing(deployment.GetId())
-		go d.enricher.blockingScan(deployment, d.getNetworkPoliciesApplied(deployment), action)
+		go d.enricher.blockingScan(ctx, deployment, d.getNetworkPoliciesApplied(deployment), action)
 	}
 }
 
@@ -522,7 +525,7 @@ func (d *detectorImpl) processIndicator(pi *storage.ProcessIndicator) {
 	select {
 	case <-d.alertStopSig.Done():
 		return
-		// TODO(ROX-17326): Add context to detector messages
+		// TODO(ROX-18818): Add context to indicator alerts
 	case d.output <- createAlertResultsMsg(context.TODO(), central.ResourceAction_CREATE_RESOURCE, alertResults):
 	}
 }

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -414,9 +414,15 @@ func (d *detectorImpl) markDeploymentForProcessing(id string) {
 }
 
 func (d *detectorImpl) ProcessDeployment(ctx context.Context, deployment *storage.Deployment, action central.ResourceAction) {
+	// Don't  process the deployment if the context has already expired
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
 	d.deploymentDetectionLock.Lock()
 	defer d.deploymentDetectionLock.Unlock()
-
 	d.processDeploymentNoLock(ctx, deployment, action)
 }
 

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -32,6 +32,7 @@ var (
 )
 
 type scanResult struct {
+	context                context.Context
 	action                 central.ResourceAction
 	deployment             *storage.Deployment
 	images                 []*storage.Image
@@ -289,11 +290,12 @@ func (e *enricher) getImages(deployment *storage.Deployment) []*storage.Image {
 	return images
 }
 
-func (e *enricher) blockingScan(deployment *storage.Deployment, netpolApplied *augmentedobjs.NetworkPoliciesApplied, action central.ResourceAction) {
+func (e *enricher) blockingScan(ctx context.Context, deployment *storage.Deployment, netpolApplied *augmentedobjs.NetworkPoliciesApplied, action central.ResourceAction) {
 	select {
 	case <-e.stopSig.Done():
 		return
 	case e.scanResultChan <- scanResult{
+		context:                ctx,
 		action:                 action,
 		deployment:             deployment,
 		images:                 e.getImages(deployment),

--- a/sensor/common/detector/mocks/detector.go
+++ b/sensor/common/detector/mocks/detector.go
@@ -79,15 +79,15 @@ func (mr *MockDetectorMockRecorder) ProcessDeployment(ctx, deployment, action in
 }
 
 // ProcessIndicator mocks base method.
-func (m *MockDetector) ProcessIndicator(indicator *storage.ProcessIndicator) {
+func (m *MockDetector) ProcessIndicator(ctx context.Context, indicator *storage.ProcessIndicator) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ProcessIndicator", indicator)
+	m.ctrl.Call(m, "ProcessIndicator", ctx, indicator)
 }
 
 // ProcessIndicator indicates an expected call of ProcessIndicator.
-func (mr *MockDetectorMockRecorder) ProcessIndicator(indicator interface{}) *gomock.Call {
+func (mr *MockDetectorMockRecorder) ProcessIndicator(ctx, indicator interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessIndicator", reflect.TypeOf((*MockDetector)(nil).ProcessIndicator), indicator)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessIndicator", reflect.TypeOf((*MockDetector)(nil).ProcessIndicator), ctx, indicator)
 }
 
 // ProcessMessage mocks base method.

--- a/sensor/common/detector/mocks/detector.go
+++ b/sensor/common/detector/mocks/detector.go
@@ -67,15 +67,15 @@ func (mr *MockDetectorMockRecorder) Notify(e interface{}) *gomock.Call {
 }
 
 // ProcessDeployment mocks base method.
-func (m *MockDetector) ProcessDeployment(deployment *storage.Deployment, action central.ResourceAction) {
+func (m *MockDetector) ProcessDeployment(ctx context.Context, deployment *storage.Deployment, action central.ResourceAction) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ProcessDeployment", deployment, action)
+	m.ctrl.Call(m, "ProcessDeployment", ctx, deployment, action)
 }
 
 // ProcessDeployment indicates an expected call of ProcessDeployment.
-func (mr *MockDetectorMockRecorder) ProcessDeployment(deployment, action interface{}) *gomock.Call {
+func (mr *MockDetectorMockRecorder) ProcessDeployment(ctx, deployment, action interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessDeployment", reflect.TypeOf((*MockDetector)(nil).ProcessDeployment), deployment, action)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessDeployment", reflect.TypeOf((*MockDetector)(nil).ProcessDeployment), ctx, deployment, action)
 }
 
 // ProcessIndicator mocks base method.
@@ -117,17 +117,17 @@ func (mr *MockDetectorMockRecorder) ProcessNetworkFlow(ctx, flow interface{}) *g
 }
 
 // ProcessPolicySync mocks base method.
-func (m *MockDetector) ProcessPolicySync(sync *central.PolicySync) error {
+func (m *MockDetector) ProcessPolicySync(ctx context.Context, sync *central.PolicySync) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessPolicySync", sync)
+	ret := m.ctrl.Call(m, "ProcessPolicySync", ctx, sync)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessPolicySync indicates an expected call of ProcessPolicySync.
-func (mr *MockDetectorMockRecorder) ProcessPolicySync(sync interface{}) *gomock.Call {
+func (mr *MockDetectorMockRecorder) ProcessPolicySync(ctx, sync interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessPolicySync", reflect.TypeOf((*MockDetector)(nil).ProcessPolicySync), sync)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessPolicySync", reflect.TypeOf((*MockDetector)(nil).ProcessPolicySync), ctx, sync)
 }
 
 // ProcessReassessPolicies mocks base method.

--- a/sensor/common/processsignal/pipeline.go
+++ b/sensor/common/processsignal/pipeline.go
@@ -141,8 +141,7 @@ func (p *Pipeline) sendIndicatorEvent() {
 		if !p.processFilter.Add(indicator) {
 			continue
 		}
-		// TODO(ROX-18818): Pass context to indicators detection
-		p.detector.ProcessIndicator(indicator)
+		p.detector.ProcessIndicator(p.getCurrentContext(), indicator)
 		p.indicators <- message.NewExpiring(p.getCurrentContext(), &central.MsgFromSensor{
 			Msg: &central.MsgFromSensor_Event{
 				Event: &central.SensorEvent{

--- a/sensor/common/processsignal/pipeline.go
+++ b/sensor/common/processsignal/pipeline.go
@@ -141,6 +141,7 @@ func (p *Pipeline) sendIndicatorEvent() {
 		if !p.processFilter.Add(indicator) {
 			continue
 		}
+		// TODO(ROX-18818): Pass context to indicators detection
 		p.detector.ProcessIndicator(indicator)
 		p.indicators <- message.NewExpiring(p.getCurrentContext(), &central.MsgFromSensor{
 			Msg: &central.MsgFromSensor_Event{

--- a/sensor/common/processsignal/pipeline_test.go
+++ b/sensor/common/processsignal/pipeline_test.go
@@ -154,7 +154,7 @@ func TestProcessPipelineOffline(t *testing.T) {
 			mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).
 				MinTimes(2).
 				MaxTimes(2).
-				DoAndReturn(func(ind *storage.ProcessIndicator) {
+				DoAndReturn(func(_ context.Context, ind *storage.ProcessIndicator) {
 					assert.Contains(t,
 						[]string{tc.initialSignal.expectDeploymentID, tc.laterSignal.expectDeploymentID},
 						ind.GetDeploymentId())
@@ -274,7 +274,7 @@ func TestProcessPipelineOnline(t *testing.T) {
 	signal := storage.ProcessSignal{
 		ContainerId: containerID,
 	}
-	mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).DoAndReturn(func(ind *storage.ProcessIndicator) {
+	mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, ind *storage.ProcessIndicator) {
 		assert.Equal(t, deploymentID, ind.GetDeploymentId())
 	})
 	p.Process(&signal)
@@ -288,7 +288,7 @@ func TestProcessPipelineOnline(t *testing.T) {
 	signal = storage.ProcessSignal{
 		ContainerId: containerID,
 	}
-	mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).DoAndReturn(func(ind *storage.ProcessIndicator) {
+	mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, ind *storage.ProcessIndicator) {
 		assert.Equal(t, deploymentID, ind.GetDeploymentId())
 	})
 	p.Process(&signal)
@@ -302,7 +302,7 @@ func TestProcessPipelineOnline(t *testing.T) {
 	signal = storage.ProcessSignal{
 		ContainerId: containerID,
 	}
-	mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).DoAndReturn(func(ind *storage.ProcessIndicator) {
+	mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, ind *storage.ProcessIndicator) {
 		assert.Equal(t, deploymentID, ind.GetDeploymentId())
 	})
 	p.Process(&signal)
@@ -310,7 +310,7 @@ func TestProcessPipelineOnline(t *testing.T) {
 	msg = <-actualEvents
 	assert.NotNil(t, msg)
 	assert.Equal(t, deploymentID, msg.GetEvent().GetProcessIndicator().GetDeploymentId())
-	mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).DoAndReturn(func(ind *storage.ProcessIndicator) {
+	mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, ind *storage.ProcessIndicator) {
 		assert.Equal(t, deploymentID, ind.GetDeploymentId())
 	})
 	p.Process(&signal)

--- a/sensor/common/processsignal/pipeline_test.go
+++ b/sensor/common/processsignal/pipeline_test.go
@@ -151,7 +151,7 @@ func TestProcessPipelineOffline(t *testing.T) {
 			defer deleteStore(containerMetadata2.DeploymentID, mockStore)
 
 			// Detector can be called in any order, so no assertions regarding the order of events.
-			mockDetector.EXPECT().ProcessIndicator(gomock.Any()).
+			mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).
 				MinTimes(2).
 				MaxTimes(2).
 				DoAndReturn(func(ind *storage.ProcessIndicator) {
@@ -274,7 +274,7 @@ func TestProcessPipelineOnline(t *testing.T) {
 	signal := storage.ProcessSignal{
 		ContainerId: containerID,
 	}
-	mockDetector.EXPECT().ProcessIndicator(gomock.Any()).DoAndReturn(func(ind *storage.ProcessIndicator) {
+	mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).DoAndReturn(func(ind *storage.ProcessIndicator) {
 		assert.Equal(t, deploymentID, ind.GetDeploymentId())
 	})
 	p.Process(&signal)
@@ -288,7 +288,7 @@ func TestProcessPipelineOnline(t *testing.T) {
 	signal = storage.ProcessSignal{
 		ContainerId: containerID,
 	}
-	mockDetector.EXPECT().ProcessIndicator(gomock.Any()).DoAndReturn(func(ind *storage.ProcessIndicator) {
+	mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).DoAndReturn(func(ind *storage.ProcessIndicator) {
 		assert.Equal(t, deploymentID, ind.GetDeploymentId())
 	})
 	p.Process(&signal)
@@ -302,7 +302,7 @@ func TestProcessPipelineOnline(t *testing.T) {
 	signal = storage.ProcessSignal{
 		ContainerId: containerID,
 	}
-	mockDetector.EXPECT().ProcessIndicator(gomock.Any()).DoAndReturn(func(ind *storage.ProcessIndicator) {
+	mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).DoAndReturn(func(ind *storage.ProcessIndicator) {
 		assert.Equal(t, deploymentID, ind.GetDeploymentId())
 	})
 	p.Process(&signal)
@@ -310,7 +310,7 @@ func TestProcessPipelineOnline(t *testing.T) {
 	msg = <-actualEvents
 	assert.NotNil(t, msg)
 	assert.Equal(t, deploymentID, msg.GetEvent().GetProcessIndicator().GetDeploymentId())
-	mockDetector.EXPECT().ProcessIndicator(gomock.Any()).DoAndReturn(func(ind *storage.ProcessIndicator) {
+	mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).DoAndReturn(func(ind *storage.ProcessIndicator) {
 		assert.Equal(t, deploymentID, ind.GetDeploymentId())
 	})
 	p.Process(&signal)

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -264,7 +264,7 @@ func (s *centralCommunicationImpl) initialPolicySync(stream central.SensorServic
 	if msg.GetPolicySync() == nil {
 		return errors.Errorf("second message received from Sensor was not a policy sync: %T", msg.Msg)
 	}
-	if err := detector.ProcessPolicySync(msg.GetPolicySync()); err != nil {
+	if err := detector.ProcessPolicySync(context.Background(), msg.GetPolicySync()); err != nil {
 		return errors.Wrap(err, "policy sync could not be successfully processed")
 	}
 

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -81,7 +81,7 @@ func (q *outputQueueImpl) runOutputQueue() {
 		// The order here is important. We rely on the ReprocessDeployment being called before ProcessDeployment to remove the deployments from the deduper.
 		q.detector.ReprocessDeployments(msg.ReprocessDeployments...)
 		for _, detectorRequest := range msg.DetectorMessages {
-			q.detector.ProcessDeployment(detectorRequest.Object, detectorRequest.Action)
+			q.detector.ProcessDeployment(msg.Context, detectorRequest.Object, detectorRequest.Action)
 		}
 		metrics.DecOutputChannelSize()
 	}

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -77,7 +77,6 @@ func (q *outputQueueImpl) runOutputQueue() {
 			}
 		}
 
-		// TODO(ROX-17326): Don't process message in the detector if message expired
 		// The order here is important. We rely on the ReprocessDeployment being called before ProcessDeployment to remove the deployments from the deduper.
 		q.detector.ReprocessDeployments(msg.ReprocessDeployments...)
 		for _, detectorRequest := range msg.DetectorMessages {

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -78,6 +78,12 @@ func (p *eventPipeline) stopCurrentContext() {
 	}
 }
 
+func (p *eventPipeline) getCurrentContext() context.Context {
+	p.contextMtx.Lock()
+	defer p.contextMtx.Unlock()
+	return p.context
+}
+
 func (p *eventPipeline) createNewContext() {
 	p.contextMtx.Lock()
 	defer p.contextMtx.Unlock()
@@ -155,7 +161,7 @@ func (p *eventPipeline) forwardMessages() {
 
 func (p *eventPipeline) processPolicySync(sync *central.PolicySync) error {
 	log.Debug("PolicySync message received from central")
-	return p.detector.ProcessPolicySync(sync)
+	return p.detector.ProcessPolicySync(p.getCurrentContext(), sync)
 }
 
 func (p *eventPipeline) processReassessPolicies() error {
@@ -168,6 +174,7 @@ func (p *eventPipeline) processReassessPolicies() error {
 		// TODO(ROX-14310): Add WithSkipResolving to the DeploymentReference (Revert: https://github.com/stackrox/stackrox/pull/5551)
 		msg.AddDeploymentReference(resolver.ResolveAllDeployments(),
 			component.WithForceDetection())
+		msg.Context = p.getCurrentContext()
 		p.resolver.Send(msg)
 	}
 	return nil
@@ -183,6 +190,7 @@ func (p *eventPipeline) processReprocessDeployments() error {
 		// TODO(ROX-14310): Add WithSkipResolving to the DeploymentReference (Revert: https://github.com/stackrox/stackrox/pull/5551)
 		msg.AddDeploymentReference(resolver.ResolveAllDeployments(),
 			component.WithForceDetection())
+		msg.Context = p.getCurrentContext()
 		p.resolver.Send(msg)
 	}
 	return nil
@@ -198,6 +206,7 @@ func (p *eventPipeline) processUpdatedImage(image *storage.Image) error {
 		msg.AddDeploymentReference(resolver.ResolveDeploymentsByImages(image),
 			component.WithForceDetection(),
 			component.WithSkipResolving())
+		msg.Context = p.getCurrentContext()
 		p.resolver.Send(msg)
 	}
 	return nil
@@ -213,6 +222,7 @@ func (p *eventPipeline) processReprocessDeployment(req *central.ReprocessDeploym
 		msg.AddDeploymentReference(resolver.ResolveDeploymentIds(req.GetDeploymentIds()...),
 			component.WithForceDetection(),
 			component.WithSkipResolving())
+		msg.Context = p.getCurrentContext()
 		p.resolver.Send(msg)
 	}
 	return nil
@@ -237,6 +247,7 @@ func (p *eventPipeline) processInvalidateImageCache(req *central.InvalidateImage
 		msg.AddDeploymentReference(resolver.ResolveDeploymentsByImages(keys...),
 			component.WithForceDetection(),
 			component.WithSkipResolving())
+		msg.Context = p.getCurrentContext()
 		p.resolver.Send(msg)
 	}
 	return nil

--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -205,7 +205,7 @@ func (s *eventPipelineSuite) Test_PolicySync() {
 			},
 		},
 	}
-	s.detector.EXPECT().ProcessPolicySync(gomock.Any(), gomock.Any()).Times(1).Do(func(_ interface{}) {
+	s.detector.EXPECT().ProcessPolicySync(gomock.Any(), gomock.Any()).Times(1).Do(func(_, _ interface{}) {
 		defer messageReceived.Done()
 	})
 

--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -205,7 +205,7 @@ func (s *eventPipelineSuite) Test_PolicySync() {
 			},
 		},
 	}
-	s.detector.EXPECT().ProcessPolicySync(gomock.Any()).Times(1).Do(func(_ interface{}) {
+	s.detector.EXPECT().ProcessPolicySync(gomock.Any(), gomock.Any()).Times(1).Do(func(_ interface{}) {
 		defer messageReceived.Done()
 	})
 


### PR DESCRIPTION
## Description

Rather than having detector have its own context (like we first discussed), this PR proposes a simpler approach. Add `context.Context` to the detector API, allowing the components left of detector in pipeline to provide their context in the messages. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Integration tests passing should be sufficient