### PR TITLE
ROX-18956: Generate empty report to download in case of no cve found

### DIFF
--- a/central/reports/common/report_formatter.go
+++ b/central/reports/common/report_formatter.go
@@ -140,10 +140,6 @@ func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults [
 		}
 	}
 
-	if csvWriter.IsEmpty() {
-		return nil, nil
-	}
-
 	var buf bytes.Buffer
 	err := csvWriter.WriteBytes(&buf)
 	if err != nil {

--- a/central/reports/common/report_formatter.go
+++ b/central/reports/common/report_formatter.go
@@ -82,7 +82,7 @@ type WatchedImagesResult struct {
 
 // Format takes in the results of vuln report query, converts to CSV and returns zipped CSV data and
 // a flag if the report is empty or not
-func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults []WatchedImagesResult) (*bytes.Buffer, error) {
+func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults []WatchedImagesResult) (*bytes.Buffer, bool, error) {
 	csvWriter := csv.NewGenericWriter(csvHeader, true)
 	for _, r := range deployedImagesResults {
 		for _, d := range r.Deployments {
@@ -140,28 +140,30 @@ func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults [
 		}
 	}
 
+	empty := csvWriter.IsEmpty()
+
 	var buf bytes.Buffer
 	err := csvWriter.WriteBytes(&buf)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating csv report")
+		return nil, true, errors.Wrap(err, "error creating csv report")
 	}
 
 	var zipBuf bytes.Buffer
 	zipWriter := zip.NewWriter(&zipBuf)
 	zipFile, err := zipWriter.Create(fmt.Sprintf("RHACS_Vulnerability_Report_%s.csv", time.Now().Format("02_January_2006")))
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to create a zip file of the vuln report")
+		return nil, true, errors.Wrap(err, "unable to create a zip file of the vuln report")
 
 	}
 	_, err = zipFile.Write(buf.Bytes())
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to create a zip file of the vuln report")
+		return nil, true, errors.Wrap(err, "unable to create a zip file of the vuln report")
 	}
 	err = zipWriter.Close()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to create a zip file of the vuln report")
+		return nil, true, errors.Wrap(err, "unable to create a zip file of the vuln report")
 	}
-	return &zipBuf, nil
+	return &zipBuf, empty, nil
 }
 
 // GetClusterName returns name of cluster containing the Deployment

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -277,7 +277,7 @@ func (s *scheduler) sendReportResults(req *ReportRequest) error {
 		return err
 	}
 	// Format results into CSV
-	zippedCSVData, err := common.Format(reportData, nil)
+	zippedCSVData, empty, err := common.Format(reportData, nil)
 	if err != nil {
 		return errors.Wrap(err, "error formatting the report data")
 	}
@@ -285,8 +285,9 @@ func (s *scheduler) sendReportResults(req *ReportRequest) error {
 	// will indicate that no vulns were found
 
 	templateStr := vulnReportEmailTemplate
-	if zippedCSVData == nil {
+	if empty {
 		// If it is an empty report, the email body will indicate that no vulns were found
+		zippedCSVData = nil
 		templateStr = noVulnsFoundEmailTemplate
 	}
 

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -160,7 +160,7 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 
 func (rg *reportGeneratorImpl) saveReportData(configID, reportID string, data *bytes.Buffer) error {
 	if data == nil {
-		return errors.Errorf("Unexpected empty downloadable report for report config=%q, id=%q", configID, reportID)
+		return errors.Errorf("No data found for report config %q and id %q", configID, reportID)
 	}
 
 	// Store downloadable report in blob storage

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -127,6 +127,12 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 		return errors.Wrap(err, "error formatting the report email text")
 	}
 
+	if zippedCSVData == nil {
+		err = errors.Errorf("Unexpected empty downloadable report for report config=%q, id=%q", req.ReportSnapshot.GetReportConfigurationId(), req.ReportSnapshot.GetReportId())
+		utils.Should(err)
+		return err
+	}
+
 	switch req.ReportSnapshot.ReportStatus.ReportNotificationMethod {
 	case storage.ReportStatus_DOWNLOAD:
 		if err = rg.saveReportData(req.ReportSnapshot.GetReportConfigurationId(),
@@ -157,10 +163,6 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 }
 
 func (rg *reportGeneratorImpl) saveReportData(configID, reportID string, data *bytes.Buffer) error {
-	if data == nil {
-		data = bytes.NewBuffer([]byte{})
-	}
-
 	// Store downloadable report in blob storage
 	b := &storage.Blob{
 		Name:         common.GetReportBlobPath(configID, reportID),

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl_test.go
@@ -118,14 +118,6 @@ func (s *EnhancedReportingTestSuite) TestSaveReportData() {
 	s.Require().NoError(err)
 	s.Require().True(exists)
 	s.Equal(data, newBuf.Bytes())
-
-	// Save empty report
-	reportID = "anotherid"
-	s.Require().NoError(s.reportGenerator.saveReportData(configID, reportID, nil))
-	newBuf, _, exists, err = s.blobStore.GetBlobWithDataInBuffer(s.ctx, common.GetReportBlobPath(configID, reportID))
-	s.Require().NoError(err)
-	s.Require().True(exists)
-	s.Zero(newBuf.Len())
 }
 
 func (s *EnhancedReportingTestSuite) TestGetReportData() {

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl_test.go
@@ -118,6 +118,10 @@ func (s *EnhancedReportingTestSuite) TestSaveReportData() {
 	s.Require().NoError(err)
 	s.Require().True(exists)
 	s.Equal(data, newBuf.Bytes())
+
+	// Save empty report
+	reportID = "anotherid"
+	s.Require().Error(s.reportGenerator.saveReportData(configID, reportID, nil))
 }
 
 func (s *EnhancedReportingTestSuite) TestGetReportData() {


### PR DESCRIPTION
## Description

If the report is empty and it is to be
1. emailed: keep the current logic to not send an attachment
2. downloaded: write the compressed empty report to blob to be downloaded.

## Checklist
- [ ] Investigated and inspected CI test results
- ~ ] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed
existing unit tests.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
