### PR TITLE
ROX-16861: Test Sensor's RHCOS functions

### DIFF
--- a/pkg/centralsensor/caps_list.go
+++ b/pkg/centralsensor/caps_list.go
@@ -31,9 +31,6 @@ const (
 	// ScopedImageIntegrations identifies the capability to have image integrations with sources from image pull secrets
 	ScopedImageIntegrations SensorCapability = "ScopedImageIntegrations"
 
-	// NodeScanningCap identifies the capability to scan nodes and provide node components for vulnerability analysis.
-	NodeScanningCap SensorCapability = "NodeScanning"
-
 	// ListeningEndpointsWithProcessesCap identifies the capability for sensor to process and send information about listening endpoints and their processes, AKA processes listening on ports
 	ListeningEndpointsWithProcessesCap SensorCapability = "ListeningEndpointsWithProcesses"
 

--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -36,7 +36,7 @@ func (c *nodeInventoryHandlerImpl) Stopped() concurrency.ReadOnlyErrorSignal {
 }
 
 func (c *nodeInventoryHandlerImpl) Capabilities() []centralsensor.SensorCapability {
-	return []centralsensor.SensorCapability{centralsensor.NodeScanningCap}
+	return nil
 }
 
 // ResponsesC returns a channel with messages to Central. It must be called after Start() for the channel to be not nil

--- a/sensor/common/compliance/node_inventory_handler_test.go
+++ b/sensor/common/compliance/node_inventory_handler_test.go
@@ -63,6 +63,13 @@ func (s *NodeInventoryHandlerTestSuite) TearDownTest() {
 	assertNoGoroutineLeaks(s.T())
 }
 
+func (s *NodeInventoryHandlerTestSuite) TestCapabilities() {
+	inventories := make(chan *storage.NodeInventory)
+	defer close(inventories)
+	h := NewNodeInventoryHandler(inventories, &mockAlwaysHitNodeIDMatcher{})
+	s.Nil(h.Capabilities())
+}
+
 func (s *NodeInventoryHandlerTestSuite) TestResponsesCShouldPanicWhenNotStarted() {
 	inventories := make(chan *storage.NodeInventory)
 	defer close(inventories)


### PR DESCRIPTION
## Description

Apparently Sensor `NodenIventoryHandler` was already pretty well tested (coverage 91%). I iterated over the code again and improved few things. The coverage for that file is now at 94.4%.

The original idea to implement that with e2e tests has not been followed, because equivalent unit tests were possible.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

### N/A
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- [x] CI and the tests that were added
