### PR TITLE
fix(ui): Add useTimeout hook and apply to CIDR modal

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModal.tsx
@@ -10,6 +10,7 @@ import {
     postCIDRBlock,
     patchCIDRBlock,
 } from 'services/NetworkService';
+import useTimeout from 'hooks/useTimeout';
 import { getHasDuplicateCIDRNames, getHasDuplicateCIDRAddresses } from './cidrFormUtils';
 import DefaultCIDRToggle from './DefaultCIDRToggle';
 import CIDRForm, { emptyCIDRBlockRow, CIDRBlockEntity, CIDRBlockEntities } from './CIDRForm';
@@ -98,6 +99,15 @@ function CIDRFormModal({ selectedClusterId, isOpen, onClose }: CIDRFormModalProp
         }
     }, [isOpen, selectedClusterId]);
 
+    const [setModalCloseTimeout, cancelTimeout] = useTimeout(onCloseHandler);
+
+    useEffect(() => {
+        // When the modal is closed, cancel any callback that would close it again
+        if (!isOpen) {
+            cancelTimeout();
+        }
+    }, [isOpen, cancelTimeout]);
+
     function updateCIDRBlocksHandler() {
         setFormCallout(emptyFormCallout);
 
@@ -145,7 +155,9 @@ function CIDRFormModal({ selectedClusterId, isOpen, onClose }: CIDRFormModalProp
                         'CIDR blocks have been successfully configured. This modal will now close.',
                 });
                 // updateNetworkNodes();
