### PR TITLE
feat(search): Add capability to run time range query

### DIFF
--- a/pkg/search/postgres/index_test.go
+++ b/pkg/search/postgres/index_test.go
@@ -580,6 +580,12 @@ func (s *IndexSuite) TestTime() {
 			q:               search.NewQueryBuilder().AddStrings(search.TestTimestamp, "-3000d-1d").ProtoQuery(),
 			expectedResults: []*storage.TestStruct{testStruct2029Mar09Noon},
 		},
+		{
+			desc: "range time query",
+			q: search.NewQueryBuilder().AddTimeRangeField(search.TestTimestamp,
+				protoconv.ConvertTimestampToTimeOrNow(testStruct2020Mar09Noon.Timestamp), protoconv.ConvertTimestampToTimeOrNow(testStruct2022Feb09Noon.Timestamp)).ProtoQuery(),
+			expectedResults: []*storage.TestStruct{testStruct2020Mar09Noon, testStruct2021Mar09Noon},
+		},
 	})
 }
 

--- a/pkg/search/postgres/query/time_query.go
+++ b/pkg/search/postgres/query/time_query.go
@@ -1,11 +1,14 @@
 package pgsearch
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/stringutils"
 )
 
 const (
@@ -18,6 +21,17 @@ func newTimeQuery(ctx *queryAndFieldContext) (*QueryEntry, error) {
 	if len(ctx.queryModifiers) > 0 {
 		return nil, errors.New("modifiers not supported for time query")
 	}
+	from, to, ok, err := parseTimeRange(ctx.value)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing time range")
+	}
+	if ok {
+		return qeWithSelectFieldIfNeeded(ctx, &WhereClause{
+			Query:  fmt.Sprintf("%s >= $$ and %s < $$", ctx.qualifiedColumnName, ctx.qualifiedColumnName),
+			Values: []interface{}{from.Format(sqlTimeStampFormat), to.Format(sqlTimeStampFormat)},
+		}, nil), nil
+	}
+
 	prefix, trimmedValue := parseNumericPrefix(ctx.value)
 	if t, ok := parseTimeString(trimmedValue); ok {
 		// If the date query is a singular datetime with no prefix, then need to create a numeric query with the min = date. max = date + 1
@@ -60,6 +74,29 @@ func timeQueryEntry(ctx *queryAndFieldContext, prefix, formattedTime string) *Qu
 		Query:  fmt.Sprintf("%s %s $$", ctx.qualifiedColumnName, prefix),
 		Values: []interface{}{formattedTime},
 	}, nil)
+}
+
+func parseTimeRange(value string) (from, to time.Time, ok bool, err error) {
+	if !strings.HasPrefix(value, search.TimeRangePrefix) {
+		return
+	}
+	value = value[len(search.TimeRangePrefix):]
+
+	fromStr, toStr := stringutils.Split2(value, "-")
+	if fromStr == "" || toStr == "" {
+		err = errors.Errorf("malformed time range query string: %s", value)
+		return
+	}
+
+	fromMillis, err := strconv.ParseInt(fromStr, 10, 64)
+	if err != nil {
+		return
+	}
+	toMillis, err := strconv.ParseInt(toStr, 10, 64)
+	if err != nil {
+		return
+	}
+	return time.UnixMilli(fromMillis).UTC(), time.UnixMilli(toMillis).UTC(), true, nil
 }
 
 func maybeParseDurationAsRange(value string) (lower, upper time.Duration, err error) {

--- a/pkg/search/postgres/query/time_query.go
+++ b/pkg/search/postgres/query/time_query.go
@@ -76,6 +76,8 @@ func timeQueryEntry(ctx *queryAndFieldContext, prefix, formattedTime string) *Qu
 	}, nil)
 }
 
+// parseTimeRange checks if the value is in the format of tr/<from millisecond>-<to millisecond> which is currently
+// the format that the TimeRangeQuery query builder outputs
 func parseTimeRange(value string) (from, to time.Time, ok bool, err error) {
 	if !strings.HasPrefix(value, search.TimeRangePrefix) {
 		return

--- a/pkg/search/postgres/query/time_query_test.go
+++ b/pkg/search/postgres/query/time_query_test.go
@@ -1,6 +1,7 @@
 package pgsearch
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -11,6 +12,8 @@ import (
 
 func TestTimeQuery(t *testing.T) {
 	fakeNow := timeutil.MustParse(time.RFC3339, "2022-06-24T12:00:00Z")
+	fake1DayAgo := fakeNow.Add(-24 * time.Hour)
+	tsNow := fakeNow.Format(sqlTimeStampFormat)
 	ts1dayLater := fakeNow.Add(24 * time.Hour).Format(sqlTimeStampFormat)
 	ts1dayAgo := fakeNow.Add(-24 * time.Hour).Format(sqlTimeStampFormat)
 	ts10daysAgo := fakeNow.Add(-10 * 24 * time.Hour).Format(sqlTimeStampFormat)
@@ -54,6 +57,16 @@ func TestTimeQuery(t *testing.T) {
 			value:          "-1d-10d",
 			expectedQuery:  "blah > $$ and blah < $$",
 			expectedValues: []interface{}{ts10daysAgo, ts1dayLater},
+		},
+		{
+			value:          "-1d-10d",
+			expectedQuery:  "blah > $$ and blah < $$",
+			expectedValues: []interface{}{ts10daysAgo, ts1dayLater},
+		},
+		{
+			value:          fmt.Sprintf("tr/%d-%d", fake1DayAgo.UnixMilli(), fakeNow.UnixMilli()),
+			expectedQuery:  "blah >= $$ and blah < $$",
+			expectedValues: []interface{}{ts1dayAgo, tsNow},
 		},
 	}
 

--- a/pkg/search/query_builder.go
+++ b/pkg/search/query_builder.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"time"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
@@ -32,6 +33,9 @@ const (
 
 	// EqualityPrefixSuffix is the prefix for an exact match
 	EqualityPrefixSuffix = `"`
+
+	// TimeRangePrefix is the prefix for a time range query
+	TimeRangePrefix = "tr/"
 
 	// MaxQueryParameters is the maximum number of query parameters for a single statement
 	MaxQueryParameters = math.MaxUint16
@@ -408,6 +412,13 @@ func (qb *QueryBuilder) AddBools(k FieldLabel, v ...bool) *QueryBuilder {
 	bools := conv.FormatBool(v...)
 
 	qb.fieldsToValues[k] = append(qb.fieldsToValues[k], bools...)
+	return qb
+}
+
+// AddTimeRangeField adds a range query between two times for the specific field.
+func (qb *QueryBuilder) AddTimeRangeField(field FieldLabel, from, to time.Time) *QueryBuilder {
+	value := fmt.Sprintf("%s%d-%d", TimeRangePrefix, from.UnixMilli(), to.UnixMilli())
+	qb.fieldsToValues[field] = append(qb.fieldsToValues[field], value)
 	return qb
 }
 


### PR DESCRIPTION
## Description

This adds support for being able to run queries such that you can select a specific interval of time

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests
