### PR TITLE
ROX-18844: Fix sensor integration test harness

### DIFF
--- a/sensor/tests/connection/alerts/alert_test.go
+++ b/sensor/tests/connection/alerts/alert_test.go
@@ -42,7 +42,7 @@ func Test_AlertsAreSentAfterConnectionRestart(t *testing.T) {
 
 		testContext.WaitForSyncEvent(t, 2*time.Minute)
 
-		_, err = c.ApplyResourceAndWaitNoObject(t, ctx, helper.DefaultNamespace, DeploymentWithViolation, nil)
+		_, err = c.ApplyResourceAndWaitNoObject(ctx, t, helper.DefaultNamespace, DeploymentWithViolation, nil)
 		require.NoError(t, err)
 
 		// After first deployment, should see an alert for deployment

--- a/sensor/tests/connection/alerts/alert_test.go
+++ b/sensor/tests/connection/alerts/alert_test.go
@@ -46,7 +46,7 @@ func Test_AlertsAreSentAfterConnectionRestart(t *testing.T) {
 		require.NoError(t, err)
 
 		// After first deployment, should see an alert for deployment
-		testContext.LastViolationState(DeploymentWithViolation.Name, hasRequiredLabelAlert, "Deployment should have alerts")
+		testContext.LastViolationState(t, DeploymentWithViolation.Name, hasRequiredLabelAlert, "Deployment should have alerts")
 
 		// We need to wait some virtual time until all the deployment updates happen before restarting. Otherwise,
 		// the deployment will continue to receive updates (e.g. image SHA update) and the test will pass even if
@@ -60,7 +60,7 @@ func Test_AlertsAreSentAfterConnectionRestart(t *testing.T) {
 		testContext.WaitForSyncEvent(2 * time.Minute)
 
 		// Should see the alert *again* on a connection restart
-		testContext.LastViolationState(DeploymentWithViolation.Name, hasRequiredLabelAlert, "Deployment should have alerts")
+		testContext.LastViolationState(t, DeploymentWithViolation.Name, hasRequiredLabelAlert, "Deployment should have alerts")
 	}))
 
 }

