### PR TITLE
ROX-18560: Re-add padding to NG sidebar menu td cells

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -16,10 +16,6 @@
     min-width: 430px !important;
 }
 
-/* minimize the space used by the kabob menu as much as possible so that other columns do not become squished / truncated */
-.pf-c-drawer__panel .pf-c-table.pf-m-compact tr:not(.pf-c-table__expandable-row)>*:last-child {
-    padding-right: 0 !important;
-}
 .pf-c-drawer__panel .pf-c-dropdown__toggle.pf-m-plain:not(.pf-m-text) {
     padding-left: var(--pf-global--spacer--xs) !important;
     padding-right: var(--pf-global--spacer--xs) !important;


### PR DESCRIPTION
## Description

As titled. The compact padding was foiled by the addition of the "Feedback" button.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the NG and view tables with kebab menus in the sidebar.

Before:
![image](https://github.com/stackrox/stackrox/assets/1292638/265aab08-4320-4d4f-ad4f-4a5e2cb3ee9f)
After:
![image](https://github.com/stackrox/stackrox/assets/1292638/cba57d45-7cb1-482c-b882-abcca16bcc01)

Before:
![image](https://github.com/stackrox/stackrox/assets/1292638/c9447bc6-3c95-4acc-bc62-6990895a86c1)
After:
![image](https://github.com/stackrox/stackrox/assets/1292638/299731fa-31e9-4e88-9fc2-9f5f76afeea6)



