### PR TITLE
fix(ui): Fix accessibility problem with heading levels

### DIFF
--- a/ui/apps/platform/src/Components/CollapsibleCard.js
+++ b/ui/apps/platform/src/Components/CollapsibleCard.js
@@ -36,7 +36,7 @@ class CollapsibleCard extends Component {
         const className = isCollapsible ? titleClassName : `${titleClassName} pointer-events-none`;
         return (
             <div className={className}>
-                <h1 className="flex flex-1 p-3 pb-2 text-base-600 font-700 text-lg">{title}</h1>
+                <h3 className="flex flex-1 p-3 pb-2 text-base-600 font-700 text-lg">{title}</h3>
                 {headerComponents && <div className="pointer-events-auto">{headerComponents}</div>}
                 {isCollapsible && <div className="flex px-3">{icons[cardState]}</div>}
             </div>

--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.js
@@ -34,7 +34,7 @@ const ClusterDeploymentPage = ({
         <div className="md:max-w-sm">
             <div className="md:pr-4">
                 {editing && clusterCheckedIn && (
-                    <Alert variant="info" isInline title={managerTypeTitle}>
+                    <Alert variant="info" isInline title={managerTypeTitle} component="h3">
                         {managerTypeText}
                     </Alert>
                 )}

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterSummary.js
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterSummary.js
@@ -38,7 +38,7 @@ const ClusterSummary = ({
     clusterRetentionInfo,
     isManagerTypeNonConfigurable,
 }) => (
-    <CollapsibleSection title="Cluster Summary" titleClassName="text-xl">
+    <CollapsibleSection title="Cluster Summary">
         <div className="grid grid-columns-1 md:grid-columns-2 xl:grid-columns-4 grid-gap-4 xl:grid-gap-6 mb-4 w-full">
             <div className="s-1">
                 <Metadata

--- a/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationSection.js
+++ b/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationSection.js
@@ -28,10 +28,7 @@ const DynamicConfigurationSection = ({
 
     // @TODO, replace open prop with dynamic logic, based on clusterType
     return (
-        <CollapsibleSection
-            title="Dynamic Configuration (syncs with Sensor)"
-            titleClassName="text-xl"
-        >
+        <CollapsibleSection title="Dynamic Configuration (syncs with Sensor)">
             <div className="bg-base-100 pb-3 pt-1 px-3 rounded shadow">
                 <div className={wrapperMarginClassName}>
                     <label htmlFor="dynamicConfig.registryOverride" className={labelClassName}>

--- a/ui/apps/platform/src/Containers/Clusters/StaticConfigurationSection.js
+++ b/ui/apps/platform/src/Containers/Clusters/StaticConfigurationSection.js
@@ -80,10 +80,7 @@ const StaticConfigurationSection = ({
     const isTypeOpenShift3 = selectedCluster?.type === clusterTypes.OPENSHIFT_3;
 
     return (
-        <CollapsibleSection
-            title="Static Configuration (requires deployment)"
-            titleClassName="text-xl"
-        >
+        <CollapsibleSection title="Static Configuration (requires deployment)">
             <div className="bg-base-100 pb-3 pt-1 px-3 rounded shadow">
                 <div className={wrapperMarginClassName}>
                     <label htmlFor="name" className={labelClassName}>

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/MostRecentViolations.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/MostRecentViolations.tsx
@@ -17,7 +17,7 @@ export type MostRecentViolationsProps = {
 function MostRecentViolations({ alerts }: MostRecentViolationsProps) {
     return (
         <>
-            <Title headingLevel="h5" className="pf-u-mb-sm">
+            <Title headingLevel="h3" className="pf-u-mb-sm">
                 Most recent violations with critical severity
             </Title>
             {alerts.length > 0 ? (

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/NoDataEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/NoDataEmptyState.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import { EmptyState, EmptyStateVariant, EmptyStateIcon, Title } from '@patternfly/react-core';
+import { EmptyState, EmptyStateVariant, EmptyStateIcon } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 
 function NoDataEmptyState() {
     return (
         <EmptyState className="pf-u-h-100" variant={EmptyStateVariant.xs}>
             <EmptyStateIcon className="pf-u-font-size-xl" icon={SearchIcon} />
-            <Title headingLevel="h3" size="md">
-                No data was found in the selected resources.
-            </Title>
+            <div>No data was found in the selected resources.</div>
         </EmptyState>
     );
 }

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyDetailsForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyDetailsForm.tsx
@@ -68,6 +68,7 @@ function PolicyDetailsForm({ id, mitreVectorsLocked }: PolicyDetailsFormProps): 
                                 variant="info"
                                 isInline
                                 title="Editing MITRE ATT&CK is disabled for system default policies"
+                                component="h3"
                                 className="pf-u-mt-sm"
                             >
                                 If you need to edit MITRE ATT&CK, clone this policy or create a new

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -1,21 +1,20 @@
 import React, { useState } from 'react';
 import {
     Alert,
-    Title,
+    Card,
+    CardBody,
+    CardHeader,
+    CardTitle,
+    Checkbox,
+    Flex,
     Form,
     FormGroup,
-    Radio,
     Divider,
-    Flex,
-    Checkbox,
-    Card,
-    CardHeader,
-    CardBody,
-    CardTitle,
-    CardActions,
-    Switch,
     Grid,
     GridItem,
+    Radio,
+    Switch,
+    Title,
 } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import cloneDeep from 'lodash/cloneDeep';
@@ -178,7 +177,13 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                     Select which stage of a container lifecycle this policy applies. Event sources
                     can only be chosen for policies that apply at runtime.
                 </div>
-                <Alert variant="info" isInline title="Info" className="pf-u-my-md">
+                <Alert
+                    variant="info"
+                    isInline
+                    title="Lifecycle stages"
+                    component="h3"
+                    className="pf-u-my-md"
+                >
                     <Flex
                         direction={{ default: 'column' }}
                         spaceItems={{ default: 'spaceItemsSm' }}
@@ -242,6 +247,7 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                             isInline
                             variant="warning"
                             title="Policy has active violations, and the lifecycle stage cannot be changed. To update the lifecycle, clone and create a new policy."
+                            component="div"
                         />
                     )}
                     <FormGroup
@@ -321,85 +327,78 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                             <GridItem span={4}>
                                 <Card className="pf-u-h-100 policy-enforcement-card">
                                     <CardHeader>
-                                        <CardTitle>Build</CardTitle>
-                                        <CardActions>
-                                            <Switch
-                                                isChecked={hasEnforcementActionForLifecycleStage(
-                                                    'BUILD',
-                                                    values.enforcementActions
-                                                )}
-                                                isDisabled={!hasBuild}
-                                                onChange={(isChecked) => {
-                                                    onChangeEnforcementActions('BUILD', isChecked);
-                                                }}
-                                                label="Enforce on Build"
-                                            />
-                                        </CardActions>
+                                        <CardTitle component="h3">Build</CardTitle>
                                     </CardHeader>
                                     <CardBody>
-                                        If enabled, your CI builds will be failed when images
-                                        violate this policy. Download the CLI to get started.
-                                        <Flex
-                                            justifyContent={{ default: 'justifyContentCenter' }}
-                                            className="pf-u-pt-md"
-                                        >
-                                            <DownloadCLIDropdown hasBuild={hasBuild} />
-                                        </Flex>
+                                        <Switch
+                                            isChecked={hasEnforcementActionForLifecycleStage(
+                                                'BUILD',
+                                                values.enforcementActions
+                                            )}
+                                            isDisabled={!hasBuild}
+                                            onChange={(isChecked) => {
+                                                onChangeEnforcementActions('BUILD', isChecked);
+                                            }}
+                                            label="Enforce on Build"
+                                        />
+                                        <p className="pf-u-pt-md pf-u-pb-md">
+                                            If enabled, your CI builds will be failed when images
+                                            violate this policy. Download the CLI to get started.
+                                        </p>
+                                        <DownloadCLIDropdown hasBuild={hasBuild} />
                                     </CardBody>
                                 </Card>
                             </GridItem>
                             <GridItem span={4}>
                                 <Card className="policy-enforcement-card">
                                     <CardHeader>
-                                        <CardTitle>Deploy</CardTitle>
-                                        <CardActions>
-                                            <Switch
-                                                isChecked={hasEnforcementActionForLifecycleStage(
-                                                    'DEPLOY',
-                                                    values.enforcementActions
-                                                )}
-                                                isDisabled={!hasDeploy}
-                                                onChange={(isChecked) => {
-                                                    onChangeEnforcementActions('DEPLOY', isChecked);
-                                                }}
-                                                label="Enforce on Deploy"
-                                            />
-                                        </CardActions>
+                                        <CardTitle component="h3">Deploy</CardTitle>
                                     </CardHeader>
                                     <CardBody>
-                                        If enabled, creation of deployments that violate this policy
-                                        will be blocked. In clusters with the admission controller
-                                        enabled, the Kubernetes API server will block deployments
-                                        that violate this policy to prevent pods from being
-                                        scheduled.
+                                        <Switch
+                                            isChecked={hasEnforcementActionForLifecycleStage(
+                                                'DEPLOY',
+                                                values.enforcementActions
+                                            )}
+                                            isDisabled={!hasDeploy}
+                                            onChange={(isChecked) => {
+                                                onChangeEnforcementActions('DEPLOY', isChecked);
+                                            }}
+                                            label="Enforce on Deploy"
+                                        />
+                                        <p className="pf-u-pt-md">
+                                            If enabled, creation of deployments that violate this
+                                            policy will be blocked. In clusters with the admission
+                                            controller enabled, the Kubernetes API server will block
+                                            deployments that violate this policy to prevent pods
+                                            from being scheduled.
+                                        </p>
                                     </CardBody>
                                 </Card>
                             </GridItem>
                             <GridItem span={4}>
                                 <Card className="policy-enforcement-card">
                                     <CardHeader>
-                                        <CardTitle>Runtime</CardTitle>
-                                        <CardActions>
-                                            <Switch
-                                                isChecked={hasEnforcementActionForLifecycleStage(
-                                                    'RUNTIME',
-                                                    values.enforcementActions
-                                                )}
-                                                isDisabled={!hasRuntime}
-                                                onChange={(isChecked) => {
-                                                    onChangeEnforcementActions(
-                                                        'RUNTIME',
-                                                        isChecked
-                                                    );
-                                                }}
-                                                label="Enforce on Runtime"
-                                            />
-                                        </CardActions>
+                                        <CardTitle component="h3">Runtime</CardTitle>
                                     </CardHeader>
                                     <CardBody>
-                                        If enabled, executions within a pod that violate this policy
-                                        will result in the pod being deleted. Actions taken through
-                                        the API server that violate this policy will be blocked.
+                                        <Switch
+                                            isChecked={hasEnforcementActionForLifecycleStage(
+                                                'RUNTIME',
+                                                values.enforcementActions
+                                            )}
+                                            isDisabled={!hasRuntime}
+                                            onChange={(isChecked) => {
+                                                onChangeEnforcementActions('RUNTIME', isChecked);
+                                            }}
+                                            label="Enforce on Runtime"
+                                        />
+                                        <p className="pf-u-pt-md">
+                                            If enabled, executions within a pod that violate this
+                                            policy will result in the pod being deleted. Actions
+                                            taken through the API server that violate this policy
+                                            will be blocked.
+                                        </p>
                                     </CardBody>
                                 </Card>
                             </GridItem>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
@@ -74,6 +74,7 @@ function PolicyCriteriaForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                         variant="info"
                         isInline
                         title="Editing policy criteria is disabled for system default policies"
+                        component="h3"
                         className="pf-u-mt-sm pf-u-mb-md"
                         data-testid="default-policy-alert"
                     >
@@ -85,6 +86,7 @@ function PolicyCriteriaForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                         variant="warning"
                         isInline
                         title="This policy has active violations, and the policy criteria cannot be changed. To update criteria, clone and create a new policy."
+                        component="div"
                         className="pf-u-mt-sm pf-u-mb-md"
                         data-testid="active-violations-policy-alert"
                     />

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
@@ -47,7 +47,7 @@ function PolicyCategoriesPage(): React.ReactElement {
         listContent = (
             <PageSection variant="light" isFilled id="policies-table-error">
                 <Bullseye>
-                    <Alert variant="danger" title={errorMessage} />
+                    <Alert variant="danger" title={errorMessage} component="div" />
                 </Bullseye>
             </PageSection>
         );
@@ -118,6 +118,7 @@ function PolicyCategoriesPage(): React.ReactElement {
                     <Alert
                         variant={AlertVariant[variant]}
                         title={title}
+                        component="div"
                         timeout={4000}
                         onTimeout={() => removeToast(key)}
                         actionClose={


### PR DESCRIPTION
## Description

### Problem

Moderate issue from axe DevTools:

> Heading levels should only increase by one

1. /main/dashboard
2. /main/clusters click a row and then click Next
3. /main/policy-management/policies wizard steps 1 2 3
4. /main/policy-management/policy-categories lucky timing when axe DevTools scanned the create category modal and found a transient alert on Create

### Analysis

1. Main dashboard
    * Cards have `h2` element, but **Policy violations by severity** has `h5` element.
    * Also `h3` element for information that is not a heading.
2. Clusters
    * List has `h1` element and side panel has `h2` element.
    * Collapsible sections on first step of side panel do not have heading elements (see **Residue** item 1).
    * Widgets on first step of side panel do hot have heading elements (see **Residue** item 1).
    * Sections on second step of side panel have `h1` elements.
    * PatternFly `Alert` element has default `h4` element.
3. Policies: edit a system default policy. For example, **Fixable Severity at least Important**
    * Step 1 has `h1` and `h2` elements, but PatternFly `Alert` element about MITRE ATT&CK has `h4` element.
    * Step 2 has `h1` and `h2` elements, but PatternFly `Alert` element about lifecycle stage has `h4` element. Also, it does not separate the information into heading and content.
    * Step 2 enforcement behavior cards have heading-ish formatting but not `h3` elements.
    * Step 3 has `h1` and `h2` elements, but PatternFly `Alert` element about policy criteria has `h4` element. It does separate the information into heading and content.
    * Step 3 policy criteria cards have heading-ish formatting but not `h3` elements. Aha, it would be `h4` because section name, which is often empty, would be `h3` level.
4. Policy categories
    * Page has `h1` and `h2` elements, and also `h3` if side panel is open. Toast alert has `h4` element. Also its title is its content.
    * Also, inline `Alert` element for error message.

### Solution

1. Main dashboard
    * Replace `h5` with `h3` element.
    * Replace `h3` with `div` element.
2. Clusters
    * Replace `h1` with `h3` in `CollapsibleCard` component. A quick look at a few of 36 results in 9 files suggests similar to this use.
    * Specify `component="h3"` prop for `Alert` element.
    * Bonus found while investigating heading levels: delete `titleClassName="text-xl"` prop for default text-lg 16px font size.
3. Policies
    * Step 1:
    * Step 2: Replace `title="Info"` with `title="Lifecycle stages"` and add `component="h3"` prop to info alert.
    * Step 2: Add `component="div"` prop for warning alert, because the title is the content.
    * Step 2: Add `component="h3"` prop for `CardTitle` element. Move `Switch` element from `CardActions` into `CardBody` for layout at 1440px laptop width. Remove center alignment from **Download CLI** element.
    * Step 3: Add `component="h3"` and `component="div"` props, similar to Step 2.
4. Policy categories
    * Add `component="div"` prop for alerts in which title consists of content.

### Residue

1. Add `h2` for side panels in workflow containers, and then replace `span` with `h3` for title in CollapsibleSection, and `div` with `h4` in cluster widgets.
2. Investigate only 4 remaining occurrences of `text-xl` Tailwind class.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui
3. `yarn start` in ui

### Manual testing

1. Visit /main/dashboard
    ![dashboard](https://github.com/stackrox/stackrox/assets/11862657/64a44705-adde-4ba1-bc45-2ea53173d0ad)

2. Visit /main/clusters, click a row, and then click **Next**
    ![clusters](https://github.com/stackrox/stackrox/assets/11862657/3709e50d-b626-47a5-b080-90fb031955dd)

3. Visit /main/policy-management/policies, click **Fixable Severity at least Important**, click **Actions**, and then click **Edit policy**

    * Step 1
        ![policies_1](https://github.com/stackrox/stackrox/assets/11862657/c86180f7-de17-4c11-9af2-dd0f5c68117f)

    * Step 2
        ![policies_2](https://github.com/stackrox/stackrox/assets/11862657/592b6606-0361-45a0-ac31-09801b00b9b8)

    * Step 2 scroll down
        ![policies_2_enforcement](https://github.com/stackrox/stackrox/assets/11862657/1410bb2f-f44a-4289-b3a1-1d0f1e1ea802)

    * Step 3
        ![policies_3](https://github.com/stackrox/stackrox/assets/11862657/025f9296-800d-4e69-ad58-7ec0f30afbf9)

4. Visit /main/policy-management/policy-categories and temporarily comment out timeout of toast notification

### Integration testing

1. `yarn cypress-open` in ui/apps/platform
    * clusters/clusters.test.js
    * policies/policyTable.test.js
    * policies/policyWizardStep3.test.js

### Unit testing

1. `yarn test` in ui/apps/platform
    * AgingImages.test.js
    * ImagesAtMostRisk.test.js
    * ViolationsByPolicyCategory.test.js
    * ViolationsByPolicySeverity.test.js
    * formatDeploymentPorts.test.js
