### PR TITLE
chore(tests): expose flakes in prow 

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1056,7 +1056,7 @@ post_process_test_results() {
 
         csv_output="$(mktemp --suffix=.csv)"
 
-        curl --retry 5 -SsfL https://github.com/stackrox/junit2jira/releases/download/v0.0.9/junit2jira -o junit2jira && \
+        curl --retry 5 -SsfL https://github.com/stackrox/junit2jira/releases/download/v0.0.10/junit2jira -o junit2jira && \
         chmod +x junit2jira && \
         ./junit2jira \
             -base-link "$(echo "$JOB_SPEC" | jq ".refs.base_link" -r)" \
@@ -1068,6 +1068,7 @@ post_process_test_results() {
             -junit-reports-dir "${ARTIFACT_DIR}" \
             -orchestrator "${ORCHESTRATOR_FLAVOR:-PROW}" \
             -threshold 5 \
+            -html-output "$ARTIFACT_DIR/junit2jira-summary.html" \
             "${extra_args[@]}"
 
         info "Creating Big Query test records from ${csv_output}"


### PR DESCRIPTION
## Description

Expose user friendly information about possible flakes that were already reported to jira.
Example: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/7250/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1688887101317189632

![image](https://github.com/stackrox/stackrox/assets/1616386/a20d5cc5-b5ae-4e07-b8eb-4c1807d95b27)

Refs: 
- https://github.com/stackrox/junit2jira/pull/16


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

N/A
