### PR TITLE
ROX-18838: discard unused Docker socket mount in Collector container

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -64,9 +64,6 @@ spec:
           privileged: true
           readOnlyRootFilesystem: true
         volumeMounts:
-        - mountPath: /host/var/run/docker.sock
-          name: var-run-docker-sock
-          readOnly: true
         - mountPath: /host/proc
           name: proc-ro
           readOnly: true
@@ -172,9 +169,6 @@ spec:
            name: cache-volume
       {{- end }}
       volumes:
-      - hostPath:
-          path: /var/run/docker.sock
-        name: var-run-docker-sock
       - hostPath:
           path: /proc
         name: proc-ro


### PR DESCRIPTION
## Description

The current definition of the Collector _daemonset_ contains a volume to access to the Docker socket. This is not used anymore and could cause security concern.

Let's discard it.

## Checklist
- [x] Investigated and inspected CI test results

