### PR TITLE
ROX-9134: add cache for compliance aggregations

### DIFF
--- a/central/compliance/datastore/datastore_impl.go
+++ b/central/compliance/datastore/datastore_impl.go
@@ -174,11 +174,6 @@ func (ds *datastoreImpl) StoreComplianceDomain(ctx context.Context, domain *stor
 }
 
 func (ds *datastoreImpl) PerformStoredAggregation(ctx context.Context, args *StoredAggregationArgs) ([]*storage.ComplianceAggregation_Result, []*storage.ComplianceAggregation_Source, map[*storage.ComplianceAggregation_Result]*storage.ComplianceDomain, error) {
-	// TODO(ROX-9134): consider storing compliance results for Unrestricted scope
-	if true {
-		return args.AggregationFunc()
-	}
-
 	// Check for a pre-computed aggregation for this query
 	results, sources, domainMap, err := ds.storage.GetAggregationResult(ctx, args.QueryString, args.GroupBy, args.Unit)
 	if err != nil {

--- a/central/compliance/datastore/internal/store/postgres/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/store_test.go
@@ -1,0 +1,112 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/mocks"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestAggregationCache(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	db := mocks.NewMockDB(mockCtrl)
+	store := NewStore(db)
+
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Compliance)))
+	singleClusterCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Compliance),
+			sac.ClusterScopeKeys("validClusterID")))
+
+	t.Run("empty cache returns no data", func(t *testing.T) {
+		result, sources, domainMap, err := store.GetAggregationResult(
+			ctx,
+			"query",
+			[]storage.ComplianceAggregation_Scope{storage.ComplianceAggregation_CLUSTER},
+			storage.ComplianceAggregation_STANDARD,
+		)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+		assert.Nil(t, sources)
+		assert.Nil(t, domainMap)
+	})
+
+	t.Run("panic when no SAC in context", func(t *testing.T) {
+		assert.Panics(t, func() {
+			_ = store.StoreAggregationResult(context.Background(),
+				"query",
+				nil,
+				storage.ComplianceAggregation_STANDARD,
+				nil,
+				nil,
+				nil,
+			)
+		})
+	})
+
+	t.Run("store data", func(t *testing.T) {
+		err := store.StoreAggregationResult(
+			ctx,
+			"query",
+			[]storage.ComplianceAggregation_Scope{storage.ComplianceAggregation_NODE, storage.ComplianceAggregation_CLUSTER},
+			storage.ComplianceAggregation_STANDARD,
+			[]*storage.ComplianceAggregation_Result{},
+			[]*storage.ComplianceAggregation_Source{},
+			map[*storage.ComplianceAggregation_Result]*storage.ComplianceDomain{},
+		)
+		assert.NoError(t, err)
+	})
+
+	t.Run("read stored data", func(t *testing.T) {
+		result, sources, domainMap, err := store.GetAggregationResult(
+			ctx,
+			"query",
+			[]storage.ComplianceAggregation_Scope{storage.ComplianceAggregation_CLUSTER, storage.ComplianceAggregation_NODE},
+			storage.ComplianceAggregation_STANDARD,
+		)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.NotNil(t, sources)
+		assert.NotNil(t, domainMap)
+	})
+
+	t.Run("read stored data with different access returns nils", func(t *testing.T) {
+		result, sources, domainMap, err := store.GetAggregationResult(
+			singleClusterCtx,
+			"query",
+			[]storage.ComplianceAggregation_Scope{storage.ComplianceAggregation_NODE, storage.ComplianceAggregation_CLUSTER},
+			storage.ComplianceAggregation_STANDARD,
+		)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+		assert.Nil(t, sources)
+		assert.Nil(t, domainMap)
+	})
+
+	t.Run("clear cache return no error", func(t *testing.T) {
+		err := store.ClearAggregationResults(context.Background())
+		assert.NoError(t, err)
+	})
+
+	t.Run("cleared cache returns no data", func(t *testing.T) {
+		result, sources, domainMap, err := store.GetAggregationResult(
+			ctx,
+			"query",
+			[]storage.ComplianceAggregation_Scope{storage.ComplianceAggregation_CLUSTER},
+			storage.ComplianceAggregation_STANDARD,
+		)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+		assert.Nil(t, sources)
+		assert.Nil(t, domainMap)
+	})
+}

