### PR TITLE
ci(scanner): build multi-arch Scanner images

### DIFF
--- a/.github/workflows/build-scanner.yml
+++ b/.github/workflows/build-scanner.yml
@@ -16,6 +16,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goarch: ['arm64', 'amd64', 'ppc64le']
+        goos: ['linux']
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.59
       env:
@@ -30,12 +34,18 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
     - name: Ignore dubious repository ownership
       run: |
         # Prevent fatal error "detected dubious ownership in repository" from recent git.
         git config --global --add safe.directory "$(pwd)"
 
     - name: Build Scanner and ScannerDB images
-      run: make -C scanner images
+      run: make -C scanner GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} images
 
 # TODO: Push Scanner and ScannerDB images

--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -32,10 +32,8 @@ ifeq ($(UNAME_S),Darwin)
 	HOST_OS := darwin
 endif
 
-ARCH := x86_64
 GOARCH := amd64
 ifeq ($(UNAME_M),arm64)
-	ARCH := aarch64
 	GOARCH := arm64
 endif
 
@@ -95,13 +93,13 @@ endif
 scanner-image: scanner-go-build copy-scripts $(OSSLS_NOTICE_DEP)
 	$(SILENT)echo "+ $@"
 	$(SILENT)echo "Building scanner:$(TAG)"
-	$(SILENT)GOARCH=$(GOARCH) $(DOCKERBUILD) -t scanner:$(TAG) -f image/scanner/Dockerfile image/scanner
+	$(SILENT)$(DOCKERBUILD) -t scanner:$(TAG) -f image/scanner/Dockerfile image/scanner
 
 .PHONY: db-image
 db-image: copy-db-scripts copy-db-sigs
 	$(SILENT)echo "+ $@"
 	$(SILENT)echo "Building scanner-db:$(TAG)"
-	$(SILENT)GOARCH=$(GOARCH) $(DOCKERBUILD) -t scanner-db:$(TAG) --build-arg POSTGRESQL_ARCH=${ARCH} -f image/db/Dockerfile image/db
+	$(SILENT)$(DOCKERBUILD) -t scanner-db:$(TAG) -f image/db/Dockerfile image/db
 
 ###########
 ## Tests ##
@@ -141,7 +139,6 @@ copy-scripts: $(addprefix ../image/rhel/static-bin/,$(SCRIPTS))
 	$(SILENT)echo "+ $@"
 	$(SILENT)cp $^ image/scanner/scripts
 
-DB_SCRIPTS := download.sh
 .PHONY: copy-db-scripts
 copy-db-scripts: ../image/postgres/download.sh
 	$(SILENT)echo "+ $@"

--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -48,12 +48,17 @@ endif
 BUILD_FLAGS := CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH}
 BUILD_CMD := go build -trimpath -ldflags="-X github.com/stackrox/stackrox/scanner/internal/version.Version=$(TAG)" -o image/scanner/bin/scanner ./cmd/scanner
 
+DOCKERBUILD := $(CURDIR)/../scripts/docker-build.sh
+
+.PHONY: all
+all: deps scanner-go-build images
+
 ###############################################################
 ###### Binaries we depend on (need to be defined on top) ######
 ###############################################################
 
 OSSLS_BIN := $(GOBIN)/ossls
-$(OSSLS_BIN): deps
+$(OSSLS_BIN):
 	$(SILENT)echo "+ $@"
 	$(SILENT)cd tools/ && go install github.com/stackrox/ossls
 
@@ -82,17 +87,21 @@ scanner-go-build-local:
 	$(SILENT)echo "+ $@"
 	$(SILENT)$(MAKE) GOOS=${HOST_OS} scanner-go-build
 
+OSSLS_NOTICE_DEP := ossls-notice
+ifdef CI
+	OSSLS_NOTICE_DEP := ossls-notice-no-download
+endif
 .PHONY: scanner-image
-scanner-image: scanner-go-build copy-scripts ossls-notice
+scanner-image: scanner-go-build copy-scripts $(OSSLS_NOTICE_DEP)
 	$(SILENT)echo "+ $@"
 	$(SILENT)echo "Building scanner:$(TAG)"
-	$(SILENT)docker build -t scanner:$(TAG) -f image/scanner/Dockerfile image/scanner
+	$(SILENT)GOARCH=$(GOARCH) $(DOCKERBUILD) -t scanner:$(TAG) -f image/scanner/Dockerfile image/scanner
 
 .PHONY: db-image
-db-image:
+db-image: copy-db-scripts copy-db-sigs
 	$(SILENT)echo "+ $@"
 	$(SILENT)echo "Building scanner-db:$(TAG)"
-	$(SILENT)docker build -t scanner-db:$(TAG) --build-arg POSTGRESQL_ARCH=${ARCH} -f image/db/Dockerfile image/db
+	$(SILENT)GOARCH=$(GOARCH) $(DOCKERBUILD) -t scanner-db:$(TAG) --build-arg POSTGRESQL_ARCH=${ARCH} -f image/db/Dockerfile image/db
 
 ###########
 ## Tests ##
@@ -114,6 +123,12 @@ endif
 	$(SILENT)go mod verify
 	$(SILENT)touch deps
 
+.PHONY: ossls-notice-no-download
+ossls-notice-no-download: deps
+	$(SILENT)echo "+ $@"
+	$(SILENT)ossls version
+	$(SILENT)ossls audit --export image/scanner/THIRD_PARTY_NOTICES
+
 .PHONY: ossls-notice
 ossls-notice: deps $(OSSLS_BIN)
 	$(SILENT)echo "+ $@"
