### PR TITLE
fix(builds): skip latest manifest for collector images

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -195,13 +195,6 @@ push_image_manifest_lists() {
     for image in "${amd64_image_set[@]}"; do
         "$SCRIPTS_ROOT/scripts/ci/push-as-multiarch-manifest-list.sh" "${registry}/${image}:${tag}" "amd64" | cat
     done
-    if [[ "$push_context" == "merge-to-master" ]]; then
-        # Scanner images do not utilize a 'latest' tag
-        amd64_image_set=("collector" "collector-slim")
-        for image in "${amd64_image_set[@]}"; do
-            "$SCRIPTS_ROOT/scripts/ci/push-as-multiarch-manifest-list.sh" "${registry}/${image}:latest" "amd64" | cat
-        done
-    fi
 }
 
 push_main_image_set() {


### PR DESCRIPTION
## Description

I thought collector images were produced with `:latest-<arch>` tags but it is not so.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.