### PR TITLE
ROX-17689: Move policy error definitions to datastore from bolt store

### DIFF
--- a/central/policy/datastore/datastore_impl_test.go
+++ b/central/policy/datastore/datastore_impl_test.go
@@ -9,7 +9,6 @@ import (
 	clusterMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	notifierMocks "github.com/stackrox/rox/central/notifier/datastore/mocks"
 	indexMocks "github.com/stackrox/rox/central/policy/index/mocks"
-	"github.com/stackrox/rox/central/policy/store/boltdb"
 	storeMocks "github.com/stackrox/rox/central/policy/store/mocks"
 	categoriesMocks "github.com/stackrox/rox/central/policycategory/datastore/mocks"
 	policyCategoryMocks "github.com/stackrox/rox/central/policycategory/datastore/mocks"
@@ -212,18 +211,18 @@ func (s *PolicyDatastoreTestSuite) TestImportPolicyMixedSuccessAndFailure() {
 	}
 
 	errString := "some error string"
-	errorFail1 := &boltdb.PolicyStoreErrorList{
+	errorFail1 := &PolicyStoreErrorList{
 		Errors: []error{
-			&boltdb.NameConflictError{
+			&NameConflictError{
 				ErrString:          errString,
 				ExistingPolicyName: fail1Name,
 			},
 		},
 	}
 	fail2Name := "fail 2 name"
-	errorFail2 := &boltdb.PolicyStoreErrorList{
+	errorFail2 := &PolicyStoreErrorList{
 		Errors: []error{
-			&boltdb.IDConflictError{
+			&IDConflictError{
 				ErrString:          errString,
 				ExistingPolicyName: fail2Name,
 			},

--- a/central/policy/store/boltdb/store.go
+++ b/central/policy/store/boltdb/store.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/bolthelper"
 	"github.com/stackrox/rox/pkg/defaults/policies"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/policyutils"
 	"github.com/stackrox/rox/pkg/set"
@@ -25,35 +24,6 @@ var (
 
 	log = logging.LoggerForModule()
 )
-
-// PolicyStoreErrorList is used to encapsulate multiple errors returned from policy store methods
-type PolicyStoreErrorList struct {
-	Errors []error
-}
-
-func (p *PolicyStoreErrorList) Error() string {
-	return errorhelpers.NewErrorListWithErrors("policy store encountered errors", p.Errors).String()
-}
-
-// IDConflictError can be returned by AddPolicies when a policy exists with the same ID as a new policy
-type IDConflictError struct {
-	ErrString          string
-	ExistingPolicyName string
-}
-
-func (i *IDConflictError) Error() string {
-	return i.ErrString
-}
-
-// NameConflictError can be returned by AddPolicies when a policy exists with the same name as a new policy
-type NameConflictError struct {
-	ErrString          string
-	ExistingPolicyName string
-}
-
-func (i *NameConflictError) Error() string {
-	return i.ErrString
-}
 
 // Store provides storage functionality for policies.
 //


### PR DESCRIPTION
## Description
Required for bolt cleanup.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
