### PR TITLE
ROX-17414: remove duplicated existence check

### DIFF
--- a/central/compliance/aggregation/aggregation.go
+++ b/central/compliance/aggregation/aggregation.go
@@ -385,13 +385,8 @@ func getAggregationKeys(groupByKey groupByKey) []*storage.ComplianceAggregation_
 func (a *aggregatorImpl) getCategoryID(controlID string) string {
 	// Controls can now be removed with the addition of the compliance operator
 	// All controls should have categories if they exist
-	if control := a.standards.Control(controlID); control == nil {
-		return ""
-	}
-
 	category := a.standards.GetCategoryByControl(controlID)
 	if category == nil {
-		utils.Should(errors.Errorf("no category found for control %q", controlID))
 		return ""
 	}
 	return category.QualifiedID()


### PR DESCRIPTION
## Description

This PR removes superfluous code and reduces memory use for > 90%.

In `Control` implementation we do heavy operation of creating new object (`ToProto`)
https://github.com/stackrox/stackrox/blob/1bc6e2e294ee09a3cfffa8cfad5d11e4c20acf59/central/compliance/standards/registry.go#L212-L217
This is not necessary as in `GetCategoryByControl` we access the same element (`r.controlsByID[controlID]`) and return it without any modifications.
By removing first check we can significantly reduce number of allocations.

https://github.com/stackrox/stackrox/blob/1bc6e2e294ee09a3cfffa8cfad5d11e4c20acf59/central/compliance/standards/registry.go#L201-L209

```bash
# go test -bench=. ./central/compliance/aggregation/... -benchtime=10s -benchmem -count 10

name                 old time/op    new time/op    delta
AggregatedResults-8     175ms ± 1%     153ms ± 2%  -12.22%  (p=0.000 n=10+10)

name                 old alloc/op   new alloc/op   delta
AggregatedResults-8    13.0MB ± 0%     0.0MB ± 1%  -99.99%  (p=0.000 n=9+10)

name                 old allocs/op  new allocs/op  delta
AggregatedResults-8     90.0k ± 0%      0.0k ± 0%  -99.99%  (p=0.000 n=10+10)
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
