### PR TITLE
ROX-17319: Handle offline mode for collector driver downloads (fixed)

### DIFF
--- a/central/probeupload/manager/manager.go
+++ b/central/probeupload/manager/manager.go
@@ -14,7 +14,7 @@ type Manager interface {
 
 	StoreFile(ctx context.Context, file string, data io.Reader, size int64, crc32 uint32) error
 
-	// OpenFile attempts to open a probe file, returning the data reader and its size, or an error. This function does
+	// LoadProbe attempts to open a probe file, returning the data reader and its size, or an error. This function does
 	// not perform any access checks.
 	LoadProbe(ctx context.Context, file string) (io.ReadCloser, int64, error)
 

--- a/pkg/probeupload/server_handler.go
+++ b/pkg/probeupload/server_handler.go
@@ -49,7 +49,7 @@ func LogCallback(logger logging.Logger) func(error) {
 // and thus cannot be transmitted  to the client via status/headers. It may be nil, in which case errors are ignored.
 func NewProbeServerHandler(errorCallback func(error), sources ...ProbeSource) *probeServerHandler {
 	psh := NewSensorProbeServerHandler(errorCallback, sources...)
-	psh.GoOnline() // this hadler is used in Central as well and it must be immediately online for backwards compat.
+	psh.GoOnline() // this handler is used in Central as well and it must be immediately online for backwards compat.
 	return psh
 }
 

--- a/pkg/probeupload/server_handler.go
+++ b/pkg/probeupload/server_handler.go
@@ -48,14 +48,14 @@ func LogCallback(logger logging.Logger) func(error) {
 // when serving on a sub-path. The errorCallback is invoked for errors that happen during writing the response body,
 // and thus cannot be transmitted  to the client via status/headers. It may be nil, in which case errors are ignored.
 func NewProbeServerHandler(errorCallback func(error), sources ...ProbeSource) *probeServerHandler {
-	psh := NewSensorProbeServerHandler(errorCallback, sources...)
+	psh := NewConnectionAwareProbeHandler(errorCallback, sources...)
 	psh.GoOnline() // this handler is used in Central as well and it must be immediately online for backwards compat.
 	return psh
 }
 
-// NewSensorProbeServerHandler returns the same http.Handler as in NewProbeServerHandler to be used in Sensor.
+// NewConnectionAwareProbeHandler returns the same http.Handler as in NewProbeServerHandler to be used in Sensor.
 // The difference to NewProbeServerHandler is that it starts in offline mode
-func NewSensorProbeServerHandler(errorCallback func(error), sources ...ProbeSource) *probeServerHandler {
+func NewConnectionAwareProbeHandler(errorCallback func(error), sources ...ProbeSource) *probeServerHandler {
 	return &probeServerHandler{
 		errorCallback: errorCallback,
 		sources:       sources,

--- a/pkg/probeupload/server_handler.go
+++ b/pkg/probeupload/server_handler.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -28,9 +29,10 @@ type ProbeSource interface {
 	IsAvailable(ctx context.Context) (bool, error)
 }
 
-type handler struct {
+type probeServerHandler struct {
 	sources       []ProbeSource
 	errorCallback func(error)
+	centralReady  concurrency.Signal
 }
 
 // LogCallback returns an error callback that simply logs.
@@ -40,18 +42,27 @@ func LogCallback(logger logging.Logger) func(error) {
 	}
 }
 
-// NewProbeServerHandler returns an http.Handler for serving kernel probes. The handler assumes the path of kernel
+// NewProbeServerHandler returns a http.Handler for serving kernel probes. The probeServerHandler assumes the path of kernel
 // probes is rooted at `/`, i.e., wrap this via `http.StripPrefix` when serving on a sub-path.
 // The errorCallback is invoked for errors that happen during writing the response body, and thus cannot be transmitted
 // to the client via status/headers. It may be nil, in which case errors are simply ignored.
-func NewProbeServerHandler(errorCallback func(error), sources ...ProbeSource) http.Handler {
-	return &handler{
+func NewProbeServerHandler(errorCallback func(error), sources ...ProbeSource) *probeServerHandler {
+	return &probeServerHandler{
 		errorCallback: errorCallback,
 		sources:       sources,
+		centralReady:  concurrency.NewSignal(),
 	}
 }
 
-func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+func (h *probeServerHandler) GoOnline() {
+	h.centralReady.Signal()
+}
+
+func (h *probeServerHandler) GoOffline() {
+	h.centralReady.Reset()
+}
+
+func (h *probeServerHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodGet {
 		msg := fmt.Sprintf("invalid method %s, only %s requests are supported", req.Method, http.MethodGet)
 		log.Error(msg)
@@ -104,6 +115,12 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	defer utils.IgnoreError(data.Close)
+
+	if !h.centralReady.IsDone() {
+		log.Error("sensor is running in offline mode")
+		http.Error(w, "sensor running in offline mode", http.StatusServiceUnavailable)
+		return
+	}
 
 	hdr := w.Header()
 	if size >= 0 { // size < 0 means unknown

--- a/pkg/probeupload/server_handler_test.go
+++ b/pkg/probeupload/server_handler_test.go
@@ -1,0 +1,122 @@
+package probeupload
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_probeServerHandler_ServeHTTP focuses on testing the probeServerHandler, but not on the impl. of ProbeSource
+func Test_probeServerHandler_ServeHTTP(t *testing.T) {
+	const (
+		validPath   = "b6745d795b8497aaf387843dc8aa07463c944d3ad67288389b754daaebea4b62/collector-4.18.0-305.28.1.el8_4.x86_64.ko.gz"
+		invalidPath = "a/b/c/d/xyz.jpeg"
+	)
+	tests := map[string]struct {
+		source             ProbeSource
+		isOnline           bool
+		reqMethod          string
+		reqURL             string
+		expectCode         int
+		expectBodyContains string
+	}{
+		"Method other than GET should return code 405": {
+			source:             nil,
+			isOnline:           true,
+			reqMethod:          "POST",
+			reqURL:             "/",
+			expectCode:         405,
+			expectBodyContains: "invalid method",
+		},
+		"Invalid prefix should return code 400": {
+			source:             nil,
+			isOnline:           true,
+			reqMethod:          "GET",
+			reqURL:             "invalid-prefix",
+			expectCode:         400,
+			expectBodyContains: "invalid",
+		},
+		"Valid kernel path for non-existing kernel should return code 404": {
+			source:             mockLoadProbe{},
+			isOnline:           true,
+			reqMethod:          "GET",
+			reqURL:             "/" + validPath,
+			expectCode:         404,
+			expectBodyContains: "not found",
+		},
+		"Invalid kernel path should return code 404": {
+			source:             nil,
+			isOnline:           true,
+			reqMethod:          "GET",
+			reqURL:             "/" + invalidPath,
+			expectCode:         404,
+			expectBodyContains: "not found",
+		},
+		"Valid kernel path for existing kernel should return code 200 in online mode": {
+			source:             mockLoadProbe{availableProbe: validPath},
+			isOnline:           true,
+			reqMethod:          "GET",
+			reqURL:             "/" + validPath,
+			expectCode:         200,
+			expectBodyContains: "",
+		},
+		"Valid kernel path for existing kernel should return code 503 in offline mode": {
+			source:             mockLoadProbe{availableProbe: validPath},
+			isOnline:           false,
+			reqMethod:          "GET",
+			reqURL:             "/" + validPath,
+			expectCode:         503,
+			expectBodyContains: "sensor running in offline mode",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := NewProbeServerHandler(func(err error) {
+				assert.NoError(t, err)
+			}, tt.source)
+			h.GoOnline()
+			if !tt.isOnline {
+				h.GoOffline()
+			}
+
+			res := httptest.NewRecorder()
+			req, err := http.NewRequest(tt.reqMethod, tt.reqURL, nil)
+			assert.NoError(t, err)
+			h.ServeHTTP(res, req)
+
+			assert.Equal(t, tt.expectCode, res.Result().StatusCode)
+
+			bodyData, err := io.ReadAll(res.Result().Body)
+			assert.NoError(t, err)
+			defer func(b io.ReadCloser) {
+				assert.NoError(t, b.Close())
+			}(res.Result().Body)
+			assert.Contains(t, string(bodyData), tt.expectBodyContains)
+
+		})
+	}
+}
+
+var _ ProbeSource = (*mockLoadProbe)(nil)
+
+type mockLoadProbe struct {
+	availableProbe string
+}
+
+func (m mockLoadProbe) LoadProbe(_ context.Context, fileName string) (io.ReadCloser, int64, error) {
+	kernelData := &bytes.Buffer{}
+	if m.availableProbe == fileName {
+		size, err := kernelData.WriteString("I am the kernel")
+		return io.NopCloser(kernelData), int64(size), err // simulate finding kernel
+	}
+	return nil, 0, nil // simulate not finding the kernel
+}
+
+func (m mockLoadProbe) IsAvailable(_ context.Context) (bool, error) {
+	return true, nil
+}

--- a/pkg/probeupload/server_handler_test.go
+++ b/pkg/probeupload/server_handler_test.go
@@ -76,7 +76,7 @@ func Test_probeServerHandler_ServeHTTP(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			h := NewProbeServerHandler(func(err error) {
+			h := NewSensorProbeServerHandler(func(err error) {
 				assert.NoError(t, err)
 			}, tt.source)
 			h.GoOnline()

--- a/pkg/probeupload/server_handler_test.go
+++ b/pkg/probeupload/server_handler_test.go
@@ -16,7 +16,7 @@ const (
 	invalidPath = "a/b/c/d/xyz.jpeg"
 )
 
-// Test_probeServerHandler_Sensor tests the behavior of the handler from `NewSensorProbeServerHandler`.
+// Test_probeServerHandler_Sensor tests the behavior of the handler from `NewConnectionAwareProbeHandler`.
 // It focuses on testing the probeServerHandler, but not on the impl. of ProbeSource
 func Test_probeServerHandler_Sensor(t *testing.T) {
 	tests := map[string]struct {
@@ -78,7 +78,7 @@ func Test_probeServerHandler_Sensor(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			h := NewSensorProbeServerHandler(func(err error) {
+			h := NewConnectionAwareProbeHandler(func(err error) {
 				assert.NoError(t, err)
 			}, tt.source)
 			h.GoOnline()

--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -22,16 +22,24 @@ const (
 	SensorComponentEventOfflineMode SensorComponentEvent = "offline-mode"
 )
 
-// LogSensorComponentEvent returns an unified string for logging the transition between component states
-func LogSensorComponentEvent(e SensorComponentEvent) string {
+// LogSensorComponentEvent returns a unified string for logging the transition between component states/
+// For OfflineAware components, the optional parameter with component name should be provided.
+// Variadic `optComponentName` is used for backwards compatibility;
+// only first element of `optComponentName` will be printed if more elements are provided.
+func LogSensorComponentEvent(e SensorComponentEvent, optComponentName ...string) string {
+	name := "Component"
+	if len(optComponentName) > 0 {
+		name += fmt.Sprintf(" '%s'", optComponentName[0])
+	}
+	mode := fmt.Sprintf("unknown (%s)", e)
 	switch e {
 	case SensorComponentEventCentralReachable:
-		return "Component runs now in Online mode"
+		mode = "Online"
 	case SensorComponentEventOfflineMode:
-		return "Component runs now in Offline mode"
-	default:
-		return fmt.Sprintf("Unsupported component mode: %s", e)
+		mode = "Offline"
 	}
+	return fmt.Sprintf("%s runs now in %s mode", name, mode)
+
 }
 
 // Notifiable is the interface used by Sensor to notify components of state changes in Central<->Sensor connectivity.

--- a/sensor/common/scannerdefinitions/http_handler.go
+++ b/sensor/common/scannerdefinitions/http_handler.go
@@ -44,7 +44,7 @@ func NewDefinitionsHandler(centralEndpoint string) (*Handler, error) {
 
 // Notify reacts to sensor going into online/offline mode.
 func (h *Handler) Notify(e common.SensorComponentEvent) {
-	log.Info(common.LogSensorComponentEvent(e))
+	log.Info(common.LogSensorComponentEvent(e, "Scanner definitions handler"))
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		h.centralReachable.Store(true)

--- a/sensor/common/sensor/notifiable.go
+++ b/sensor/common/sensor/notifiable.go
@@ -1,0 +1,33 @@
+package sensor
+
+import "github.com/stackrox/rox/sensor/common"
+
+// OfflineAware is meant to replace common.Notifiable for non-components, so that a pkg unrelated to Sensor
+// is not forced to import sensor code.
+type OfflineAware interface {
+	GoOnline()
+	GoOffline()
+}
+
+// WrapNotifiable makes OfflineAware struct implement the Notifiable interface
+func WrapNotifiable(oa OfflineAware, name string) common.Notifiable {
+	return &notifiableImpl{
+		name: name,
+		oa:   oa,
+	}
+}
+
+type notifiableImpl struct {
+	name string
+	oa   OfflineAware
+}
+
+func (ni *notifiableImpl) Notify(e common.SensorComponentEvent) {
+	log.Info(common.LogSensorComponentEvent(e, ni.name))
+	switch e {
+	case common.SensorComponentEventCentralReachable:
+		ni.oa.GoOnline()
+	case common.SensorComponentEventOfflineMode:
+		ni.oa.GoOffline()
+	}
+}

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -179,6 +179,7 @@ func (s *Sensor) Start() {
 			Compression:   false, // kernel objects are compressed
 		}
 		customRoutes = append(customRoutes, koCacheRoute)
+		s.AddNotifiable(WrapNotifiable(probeDownloadHandler, "Kernel probe server handler"))
 	}
 
 	// Enable endpoint to retrieve vulnerability definitions if local image scanning is enabled.

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -171,7 +171,7 @@ func (s *Sensor) Start() {
 	if err != nil {
 		utils.Should(errors.Wrap(err, "Failed to create kernel object download/caching layer"))
 	} else {
-		probeDownloadHandler := probeupload.NewProbeServerHandler(probeupload.LogCallback(log), koCacheSource)
+		probeDownloadHandler := probeupload.NewSensorProbeServerHandler(probeupload.LogCallback(log), koCacheSource)
 		koCacheRoute := routes.CustomRoute{
 			Route:         "/kernel-objects/",
 			Authorizer:    idcheck.CollectorOnly(),

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -171,7 +171,7 @@ func (s *Sensor) Start() {
 	if err != nil {
 		utils.Should(errors.Wrap(err, "Failed to create kernel object download/caching layer"))
 	} else {
-		probeDownloadHandler := probeupload.NewSensorProbeServerHandler(probeupload.LogCallback(log), koCacheSource)
+		probeDownloadHandler := probeupload.NewConnectionAwareProbeHandler(probeupload.LogCallback(log), koCacheSource)
 		koCacheRoute := routes.CustomRoute{
 			Route:         "/kernel-objects/",
 			Authorizer:    idcheck.CollectorOnly(),


### PR DESCRIPTION
## Description

This PR readds https://github.com/stackrox/stackrox/pull/7178 after adding a fix. 

Please review by commits:
This PR reverts the revert (1st commit) and adds a fix (2nd commit) for the bug where the Central handler was starting in offline mode and never went online.
Additionally, it names one component to make identification of it easier in the logs (3rd commit), and adds regression test  (4th commit) for the issue fixed in the 2nd commit.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

### N/A
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- [x] CI that failed on master for https://github.com/stackrox/stackrox/pull/7178 
