### PR TITLE
feat(operator): Add skip-tls-verify flag for opm render

### DIFF
--- a/operator/hack/build-index-image.sh
+++ b/operator/hack/build-index-image.sh
@@ -23,7 +23,7 @@ OPTION:
   --clean-output-dir   Delete '{base-dir}/build/index' directory.
   --use-http           Use plain HTTP for container image registries.
   --skip-build         Skip the actual \"docker build\" command.
-  --skip-tls-verify    Skip TLS certificate verification for container image registries while pulling bundles
+  --skip-tls-verify    Skip TLS certificate verification for container image registries while pulling bundles.
 " >&2
 }
 


### PR DESCRIPTION
## Description

Add `skip-tls-verify` flag for opm render to be able to build index image with insecure registry.
I added this flag for development purposes, similar to the `--use-http` flag.
It is needed to pull bundle images from insecure registries, in particular OpenShift internal registries, namely `crc` and infra. This allows you to test local changes on OpenShift clusters without pushing the changes, open a PR and wait for CI to push the images, speeding up development time.
It seems like `opm render` does not use docker daemon and fails to pull the images even if I specify an insecure registry in the docker configuration.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Tested locally 
