### PR TITLE
fix(ui): Replace count colors with black versus gray

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
@@ -3,18 +3,9 @@ import { Flex, Label, Tooltip, pluralize, capitalize } from '@patternfly/react-c
 import { EllipsisHIcon } from '@patternfly/react-icons';
 
 import SeverityIcons from 'Components/PatternFly/SeverityIcons';
-import { noViolationsColor } from 'constants/severityColors';
-import { VulnerabilitySeverity } from 'types/cve.proto';
+import { noViolationsClassName, noViolationsColor } from 'constants/severityColors';
 
 import { VulnerabilitySeverityLabel } from '../types';
-
-const vulnSeverityTextColors: Record<VulnerabilitySeverity, string> = {
-    LOW_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--blue-500)',
-    MODERATE_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--gold-600)',
-    IMPORTANT_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--orange-500)',
-    CRITICAL_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--red-200)',
-    UNKNOWN_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--black-400)',
-};
 
 type SeverityCountLabelsProps = {
     criticalCount: number;
@@ -33,6 +24,11 @@ function getTooltipContent(severity: string, severityCount?: number, entity?: st
         return `${pluralize(severityCount, `${severity} severity CVE`)} across this ${entity}`;
     }
     return `${pluralize(severityCount, 'image')} with ${severity} severity`;
+}
+
+function getClassNameForCount(count?: number) {
+    // Render non-zero count in normal black versus zero (or undefined) count in gray.
+    return count ? '' : noViolationsClassName;
 }
 
 function SeverityCountLabels({
@@ -64,16 +60,9 @@ function SeverityCountLabels({
                 <Label
                     aria-label={getTooltipContent('critical', critical, entity)}
                     variant="outline"
-                    className="pf-u-font-weight-bold"
                     icon={<CriticalIcon color={critical ? undefined : noViolationsColor} />}
                 >
-                    <span
-                        style={{
-                            color: critical
-                                ? vulnSeverityTextColors.CRITICAL_VULNERABILITY_SEVERITY
-                                : noViolationsColor,
-                        }}
-                    >
+                    <span className={getClassNameForCount(critical)}>
                         {!critical && critical !== 0 ? (
                             <EllipsisHIcon className="pf-u-my-xs" />
                         ) : (
@@ -86,16 +75,9 @@ function SeverityCountLabels({
                 <Label
                     aria-label={getTooltipContent('important', important, entity)}
                     variant="outline"
-                    className="pf-u-font-weight-bold"
                     icon={<ImportantIcon color={important ? undefined : noViolationsColor} />}
                 >
-                    <span
-                        style={{
-                            color: important
-                                ? vulnSeverityTextColors.IMPORTANT_VULNERABILITY_SEVERITY
-                                : noViolationsColor,
-                        }}
-                    >
+                    <span className={getClassNameForCount(important)}>
                         {!important && important !== 0 ? (
                             <EllipsisHIcon className="pf-u-my-xs" />
                         ) : (
@@ -108,16 +90,9 @@ function SeverityCountLabels({
                 <Label
                     aria-label={getTooltipContent('moderate', moderate, entity)}
                     variant="outline"
-                    className="pf-u-font-weight-bold"
                     icon={<ModerateIcon color={moderate ? undefined : noViolationsColor} />}
                 >
-                    <span
-                        style={{
-                            color: moderate
-                                ? vulnSeverityTextColors.MODERATE_VULNERABILITY_SEVERITY
-                                : noViolationsColor,
-                        }}
-                    >
+                    <span className={getClassNameForCount(moderate)}>
                         {!moderate && moderate !== 0 ? (
                             <EllipsisHIcon className="pf-u-my-xs" />
                         ) : (
@@ -130,16 +105,9 @@ function SeverityCountLabels({
                 <Label
                     aria-label={getTooltipContent('low', low, entity)}
                     variant="outline"
-                    className="pf-u-font-weight-bold"
                     icon={<LowIcon color={low ? undefined : noViolationsColor} />}
                 >
-                    <span
-                        style={{
-                            color: low
-                                ? vulnSeverityTextColors.LOW_VULNERABILITY_SEVERITY
-                                : noViolationsColor,
-                        }}
-                    >
+                    <span className={getClassNameForCount(low)}>
                         {!low && low !== 0 ? <EllipsisHIcon className="pf-u-my-xs" /> : low}
                     </span>
                 </Label>

--- a/ui/apps/platform/src/constants/severityColors.ts
+++ b/ui/apps/platform/src/constants/severityColors.ts
@@ -1,6 +1,7 @@
 import { VulnerabilitySeverity } from 'types/cve.proto';
 import { PolicySeverity } from 'types/policy.proto';
 
+export const noViolationsClassName = 'pf-u-color-200';
 export const noViolationsColor = 'var(--pf-global--Color--200)';
 
 /*


### PR DESCRIPTION
## Description

**Mansur**, it seemed clearest to open a candidate pull request to illustrate an accessibility issue and potential solution.

We can discuss via chat whether to move in this direction or adjust.

### Problems

1. General principle: except for PatternFly elements like alerts, buttons, or links, text color is a potential accessibility problem (for color vision, even if it passes color contrast).
2. Specific situation:
    * The distinction between standard severity color for icon and color for count subtle. In addition to minimum **absolute** contrast ratio, we need to consider small differences in **relative** contrast ratio.
    * When (not if) Red Hat design community updates severity colors, we cannot assume that there will be a set of text colors.

### Analysis and solution

Because only `SeverityCountLabels` has these colors, we recently moved them in #7190

1. Edit src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
    * Add `getClassNameForCount` helper function to return empty string for normal black versus gray class name for zero or undefined count.
    * Delete bold font weight which made the original color versus gray subtle and also made black versus gray subtle.
    * Replace conditional `color` with `className` prop for `span` element.

2. Edit src/constants/vulnerabilityColors.ts file
    * Add `noViolationsClassName` for `className` prop that corresponds to `noViolationsColor` for `color` prop.

### Residue

1. Label borders and subtle lane shift for rows that have a count of 1 cause my poor vision to work overtime. A possible alternative to explore might be 4 (invisible) columns under **Images by severity** table head cell that has column span. In each column, instead of label element, horizontal flex alignment with justify-between so:
    * Icons align consistently at (invisible, if possible) left edge of cells.
    * Counts align consistently at right edge of cells, which is conventional alignment for a column of numbers.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Visit /main/vulnerabilities/workload-cves?entityTab=CVE

    * Original **color** versus gray with **bold** font weight
        ![color_gray](https://github.com/stackrox/stackrox/assets/11862657/62a2d8c3-a9be-40cc-90b0-fa4154f5d5df)

    * Changed **black** versus gray with **normal** font weight
        ![black_gray](https://github.com/stackrox/stackrox/assets/11862657/1c182af6-a4da-4221-a72d-8d5b2d0855a7)
