### PR TITLE
ROX-18810: Add ImageScanningTest to the parallel set

### DIFF
--- a/qa-tests-backend/src/main/groovy/common/Constants.groovy
+++ b/qa-tests-backend/src/main/groovy/common/Constants.groovy
@@ -46,6 +46,16 @@ class Constants {
     // tests fail.
     static final TEST_FEATURE_TIMEOUT_PAD = 360
 
+    // Used for @Tag("Parallel") tests to gate their requirements for scanner
+    // configuration.
+    // A ResourceAccessMode.READ_WRITE @ResourceLock means the test will modify
+    // scanner integrations and other tests that require a READ or READ_WRITE
+    // lock are blocked.
+    // A ResourceAccessMode.READ @ResourceLock means the test relies on the
+    // default scanner configuration (currently Stackrox Scanner). Other READ
+    // tests will run. READ_WRITE tests are blocked.
+    static final String RESOURCE_SCANNER_INTEGRATION = "RESOURCE_SCANNER_INTEGRATION"
+
     /*
         StackRox Product Feature Flags
 

--- a/qa-tests-backend/src/main/groovy/services/PolicyService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/PolicyService.groovy
@@ -38,6 +38,15 @@ class PolicyService extends BaseService {
         return policyID
     }
 
+    static PolicyOuterClass.Policy createAndFetchPolicy(PolicyOuterClass.Policy policy) {
+        return getPolicyClient().postPolicy(
+                PolicyServiceOuterClass.PostPolicyRequest.newBuilder().
+                        setPolicy(policy).
+                        setEnableStrictValidation(true).
+                        build()
+        )
+    }
+
     static deletePolicy(String policyID) {
         try {
             getPolicyClient().deletePolicy(

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -7,6 +7,8 @@ import orchestratormanager.OrchestratorTypes
 import io.stackrox.proto.api.v1.SearchServiceOuterClass
 import io.stackrox.proto.storage.ImageIntegrationOuterClass
 import io.stackrox.proto.storage.ImageOuterClass
+import io.stackrox.proto.storage.PolicyOuterClass.Policy
+import io.stackrox.proto.storage.ScopeOuterClass.Scope
 import io.stackrox.proto.storage.Vulnerability
 
 import common.Constants
@@ -23,16 +25,24 @@ import objects.StackroxScannerIntegration
 import services.ClusterService
 import services.ImageIntegrationService
 import services.ImageService
+import services.PolicyService
 import util.Env
 import util.Timer
 
 import org.junit.Assume
 import org.junit.AssumptionViolatedException
+import org.spockframework.runtime.model.parallel.ResourceAccessMode
+import spock.lang.ResourceLock
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Unroll
 
+// @ResourceLock() - Block other tests that rely on a default scanner configuration.
+@ResourceLock(value = Constants.RESOURCE_SCANNER_INTEGRATION, mode = ResourceAccessMode.READ_WRITE)
+@Tag("Parallel")
 class ImageScanningTest extends BaseSpecification {
+    static final private String TEST_NAMESPACE = "qa-image-scanning-test"
+    private final static String CLONED_POLICY_SUFFIX = "(${TEST_NAMESPACE})"
 
     static final private String UBI8_0_IMAGE = "registry.access.redhat.com/ubi8:8.0-208"
     static final private String RHEL7_IMAGE =
@@ -55,11 +65,15 @@ class ImageScanningTest extends BaseSpecification {
             "Secure Shell (ssh) Port Exposed in Image",
     ]
 
+    @Shared
+    private List<Policy> policiesScopedForTest
+
     static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = isRaceBuild() ? 450 : 30
 
     static final private Map<String, Deployment> DEPLOYMENTS = [
             "quay": new Deployment()
                     .setName("quay-image-scanning-test")
+                    .setNamespace(TEST_NAMESPACE)
                     // same image as us.gcr.io/stackrox-ci/qa/registry-image:0.3 but just retagged
                     // Alternatively can use quay.io/rhacs-eng/qa:struts-app but that doesn't have as many
                     // dockerfile violations
@@ -68,17 +82,20 @@ class ImageScanningTest extends BaseSpecification {
                     .addImagePullSecret("quay-image-scanning-test"),
             "gcr": new Deployment()
                     .setName("gcr-image-scanning-test")
+                    .setNamespace(TEST_NAMESPACE)
                     .setImage("us.gcr.io/stackrox-ci/qa/registry-image:0.3")
                     .addLabel("app", "gcr-image-scanning-test")
                     .addImagePullSecret("gcr-image-scanning-test"),
             "ecr": new Deployment()
                     .setName("ecr-image-registry-test")
+                    .setNamespace(TEST_NAMESPACE)
                     .setImage("${Env.mustGetAWSECRRegistryID()}.dkr.ecr.${Env.mustGetAWSECRRegistryRegion()}." +
                             "amazonaws.com/stackrox-qa-ecr-test:registry-image-no-secrets")
                     .addLabel("app", "ecr-image-registry-test")
                     .addImagePullSecret("ecr-image-registry-test"),
             "acr": new Deployment()
                     .setName("acr-image-registry-test")
+                    .setNamespace(TEST_NAMESPACE)
                     .setImage("stackroxci.azurecr.io/stackroxci/registry-image:0.3")
                     .addLabel("app", "acr-image-registry-test")
                     .addImagePullSecret("acr-image-registry-test"),
@@ -87,53 +104,63 @@ class ImageScanningTest extends BaseSpecification {
     static final private Map<String, Secret> IMAGE_PULL_SECRETS = [
             "quay": new Secret(
                     name: "quay-image-scanning-test",
-                    namespace: Constants.ORCHESTRATOR_NAMESPACE,
+                    namespace: TEST_NAMESPACE,
                     username: Env.mustGet("QUAY_RHACS_ENG_RO_USERNAME"),
                     password: Env.mustGet("QUAY_RHACS_ENG_RO_PASSWORD"),
                     server: "https://quay.io"),
             "gcr": new Secret(
                     name: "gcr-image-scanning-test",
-                    namespace: Constants.ORCHESTRATOR_NAMESPACE,
+                    namespace: TEST_NAMESPACE,
                     username: "_json_key",
                     password: Env.mustGet("GOOGLE_CREDENTIALS_GCR_SCANNER"),
                     server: "https://us.gcr.io"),
             "ecr": new Secret(
                     name: "ecr-image-registry-test",
-                    namespace: Constants.ORCHESTRATOR_NAMESPACE,
+                    namespace: TEST_NAMESPACE,
                     username: "AWS",
                     password: Env.mustGetAWSECRDockerPullPassword(),
                     server: "https://${Env.mustGetAWSECRRegistryID()}.dkr.ecr."+
                             "${Env.mustGetAWSECRRegistryRegion()}.amazonaws.com"),
             "acr": new Secret(
                     name: "acr-image-registry-test",
-                    namespace: Constants.ORCHESTRATOR_NAMESPACE,
+                    namespace: TEST_NAMESPACE,
                     username: "stackroxci",
                     password: Env.mustGet("AZURE_REGISTRY_PASSWORD"),
                     server: "https://stackroxci.azurecr.io"),
     ]
-
-    @Shared
-    static final private List<String> UPDATED_POLICIES = []
 
     def setupSpec() {
         ImageIntegrationService.deleteStackRoxScannerIntegrationIfExists()
         removeGCRImagePullSecret()
         ImageIntegrationService.deleteAutoRegisteredGCRIntegrationIfExists()
 
-        // Enable specific policies to test image integrations
-        for (String policy : POLICIES) {
-            if (Services.setPolicyDisabled(policy, false)) {
-                UPDATED_POLICIES.add(policy)
-            }
+        // Create namespace scoped policies for test.
+        policiesScopedForTest = []
+        for (String policyName : POLICIES) {
+            Policy policy = Services.getPolicyByName(policyName)
+            Policy scopedPolicyForTest = policy.toBuilder()
+                .clearId()
+                .setName(policy.getName() + " ${CLONED_POLICY_SUFFIX}")
+                .setDisabled(false)
+                .clearScope()
+                .addScope(Scope.newBuilder().setNamespace(TEST_NAMESPACE))
+                .build()
+            Policy created = PolicyService.createAndFetchPolicy(scopedPolicyForTest)
+            assert created
+            policiesScopedForTest.add(created)
         }
+
+        orchestrator.ensureNamespaceExists(TEST_NAMESPACE)
     }
 
     def cleanupSpec() {
+        orchestrator.deleteNamespace(TEST_NAMESPACE)
+
         ImageIntegrationService.addStackroxScannerIntegration()
         addGCRImagePullSecret()
 
-        for (String policy : UPDATED_POLICIES) {
-            Services.setPolicyDisabled(policy, true)
+        for (Policy policy : policiesScopedForTest) {
+            PolicyService.deletePolicy(policy.getId())
         }
     }
 
@@ -226,8 +253,8 @@ class ImageScanningTest extends BaseSpecification {
 
         and:
         "validate expected violations based on dockerfile"
-        for (String policy : POLICIES) {
-            assert Services.waitForViolation(deployment.name, policy, WAIT_FOR_VIOLATION_TIMEOUT)
+        for (Policy policy : policiesScopedForTest) {
+            assert Services.waitForViolation(deployment.name, policy.getName(), WAIT_FOR_VIOLATION_TIMEOUT)
         }
 
         when:
@@ -577,8 +604,8 @@ class ImageScanningTest extends BaseSpecification {
 
         and:
         "validate expected violations based on dockerfile"
-        for (String policy : POLICIES) {
-            assert Services.waitForViolation(deployment.name, policy, WAIT_FOR_VIOLATION_TIMEOUT)
+        for (Policy policy : policiesScopedForTest) {
+            assert Services.waitForViolation(deployment.name, policy.getName(), WAIT_FOR_VIOLATION_TIMEOUT)
         }
 
         cleanup:

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -127,7 +127,6 @@ get_initial_options() {
 if [[ ! -f "/i-am-rox-ci-image" ]]; then
     handle_tag_requirements "$@"
     kubeconfig="${KUBECONFIG:-${HOME}/.kube/config}"
-    mkdir -p "${HOME}/.gradle/caches"
     mkdir -p "$QA_TEST_DEBUG_LOGS"
     info "Running in a container..."
     docker run \


### PR DESCRIPTION
## Description

This change adds ImageScanningTest to the parallel test set. In practice it will run after AdmissionControllerTest because ImageScanningTest requires a READ/WRITE lock on scanning configuration so they will not run together (and A is before I). As more tests are parallelized however these will be able to run concurrently with ImageScanningTest. i.e. no immediate performance benefit is expected from this change.

There are essentially three changes:
- A lock to prevent tests with different scanner requirements affecting each other (documented in the code).
- A separate namespace used for the tests deployments.
- A clone of policies used by the test scoped to the tests namespace.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI + A standalone cycle of 50 runs. Some flakeage was seen but this is consistent with the test flakiness in serial operation.

Two results:
- the first cycle ran 35 loops of all 4 parallel tests before the first failure. This failure was from `ImageScanningTest.Image metadata from registry test - acr-auto-and-config` which is a known flake https://issues.redhat.com/browse/ROX-18171. 
- the second cycle ran 45 loops of only the BAT portion of the 4 parallel tests before the first failure. This failure was from `ImageScanningTest.Image metadata from registry test - ecr-auto` which is another known flake `https://issues.redhat.com/browse/ROX-18339`

Logs:
[out8.txt](https://github.com/stackrox/stackrox/files/12294811/out8.txt)
[out7.txt](https://github.com/stackrox/stackrox/files/12294817/out7.txt)

