### PR TITLE
fix(build): Add support for tagged builds to manifest push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -476,6 +476,8 @@ jobs:
       if: matrix.name == 'race-condition-debug'
       run: echo "BUILD_TAG=$(make --quiet --no-print-directory tag)-rcd" >> "$GITHUB_ENV"
 
+    - uses: ./.github/actions/handle-tagged-build
+
     - name: Build and push manifest lists
       # Skip for external contributions.
       if: |


### PR DESCRIPTION
## Description

Fix the make tag for manifest list pushes

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI + nightly