### PR TITLE
feat(metrics): buildinfo labels

### DIFF
--- a/central/metrics/telemetry/gauges.go
+++ b/central/metrics/telemetry/gauges.go
@@ -7,6 +7,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	installationStore "github.com/stackrox/rox/central/installation/store"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/branding"
+	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/sac"
@@ -52,6 +54,8 @@ func newGaugeMap(installation installationStore.Store) map[string]prometheus.Gau
 	installInfo, err := FetchInstallInfo(context.Background(), installation)
 	utils.Should(err)
 	labels := prometheus.Labels{
+		"branding":        branding.GetProductNameShort(),
+		"build":           buildinfo.BuildFlavor,
 		"central_id":      installInfo.GetId(),
 		"central_version": version.GetMainVersion(),
 		"hosting":         getHosting(),

--- a/central/metrics/telemetry/gauges.go
+++ b/central/metrics/telemetry/gauges.go
@@ -8,7 +8,6 @@ import (
 	installationStore "github.com/stackrox/rox/central/installation/store"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/branding"
-	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/sac"
@@ -55,7 +54,7 @@ func newGaugeMap(installation installationStore.Store) map[string]prometheus.Gau
 	utils.Should(err)
 	labels := prometheus.Labels{
 		"branding":        branding.GetProductNameShort(),
-		"build":           buildinfo.BuildFlavor,
+		"build":           metrics.GetBuildType(),
 		"central_id":      installInfo.GetId(),
 		"central_version": version.GetMainVersion(),
 		"hosting":         getHosting(),

--- a/pkg/metrics/util.go
+++ b/pkg/metrics/util.go
@@ -4,6 +4,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/version"
 )
 
 // EmplaceCollector registers, or re-registers, the given metrics collector.
@@ -32,4 +33,12 @@ func CollectToSlice(vec *prometheus.GaugeVec) ([]*dto.Metric, error) {
 		metricSlice = append(metricSlice, dtoMetric)
 	}
 	return metricSlice, errList.ToError()
+}
+
+// GetBuildType returns the build type of the binary for telemetry purposes.
+func GetBuildType() string {
+	if version.IsReleaseVersion() {
+		return "release"
+	}
+	return "internal"
 }

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -4,7 +4,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/branding"
-	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/version"
@@ -151,7 +150,7 @@ var (
 
 	telemetryLabels = prometheus.Labels{
 		"branding":       branding.GetProductNameShort(),
-		"build":          buildinfo.BuildFlavor,
+		"build":          metrics.GetBuildType(),
 		"hosting":        getHosting(),
 		"install_method": env.InstallMethod.Setting(),
 		"sensor_version": version.GetMainVersion(),

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -3,6 +3,8 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/branding"
+	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/version"
@@ -148,9 +150,11 @@ var (
 	})
 
 	telemetryLabels = prometheus.Labels{
-		"sensor_version": version.GetMainVersion(),
+		"branding":       branding.GetProductNameShort(),
+		"build":          buildinfo.BuildFlavor,
 		"hosting":        getHosting(),
 		"install_method": env.InstallMethod.Setting(),
+		"sensor_version": version.GetMainVersion(),
 	}
 	telemetrySecuredNodes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
## Description

Add `build` (release / development) and `branding` (stackrox / ACS) labels to `rox_central_info` / `rox_sensor_info`.

<img width="1263" alt="Screenshot 2023-08-03 at 02 57 47" src="https://github.com/stackrox/stackrox/assets/55607356/1dbfc486-fc7d-4383-b4ea-8bd11af56cc3">

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

see screenshot