### PR TITLE
feat(metrics): separate info metric into telemetry gauges for Sensor

### DIFF
--- a/sensor/common/metrics/init.go
+++ b/sensor/common/metrics/init.go
@@ -24,6 +24,7 @@ func init() {
 		k8sObjectIngestionToSendDuration,
 		resolverChannelSize,
 		outputChannelSize,
-		info,
+		telemetrySecuredNodes,
+		telemetrySecuredVCPU,
 	)
 }

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -275,10 +275,12 @@ func DecOutputChannelSize() {
 
 // SetInfoMetric sets the cluster metrics for the telemetry metrics.
 func SetInfoMetric(cm *central.ClusterMetrics) {
+	telemetrySecuredNodes.Reset()
 	telemetrySecuredNodes.WithLabelValues(
 		centralid.Get(),
 		clusterid.GetNoWait(),
 	).Set(float64(cm.GetNodeCount()))
+	telemetrySecuredVCPU.Reset()
 	telemetrySecuredVCPU.WithLabelValues(
 		centralid.Get(),
 		clusterid.GetNoWait(),

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -273,8 +273,8 @@ func DecOutputChannelSize() {
 	outputChannelSize.Dec()
 }
 
-// SetInfoMetric sets the cluster metrics for the telemetry metrics.
-func SetInfoMetric(cm *central.ClusterMetrics) {
+// SetTelemetryMetrics sets the cluster metrics for the telemetry metrics.
+func SetTelemetryMetrics(cm *central.ClusterMetrics) {
 	telemetrySecuredNodes.Reset()
 	telemetrySecuredNodes.WithLabelValues(
 		centralid.Get(),

--- a/sensor/kubernetes/clustermetrics/cluster_metrics.go
+++ b/sensor/kubernetes/clustermetrics/cluster_metrics.go
@@ -114,7 +114,7 @@ func (cm *clusterMetricsImpl) runPipeline() {
 				ClusterMetrics: metrics,
 			},
 		})
-		metricsPkg.SetInfoMetric(metrics)
+		metricsPkg.SetTelemetryMetrics(metrics)
 	} else {
 		log.Errorf("Collection of cluster metrics failed: %v", err.Error())
 	}


### PR DESCRIPTION
## Description

This is the follow up for Sensor. Basically we change the single info style metric into two gauge metrics.

New metrics:

* `rox_sensor_secured_nodes`
* `rox_sensor_secured_vcpu`

<img width="1292" alt="Screenshot 2023-08-07 at 15 11 05" src="https://github.com/stackrox/stackrox/assets/55607356/3f248e7d-1092-4cd6-8eac-aa8205d1e590">


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
