### PR TITLE
fix(builds): create the -rcd manifest with the -rcd-amd64 image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,7 @@ jobs:
           if ! is_in_PR_context || pr_has_label ci-build-race-condition-debug; then
             matrix="$(jq '.pre_build_go_binaries.name += ["race-condition-debug"]' <<< "$matrix")"
             matrix="$(jq '.build_and_push_main.name += ["race-condition-debug"]' <<< "$matrix")"
+            matrix="$(jq '.push_main_multiarch_manifests.name += ["race-condition-debug"]' <<< "$matrix")"
             # Exclude "arm64", "ppc64le"
             matrix="$(jq '.pre_build_go_binaries.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
             matrix="$(jq '.pre_build_go_binaries.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
@@ -478,7 +479,11 @@ jobs:
         if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "master" ]]; then
           push_context="merge-to-master"
         fi
-        push_image_manifest_lists "$push_context" "${{ env.ROX_PRODUCT_BRANDING }}"
+        architectures="amd64,arm64,ppc64le"
+        if [[ "${{ matrix.name }}" == "race-condition-debug" ]]; then
+          architectures="amd64"
+        fi
+        push_image_manifest_lists "$push_context" "${{ env.ROX_PRODUCT_BRANDING }}" "$architectures"
 
     - name: Comment on the PR
       # Skip for external contributions.

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -160,15 +160,15 @@ get_central_diagnostics() {
 push_image_manifest_lists() {
     info "Pushing main, roxctl and central-db images as manifest lists"
 
-    if [[ "$#" -ne 2 ]]; then
-        die "missing arg. usage: push_image_manifest_lists <push_context> <brand>"
+    if [[ "$#" -ne 3 ]]; then
+        die "missing arg. usage: push_image_manifest_lists <push_context> <brand> <architectures (CSV)>"
     fi
 
     local push_context="$1"
     local brand="$2"
+    local architectures="$3"
 
     local main_image_set=("main" "roxctl" "central-db")
-    local architectures="amd64,arm64,ppc64le"
 
     local registry
     if [[ "$brand" == "STACKROX_BRANDING" ]]; then


### PR DESCRIPTION
## Description

Missed on https://github.com/stackrox/stackrox/pull/7232. This is needed for the `-race` test.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient. 
/test gke-race-condition-qa-e2e-tests