### PR TITLE
Fix blob path id generation in report service to match the path generated by report generator

### DIFF
--- a/central/reports/common/blob.go
+++ b/central/reports/common/blob.go
@@ -10,6 +10,6 @@ const (
 )
 
 // GetReportBlobPath creates the Blob path for report
-func GetReportBlobPath(reportID, configID string) string {
+func GetReportBlobPath(configID, reportID string) string {
 	return fmt.Sprintf(reportBlobPathTemplate, configID, reportID)
 }

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -466,7 +466,7 @@ func (s *serviceImpl) DeleteReport(ctx context.Context, req *apiV2.DeleteReportR
 		return nil, errors.Wrapf(errox.InvalidArgs, "Report job id %q did not generate a downloadable report and hence no report to delete.", req.GetId())
 	}
 
-	blobName := common.GetReportBlobPath(req.GetId(), rep.GetReportConfigurationId())
+	blobName := common.GetReportBlobPath(rep.GetReportConfigurationId(), req.GetId())
 	switch status.GetRunState() {
 	case storage.ReportStatus_FAILURE:
 		return nil, errors.Errorf("Report job %q has failed and no downloadable report to delete", req.GetId())

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -425,7 +425,7 @@ func (s *serviceImpl) DownloadReport(ctx context.Context, req *apiV2.DownloadRep
 			sac.ResourceScopeKeys(resources.Administration)),
 	)
 
-	_, exists, err := s.blobStore.Get(ctx, common.GetReportBlobPath(req.GetId(), rep.GetReportConfigurationId()), buf)
+	_, exists, err := s.blobStore.Get(ctx, common.GetReportBlobPath(rep.GetReportConfigurationId(), req.GetId()), buf)
 	if err != nil {
 		return nil, errors.Wrap(errox.InvariantViolation, "Failed to fetch report data")
 	}

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -1010,7 +1010,7 @@ func (s *ReportServiceTestSuite) TestDownloadReport() {
 	user := reportSnapshot.GetRequester()
 	userContext := s.getContextForUser(user)
 	blob, blobData := fixtures.GetBlobWithData()
-	blobName := common.GetReportBlobPath(reportSnapshot.GetReportId(), reportSnapshot.GetReportConfigurationId())
+	blobName := common.GetReportBlobPath(reportSnapshot.GetReportConfigurationId(), reportSnapshot.GetReportId())
 
 	testCases := []struct {
 		desc    string
@@ -1164,7 +1164,7 @@ func (s *ReportServiceTestSuite) TestDeleteReport() {
 	reportSnapshot.ReportStatus.ReportNotificationMethod = storage.ReportStatus_DOWNLOAD
 	user := reportSnapshot.GetRequester()
 	userContext := s.getContextForUser(user)
-	blobName := common.GetReportBlobPath(reportSnapshot.GetReportId(), reportSnapshot.GetReportConfigurationId())
+	blobName := common.GetReportBlobPath(reportSnapshot.GetReportConfigurationId(), reportSnapshot.GetReportId())
 
 	testCases := []struct {
 		desc    string


### PR DESCRIPTION
## Description

Report Generator generates blob path as `common.GetReportBlobPath(configID, reportID)` but download report service generated blob path as `common.GetReportBlobPath(reportID, configID)`. This PR makes both ordering consistent.

A detailed explanation of the changes in your PR.

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Manual testing

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
