### PR TITLE
ROX-18918: Add clarifying comments for the webhook kustomization

### DIFF
--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -33,6 +33,8 @@ patchesStrategicMerge:
 # through a ComponentConfig type
 #- manager_config_patch.yaml
 
+# Order is important for manager deployment patches with volumes and volumeMounts
+# because the first volumeMount is removed for OLM installation (see operator/config/manifests/kustomization.yaml).
 - manager_webhook_patch.yaml
 - webhookcainjection_patch.yaml
 

--- a/operator/config/default/manager_webhook_patch.yaml
+++ b/operator/config/default/manager_webhook_patch.yaml
@@ -1,3 +1,5 @@
+# The patch is only required for non-OLM-based installations because OLM creates and mounts these volumes itself.
+# Should be kept in sync with operator/config/default/manager_webhook_patch.yaml which negates this patch for the OLM installation.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/operator/config/default/manager_webhook_patch.yaml
+++ b/operator/config/default/manager_webhook_patch.yaml
@@ -1,4 +1,4 @@
-# The patch is only required for non-OLM-based installations because OLM creates and mounts these volumes itself.
+# The patch is only required for non-OLM-based installations because OLM creates volumes and volumeMounts itself dynamically at runtime.
 # Should be kept in sync with operator/config/default/manager_webhook_patch.yaml which negates this patch for the OLM installation.
 apiVersion: apps/v1
 kind: Deployment

--- a/operator/config/manifests/kustomization.yaml
+++ b/operator/config/manifests/kustomization.yaml
@@ -7,6 +7,9 @@ resources:
 - ../scorecard-versioned
 
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.
+# The patch is only required for OLM-based installations because OLM creates and mounts these volumes itself.
+# In other words, the patch will NOT be executed for non-OLM-based installations.
+# Should be kept in sync with operator/config/default/manager_webhook_patch.yaml.
 patchesJson6902:
 - target:
     group: apps

--- a/operator/config/manifests/kustomization.yaml
+++ b/operator/config/manifests/kustomization.yaml
@@ -7,7 +7,8 @@ resources:
 - ../scorecard-versioned
 
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.
-# The patch is only required for OLM-based installations because OLM creates and mounts these volumes itself.
+# The patch is only required for OLM-based installations.
+# This is because OLM creates volumes and volumeMounts itself dynamically at runtime, so we need to remove them here to prevent clashes.
 # In other words, the patch will NOT be executed for non-OLM-based installations.
 # Should be kept in sync with operator/config/default/manager_webhook_patch.yaml.
 patchesJson6902:


### PR DESCRIPTION
## Description
When I tried to add another volumeMount to the deployment, it added the webhook mount instead of mine, which was confusing. This change adds a few more comments for future generations explaining why the kustomization is done this way.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Comment changes only, CI is sufficient.