### PR TITLE
fix(builds): skip latest manifest for scanner images

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -184,21 +184,24 @@ push_image_manifest_lists() {
 
     registry_rw_login "$registry"
     for image in "${main_image_set[@]}"; do
-         "$SCRIPTS_ROOT/scripts/ci/push-as-multiarch-manifest-list.sh" "${registry}/${image}:${tag}" "$architectures" | cat
-          if [[ "$push_context" == "merge-to-master" ]]; then
-              "$SCRIPTS_ROOT/scripts/ci/push-as-multiarch-manifest-list.sh" "${registry}/${image}:latest" "$architectures" | cat
-          fi
+        "$SCRIPTS_ROOT/scripts/ci/push-as-multiarch-manifest-list.sh" "${registry}/${image}:${tag}" "$architectures" | cat
+        if [[ "$push_context" == "merge-to-master" ]]; then
+            "$SCRIPTS_ROOT/scripts/ci/push-as-multiarch-manifest-list.sh" "${registry}/${image}:latest" "$architectures" | cat
+        fi
     done
 
     # Push manifest lists for scanner and collector for amd64 only
     local amd64_image_set=("scanner" "scanner-db" "scanner-slim" "scanner-db-slim" "collector" "collector-slim")
     for image in "${amd64_image_set[@]}"; do
-         "$SCRIPTS_ROOT/scripts/ci/push-as-multiarch-manifest-list.sh" "${registry}/${image}:${tag}" "amd64" | cat
-          if [[ "$push_context" == "merge-to-master" ]]; then
-              "$SCRIPTS_ROOT/scripts/ci/push-as-multiarch-manifest-list.sh" "${registry}/${image}:latest" "amd64" | cat
-          fi
+        "$SCRIPTS_ROOT/scripts/ci/push-as-multiarch-manifest-list.sh" "${registry}/${image}:${tag}" "amd64" | cat
     done
-
+    if [[ "$push_context" == "merge-to-master" ]]; then
+        # Scanner images do not utilize a 'latest' tag
+        amd64_image_set=("collector" "collector-slim")
+        for image in "${amd64_image_set[@]}"; do
+            "$SCRIPTS_ROOT/scripts/ci/push-as-multiarch-manifest-list.sh" "${registry}/${image}:latest" "amd64" | cat
+        done
+    fi
 }
 
 push_main_image_set() {


### PR DESCRIPTION
## Description

Per title. Scanner images are not produced with 'latest' tags, so there is no need for a manifest for them.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient