### PR TITLE
chore(tests): remove header from title

### DIFF
--- a/qa-tests-backend/scripts/lib.sh
+++ b/qa-tests-backend/scripts/lib.sh
@@ -56,7 +56,7 @@ surface_spec_logs() {
     cat > "$artifact_file" <<- HEAD
 <html>
     <head>
-        <title><h4>Groovy Test Logs</h4></title>
+        <title>Groovy Test Logs</title>
         <style>
           body { color: #e8e8e8; background-color: #424242; font-family: "Roboto", "Helvetica", "Arial", sans-serif }
           a { color: #ff8caa }

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -345,7 +345,7 @@ create_log_explorer_links() {
     cat > "$artifact_file" <<- HEAD
 <html>
     <head>
-        <title><h4>GKE Logs Explorer</h4></title>
+        <title>GKE Logs Explorer</title>
         <style>
           body { color: #e8e8e8; background-color: #424242; font-family: "Roboto", "Helvetica", "Arial", sans-serif }
           a { color: #ff8caa }

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1515,7 +1515,7 @@ highlight_cluster_versions() {
     cat > "$artifact_file" <<- HEAD
 <html>
     <head>
-        <title><h4>Cluster Versions</h4></title>
+        <title>Cluster Versions</title>
         <style>
           body { color: #e8e8e8; background-color: #424242; font-family: "Roboto", "Helvetica", "Arial", sans-serif }
           a { color: #ff8caa }

--- a/scripts/ci/store-artifacts.sh
+++ b/scripts/ci/store-artifacts.sh
@@ -147,7 +147,7 @@ make_artifacts_help() {
     cat > "$help_file" <<- EOH
         <html>
         <head>
-        <title><h4>Additional StackRox e2e artifacts</h4></title>
+        <title>Additional StackRox e2e artifacts</title>
         <style>
           body { color: #e8e8e8; background-color: #424242; font-family: "Roboto", "Helvetica", "Arial", sans-serif }
           a { color: #ff8caa }

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -135,7 +135,7 @@ store_as_spyglass_artifact() {
     cat > "$artifact_file" <<- HEAD
 <html>
     <head>
-        <title><h4>Scale test comparison with baseline: ${metrics_name}</h4></title>
+        <title>Scale test comparison with baseline: ${metrics_name}</title>
     </head>
     <body>
     <pre style="background: #fff;">


### PR DESCRIPTION
## Description

It's just a styling change to keep our custom list font smaller. Currently we are using `<h4>` that is `24px` the same size as `.mdl-card__title-text` (aka `JUnit` lens section title)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

N/A
