### PR TITLE
ROX-18824: size stats only for specified db when external

### DIFF
--- a/central/telemetry/gatherers/postgres.go
+++ b/central/telemetry/gatherers/postgres.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgadmin"
+	"github.com/stackrox/rox/pkg/postgres/pgconfig"
 	"github.com/stackrox/rox/pkg/telemetry/data"
 )
 
@@ -27,16 +28,17 @@ func newPostgresGatherer(db postgres.DB, adminConfig *postgres.Config) *postgres
 func (d *postgresGatherer) Gather(ctx context.Context) *data.DatabaseStats {
 	errorList := errorhelpers.NewErrorList("postgres telemetry gather")
 
-	totalSize, err := pgadmin.GetTotalPostgresSize(d.adminConfig)
-	errorList.AddError(err)
-
 	dbStats := globaldb.CollectPostgresStats(ctx, d.db)
 	dbStats.Type = "postgres"
-	dbStats.UsedBytes = totalSize
+	
 	dbStats.DatabaseDetails = globaldb.CollectPostgresDatabaseSizes(d.adminConfig)
 
 	// Check Postgres remaining capacity
-	if !env.ManagedCentral.BooleanSetting() {
+	if !env.ManagedCentral.BooleanSetting() && !pgconfig.IsExternalDatabase() {
+		totalSize, err := pgadmin.GetTotalPostgresSize(d.adminConfig)
+		errorList.AddError(err)
+		dbStats.UsedBytes = totalSize
+
 		availableDBBytes, err := pgadmin.GetRemainingCapacity(d.adminConfig)
 		errorList.AddError(err)
 		dbStats.AvailableBytes = availableDBBytes

--- a/central/telemetry/gatherers/postgres.go
+++ b/central/telemetry/gatherers/postgres.go
@@ -27,10 +27,9 @@ func newPostgresGatherer(db postgres.DB, adminConfig *postgres.Config) *postgres
 // Gather returns telemetry information about the Postgres database used by this central
 func (d *postgresGatherer) Gather(ctx context.Context) *data.DatabaseStats {
 	errorList := errorhelpers.NewErrorList("postgres telemetry gather")
-
 	dbStats := globaldb.CollectPostgresStats(ctx, d.db)
 	dbStats.Type = "postgres"
-	
+
 	dbStats.DatabaseDetails = globaldb.CollectPostgresDatabaseSizes(d.adminConfig)
 
 	// Check Postgres remaining capacity


### PR DESCRIPTION
## Description

When connecting to an external postgres we will likely not have access to other databases within that instance and we shouldn't.  We also do not care about the sizes of those databases.  So we only need to grab the size for the specified database in the connection so that growth can be monitored through our metrics.

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

```
# HELP rox_central_postgres_db_size_bytes bytes being used by a Postgres Database
# TYPE rox_central_postgres_db_size_bytes gauge
rox_central_postgres_db_size_bytes{database="stackrox"} 2.2802991e+07
# HELP rox_central_postgres_maximum_db_connections number of total connections allowed to the Postgres database server
```
