### PR TITLE
ROX-18747: Enable prevent sensor restart feature flag 

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -34,7 +34,7 @@ var (
 	StoreEventHashes = registerFeature("Store Event Hashes", "ROX_STORE_EVENT_HASHES", true)
 
 	// PreventSensorRestartOnDisconnect enables a new behavior in Sensor where it avoids restarting when the gRPC connection with Central ends.
-	PreventSensorRestartOnDisconnect = registerFeature("Prevent Sensor restart on disconnect", "ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT", false)
+	PreventSensorRestartOnDisconnect = registerFeature("Prevent Sensor restart on disconnect", "ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT", true)
 
 	// SyslogNamespaceLabels enables sending namespace labels as part of the syslog alert notification.
 	SyslogNamespaceLabels = registerFeature("Send namespace labels as part of the syslog alert notification", "ROX_SEND_NAMESPACE_LABELS_IN_SYSLOG", true)

--- a/sensor/tests/connection/connection_test.go
+++ b/sensor/tests/connection/connection_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/sensor/tests/helper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,10 +17,6 @@ var (
 )
 
 func Test_SensorHello(t *testing.T) {
-	// TODO(ROX-18747): Remove this when the feature flag is enabled
-	if buildinfo.ReleaseBuild {
-		t.Skipf("Don't run test in release mode: feature flag cannot be enabled")
-	}
 	t.Setenv("ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT", "true")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", "1s")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL", "2s")
@@ -48,11 +43,6 @@ func Test_SensorHello(t *testing.T) {
 func Test_SensorReconnects(t *testing.T) {
 	// TODO(ROX-18197) Address flakiness
 	t.Skipf("This test is too flaky. Has to be fixed before re-enabled")
-
-	// TODO(ROX-18747): Remove this when the feature flag is enabled
-	if buildinfo.ReleaseBuild {
-		t.Skipf("Don't run test in release mode: feature flag cannot be enabled")
-	}
 
 	t.Setenv("ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT", "true")
 	t.Setenv("ROX_RESYNC_DISABLED", "true")


### PR DESCRIPTION
## Description

Enables `ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT` feature flag.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~


## Testing Performed

Many since the beginning of the release
