### PR TITLE
ROX-17423, ROX-18778:  migration helper context

### DIFF
--- a/migrator/README.md
+++ b/migrator/README.md
@@ -1,5 +1,8 @@
 # StackRox Database migration
 
+## IMPORTANT
+All migrations must be backwards compatible in order to ensure a safe and successful rollback.
+
 ## Purpose of database migrations
 
 When changing the data model for stored objects, data conversions may be required. All migrations
@@ -7,8 +10,11 @@ are in the `migrations` subdirectory.
 
 Migrations are organized with sequence numbers and executed in sequence. Each migration is provided
 with a pointer to `types.Databases` where the pointed object contains all necessary database instances,
-including `Bolt`, `RocksDB`, `Postgres` and `GormDB` (datamodel for postgres). Depending on the version
-a migration is operating on, some database instances may be nil.
+including `Bolt`, `RocksDB`, `Postgres` and `GormDB` (datamodel for postgres) as well as a context `DBCtx`. 
+The context allows for the migrations to be wrapped in a transaction so they can be committed as they 
+are processed.  (Migrations moving data with `GormDB` will not be part of the outer transaction, 
+as such care should be taken when using `GormDB` to move data.)  Depending on the version a migration 
+is operating on, some database instances may be nil.
 
 A migration can read from any of the databases, make changes to the data or to the datamodel
 (database schema when working with postgres), then persist these changes to the database.
@@ -116,7 +122,7 @@ to generate current schema which can be find in each Postgres store.
 pg-schema-migration-helper --type=<prototype> --search-category ...
 ```
 
-This tool also generates conversion tools for schema, you may remove the 
+This tool also generates conversion tools for schema, you may remove them. 
 
 #### Create or upgrade the schema of a table.
 
@@ -144,7 +150,7 @@ In migrator, there are a multiple ways to access data.
 
     Raw SQL commands are always available to databases and it has good isolation from current release. It is used frequently in
     migrations before Postgres. Migrations with raw SQL command needs less maintenance but it may not be convenient
-    and it could be error-prone.
+    and it could be error-prone.  This model supports the transaction passed via the databases.DBCtx.
     We try to provide more convenient way to read and update the data.
 
 2. Gorm
@@ -193,12 +199,15 @@ In migrator, there are a multiple ways to access data.
        Serialized []byte    `gorm:"column:serialized;type:bytea"`
    }
    ```
+   Gorm cannot participate in the transaction passed via the context.  The risk and possible ramifications of that
+   should be considered before deciding to use Gorm to move the data.
 
 3. Duplicate the Postgres Store
    This method is used in version 73 and 74 to migrate all tables from RocksDB to Postgres. In addition to frozen schema,
    the store to access the data are also frozen for migration. The migrations with this method are closely associated
    with current release eg. search/delete with schema and the prototypes of the objects. This method is NOT recommended for
    4.0 and beyond.
+   This model supports the transaction passed via the databases.DBCtx.
 
 #### Conversion tool
 

--- a/migrator/README.md
+++ b/migrator/README.md
@@ -96,6 +96,9 @@ in `migrations` directory, or at the examples listed below.
 
 ## Writing postgres migration tests
 
+Follow the TODOs listed in `migration_test.go`.  This includes a recommended test to verify the pre-migration SQL statements provide
+the expected results against the post-migration database in order to verify backwards compatiblity.
+
 ### Migrator limitations
 
 Migrator upgrades the data from a previous datamodel to the current one. In the case of data manipulation migrations,

--- a/tools/generate-helpers/bootstrap-migration/migration_impl.go.tpl
+++ b/tools/generate-helpers/bootstrap-migration/migration_impl.go.tpl
@@ -2,10 +2,7 @@
 package {{.packageName}}
 
 import (
-	"context"
-
 	"github.com/stackrox/rox/migrator/types"
-	"github.com/stackrox/rox/pkg/sac"
 )
 
 // {{template "TODO"}}: generate/write and import any store required for the migration (skip any unnecessary step):
@@ -38,9 +35,8 @@ import (
 // to a software version that can no longer be supported by the database.
 
 func migrate(database *types.Databases) error {
-	ctx := sac.WithAllAccess(context.Background())
 	_ = database // {{template "TODO"}}: remove this line, it is there to make the compiler happy while the migration code is being written.
-	_ = ctx // {{template "TODO"}}: remove this line, it is there to make the compiler happy while the migration code is being written.
+	// Use databases.DBCtx to take advantage of the transaction wrapping present in the migration initiator
 
 	// {{template "TODO"}}: Migration code comes here
 

--- a/tools/generate-helpers/bootstrap-migration/migration_test.go.tpl
+++ b/tools/generate-helpers/bootstrap-migration/migration_test.go.tpl
@@ -56,6 +56,9 @@ func (s *migrationTestSuite) TestMigration() {
 
 	// {{template "TODO"}}: validate that the post-migration dataset has the expected content
 
+	// {{template "TODO"}}: validate that pre-migration queries and statements execute against the
+	// post-migration database to ensure backwards compatibility
+
 }
 
 // {{template "TODO"}}: remove any pending TODO

--- a/tools/generate-helpers/bootstrap-migration/migration_test.go.tpl
+++ b/tools/generate-helpers/bootstrap-migration/migration_test.go.tpl
@@ -13,14 +13,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-var (
-	ctx = sac.WithAllAccess(context.Background())
-)
-
 type migrationTestSuite struct {
 	suite.Suite
 
 	db *pghelper.TestPostgres
+	ctx context.Context
 }
 
 func TestMigration(t *testing.T) {
@@ -29,6 +26,7 @@ func TestMigration(t *testing.T) {
 
 
 func (s *migrationTestSuite) SetupSuite() {
+	s.ctx = sac.WithAllAccess(context.Background())
 	s.db = pghelper.ForT(s.T(), false)
 	// {{template "TODO"}}: Create the schemas and tables required for the pre-migration dataset push to DB
 }
@@ -47,6 +45,7 @@ func (s *migrationTestSuite) TestMigration() {
 	dbs := &types.Databases{
 		GormDB:     s.db.GetGormDB(),
 		PostgresDB: s.db.DB,
+		DBCtx:      s.ctx,
 	}
 
 	s.Require().NoError(migration.Run(dbs))

--- a/tools/generate-helpers/bootstrap-migration/seq_num.go.tpl
+++ b/tools/generate-helpers/bootstrap-migration/seq_num.go.tpl
@@ -9,4 +9,7 @@ var (
 
 	// LastRocksDBVersionSeqNum is the sequence number for the last RocksDB version.
 	LastRocksDBVersionSeqNum = 112
+
+	// LastRocksDBToPostgresVersionSeqNum is the sequence number for the last Rocks -> Postgres migration (n migration)
+	LastRocksDBToPostgresVersionSeqNum = 57
 )


### PR DESCRIPTION
## Description

Update the migration templates to use the context that is passed in via the databases object.  Updates are shown in PR #7359 for reference of what the results are.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

#7359 demonstrates the results of these update
