### PR TITLE
ROX-18861: migration rollback issue

### DIFF
--- a/migrator/runner/runner.go
+++ b/migrator/runner/runner.go
@@ -55,10 +55,10 @@ func Run(databases *types.Databases) error {
 		return nil
 	}
 	if dbSeqNum > currSeqNum {
-		return fmt.Errorf("DB sequence number %d is greater than the latest one we have (%d). This means "+
-			"the migration binary is likely out of date", dbSeqNum, currSeqNum)
+		log.WriteToStderrf("DB sequence number %d is greater than the latest one we have (%d). This means "+
+			"we are in a rollback.", dbSeqNum, currSeqNum)
 	}
-	if dbSeqNum != currSeqNum {
+	if dbSeqNum <= currSeqNum {
 		log.WriteToStderrf("Found DB at version %d, which is less than what we expect (%d). Running migrations...", dbSeqNum, currSeqNum)
 		if err := runMigrations(databases, dbSeqNum); err != nil {
 			return err


### PR DESCRIPTION
## Description

There was a lingering check that prevented a rollback after a migration. Now that all changes must be backwards compatible that check no longer makes sense.  Changes it to log that we are in a rollback scenario.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Used the image in #6200 that added a migration to test this.  

- Started with image in this PR, verified the sequence number was 186
- upgraded with the image in #6200.  
- Verified that the migration executed to migrate a blob.  And the sequence number moved to 187
- Rolled back to the image in this PR and ensured that central started successfully and that the sequence number returned to 186 and all data was correct.

Verified I could reproduce it:
- Started with an image before this PR and verified the sequence number was 186
- upgraded with the image in #6200.  
- Verified that the migration executed to migrate a blob.  And the sequence number moved to 187
- Rolled back to an image before this PR and verified that central was in a crash loop
- Tested a work around in case we need it while central was crashing
- logged into central-db
- ran `update versions set seqnum = 186;`
- verified that central started and the migration version was 186
- upgraded back to #6200 and verified the blob was migrated and sequence number returned to 187