-                setTimeout(onCloseHandler, 2000);
+                if (isOpen) {
+                    setModalCloseTimeout(2000);
+                }
             })
             .catch((error) => {
                 setFormCallout({

--- a/ui/apps/platform/src/hooks/useTimeout.test.ts
+++ b/ui/apps/platform/src/hooks/useTimeout.test.ts
@@ -1,0 +1,67 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import useTimeout from './useTimeout';
+
+test('should call the passed callback after the specified delay', async () => {
+    jest.useFakeTimers();
+    const callback = jest.fn();
+    const { result } = renderHook(() => useTimeout(callback));
+
+    act(() => {
+        const [startTimeout] = result.current;
+        startTimeout(1000);
+    });
+
+    expect(callback).not.toBeCalled();
+    jest.advanceTimersByTime(500);
+    expect(callback).not.toBeCalled();
+    jest.advanceTimersByTime(500);
+    expect(callback).toBeCalled();
+});
+
+test('should call the passed callback after the specified delay with the specified arguments', async () => {
+    jest.useFakeTimers();
+    const callback = jest.fn((a: string, b: string) => a + b);
+    const { result } = renderHook(() => useTimeout(callback));
+
+    act(() => {
+        const [startTimeout] = result.current;
+        startTimeout(1000, 'arg1', 'arg2');
+    });
+
+    expect(callback).not.toBeCalled();
+    jest.advanceTimersByTime(1000);
+    expect(callback).toBeCalledWith('arg1', 'arg2');
+});
+
+test('should cancel the timeout when the component is unmounted', async () => {
+    jest.useFakeTimers();
+    const callback = jest.fn();
+    const { result, unmount } = renderHook(() => useTimeout(callback));
+
+    act(() => {
+        const [startTimeout] = result.current;
+        startTimeout(1000);
+    });
+
+    expect(callback).not.toBeCalled();
+    unmount();
+    jest.advanceTimersByTime(1000);
+    expect(callback).not.toBeCalled();
+});
+
+test('should cancel the timeout when the returned cleanup function is called', async () => {
+    jest.useFakeTimers();
+    const callback = jest.fn();
+    const { result } = renderHook(() => useTimeout(callback));
+
+    act(() => {
+        const [startTimeout, cancelTimeout] = result.current;
+        startTimeout(1000);
+        jest.advanceTimersByTime(500);
+        cancelTimeout();
+    });
+
+    expect(callback).not.toBeCalled();
+    jest.advanceTimersByTime(500);
+    expect(callback).not.toBeCalled();
+});

--- a/ui/apps/platform/src/hooks/useTimeout.ts
+++ b/ui/apps/platform/src/hooks/useTimeout.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useRef, useMemo } from 'react';
+
+export type UseTimeoutReturn<Args extends unknown[]> = [
+    (delay: number, ...args: Args) => void,
+    () => void
+];
+
+/**
+ * A hook that calls a callback after a delay via setTimeout. Automatically
+ * cleans up the timeout on unmount. The execute callback function expects the timeout
+ * delay as the first argument and the callback arguments as the rest of the arguments.
+ *
+ * @param callback The callback to call after the delay
+ * @returns A tuple containing a function to execute the callback and a function to cancel the pending timeout
+ */
+export default function useTimeout<Return, Args extends unknown[]>(
+    callback: (...args: Args) => Return
+): UseTimeoutReturn<Args> {
+    const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+    const callbackRef = useRef(callback);
+
+    function cleanup() {
+        if (typeof timeoutRef.current !== 'undefined') {
+            clearTimeout(timeoutRef.current);
+            timeoutRef.current = undefined;
+        }
+    }
+
+    useEffect(() => {
+        callbackRef.current = callback;
+    }, [callback]);
+
+    useEffect(() => cleanup, [timeoutRef.current]);
+
+    const execCallback = useCallback((delay: number, ...args: Args) => {
+        cleanup();
+        timeoutRef.current = setTimeout(() => callbackRef.current(...args), delay);
+    }, []);
+
+    return useMemo(() => [execCallback, cleanup], [execCallback]);
+}


### PR DESCRIPTION
## Description

Adds a `useTimeout` hook that wraps `setTimeout` and automatically cleans up when the parent component unmounts.

Implements the first usage of this hook in the CIDRModal component of the Network Graph.

## Usage

```typescript
const callback = (message: string) => console.log(string);
const [startTimeout, cancelTimeout] = useTimeout(callback);

// The delay and args are configurable each time the timeout is initialized
startTimeout(1000, "Hello after one second!");
// Setting a new timeout before the previous has fired will clean it up and not execute twice
startTimeout(2000, "Actually lets do two seconds");
// A cancel function is provided to manually cancel the timeout before the hook unmounts
cancelTimeout();
```

## Motivation

In writing tests for https://github.com/stackrox/stackrox/pull/7332 I ran into flakes during development due to an issue in the CIDR Modal on the NG page. This issue was caused by a timeout to close the modal that was initiated after modifying CIDR blocks from within the modal. The problem occurred frequently in e2e tests when:

- The CIDR blocks were modified in the modal (`setTimeout` called)
- The modal was manually closed via the "X" button
- The modal was reopened before the `setTimeout` callback was executed, which re-closed the modal during the tests

There were actually three situations that caused undesirable behavior in this modal:

1. The user closes the modal and navigates away from the NG before the timeout fires. This gives a console error, but is otherwise benign. (This issue is fixed by the hook.)
2. The user closes the modal after the API request completes, but before the timeout is fired. (This is fixed by [this check](https://github.com/stackrox/stackrox/pull/7355/files#diff-8b3fd7f1d56d5383bf9f8e718245f0c033ecbc4bf7d41189d2b5722337866ebaR104-R110).)
3. The user closes the modal before the timeout is fired _and_ before the API request completes. (This is fixed by [this check](https://github.com/stackrox/stackrox/pull/7355/files#diff-8b3fd7f1d56d5383bf9f8e718245f0c033ecbc4bf7d41189d2b5722337866ebaR158-R160).)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests +

Before (modal closes without user action):
<video controls="controls" width="800" height="600" name="Video Name">
  <source src="https://github.com/stackrox/stackrox/assets/1292638/707f8396-445c-4642-a992-b637fbb80725">
</video>

https://github.com/stackrox/stackrox/assets/1292638/707f8396-445c-4642-a992-b637fbb80725


After (modal stays open):
<video controls="controls" width="800" height="600" name="Video Name">
  <source src="https://github.com/stackrox/stackrox/assets/1292638/7a1a30cf-764c-4d2b-9771-2a104c4dd97c">
</video>

https://github.com/stackrox/stackrox/assets/1292638/7a1a30cf-764c-4d2b-9771-2a104c4dd97c



