### PR TITLE
ROX-19018: Make koCache handle Offline mode

### DIFF
--- a/central/probesources/sources.go
+++ b/central/probesources/sources.go
@@ -77,12 +77,11 @@ func (s *probeSources) initializeStandardSources(probeUploadManager probeUploadM
 		return
 	}
 
-	opts := kocache.Options{}
 	httpClient := &http.Client{
 		Transport: proxy.RoundTripper(),
 		Timeout:   httpTimeout,
 	}
-	s.probeSources = append(s.probeSources, kocache.New(context.Background(), httpClient, baseURL, opts))
+	s.probeSources = append(s.probeSources, kocache.New(context.Background(), httpClient, baseURL))
 }
 
 // Singleton returns the singleton instance for the ProbeSources entity.

--- a/pkg/kocache/entry.go
+++ b/pkg/kocache/entry.go
@@ -104,9 +104,9 @@ func (e *entry) doPopulate(client *http.Client, upstreamURL string, opts *option
 	// Note that Golang's HTTP client by default follows redirects.
 	if resp.StatusCode != http.StatusOK {
 		// If the probe does not exist, we may receive 403 Forbidden due to security constraints
-		// on the storage. Convert this to errNotFound for better visibility of this scenario.
+		// on the storage. Convert this to errProbeNotFound for better visibility of this scenario.
 		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
-			return errNotFound
+			return errProbeNotFound
 		}
 		return errors.Errorf("upstream HTTP request returned status %s", resp.Status)
 	}

--- a/pkg/kocache/entry.go
+++ b/pkg/kocache/entry.go
@@ -74,13 +74,13 @@ func (e *entry) IsError() bool {
 	return ok && err != nil
 }
 
