### PR TITLE
Do not error out on missing attachments when generating report config response

### DIFF
--- a/central/reportconfigurations/service/v2/convert_test.go
+++ b/central/reportconfigurations/service/v2/convert_test.go
@@ -262,8 +262,7 @@ func TestConvertProtoReportConfigurationToV2(t *testing.T) {
 			}
 
 			expected := c.resultGen()
-			converted, err := convertProtoReportConfigurationToV2(reportConfig, collectionDatastore, notifierDatastore)
-			assert.NoError(t, err)
+			converted := convertProtoReportConfigurationToV2(reportConfig, collectionDatastore, notifierDatastore)
 			assert.Equal(t, expected, converted)
 		})
 	}

--- a/central/reportconfigurations/service/v2/service_impl.go
+++ b/central/reportconfigurations/service/v2/service_impl.go
@@ -79,10 +79,7 @@ func (s *serviceImpl) PostReportConfiguration(ctx context.Context, request *apiV
 		return nil, err
 	}
 
-	resp, err := convertProtoReportConfigurationToV2(createdReportConfig, s.collectionDatastore, s.notifierDatastore)
-	if err != nil {
-		return nil, errors.Wrap(err, "Report config created, but encountered error generating the response")
-	}
+	resp := convertProtoReportConfigurationToV2(createdReportConfig, s.collectionDatastore, s.notifierDatastore)
 	return resp, nil
 }
 
@@ -125,11 +122,10 @@ func (s *serviceImpl) GetReportConfigurations(ctx context.Context, query *apiV2.
 	v2Configs := make([]*apiV2.ReportConfiguration, 0, len(reportConfigs))
 
 	for _, config := range reportConfigs {
-		converted, err := convertProtoReportConfigurationToV2(config, s.collectionDatastore, s.notifierDatastore)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Error converting storage report configuration with id %s to response", config.GetId())
+		converted := convertProtoReportConfigurationToV2(config, s.collectionDatastore, s.notifierDatastore)
+		if converted != nil {
+			v2Configs = append(v2Configs, converted)
 		}
-		v2Configs = append(v2Configs, converted)
 	}
 	return &apiV2.GetReportConfigurationsResponse{ReportConfigs: v2Configs}, nil
 }
@@ -146,10 +142,7 @@ func (s *serviceImpl) GetReportConfiguration(ctx context.Context, id *apiV2.Reso
 		return nil, errors.Wrapf(errox.NotFound, "report configuration with id '%s' does not exist", id)
 	}
 
-	converted, err := convertProtoReportConfigurationToV2(config, s.collectionDatastore, s.notifierDatastore)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Error converting storage report configuration with id %s to response", config.GetId())
-	}
+	converted := convertProtoReportConfigurationToV2(config, s.collectionDatastore, s.notifierDatastore)
 	return converted, nil
 }
 

