### PR TITLE
ROX-18114: Compliance by profile widget

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Dashboard/ComplianceDashboardPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Flex, FlexItem, Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
 
 import ComplianceByCluster from './Widgets/ComplianceByCluster';
+import ComplianceByProfile from './Widgets/ComplianceByProfile';
 
 function ComplianceDashboardPage() {
     return (
@@ -19,6 +20,9 @@ function ComplianceDashboardPage() {
                     <Grid hasGutter md={6} xl2={4}>
                         <GridItem>
                             <ComplianceByCluster />
+                        </GridItem>
+                        <GridItem>
+                            <ComplianceByProfile />
                         </GridItem>
                     </Grid>
                 </PageSection>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Dashboard/Widgets/ComplianceByProfile.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Dashboard/Widgets/ComplianceByProfile.tsx
@@ -4,53 +4,43 @@ import WidgetCard from 'Components/PatternFly/WidgetCard';
 
 import HorizontalBarChart from './HorizontalBarChart';
 
-export type ComplianceByClusterData = {
+export type ComplianceByProfileData = {
     name: string;
     passing: number;
     link: string;
 }[];
 
-const mockComplianceData: ComplianceByClusterData = [
+const mockComplianceData: ComplianceByProfileData = [
     {
-        name: 'staging',
-        passing: 100,
+        name: 'HIPPA',
+        passing: 83,
         link: '',
     },
     {
-        name: 'production',
+        name: 'PCI',
         passing: 80,
         link: '',
     },
     {
-        name: 'payments',
+        name: 'CIS Docker',
         passing: 73,
         link: '',
     },
     {
-        name: 'patient-charts',
+        name: 'CIS K8s',
         passing: 69,
-        link: '',
-    },
-    {
-        name: 'another-cluster',
-        passing: 67,
-        link: '',
-    },
-    {
-        name: 'cluster-name',
-        passing: 39,
         link: '',
     },
 ];
 
-function ComplianceByCluster() {
+function ComplianceByProfile() {
     const [complianceData] = useState(mockComplianceData);
 
     return (
-        <WidgetCard isLoading={false} header="Compliance by cluster">
+        <WidgetCard isLoading={false} header="Compliance by profile">
             <HorizontalBarChart passingRateData={complianceData} />
         </WidgetCard>
     );
 }
 
-export default ComplianceByCluster;
+export default ComplianceByProfile;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Dashboard/Widgets/HorizontalBarChart.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Dashboard/Widgets/HorizontalBarChart.tsx
@@ -12,12 +12,12 @@ import {
 import { getBarColor } from './ColorsForCompliance';
 import { PassingRateData } from '../types';
 
-const labelLinkCallback = ({ datum }: ChartLabelProps, data: PassingRateData) => {
+const labelLinkCallback = ({ datum }: ChartLabelProps, data: PassingRateData[]) => {
     return typeof datum === 'number' ? data[datum - 1]?.link ?? '' : '';
 };
 
 type HorizontalBarChartProps = {
-    passingRateData: PassingRateData;
+    passingRateData: PassingRateData[];
 };
 
 function HorizontalBarChart({ passingRateData }: HorizontalBarChartProps) {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Dashboard/Widgets/HorizontalBarChart.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Dashboard/Widgets/HorizontalBarChart.tsx
@@ -58,7 +58,7 @@ function HorizontalBarChart({ passingRateData }: HorizontalBarChartProps) {
                             key={name}
                             barWidth={defaultChartBarWidth}
                             data={[{ x: name, y: passing }]}
-                            labels={({ datum }) => `${Math.round(parseInt(datum.y, 10))}%`}
+                            labels={({ datum }) => `${parseInt(datum.y, 10)}%`}
                             style={{
                                 data: {
                                     fill: ({ datum }) => getBarColor(datum.y),

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Dashboard/Widgets/HorizontalBarChart.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Dashboard/Widgets/HorizontalBarChart.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { Chart, ChartAxis, ChartBar, ChartGroup, ChartLabelProps } from '@patternfly/react-charts';
+
+import { LinkableChartLabel } from 'Components/PatternFly/Charts/LinkableChartLabel';
+import useResizeObserver from 'hooks/useResizeObserver';
+import {
+    defaultChartBarWidth,
+    defaultChartHeight,
+    patternflySeverityTheme,
+} from 'utils/chartUtils';
+
+import { getBarColor } from './ColorsForCompliance';
+import { PassingRateData } from '../types';
+
+const labelLinkCallback = ({ datum }: ChartLabelProps, data: PassingRateData) => {
+    return typeof datum === 'number' ? data[datum - 1]?.link ?? '' : '';
+};
+
+type HorizontalBarChartProps = {
+    passingRateData: PassingRateData;
+};
+
+function HorizontalBarChart({ passingRateData }: HorizontalBarChartProps) {
+    const [widgetContainer, setWidgetContainer] = useState<HTMLDivElement | null>(null);
+    const widgetContainerResizeEntry = useResizeObserver(widgetContainer);
+
+    return (
+        <div ref={setWidgetContainer}>
+            <Chart
+                animate={{ duration: 300 }}
+                domainPadding={{ x: [20, 20] }}
+                height={defaultChartHeight}
+                width={widgetContainerResizeEntry?.contentRect.width}
+                padding={{
+                    top: 0,
+                    left: 150,
+                    right: 50,
+                    bottom: 30,
+                }}
+                theme={patternflySeverityTheme}
+            >
+                <ChartAxis
+                    tickLabelComponent={
+                        <LinkableChartLabel
+                            linkWith={(props) => labelLinkCallback(props, passingRateData)}
+                        />
+                    }
+                />
+                <ChartAxis
+                    tickValues={[0, 50, 100]}
+                    tickFormat={['0', '50%', '100%']}
+                    padding={{ bottom: 10 }}
+                    dependentAxis
+                />
+                <ChartGroup horizontal>
+                    {passingRateData.map(({ name, passing }) => (
+                        <ChartBar
+                            key={name}
+                            barWidth={defaultChartBarWidth}
+                            data={[{ x: name, y: passing }]}
+                            labels={({ datum }) => `${Math.round(parseInt(datum.y, 10))}%`}
+                            style={{
+                                data: {
+                                    fill: ({ datum }) => getBarColor(datum.y),
+                                },
+                            }}
+                            sortOrder="ascending"
+                        />
+                    ))}
+                </ChartGroup>
+            </Chart>
+        </div>
+    );
+}
+
+export default HorizontalBarChart;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Dashboard/types.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Dashboard/types.ts
@@ -1,0 +1,5 @@
+export type PassingRateData = {
+    name: string;
+    passing: number;
+    link: string;
+}[];

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Dashboard/types.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Dashboard/types.ts
@@ -2,4 +2,4 @@ export type PassingRateData = {
     name: string;
     passing: number;
     link: string;
-}[];
+};


### PR DESCRIPTION
## Description

Create the compliance by profile widget. Should display the percent of compliance by profile. Create a reusable component for both compliance by profile and compliance by cluster to use.

Note: currently uses static data

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
![Screenshot 2023-08-02 at 1 28 32 PM](https://github.com/stackrox/stackrox/assets/61400697/333235f0-8ca2-43d5-8691-68c1749010ca)