-func (e *entry) Populate(client *http.Client, upstreamURL string, opts Options) {
+func (e *entry) Populate(client *http.Client, upstreamURL string, opts *options) {
 	err := e.doPopulate(client, upstreamURL, opts)
 	defer e.done.SignalWithError(err)
 	e.lastAccess.StoreAtomic(timestamp.Now())
 }
 
-func (e *entry) doPopulate(client *http.Client, upstreamURL string, opts Options) error {
+func (e *entry) doPopulate(client *http.Client, upstreamURL string, opts *options) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 

--- a/pkg/kocache/kocache.go
+++ b/pkg/kocache/kocache.go
@@ -24,7 +24,9 @@ const (
 )
 
 var (
-	errNotFound = errors.New("not found")
+	errCentralUnreachable  = errors.New("central is currently unreachable")
+	errKoCacheShuttingDown = errors.New("kernel object cache is shutting down")
+	errProbeNotFound       = errors.New("probe not found")
 )
 
 // options controls the behavior of the kernel object cache.
@@ -131,9 +133,9 @@ func (c *koCache) getOrAddEntry(path string) (*entry, error) {
 
 	if e == nil {
 		if !c.centralReady.Load() {
-			return nil, errors.New("central is currently unreachable")
+			return nil, errCentralUnreachable
 		} else if c.entries == nil {
-			return nil, errors.New("kernel object cache is shutting down")
+			return nil, errKoCacheShuttingDown
 		} else {
 			e = newEntry()
 			c.entries[path] = e

--- a/pkg/kocache/kocache_test.go
+++ b/pkg/kocache/kocache_test.go
@@ -1,0 +1,276 @@
+package kocache
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/ioutils"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/timestamp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartOffline(t *testing.T) {
+	tests := map[string]struct {
+		initial *options
+		want    *options
+	}{
+		"Transition from offline should be offline": {
+			initial: &options{
+				StartOnline: false,
+			},
+			want: &options{
+				StartOnline: false,
+			},
+		},
+		"Transition from online should be offline": {
+			initial: &options{
+				StartOnline: true,
+			},
+			want: &options{
+				StartOnline: false,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			o := tt.initial
+			StartOffline()(o)
+			assert.Equal(t, tt.want.StartOnline, o.StartOnline)
+		})
+	}
+}
+
+func Test_applyDefaults(t *testing.T) {
+	tests := map[string]struct {
+		initial *options
+		want    *options
+	}{
+		"Default values should be as defined": {
+			initial: &options{},
+			want: &options{
+				ObjMemLimit:      1048576,
+				ObjHardLimit:     10485760,
+				CleanupThreshold: 10,
+				CleanupAge:       300000000000,
+				ErrorCleanUpAge:  30000000000,
+				CleanupInterval:  60000000000,
+				StartOnline:      true,
+				ModifyRequest:    nil,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			o := tt.initial
+			applyDefaults(o)
+			assert.Equal(t, tt.want, o)
+		})
+	}
+}
+
+func Test_koCache_GoOffline(t *testing.T) {
+	tests := map[string]struct {
+		startOnline bool
+	}{
+		"Starting online":  {startOnline: true},
+		"Starting offline": {startOnline: false},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			fn := func(o *options) {
+				if tt.startOnline {
+					o.StartOnline = true
+				}
+			}
+			ctx, cancel := context.WithCancelCause(context.Background())
+			defer cancel(errors.New("test ended"))
+			c := New(ctx, nil, "URL", fn)
+			c.GoOffline()
+			assert.False(t, c.centralReady.Load())
+			assert.Error(t, c.onlineCtx.Err())
+			assert.ErrorIs(t, c.onlineCtx.Err(), context.Canceled)
+			assert.ErrorIs(t, context.Cause(c.onlineCtx), errCentralUnreachable)
+		})
+	}
+}
+
+func Test_koCache_GoOnline(t *testing.T) {
+	tests := map[string]struct {
+		startOnline bool
+	}{
+		"Starting online":  {startOnline: true},
+		"Starting offline": {startOnline: false},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			fn := func(o *options) {
+				if tt.startOnline {
+					o.StartOnline = true
+				}
+			}
+			ctx, cancel := context.WithCancelCause(context.Background())
+			defer cancel(errors.New("test ended"))
+			c := New(ctx, nil, "URL", fn)
+			c.GoOnline()
+			assert.True(t, c.centralReady.Load())
+			assert.NoError(t, c.onlineCtx.Err())
+		})
+	}
+}
+
+func Test_koCache_cleanup(t *testing.T) {
+	t.Skip("test unimplemented")
+}
+
+type mockClock struct{}
+
+func (m *mockClock) Now() time.Time {
+	return time.Date(2000, 1, 1, 0, 0, 0, 0, time.Local)
+}
+
+func (m *mockClock) TimestampNow() timestamp.MicroTS {
+	return timestamp.FromGoTime(m.Now())
+}
+
+func Test_koCache_getOrAddEntry(t *testing.T) {
+	errEntryExpired := errors.New("entry expired")
+	en1 := &entry{
+		done:         concurrency.NewErrorSignal(),
+		references:   sync.WaitGroup{},
+		data:         nil,
+		clock:        &mockClock{},
+		creationTime: time.Date(2000, 1, 1, 0, 0, 0, 0, time.Local),
+		lastAccess:   0,
+	}
+	expiredEntry := &entry{
+		done:         concurrency.NewErrorSignal(),
+		references:   sync.WaitGroup{},
+		data:         nil,
+		clock:        &mockClock{},
+		creationTime: time.Date(2000, 1, 1, 0, 0, 0, 0, time.Local),
+		lastAccess:   0,
+	}
+	expiredEntry.done.SignalWithError(errEntryExpired)
+	assert.Error(t, expiredEntry.DoneSig().Wait())
+	assert.ErrorIs(t, expiredEntry.DoneSig().Wait(), errEntryExpired)
+	assert.True(t, expiredEntry.DoneSig().IsDone())
+
+	tests := map[string]struct {
+		entries            map[string]*entry
+		key                string
+		centralReachable   bool
+		centralReplyStatus int
+		centralReplyError  error
+		centralReplyBody   string
+		wantCentralCall    bool
+		wantData           *ioutils.RWBuf
+		wantCreationTime   time.Time
+		wantErr            bool
+	}{
+		"Existing non-expired entry shall be found": {
+			entries:          map[string]*entry{"en1": en1},
+			key:              "en1",
+			wantCentralCall:  false,
+			centralReachable: true,
+			wantCreationTime: en1.CreationTime(),
+			wantData:         en1.data,
+			wantErr:          false,
+		},
+		"Existing expired entry shall be found and replaced by a fresh one from Central": {
+			entries:            map[string]*entry{"expired": expiredEntry},
+			key:                "expired",
+			wantCentralCall:    true,
+			centralReachable:   true,
+			centralReplyStatus: 200,
+			wantCreationTime:   expiredEntry.CreationTime(),
+			wantData:           expiredEntry.data,
+			wantErr:            false,
+		},
+		"Non-existing entry shall trigger a call to central": {
+			entries:            make(map[string]*entry),
+			key:                "en2",
+			wantCentralCall:    true,
+			centralReachable:   true,
+			centralReplyStatus: 200,
+			wantCreationTime:   en1.CreationTime(),
+			wantData:           en1.data,
+			wantErr:            false,
+		},
+		"Call to central in offline mode shall not be attempted and yield an error": {
+			entries:          make(map[string]*entry),
+			key:              "en2",
+			wantCentralCall:  false,
+			centralReachable: false,
+			wantErr:          true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			cli := newMockHTTPClient(tt.centralReplyStatus, tt.centralReplyError, io.NopCloser(bytes.NewBufferString(tt.centralReplyBody)))
+			c := New(context.Background(), cli, "/")
+			c.clock = &mockClock{}
+			c.entries = tt.entries
+			c.centralReady.Store(tt.centralReachable)
+
+			got, err := c.getOrAddEntry(tt.key)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantData, got.data)
+				assert.Equal(t, tt.wantCreationTime, got.CreationTime())
+				if tt.wantCentralCall {
+					// Wait until `Populate` method finishes
+					err, ok := got.DoneSig().WaitWithTimeout(time.Second)
+					assert.True(t, ok)
+					assert.NoError(t, err)
+				}
+			}
+			assert.Equal(t, tt.wantCentralCall, cli.HasBeenCalled())
+		})
+	}
+}
+
+func newMockHTTPClient(code int, err error, body io.ReadCloser) *mockClient {
+	return &mockClient{
+		err:  err,
+		code: code,
+		body: body,
+	}
+}
+
+type mockClient struct {
+	err           error
+	code          int
+	body          io.ReadCloser
+	hasBeenCalled bool
+}
+
+func (m *mockClient) HasBeenCalled() bool {
+	return m.hasBeenCalled
+}
+
+func (m *mockClient) Do(_ *http.Request) (*http.Response, error) {
+	m.hasBeenCalled = true
+	if m.err != nil {
+		return &http.Response{
+			StatusCode: m.code,
+			Header:     nil,
+			Body:       m.body,
+		}, m.err
+	}
+	return &http.Response{
+		StatusCode: m.code,
+		Header:     nil,
+		Body:       m.body,
+	}, nil
+}

