### PR TITLE
fix(helm): Set 'readOnlyRootFilesystem: false'

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/collector-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector-scc.yaml
@@ -20,7 +20,7 @@ fsGroup:
   type: RunAsAny
 groups: []
 priority: 0
-readOnlyRootFilesystem: true
+readOnlyRootFilesystem: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:


### PR DESCRIPTION
## Description

As this scc is based on scc **privileged**, when it is used by a serviceaccount, it runs as root but since `readOnlyRootFilesystem: true`, it prevents access to files/folders owned by user **root**.

`readOnlyRootFilesystem: true` in this scc has caused problems during the upgrades on openshift, because, the version job pod created by CVO, sometimes uses this scc and is unable to remove folders/files owned by user root.

List of related issues:-
- https://access.redhat.com/solutions/5911951
- https://access.redhat.com/solutions/6985485
- https://issues.redhat.com/browse/OTA-680
- https://github.com/openshift/cluster-version-operator/pull/824

## Testing Performed

During the upgrade on OKD, we changed  'readOnlyRootFilesystem: false' and then only the version job pod created successfully and the upgrade started.
