### PR TITLE
ROX-18322: Mask deployments for network graph in a deterministic way

### DIFF
--- a/central/networkgraph/service/masker.go
+++ b/central/networkgraph/service/masker.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/uuid"
 )
 
@@ -15,6 +17,8 @@ const (
 )
 
 type flowGraphMasker struct {
+	deploymentsToMask      map[string]*storage.ListDeployment
+	namespaceNamesToMask   set.Set[string]
 	maskedDeployments      []*storage.ListDeployment
 	realToMaskedDeployment map[string]*storage.ListDeployment
 	realToMaskedNamespace  map[string]string
@@ -22,32 +26,54 @@ type flowGraphMasker struct {
 
 func newFlowGraphMasker() *flowGraphMasker {
 	return &flowGraphMasker{
+		deploymentsToMask:      make(map[string]*storage.ListDeployment),
 		realToMaskedDeployment: make(map[string]*storage.ListDeployment),
 		realToMaskedNamespace:  make(map[string]string),
 	}
 }
 
+func (m *flowGraphMasker) RegisterDeploymentForMasking(deployment *storage.ListDeployment) {
+	m.deploymentsToMask[deployment.GetId()] = &storage.ListDeployment{
+		Id:        deployment.GetId(),
+		Name:      deployment.GetName(),
+		Cluster:   deployment.GetCluster(),
+		ClusterId: deployment.GetClusterId(),
+		Namespace: deployment.GetNamespace(),
+	}
+	m.namespaceNamesToMask.Add(deployment.GetNamespace())
+}
+
+func (m *flowGraphMasker) MaskDeploymentsAndNamespaces() {
+	orderedNamespaceNamesToMask := m.namespaceNamesToMask.AsSlice()
+	sort.Strings(orderedNamespaceNamesToMask)
+	for ix, ns := range orderedNamespaceNamesToMask {
+		maskedNS := fmt.Sprintf("%s #%d", MaskedNamespaceName, ix+1)
+		m.realToMaskedNamespace[ns] = maskedNS
+	}
+	m.namespaceNamesToMask.Clear()
+	orderedDeploymentIDsToMask := make([]string, 0, len(m.deploymentsToMask))
+	for deploymentID := range m.deploymentsToMask {
+		orderedDeploymentIDsToMask = append(orderedDeploymentIDsToMask, deploymentID)
+	}
+	sort.Strings(orderedDeploymentIDsToMask)
+	for ix, deploymentID := range orderedDeploymentIDsToMask {
+		origDeployment := m.deploymentsToMask[deploymentID]
+		maskedDeploymentName := fmt.Sprintf("%s #%d", MaskedDeploymentName, ix+1)
+		maskedDeployment := &storage.ListDeployment{
+			Id:        uuid.NewV4().String(),
+			Name:      maskedDeploymentName,
+			Cluster:   origDeployment.GetCluster(),
+			ClusterId: origDeployment.GetClusterId(),
+			Namespace: m.realToMaskedNamespace[origDeployment.GetNamespace()],
+		}
+		m.realToMaskedDeployment[deploymentID] = maskedDeployment
+		m.maskedDeployments = append(m.maskedDeployments, maskedDeployment)
+		delete(m.deploymentsToMask, deploymentID)
+	}
+}
+
 func (m *flowGraphMasker) GetMaskedDeployment(origDeployment *storage.ListDeployment) *storage.ListDeployment {
-	if masked := m.realToMaskedDeployment[origDeployment.GetId()]; masked != nil {
-		return masked
-	}
-
-	var maskedNS string
-	if maskedNS = m.realToMaskedNamespace[origDeployment.GetNamespace()]; maskedNS == "" {
-		maskedNS = fmt.Sprintf("%s #%d", MaskedNamespaceName, len(m.realToMaskedNamespace)+1)
-		m.realToMaskedNamespace[origDeployment.GetNamespace()] = maskedNS
-	}
-
-	masked := &storage.ListDeployment{
-		Id:        uuid.NewV4().String(),
-		Name:      fmt.Sprintf("%s #%d", MaskedDeploymentName, len(m.realToMaskedDeployment)+1),
-		Namespace: maskedNS,
-		Cluster:   origDeployment.GetCluster(),
-		ClusterId: origDeployment.GetClusterId(),
-	}
-	m.realToMaskedDeployment[origDeployment.GetId()] = masked
-	m.maskedDeployments = append(m.maskedDeployments, masked)
-	return masked
+	return m.realToMaskedDeployment[origDeployment.GetId()]
 }
 
 func (m *flowGraphMasker) GetMaskedDeployments() []*storage.ListDeployment {

--- a/central/networkgraph/service/service_impl.go
+++ b/central/networkgraph/service/service_impl.go
@@ -540,6 +540,44 @@ func filterFlowsAndMaskScopeAlienDeployments(
 	// Step 2: Mask deployments a user is not allowed to see.
 	masker := newFlowGraphMasker()
 
+	// Step 2.1: Register deployments a user is not allowed to see for masking.
+	for _, flow := range flows {
+		skipFlow := false
+		entities := []*storage.NetworkEntityInfo{flow.GetProps().GetSrcEntity(), flow.GetProps().GetDstEntity()}
+		for _, entity := range entities {
+			// no masking or skipping required for non-deployment type entities.
+			if entity.GetType() != storage.NetworkEntityInfo_DEPLOYMENT {
+				continue
+			}
+
+			// no masking or skipping required for deployments already in the set.
+			if deploymentsMap[entity.GetId()] != nil {
+				continue
+			}
+
+			// no masking or skipping required for neighboring deployments.
+			if visibleNeighboringDeployments.Contains(entity.GetId()) {
+				continue
+			}
+
+			invisibleDeployment := existingButInvisibleDeploymentsMap[entity.GetId()]
+			if invisibleDeployment == nil {
+				skipFlow = true // deployment has been deleted or does not satisfy scope.
+				break
+			}
+
+			// To avoid information leak we always show all masked neighbors
+			masker.RegisterDeploymentForMasking(invisibleDeployment)
+		}
+		if skipFlow {
+			continue
+		}
+	}
+
+	// Step 2.2: Pre-compute deployment masking information.
+	masker.MaskDeploymentsAndNamespaces()
+
+	// Step 2.3: Replace deployments a user is not allowed to see with their masked counterparts.
 	for _, flow := range flows {
 		skipFlow := false
 		entities := []*storage.NetworkEntityInfo{flow.GetProps().GetSrcEntity(), flow.GetProps().GetDstEntity()}

--- a/central/networkgraph/service/service_impl_test.go
+++ b/central/networkgraph/service/service_impl_test.go
@@ -396,17 +396,17 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSAC() {
 		"foo/depA <- foo/depB",
 		"foo/depA <- bar/depD",
 		"foo/depA <- bar/depE",
-		"foo/depA <- masked namespace #1/masked deployment #1",
-		"foo/depA <- masked namespace #1/masked deployment #2",
+		"foo/depA <- masked namespace #1/masked deployment #2", // depX
+		"foo/depA <- masked namespace #1/masked deployment #3", // depZ
 		"foo/depA <- mycluster__net1",
 		"foo/depA <- " + es2ID.String(),
 		"foo/depA <- " + es3ID.String(), // non-existent es5 mapped to supernet es3
 		"foo/depB <- foo/depA",
 		"foo/depB <- baz/depF",
-		"foo/depB <- masked namespace #1/masked deployment #1",
-		"foo/depB <- masked namespace #2/masked deployment #3",
+		"foo/depB <- masked namespace #1/masked deployment #2", // depX
+		"foo/depB <- masked namespace #2/masked deployment #1", // depW
 		"foo/depC <- foo/depA",
-		"foo/depC <- masked namespace #2/masked deployment #3",
+		"foo/depC <- masked namespace #2/masked deployment #1", // depW
 		"foo/depC <- " + networkgraph.InternetExternalSourceID,
 		"bar/depD <- foo/depA",
 		"bar/depE <- foo/depB",


### PR DESCRIPTION
## Description

The investigation of the CI issue in the ROX-18322 highlighted the fact that namespaces and deployments can show up in different order in the sequence in which these are masked.
In order to ensure that two consecutive calls to `GetNetworkGraph` get the same results regardless of the order in which flows and entities are fetched from database.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.

New Unit test output against master
```
=== RUN   TestNetworkGraph/TestGenerateNetworkGraphWithSACDeterministicMasking
    service_impl_test.go:840: 
        	Error Trace:	/Users/ybrillou/go/src/github.com/stackrox/stackrox/central/networkgraph/service/service_impl_test.go:840
        	Error:      	Not equal: 
        	            	expected: []string{"bar/depD <- foo/depA", "bar/depE <- foo/depB", "baz/depF <- foo/depB", "foo/depA <- bar/depD", "foo/depA <- bar/depE", "foo/depA <- foo/depB", "foo/depA <- masked namespace #1/masked deployment #2", "foo/depA <- masked namespace #1/masked deployment #3", "foo/depA <- mycluster__MzUuMTg3LjE0NC4wLzIz", "foo/depA <- mycluster__MzYuMTg4LjAuMC8xNg", "foo/depA <- mycluster__net1", "foo/depB <- baz/depF", "foo/depB <- foo/depA", "foo/depB <- masked namespace #1/masked deployment #2", "foo/depB <- masked namespace #2/masked deployment #1", "foo/depC <- afa12424-bde3-4313-b810-bb463cbe8f90", "foo/depC <- foo/depA", "foo/depC <- masked namespace #2/masked deployment #1", "mycluster__net1 <- foo/depA"}
        	            	actual  : []string{"bar/depD <- foo/depA", "bar/depE <- foo/depB", "baz/depF <- foo/depB", "foo/depA <- bar/depD", "foo/depA <- bar/depE", "foo/depA <- foo/depB", "foo/depA <- masked namespace #1/masked deployment #1", "foo/depA <- masked namespace #1/masked deployment #2", "foo/depA <- mycluster__MzUuMTg3LjE0NC4wLzIz", "foo/depA <- mycluster__MzYuMTg4LjAuMC8xNg", "foo/depA <- mycluster__net1", "foo/depB <- baz/depF", "foo/depB <- foo/depA", "foo/depB <- masked namespace #1/masked deployment #1", "foo/depB <- masked namespace #2/masked deployment #3", "foo/depC <- afa12424-bde3-4313-b810-bb463cbe8f90", "foo/depC <- foo/depA", "foo/depC <- masked namespace #2/masked deployment #3", "mycluster__net1 <- foo/depA"}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -7,4 +7,4 @@
        	            	  (string) (len=20) "foo/depA <- foo/depB",
        	            	+ (string) (len=52) "foo/depA <- masked namespace #1/masked deployment #1",
        	            	  (string) (len=52) "foo/depA <- masked namespace #1/masked deployment #2",
        	            	- (string) (len=52) "foo/depA <- masked namespace #1/masked deployment #3",
        	            	  (string) (len=43) "foo/depA <- mycluster__MzUuMTg3LjE0NC4wLzIz",
        	            	@@ -14,7 +14,7 @@
        	            	  (string) (len=20) "foo/depB <- foo/depA",
        	            	- (string) (len=52) "foo/depB <- masked namespace #1/masked deployment #2",
        	            	- (string) (len=52) "foo/depB <- masked namespace #2/masked deployment #1",
        	            	+ (string) (len=52) "foo/depB <- masked namespace #1/masked deployment #1",
        	            	+ (string) (len=52) "foo/depB <- masked namespace #2/masked deployment #3",
        	            	  (string) (len=48) "foo/depC <- afa12424-bde3-4313-b810-bb463cbe8f90",
        	            	  (string) (len=20) "foo/depC <- foo/depA",
        	            	- (string) (len=52) "foo/depC <- masked namespace #2/masked deployment #1",
        	            	+ (string) (len=52) "foo/depC <- masked namespace #2/masked deployment #3",
        	            	  (string) (len=27) "mycluster__net1 <- foo/depA"
        	Test:       	TestNetworkGraph/TestGenerateNetworkGraphWithSACDeterministicMasking
    service_impl_test.go:879: 
        	Error Trace:	/Users/ybrillou/go/src/github.com/stackrox/stackrox/central/networkgraph/service/service_impl_test.go:879
        	Error:      	Not equal: 
        	            	expected: []string{"bar/depD <- foo/depA", "bar/depE <- foo/depB", "baz/depF <- foo/depB", "foo/depA <- bar/depD", "foo/depA <- bar/depE", "foo/depA <- foo/depB", "foo/depA <- masked namespace #1/masked deployment #2", "foo/depA <- masked namespace #1/masked deployment #3", "foo/depA <- mycluster__MzUuMTg3LjE0NC4wLzIz", "foo/depA <- mycluster__MzYuMTg4LjAuMC8xNg", "foo/depA <- mycluster__net1", "foo/depB <- baz/depF", "foo/depB <- foo/depA", "foo/depB <- masked namespace #1/masked deployment #2", "foo/depB <- masked namespace #2/masked deployment #1", "foo/depC <- afa12424-bde3-4313-b810-bb463cbe8f90", "foo/depC <- foo/depA", "foo/depC <- masked namespace #2/masked deployment #1", "mycluster__net1 <- foo/depA"}
        	            	actual  : []string{"bar/depD <- foo/depA", "bar/depE <- foo/depB", "baz/depF <- foo/depB", "foo/depA <- bar/depD", "foo/depA <- bar/depE", "foo/depA <- foo/depB", "foo/depA <- masked namespace #2/masked deployment #2", "foo/depA <- masked namespace #2/masked deployment #3", "foo/depA <- mycluster__MzUuMTg3LjE0NC4wLzIz", "foo/depA <- mycluster__MzYuMTg4LjAuMC8xNg", "foo/depA <- mycluster__net1", "foo/depB <- baz/depF", "foo/depB <- foo/depA", "foo/depB <- masked namespace #1/masked deployment #1", "foo/depB <- masked namespace #2/masked deployment #3", "foo/depC <- afa12424-bde3-4313-b810-bb463cbe8f90", "foo/depC <- foo/depA", "foo/depC <- masked namespace #1/masked deployment #1", "mycluster__net1 <- foo/depA"}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -7,4 +7,4 @@
        	            	  (string) (len=20) "foo/depA <- foo/depB",
        	            	- (string) (len=52) "foo/depA <- masked namespace #1/masked deployment #2",
        	            	- (string) (len=52) "foo/depA <- masked namespace #1/masked deployment #3",
        	            	+ (string) (len=52) "foo/depA <- masked namespace #2/masked deployment #2",
        	            	+ (string) (len=52) "foo/depA <- masked namespace #2/masked deployment #3",
        	            	  (string) (len=43) "foo/depA <- mycluster__MzUuMTg3LjE0NC4wLzIz",
        	            	@@ -14,7 +14,7 @@
        	            	  (string) (len=20) "foo/depB <- foo/depA",
        	            	- (string) (len=52) "foo/depB <- masked namespace #1/masked deployment #2",
        	            	- (string) (len=52) "foo/depB <- masked namespace #2/masked deployment #1",
        	            	+ (string) (len=52) "foo/depB <- masked namespace #1/masked deployment #1",
        	            	+ (string) (len=52) "foo/depB <- masked namespace #2/masked deployment #3",
        	            	  (string) (len=48) "foo/depC <- afa12424-bde3-4313-b810-bb463cbe8f90",
        	            	  (string) (len=20) "foo/depC <- foo/depA",
        	            	- (string) (len=52) "foo/depC <- masked namespace #2/masked deployment #1",
        	            	+ (string) (len=52) "foo/depC <- masked namespace #1/masked deployment #1",
        	            	  (string) (len=27) "mycluster__net1 <- foo/depA"
        	Test:       	TestNetworkGraph/TestGenerateNetworkGraphWithSACDeterministicMasking
```
In the first run, the masking mapping is :
```
deployments:
depW -> masked namespace #2/masked deployment #3
depX -> masked namespace #1/masked deployment #1
depZ -> masked namespace #1/masked deployment #2
namespaces:
secretns -> masked namespace #1
supersecretns -> masked namespace #2
```
In the second run, the masking mapping is :
```
deployments:
depW -> masked namespace #1/masked deployment #1
depX -> masked namespace #2/masked deployment #3
depZ -> masked namespace #2/masked deployment #2
namespaces:
secretns -> masked namespace #2
supersecretns -> masked namespace #1
```