--- a/pkg/kocache/kocache_test.go
+++ b/pkg/kocache/kocache_test.go
@@ -75,19 +75,10 @@ func Test_applyDefaults(t *testing.T) {
 }
 
 func Test_koCache_GoOffline(t *testing.T) {
-	tests := map[string]struct {
-		startOnline bool
-	}{
-		"Starting online":  {startOnline: true},
-		"Starting offline": {startOnline: false},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
+	for _, startOnline := range []bool{true, false} {
+		t.Run(fmt.Sprintf("Start online: %t", startOnline), func(t *testing.T) {
 			fn := func(o *options) {
-				if tt.startOnline {
-					o.StartOnline = true
-				}
+				o.StartOnline = startOnline
 			}
 			ctx, cancel := context.WithCancelCause(context.Background())
 			defer cancel(errors.New("test ended"))

--- a/pkg/kocache/kocache_test.go
+++ b/pkg/kocache/kocache_test.go
@@ -3,6 +3,7 @@ package kocache
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -98,19 +99,10 @@ func Test_koCache_GoOffline(t *testing.T) {
 }
 
 func Test_koCache_GoOnline(t *testing.T) {
-	tests := map[string]struct {
-		startOnline bool
-	}{
-		"Starting online":  {startOnline: true},
-		"Starting offline": {startOnline: false},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
+	for _, startOnline := range []bool{true, false} {
+		t.Run(fmt.Sprintf("Start online: %t", startOnline), func(t *testing.T) {
 			fn := func(o *options) {
-				if tt.startOnline {
-					o.StartOnline = true
-				}
+				o.StartOnline = startOnline
 			}
 			ctx, cancel := context.WithCancelCause(context.Background())
 			defer cancel(errors.New("test ended"))

--- a/pkg/kocache/offlinectrl.go
+++ b/pkg/kocache/offlinectrl.go
@@ -40,6 +40,8 @@ func (o *offlineCtrl) IsOnline() bool {
 }
 
 func (o *offlineCtrl) Context() context.Context {
+	o.ctxMutex.Lock()
+	defer o.ctxMutex.Unlock()
 	return o.onlineCtx
 }
 

--- a/pkg/kocache/offlinectrl.go
+++ b/pkg/kocache/offlinectrl.go
@@ -1,0 +1,54 @@
+package kocache
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var errCentralUnreachable = errors.New("central is currently unreachable")
+
+// offlineCtrl exists to ensure consistency between variables being related to offline state
+type offlineCtrl struct {
+	parentCtx context.Context
+	// onlineCtx will be canceled when connectivity to central is lost
+	onlineCtx       context.Context
+	onlineCtxCancel context.CancelCauseFunc
+	ctxMutex        *sync.Mutex
+}
+
+func newOfflineCtrl(parentCtx context.Context, startOnline bool) *offlineCtrl {
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	onlineCtx, onlineCtxCancel := context.WithCancelCause(parentCtx)
+	oc := &offlineCtrl{
+		parentCtx:       parentCtx,
+		onlineCtx:       onlineCtx,
+		onlineCtxCancel: onlineCtxCancel,
+		ctxMutex:        &sync.Mutex{},
+	}
+	if !startOnline {
+		oc.GoOffline()
+	}
+	return oc
+}
+
+func (o *offlineCtrl) IsOnline() bool {
+	return o.onlineCtx.Err() == nil
+}
+
+func (o *offlineCtrl) Context() context.Context {
+	return o.onlineCtx
+}
+
+func (o *offlineCtrl) GoOnline() {
+	o.ctxMutex.Lock()
+	defer o.ctxMutex.Unlock()
+	o.onlineCtx, o.onlineCtxCancel = context.WithCancelCause(o.parentCtx)
+}
+
+func (o *offlineCtrl) GoOffline() {
+	o.onlineCtxCancel(errCentralUnreachable)
+}

--- a/pkg/kocache/offlinectrl_test.go
+++ b/pkg/kocache/offlinectrl_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Test_DataRace is intended for the race tests
 func Test_DataRace(_ *testing.T) {
 	o := newOfflineCtrl(context.Background(), false)
 

--- a/pkg/kocache/offlinectrl_test.go
+++ b/pkg/kocache/offlinectrl_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_DataRace(t *testing.T) {
+// Test_DataRace is intended for the race tests
+func Test_DataRace(_ *testing.T) {
 	o := newOfflineCtrl(context.Background(), false)
 
 	// Go Online periodically

--- a/pkg/kocache/offlinectrl_test.go
+++ b/pkg/kocache/offlinectrl_test.go
@@ -1,0 +1,94 @@
+package kocache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_offlineCtrl(t *testing.T) {
+	tests := map[string]struct {
+		parentCtx          context.Context
+		startOnline        bool
+		transition         func(o *offlineCtrl)
+		wantOnline         bool
+		wantCtxCancelCause error
+	}{
+		"Starting with parent ctx as nil should take background ctx as parent": {
+			parentCtx:          nil,
+			startOnline:        true,
+			transition:         func(o *offlineCtrl) {},
+			wantOnline:         true,
+			wantCtxCancelCause: nil,
+		},
+		"Starting online should report being online": {
+			parentCtx:          context.Background(),
+			startOnline:        true,
+			transition:         func(o *offlineCtrl) {},
+			wantOnline:         true,
+			wantCtxCancelCause: nil,
+		},
+		"Starting offline should report being offline": {
+			parentCtx:          context.Background(),
+			startOnline:        false,
+			transition:         func(o *offlineCtrl) {},
+			wantOnline:         false,
+			wantCtxCancelCause: errCentralUnreachable,
+		},
+		"Starting online and transitioning to online should report being online": {
+			parentCtx:   context.Background(),
+			startOnline: true,
+			transition: func(o *offlineCtrl) {
+				o.GoOnline()
+			},
+			wantOnline:         true,
+			wantCtxCancelCause: nil,
+		},
+		"Starting online and transitioning to offline should report being offline": {
+			parentCtx:   context.Background(),
+			startOnline: true,
+			transition: func(o *offlineCtrl) {
+				o.GoOffline()
+			},
+			wantOnline:         false,
+			wantCtxCancelCause: errCentralUnreachable,
+		},
+		"Starting offline and transitioning to online should report being online": {
+			parentCtx:   context.Background(),
+			startOnline: false,
+			transition: func(o *offlineCtrl) {
+				o.GoOnline()
+			},
+			wantOnline:         true,
+			wantCtxCancelCause: nil,
+		},
+		"Starting offline and transitioning to offline should report being offline": {
+			parentCtx:   context.Background(),
+			startOnline: false,
+			transition: func(o *offlineCtrl) {
+				o.GoOffline()
+			},
+			wantOnline:         false,
+			wantCtxCancelCause: errCentralUnreachable,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			o := newOfflineCtrl(tt.parentCtx, tt.startOnline)
+			if tt.transition != nil {
+				tt.transition(o)
+			}
+			switch tt.wantOnline {
+			case true:
+				assert.True(t, o.IsOnline())
+				assert.NoError(t, o.Context().Err())
+			case false:
+				assert.False(t, o.IsOnline())
+				assert.Error(t, o.Context().Err())
+				assert.ErrorIs(t, o.Context().Err(), context.Canceled)
+				assert.ErrorIs(t, context.Cause(o.Context()), tt.wantCtxCancelCause)
+			}
+		})
+	}
+}

--- a/pkg/kocache/source.go
+++ b/pkg/kocache/source.go
@@ -54,7 +54,7 @@ func (c *koCache) LoadProbe(ctx context.Context, filePath string) (io.ReadCloser
 
 	data, size, err := e.Contents()
 	if err != nil {
-		if errors.Is(err, errNotFound) {
+		if errors.Is(err, errProbeNotFound) {
 			log.Errorf("probe %s does not exist in upstream %s", filePath, c.upstreamBaseURL)
 			err = nil
 		}

--- a/pkg/kocache/source.go
+++ b/pkg/kocache/source.go
@@ -38,7 +38,6 @@ func (c *koCache) LoadProbe(ctx context.Context, filePath string) (io.ReadCloser
 
 	e, err := c.getOrAddEntry(filePath)
 	if err != nil || e == nil {
-		log.Error(err)
 		return nil, 0, err
 	}
 	releaseRef := true

--- a/pkg/kocache/source.go
+++ b/pkg/kocache/source.go
@@ -36,27 +36,26 @@ func (c *koCache) LoadProbe(ctx context.Context, filePath string) (io.ReadCloser
 		return nil, 0, nil
 	}
 
-	entry := c.GetOrAddEntry(filePath)
-	if entry == nil {
-		msg := "kernel object cache is shutting down"
-		log.Error(msg)
-		return nil, 0, errors.New(msg)
+	e, err := c.getOrAddEntry(filePath)
+	if err != nil || e == nil {
+		log.Error(err)
+		return nil, 0, err
 	}
 	releaseRef := true
 	defer func() {
 		if releaseRef {
-			entry.ReleaseRef()
+			e.ReleaseRef()
 		}
 	}()
 
-	if !concurrency.WaitInContext(entry.DoneSig(), ctx) {
+	if !concurrency.WaitInContext(e.DoneSig(), ctx) {
 		log.Errorf("context error waiting for download of %s from upstream: %v", filePath, ctx.Err())
 		return nil, 0, errors.Wrap(ctx.Err(), "context error waiting for download from upstream")
 	}
 
-	data, size, err := entry.Contents()
+	data, size, err := e.Contents()
 	if err != nil {
-		if err == errNotFound {
+		if errors.Is(err, errNotFound) {
 			log.Errorf("probe %s does not exist in upstream %s", filePath, c.upstreamBaseURL)
 			err = nil
 		}
@@ -64,12 +63,12 @@ func (c *koCache) LoadProbe(ctx context.Context, filePath string) (io.ReadCloser
 	}
 
 	log.Infof("loading probe %s from upstream %s", filePath, c.upstreamBaseURL)
-	// We need to make sure that `entry` does not get destroyed before reading from the reader is complete, so shift
+	// We need to make sure that `e` does not get destroyed before reading from the reader is complete, so shift
 	// the responsibility to release the reference to the `Close()` method of the returned reader.
 	dataReader := io.NewSectionReader(data, 0, size)
 
 	dataReaderWithCloser := ioutils.ReaderWithCloser(dataReader, func() error {
-		entry.ReleaseRef()
+		e.ReleaseRef()
 		return nil
 	})
 	releaseRef = false // prevent releasing reference upon return

--- a/pkg/probeupload/server_handler.go
+++ b/pkg/probeupload/server_handler.go
@@ -120,16 +120,15 @@ func (h *probeServerHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
+		if !h.centralReady.IsDone() {
+			log.Error("sensor is running in offline mode")
+			http.Error(w, "sensor running in offline mode", http.StatusServiceUnavailable)
+			return
+		}
 		http.Error(w, firstErr.Error(), http.StatusInternalServerError)
 		return
 	}
 	defer utils.IgnoreError(data.Close)
-
-	if !h.centralReady.IsDone() {
-		log.Error("sensor is running in offline mode")
-		http.Error(w, "sensor running in offline mode", http.StatusServiceUnavailable)
-		return
-	}
 
 	hdr := w.Header()
 	if size >= 0 { // size < 0 means unknown

--- a/sensor/common/sensor/notifiable.go
+++ b/sensor/common/sensor/notifiable.go
@@ -2,15 +2,15 @@ package sensor
 
 import "github.com/stackrox/rox/sensor/common"
 
-// OfflineAware is meant to replace common.Notifiable for non-components, so that a pkg unrelated to Sensor
+// offlineAware is meant to replace common.Notifiable for non-components, so that a pkg unrelated to Sensor
 // is not forced to import sensor code.
-type OfflineAware interface {
+type offlineAware interface {
 	GoOnline()
 	GoOffline()
 }
 
-// WrapNotifiable makes OfflineAware struct implement the Notifiable interface
-func WrapNotifiable(oa OfflineAware, name string) common.Notifiable {
+// wrapNotifiable makes offlineAware struct implement the Notifiable interface
+func wrapNotifiable(oa offlineAware, name string) common.Notifiable {
 	return &notifiableImpl{
 		name: name,
 		oa:   oa,
@@ -19,7 +19,7 @@ func WrapNotifiable(oa OfflineAware, name string) common.Notifiable {
 
 type notifiableImpl struct {
 	name string
-	oa   OfflineAware
+	oa   offlineAware
 }
 
 func (ni *notifiableImpl) Notify(e common.SensorComponentEvent) {

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -126,7 +126,7 @@ func (s *Sensor) startProfilingServer() *http.Server {
 // offlineAwareProbeSource is an interface that abstracts the functionality of loading a kernel probe.
 type offlineAwareProbeSource interface {
 	probeupload.ProbeSource
-	OfflineAware
+	offlineAware
 }
 
 func createKOCacheSource(centralEndpoint string) (offlineAwareProbeSource, error) {
@@ -185,8 +185,8 @@ func (s *Sensor) Start() {
 			Compression:   false, // kernel objects are compressed
 		}
 		customRoutes = append(customRoutes, koCacheRoute)
-		s.AddNotifiable(WrapNotifiable(probeDownloadHandler, "Kernel probe server handler"))
-		s.AddNotifiable(WrapNotifiable(koCacheSource, "Kernel object cache"))
+		s.AddNotifiable(wrapNotifiable(probeDownloadHandler, "Kernel probe server handler"))
+		s.AddNotifiable(wrapNotifiable(koCacheSource, "Kernel object cache"))
 	}
 
 	// Enable endpoint to retrieve vulnerability definitions if local image scanning is enabled.


### PR DESCRIPTION
## Description

The KoCache object is an active cache. On cache miss, it contacts Central and attempts to download kernel object (ko).
In this PR we make it offline-aware. It means that it still does what it was designed to, but produces more informative error logs when Sensor runs in offline mode (see example below).

Additionally, I refactored the affected code:
- Extract reusable errors into vars and slightly rephrase some error messages
- Remove collisions between var names and pkg names (`entry`)
- Restructured `Options` object, so that defaults are always used by default
- Made internal things unexported

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

### N/A
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

- [x] CI
- [x] Manual tests on the cluster - the same scenario as in [this Slack message](https://redhat-internal.slack.com/archives/C05696DAMF0/p1691587492779519)


```
// Central goes offline
sensor-8645b495f7-75kxj common/sensor: 2023/08/10 11:31:07.775734 central_communication_impl.go:181: Info: Communication with central ended.
(...)
sensor-8645b495f7-75kxj common/sensor: 2023/08/10 11:31:07.776172 notifiable.go:26: Info: Component 'Kernel probe server handler' runs now in Offline mode
sensor-8645b495f7-75kxj common/sensor: 2023/08/10 11:31:07.776183 notifiable.go:26: Info: Component 'Kernel object cache' runs now in Offline mode
sensor-8645b495f7-75kxj common/sensor: 2023/08/10 11:31:07.776206 sensor.go:399: Info: Central communication stopped: communication stopped. Retrying after 31s...
(...)
sensor-8645b495f7-75kxj pkg/probeupload: 2023/08/10 11:31:28.179360 server_handler.go:111: Error: error loading probe 2.5.0/collector-ebpf-5.14.0-284.23.1.el9_2.x86_64.o.gz: central is currently unreachable
sensor-8645b495f7-75kxj pkg/probeupload: 2023/08/10 11:31:33.181124 server_handler.go:111: Error: error loading probe 2.5.0/collector-ebpf-5.14.0-284.23.1.el9_2.x86_64.o.gz: central is currently unreachable
// This message repeats every 3 seconds while Central is offline, because Collector checks every 3s
(...)
// Central goes online
sensor-8645b495f7-75kxj common/sensor: 2023/08/10 11:33:47.563782 notifiable.go:26: Info: Component 'Kernel probe server handler' runs now in Online mode
sensor-8645b495f7-75kxj common/sensor: 2023/08/10 11:33:47.563801 notifiable.go:26: Info: Component 'Kernel object cache' runs now in Online mode
(...)
sensor-8645b495f7-75kxj common/sensor: 2023/08/10 11:33:48.011272 central_communication_impl.go:176: Info: Communication with central started.
(...)
sensor-8645b495f7-75kxj pkg/kocache: 2023/08/10 11:33:49.072054 source.go:65: Info: loading probe 2.5.0/collector-ebpf-5.14.0-284.23.1.el9_2.x86_64.o.gz from upstream /kernel-objects
```
