### PR TITLE
ROX-18967: Add IntegrationsSplunkViolationsTest to the parallel set

### DIFF
--- a/qa-tests-backend/src/main/groovy/common/Constants.groovy
+++ b/qa-tests-backend/src/main/groovy/common/Constants.groovy
@@ -45,6 +45,7 @@ class Constants {
     // common functionality that occurs for all tests such as debug gathering when
     // tests fail.
     static final TEST_FEATURE_TIMEOUT_PAD = 360
+    static final String SPLUNK_TEST_NAMESPACE = "qa-splunk"
 
     /*
         StackRox Product Feature Flags

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -105,6 +105,7 @@ class Helpers {
             shellCmd("./scripts/ci/collect-service-logs.sh stackrox ${collectionDir}/stackrox-k8s-logs")
             shellCmd("./scripts/ci/collect-service-logs.sh kube-system ${collectionDir}/kube-system-k8s-logs")
             shellCmd("./scripts/ci/collect-qa-service-logs.sh ${collectionDir}/qa-k8s-logs")
+            shellCmd("./scripts/ci/collect-splunk-logs.sh ${Constants.SPLUNK_TEST_NAMESPACE} ${collectionDir}/splunk-logs")
             shellCmd("./scripts/grab-data-from-central.sh ${collectionDir}/central-data")
         }
         catch (Exception e) {

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -129,6 +129,7 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
     }
 
     @Tag("Integration")
+    @Tag("Parallel")
     def "Verify Splunk violations: StackRox violations reach Splunk TA"() {
         given:
         "Splunk TA is installed and configured, network and process violations triggered"

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -45,7 +45,7 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
     "splunk-common-information-model-cim_511.tgz")
     private static final String STACKROX_REMOTE_LOCATION = "/tmp/stackrox.spl"
     private static final String CIM_REMOTE_LOCATION = "/tmp/cim.tgz"
-    private static final String TEST_NAMESPACE = "qa-splunk-violation"
+    private static final String TEST_NAMESPACE = Constants.SPLUNK_TEST_NAMESPACE
     private static final String SPLUNK_INPUT_NAME = "stackrox-violations-input"
 
     private SplunkDeployment splunkDeployment

--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -38,6 +38,7 @@ import services.AlertService
 import services.BaseService
 import services.ImageService
 import services.NetworkPolicyService
+import services.PolicyService
 import util.Timer
 
 @CompileStatic
@@ -387,6 +388,17 @@ class Services extends BaseService {
             LOG.info "Updated enforcement of '${policyName}' to have no enforcement actions"
         }
         return policyMeta.getEnforcementActionsList()
+    }
+
+    static Policy clonePolicyAndScopeByTestNamespace(String name, String namespace) {
+        Policy policy = getPolicyByName(name)
+        Policy scopedPolicyForTest = policy.toBuilder()
+            .clearId()
+            .setName("${name} - ${namespace}")
+            .clearScope()
+            .addScope(ScopeOuterClass.Scope.newBuilder().setNamespace(namespace))
+            .build()
+        return PolicyService.createAndFetchPolicy(scopedPolicyForTest)
     }
 
     static boolean roxDetectedDeployment(String deploymentID, String name) {

--- a/scripts/ci/collect-splunk-logs.sh
+++ b/scripts/ci/collect-splunk-logs.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Collect logs from as splunk pod daemon
+#
+# Usage:
+#   collect-splunk-logs.sh NAMESPACE DIR
+
+usage() {
+    echo "./scripts/ci/collect-splunk-logs.sh <namespace> <output-dir>"
+}
+
+main() {
+    if [[ "$#" -lt 2 ]]; then
+        usage
+        exit 1
+    fi
+
+    namespace="$1"
+    log_dir="$2"
+
+    if ! kubectl get ns "${namespace}"; then
+        echo "Collection is skipped when the splunk namespace is missing: ${namespace}"
+        exit 0
+    fi
+
+    mkdir -p "${log_dir}"
+
+    splunk_pod="$(kubectl -n "${namespace}" get pods -o json \
+      | jq -r '.items[] | select(.metadata.labels["app"]? | match("^splunk")) | .metadata.name')"
+
+    kubectl -n "${namespace}" exec "${splunk_pod}" -- \
+      sudo tar cf - --warning=no-file-changed /opt/splunk/var/log/splunk | \
+      tar xf - --strip 5 -C "${log_dir}"
+
+    echo "Splunk logs saved to ${log_dir}"
+}
+
+main "$@"


### PR DESCRIPTION
## Description

With this PR IntegrationsSplunkViolationsTest will now run concurrently with its `@Tag("Parallel")` buddies. The only change was to clone the policies that this test relies on to avoid contention with other tests.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI + a repeat test spin cycle.

Repeated runs:
~- testParallel ran 27 times before the first flake. Which was `ImageScanningTest.Verify Image Registry+Scanner Integrations: gcr-keep-autogenerated` a known [flake](https://issues.redhat.com/issues/?jql=project%20%3D%20ROX%20AND%20text%20~%20%22Verify%20Image%20Registry%2BScanner%20Integrations%22%20ORDER%20BY%20key%20DESC) IMO. [out6.txt](https://github.com/stackrox/stackrox/files/12307547/out6.txt)~
~- testParallelBAT also ran 27 times :shock: before the first flake. Which was `ImageScanningTest.Image metadata from registry test - ecr-config-only` also a known flake. [out7.txt](https://github.com/stackrox/stackrox/files/12314612/out7.txt)~

(crossed out the first two because I'd actually forgotten to tag the test :shame:)