### PR TITLE
ROX-17192: Update np-guard/netpol-analyzer to v0.4.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/np-guard/cluster-topology-analyzer v1.7.0
-	github.com/np-guard/netpol-analyzer v0.3.2
+	github.com/np-guard/netpol-analyzer v0.4.2
 	github.com/nxadm/tail v1.4.8
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/np-guard/cluster-topology-analyzer v1.7.0
-	github.com/np-guard/netpol-analyzer v0.4.2
+	github.com/np-guard/netpol-analyzer v0.4.3
 	github.com/nxadm/tail v1.4.8
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -1205,8 +1205,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/np-guard/cluster-topology-analyzer v1.7.0 h1:MtXZ7XF8EFQbM8uJO+RCS6KnArk88Rn4U0CnuFWu7BM=
 github.com/np-guard/cluster-topology-analyzer v1.7.0/go.mod h1:WDOpAZdQcD4t61J4ZsG9BoXhlG04sqKTZgkohng0p3A=
-github.com/np-guard/netpol-analyzer v0.4.2 h1:PAtryJzHzYWXgtHurjz2KERwXD0xry9GU/SpKDISfVw=
-github.com/np-guard/netpol-analyzer v0.4.2/go.mod h1:2MUl7DNbq01PGJLi7PJbzlEIcI72jwchzTGzazoIio8=
+github.com/np-guard/netpol-analyzer v0.4.3 h1:D8ad4TfQv3QIGKc+wfKb3T+ES8YX6fIJfnKAD7He8a8=
+github.com/np-guard/netpol-analyzer v0.4.3/go.mod h1:2MUl7DNbq01PGJLi7PJbzlEIcI72jwchzTGzazoIio8=
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=

--- a/go.sum
+++ b/go.sum
@@ -1205,8 +1205,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/np-guard/cluster-topology-analyzer v1.7.0 h1:MtXZ7XF8EFQbM8uJO+RCS6KnArk88Rn4U0CnuFWu7BM=
 github.com/np-guard/cluster-topology-analyzer v1.7.0/go.mod h1:WDOpAZdQcD4t61J4ZsG9BoXhlG04sqKTZgkohng0p3A=
-github.com/np-guard/netpol-analyzer v0.3.2 h1:bYouZtP6vxFs01snG3vQtVibxyCUiaRgLgJvE7pW9S4=
-github.com/np-guard/netpol-analyzer v0.3.2/go.mod h1:2MUl7DNbq01PGJLi7PJbzlEIcI72jwchzTGzazoIio8=
+github.com/np-guard/netpol-analyzer v0.4.2 h1:PAtryJzHzYWXgtHurjz2KERwXD0xry9GU/SpKDISfVw=
+github.com/np-guard/netpol-analyzer v0.4.2/go.mod h1:2MUl7DNbq01PGJLi7PJbzlEIcI72jwchzTGzazoIio8=
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=

--- a/roxctl/connectivity-map/cta.go
+++ b/roxctl/connectivity-map/cta.go
@@ -16,13 +16,13 @@ const (
 )
 
 type netpolAnalyzer interface {
-	ConnlistFromDirPath(dirPath string) ([]npguard.Peer2PeerConnection, error)
+	ConnlistFromDirPath(dirPath string) ([]npguard.Peer2PeerConnection, []npguard.Peer, error)
 	ConnectionsListToString(conns []npguard.Peer2PeerConnection) (string, error)
 	Errors() []npguard.ConnlistError
 }
 
 func (cmd *analyzeNetpolCommand) analyzeNetpols(analyzer netpolAnalyzer) error {
-	conns, err := analyzer.ConnlistFromDirPath(cmd.inputFolderPath)
+	conns, _, err := analyzer.ConnlistFromDirPath(cmd.inputFolderPath)
 	if err != nil {
 		return errors.Wrap(err, "error in connectivity analysis")
 	}

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-map-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-map-development.bats
@@ -51,9 +51,9 @@ teardown() {
 
   run roxctl-development connectivity-map "$out_dir/" --remove --output-file=/dev/null --fail
   assert_failure
-  assert_output --partial 'YAML document is malformed'
-  assert_output --partial 'file1.yaml'
-  refute_output --partial 'file2.yaml'
+  assert_line --index 0 --partial 'This is a Technology Preview feature'
+  assert_line --index 1 --partial 'YAML document is malformed'  # expect only one line with this error 
+  assert_line --index 2 --partial 'there were errors during execution'  # last line 
 }
 
 @test "roxctl-development connectivity-map produces no output when all yamls are templated" {

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-map-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-map-development.bats
@@ -52,8 +52,8 @@ teardown() {
   run roxctl-development connectivity-map "$out_dir/" --remove --output-file=/dev/null --fail
   assert_failure
   assert_line --index 0 --partial 'This is a Technology Preview feature'
-  assert_line --index 1 --partial 'YAML document is malformed'  # expect only one line with this error 
-  assert_line --index 2 --partial 'there were errors during execution'  # last line 
+  assert_line --index 1 --partial 'YAML document is malformed'  # expect only one line with this error
+  assert_line --index 2 --partial 'there were errors during execution'  # last line
 }
 
 @test "roxctl-development connectivity-map produces no output when all yamls are templated" {

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-map-release.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-map-release.bats
@@ -51,9 +51,9 @@ teardown() {
 
   run roxctl-release connectivity-map "$out_dir/" --remove --output-file=/dev/null --fail
   assert_failure
-  assert_output --partial 'YAML document is malformed'
-  assert_output --partial 'file1.yaml'
-  refute_output --partial 'file2.yaml'
+  assert_line --index 0 --partial 'This is a Technology Preview feature'
+  assert_line --index 1 --partial 'YAML document is malformed'  # expect only one line with this error 
+  assert_line --index 2 --partial 'there were errors during execution'  # last line 
 }
 
 @test "roxctl-release connectivity-map produces no output when all yamls are templated" {

--- a/tests/roxctl/bats-tests/local/roxctl-connectivity-map-release.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-connectivity-map-release.bats
@@ -52,8 +52,8 @@ teardown() {
   run roxctl-release connectivity-map "$out_dir/" --remove --output-file=/dev/null --fail
   assert_failure
   assert_line --index 0 --partial 'This is a Technology Preview feature'
-  assert_line --index 1 --partial 'YAML document is malformed'  # expect only one line with this error 
-  assert_line --index 2 --partial 'there were errors during execution'  # last line 
+  assert_line --index 1 --partial 'YAML document is malformed'  # expect only one line with this error
+  assert_line --index 2 --partial 'there were errors during execution'  # last line
 }
 
 @test "roxctl-release connectivity-map produces no output when all yamls are templated" {


### PR DESCRIPTION
## Description

Update  np-guard/netpol-analyzer to v0.4.3 
Includes a few compatibility updates:
- update to `roxctl/connectivity-map/cta.go`
- update to connectivity-map bats tests, since netpol-analyzer v0.4.3 does not necessarily traverses input YAML files by lexical order.