### PR TITLE
ROX-18887: Add conditional RBAC in Vulnerability Management 1.0

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.selectors.js
@@ -7,7 +7,7 @@ export const listSelectors = {
     metadataDescription: '[data-testid="metadata-description"]',
     statusChips: '[data-testid="label-chip"]',
     failingDeploymentCountLink: '[data-testid="failingDeploymentsCountLink"]',
-    cveAddToPolicyButton: '[data-testid="panel-button-add-cves-to-policy"]',
+    cveAddToPolicyButton: 'button:contains("Add to policy")',
     cveAddToPolicyShortForm: {
         // TODO: fix the following selector for react-select, that evil component
         select: '[data-testid="policy-short-form"] select',

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.js
@@ -22,6 +22,7 @@ import getImageScanMessage from 'Containers/VulnMgmt/VulnMgmt.utils/getImageScan
 import { workflowListPropTypes, workflowListDefaultProps } from 'constants/entityPageProps';
 import removeEntityContextColumns from 'utils/tableUtils';
 import { imageSortFields } from 'constants/sortFields';
+import usePermissions from 'hooks/usePermissions';
 import queryService from 'utils/queryService';
 import WatchedImagesDialog from './WatchedImagesDialog';
 import WorkflowListPage from '../WorkflowListPage';
@@ -199,6 +200,9 @@ const VulnMgmtImages = ({
     refreshTrigger,
     setRefreshTrigger,
 }) => {
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForWatchedImage = hasReadWriteAccess('WatchedImage');
+
     const [showWatchedImagesDialog, setShowWatchedImagesDialog] = useState(false);
     const workflowState = useContext(workflowStateContext);
     const fragmentToUse = IMAGE_LIST_FRAGMENT;
@@ -236,11 +240,12 @@ const VulnMgmtImages = ({
 
         setShowWatchedImagesDialog(!showWatchedImagesDialog);
     }
-    const tableHeaderComponents = inactiveImageScanningEnabled ? (
-        <Button variant="secondary" onClick={toggleWatchedImagesDialog}>
-            Manage watches
-        </Button>
-    ) : null;
+    const tableHeaderComponents =
+        hasWriteAccessForWatchedImage && inactiveImageScanningEnabled ? (
+            <Button variant="secondary" onClick={toggleWatchedImagesDialog}>
+                Manage watches
+            </Button>
+        ) : null;
 
     const getImageTableColumns = getCurriedImageTableColumns(toggleWatchedImagesDialog);
 


### PR DESCRIPTION
## Description

### Analysis

1. VulnMgmtListCves
    * **Add to policy** is relevant only for image CVEs and requires READ_WRITE_ACCESS for WorkflowAdministration
        By the way, the interaction in the modal seems awkward and buggy.
    * **Defer and approve** requires READ_WRITE_ACCESS for Image, VulnerabilityManagementApprovals, VulnerabilityManagementRequests
    * **Reobserve** requires READ_WRITE_ACCESS for Image, VulnerabilityManagementApprovals, VulnerabilityManagementRequests (I assume by analogy, although I did not have enough skill to set up the scenario)
    * **View deferred** or **View observed** did not seem to require either Approvals or Requests resources, but Snoozed does have similar problem as Fixed boolean search.
2. VulnMgmtListImages
    * **Manage watches** requires READ_WRITE_ACCESS for WatchedImage

### Solution

1. VulnMgmtListCves
    * `hasWriteAccessForAddToPolicy`
    * `hasWriteAccessForRiskAcceptance`
2. VulnMgmtListImages
    * `hasWriteAccessForWatchedImage`
3. Replace title case with sentence case in buttons.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

It looks like deletion of unused `data-testid` props more than balanced additions.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3759691 - 3759691
        total: -26 = 9932402 - 9932428
    * `ls -al build/static/js/*.js | wc -l`
        0 = 81 - 81 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/vulnerability-management click **CVEs**, and then click any of the following: Image CVEs, Node CVEs, Platform CVEs

    * See **Add to policy** button only for image CVEs and if READ_WRITE_ACCESS for WorkflowAdministration plus Policy Management route
        ![Add_to_policy](https://github.com/stackrox/stackrox/assets/11862657/2213aa3f-80f9-44ad-9b7b-9e1dff367a73)

    * See **Defer and approve** menu only if READ_WRITE_ACCESS for Image, VulnerabilityManagementApprovals, VulnerabilityManagementRequests
        ![Defer_and_approve](https://github.com/stackrox/stackrox/assets/11862657/8ec7c8f3-234f-4e23-b023-6a1e5e3a2dd2)

2. Visit /main/vulnerability-management/images

    * See **Manage watches** button only if READ_WRITE_ACCESS for WatchedImage
        ![Manage_watches](https://github.com/stackrox/stackrox/assets/11862657/f5195311-eb83-4bd9-a172-e8852649af88)

### Integration testing

* vulnmanagement/clusterCves.test.js
* vulnmanagement/dashboard.test.js
* vulnmanagement/dashboardToEntityPage.test.js
* vulnmanagement/imageCves.test.js
* vulnmanagement/images.test.js
* vulnmanagement/nodeCves.test.js