### PR TITLE
ROX-18234: Alter Compliance SAC e2e test to test runs were triggered

### DIFF
--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -1347,6 +1347,7 @@ class ComplianceTest extends BaseSpecification {
 
         then:
         "check results under SAC"
+        assert complianceRuns.keySet().size() > 0
         for (String standard : complianceRuns.keySet()) {
             def runId = complianceRuns.get(standard)
             ComplianceRunResults results = ComplianceService.getComplianceRunResult(standard, clusterId, runId).results


### PR DESCRIPTION
## Description

A regression was introduced by the migration to postgres for scoped access control on cluster-scoped resources.

The end to end Compliance SAC test could have picked it up if it had checked the count of triggered checks before iterating over them.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI is sufficient
