### PR TITLE
test(ui): Add e2e test for network graph scope, filtering, cidr blocks

### DIFF
--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
@@ -111,7 +111,7 @@ export function updateAndCloseCidrModal() {
             'CIDR blocks have been successfully configured'
         )
     );
-    // Once the above alert is show, the modal automatically closes after 2000 ms. This
+    // Once the above alert is shown, the modal automatically closes after 2000 ms. This
     // advances the clock to save time during test runs. (Otherwise every save would add 2 seconds
     // to our test job.)
     cy.tick(2000);

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
@@ -64,7 +64,9 @@ export function selectFilter(filterKey, filterValue) {
     cy.get('.react-select__value-container').click();
     cy.get(`.react-select__menu-list .react-select__option:contains("${filterKey}")`).click();
     cy.focused().type(filterValue);
-    cy.get(`.react-select__menu-list .react-select__option:contains("${filterValue}")`).click();
+    cy.get(`.react-select__menu-list .react-select__option:contains("${filterValue}")`)
+        .first()
+        .click();
     cy.get('.react-select__value-container').click();
 }
 

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
@@ -104,12 +104,16 @@ export function checkNetworkGraphEmptyState() {
 }
 
 export function updateAndCloseCidrModal() {
+    cy.clock();
     cy.get(networkGraphSelectors.updateCidrBlocksButton).click();
     cy.get(
         networkGraphSelectors.cidrModalAlertWithMessage(
             'CIDR blocks have been successfully configured'
         )
     );
-    cy.get(networkGraphSelectors.manageCidrBlocksModalClose).click();
+    // Once the above alert is show, the modal automatically closes after 2000 ms. This
+    // advances the clock to save time during test runs. (Otherwise every save would add 2 seconds
+    // to our test job.)
+    cy.tick(2000);
     cy.get(networkGraphSelectors.manageCidrBlocksModal).should('not.exist');
 }

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
@@ -2,6 +2,7 @@ import { visitFromLeftNavExpandable } from '../../helpers/nav';
 import { interactAndWaitForResponses } from '../../helpers/request';
 import { visit } from '../../helpers/visit';
 import selectSelectors from '../../selectors/select';
+import { networkGraphSelectors } from './networkGraph.selectors';
 
 const networkGraphClusterAlias = 'networkgraph/cluster/id';
 
@@ -59,6 +60,14 @@ export function selectDeployment(deployment) {
     }, routeMatcherMapForClusterInNetworkGraph);
 }
 
+export function selectFilter(filterKey, filterValue) {
+    cy.get('.react-select__value-container').click();
+    cy.get(`.react-select__menu-list .react-select__option:contains("${filterKey}")`).click();
+    cy.focused().type(filterValue);
+    cy.get(`.react-select__menu-list .react-select__option:contains("${filterValue}")`).click();
+    cy.get('.react-select__value-container').click();
+}
+
 // visit helpers
 
 export const notifiersAlias = 'notifiers';
