### PR TITLE
ROX-12724: Warn external DB without source or password

### DIFF
--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -64,6 +64,15 @@
 {{ end }}
 [< end >]
 
+{{ if $._rox.central.db.external }}
+  {{ if not $._rox.central.db.source.connectionString }}
+    {{ include "srox.warn" (list $ "You have chosen to bring your own Central DB without providing its connection string. We are using the default source string. To ensure the connection to your Central DB, you may override it with `--set central.db.source.connectionString=<ConnectionString>`.") }}
+  {{ end }}
+  {{ if not $._rox.central.db.password.value }}
+    {{ include "srox.warn" (list $ "You have chosen to bring your own Central DB without providing its password. We are using a generated password for now. To ensure the connection to your Central DB, you may provide your DB password by `--set central.db.password.value=<DBPassword>`.") }}
+  {{ end }}
+{{ end }}
+
 {{/* Initialize global prefix */}}
 {{- include "srox.initGlobalPrefix" (list $) -}}
 


### PR DESCRIPTION
## Description

Warn if external is true for central database but no password or source is provided during Helm chart install.
We still need to allow it because the secrets and configuration may be managed by operator or other sources. 


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Helm install manual test.
