### PR TITLE
ROX-17740: Create table of registry exceptions

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesList.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesList.tsx
@@ -3,25 +3,57 @@ import {
     Bullseye,
     Button,
     Card,
-    CardBody,
+    CardFooter,
     EmptyState,
     EmptyStateBody,
     Title,
 } from '@patternfly/react-core';
+import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 
-import { DelegatedRegistry } from 'services/DelegatedRegistryConfigService';
+import {
+    DelegatedRegistry,
+    DelegatedRegistryCluster,
+} from 'services/DelegatedRegistryConfigService';
+import DelegatedRegistriesTable from './DelegatedRegistriesTable';
 
 type DelegatedRegistriesListProps = {
     registries: DelegatedRegistry[];
+    clusters: DelegatedRegistryCluster[];
+    selectedClusterId: string;
+    addRegistryRow: () => void;
+    deleteRow: (number) => void;
+    handlePathChange: (number, string) => void;
+    handleClusterChange: (number, string) => void;
 };
 
-function DelegatedRegistriesList({ registries }: DelegatedRegistriesListProps) {
+function DelegatedRegistriesList({
+    registries,
+    clusters,
+    selectedClusterId,
+    handlePathChange,
+    handleClusterChange,
+    addRegistryRow,
+    deleteRow,
+}: DelegatedRegistriesListProps) {
     return (
         <Card className="pf-u-mb-lg">
             {registries.length > 0 ? (
-                <CardBody>
-                    <p>(table goes here)</p>
-                </CardBody>
+                <>
+                    <DelegatedRegistriesTable
+                        registries={registries}
+                        clusters={clusters}
+                        selectedClusterId={selectedClusterId}
+                        handlePathChange={handlePathChange}
+                        handleClusterChange={handleClusterChange}
+                        deleteRow={deleteRow}
+                        key="delegated-registries-table"
+                    />
+                    <CardFooter>
+                        <Button variant="link" icon={<PlusCircleIcon />} onClick={addRegistryRow}>
+                            Add registry
+                        </Button>
+                    </CardFooter>
+                </>
             ) : (
                 <Bullseye className="pf-u-flex-grow-1">
                     <EmptyState>
@@ -32,7 +64,9 @@ function DelegatedRegistriesList({ registries }: DelegatedRegistriesListProps) {
                             <p>All scans will be delegated to the default cluster.</p>
                             <p>You can override this for specific registries.</p>
                         </EmptyStateBody>
-                        <Button variant="primary">Add registry</Button>
+                        <Button variant="primary" onClick={addRegistryRow}>
+                            Add registry
+                        </Button>
                     </EmptyState>
                 </Bullseye>
             )}

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesList.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesList.tsx
@@ -1,3 +1,5 @@
+// TODO: remove lint override after @typescript-eslint deps can be resolved to ^5.2.x
+/* eslint-disable react/prop-types */
 import React from 'react';
 import {
     Bullseye,
@@ -24,6 +26,8 @@ type DelegatedRegistriesListProps = {
     deleteRow: (number) => void;
     handlePathChange: (number, string) => void;
     handleClusterChange: (number, string) => void;
+    // TODO: re-enable next type after @typescript-eslint deps can be resolved to ^5.2.x
+    // updateRegistriesOrder: (DelegatedRegistry[]) => void;
 };
 
 function DelegatedRegistriesList({
@@ -34,6 +38,10 @@ function DelegatedRegistriesList({
     handleClusterChange,
     addRegistryRow,
     deleteRow,
+    // TODO: remove lint override after @typescript-eslint deps can be resolved to ^5.2.x
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    updateRegistriesOrder,
 }: DelegatedRegistriesListProps) {
     return (
         <Card className="pf-u-mb-lg">
@@ -46,6 +54,10 @@ function DelegatedRegistriesList({
                         handlePathChange={handlePathChange}
                         handleClusterChange={handleClusterChange}
                         deleteRow={deleteRow}
+                        // TODO: remove lint override after @typescript-eslint deps can be resolved to ^5.2.x
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                        // @ts-ignore
+                        updateRegistriesOrder={updateRegistriesOrder}
                         key="delegated-registries-table"
                     />
                     <CardFooter>

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
@@ -7,12 +7,12 @@ import React, { useState, useEffect } from 'react';
 import { Button, Select, SelectOption, TextInput } from '@patternfly/react-core';
 import {
     TableComposable,
-    Thead,
     Tbody,
-    Tr,
-    Th,
-    Td,
     TbodyProps,
+    Td,
+    Th,
+    Thead,
+    Tr,
     TrProps,
 } from '@patternfly/react-table';
 import styles from '@patternfly/react-styles/css/components/Table/table';
@@ -237,10 +237,7 @@ function DelegatedRegistriesTable({
             >
                 {registries.map((registry, rowIndex) => (
                     <Tr
-                        // note: in spite of best practice, we have to use the array index as key here,
-                        //       because the value of path changes as the user types, and the input would lose focus
                         key={registry.uuid}
-                        // id={itemOrder[rowIndex]}
                         id={registry.uuid}
                         draggable
                         onDrop={onDrop}
@@ -266,11 +263,7 @@ function DelegatedRegistriesTable({
                             <Select
                                 className="cluster-select"
                                 placeholderText={
-                                    <span>
-                                        <span style={{ position: 'relative', top: '1px' }}>
-                                            None
-                                        </span>
-                                    </span>
+                                    <span style={{ position: 'relative', top: '1px' }}>None</span>
                                 }
                                 toggleAriaLabel="Select a cluster"
                                 onToggle={() => toggleSelect(rowIndex)}

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
@@ -50,7 +50,7 @@ function DelegatedRegistriesTable({
     const [draggingToItemIndex, setDraggingToItemIndex] = React.useState<number | null>(null);
     const [isDragging, setIsDragging] = React.useState(false);
 
-    const initialOrderIds = registries.map((_, rowIndex) => `row-${rowIndex}`);
+    const initialOrderIds = registries.map((reg) => reg.uuid as string);
     const [itemOrder, setItemOrder] = React.useState(initialOrderIds);
     const [tempItemOrder, setTempItemOrder] = React.useState<string[]>([]);
 
@@ -64,7 +64,7 @@ function DelegatedRegistriesTable({
     }
 
     useEffect(() => {
-        const orderIds = registries.map((_, rowIndex) => `row-${rowIndex}`);
+        const orderIds = registries.map((reg) => reg.uuid as string);
         setItemOrder(orderIds);
     }, [registries]);
 
@@ -165,7 +165,7 @@ function DelegatedRegistriesTable({
             // the rest of this block was added to the PF drag and drop paradigm,
             // in order to keep the form data in sync with PF's visual drop order
             const newRegistries: DelegatedRegistry[] = tempItemOrder.map((tempItem) => {
-                const newIndex = Number(tempItem.split('row-').pop());
+                const newIndex = registries.findIndex((reg) => reg.uuid === tempItem) || 0;
                 return registries[newIndex];
             });
 
@@ -239,8 +239,9 @@ function DelegatedRegistriesTable({
                     <Tr
                         // note: in spite of best practice, we have to use the array index as key here,
                         //       because the value of path changes as the user types, and the input would lose focus
-                        key={rowIndex}
-                        id={itemOrder[rowIndex]}
+                        key={registry.uuid}
+                        // id={itemOrder[rowIndex]}
+                        id={registry.uuid}
                         draggable
                         onDrop={onDrop}
                         onDragEnd={onDragEnd}

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
@@ -1,0 +1,274 @@
+/* eslint-disable @typescript-eslint/no-shadow */
+/* eslint-disable no-param-reassign */
+/* eslint-disable react/no-array-index-key */
+import React, { useState } from 'react';
+import { Button, Select, SelectOption, TextInput } from '@patternfly/react-core';
+import {
+    TableComposable,
+    Thead,
+    Tbody,
+    Tr,
+    Th,
+    Td,
+    TbodyProps,
+    TrProps,
+} from '@patternfly/react-table';
+import styles from '@patternfly/react-styles/css/components/Table/table';
+import MinusCircleIcon from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';
+
+import {
+    DelegatedRegistry,
+    DelegatedRegistryCluster,
+} from 'services/DelegatedRegistryConfigService';
+
+type DelegatedRegistriesTableProps = {
+    registries: DelegatedRegistry[];
+    clusters: DelegatedRegistryCluster[];
+    selectedClusterId: string;
+    handlePathChange: (number, string) => void;
+    handleClusterChange: (number, string) => void;
+    deleteRow: (number) => void;
+};
+
+function DelegatedRegistriesTable({
+    registries,
+    clusters,
+    selectedClusterId,
+    handlePathChange,
+    handleClusterChange,
+    deleteRow,
+}: DelegatedRegistriesTableProps) {
+    const [draggedItemId, setDraggedItemId] = React.useState<string | null>(null);
+    const [draggingToItemIndex, setDraggingToItemIndex] = React.useState<number | null>(null);
+    const [isDragging, setIsDragging] = React.useState(false);
+    const [itemOrder, setItemOrder] = React.useState(['row1', 'row2', 'row3']);
+    const [tempItemOrder, setTempItemOrder] = React.useState<string[]>([]);
+
+    const [openRow, setRowOpen] = useState<number>(-1);
+    function toggleSelect(rowToToggle: number) {
+        setRowOpen((prev) => (rowToToggle === prev ? -1 : rowToToggle));
+    }
+    function onSelect(rowIndex, value) {
+        handleClusterChange(rowIndex, value);
+        setRowOpen(-1);
+    }
+
+    const clusterSelectOptions: JSX.Element[] = clusters.map((cluster) => {
+        const optionLabel =
+            cluster.id === selectedClusterId ? `${cluster.name} (default)` : cluster.name;
+        return (
+            <SelectOption key={cluster.id} value={cluster.id}>
+                <span>{optionLabel}</span>
+            </SelectOption>
+        );
+    });
+
+    // Start PatternFly template for drag and drop
+    const bodyRef = React.useRef<HTMLTableSectionElement>();
+
+    const onDragStart: TrProps['onDragStart'] = (evt) => {
+        evt.dataTransfer.effectAllowed = 'move';
+        evt.dataTransfer.setData('text/plain', evt.currentTarget.id);
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        const draggedItemId = evt.currentTarget.id;
+
+        evt.currentTarget.classList.add(styles.modifiers.ghostRow);
+        evt.currentTarget.setAttribute('aria-pressed', 'true');
+
+        setDraggedItemId(draggedItemId);
+        setIsDragging(true);
+    };
+
+    const moveItem = (arr: string[], i1: string, toIndex: number) => {
+        const fromIndex = arr.indexOf(i1);
+        if (fromIndex === toIndex) {
+            return arr;
+        }
+        const temp = arr.splice(fromIndex, 1);
+        arr.splice(toIndex, 0, temp[0]);
+
+        return arr;
+    };
+
+    const move = (itemOrder: string[]) => {
+        const ulNode = bodyRef.current;
+        if (ulNode?.children) {
+            const nodes = Array.from(ulNode.children);
+            if (nodes.map((node) => node.id).every((id, i) => id === itemOrder[i])) {
+                return;
+            }
+            while (ulNode?.firstChild) {
+                if (ulNode.lastChild) {
+                    ulNode.removeChild(ulNode.lastChild);
+                }
+            }
+
+            itemOrder.forEach((id) => {
+                if (nodes.find((n) => n.id === id)) {
+                    ulNode.appendChild(nodes.find((n) => n.id === id) as Element);
+                }
+            });
+        }
+    };
+
+    const onDragCancel = () => {
+        if (bodyRef?.current?.children) {
+            Array.from(bodyRef.current.children).forEach((el) => {
+                el.classList.remove(styles.modifiers.ghostRow);
+                el.setAttribute('aria-pressed', 'false');
+            });
+            setDraggedItemId(null);
+            setDraggingToItemIndex(null);
+            setIsDragging(false);
+        }
+    };
+
+    const onDragLeave: TbodyProps['onDragLeave'] = (evt) => {
+        if (!isValidDrop(evt)) {
+            move(itemOrder);
+            setDraggingToItemIndex(null);
+        }
+    };
+
+    function isValidDrop(evt: React.DragEvent<HTMLTableSectionElement | HTMLTableRowElement>) {
+        if (bodyRef?.current?.getBoundingClientRect()) {
+            const ulRect = bodyRef.current.getBoundingClientRect();
+            return (
+                evt.clientX > ulRect.x &&
+                evt.clientX < ulRect.x + ulRect.width &&
+                evt.clientY > ulRect.y &&
+                evt.clientY < ulRect.y + ulRect.height
+            );
+        }
+        return false;
+    }
+
+    const onDrop: TrProps['onDrop'] = (evt) => {
+        if (isValidDrop(evt)) {
+            setItemOrder(tempItemOrder);
+        } else {
+            onDragCancel();
+        }
+    };
+
+    function onDragOver(evt): TbodyProps['onDragOver'] {
+        evt.preventDefault();
+
+        const curListItem = (evt.target as HTMLTableSectionElement).closest('tr');
+        if (
+            !curListItem ||
+            !bodyRef?.current?.contains(curListItem) ||
+            curListItem.id === draggedItemId
+        ) {
+            return undefined;
+        }
+        const dragId = curListItem.id;
+        const newDraggingToItemIndex = Array.from(bodyRef.current.children).findIndex(
+            (item) => item.id === dragId
+        );
+        if (newDraggingToItemIndex !== draggingToItemIndex) {
+            const tempItemOrder = moveItem(
+                [...itemOrder],
+                draggedItemId || '',
+                newDraggingToItemIndex
+            );
+            move(tempItemOrder);
+            setDraggingToItemIndex(newDraggingToItemIndex);
+            setTempItemOrder(tempItemOrder);
+        }
+
+        return undefined;
+    }
+
+    const onDragEnd: TrProps['onDragEnd'] = (evt) => {
+        const target = evt.target as HTMLTableRowElement;
+        target.classList.remove(styles.modifiers.ghostRow);
+        target.setAttribute('aria-pressed', 'false');
+        setDraggedItemId(null);
+        setDraggingToItemIndex(null);
+        setIsDragging(false);
+    };
+    // End PatternFly template for drag and drop
+
+    return (
+        <TableComposable
+            aria-label="Delegated registry exceptions table"
+            className={(isDragging && styles.modifiers.dragOver) || ''}
+        >
+            <Thead>
+                <Tr>
+                    <Th>Order</Th>
+                    <Th width={40}>Source registry</Th>
+                    <Th width={40}>Destination cluster (CLI/API only)</Th>
+                    <Td isActionCell />
+                </Tr>
+            </Thead>
+            <Tbody
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                ref={bodyRef}
+                onDragOver={onDragOver}
+                onDrop={onDragOver}
+                onDragLeave={onDragLeave}
+            >
+                {registries.map((registry, rowIndex) => (
+                    <Tr
+                        // note: in spite of best practice, we have to use the array index as key here,
+                        //       because the value of path changes as the user types, and the input would lose focus
+                        key={rowIndex}
+                        draggable
+                        onDrop={onDrop}
+                        onDragEnd={onDragEnd}
+                        onDragStart={onDragStart}
+                    >
+                        <Td
+                            draggableRow={{
+                                id: `draggable-row-${registry.path}`,
+                            }}
+                        />
+                        <Td dataLabel="Source registry">
+                            <TextInput
+                                isRequired
+                                type="email"
+                                id="simple-form-email-01"
+                                name="simple-form-email-01"
+                                value={registry.path}
+                                onChange={(value) => handlePathChange(rowIndex, value)}
+                            />
+                        </Td>
+                        <Td dataLabel="Destination cluster (CLI/API only)">
+                            <Select
+                                className="cluster-select"
+                                placeholderText={
+                                    <span>
+                                        <span style={{ position: 'relative', top: '1px' }}>
+                                            None
+                                        </span>
+                                    </span>
+                                }
+                                toggleAriaLabel="Select a cluster"
+                                onToggle={() => toggleSelect(rowIndex)}
+                                onSelect={(_, value) => onSelect(rowIndex, value)}
+                                isOpen={openRow === rowIndex}
+                                selections={registry.clusterId}
+                            >
+                                {clusterSelectOptions}
+                            </Select>
+                        </Td>
+                        <Td dataLabel="Delete row" isActionCell>
+                            <Button
+                                variant="plain"
+                                aria-label="Delete row"
+                                onClick={() => deleteRow(rowIndex)}
+                            >
+                                <MinusCircleIcon />
+                            </Button>
+                        </Td>
+                    </Tr>
+                ))}
+            </Tbody>
+        </TableComposable>
+    );
+}
+
+export default DelegatedRegistriesTable;

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -187,6 +187,14 @@ function DelegateScanningPage() {
         setDedicatedRegistryConfig(newState);
     }
 
+    function updateRegistriesOrder(newRegistries) {
+        const newState: DelegatedRegistryConfig = { ...delegatedRegistryConfig };
+
+        newState.registries = newRegistries;
+
+        setDedicatedRegistryConfig(newState);
+    }
+
     function onSave() {
         setAlertObj(null);
         updateDelegatedRegistryConfig(delegatedRegistryConfig)
@@ -274,6 +282,10 @@ function DelegateScanningPage() {
                                 handleClusterChange={handleClusterChange}
                                 addRegistryRow={addRegistryRow}
                                 deleteRow={deleteRow}
+                                // TODO: remove lint override after @typescript-eslint deps can be resolved to ^5.2.x
+                                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                // @ts-ignore
+                                updateRegistriesOrder={updateRegistriesOrder}
                                 key="delegated-registries-list"
                             />
                         </>

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -38,6 +38,26 @@ const initialDelegatedState: DelegatedRegistryConfig = {
     registries: [],
 };
 
+function addUuidstoRegistries(config: DelegatedRegistryConfig) {
+    const newRegistries = config.registries.map((registry) => {
+        // eslint-disable-next-line no-restricted-globals
+        const uuid = self.crypto.randomUUID();
+
+        return {
+            path: registry.path,
+            clusterId: registry.clusterId,
+            uuid,
+        };
+    });
+
+    const newState: DelegatedRegistryConfig = {
+        ...config,
+        registries: newRegistries,
+    };
+
+    return newState;
+}
+
 function DelegateScanningPage() {
     const displayedPageTitle = 'Delegate Image Scanning';
     const [delegatedRegistryConfig, setDedicatedRegistryConfig] =
@@ -56,7 +76,8 @@ function DelegateScanningPage() {
         setAlertObj(null);
         fetchDelegatedRegistryConfig()
             .then((configFetched) => {
-                setDedicatedRegistryConfig(configFetched);
+                const configWithUuids = addUuidstoRegistries(configFetched);
+                setDedicatedRegistryConfig(configWithUuids);
             })
             .catch((error) => {
                 const newErrorObj: AlertObj = {
@@ -134,7 +155,14 @@ function DelegateScanningPage() {
     function addRegistryRow() {
         const newState: DelegatedRegistryConfig = { ...delegatedRegistryConfig };
 
-        newState.registries.push({ path: '', clusterId: delegatedRegistryConfig.defaultClusterId });
+        // eslint-disable-next-line no-restricted-globals
+        const uuid = self.crypto.randomUUID();
+
+        newState.registries.push({
+            path: '',
+            clusterId: delegatedRegistryConfig.defaultClusterId,
+            uuid,
+        });
 
         setDedicatedRegistryConfig(newState);
     }

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -123,10 +123,66 @@ function DelegateScanningPage() {
         setDedicatedRegistryConfig(newState);
     }
 
-    function onChangeCluster(newClusterId) {
+    function onChangeDefaultCluster(newClusterId) {
         const newState: DelegatedRegistryConfig = { ...delegatedRegistryConfig };
 
         newState.defaultClusterId = newClusterId;
+
+        setDedicatedRegistryConfig(newState);
+    }
+
+    function addRegistryRow() {
+        const newState: DelegatedRegistryConfig = { ...delegatedRegistryConfig };
+
+        newState.registries.push({ path: '', clusterId: delegatedRegistryConfig.defaultClusterId });
+
+        setDedicatedRegistryConfig(newState);
+    }
+
+    function deleteRow(rowIndex) {
+        const newState: DelegatedRegistryConfig = { ...delegatedRegistryConfig };
+
+        const newRegistries = delegatedRegistryConfig.registries.filter((_, i) => i !== rowIndex);
+
+        newState.registries = newRegistries;
+
+        setDedicatedRegistryConfig(newState);
+    }
+
+    function handlePathChange(rowIndex: number, value: string) {
+        const newState: DelegatedRegistryConfig = { ...delegatedRegistryConfig };
+
+        const newRegistries = delegatedRegistryConfig.registries.map((registry, i) => {
+            if (i === rowIndex) {
+                return {
+                    path: value,
+                    clusterId: registry.clusterId,
+                };
+            }
+
+            return registry;
+        });
+
+        newState.registries = newRegistries;
+
+        setDedicatedRegistryConfig(newState);
+    }
+
+    function handleClusterChange(rowIndex: number, value: string) {
+        const newState: DelegatedRegistryConfig = { ...delegatedRegistryConfig };
+
+        const newRegistries = delegatedRegistryConfig.registries.map((registry, i) => {
+            if (i === rowIndex) {
+                return {
+                    path: registry.path,
+                    clusterId: value,
+                };
+            }
+
+            return registry;
+        });
+
+        newState.registries = newRegistries;
 
         setDedicatedRegistryConfig(newState);
     }
@@ -208,10 +264,17 @@ function DelegateScanningPage() {
                                 onChangeEnabledFor={onChangeEnabledFor}
                                 clusters={delegatedRegistryClusters}
                                 selectedClusterId={delegatedRegistryConfig.defaultClusterId}
-                                setSelectedClusterId={onChangeCluster}
+                                setSelectedClusterId={onChangeDefaultCluster}
                             />
                             <DelegatedRegistriesList
                                 registries={delegatedRegistryConfig.registries}
+                                clusters={delegatedRegistryClusters}
+                                selectedClusterId={delegatedRegistryConfig.defaultClusterId}
+                                handlePathChange={handlePathChange}
+                                handleClusterChange={handleClusterChange}
+                                addRegistryRow={addRegistryRow}
+                                deleteRow={deleteRow}
+                                key="delegated-registries-list"
                             />
                         </>
                     )}

--- a/ui/apps/platform/src/services/DelegatedRegistryConfigService.ts
+++ b/ui/apps/platform/src/services/DelegatedRegistryConfigService.ts
@@ -6,6 +6,7 @@ export type DelegatedRegistryConfigEnabledFor = 'NONE' | 'ALL' | 'SPECIFIC';
 export type EnabledSelections = Exclude<DelegatedRegistryConfigEnabledFor, 'NONE'>;
 
 export type DelegatedRegistry = {
+    uuid?: string;
     path: string;
     clusterId: string;
 };

--- a/ui/apps/platform/src/services/DelegatedRegistryConfigService.ts
+++ b/ui/apps/platform/src/services/DelegatedRegistryConfigService.ts
@@ -5,8 +5,15 @@ export type DelegatedRegistryConfigEnabledFor = 'NONE' | 'ALL' | 'SPECIFIC';
 
 export type EnabledSelections = Exclude<DelegatedRegistryConfigEnabledFor, 'NONE'>;
 
+// Note:
+// In order to make each row of registry/cluster exceptions work
+// with PatternFly's drag-and-drag Table variant
+// we need to add stable surrogate UUIDs to each entry
+//
+// see description in https://github.com/stackrox/stackrox/pull/7341
+// for more details
 export type DelegatedRegistry = {
-    uuid?: string;
+    uuid?: string; // not in API response
     path: string;
     clusterId: string;
 };


### PR DESCRIPTION
## Description

This creates a table of exceptions for registries and the cluster designated to scan them.

This entailed embedding some of the form elements inside a PatternFly drag-and-drop variant Table. 

This proved tricky because the API structure for this list of registry objects does not contain anything that can be used as a stable ID for each array element, in this context.
- I started by combining the path and the clusterId of each row, but then when they were being edited, that changed, and every keypress caused the text input to lose focus
- Next, I violated our lint rule and just used a row index for each row's React key. That fixed the focus problem.
- Then, when I added the drag and drag functionality, based on the PatternFly docs code, I needed IDs in the markup (because the library does direct DOM manipulation during drag). HTML IDs must start with a letter--not a number--and so I tried prepending "row-" to the indexes.
- This method proved unstable after a drag. Sometime, the first drag worked, but then subsequent ones didn't. Other times, it seemed like the first drag didn't stick, but a second drag would.
- Thanks to @alwayshooin for troubleshooting this, and then brainstorming possible solutions. She convinced me that the most likely (perhaps only) solution was to do what I had tried to avoid doing: adding stable surrogate UUIDs to each registry. That ended up working.

Note:
This is currently using the browser-native UUID functionality. This is fully supported in all recent browsers, but for Safari platforms, the support only goes back 1 year for mobile, or 18 months for desktop.
https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID

I got the idea to use the native function from this popular JS library for UUIDs, [uuidjs/uuid](https://github.com/uuidjs/uuid)

It's code falls back to the native function if it's available: https://github.com/uuidjs/uuid/blob/main/src/v4.js 

Much as I prefer not to, I could easily be convinced to add this library, with its fallbacks, as a dependcy.



## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

### Manual testing

Setup an environment with 2 clusters, that both have scanners that can be delegated to
1. Create your first cluster
2. Connect to that first cluster
3. `export export LOAD_BALANCER=lb`
4. `SENSOR_SCANNER_SUPPORT=true`
5. On first cluster, deploy Central Services
6. Copy the IP address of the Central API 
7. Create a cluster-init-bundle and save the Helm config
8. Create a second cluster
9. Connect to that second cluster
10. Run the Helm command below to deploy Secure Cluster services to the second cluster 

```
helm install -n stackrox --create-namespace stackrox-secured-cluster-services rhacs/secured-cluster-services    --set image.main.registry="quay.io"  --set image.main.name="stackrox-io/main"  --set image.main.tag="<imagetag>"  -f <cluster-init-bundle.yaml>   --set clusterName=<clustername>   --set centralEndpoint=<centralIP>:443   --set scanner.disable=false
```

Login to <IP address> and visit **<IP address>/main/clusters/delegate-scanning**

Prerequisite steps

- Turn on delegated scanning
- Select a default cluster

Actual tests
1. Click the **Add registry** button
You should see a new row, with an empty path field and the default cluster you chose above selected.

<img width="1554" alt="adding_first_registry_line_with_default_cluster" src="https://github.com/stackrox/stackrox/assets/715729/525cfe6e-a388-4487-8f71-83918b92f916">

2. Fill in a path and click **Save**
<img width="1554" alt="filling_out_first_registry_line" src="https://github.com/stackrox/stackrox/assets/715729/78058af1-c61d-4952-bfe0-44edfc375c01">

3. Click **Add registry** link/button at the bottom of the table, fill out with a different cluster selected, and save.
<img width="1554" alt="adding_second_registry_line_with_changed_cluster" src="https://github.com/stackrox/stackrox/assets/715729/6e07985d-6fa4-476e-9a77-83aeaabeab49">

4. Click **Add registry** link/button at the bottom of the table, fill out a third row, and save.
<img width="1554" alt="adding_third_registry_line" src="https://github.com/stackrox/stackrox/assets/715729/89ab2f1d-f7c4-475e-bb4d-76660cc4377b">

Drag and drop working:

https://github.com/stackrox/stackrox/assets/715729/c7e6babb-c423-4f51-a64d-94015958b28a