@@ -90,4 +99,15 @@ export function checkNetworkGraphEmptyState() {
     cy.get(
         '.pf-c-empty-state__content:contains("Select a cluster and at least one namespace to render active deployment traffic on the graph")'
     );
+}
+
+export function updateAndCloseCidrModal() {
+    cy.get(networkGraphSelectors.updateCidrBlocksButton).click();
+    cy.get(
+        networkGraphSelectors.cidrModalAlertWithMessage(
+            'CIDR blocks have been successfully configured'
+        )
+    );
+    cy.get(networkGraphSelectors.manageCidrBlocksModalClose).click();
+    cy.get(networkGraphSelectors.manageCidrBlocksModal).should('not.exist');
 }

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.selectors.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.selectors.js
@@ -1,3 +1,5 @@
+const manageCidrBlocksModal = '*[role="dialog"]:has(h1:contains("Manage CIDR blocks"))';
+
 export const networkGraphSelectors = {
     graph: '.pf-ri__topology-section .pf-topology-content [data-id="stackrox-graph"]',
     groups: '.pf-ri__topology-section .pf-topology-content [data-id="stackrox-graph"] [data-layer-id="groups"]',
@@ -9,4 +11,22 @@ export const networkGraphSelectors = {
     drawerTitle: '.pf-c-drawer__panel [data-testid="drawer-title"]',
     drawerSubtitle: '.pf-c-drawer__panel [data-testid="drawer-subtitle"]',
     drawerTabs: '.pf-c-drawer__panel .pf-c-tabs__list',
+    deploymentNode: (deploymentName) =>
+        `${networkGraphSelectors.nodes} [data-type="node"] .pf-topology__node__label:contains("${deploymentName}")`,
+    filteredNamespaceGroupNode: (namespace) =>
+        `${networkGraphSelectors.nodes} [data-type="group"] .filtered-namespace text:contains("${namespace}")`,
+    relatedNamespaceGroupNode: (namespace) =>
+        `${networkGraphSelectors.nodes} [data-type="group"] .related-namespace text:contains("${namespace}")`,
+    manageCidrBlocksButton: 'button:contains("Manage CIDR blocks")',
+    manageCidrBlocksModal,
+    manageCidrBlocksModalClose: `${manageCidrBlocksModal} button[aria-label="Close"]`,
+    cidrBlockEntryNameInputAt: (index) =>
+        `${manageCidrBlocksModal} input[name="entities.${index}.entity.name"]`,
+    cidrBlockEntryCidrInputAt: (index) =>
+        `${manageCidrBlocksModal} input[name="entities.${index}.entity.cidr"]`,
+    cidrBlockEntryDeleteButtonAt: (index) =>
+        `${manageCidrBlocksModal} button[name="entities.${index}.entity.delete"]`,
+    updateCidrBlocksButton: `${manageCidrBlocksModal} button:contains("Update configuration")`,
+    cidrModalAlertWithMessage: (message) =>
+        `${manageCidrBlocksModal} *[data-ouia-component-type="PF4/Alert"]:contains("${message}")`,
 };

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -137,7 +137,7 @@ describe('Network Graph smoke tests', () => {
         cy.get(networkGraphSelectors.filteredNamespaceGroupNode('stackrox'));
     });
 
-    it('should allow the addition and deletion of CIDR blocks', () => {
+    it.only('should allow the addition and deletion of CIDR blocks', () => {
         visitNetworkGraph();
 
         // open the CIDR block modal and add a block

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -137,7 +137,7 @@ describe('Network Graph smoke tests', () => {
         cy.get(networkGraphSelectors.filteredNamespaceGroupNode('stackrox'));
     });
 
-    it.only('should allow the addition and deletion of CIDR blocks', () => {
+    it('should allow the addition and deletion of CIDR blocks', () => {
         visitNetworkGraph();
 
         // open the CIDR block modal and add a block

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -7,6 +7,10 @@ import {
     checkNetworkGraphEmptyState,
     selectCluster,
     selectNamespace,
+    selectDeployment,
+    selectFilter,
+    clearAllSavedCidrBlocks,
+    updateAndCloseCidrModal,
 } from './networkGraph.helpers';
 import { networkGraphSelectors } from './networkGraph.selectors';
 
@@ -91,5 +95,80 @@ describe('Network Graph smoke tests', () => {
 
         // close the Legend
         cy.get('.pf-c-popover__content [aria-label="Close"]').click();
+    });
+
+    it('should correctly display entities when scope and filters are applied', () => {
+        visitNetworkGraph();
+
+        // Apply a namespace filter for 'stackrox'
+        selectNamespace('stackrox');
+
+        // Verify that 'stackrox' and 'kube-system' namespaces are present
+        cy.get(networkGraphSelectors.filteredNamespaceGroupNode('stackrox'));
+        cy.get(networkGraphSelectors.relatedNamespaceGroupNode('kube-system'));
+
+        // Verify that central, central-db, scanner, scanner-db, sensor are present
+        ['central', 'central-db', 'scanner', 'scanner-db', 'sensor'].forEach((deployment) => {
+            cy.get(networkGraphSelectors.deploymentNode(deployment));
+        });
+
+        // Apply a deployment filter for 'central-db'
+        selectDeployment('central-db');
+
+        // Verify that central, central-db are present and that scanner, sensor, sensor-db are not present
+        ['central', 'central-db'].forEach((deployment) => {
+            cy.get(networkGraphSelectors.deploymentNode(deployment));
+        });
+        ['scanner', 'scanner-db', 'sensor'].forEach((deployment) => {
+            cy.get(networkGraphSelectors.deploymentNode(deployment)).should('not.exist');
+        });
+
+        // Remove the central-db selection from the scope filter
+        selectDeployment('central-db');
+        // Apply a general filter of "Deployment Label" for 'app=central-db'
+        selectFilter('Deployment Label', 'app=central-db');
+
+        ['central', 'central-db'].forEach((deployment) => {
+            cy.get(networkGraphSelectors.deploymentNode(deployment));
+        });
+        ['scanner', 'scanner-db', 'sensor'].forEach((deployment) => {
+            cy.get(networkGraphSelectors.deploymentNode(deployment)).should('not.exist');
+        });
+
+        // Verify that the correct namespaces are displayed
+        cy.get(networkGraphSelectors.filteredNamespaceGroupNode('stackrox'));
+        cy.get(networkGraphSelectors.relatedNamespaceGroupNode('kube-system')).should('not.exist');
+    });
+
+    it('should allow the addition and deletion of CIDR blocks', () => {
+        visitNetworkGraph();
+
+        // open the CIDR block modal and add a block
+        cy.get(networkGraphSelectors.manageCidrBlocksButton).click();
+        cy.get(networkGraphSelectors.cidrBlockEntryNameInputAt(0)).type('{selectall}redhat.com');
+        cy.get(networkGraphSelectors.cidrBlockEntryCidrInputAt(0)).type('{selectall}10.0.0.0/24');
+
+        updateAndCloseCidrModal();
+
+        // Check that the values are still there
+        cy.get(networkGraphSelectors.manageCidrBlocksButton).click();
+        cy.get(networkGraphSelectors.cidrBlockEntryNameInputAt(0)).should(
+            'have.value',
+            'redhat.com'
+        );
+        cy.get(networkGraphSelectors.cidrBlockEntryCidrInputAt(0)).should(
+            'have.value',
+            '10.0.0.0/24'
+        );
+        cy.get(networkGraphSelectors.cidrBlockEntryNameInputAt(1)).should('not.exist');
+
+        // Delete the CIDR block
+        cy.get(networkGraphSelectors.cidrBlockEntryDeleteButtonAt(0)).click();
+
+        updateAndCloseCidrModal();
+
+        // Check that the values are removed
+        cy.get(networkGraphSelectors.manageCidrBlocksButton).click();
+        cy.get(networkGraphSelectors.cidrBlockEntryNameInputAt(0)).should('not.exist');
     });
 });

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -9,7 +9,6 @@ import {
     selectNamespace,
     selectDeployment,
     selectFilter,
-    clearAllSavedCidrBlocks,
     updateAndCloseCidrModal,
 } from './networkGraph.helpers';
 import { networkGraphSelectors } from './networkGraph.selectors';

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -113,7 +113,7 @@ describe('Network Graph smoke tests', () => {
         // Apply a deployment filter for 'central-db'
         selectDeployment('central-db');
 
-        // Verify that central, central-db are present and that scanner, sensor, sensor-db are not present
+        // Verify that central, central-db are present and that scanner, scanner-db, sensor are not present
         ['central', 'central-db'].forEach((deployment) => {
             cy.get(networkGraphSelectors.deploymentNode(deployment));
         });
@@ -123,13 +123,13 @@ describe('Network Graph smoke tests', () => {
 
         // Remove the central-db selection from the scope filter
         selectDeployment('central-db');
-        // Apply a general filter of "Deployment Label" for 'app=central-db'
-        selectFilter('Deployment Label', 'app=central-db');
+        // Apply a general filter of "Deployment Label" for 'app=scanner-db'
+        selectFilter('Deployment Label', 'app=scanner-db');
 
-        ['central', 'central-db'].forEach((deployment) => {
+        ['scanner', 'scanner-db'].forEach((deployment) => {
             cy.get(networkGraphSelectors.deploymentNode(deployment));
         });
-        ['scanner', 'scanner-db', 'sensor'].forEach((deployment) => {
+        ['central', 'central-db', 'sensor'].forEach((deployment) => {
             cy.get(networkGraphSelectors.deploymentNode(deployment)).should('not.exist');
         });
 

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -102,9 +102,8 @@ describe('Network Graph smoke tests', () => {
         // Apply a namespace filter for 'stackrox'
         selectNamespace('stackrox');
 
-        // Verify that 'stackrox' and 'kube-system' namespaces are present
+        // Verify that 'stackrox' namespace is present
         cy.get(networkGraphSelectors.filteredNamespaceGroupNode('stackrox'));
-        cy.get(networkGraphSelectors.relatedNamespaceGroupNode('kube-system'));
 
         // Verify that central, central-db, scanner, scanner-db, sensor are present
         ['central', 'central-db', 'scanner', 'scanner-db', 'sensor'].forEach((deployment) => {
@@ -134,9 +133,8 @@ describe('Network Graph smoke tests', () => {
             cy.get(networkGraphSelectors.deploymentNode(deployment)).should('not.exist');
         });
 
-        // Verify that the correct namespaces are displayed
+        // Verify that the correct namespace is displayed
         cy.get(networkGraphSelectors.filteredNamespaceGroupNode('stackrox'));
-        cy.get(networkGraphSelectors.relatedNamespaceGroupNode('kube-system')).should('not.exist');
     });
 
     it('should allow the addition and deletion of CIDR blocks', () => {

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormRow.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormRow.tsx
@@ -46,7 +46,12 @@ const CIDRFormRow = ({ idx, onRemoveRow, errors, touched }) => {
                 />
             </FormGroup>
             <FlexItem className={buttonClassName}>
-                <Button onClick={onRemoveRow} variant="plain" icon={<TrashIcon />} />
+                <Button
+                    name={`entities.${idx as string}.entity.delete`}
+                    onClick={onRemoveRow}
+                    variant="plain"
+                    icon={<TrashIcon />}
+                />
             </FlexItem>
         </Flex>
     );


### PR DESCRIPTION
## Description

Adds some basic tests for the Network Graph.

- Tests that changing the Cluster/NS/Deployment scope dropdowns cause the correct stackrox deployments to be visible
- Tests that applying a general filter causes the correct deployments to be visible
- Tests the ability to add and delete CIDR blocks via the modal

This does match up with some of the assertions in the test plan, so I'll make a note in that document that the items are completed when this is merged.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
