### PR TITLE
fix(builds): exclude arm64, ppc64le from -race builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,10 @@ jobs:
             # Exclude "arm64", "ppc64le"
             matrix="$(jq '.pre_build_go_binaries.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
             matrix="$(jq '.pre_build_go_binaries.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
+            matrix="$(jq '.build_and_push_main.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
+            matrix="$(jq '.build_and_push_main.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
+            matrix="$(jq '.push_main_multiarch_manifests.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
+            matrix="$(jq '.push_main_multiarch_manifests.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
           fi
 
           echo "Job matrix after conditionals:"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,14 +52,11 @@ jobs:
           if ! is_in_PR_context || pr_has_label ci-build-race-condition-debug; then
             matrix="$(jq '.pre_build_go_binaries.name += ["race-condition-debug"]' <<< "$matrix")"
             matrix="$(jq '.build_and_push_main.name += ["race-condition-debug"]' <<< "$matrix")"
-            matrix="$(jq '.push_main_multiarch_manifests.name += ["race-condition-debug"]' <<< "$matrix")"
             # Exclude "arm64", "ppc64le"
             matrix="$(jq '.pre_build_go_binaries.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
             matrix="$(jq '.pre_build_go_binaries.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
             matrix="$(jq '.build_and_push_main.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
             matrix="$(jq '.build_and_push_main.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
-            matrix="$(jq '.push_main_multiarch_manifests.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
-            matrix="$(jq '.push_main_multiarch_manifests.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
           fi
 
           echo "Job matrix after conditionals:"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,8 +54,8 @@ jobs:
             matrix="$(jq '.build_and_push_main.name += ["race-condition-debug"]' <<< "$matrix")"
             matrix="$(jq '.push_main_multiarch_manifests.name += ["race-condition-debug"]' <<< "$matrix")"
             # Exclude "arm64", "ppc64le"
-            matrix="$(jq '.pre_build_go_binaries.exclude = { "name": "race-condition-debug", "arch": "arm64" }' <<< "$matrix")"
-            matrix="$(jq '.pre_build_go_binaries.exclude += { "name": "race-condition-debug", "arch": "ppc64le" }' <<< "$matrix")"
+            matrix="$(jq '.pre_build_go_binaries.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
+            matrix="$(jq '.pre_build_go_binaries.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
           fi
 
           echo "Job matrix after conditionals:"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,9 @@ jobs:
             matrix="$(jq '.pre_build_go_binaries.name += ["race-condition-debug"]' <<< "$matrix")"
             matrix="$(jq '.build_and_push_main.name += ["race-condition-debug"]' <<< "$matrix")"
             matrix="$(jq '.push_main_multiarch_manifests.name += ["race-condition-debug"]' <<< "$matrix")"
+            # Exclude "arm64", "ppc64le"
+            matrix="$(jq '.pre_build_go_binaries.exclude = { "name": "race-condition-debug", "arch": "arm64" }' <<< "$matrix")"
+            matrix="$(jq '.pre_build_go_binaries.exclude += { "name": "race-condition-debug", "arch": "ppc64le" }' <<< "$matrix")"
           fi
 
           echo "Job matrix after conditionals:"


### PR DESCRIPTION
## Description

Per @connorgorman "we can’t build the race condition images for other arches cause cgo will be enabled and we’re relying on the fact it’s cross compiled statically". This PR removes the targets using GHA matrix exclude.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient