### PR TITLE
feat(ui): Display listening endpoint count in table

### DIFF
--- a/ui/apps/platform/cypress/integration/listeningEndpoints/listeningEndpointsTable.test.js
+++ b/ui/apps/platform/cypress/integration/listeningEndpoints/listeningEndpointsTable.test.js
@@ -29,8 +29,8 @@ describe('Listening endpoints page table', () => {
         // assert that the row contains a process name of 'postgres' and a port of '5432'
         cy.get(
             `${centralDbProcessTableSelector} ${selectors.tableRowWithValueForColumn(
-                'Process name',
-                'postgres'
+                'Exec file path',
+                '/usr/pgsql-13/bin/postgres'
             )}`
         );
         cy.get(

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -104,7 +104,7 @@ function ListeningEndpointsPage() {
     const entityToggle = useSelectToggle();
     const autocompleteToggle = useSelectToggle();
 
-    const [areAllRowsExpanded, setAllRowsExpanded] = useState<boolean>(false);
+    const [areAllRowsExpanded, setAllRowsExpanded] = useState(false);
 
     const variables = {
         query: getRequestQueryStringForAutocomplete(searchFilter, entity, searchValue),

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -104,6 +104,8 @@ function ListeningEndpointsPage() {
     const entityToggle = useSelectToggle();
     const autocompleteToggle = useSelectToggle();
 
+    const [areAllRowsExpanded, setAllRowsExpanded] = useState<boolean>(false);
+
     const variables = {
         query: getRequestQueryStringForAutocomplete(searchFilter, entity, searchValue),
         categories: searchCategories[entity.toUpperCase()],
@@ -265,6 +267,8 @@ function ListeningEndpointsPage() {
                                 <ListeningEndpointsTable
                                     deployments={data}
                                     getSortParams={getSortParams}
+                                    areAllRowsExpanded={areAllRowsExpanded}
+                                    setAllRowsExpanded={setAllRowsExpanded}
                                 />
                             )}
                         </>

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -1,5 +1,5 @@
 import React, { Dispatch, SetStateAction } from 'react';
-import { Button, ButtonVariant, Card } from '@patternfly/react-core';
+import { Button, ButtonVariant, Card, Text } from '@patternfly/react-core';
 import { Tbody, Tr, Td, TableComposable, Th, Thead } from '@patternfly/react-table';
 
 import { riskBasePath } from 'routePaths';
@@ -81,16 +81,16 @@ function ListeningEndpointsTable({
                     >
                         {/* Header for expanded column */}
                     </Th>
-                    <Th width={10}>Count</Th>
                     <Th width={30} sort={getSortParams('Deployment')}>
                         Deployment
-                    </Th>
-                    <Th width={30} sort={getSortParams('Namespace')}>
-                        Namespace
                     </Th>
                     <Th width={20} sort={getSortParams('Cluster')}>
                         Cluster
                     </Th>
+                    <Th width={30} sort={getSortParams('Namespace')}>
+                        Namespace
+                    </Th>
+                    <Th>Count</Th>
                 </Tr>
             </Thead>
             {deployments.map(({ id, name, namespace, cluster, listeningEndpoints }, rowIndex) => {
@@ -104,18 +104,13 @@ function ListeningEndpointsTable({
                 return (
                     <Tbody key={id} isExpanded={isExpanded}>
                         <Tr>
-                            {count > 0 ? (
-                                <Td
-                                    expand={{
-                                        rowIndex,
-                                        isExpanded,
-                                        onToggle: () => invertedExpansionRowSet.toggle(id),
-                                    }}
-                                />
-                            ) : (
-                                <Td />
-                            )}
-                            <Td dataLabel="Listening endpoints count">{count}</Td>
+                            <Td
+                                expand={{
+                                    rowIndex,
+                                    isExpanded,
+                                    onToggle: () => invertedExpansionRowSet.toggle(id),
+                                }}
+                            />
                             <Td dataLabel="Deployment">
                                 <Button
                                     variant={ButtonVariant.link}
@@ -126,21 +121,26 @@ function ListeningEndpointsTable({
                                     {name}
                                 </Button>
                             </Td>
-                            <Td dataLabel="Namespace">{namespace}</Td>
                             <Td dataLabel="Cluster">{cluster}</Td>
+                            <Td dataLabel="Namespace">{namespace}</Td>
+                            <Td dataLabel="Listening endpoints count">{count}</Td>
                         </Tr>
-                        {listeningEndpoints.length > 0 && (
-                            <Tr isExpanded={isExpanded}>
-                                <Td colSpan={5}>
-                                    <Card className="pf-u-m-md" isFlat>
+                        <Tr isExpanded={isExpanded}>
+                            <Td colSpan={5}>
+                                <Card className="pf-u-m-md" isFlat>
+                                    {listeningEndpoints.length > 0 ? (
                                         <EmbeddedTable
                                             deploymentId={id}
                                             listeningEndpoints={listeningEndpoints}
                                         />
-                                    </Card>
-                                </Td>
-                            </Tr>
-                        )}
+                                    ) : (
+                                        <Text className="pf-u-p-md">
+                                            No listening endpoints reported for this deployment
+                                        </Text>
+                                    )}
+                                </Card>
+                            </Td>
+                        </Tr>
                     </Tbody>
                 );
             })}

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -135,7 +135,8 @@ function ListeningEndpointsTable({
                                         />
                                     ) : (
                                         <Text className="pf-u-p-md">
-                                            No listening endpoints reported for this deployment
+                                            This deployment does not have any reported listening
+                                            endpoints
                                         </Text>
                                     )}
                                 </Card>

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -128,7 +128,7 @@ function ListeningEndpointsTable({
                         <Tr isExpanded={isExpanded}>
                             <Td colSpan={5}>
                                 <Card className="pf-u-m-md" isFlat>
-                                    {listeningEndpoints.length > 0 ? (
+                                    {count > 0 ? (
                                         <EmbeddedTable
                                             deploymentId={id}
                                             listeningEndpoints={listeningEndpoints}

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -19,10 +19,10 @@ function EmbeddedTable({
         <TableComposable isNested aria-label="Listening endpoints for deployment">
             <Thead noWrap>
                 <Tr>
-                    <Th width={20}>Process name</Th>
-                    <Th width={10}>PID</Th>
-                    <Th width={10}>Port</Th>
-                    <Th width={10}>Protocol</Th>
+                    <Th width={30}>Exec file path</Th>
+                    <Th>PID</Th>
+                    <Th>Port</Th>
+                    <Th>Protocol</Th>
                     <Th width={30}>Pod ID</Th>
                     <Th width={20}>Container name</Th>
                 </Tr>
@@ -30,7 +30,7 @@ function EmbeddedTable({
             <Tbody>
                 {listeningEndpoints.map(({ podId, endpoint, signal, containerName }) => (
                     <Tr key={`${deploymentId}/${podId}/${endpoint.port}`}>
-                        <Td dataLabel="Process name">{signal.name}</Td>
+                        <Td dataLabel="Exec file path">{signal.execFilePath}</Td>
                         <Td dataLabel="PID">{signal.pid}</Td>
                         <Td dataLabel="Port">{endpoint.port}</Td>
                         <Td dataLabel="Protocol">{l4ProtocolLabels[endpoint.protocol]}</Td>

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -1,7 +1,9 @@
 import React, { Dispatch, SetStateAction } from 'react';
-import { Card } from '@patternfly/react-core';
+import { Button, ButtonVariant, Card } from '@patternfly/react-core';
 import { Tbody, Tr, Td, TableComposable, Th, Thead } from '@patternfly/react-table';
 
+import { riskBasePath } from 'routePaths';
+import LinkShim from 'Components/PatternFly/LinkShim';
 import { ProcessListeningOnPort } from 'services/ProcessListeningOnPortsService';
 import { l4ProtocolLabels } from 'constants/networkFlow';
 import { ListDeployment } from 'types/deployment.proto';
@@ -114,7 +116,16 @@ function ListeningEndpointsTable({
                                 <Td />
                             )}
                             <Td dataLabel="Listening endpoints count">{count}</Td>
-                            <Td dataLabel="Deployment">{name}</Td>
+                            <Td dataLabel="Deployment">
+                                <Button
+                                    variant={ButtonVariant.link}
+                                    isInline
+                                    component={LinkShim}
+                                    href={`${riskBasePath}/${id}`}
+                                >
+                                    {name}
+                                </Button>
+                            </Td>
                             <Td dataLabel="Namespace">{namespace}</Td>
                             <Td dataLabel="Cluster">{cluster}</Td>
                         </Tr>

--- a/ui/apps/platform/src/hooks/useSet.ts
+++ b/ui/apps/platform/src/hooks/useSet.ts
@@ -35,5 +35,12 @@ export default function useSet<T>(initialSet: Set<T> = new Set()) {
         });
     }
 
-    return { has, toggle };
+    /**
+     * Empties the set
+     */
+    function clear() {
+        setItemSet(new Set());
+    }
+
+    return { has, toggle, clear };
 }


### PR DESCRIPTION
## Description

Adds a handful of UX enhancements to the Listening Endpoints table:

1. A new column showing the count of listening endpoints, to aid in understanding why some rows are not expandable
2. Adds a global "expand all" icon to the table header to expand/collapse all rows
3. Deployment names now link to the equivalent Risk page
4. Columns were re-ordered to more closely match the Risk page
5. The "Process name" column in the embedded table was changed to "Exec file path"
6. All rows are now expandable. Rows with no resulting endpoints contain this information in the expanded section.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the listening endpoints page and see a column for count:
![image](https://github.com/stackrox/stackrox/assets/1292638/df610536-6f57-4d2e-9b2a-b47b846ff6d0)

Use the global expand/collapse icon to manage row expansion state:
https://github.com/stackrox/stackrox/assets/1292638/0bbe5d63-6e2e-4b6c-8e1d-2d4d19cc9d25


