### PR TITLE
fix(test): Fix metrics server removal check

### DIFF
--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -295,6 +295,10 @@ deactivate_metrics_server() {
             success=1
             break
         fi
+        if ! grep -q 'metrics.k8s.io' stdout.out; then
+            success=1
+            break
+        fi
         echo "metrics.k8s.io still in API resources. Will try again..."
         cat stdout.out
         sed -e 's/^/out: /' < stderr.out # (prefix output to avoid triggering prow log focus)


### PR DESCRIPTION
## Description

Fix the check by seeing if metrics has been removed from the core api resources as well

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Upgrade test