--- a/central/compliance/datastore/test/datastore_test.go
+++ b/central/compliance/datastore/test/datastore_test.go
@@ -200,23 +200,7 @@ func (s *complianceDataStoreWithSACTestSuite) TestEnforceStoreFailure() {
 	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 }
 
-func (s *complianceDataStoreWithSACTestSuite) TestDoesNotUseStoredAggregationsWithSAC() {
-	noop := func() ([]*storage.ComplianceAggregation_Result, []*storage.ComplianceAggregation_Source, map[*storage.ComplianceAggregation_Result]*storage.ComplianceDomain, error) {
-		return nil, nil, nil, nil
-	}
-	aggArgs := &datastore.StoredAggregationArgs{
-		QueryString:     "query",
-		GroupBy:         nil,
-		Unit:            storage.ComplianceAggregation_CLUSTER,
-		AggregationFunc: noop,
-	}
-	_, _, _, err := s.dataStore.PerformStoredAggregation(context.Background(), aggArgs)
-	s.Require().NoError(err)
-}
-
 func (s *complianceDataStoreWithSACTestSuite) TestUsesStoredAggregationsWithoutSAC() {
-	s.T().Skip("ROX-9134: Re-enable or delete")
-
 	queryString := "query"
 	testUnit := storage.ComplianceAggregation_CLUSTER
 	results := []*storage.ComplianceAggregation_Result{}
@@ -233,6 +217,6 @@ func (s *complianceDataStoreWithSACTestSuite) TestUsesStoredAggregationsWithoutS
 		Unit:            testUnit,
 		AggregationFunc: noop,
 	}
-	_, _, _, err := s.dataStore.PerformStoredAggregation(context.Background(), aggArgs)
+	_, _, _, err := s.dataStore.PerformStoredAggregation(s.hasReadCtx, aggArgs)
 	s.Require().NoError(err)
 }


### PR DESCRIPTION
## Description

This PR is opssit approach to https://github.com/stackrox/stackrox/pull/7353 where we delete caching code.

This PR implements in memory cache for calculated aggregations.
The code for keeping aggregates was not implemented for postgres and not enabled for SAC (see: https://github.com/stackrox/stackrox/pull/301/files#r806715921). 
To support SAC the cache key is built from compacted scope tree and query params.

Clean cache just after scan:

| URL                                                       | code | type | source             | size  |  time  |
|-----------------------------------------------------------|------|------|--------------------|-------|:------:|
| graphql?opname=getAggregatedResultsAcrossEntity_NODE      | 200  | xhr  | main.97af8cf8.js:2 | 506 B | 665 ms |
| graphql?opname=getAggregatedResultsAcrossEntity_NAMESPACE | 200  | xhr  | main.97af8cf8.js:2 | 777 B | 665 ms |
| graphql?opname=getAggregatedResultsByEntity_CLUSTER       | 200  | xhr  | main.97af8cf8.js:2 | 583 B | 662 ms |
| graphql?opname=getAggregatedResultsAcrossEntity_CLUSTER   | 200  | xhr  | main.97af8cf8.js:2 | 592 B | 662 ms |

Reload the page:

| URL                                                       | code | type | source             | size  |  time  |
|-----------------------------------------------------------|------|------|--------------------|-------|:------:|
| graphql?opname=getAggregatedResultsAcrossEntity_NODE      | 200  | xhr  | main.97af8cf8.js:2 | 499 B | 60 ms  |
| graphql?opname=getAggregatedResultsAcrossEntity_NAMESPACE | 200  | xhr  | main.97af8cf8.js:2 | 778 B | 67 ms  |
| graphql?opname=getAggregatedResultsByEntity_CLUSTER       | 200  | xhr  | main.97af8cf8.js:2 | 581 B | 54 ms  |
| graphql?opname=getAggregatedResultsAcrossEntity_CLUSTER   | 200  | xhr  | main.97af8cf8.js:2 | 593 B | 62 ms  |

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