@@ -125,6 +140,17 @@ SCRIPTS := restore-all-dir-contents import-additional-cas save-dir-contents
 copy-scripts: $(addprefix ../image/rhel/static-bin/,$(SCRIPTS))
 	$(SILENT)echo "+ $@"
 	$(SILENT)cp $^ image/scanner/scripts
+
+DB_SCRIPTS := download.sh
+.PHONY: copy-db-scripts
+copy-db-scripts: ../image/postgres/download.sh
+	$(SILENT)echo "+ $@"
+	$(SILENT)cp $^ image/db
+
+.PHONY: copy-db-sigs
+copy-db-sigs: ../image/postgres/signatures
+	$(SILENT)echo "+ $@"
+	$(SILENT)cp -R $^ image/db/signatures
 
 ###########
 ## Clean ##

--- a/scanner/image/db/.gitignore
+++ b/scanner/image/db/.gitignore
@@ -1,0 +1,2 @@
+signatures/
+download.sh

--- a/scanner/image/db/Dockerfile
+++ b/scanner/image/db/Dockerfile
@@ -1,6 +1,12 @@
 ARG BASE_REGISTRY=registry.access.redhat.com
 ARG BASE_IMAGE=ubi8-minimal
+ARG RPMS_BASE_IMAGE=ubi8
 ARG BASE_TAG=8.8
+
+FROM ${BASE_REGISTRY}/${RPMS_BASE_IMAGE}:${BASE_TAG} AS postgres_rpms
+
+COPY download.sh /download.sh
+RUN /download.sh
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
@@ -16,34 +22,29 @@ ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/" \
     PGDATA="/var/lib/postgresql/data/pgdata"
 ENV LANG=en_US.utf8
 
+COPY signatures/RPM-GPG-KEY-PGDG-13 /
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
+COPY --from=postgres_rpms /rpms/postgres.rpm /rpms/postgres-libs.rpm /rpms/postgres-server.rpm /rpms/postgres-contrib.rpm /tmp/
 
 ARG POSTGRESQL_ARCH=x86_64
 
-RUN curl -sSLf https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-${PG_MAJOR} -o /tmp/pg_repo.key && \
-    rpm --import /tmp/pg_repo.key && \
-    curl -sSLf https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-${POSTGRESQL_ARCH}/pgdg-redhat-repo-latest.noarch.rpm -o /tmp/pg_repo.rpm && \
-    rpm -i /tmp/pg_repo.rpm && \
-    # Skip repo check for ARM as it's used only for development purposes and package has wrong signature.
-    if [[ "$POSTGRESQL_ARCH" == "aarch64" ]]; then sed -i 's/repo_gpgcheck = 1/repo_gpgcheck = 0/g' /etc/yum.repos.d/pgdg-redhat-all.repo; fi && \
-    microdnf upgrade -y && \
+RUN microdnf upgrade -y && \
+    # groupadd is in shadow-utils package that is not installed by default.
     microdnf install -y shadow-utils && \
     groupadd -g 70 postgres && \
     adduser postgres -u 70 -g 70 -d /var/lib/postgresql -s /bin/sh && \
     microdnf install -y \
-        ca-certificates libicu systemd-sysv glibc-locale-source glibc-langpack-en \
-        postgresql13-server && \
-    # The removal of /usr/share/zoneinfo from UBI minimal images is intentional.
-    # After building the image, the image is reduced in size as much as possible,
-    # and the /usr/share/zoneinfo directory is purged as it saves space
-    # in the final distribution of the image.
+        ca-certificates libicu systemd-sysv \
+        glibc-locale-source glibc-langpack-en \
+        perl-libs libxslt && \
+    rpm -i /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \
+    # Restore /usr/share/zoneinfo that's empty in ubi-minimal because postgres reads timezone data from it.
     # https://access.redhat.com/solutions/5616681
     microdnf reinstall tzdata && \
     microdnf clean all && \
-    rpm -e --nodeps $(rpm -qa 'pgdg-redhat-repo*') && \
     # (Optional) Remove line below to keep package management utilities
     rpm -e --nodeps $(rpm -qa shadow-utils curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
-    rm -rf /var/cache/dnf /var/cache/yum  /tmp/pg_repo.rpm /tmp/pg_repo.key && \
+    rm -rf /var/cache/dnf /var/cache/yum /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     chown postgres:postgres /usr/local/bin/docker-entrypoint.sh && \
     chmod +x /usr/local/bin/docker-entrypoint.sh && \

--- a/scanner/image/db/Dockerfile
+++ b/scanner/image/db/Dockerfile
@@ -26,8 +26,6 @@ COPY signatures/RPM-GPG-KEY-PGDG-13 /
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 COPY --from=postgres_rpms /rpms/postgres.rpm /rpms/postgres-libs.rpm /rpms/postgres-server.rpm /rpms/postgres-contrib.rpm /tmp/
 
-ARG POSTGRESQL_ARCH=x86_64
-
 RUN microdnf upgrade -y && \
     # groupadd is in shadow-utils package that is not installed by default.
     microdnf install -y shadow-utils && \


### PR DESCRIPTION
## Description

Build multi-arch Scanner images. This does not push these images to any registry. Building arm64, amd64, and powerpc. Skipping Z at this time

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI. Take a look at the logs for the modified steps