--- a/central/reports/common/query_builder.go
+++ b/central/reports/common/query_builder.go
@@ -41,6 +41,7 @@ func NewVulnReportQueryBuilder(collection *storage.ResourceCollection, vulnFilte
 
 // BuildQuery builds scope and cve filtering queries for vuln reporting
 func (q *queryBuilder) BuildQuery(ctx context.Context) (*ReportQuery, error) {
+	// TODO ROX-18773 : Add SAC query filter on deploymentsQuery to scope the results by report requester.
 	deploymentsQuery, err := q.collectionQueryResolver.ResolveCollectionQuery(ctx, q.collection)
 	if err != nil {
 		return nil, err

--- a/central/reports/manager/manager_impl.go
+++ b/central/reports/manager/manager_impl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/contextutil"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 )
@@ -23,6 +24,9 @@ type managerImpl struct {
 }
 
 func (m *managerImpl) Remove(ctx context.Context, id string) error {
+	if features.VulnMgmtReportingEnhancements.Enabled() {
+		return nil
+	}
 	if ok, err := reportsSAC.WriteAllowed(ctx); err != nil {
 		return err
 	} else if !ok {
@@ -33,6 +37,9 @@ func (m *managerImpl) Remove(ctx context.Context, id string) error {
 }
 
 func (m *managerImpl) Upsert(ctx context.Context, reportConfig *storage.ReportConfiguration) error {
+	if features.VulnMgmtReportingEnhancements.Enabled() {
+		return nil
+	}
 	if ok, err := reportsSAC.WriteAllowed(ctx); err != nil {
 		return err
 	} else if !ok {
@@ -45,6 +52,9 @@ func (m *managerImpl) Upsert(ctx context.Context, reportConfig *storage.ReportCo
 }
 
 func (m *managerImpl) RunReport(ctx context.Context, reportConfig *storage.ReportConfiguration) error {
+	if features.VulnMgmtReportingEnhancements.Enabled() {
+		return nil
+	}
 	/*
 	 * Multiple on demand reports cannot be executed concurrently.
 	 * An on demand report may be submitted while other scheduled reports are being run and will be
@@ -64,9 +74,15 @@ func (m *managerImpl) RunReport(ctx context.Context, reportConfig *storage.Repor
 }
 
 func (m *managerImpl) Start() {
+	if features.VulnMgmtReportingEnhancements.Enabled() {
+		return
+	}
 	m.scheduler.Start()
 }
 
 func (m *managerImpl) Stop() {
+	if features.VulnMgmtReportingEnhancements.Enabled() {
+		return
+	}
 	m.scheduler.Stop()
 }

--- a/central/reports/scheduler/v2/mocks/scheduler.go
+++ b/central/reports/scheduler/v2/mocks/scheduler.go
@@ -5,7 +5,6 @@
 package mocks
 
 import (
-	context "context"
 	reflect "reflect"
 
 	reportgenerator "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
@@ -52,18 +51,18 @@ func (mr *MockSchedulerMockRecorder) CanSubmitReportRequest(user, reportConfig i
 }
 
 // CancelReportRequest mocks base method.
-func (m *MockScheduler) CancelReportRequest(ctx context.Context, reportID string) (bool, error) {
+func (m *MockScheduler) CancelReportRequest(reportID string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CancelReportRequest", ctx, reportID)
+	ret := m.ctrl.Call(m, "CancelReportRequest", reportID)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CancelReportRequest indicates an expected call of CancelReportRequest.
-func (mr *MockSchedulerMockRecorder) CancelReportRequest(ctx, reportID interface{}) *gomock.Call {
+func (mr *MockSchedulerMockRecorder) CancelReportRequest(reportID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelReportRequest", reflect.TypeOf((*MockScheduler)(nil).CancelReportRequest), ctx, reportID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelReportRequest", reflect.TypeOf((*MockScheduler)(nil).CancelReportRequest), reportID)
 }
 
 // RemoveReportSchedule mocks base method.

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
-	"github.com/stackrox/rox/pkg/grpc/authz/allow"
 	types2 "github.com/stackrox/rox/pkg/images/types"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	postgresSchema "github.com/stackrox/rox/pkg/postgres/schema"
@@ -113,7 +112,7 @@ func (s *EnhancedReportingTestSuite) TestSaveReportData() {
 
 	// Save report
 	reportID := "reportid"
-	s.Require().NoError(s.reportGenerator.saveReportData(s.ctx, configID, reportID, buf))
+	s.Require().NoError(s.reportGenerator.saveReportData(configID, reportID, buf))
 	newBuf, _, exists, err := s.blobStore.GetBlobWithDataInBuffer(s.ctx, common.GetReportBlobPath(configID, reportID))
 	s.Require().NoError(err)
 	s.Require().True(exists)
@@ -121,7 +120,7 @@ func (s *EnhancedReportingTestSuite) TestSaveReportData() {
 
 	// Save empty report
 	reportID = "anotherid"
-	s.Require().NoError(s.reportGenerator.saveReportData(s.ctx, configID, reportID, nil))
+	s.Require().NoError(s.reportGenerator.saveReportData(configID, reportID, nil))
 	newBuf, _, exists, err = s.blobStore.GetBlobWithDataInBuffer(s.ctx, common.GetReportBlobPath(configID, reportID))
 	s.Require().NoError(err)
 	s.Require().True(exists)
@@ -129,7 +128,6 @@ func (s *EnhancedReportingTestSuite) TestSaveReportData() {
 }
 
 func (s *EnhancedReportingTestSuite) TestGetReportData() {
-	ctx := resolvers.SetAuthorizerOverride(s.ctx, allow.Anonymous())
 	clusters := []string{"c1", "c2"}
 	namespaces := []string{"ns1", "ns2"}
 	deployments, images := testDeploymentsWithImages(clusters, namespaces, 1)
@@ -266,7 +264,7 @@ func (s *EnhancedReportingTestSuite) TestGetReportData() {
 			s.NoError(err)
 
 			reportConfig := testReportConfig(tc.collection.GetId(), tc.fixability, tc.severities, tc.imageTypes)
-			deployedImgResults, watchedImgResults, err := s.reportGenerator.getReportData(ctx, reportConfig, tc.collection, nil)
+			deployedImgResults, watchedImgResults, err := s.reportGenerator.getReportData(reportConfig, tc.collection, nil)
 			s.NoError(err)
 			reportData := extractVulnReportData(deployedImgResults, watchedImgResults)
 			s.ElementsMatch(tc.expected.deploymentNames, reportData.deploymentNames)

--- a/central/reports/scheduler/v2/reportgenerator/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/types.go
@@ -1,8 +1,6 @@
 package reportgenerator
 
 import (
-	"context"
-
 	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/generated/storage"
 )
@@ -13,7 +11,6 @@ type ReportRequest struct {
 	ReportMetadata *storage.ReportMetadata
 	Collection     *storage.ResourceCollection
 	DataStartTime  *types.Timestamp
-	Ctx            context.Context
 }
 
 type reportEmailFormat struct {

--- a/central/reports/scheduler/v2/scheduler.go
+++ b/central/reports/scheduler/v2/scheduler.go
@@ -1,8 +1,6 @@
 package v2
 
 import (
-	"context"
-
 	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
 	"github.com/stackrox/rox/generated/storage"
 )
@@ -26,7 +24,7 @@ type Scheduler interface {
 
 	// CancelReportRequest cancels a report request that is still waiting in queue.
 	// If the report is already being prepared or has completed execution, it cannot be cancelled.
-	CancelReportRequest(ctx context.Context, reportID string) (bool, error)
+	CancelReportRequest(reportID string) (bool, error)
 
 	// Start scheduler. A scheduler instance can only be started once. It cannot be re-started once stopped.
 	// This func will log errors if the scheduler fails to start.

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -358,6 +358,7 @@ func (s *scheduler) queueScheduledReports() {
 	reportConfigs, err := s.reportConfigDatastore.GetReportConfigurations(scheduledCtx, query)
 	if err != nil {
 		log.Errorf("Error finding scheduled reports: %s", err)
+		return
 	}
 	for _, rc := range reportConfigs {
 		if rc.GetSchedule() != nil {

--- a/central/reports/service/singleton.go
+++ b/central/reports/service/singleton.go
@@ -32,10 +32,12 @@ func initializeManager() manager.Manager {
 
 	query := search.NewQueryBuilder().AddExactMatches(search.ReportType, storage.ReportConfiguration_VULNERABILITY.String()).ProtoQuery()
 	reportConfigs, err := datastore.Singleton().GetReportConfigurations(ctx, query)
-	if err != nil {
-		panic(err)
-	}
 	mgr := manager.Singleton()
+	if err != nil {
+		log.Errorf("Error finding scheduled reports: %s", err)
+		return mgr
+	}
+
 	for _, rc := range reportConfigs {
 		if err := mgr.Upsert(ctx, rc); err != nil {
 			log.Errorf("error upserting report config: %v", err)

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -158,8 +158,6 @@ func (s *serviceImpl) RunReport(ctx context.Context, req *apiV2.RunReportRequest
 		reportReq.ReportMetadata.ReportStatus.ReportNotificationMethod = storage.ReportStatus_EMAIL
 	} else {
 		reportReq.ReportMetadata.ReportStatus.ReportNotificationMethod = storage.ReportStatus_DOWNLOAD
-		// Scope the downloadable reports to the access scope of user demanding the report
-		reportReq.Ctx = ctx
 	}
 	reportID, err := s.scheduler.SubmitReportRequest(reportReq, false)
 	if err != nil {
@@ -201,7 +199,7 @@ func (s *serviceImpl) CancelReport(ctx context.Context, req *apiV2.ResourceByID)
 		return nil, errors.Wrap(errox.NotAuthorized, "Report cannot be cancelled by a user who did not request the report.")
 	}
 
-	cancelled, err := s.scheduler.CancelReportRequest(ctx, req.GetId())
+	cancelled, err := s.scheduler.CancelReportRequest(req.GetId())
 	if err != nil {
 		return nil, err
 	}

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -219,7 +219,6 @@ func (suite *ReportServiceTestSuite) TestRunReport() {
 				suite.reportConfigStore.EXPECT().GetReportConfiguration(userContext, reportConfig.Id).
 					Return(reportConfig, true, nil).Times(1)
 				reportReq := getReportRequest(user, reportConfig, storage.ReportStatus_DOWNLOAD)
-				reportReq.Ctx = userContext
 				suite.scheduler.EXPECT().SubmitReportRequest(reportReq, false).
 					Return("reportID", nil).Times(1)
 			},
@@ -347,7 +346,7 @@ func (suite *ReportServiceTestSuite) TestCancelReport() {
 			mockGen: func() {
 				suite.reportMetadataStore.EXPECT().Get(userContext, reportMetadata.GetReportId()).
 					Return(reportMetadata, true, nil).Times(1)
-				suite.scheduler.EXPECT().CancelReportRequest(gomock.Any(), gomock.Any()).
+				suite.scheduler.EXPECT().CancelReportRequest(gomock.Any()).
 					Return(false, errors.New("Datastore error")).
 					Times(1)
 			},
@@ -362,7 +361,7 @@ func (suite *ReportServiceTestSuite) TestCancelReport() {
 			mockGen: func() {
 				suite.reportMetadataStore.EXPECT().Get(userContext, reportMetadata.GetReportId()).
 					Return(reportMetadata, true, nil).Times(1)
-				suite.scheduler.EXPECT().CancelReportRequest(gomock.Any(), gomock.Any()).
+				suite.scheduler.EXPECT().CancelReportRequest(gomock.Any()).
 					Return(false, nil).
 					Times(1)
 			},
@@ -377,7 +376,7 @@ func (suite *ReportServiceTestSuite) TestCancelReport() {
 			mockGen: func() {
 				suite.reportMetadataStore.EXPECT().Get(userContext, reportMetadata.GetReportId()).
 					Return(reportMetadata, true, nil).Times(1)
-				suite.scheduler.EXPECT().CancelReportRequest(gomock.Any(), gomock.Any()).
+				suite.scheduler.EXPECT().CancelReportRequest(gomock.Any()).
 					Return(true, nil).
 					Times(1)
 			},


### PR DESCRIPTION
## Description

If the collection of notifier attached to a report configuration is deleted, the conversion from `storage.ReportConfiguration` to `apiV2.ReportConfiguration` errored out when the attached entity was not found. This caused the `ListReportConfigurations` API to error out. This PR removes the errors returned from conversion and just logs those errors. If a collection/notifier is not found, the response would just have the collection name/notifier name as empty string.

Deleting a notifier or a collection attached to a report configuration should be prevented. This will be added in a separate PR.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Manual testing by deleting a notifier attached to a report config and making sure the report config list page doesn't crash.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
