### PR TITLE
ROX-17647: Use kubernetes timeouts for gRPC

### DIFF
--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -30,10 +30,10 @@ var (
 	ResyncDisabled = RegisterBooleanSetting("ROX_RESYNC_DISABLED", true)
 
 	// ConnectionRetryInitialInterval defines how long it takes for sensor to retry gRPC connection when it first disconnects.
-	ConnectionRetryInitialInterval = registerDurationSetting("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", time.Minute)
+	ConnectionRetryInitialInterval = registerDurationSetting("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", 10*time.Second)
 
 	// ConnectionRetryMaxInterval defines the maximum interval between retries after the gRPC connection disconnects.
-	ConnectionRetryMaxInterval = registerDurationSetting("ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL", 10*time.Minute)
+	ConnectionRetryMaxInterval = registerDurationSetting("ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL", 5*time.Minute)
 
 	// ScanTimeout defines the scan timeout duration for Sensor initiated scans
 	ScanTimeout = registerDurationSetting("ROX_SCAN_TIMEOUT", 6*time.Minute)


### PR DESCRIPTION
## Description

Changed exponential backoff for gRPC connection to match Kubernetes at 10s initial, 5min max.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Confirmed that the new values match the restart policy of Kubernetes, seen here: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
