### PR TITLE
ROX-14380: Increase Cypress request timeout when scanning compliance

### DIFF
--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -60,7 +60,7 @@ export function interceptRequests(routeMatcherMap, staticResponseMap) {
  *
  * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
  * @param {Parameters<Cypress.Chainable['wait']>[1]} [waitOptions]
- * @returns {{ request: Record<string, unknown>, response: Record<string, unknown>}[]}
+ * @returns {Cypress.Chainable | never[]}
  */
 export function waitForResponses(routeMatcherMap, waitOptions = {}) {
     if (routeMatcherMap) {
@@ -79,8 +79,7 @@ export function waitForResponses(routeMatcherMap, waitOptions = {}) {
  * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  * @param {Parameters<Cypress.Chainable['wait']>[1]} [waitOptions]
-
- * @returns {{ request: Record<string, unknown>, response: Record<string, unknown>}[]}
+ * @returns {Cypress.Chainable | never[]}
  */
 export function interactAndWaitForResponses(
     interactionCallback,

--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -59,13 +59,14 @@ export function interceptRequests(routeMatcherMap, staticResponseMap) {
  * Wait for responses after initial page visit or subsequent interaction.
  *
  * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
+ * @param {TODO} waitOptions
  * @returns {{ request: Record<string, unknown>, response: Record<string, unknown>}[]}
  */
-export function waitForResponses(routeMatcherMap) {
+export function waitForResponses(routeMatcherMap, waitOptions = {}) {
     if (routeMatcherMap) {
         const aliases = Object.keys(routeMatcherMap).map((alias) => `@${alias}`);
 
-        return cy.wait(aliases);
+        return cy.wait(aliases, waitOptions);
     }
 
     return [];
@@ -77,16 +78,18 @@ export function waitForResponses(routeMatcherMap) {
  * @param {() => void} interactionCallback
  * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ * @param {TODO} waitOptions
  * @returns {{ request: Record<string, unknown>, response: Record<string, unknown>}[]}
  */
 export function interactAndWaitForResponses(
     interactionCallback,
     routeMatcherMap,
-    staticResponseMap
+    staticResponseMap,
+    waitOptions
 ) {
     interceptRequests(routeMatcherMap, staticResponseMap);
 
     interactionCallback();
 
-    return waitForResponses(routeMatcherMap);
+    return waitForResponses(routeMatcherMap, waitOptions);
 }

--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -59,7 +59,7 @@ export function interceptRequests(routeMatcherMap, staticResponseMap) {
  * Wait for responses after initial page visit or subsequent interaction.
  *
  * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
- * @param {TODO} waitOptions
+ * @param {Parameters<Cypress.Chainable['wait']>[1]} [waitOptions]
  * @returns {{ request: Record<string, unknown>, response: Record<string, unknown>}[]}
  */
 export function waitForResponses(routeMatcherMap, waitOptions = {}) {
@@ -78,7 +78,8 @@ export function waitForResponses(routeMatcherMap, waitOptions = {}) {
  * @param {() => void} interactionCallback
  * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
- * @param {TODO} waitOptions
+ * @param {Parameters<Cypress.Chainable['wait']>[1]} [waitOptions]
+
  * @returns {{ request: Record<string, unknown>, response: Record<string, unknown>}[]}
  */
 export function interactAndWaitForResponses(

--- a/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
@@ -103,7 +103,7 @@ export function visitComplianceDashboard() {
 /*
  * Assume location is compliance dashboard.
  */
-export function scanCompliance() {
+function scanCompliance() {
     const routeMatcherMapForTriggerScan = getRouteMatcherMapForGraphQL(['triggerScan']);
     const routeMatcherMap = {
         ...routeMatcherMapForTriggerScan,
@@ -114,10 +114,15 @@ export function scanCompliance() {
 
     cy.get(scanButton).should('not.have.attr', 'disabled');
 
-    interactAndWaitForResponses(() => {
-        cy.get(scanButton).click();
-        cy.get(scanButton).should('have.attr', 'disabled');
-    }, routeMatcherMap);
+    interactAndWaitForResponses(
+        () => {
+            cy.get(scanButton).click();
+            cy.get(scanButton).should('have.attr', 'disabled');
+        },
+        routeMatcherMap,
+        undefined,
+        { timeout: 20000 }
+    );
 
     cy.get(scanButton).should('not.have.attr', 'disabled');
 }

--- a/ui/apps/platform/cypress/integration/compliance/complianceDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/compliance/complianceDashboard.test.js
@@ -3,7 +3,7 @@ import { getRegExpForTitleWithBranding } from '../../helpers/title';
 
 import {
     interactAndWaitForComplianceStandard,
-    scanCompliance,
+    triggerScan,
     verifyDashboardEntityLink,
     visitComplianceDashboard,
 } from './Compliance.helpers';
@@ -25,8 +25,7 @@ describe('Compliance Dashboard', () => {
     withAuth();
 
     it('should scan for compliance data', () => {
-        visitComplianceDashboard();
-        scanCompliance(); // prerequisite for the following tests
+        triggerScan(); // prerequisite for the following tests
     });
 
     it('should have title', () => {

--- a/ui/apps/platform/cypress/integration/compliance/hideScanResults.test.js
+++ b/ui/apps/platform/cypress/integration/compliance/hideScanResults.test.js
@@ -1,7 +1,7 @@
 import withAuth from '../../helpers/basicAuth';
 import { getInputByLabel } from '../../helpers/formHelpers';
 
-import { scanCompliance, visitComplianceDashboard } from './Compliance.helpers';
+import { triggerScan, visitComplianceDashboard } from './Compliance.helpers';
 import {
     clickSaveAndWaitForPatchComplianceStandards,
     openModal,
@@ -58,8 +58,7 @@ describe('Compliance hideScanResults', () => {
     withAuth();
 
     it('should open modal and then cancel', () => {
-        visitComplianceDashboard();
-        scanCompliance(); // in case complianceDashboard.test.js is skipped
+        triggerScan(); // in case complianceDashboard.test.js is skipped
         openModal();
 
         cy.get(selectorInModal('button:contains("Save")')).should('be.disabled');


### PR DESCRIPTION
## Description

Test flake fix that has been becoming more frequent lately.

Each flake was due to a network timeout waiting for a large number of requests to return. On my local machine, it can take 5-6 seconds for the scan to complete and all requests to finish, so it is not unreasonable that this would take > 10 seconds in CI.

The fix here increases the `requestTimeout` for each test that runs a compliance scan to 20 seconds. This extends the `waitForResponses` helper to allow pass-through of an options object to `cy.wait()`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI

Verified the new timeout locally by setting it to `200ms` and verifying that local Cypress runs would fail for these specific tests.
![image](https://github.com/stackrox/stackrox/assets/1292638/265a01d9-3172-4bf6-93db-2d64b2746af8)