--- a/sensor/tests/connection/alerts/alert_test.go
+++ b/sensor/tests/connection/alerts/alert_test.go
@@ -37,12 +37,12 @@ func Test_AlertsAreSentAfterConnectionRestart(t *testing.T) {
 	c, err := helper.NewContextWithConfig(t, config)
 	require.NoError(t, err)
 
-	c.RunTest(helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {
+	c.RunTest(t, helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {
 		ctx := context.Background()
 
-		testContext.WaitForSyncEvent(2 * time.Minute)
+		testContext.WaitForSyncEvent(t, 2*time.Minute)
 
-		_, err = c.ApplyResourceAndWaitNoObject(ctx, helper.DefaultNamespace, DeploymentWithViolation, nil)
+		_, err = c.ApplyResourceAndWaitNoObject(t, ctx, helper.DefaultNamespace, DeploymentWithViolation, nil)
 		require.NoError(t, err)
 
 		// After first deployment, should see an alert for deployment
@@ -57,7 +57,7 @@ func Test_AlertsAreSentAfterConnectionRestart(t *testing.T) {
 		testContext.RestartFakeCentralConnection()
 
 		// Wait for reconciliation to finish
-		testContext.WaitForSyncEvent(2 * time.Minute)
+		testContext.WaitForSyncEvent(t, 2*time.Minute)
 
 		// Should see the alert *again* on a connection restart
 		testContext.LastViolationState(t, DeploymentWithViolation.Name, hasRequiredLabelAlert, "Deployment should have alerts")

--- a/sensor/tests/connection/connection_test.go
+++ b/sensor/tests/connection/connection_test.go
@@ -94,7 +94,7 @@ func Test_SensorReconnects(t *testing.T) {
 		assert.False(t, testContext.SensorStopped())
 
 		// We applied the resource _after_ Sensor restarted. Now we should check that this deployment will be sent to Central.
-		_, err = c.ApplyResourceAndWaitNoObject(t, context.Background(), helper.DefaultNamespace, NginxDeployment1, nil)
+		_, err = c.ApplyResourceAndWaitNoObject(context.Background(), t, helper.DefaultNamespace, NginxDeployment1, nil)
 		require.NoError(t, err)
 	}))
 }

--- a/sensor/tests/connection/connection_test.go
+++ b/sensor/tests/connection/connection_test.go
@@ -33,12 +33,12 @@ func Test_SensorHello(t *testing.T) {
 
 	require.NoError(t, err)
 
-	c.RunTest(helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {
-		hello1 := testContext.WaitForHello(3 * time.Minute)
+	c.RunTest(t, helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {
+		hello1 := testContext.WaitForHello(t, 3*time.Minute)
 		require.NotNil(t, hello1)
 		assert.Equal(t, central.SensorHello_STARTUP, hello1.GetSensorState())
 		testContext.RestartFakeCentralConnection()
-		hello2 := testContext.WaitForHello(3 * time.Minute)
+		hello2 := testContext.WaitForHello(t, 3*time.Minute)
 		require.NotNil(t, hello2)
 		assert.Equal(t, central.SensorHello_RECONNECT, hello2.GetSensorState())
 	}))
@@ -66,7 +66,7 @@ func Test_SensorReconnects(t *testing.T) {
 
 	require.NoError(t, err)
 
-	c.RunTest(helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {
+	c.RunTest(t, helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {
 
 		// This test case will make sure that:
 		//  1) Sensor does not crash when ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT is set.
@@ -85,16 +85,16 @@ func Test_SensorReconnects(t *testing.T) {
 		// Note that this behavior is *not* acceptable in production. There are follow-up tasks (ROX-17327 and ROX-17157)
 		// that will tackle this, and only then the sleep timer could be removed.
 
-		testContext.WaitForSyncEvent(2 * time.Minute)
+		testContext.WaitForSyncEvent(t, 2*time.Minute)
 
 		// Stop fake central gRPC server and create a new one immediately after.
 		testContext.RestartFakeCentralConnection()
-		testContext.WaitForSyncEvent(2 * time.Minute)
+		testContext.WaitForSyncEvent(t, 2*time.Minute)
 
 		assert.False(t, testContext.SensorStopped())
 
 		// We applied the resource _after_ Sensor restarted. Now we should check that this deployment will be sent to Central.
-		_, err = c.ApplyResourceAndWaitNoObject(context.Background(), helper.DefaultNamespace, NginxDeployment1, nil)
+		_, err = c.ApplyResourceAndWaitNoObject(t, context.Background(), helper.DefaultNamespace, NginxDeployment1, nil)
 		require.NoError(t, err)
 	}))
 }

--- a/sensor/tests/connection/k8sreconciliation/reconcile_test.go
+++ b/sensor/tests/connection/k8sreconciliation/reconcile_test.go
@@ -53,18 +53,18 @@ func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
 		ctx := context.Background()
 
 		testContext.WaitForSyncEvent(t, 2*time.Minute)
-		_, err = c.ApplyResourceAndWaitNoObject(t, ctx, helper.DefaultNamespace, NginxDeployment1, nil)
+		_, err = c.ApplyResourceAndWaitNoObject(ctx, t, helper.DefaultNamespace, NginxDeployment1, nil)
 		require.NoError(t, err)
-		deleteDeployment2, err := c.ApplyResourceAndWaitNoObject(t, ctx, helper.DefaultNamespace, NginxDeployment2, nil)
+		deleteDeployment2, err := c.ApplyResourceAndWaitNoObject(ctx, t, helper.DefaultNamespace, NginxDeployment2, nil)
 		require.NoError(t, err)
 
-		_, err = c.ApplyResourceAndWaitNoObject(t, ctx, helper.DefaultNamespace, NetpolBlockEgress, nil)
+		_, err = c.ApplyResourceAndWaitNoObject(ctx, t, helper.DefaultNamespace, NetpolBlockEgress, nil)
 		require.NoError(t, err)
 
 		testContext.StopCentralGRPC()
 
 		obj := &appsV1.Deployment{}
-		_, err = c.ApplyResource(t, ctx, helper.DefaultNamespace, &NginxDeployment3, obj, nil)
+		_, err = c.ApplyResource(ctx, t, helper.DefaultNamespace, &NginxDeployment3, obj, nil)
 		require.NoError(t, err)
 
 		require.NoError(t, deleteDeployment2())

--- a/sensor/tests/connection/k8sreconciliation/reconcile_test.go
+++ b/sensor/tests/connection/k8sreconciliation/reconcile_test.go
@@ -81,8 +81,8 @@ func Test_SensorReconcilesKubernetesEvents(t *testing.T) {
 		//   No event for nginx-deployment-2 (was deleted while connection was down)
 		// This reconciliation state will make Central delete Nginx2, keep Nginx1 and create Nginx3
 		testContext.WaitForSyncEvent(2 * time.Minute)
-		testContext.FirstDeploymentReceivedWithAction(NginxDeployment1.Name, central.ResourceAction_SYNC_RESOURCE)
-		testContext.FirstDeploymentReceivedWithAction(NginxDeployment3.Name, central.ResourceAction_SYNC_RESOURCE)
+		testContext.FirstDeploymentReceivedWithAction(t, NginxDeployment1.Name, central.ResourceAction_SYNC_RESOURCE)
+		testContext.FirstDeploymentReceivedWithAction(t, NginxDeployment3.Name, central.ResourceAction_SYNC_RESOURCE)
 
 		// This assertion will fail if events are not properly cleared from the internal queues and in-memory stores
 		testContext.DeploymentNotReceived(NginxDeployment2.Name)

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -310,7 +310,7 @@ func (c *TestContext) run(t *testing.T, tr *testRun) {
 		c.runBare(t, tr.testCase)
 	} else {
 		if tr.permutation {
-			c.runWithResourcesPermutation(tr, t)
+			c.runWithResourcesPermutation(t, tr)
 		} else {
 			if err := c.runWithResources(t, tr.resources, tr.testCase, tr.retryCallback); err != nil {
 				t.Fatalf(err.Error())
@@ -359,7 +359,7 @@ func (c *TestContext) runBare(t *testing.T, testCase TestCallback) {
 
 // runWithResourcesPermutation runs the test cases using `resources` similarly to `runWithResources` but it will run the
 // test case for each possible permutation of `resources` slice.
-func (c *TestContext) runWithResourcesPermutation(tr *testRun, t *testing.T) {
+func (c *TestContext) runWithResourcesPermutation(t *testing.T, tr *testRun) {
 	runPermutation(tr.resources, 0, func(f []K8sResourceInfo) {
 		newF := make([]K8sResourceInfo, len(f))
 		copy(newF, f)

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -331,7 +331,7 @@ func (c *TestContext) runWithResources(t *testing.T, resources []K8sResourceInfo
 	fileToObj := map[string]k8s.Object{}
 	for i := range resources {
 		obj := objByKind(resources[i].Kind)
-		removeFn, err := c.ApplyResourceAndWait(t, context.Background(), DefaultNamespace, &resources[i], obj, retryFn)
+		removeFn, err := c.ApplyResourceAndWait(context.Background(), t, DefaultNamespace, &resources[i], obj, retryFn)
 		if err != nil {
 			return errors.Errorf("fail to apply resource: %s", err)
 		}
@@ -726,14 +726,14 @@ func createConnectionAndStartServer(fakeCentral *centralDebug.FakeService) (*grp
 
 // ApplyResourceAndWaitNoObject creates a Kubernetes resource using `ApplyResourceAndWait` without requiring an object reference.
 // Use this if there is no need to get or manipulate the data in the YAML file.
-func (c *TestContext) ApplyResourceAndWaitNoObject(t *testing.T, ctx context.Context, ns string, resource K8sResourceInfo, retryFn RetryCallback) (func() error, error) {
+func (c *TestContext) ApplyResourceAndWaitNoObject(ctx context.Context, t *testing.T, ns string, resource K8sResourceInfo, retryFn RetryCallback) (func() error, error) {
 	obj := objByKind(resource.Kind)
-	return c.ApplyResourceAndWait(t, ctx, ns, &resource, obj, retryFn)
+	return c.ApplyResourceAndWait(ctx, t, ns, &resource, obj, retryFn)
 }
 
 // ApplyResourceAndWait calls ApplyResource and waits for the resource if it's "waitable" (e.g. Deployment or Pod).
-func (c *TestContext) ApplyResourceAndWait(t *testing.T, ctx context.Context, ns string, resource *K8sResourceInfo, obj k8s.Object, retryFn RetryCallback) (func() error, error) {
-	fn, err := c.ApplyResource(t, ctx, ns, resource, obj, retryFn)
+func (c *TestContext) ApplyResourceAndWait(ctx context.Context, t *testing.T, ns string, resource *K8sResourceInfo, obj k8s.Object, retryFn RetryCallback) (func() error, error) {
+	fn, err := c.ApplyResource(ctx, t, ns, resource, obj, retryFn)
 	if err != nil {
 		return nil, err
 	}
@@ -752,7 +752,7 @@ func (c *TestContext) ApplyResourceAndWait(t *testing.T, ctx context.Context, ns
 // with the properties from the resource definition. In case the creation fails (due to the client
 // API rejecting the definition), a `RetryCallback` function can be provided to manipulate the
 // object prior to the retry.
-func (c *TestContext) ApplyResource(t *testing.T, ctx context.Context, ns string, resource *K8sResourceInfo, obj k8s.Object, retryFn RetryCallback) (func() error, error) {
+func (c *TestContext) ApplyResource(ctx context.Context, t *testing.T, ns string, resource *K8sResourceInfo, obj k8s.Object, retryFn RetryCallback) (func() error, error) {
 	if resource.Obj != nil {
 		var ok bool
 		obj, ok = resource.Obj.(k8s.Object)

--- a/sensor/tests/resource/imagescan/imagescan_test.go
+++ b/sensor/tests/resource/imagescan/imagescan_test.go
@@ -81,7 +81,7 @@ func (s *ImageScanSuite) Test_AlertsUpdatedOnImageUpdate() {
 			var image *storage.ContainerImage
 			// Image should be received by central
 			fmt.Println("lvm: waiting for pod")
-			tc.LastDeploymentStateWithTimeout("myapp", func(dp *storage.Deployment, _ central.ResourceAction) error {
+			tc.LastDeploymentStateWithTimeout(t, "myapp", func(dp *storage.Deployment, _ central.ResourceAction) error {
 				if len(dp.GetContainers()) != 1 {
 					return errors.Errorf("expected 1 container found %d", len(dp.GetContainers()))
 				}
@@ -95,7 +95,7 @@ func (s *ImageScanSuite) Test_AlertsUpdatedOnImageUpdate() {
 			}, "myapp should have started the container and have an imageID", 2*time.Minute)
 
 			// There should be no violation yet, because there are no components provided for this image
-			tc.LastViolationState("myapp", func(result *central.AlertResults) error {
+			tc.LastViolationState(t, "myapp", func(result *central.AlertResults) error {
 				if checkIfAlertsHaveViolation(result, Policies[0].GetName()) {
 					return errors.New("violation found for deployment")
 				}
@@ -128,7 +128,7 @@ func (s *ImageScanSuite) Test_AlertsUpdatedOnImageUpdate() {
 			})
 
 			// Violation should eventually happen for myapp, since the image scanned has rpm installed
-			tc.LastViolationStateWithTimeout("myapp", func(result *central.AlertResults) error {
+			tc.LastViolationStateWithTimeout(t, "myapp", func(result *central.AlertResults) error {
 				if !checkIfAlertsHaveViolation(result, Policies[0].GetName()) {
 					return errors.New("violation not found for deployment")
 				}

--- a/sensor/tests/resource/imagescan/imagescan_test.go
+++ b/sensor/tests/resource/imagescan/imagescan_test.go
@@ -65,7 +65,7 @@ func (s *ImageScanSuite) SetupSuite() {
 	s.T().Setenv("ROX_RESYNC_DISABLED", "true")
 	customConfig := helper.DefaultCentralConfig()
 	customConfig.InitialSystemPolicies = Policies
-	testContext, err := helper.NewContextWithConfig(t, customConfig)
+	testContext, err := helper.NewContextWithConfig(s.T(), customConfig)
 	s.Require().NoError(err)
 	s.testContext = testContext
 }
@@ -75,7 +75,7 @@ func (s *ImageScanSuite) TearDownTest() {
 }
 
 func (s *ImageScanSuite) Test_AlertsUpdatedOnImageUpdate() {
-	s.testContext.RunTest(
+	s.testContext.RunTest(s.T(),
 		helper.WithResources([]helper.K8sResourceInfo{Pod}),
 		helper.WithTestCase(func(t *testing.T, tc *helper.TestContext, resource map[string]k8s.Object) {
 			var image *storage.ContainerImage

--- a/sensor/tests/resource/imagescan/imagescan_test.go
+++ b/sensor/tests/resource/imagescan/imagescan_test.go
@@ -65,7 +65,7 @@ func (s *ImageScanSuite) SetupSuite() {
 	s.T().Setenv("ROX_RESYNC_DISABLED", "true")
 	customConfig := helper.DefaultCentralConfig()
 	customConfig.InitialSystemPolicies = Policies
-	testContext, err := helper.NewContextWithConfig(s.T(), customConfig)
+	testContext, err := helper.NewContextWithConfig(t, customConfig)
 	s.Require().NoError(err)
 	s.testContext = testContext
 }

--- a/sensor/tests/resource/networkpolicy/networkpolicy_test.go
+++ b/sensor/tests/resource/networkpolicy/networkpolicy_test.go
@@ -96,7 +96,7 @@ func (s *NetworkPolicySuite) Test_Deployment_NetpolViolations() {
 	for name, testCase := range testCases {
 		s.T().Run(name, func(t *testing.T) {
 			resourcesToApply := append(testCase.netpolsApplied, NginxDeployment)
-			s.testContext.RunTest(
+			s.testContext.RunTest(t,
 				helper.WithResources(resourcesToApply),
 				helper.WithTestCase(func(t *testing.T, tc *helper.TestContext, objects map[string]k8s.Object) {
 					tc.LastViolationState(t, "nginx-deployment", checkViolations(testCase.violationsExpected), name)

--- a/sensor/tests/resource/networkpolicy/networkpolicy_test.go
+++ b/sensor/tests/resource/networkpolicy/networkpolicy_test.go
@@ -99,7 +99,7 @@ func (s *NetworkPolicySuite) Test_Deployment_NetpolViolations() {
 			s.testContext.RunTest(
 				helper.WithResources(resourcesToApply),
 				helper.WithTestCase(func(t *testing.T, tc *helper.TestContext, objects map[string]k8s.Object) {
-					tc.LastViolationState("nginx-deployment", checkViolations(testCase.violationsExpected), name)
+					tc.LastViolationState(t, "nginx-deployment", checkViolations(testCase.violationsExpected), name)
 				}))
 		})
 

--- a/sensor/tests/resource/pod/pod_test.go
+++ b/sensor/tests/resource/pod/pod_test.go
@@ -139,7 +139,7 @@ func (s *PodHierarchySuite) Test_DeleteDeployment() {
 	s.testContext.RunTest(s.T(), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
 		var id string
 		k8sDeployment := &appsv1.Deployment{}
-		deleteDep, err := testC.ApplyResourceAndWait(t, context.Background(), helper.DefaultNamespace, &NginxDeployment, k8sDeployment, nil)
+		deleteDep, err := testC.ApplyResourceAndWait(context.Background(), t, helper.DefaultNamespace, &NginxDeployment, k8sDeployment, nil)
 		require.NoError(t, err)
 		id = string(k8sDeployment.GetUID())
 		// Check the deployment is processed
@@ -170,7 +170,7 @@ func (s *PodHierarchySuite) Test_DeletePod() {
 	s.testContext.RunTest(s.T(), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
 		var id string
 		k8sPod := &v1.Pod{}
-		deletePod, err := testC.ApplyResourceAndWait(t, context.Background(), helper.DefaultNamespace, &NginxPod, k8sPod, nil)
+		deletePod, err := testC.ApplyResourceAndWait(context.Background(), t, helper.DefaultNamespace, &NginxPod, k8sPod, nil)
 		require.NoError(t, err)
 		id = string(k8sPod.GetUID())
 		// Check the pod is processed

--- a/sensor/tests/resource/pod/pod_test.go
+++ b/sensor/tests/resource/pod/pod_test.go
@@ -91,7 +91,7 @@ func (s *PodHierarchySuite) Test_ContainerSpecOnDeployment() {
 
 			s.Require().NoError(err)
 
-			testC.LastDeploymentState("nginx-deployment",
+			testC.LastDeploymentState(t, "nginx-deployment",
 				assertDeploymentContainerImages("docker.io/library/nginx:1.14.2"),
 				"nginx deployment should have a single container with nginx:1.14.2 image")
 
@@ -117,7 +117,7 @@ func (s *PodHierarchySuite) Test_ParentlessPodsAreTreatedAsDeployments() {
 
 			s.Require().NoError(err)
 
-			testC.LastDeploymentState("nginx-rogue",
+			testC.LastDeploymentState(t, "nginx-rogue",
 				assertDeploymentContainerImages("docker.io/library/nginx:1.14.1"),
 				"nginx standalone pod should have a single container with nginx:1.14.1 image")
 
@@ -144,14 +144,14 @@ func (s *PodHierarchySuite) Test_DeleteDeployment() {
 			require.NoError(t, err)
 			id = string(k8sDeployment.GetUID())
 			// Check the deployment is processed
-			testC.WaitForDeploymentEvent("nginx-deployment")
+			testC.WaitForDeploymentEvent(t, "nginx-deployment")
 			testC.GetFakeCentral().ClearReceivedBuffer()
 
 			// Delete the deployment
 			require.NoError(t, deleteDep())
 
 			// Check deployment and action
-			testC.LastDeploymentStateWithTimeout("nginx-deployment", func(_ *storage.Deployment, action central.ResourceAction) error {
+			testC.LastDeploymentStateWithTimeout(t, "nginx-deployment", func(_ *storage.Deployment, action central.ResourceAction) error {
 				if action != central.ResourceAction_REMOVE_RESOURCE {
 					return errors.New("ResourceAction should be REMOVE_RESOURCE")
 				}
@@ -177,14 +177,14 @@ func (s *PodHierarchySuite) Test_DeletePod() {
 			require.NoError(t, err)
 			id = string(k8sPod.GetUID())
 			// Check the pod is processed
-			testC.WaitForDeploymentEvent("nginx-rogue")
+			testC.WaitForDeploymentEvent(t, "nginx-rogue")
 			testC.GetFakeCentral().ClearReceivedBuffer()
 
 			// Delete the pod
 			require.NoError(t, deletePod())
 
 			// Check pod and action
-			testC.LastDeploymentStateWithTimeout("nginx-rogue", func(_ *storage.Deployment, action central.ResourceAction) error {
+			testC.LastDeploymentStateWithTimeout(t, "nginx-rogue", func(_ *storage.Deployment, action central.ResourceAction) error {
 				if action != central.ResourceAction_REMOVE_RESOURCE {
 					return errors.New("ResourceAction should be REMOVE_RESOURCE")
 				}

--- a/sensor/tests/resource/role/role_test.go
+++ b/sensor/tests/resource/role/role_test.go
@@ -76,38 +76,30 @@ func assertBindingHasRoleID(roleID string) helper.AssertFuncAny {
 
 func (s *RoleDependencySuite) Test_RolePermutationTest() {
 	s.testContext.GetFakeCentral().ClearReceivedBuffer()
-	s.testContext.RunTest(
-		helper.WithResources([]helper.K8sResourceInfo{
-			NginxDeployment,
-			NginxRole,
-			NginxRoleBinding,
-		}),
-		helper.WithPermutation(),
-		helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, objects map[string]k8s.Object) {
-			testC.LastDeploymentState(t, "nginx-deployment",
-				assertPermissionLevel(storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
-				"Permission level has to be elevated in namespace")
-			testC.GetFakeCentral().ClearReceivedBuffer()
-		}),
-	)
+	s.testContext.RunTest(s.T(), helper.WithResources([]helper.K8sResourceInfo{
+		NginxDeployment,
+		NginxRole,
+		NginxRoleBinding,
+	}), helper.WithPermutation(), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, objects map[string]k8s.Object) {
+		testC.LastDeploymentState(t, "nginx-deployment",
+			assertPermissionLevel(storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
+			"Permission level has to be elevated in namespace")
+		testC.GetFakeCentral().ClearReceivedBuffer()
+	}))
 }
 
 func (s *RoleDependencySuite) Test_ClusterRolePermutationTest() {
 	s.testContext.GetFakeCentral().ClearReceivedBuffer()
-	s.testContext.RunTest(
-		helper.WithResources([]helper.K8sResourceInfo{
-			NginxDeployment,
-			NginxClusterRole,
-			NginxClusterBinding,
-		}),
-		helper.WithPermutation(),
-		helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, objects map[string]k8s.Object) {
-			testC.LastDeploymentState(t, "nginx-deployment",
-				assertPermissionLevel(storage.PermissionLevel_ELEVATED_CLUSTER_WIDE),
-				"Permission level has to be elevated cluster wide")
-			testC.GetFakeCentral().ClearReceivedBuffer()
-		}),
-	)
+	s.testContext.RunTest(s.T(), helper.WithResources([]helper.K8sResourceInfo{
+		NginxDeployment,
+		NginxClusterRole,
+		NginxClusterBinding,
+	}), helper.WithPermutation(), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, objects map[string]k8s.Object) {
+		testC.LastDeploymentState(t, "nginx-deployment",
+			assertPermissionLevel(storage.PermissionLevel_ELEVATED_CLUSTER_WIDE),
+			"Permission level has to be elevated cluster wide")
+		testC.GetFakeCentral().ClearReceivedBuffer()
+	}))
 }
 
 func matchBinding(namespace, id string) helper.MatchResource {
@@ -120,33 +112,31 @@ func matchBinding(namespace, id string) helper.MatchResource {
 }
 
 func (s *RoleDependencySuite) Test_BindingHasNoRoleId() {
-	s.testContext.RunTest(
-		helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
-			deleteDep, err := testC.ApplyResourceAndWaitNoObject(context.Background(), "sensor-integration", NginxDeployment, nil)
-			defer utils.IgnoreError(deleteDep)
-			require.NoError(t, err)
+	s.testContext.RunTest(s.T(), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
+		deleteDep, err := testC.ApplyResourceAndWaitNoObject(t, context.Background(), "sensor-integration", NginxDeployment, nil)
+		defer utils.IgnoreError(deleteDep)
+		require.NoError(t, err)
 
-			var binding v12.RoleBinding
-			deleteRoleBinding, err := testC.ApplyResourceAndWait(context.Background(), "sensor-integration", &NginxRoleBinding, &binding, nil)
-			defer utils.IgnoreError(deleteRoleBinding)
-			require.NoError(t, err)
+		var binding v12.RoleBinding
+		deleteRoleBinding, err := testC.ApplyResourceAndWait(t, context.Background(), "sensor-integration", &NginxRoleBinding, &binding, nil)
+		defer utils.IgnoreError(deleteRoleBinding)
+		require.NoError(t, err)
 
-			testC.LastResourceState(t, matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(""), "No RoleID")
+		testC.LastResourceState(t, matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(""), "No RoleID")
 
-			var role v12.Role
-			deleteRole, err := testC.ApplyResourceAndWait(context.Background(), "sensor-integration", &NginxRole, &role, nil)
-			defer utils.IgnoreError(deleteRole)
-			require.NoError(t, err)
+		var role v12.Role
+		deleteRole, err := testC.ApplyResourceAndWait(t, context.Background(), "sensor-integration", &NginxRole, &role, nil)
+		defer utils.IgnoreError(deleteRole)
+		require.NoError(t, err)
 
-			testC.LastResourceState(t, matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(string(role.GetUID())), "Has RoleID")
+		testC.LastResourceState(t, matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(string(role.GetUID())), "Has RoleID")
 
-			testC.GetFakeCentral().ClearReceivedBuffer()
-		}),
-	)
+		testC.GetFakeCentral().ClearReceivedBuffer()
+	}))
 }
 
 func (s *RoleDependencySuite) Test_GroupSubjects() {
-	s.testContext.RunTest(
+	s.testContext.RunTest(s.T(),
 		helper.WithResources([]helper.K8sResourceInfo{
 			NginxDeployment,
 			NginxRole,
@@ -167,7 +157,7 @@ func (s *RoleDependencySuite) Test_GroupSubjects() {
 }
 
 func (s *RoleDependencySuite) Test_PermissionLevelIsNone() {
-	s.testContext.RunTest(
+	s.testContext.RunTest(s.T(),
 		helper.WithResources([]helper.K8sResourceInfo{
 			NginxDeployment,
 			NginxRole,
@@ -182,33 +172,31 @@ func (s *RoleDependencySuite) Test_PermissionLevelIsNone() {
 }
 
 func (s *RoleDependencySuite) Test_MultipleDeploymentUpdates() {
-	s.testContext.RunTest(
-		helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
-			deleteDep, err := testC.ApplyResourceAndWaitNoObject(context.Background(), "sensor-integration", NginxDeployment, nil)
-			defer utils.IgnoreError(deleteDep)
-			require.NoError(t, err)
+	s.testContext.RunTest(s.T(), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
+		deleteDep, err := testC.ApplyResourceAndWaitNoObject(t, context.Background(), "sensor-integration", NginxDeployment, nil)
+		defer utils.IgnoreError(deleteDep)
+		require.NoError(t, err)
 
-			deleteRoleBinding, err := testC.ApplyResourceAndWaitNoObject(context.Background(), "sensor-integration", NginxRoleBinding, nil)
-			defer utils.IgnoreError(deleteRoleBinding)
-			require.NoError(t, err)
+		deleteRoleBinding, err := testC.ApplyResourceAndWaitNoObject(t, context.Background(), "sensor-integration", NginxRoleBinding, nil)
+		defer utils.IgnoreError(deleteRoleBinding)
+		require.NoError(t, err)
 
-			deleteRole, err := testC.ApplyResourceAndWaitNoObject(context.Background(), "sensor-integration", NginxRole, nil)
+		deleteRole, err := testC.ApplyResourceAndWaitNoObject(t, context.Background(), "sensor-integration", NginxRole, nil)
 
-			defer utils.IgnoreError(deleteRole)
-			require.NoError(t, err)
+		defer utils.IgnoreError(deleteRole)
+		require.NoError(t, err)
 
-			testC.LastDeploymentState(t, "nginx-deployment",
-				assertPermissionLevel(storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
-				"Permission level has to be elevated in namespace")
-			testC.GetFakeCentral().ClearReceivedBuffer()
+		testC.LastDeploymentState(t, "nginx-deployment",
+			assertPermissionLevel(storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
+			"Permission level has to be elevated in namespace")
+		testC.GetFakeCentral().ClearReceivedBuffer()
 
-			utils.IgnoreError(deleteRole)
-			utils.IgnoreError(deleteRoleBinding)
+		utils.IgnoreError(deleteRole)
+		utils.IgnoreError(deleteRoleBinding)
 
-			testC.LastDeploymentState(t, "nginx-deployment",
-				assertPermissionLevel(storage.PermissionLevel_NONE),
-				"Permission level has to be none after deleting role and binding")
-			testC.GetFakeCentral().ClearReceivedBuffer()
-		}),
-	)
+		testC.LastDeploymentState(t, "nginx-deployment",
+			assertPermissionLevel(storage.PermissionLevel_NONE),
+			"Permission level has to be none after deleting role and binding")
+		testC.GetFakeCentral().ClearReceivedBuffer()
+	}))
 }

--- a/sensor/tests/resource/role/role_test.go
+++ b/sensor/tests/resource/role/role_test.go
@@ -113,19 +113,19 @@ func matchBinding(namespace, id string) helper.MatchResource {
 
 func (s *RoleDependencySuite) Test_BindingHasNoRoleId() {
 	s.testContext.RunTest(s.T(), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
-		deleteDep, err := testC.ApplyResourceAndWaitNoObject(t, context.Background(), "sensor-integration", NginxDeployment, nil)
+		deleteDep, err := testC.ApplyResourceAndWaitNoObject(context.Background(), t, "sensor-integration", NginxDeployment, nil)
 		defer utils.IgnoreError(deleteDep)
 		require.NoError(t, err)
 
 		var binding v12.RoleBinding
-		deleteRoleBinding, err := testC.ApplyResourceAndWait(t, context.Background(), "sensor-integration", &NginxRoleBinding, &binding, nil)
+		deleteRoleBinding, err := testC.ApplyResourceAndWait(context.Background(), t, "sensor-integration", &NginxRoleBinding, &binding, nil)
 		defer utils.IgnoreError(deleteRoleBinding)
 		require.NoError(t, err)
 
 		testC.LastResourceState(t, matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(""), "No RoleID")
 
 		var role v12.Role
-		deleteRole, err := testC.ApplyResourceAndWait(t, context.Background(), "sensor-integration", &NginxRole, &role, nil)
+		deleteRole, err := testC.ApplyResourceAndWait(context.Background(), t, "sensor-integration", &NginxRole, &role, nil)
 		defer utils.IgnoreError(deleteRole)
 		require.NoError(t, err)
 
@@ -173,15 +173,15 @@ func (s *RoleDependencySuite) Test_PermissionLevelIsNone() {
 
 func (s *RoleDependencySuite) Test_MultipleDeploymentUpdates() {
 	s.testContext.RunTest(s.T(), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
-		deleteDep, err := testC.ApplyResourceAndWaitNoObject(t, context.Background(), "sensor-integration", NginxDeployment, nil)
+		deleteDep, err := testC.ApplyResourceAndWaitNoObject(context.Background(), t, "sensor-integration", NginxDeployment, nil)
 		defer utils.IgnoreError(deleteDep)
 		require.NoError(t, err)
 
-		deleteRoleBinding, err := testC.ApplyResourceAndWaitNoObject(t, context.Background(), "sensor-integration", NginxRoleBinding, nil)
+		deleteRoleBinding, err := testC.ApplyResourceAndWaitNoObject(context.Background(), t, "sensor-integration", NginxRoleBinding, nil)
 		defer utils.IgnoreError(deleteRoleBinding)
 		require.NoError(t, err)
 
-		deleteRole, err := testC.ApplyResourceAndWaitNoObject(t, context.Background(), "sensor-integration", NginxRole, nil)
+		deleteRole, err := testC.ApplyResourceAndWaitNoObject(context.Background(), t, "sensor-integration", NginxRole, nil)
 
 		defer utils.IgnoreError(deleteRole)
 		require.NoError(t, err)

--- a/sensor/tests/resource/role/role_test.go
+++ b/sensor/tests/resource/role/role_test.go
@@ -84,7 +84,7 @@ func (s *RoleDependencySuite) Test_RolePermutationTest() {
 		}),
 		helper.WithPermutation(),
 		helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, objects map[string]k8s.Object) {
-			testC.LastDeploymentState("nginx-deployment",
+			testC.LastDeploymentState(t, "nginx-deployment",
 				assertPermissionLevel(storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
 				"Permission level has to be elevated in namespace")
 			testC.GetFakeCentral().ClearReceivedBuffer()
@@ -102,7 +102,7 @@ func (s *RoleDependencySuite) Test_ClusterRolePermutationTest() {
 		}),
 		helper.WithPermutation(),
 		helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, objects map[string]k8s.Object) {
-			testC.LastDeploymentState("nginx-deployment",
+			testC.LastDeploymentState(t, "nginx-deployment",
 				assertPermissionLevel(storage.PermissionLevel_ELEVATED_CLUSTER_WIDE),
 				"Permission level has to be elevated cluster wide")
 			testC.GetFakeCentral().ClearReceivedBuffer()
@@ -131,14 +131,14 @@ func (s *RoleDependencySuite) Test_BindingHasNoRoleId() {
 			defer utils.IgnoreError(deleteRoleBinding)
 			require.NoError(t, err)
 
-			testC.LastResourceState(matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(""), "No RoleID")
+			testC.LastResourceState(t, matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(""), "No RoleID")
 
 			var role v12.Role
 			deleteRole, err := testC.ApplyResourceAndWait(context.Background(), "sensor-integration", &NginxRole, &role, nil)
 			defer utils.IgnoreError(deleteRole)
 			require.NoError(t, err)
 
-			testC.LastResourceState(matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(string(role.GetUID())), "Has RoleID")
+			testC.LastResourceState(t, matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(string(role.GetUID())), "Has RoleID")
 
 			testC.GetFakeCentral().ClearReceivedBuffer()
 		}),
@@ -158,7 +158,7 @@ func (s *RoleDependencySuite) Test_GroupSubjects() {
 			// used to reference a set of ServiceAccounts, see: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-binding-examples
 			// Using `system:serviceaccounts:sensor-integration` as a group to set PermissionLevel to all deployments
 			// with any ServiceAccount is not supported by ACS.
-			testC.LastDeploymentState("nginx-deployment",
+			testC.LastDeploymentState(t, "nginx-deployment",
 				assertPermissionLevel(storage.PermissionLevel_NONE),
 				"Group / User permission levels should be ignored")
 			testC.GetFakeCentral().ClearReceivedBuffer()
@@ -173,7 +173,7 @@ func (s *RoleDependencySuite) Test_PermissionLevelIsNone() {
 			NginxRole,
 		}),
 		helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
-			testC.LastDeploymentState("nginx-deployment",
+			testC.LastDeploymentState(t, "nginx-deployment",
 				assertPermissionLevel(storage.PermissionLevel_NONE),
 				"Permission level has to be none if role binding is missing")
 			testC.GetFakeCentral().ClearReceivedBuffer()
@@ -197,7 +197,7 @@ func (s *RoleDependencySuite) Test_MultipleDeploymentUpdates() {
 			defer utils.IgnoreError(deleteRole)
 			require.NoError(t, err)
 
-			testC.LastDeploymentState("nginx-deployment",
+			testC.LastDeploymentState(t, "nginx-deployment",
 				assertPermissionLevel(storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
 				"Permission level has to be elevated in namespace")
 			testC.GetFakeCentral().ClearReceivedBuffer()
@@ -205,7 +205,7 @@ func (s *RoleDependencySuite) Test_MultipleDeploymentUpdates() {
 			utils.IgnoreError(deleteRole)
 			utils.IgnoreError(deleteRoleBinding)
 
-			testC.LastDeploymentState("nginx-deployment",
+			testC.LastDeploymentState(t, "nginx-deployment",
 				assertPermissionLevel(storage.PermissionLevel_NONE),
 				"Permission level has to be none after deleting role and binding")
 			testC.GetFakeCentral().ClearReceivedBuffer()

--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -140,7 +140,7 @@ func (s *DeploymentExposureSuite) SetupSuite() {
 	}
 	customConfig := helper.DefaultCentralConfig()
 	customConfig.InitialSystemPolicies = policies
-	if testContext, err := helper.NewContextWithConfig(t, customConfig); err != nil {
+	if testContext, err := helper.NewContextWithConfig(s.T(), customConfig); err != nil {
 		s.Fail("failed to setup test context: %s", err)
 	} else {
 		s.testContext = testContext

--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -140,7 +140,7 @@ func (s *DeploymentExposureSuite) SetupSuite() {
 	}
 	customConfig := helper.DefaultCentralConfig()
 	customConfig.InitialSystemPolicies = policies
-	if testContext, err := helper.NewContextWithConfig(s.T(), customConfig); err != nil {
+	if testContext, err := helper.NewContextWithConfig(t, customConfig); err != nil {
 		s.Fail("failed to setup test context: %s", err)
 	} else {
 		s.testContext = testContext
@@ -148,45 +148,41 @@ func (s *DeploymentExposureSuite) SetupSuite() {
 }
 
 func (s *DeploymentExposureSuite) Test_ClusterIpPermutation() {
-	s.testContext.RunTest(
-		helper.WithResources([]helper.K8sResourceInfo{
-			NginxDeployment,
-			NginxServiceClusterIP,
-		}),
-		helper.WithPermutation(),
-		helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
-			// Test context already takes care of creating and destroying resources
-			testC.LastDeploymentState(t, nginxDeploymentName,
-				assertLastDeploymentHasPortExposure([]*storage.PortConfig{
-					{
-						Protocol:      "TCP",
-						ContainerPort: 9376,
-						Exposure:      storage.PortConfig_INTERNAL,
-						ExposureInfos: []*storage.PortConfig_ExposureInfo{
-							{
-								ServiceName: "nginx-svc-cluster-ip",
-								ServicePort: 80,
-								Level:       storage.PortConfig_INTERNAL,
-							},
+	s.testContext.RunTest(s.T(), helper.WithResources([]helper.K8sResourceInfo{
+		NginxDeployment,
+		NginxServiceClusterIP,
+	}), helper.WithPermutation(), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
+		// Test context already takes care of creating and destroying resources
+		testC.LastDeploymentState(t, nginxDeploymentName,
+			assertLastDeploymentHasPortExposure([]*storage.PortConfig{
+				{
+					Protocol:      "TCP",
+					ContainerPort: 9376,
+					Exposure:      storage.PortConfig_INTERNAL,
+					ExposureInfos: []*storage.PortConfig_ExposureInfo{
+						{
+							ServiceName: "nginx-svc-cluster-ip",
+							ServicePort: 80,
+							Level:       storage.PortConfig_INTERNAL,
 						},
 					},
 				},
-				),
-				"'PortConfig' for Cluster IP service test not found",
-			)
-			testC.LastViolationState(t, nginxDeploymentName,
-				assertAlertNotTriggered(
-					&storage.Alert{
-						Policy: &storage.Policy{
-							Name: servicePolicyName,
-						},
-						State: storage.ViolationState_ACTIVE,
+			},
+			),
+			"'PortConfig' for Cluster IP service test not found",
+		)
+		testC.LastViolationState(t, nginxDeploymentName,
+			assertAlertNotTriggered(
+				&storage.Alert{
+					Policy: &storage.Policy{
+						Name: servicePolicyName,
 					},
-				),
-				fmt.Sprintf("Alert '%s' should not be triggered", servicePolicyName))
-			testC.GetFakeCentral().ClearReceivedBuffer()
-		}),
-	)
+					State: storage.ViolationState_ACTIVE,
+				},
+			),
+			fmt.Sprintf("Alert '%s' should not be triggered", servicePolicyName))
+		testC.GetFakeCentral().ClearReceivedBuffer()
+	}))
 }
 
 func (s *DeploymentExposureSuite) Test_NodePortPermutation() {
@@ -228,37 +224,33 @@ func (s *DeploymentExposureSuite) Test_NodePortPermutation() {
 
 	for _, c := range cases {
 		setDynamicFieldsInSlice(c.orderedResources, c.portConfig, serviceNodePortFmt, getPort(s.T()), c.selector, setNodePort, setPortConfigNode)
-		s.testContext.RunTest(
-			helper.WithResources(c.orderedResources),
-			helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
-				// Test context already takes care of creating and destroying resources
-				testC.LastDeploymentState(t, nginxDeploymentName,
-					assertLastDeploymentHasPortExposure(c.portConfig), "'PortConfig' for Node Port service test not found")
-				testC.LastViolationState(t, nginxDeploymentName,
-					assertAlertTriggered(
-						&storage.Alert{
-							Policy: &storage.Policy{
-								Name: servicePolicyName,
-							},
-							State: storage.ViolationState_ACTIVE,
+		s.testContext.RunTest(s.T(), helper.WithResources(c.orderedResources), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
+			// Test context already takes care of creating and destroying resources
+			testC.LastDeploymentState(t, nginxDeploymentName,
+				assertLastDeploymentHasPortExposure(c.portConfig), "'PortConfig' for Node Port service test not found")
+			testC.LastViolationState(t, nginxDeploymentName,
+				assertAlertTriggered(
+					&storage.Alert{
+						Policy: &storage.Policy{
+							Name: servicePolicyName,
 						},
-					),
-					fmt.Sprintf("Alert '%s' should be triggered", servicePolicyName))
-				testC.GetFakeCentral().ClearReceivedBuffer()
-			}),
-			helper.WithRetryCallback(func(err error, obj k8s.Object) error {
-				// Only checking services
-				if _, ok := obj.(*v1.Service); !ok {
-					return nil
-				}
-				// If the error is different from "provided port is already allocated" we fail the test
-				if !strings.Contains(err.Error(), "provided port is already allocated") {
-					return err
-				}
-				setDynamicFieldsInSlice(c.orderedResources, c.portConfig, serviceNodePortFmt, getPort(s.T()), c.selector, setNodePort, setPortConfigNode)
+						State: storage.ViolationState_ACTIVE,
+					},
+				),
+				fmt.Sprintf("Alert '%s' should be triggered", servicePolicyName))
+			testC.GetFakeCentral().ClearReceivedBuffer()
+		}), helper.WithRetryCallback(func(err error, obj k8s.Object) error {
+			// Only checking services
+			if _, ok := obj.(*v1.Service); !ok {
 				return nil
-			}),
-		)
+			}
+			// If the error is different from "provided port is already allocated" we fail the test
+			if !strings.Contains(err.Error(), "provided port is already allocated") {
+				return err
+			}
+			setDynamicFieldsInSlice(c.orderedResources, c.portConfig, serviceNodePortFmt, getPort(s.T()), c.selector, setNodePort, setPortConfigNode)
+			return nil
+		}))
 	}
 }
 
@@ -301,42 +293,38 @@ func (s *DeploymentExposureSuite) Test_LoadBalancerPermutation() {
 
 	for _, c := range cases {
 		setDynamicFieldsInSlice(c.orderedResources, c.portConfig, serviceLoadBalancerFmt, getPort(s.T()), c.selector, setLoadBalancer, setPortConfigExternal)
-		s.testContext.RunTest(
-			helper.WithResources(c.orderedResources),
-			helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
-				// Test context already takes care of creating and destroying resources
-				testC.LastDeploymentState(t, nginxDeploymentName,
-					assertLastDeploymentHasPortExposure(c.portConfig), "'PortConfig' for Node Port service test not found")
-				testC.LastViolationState(t, nginxDeploymentName,
-					assertAlertTriggered(
-						&storage.Alert{
-							Policy: &storage.Policy{
-								Name: servicePolicyName,
-							},
-							State: storage.ViolationState_ACTIVE,
+		s.testContext.RunTest(s.T(), helper.WithResources(c.orderedResources), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
+			// Test context already takes care of creating and destroying resources
+			testC.LastDeploymentState(t, nginxDeploymentName,
+				assertLastDeploymentHasPortExposure(c.portConfig), "'PortConfig' for Node Port service test not found")
+			testC.LastViolationState(t, nginxDeploymentName,
+				assertAlertTriggered(
+					&storage.Alert{
+						Policy: &storage.Policy{
+							Name: servicePolicyName,
 						},
-					),
-					fmt.Sprintf("Alert '%s' should be triggered", servicePolicyName))
-				testC.GetFakeCentral().ClearReceivedBuffer()
-			}),
-			helper.WithRetryCallback(func(err error, obj k8s.Object) error {
-				// Only checking services
-				if _, ok := obj.(*v1.Service); !ok {
-					return nil
-				}
-				// If the error is different from "provided port is already allocated" we fail the test
-				if !strings.Contains(err.Error(), "provided port is already allocated") {
-					return err
-				}
-				setDynamicFieldsInSlice(c.orderedResources, c.portConfig, serviceLoadBalancerFmt, getPort(s.T()), c.selector, setLoadBalancer, setPortConfigExternal)
+						State: storage.ViolationState_ACTIVE,
+					},
+				),
+				fmt.Sprintf("Alert '%s' should be triggered", servicePolicyName))
+			testC.GetFakeCentral().ClearReceivedBuffer()
+		}), helper.WithRetryCallback(func(err error, obj k8s.Object) error {
+			// Only checking services
+			if _, ok := obj.(*v1.Service); !ok {
 				return nil
-			}),
-		)
+			}
+			// If the error is different from "provided port is already allocated" we fail the test
+			if !strings.Contains(err.Error(), "provided port is already allocated") {
+				return err
+			}
+			setDynamicFieldsInSlice(c.orderedResources, c.portConfig, serviceLoadBalancerFmt, getPort(s.T()), c.selector, setLoadBalancer, setPortConfigExternal)
+			return nil
+		}))
 	}
 }
 
 func (s *DeploymentExposureSuite) Test_NoExposure() {
-	s.testContext.RunTest(
+	s.testContext.RunTest(s.T(),
 		helper.WithResources([]helper.K8sResourceInfo{
 			NginxDeployment,
 		}),
@@ -372,104 +360,101 @@ func (s *DeploymentExposureSuite) Test_MultipleDeploymentUpdates() {
 	// We need to use different ports in each NodePort/LoadBalancer test otherwise k8s could throw an error when the service is being created (provided port is already allocated).
 	// Waiting for the resources to get Deleted is not enough, k8s reports that the resource has been deleted but on creation sometimes we still get the same error.
 	// Adding retries on creation helped a lot, but it's still not enough.
-	s.testContext.RunTest(
-		helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
-			deleteDep, err := testC.ApplyResourceAndWaitNoObject(context.Background(), helper.DefaultNamespace, NginxDeployment, nil)
-			defer utils.IgnoreError(deleteDep)
-			require.NoError(t, err)
+	s.testContext.RunTest(s.T(), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
+		deleteDep, err := testC.ApplyResourceAndWaitNoObject(t, context.Background(), helper.DefaultNamespace, NginxDeployment, nil)
+		defer utils.IgnoreError(deleteDep)
+		require.NoError(t, err)
 
-			port := getPort(t)
-			svc := &v1.Service{}
-			sel := map[string]string{
-				"app": "nginx",
+		port := getPort(t)
+		svc := &v1.Service{}
+		sel := map[string]string{
+			"app": "nginx",
+		}
+		nginxServiceNodePort := helper.K8sResourceInfo{
+			Kind: "Service",
+			Obj:  svc,
+		}
+		setDynamicFields(svc, serviceNodePortFmt, port, sel, setNodePort)
+
+		deleteService, err := testC.ApplyResourceAndWaitNoObject(t, context.Background(), helper.DefaultNamespace, nginxServiceNodePort, func(err error, obj k8s.Object) error {
+			// Only checking services
+			if _, ok := obj.(*v1.Service); !ok {
+				return nil
 			}
-			nginxServiceNodePort := helper.K8sResourceInfo{
-				Kind: "Service",
-				Obj:  svc,
+			// If the error is different from "provided port is already allocated" we fail the test
+			if !strings.Contains(err.Error(), "provided port is already allocated") {
+				return err
 			}
+			port = getPort(t)
 			setDynamicFields(svc, serviceNodePortFmt, port, sel, setNodePort)
+			return nil
+		})
+		require.NoError(t, err)
 
-			deleteService, err := testC.ApplyResourceAndWaitNoObject(context.Background(), helper.DefaultNamespace, nginxServiceNodePort,
-				func(err error, obj k8s.Object) error {
-					// Only checking services
-					if _, ok := obj.(*v1.Service); !ok {
-						return nil
-					}
-					// If the error is different from "provided port is already allocated" we fail the test
-					if !strings.Contains(err.Error(), "provided port is already allocated") {
-						return err
-					}
-					port = getPort(t)
-					setDynamicFields(svc, serviceNodePortFmt, port, sel, setNodePort)
-					return nil
-				})
-			require.NoError(t, err)
-
-			testC.LastDeploymentState(t, nginxDeploymentName,
-				assertLastDeploymentHasPortExposure([]*storage.PortConfig{
-					{
-						Protocol:      "TCP",
-						ContainerPort: 80,
-						Exposure:      storage.PortConfig_NODE,
-						ExposureInfos: []*storage.PortConfig_ExposureInfo{
-							{
-								ServiceName: fmt.Sprintf(serviceNodePortFmt, port),
-								ServicePort: 80,
-								NodePort:    port,
-								Level:       storage.PortConfig_NODE,
-							},
+		testC.LastDeploymentState(t, nginxDeploymentName,
+			assertLastDeploymentHasPortExposure([]*storage.PortConfig{
+				{
+					Protocol:      "TCP",
+					ContainerPort: 80,
+					Exposure:      storage.PortConfig_NODE,
+					ExposureInfos: []*storage.PortConfig_ExposureInfo{
+						{
+							ServiceName: fmt.Sprintf(serviceNodePortFmt, port),
+							ServicePort: 80,
+							NodePort:    port,
+							Level:       storage.PortConfig_NODE,
 						},
 					},
 				},
-				),
-				"'PortConfig' for Multiple Deployment Updates test not found",
-			)
-			testC.LastViolationState(t, nginxDeploymentName,
-				assertAlertTriggered(
-					&storage.Alert{
-						Policy: &storage.Policy{
-							Name: servicePolicyName,
-						},
-						State: storage.ViolationState_ACTIVE,
+			},
+			),
+			"'PortConfig' for Multiple Deployment Updates test not found",
+		)
+		testC.LastViolationState(t, nginxDeploymentName,
+			assertAlertTriggered(
+				&storage.Alert{
+					Policy: &storage.Policy{
+						Name: servicePolicyName,
 					},
-				),
-				fmt.Sprintf("Alert '%s' should be triggered", servicePolicyName))
-			testC.GetFakeCentral().ClearReceivedBuffer()
+					State: storage.ViolationState_ACTIVE,
+				},
+			),
+			fmt.Sprintf("Alert '%s' should be triggered", servicePolicyName))
+		testC.GetFakeCentral().ClearReceivedBuffer()
 
-			require.NoError(t, deleteService())
+		require.NoError(t, deleteService())
 
-			testC.LastDeploymentState(t, nginxDeploymentName,
-				assertLastDeploymentMissingPortExposure([]*storage.PortConfig{
-					{
-						Protocol:      "TCP",
-						ContainerPort: 80,
-						Exposure:      storage.PortConfig_NODE,
-						ExposureInfos: []*storage.PortConfig_ExposureInfo{
-							{
-								ServiceName: fmt.Sprintf(serviceNodePortFmt, port),
-								ServicePort: 80,
-								NodePort:    port,
-								Level:       storage.PortConfig_NODE,
-							},
+		testC.LastDeploymentState(t, nginxDeploymentName,
+			assertLastDeploymentMissingPortExposure([]*storage.PortConfig{
+				{
+					Protocol:      "TCP",
+					ContainerPort: 80,
+					Exposure:      storage.PortConfig_NODE,
+					ExposureInfos: []*storage.PortConfig_ExposureInfo{
+						{
+							ServiceName: fmt.Sprintf(serviceNodePortFmt, port),
+							ServicePort: 80,
+							NodePort:    port,
+							Level:       storage.PortConfig_NODE,
 						},
 					},
 				},
-				),
-				"'PortConfig' for Multiple Deployment Updates test found",
-			)
-			testC.LastViolationState(t, nginxDeploymentName,
-				assertAlertNotTriggered(
-					&storage.Alert{
-						Policy: &storage.Policy{
-							Name: servicePolicyName,
-						},
-						State: storage.ViolationState_RESOLVED,
+			},
+			),
+			"'PortConfig' for Multiple Deployment Updates test found",
+		)
+		testC.LastViolationState(t, nginxDeploymentName,
+			assertAlertNotTriggered(
+				&storage.Alert{
+					Policy: &storage.Policy{
+						Name: servicePolicyName,
 					},
-				),
-				fmt.Sprintf("Alert '%s' should not be triggered", servicePolicyName))
-			testC.GetFakeCentral().ClearReceivedBuffer()
-		}),
-	)
+					State: storage.ViolationState_RESOLVED,
+				},
+			),
+			fmt.Sprintf("Alert '%s' should not be triggered", servicePolicyName))
+		testC.GetFakeCentral().ClearReceivedBuffer()
+	}))
 }
 
 func (s *DeploymentExposureSuite) Test_NodePortPermutationWithPod() {
@@ -511,37 +496,33 @@ func (s *DeploymentExposureSuite) Test_NodePortPermutationWithPod() {
 
 	for _, c := range cases {
 		setDynamicFieldsInSlice(c.orderedResources, c.portConfig, serviceNodePortFmt, getPort(s.T()), c.selector, setNodePort, setPortConfigNode)
-		s.testContext.RunTest(
-			helper.WithResources(c.orderedResources),
-			helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
-				// Test context already takes care of creating and destroying resources
-				testC.LastDeploymentState(t, nginxPodName,
-					assertLastDeploymentHasPortExposure(c.portConfig), "'PortConfig' for Node Port service test not found")
-				testC.LastViolationState(t, nginxPodName,
-					assertAlertTriggered(
-						&storage.Alert{
-							Policy: &storage.Policy{
-								Name: servicePolicyName,
-							},
-							State: storage.ViolationState_ACTIVE,
+		s.testContext.RunTest(s.T(), helper.WithResources(c.orderedResources), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
+			// Test context already takes care of creating and destroying resources
+			testC.LastDeploymentState(t, nginxPodName,
+				assertLastDeploymentHasPortExposure(c.portConfig), "'PortConfig' for Node Port service test not found")
+			testC.LastViolationState(t, nginxPodName,
+				assertAlertTriggered(
+					&storage.Alert{
+						Policy: &storage.Policy{
+							Name: servicePolicyName,
 						},
-					),
-					fmt.Sprintf("Alert '%s' should be triggered", servicePolicyName))
-				testC.GetFakeCentral().ClearReceivedBuffer()
-			}),
-			helper.WithRetryCallback(func(err error, obj k8s.Object) error {
-				// Only checking services
-				if _, ok := obj.(*v1.Service); !ok {
-					return nil
-				}
-				// If the error is different from "provided port is already allocated" we fail the test
-				if !strings.Contains(err.Error(), "provided port is already allocated") {
-					return err
-				}
-				setDynamicFieldsInSlice(c.orderedResources, c.portConfig, serviceNodePortFmt, getPort(s.T()), c.selector, setNodePort, setPortConfigNode)
+						State: storage.ViolationState_ACTIVE,
+					},
+				),
+				fmt.Sprintf("Alert '%s' should be triggered", servicePolicyName))
+			testC.GetFakeCentral().ClearReceivedBuffer()
+		}), helper.WithRetryCallback(func(err error, obj k8s.Object) error {
+			// Only checking services
+			if _, ok := obj.(*v1.Service); !ok {
 				return nil
-			}),
-		)
+			}
+			// If the error is different from "provided port is already allocated" we fail the test
+			if !strings.Contains(err.Error(), "provided port is already allocated") {
+				return err
+			}
+			setDynamicFieldsInSlice(c.orderedResources, c.portConfig, serviceNodePortFmt, getPort(s.T()), c.selector, setNodePort, setPortConfigNode)
+			return nil
+		}))
 	}
 }
 

--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -361,7 +361,7 @@ func (s *DeploymentExposureSuite) Test_MultipleDeploymentUpdates() {
 	// Waiting for the resources to get Deleted is not enough, k8s reports that the resource has been deleted but on creation sometimes we still get the same error.
 	// Adding retries on creation helped a lot, but it's still not enough.
 	s.testContext.RunTest(s.T(), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
-		deleteDep, err := testC.ApplyResourceAndWaitNoObject(t, context.Background(), helper.DefaultNamespace, NginxDeployment, nil)
+		deleteDep, err := testC.ApplyResourceAndWaitNoObject(context.Background(), t, helper.DefaultNamespace, NginxDeployment, nil)
 		defer utils.IgnoreError(deleteDep)
 		require.NoError(t, err)
 
@@ -376,7 +376,7 @@ func (s *DeploymentExposureSuite) Test_MultipleDeploymentUpdates() {
 		}
 		setDynamicFields(svc, serviceNodePortFmt, port, sel, setNodePort)
 
-		deleteService, err := testC.ApplyResourceAndWaitNoObject(t, context.Background(), helper.DefaultNamespace, nginxServiceNodePort, func(err error, obj k8s.Object) error {
+		deleteService, err := testC.ApplyResourceAndWaitNoObject(context.Background(), t, helper.DefaultNamespace, nginxServiceNodePort, func(err error, obj k8s.Object) error {
 			// Only checking services
 			if _, ok := obj.(*v1.Service); !ok {
 				return nil

--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -156,7 +156,7 @@ func (s *DeploymentExposureSuite) Test_ClusterIpPermutation() {
 		helper.WithPermutation(),
 		helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
 			// Test context already takes care of creating and destroying resources
-			testC.LastDeploymentState(nginxDeploymentName,
+			testC.LastDeploymentState(t, nginxDeploymentName,
 				assertLastDeploymentHasPortExposure([]*storage.PortConfig{
 					{
 						Protocol:      "TCP",
@@ -174,7 +174,7 @@ func (s *DeploymentExposureSuite) Test_ClusterIpPermutation() {
 				),
 				"'PortConfig' for Cluster IP service test not found",
 			)
-			testC.LastViolationState(nginxDeploymentName,
+			testC.LastViolationState(t, nginxDeploymentName,
 				assertAlertNotTriggered(
 					&storage.Alert{
 						Policy: &storage.Policy{
@@ -232,9 +232,9 @@ func (s *DeploymentExposureSuite) Test_NodePortPermutation() {
 			helper.WithResources(c.orderedResources),
 			helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
 				// Test context already takes care of creating and destroying resources
-				testC.LastDeploymentState(nginxDeploymentName,
+				testC.LastDeploymentState(t, nginxDeploymentName,
 					assertLastDeploymentHasPortExposure(c.portConfig), "'PortConfig' for Node Port service test not found")
-				testC.LastViolationState(nginxDeploymentName,
+				testC.LastViolationState(t, nginxDeploymentName,
 					assertAlertTriggered(
 						&storage.Alert{
 							Policy: &storage.Policy{
@@ -305,9 +305,9 @@ func (s *DeploymentExposureSuite) Test_LoadBalancerPermutation() {
 			helper.WithResources(c.orderedResources),
 			helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
 				// Test context already takes care of creating and destroying resources
-				testC.LastDeploymentState(nginxDeploymentName,
+				testC.LastDeploymentState(t, nginxDeploymentName,
 					assertLastDeploymentHasPortExposure(c.portConfig), "'PortConfig' for Node Port service test not found")
-				testC.LastViolationState(nginxDeploymentName,
+				testC.LastViolationState(t, nginxDeploymentName,
 					assertAlertTriggered(
 						&storage.Alert{
 							Policy: &storage.Policy{
@@ -342,7 +342,7 @@ func (s *DeploymentExposureSuite) Test_NoExposure() {
 		}),
 		helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
 			// Test context already takes care of creating and destroying resources
-			testC.LastDeploymentState(nginxDeploymentName,
+			testC.LastDeploymentState(t, nginxDeploymentName,
 				assertLastDeploymentHasPortExposure([]*storage.PortConfig{
 					{
 						Protocol:      "TCP",
@@ -353,7 +353,7 @@ func (s *DeploymentExposureSuite) Test_NoExposure() {
 				),
 				"PortConfig",
 			)
-			testC.LastViolationState(nginxDeploymentName,
+			testC.LastViolationState(t, nginxDeploymentName,
 				assertAlertNotTriggered(
 					&storage.Alert{
 						Policy: &storage.Policy{
@@ -405,7 +405,7 @@ func (s *DeploymentExposureSuite) Test_MultipleDeploymentUpdates() {
 				})
 			require.NoError(t, err)
 
-			testC.LastDeploymentState(nginxDeploymentName,
+			testC.LastDeploymentState(t, nginxDeploymentName,
 				assertLastDeploymentHasPortExposure([]*storage.PortConfig{
 					{
 						Protocol:      "TCP",
@@ -424,7 +424,7 @@ func (s *DeploymentExposureSuite) Test_MultipleDeploymentUpdates() {
 				),
 				"'PortConfig' for Multiple Deployment Updates test not found",
 			)
-			testC.LastViolationState(nginxDeploymentName,
+			testC.LastViolationState(t, nginxDeploymentName,
 				assertAlertTriggered(
 					&storage.Alert{
 						Policy: &storage.Policy{
@@ -438,7 +438,7 @@ func (s *DeploymentExposureSuite) Test_MultipleDeploymentUpdates() {
 
 			require.NoError(t, deleteService())
 
-			testC.LastDeploymentState(nginxDeploymentName,
+			testC.LastDeploymentState(t, nginxDeploymentName,
 				assertLastDeploymentMissingPortExposure([]*storage.PortConfig{
 					{
 						Protocol:      "TCP",
@@ -457,7 +457,7 @@ func (s *DeploymentExposureSuite) Test_MultipleDeploymentUpdates() {
 				),
 				"'PortConfig' for Multiple Deployment Updates test found",
 			)
-			testC.LastViolationState(nginxDeploymentName,
+			testC.LastViolationState(t, nginxDeploymentName,
 				assertAlertNotTriggered(
 					&storage.Alert{
 						Policy: &storage.Policy{
@@ -515,9 +515,9 @@ func (s *DeploymentExposureSuite) Test_NodePortPermutationWithPod() {
 			helper.WithResources(c.orderedResources),
 			helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
 				// Test context already takes care of creating and destroying resources
-				testC.LastDeploymentState(nginxPodName,
+				testC.LastDeploymentState(t, nginxPodName,
 					assertLastDeploymentHasPortExposure(c.portConfig), "'PortConfig' for Node Port service test not found")
-				testC.LastViolationState(nginxPodName,
+				testC.LastViolationState(t, nginxPodName,
 					assertAlertTriggered(
 						&storage.Alert{
 							Policy: &storage.Policy{


### PR DESCRIPTION
## Description

Calls to `c.t.FailNow` or `c.t.Fatal` can lead into a situation where we use the incorrect `t` object and the parent test is being failed from a subtest. This is not allowed (see for example https://github.com/golang/go/issues/58129) and may lead to following failures:

```
=== NAME  Test_NetworkPolicy
    helper.go:607: timeout reached waiting for violation state (Ingress applied: egress violation): expected violations not found: [Deployments should have at least one egress Network Policy]
=== NAME  Test_NetworkPolicy/Test_Deployment_NetpolViolations/Ingress_applied:_egress_violation
    testing.go:1471: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
=== NAME  Test_NetworkPolicy/Test_Deployment_NetpolViolations
    testing.go:1471: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
--- FAIL: Test_NetworkPolicy (15.12s)
    --- FAIL: Test_NetworkPolicy/Test_Deployment_NetpolViolations (14.46s)
        --- FAIL: Test_NetworkPolicy/Test_Deployment_NetpolViolations/Ingress_applied:_egress_violation (14.46s)
FAIL
coverage: [no statements]
FAIL	github.com/stackrox/rox/sensor/tests/resource/networkpolicy	15.427s
FAIL
make: *** [Makefile:480: sensor-integration-test] Error 1
``` 

Note that after applying this PR's changes, the test fails correctly:

```
(...)
common/sensor: 2023/08/03 15:28:02.470576 central_sender_impl.go:106: Info: Sending synced signal to Central
kubernetes/clusterstatus: 2023/08/03 15:28:02.731231 updater.go:254: Info: No Cloud Provider metadata is found
common/detector: 2023/08/03 15:28:03.148028 enricher.go:163: Error: Scan request failed for image docker.io/library/nginx:1.14.2: rpc error: code = Unimplemented desc = unknown service v1.ImageService
common/detector: 2023/08/03 15:28:03.220269 enricher.go:199: Warn: Skipping image scan for image: docker.io/library/nginx:1.14.2. Not pullable
common/detector: 2023/08/03 15:28:05.054751 enricher.go:199: Warn: Skipping image scan for image: docker.io/library/nginx:1.14.2. Not pullable
    helper.go:605: timeout reached waiting for violation state (Ingress applied: egress violation): expected violations not found: [Deployments should have at least one egress Network Policy]
common/detector: 2023/08/03 15:28:05.482988 enricher.go:199: Warn: Skipping image scan for image: docker.io/library/nginx:1.14.2. Not pullable
=== RUN   Test_NetworkPolicy/Test_Deployment_NetpolViolations/Egress_applied:_ingress_violation
=== RUN   Test_NetworkPolicy/Test_Deployment_NetpolViolations/No_policies_applied:_should_have_two_violations
kubernetes/clusterhealth: 2023/08/03 15:28:31.233286 updater.go:167: Error: Errors while getting collector info: [unable to find collector DaemonSet in namespace "stackrox": daemonsets.apps "collector" not found]
kubernetes/clusterhealth: 2023/08/03 15:28:31.287293 updater.go:190: Error: Errors while getting admission control info: [unable to find admission control deployments in namespace "stackrox": unable to find admission control deployments in namespace "stackrox": deployments.apps "admission-control" not found]
=== RUN   Test_NetworkPolicy/Test_Deployment_NetpolViolations/Both_policies_applied:_should_have_no_violations
--- FAIL: Test_NetworkPolicy (49.73s)
    --- FAIL: Test_NetworkPolicy/Test_Deployment_NetpolViolations (49.10s)
        --- FAIL: Test_NetworkPolicy/Test_Deployment_NetpolViolations/Ingress_applied:_egress_violation (14.44s)
        --- PASS: Test_NetworkPolicy/Test_Deployment_NetpolViolations/Egress_applied:_ingress_violation (11.34s)
        --- PASS: Test_NetworkPolicy/Test_Deployment_NetpolViolations/No_policies_applied:_should_have_two_violations (11.32s)
        --- PASS: Test_NetworkPolicy/Test_Deployment_NetpolViolations/Both_policies_applied:_should_have_no_violations (12.00s)
FAIL
coverage: [no statements]
FAIL	github.com/stackrox/rox/sensor/tests/resource/networkpolicy	50.002s
FAIL
make: *** [Makefile:480: sensor-integration-test] Error 1
```

## Checklist
- [x] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

- CI: `gke-sensor-integration-tests` should fail in a correct way
- Manual search of code occurrences
   - All calls to `c.t` were replaced wit `t` passed in the params list
   - Removed `t` as member of the `TestContext`  
