### PR TITLE
ROX-18767: add lock in Cleanup

### DIFF
--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -89,6 +89,8 @@ func NewRegistryStore(checkTLS CheckTLS) *Store {
 func (rs *Store) Cleanup() {
 	rs.mutex.Lock()
 	defer rs.mutex.Unlock()
+	rs.clusterLocalRegistryHostsMutex.Lock()
+	defer rs.clusterLocalRegistryHostsMutex.Unlock()
 
 	rs.store = make(map[string]registries.Set)
 	rs.globalRegistries = registries.NewSet(rs.factory)

--- a/sensor/common/registry/registry_store_test.go
+++ b/sensor/common/registry/registry_store_test.go
@@ -297,7 +297,7 @@ func TestRegistryStore_GenImgIntName(t *testing.T) {
 	}
 }
 
-func TestDataRaceAtCleanup(t *testing.T) {
+func TestDataRaceAtCleanup(_ *testing.T) {
 	testNamespace := "test-ns"
 	regStore := NewRegistryStore(alwaysInsecureCheckTLS)
 	regStore.store[testNamespace] = registries.NewSet(regStore.factory)

--- a/sensor/common/registry/registry_store_test.go
+++ b/sensor/common/registry/registry_store_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/registries"
 	"github.com/stackrox/rox/pkg/registries/docker"
 	"github.com/stackrox/rox/pkg/registries/rhel"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
## Description

This PR aims to fix a data race in the registry store (see [ci failure](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-sensor-integration-tests/1686673827150434304))

* ~Should fix~ Partially fixes: [ROX-18767](https://issues.redhat.com/browse/ROX-18767)

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- [x] CI
- [x] Unit test
