### PR TITLE
ROX-18867: Add conditional RBAC in Compliance 1.0

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -26,6 +26,8 @@ import ComplianceDashboardTile from './ComplianceDashboardTile';
 
 function ComplianceDashboardPage(): ReactElement {
     const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForCompliance = hasReadWriteAccess('Compliance');
+
     const [isFetchingStandards, setIsFetchingStandards] = useState(false);
     const [errorMessageFetching, setErrorMessageFetching] = useState('');
     const [standards, setStandards] = useState<ComplianceStandardMetadata[]>([]);
@@ -39,9 +41,6 @@ function ComplianceDashboardPage(): ReactElement {
     const darkModeClasses = `${
         isDarkMode ? 'text-base-600 hover:bg-primary-200' : 'text-base-100 hover:bg-primary-800'
     }`;
-
-    const hasWriteAccessForComplianceStandards = hasReadWriteAccess('Compliance'); // TODO confirm
-    const hasManageStandardsButton = hasWriteAccessForComplianceStandards;
 
     function clickManageStandardsButton() {
         setIsFetchingStandards(true);
@@ -89,43 +88,38 @@ function ComplianceDashboardPage(): ReactElement {
                         <ComplianceDashboardTile entityType="NAMESPACE" />
                         <ComplianceDashboardTile entityType="NODE" />
                         <ComplianceDashboardTile entityType="DEPLOYMENT" />
-                        <div className="ml-1 border-l-2 border-base-400 mr-3" />
-                        <div className="flex items-center">
+                        {hasWriteAccessForCompliance && (
+                            <ScanButton
+                                className={`flex items-center justify-center border-2 btn btn-base h-10 lg:min-w-32 xl:min-w-43 ${darkModeClasses}`}
+                                text="Scan environment"
+                                textClass="hidden lg:block"
+                                textCondensed="Scan all"
+                                clusterId="*"
+                                standardId="*"
+                            />
+                        )}
+                        {hasWriteAccessForCompliance && (
                             <div className="flex items-center">
-                                <ScanButton
-                                    className={`flex items-center justify-center border-2 btn btn-base h-10 lg:min-w-32 xl:min-w-43 ${darkModeClasses}`}
-                                    text="Scan environment"
-                                    textClass="hidden lg:block"
-                                    textCondensed="Scan all"
-                                    clusterId="*"
-                                    standardId="*"
+                                <Button
+                                    text="Manage standards"
+                                    className="btn btn-base h-10 ml-2"
+                                    onClick={() => {
+                                        clickManageStandardsButton();
+                                    }}
+                                    disabled={isFetchingStandards}
+                                    isLoading={isFetchingStandards}
                                 />
                             </div>
-                            {hasManageStandardsButton && (
-                                <div className="flex items-center">
-                                    <Button
-                                        text="Manage standards"
-                                        className="btn btn-base h-10 ml-2"
-                                        onClick={() => {
-                                            clickManageStandardsButton();
-                                        }}
-                                        disabled={isFetchingStandards}
-                                        isLoading={isFetchingStandards}
-                                    />
-                                </div>
-                            )}
-                            <div className="flex items-center">
-                                <ExportButton
-                                    fileName="Compliance Dashboard Report"
-                                    textClass="hidden lg:block"
-                                    type="ALL"
-                                    page={useCaseTypes.COMPLIANCE}
-                                    pdfId="capture-dashboard"
-                                    isExporting={isExporting}
-                                    setIsExporting={setIsExporting}
-                                />
-                            </div>
-                        </div>
+                        )}
+                        <ExportButton
+                            fileName="Compliance Dashboard Report"
+                            textClass="hidden lg:block"
+                            type="ALL"
+                            page={useCaseTypes.COMPLIANCE}
+                            pdfId="capture-dashboard"
+                            isExporting={isExporting}
+                            setIsExporting={setIsExporting}
+                        />
                     </div>
                 </div>
             </PageHeader>

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Header.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Header.js
@@ -7,6 +7,7 @@ import ScanButton from 'Containers/Compliance/ScanButton';
 import ExportButton from 'Components/ExportButton';
 import useCaseTypes from 'constants/useCaseTypes';
 import entityTypes from 'constants/entityTypes';
+import usePermissions from 'hooks/usePermissions';
 
 import { entityNounSentenceCaseSingular } from '../entitiesForCompliance';
 
@@ -19,6 +20,9 @@ const EntityHeader = ({
     isExporting,
     setIsExporting,
 }) => {
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForCompliance = hasReadWriteAccess('Compliance');
+
     const header = entityName || 'Loading...';
     const subHeader = entityNounSentenceCaseSingular[entityType];
     // Leave raw entity types in case customer depends on this convention for export file name.
@@ -34,29 +38,19 @@ const EntityHeader = ({
     return (
         <PageHeader classes="bg-base-100" header={header} subHeader={subHeader}>
             {searchComponent}
-            <div className="flex flex-1 justify-end">
-                <div className="flex">
-                    <div className="flex items-center">
-                        <>
-                            {scanCluster && (
-                                <ScanButton
-                                    text="Scan"
-                                    clusterId={scanCluster}
-                                    standardId={scanStandard}
-                                />
-                            )}
-                            <ExportButton
-                                fileName={exportFilename}
-                                type={entityType}
-                                page={useCaseTypes.COMPLIANCE}
-                                id={entityId}
-                                pdfId={pdfId}
-                                isExporting={isExporting}
-                                setIsExporting={setIsExporting}
-                            />
-                        </>
-                    </div>
-                </div>
+            <div className="flex flex-1 items-center justify-end pl-4">
+                {hasWriteAccessForCompliance && scanCluster && (
+                    <ScanButton text="Scan" clusterId={scanCluster} standardId={scanStandard} />
+                )}
+                <ExportButton
+                    fileName={exportFilename}
+                    type={entityType}
+                    page={useCaseTypes.COMPLIANCE}
+                    id={entityId}
+                    pdfId={pdfId}
+                    isExporting={isExporting}
+                    setIsExporting={setIsExporting}
+                />
             </div>
         </PageHeader>
     );

--- a/ui/apps/platform/src/Containers/Compliance/List/Header.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/Header.js
@@ -10,8 +10,12 @@ import ExportButton from 'Components/ExportButton';
 import ScanButton from 'Containers/Compliance/ScanButton';
 import { standardLabels } from 'messages/standards';
 import useCaseTypes from 'constants/useCaseTypes';
+import usePermissions from 'hooks/usePermissions';
 
 const ListHeader = ({ entityType, searchComponent, standard, isExporting, setIsExporting }) => {
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForCompliance = hasReadWriteAccess('Compliance');
+
     const standardId = findKey(standardLabels, (key) => key === standard);
 
     const headerText = standardId
@@ -33,25 +37,20 @@ const ListHeader = ({ entityType, searchComponent, standard, isExporting, setIsE
     return (
         <PageHeader header={headerText} subHeader={subHeaderText}>
             <div className="w-full">{searchComponent}</div>
-            <div className="flex flex-1 justify-end">
-                <div className="border-l-2 border-base-300 mx-3" />
-                <div className="flex">
-                    <div className="flex items-center">
-                        <div className="flex">
-                            {standardId && <ScanButton text="Scan" standardId={standardId} />}
-                            <ExportButton
-                                fileName={`${headerText} Compliance Report`}
-                                id={standardId || entityType}
-                                type={standardId ? 'STANDARD' : ''}
-                                page={useCaseTypes.COMPLIANCE}
-                                pdfId="capture-list"
-                                tableOptions={tableOptions}
-                                isExporting={isExporting}
-                                setIsExporting={setIsExporting}
-                            />
-                        </div>
-                    </div>
-                </div>
+            <div className="flex flex-1 items-center justify-end pl-4">
+                {hasWriteAccessForCompliance && standardId && (
+                    <ScanButton text="Scan" standardId={standardId} />
+                )}
+                <ExportButton
+                    fileName={`${headerText} Compliance Report`}
+                    id={standardId || entityType}
+                    type={standardId ? 'STANDARD' : ''}
+                    page={useCaseTypes.COMPLIANCE}
+                    pdfId="capture-list"
+                    tableOptions={tableOptions}
+                    isExporting={isExporting}
+                    setIsExporting={setIsExporting}
+                />
             </div>
         </PageHeader>
     );


### PR DESCRIPTION
## Description

### Analysis

Because of links between entities, routePaths specifies all needed resources.

Scan requires READ_WRITE_ACCESS for Compliance resource.

### Solution

Each component that has conditional rendering takes responsibility to get permissions via hook.

Delete extra levels of flex alignment in Header components.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

It looks like deletions more than balanced additions.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3759691 - 3759691
        total: -450 = 9931978 - 9932428
    * `ls -al build/static/js/*.js | wc -l`
        0 = 81 - 81 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/compliance
    * See **Scan environment** and **Manage standards** buttons only if READ_WRITE_ACCESS for Compliance

2. Click a standard link
    * See **Scan** button only if READ_WRITE_ACCESS for Compliance

3. Click a control, and then click link to single page
    * See **Scan** button only if READ_WRITE_ACCESS for Compliance

Ditto item 3 for **entity** single page.

It seems like scope of scan could be more explicit for items 2 and 3.

### Integration testing

* compliance/complianceDashboard.test.js
* compliance/complianceList.test.js
* compliance/hideScanResults.test.js