### PR TITLE
fix(ui): Add traditional pagination to listening endpoints page

### DIFF
--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -1,10 +1,8 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
     Bullseye,
     Button,
     Divider,
-    Flex,
-    FlexItem,
     PageSection,
     Pagination,
     Select,
@@ -31,8 +29,10 @@ import { searchValueAsArray } from 'utils/searchUtils';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
 import useURLSearch from 'hooks/useURLSearch';
+import useRestQuery from 'hooks/useRestQuery';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import SEARCH_AUTOCOMPLETE_QUERY from 'queries/searchAutocomplete';
+import { fetchDeploymentsCount } from 'services/DeploymentsService';
 import { SearchFilter } from 'types/search';
 import { useDeploymentListeningEndpoints } from './hooks/useDeploymentListeningEndpoints';
 import ListeningEndpointsTable from './ListeningEndpointsTable';
@@ -87,6 +87,13 @@ function ListeningEndpointsPage() {
     const [searchValue, setSearchValue] = useState('');
     const [entity, setEntity] = useState('Deployment');
 
+    const deploymentCountFetcher = useCallback(
+        () => fetchDeploymentsCount(searchFilter),
+        [searchFilter]
+    );
+
+    const countQuery = useRestQuery(deploymentCountFetcher);
+
     const { data, error, loading } = useDeploymentListeningEndpoints(
         searchFilter,
         sortOption,
@@ -138,8 +145,11 @@ function ListeningEndpointsPage() {
             >
                 <Toolbar>
                     <ToolbarContent>
-                        <ToolbarItem variant="search-filter" className="pf-u-flex-grow-1">
-                            <Flex spaceItems={{ default: 'spaceItemsNone' }}>
+                        <ToolbarGroup className="pf-u-flex-grow-1">
+                            <ToolbarItem
+                                variant="search-filter"
+                                className="pf-u-display-flex pf-u-flex-grow-1"
+                            >
                                 <Select
                                     variant="single"
                                     toggleAriaLabel="Search entity selection menu toggle"
@@ -160,48 +170,46 @@ function ListeningEndpointsPage() {
                                         Cluster
                                     </SelectOption>
                                 </Select>
-                                <FlexItem flex={{ default: 'flex_1' }}>
-                                    <Select
-                                        typeAheadAriaLabel={`Search by ${entity}`}
-                                        aria-label={`Filter by ${entity}`}
-                                        onSelect={(e, value) => {
-                                            onSelectAutocompleteValue(value);
-                                        }}
-                                        onToggle={autocompleteToggle.onToggle}
-                                        isOpen={autocompleteToggle.isOpen}
-                                        placeholderText={`Filter results by ${entity}`}
-                                        variant="typeaheadmulti"
-                                        isCreatable
-                                        createText="Add"
-                                        selections={searchFilter[entity]}
-                                        onTypeaheadInputChanged={(val: string) => {
-                                            updateSearchValue(val);
-                                        }}
-                                        className="pf-u-flex-grow-1"
-                                    >
-                                        {autoCompleteData?.searchAutocomplete?.map((value) => (
-                                            <SelectOption key={value} value={value} />
-                                        ))}
-                                    </Select>
-                                </FlexItem>
-                            </Flex>
-                        </ToolbarItem>
-                        <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
-                            <Pagination
-                                toggleTemplate={({ firstIndex, lastIndex }) => (
-                                    <span>
-                                        <b>
-                                            {firstIndex} - {lastIndex}
-                                        </b>{' '}
-                                        of <b>many</b>
-                                    </span>
-                                )}
-                                page={page}
-                                perPage={perPage}
-                                onSetPage={(_, newPage) => setPage(newPage)}
-                                onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
-                            />
-                        </ToolbarItem>
+                                <Select
+                                    typeAheadAriaLabel={`Search by ${entity}`}
+                                    aria-label={`Filter by ${entity}`}
+                                    onSelect={(e, value) => {
+                                        onSelectAutocompleteValue(value);
+                                    }}
+                                    onToggle={autocompleteToggle.onToggle}
+                                    isOpen={autocompleteToggle.isOpen}
+                                    placeholderText={`Filter results by ${entity}`}
+                                    variant="typeaheadmulti"
+                                    isCreatable
+                                    createText="Add"
+                                    selections={searchFilter[entity]}
+                                    onTypeaheadInputChanged={(val: string) => {
+                                        updateSearchValue(val);
+                                    }}
+                                    className="pf-u-flex-grow-1"
+                                >
+                                    {autoCompleteData?.searchAutocomplete?.map((value) => (
+                                        <SelectOption key={value} value={value} />
+                                    ))}
+                                </Select>
+                            </ToolbarItem>
+                        </ToolbarGroup>
+                        <ToolbarGroup>
+                            <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
+                                <Pagination
+                                    itemCount={countQuery.data ?? 0}
+                                    page={page}
+                                    perPage={perPage}
+                                    onSetPage={(_, newPage) => setPage(newPage)}
+                                    onPerPageSelect={(_, newPerPage) => {
+                                        if ((countQuery.data ?? 0) < (page - 1) * newPerPage) {
+                                            setPage(1);
+                                        }
+                                        setPerPage(newPerPage);
+                                    }}
+                                />
+                            </ToolbarItem>
+                        </ToolbarGroup>
 
                         <ToolbarGroup className="pf-u-w-100">
                             <SearchFilterChips

--- a/ui/apps/platform/src/Containers/Risk/RiskTablePanel.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskTablePanel.js
@@ -15,7 +15,7 @@ import { searchParams, sortParams, pagingParams } from 'constants/searchParams';
 import workflowStateContext from 'Containers/workflowStateContext';
 import {
     fetchDeploymentsWithProcessInfoLegacy as fetchDeploymentsWithProcessInfo,
-    fetchDeploymentsCount,
+    fetchDeploymentsCountLegacy,
 } from 'services/DeploymentsService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import {
@@ -78,7 +78,7 @@ function RiskTablePanel({
          * Although count does not depend on change to sort option or page offset,
          * request in case of change to count of deployments in Kubernetes environment.
          */
-        fetchDeploymentsCount(restSearch)
+        fetchDeploymentsCountLegacy(restSearch)
             .then(setDeploymentsCount)
             .catch(() => {
                 setDeploymentsCount(0);

--- a/ui/apps/platform/src/services/DeploymentsService.ts
+++ b/ui/apps/platform/src/services/DeploymentsService.ts
@@ -137,7 +137,7 @@ export type ListDeploymentWithProcessInfo = {
 /**
  * Fetches count of registered deployments.
  */
-export function fetchDeploymentsCount(options: RestSearchOption[]): Promise<number> {
+export function fetchDeploymentsCountLegacy(options: RestSearchOption[]): Promise<number> {
     let searchOptions: RestSearchOption[] = options;
     if (shouldHideOrchestratorComponents()) {
         searchOptions = [...options, ...orchestratorComponentsOption];
@@ -149,6 +149,15 @@ export function fetchDeploymentsCount(options: RestSearchOption[]): Promise<numb
                   query,
               }
             : {};
+    const params = queryString.stringify(queryObject, { arrayFormat: 'repeat' });
+    return axios
+        .get<{ count: number }>(`${deploymentsCountUrl}?${params}`)
+        .then((response) => response?.data?.count ?? 0);
+}
+
+export function fetchDeploymentsCount(searchFilter: SearchFilter): Promise<number> {
+    const query = getRequestQueryStringForSearchFilter(searchFilter);
+    const queryObject = query ? { query } : {};
     const params = queryString.stringify(queryObject, { arrayFormat: 'repeat' });
     return axios
         .get<{ count: number }>(`${deploymentsCountUrl}?${params}`)


### PR DESCRIPTION
## Description

Switches from the indeterminate "1 of many" pagination UX to the traditional paged UX. Initially it wasn't possible to determine how many rows were in the table, but with the updated expandable design we can easily do this.

Bonus fix: fixes the layout of the toolbar in Firefox.

Best reviewed with "Hide whitespace" on.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

View the listening endpoints page and test the traditional pagination:
![image](https://github.com/stackrox/stackrox/assets/1292638/5b5e517f-6bc1-4bf4-93b3-cb3e1d397ba6)

Firefox before:
![image](https://github.com/stackrox/stackrox/assets/1292638/894c367d-6077-46e3-be84-777e1dee8ec7)

Firefox after (still not pixel perfect, but no longer broken):
![image](https://github.com/stackrox/stackrox/assets/1292638/91f927cc-6b3b-43db-9ca4-fcd24fd5454c)
