### PR TITLE
ROX-18991: Add conditional RBAC in main dashboard

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/DashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/DashboardPage.tsx
@@ -20,14 +20,23 @@ const minWidgetWidth = 510;
 function DashboardPage() {
     const { hasReadAccess } = usePermissions();
     const hasReadAccessForAlert = hasReadAccess('Alert');
+    const hasReadAccessForCluster = hasReadAccess('Cluster');
     const hasReadAccessForCompliance = hasReadAccess('Compliance');
     const hasReadAccessForDeployment = hasReadAccess('Deployment');
     const hasReadAccessForImage = hasReadAccess('Image');
+    const hasReadAccessForNamespace = hasReadAccess('Namespace');
+    const hasReadAccessForNode = hasReadAccess('Node');
+    const hasReadAccessForSecret = hasReadAccess('Secret');
 
     return (
         <>
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
-                <SummaryCounts />
+                {hasReadAccessForAlert &&
+                    hasReadAccessForCluster &&
+                    hasReadAccessForDeployment &&
+                    hasReadAccessForImage &&
+                    hasReadAccessForNode &&
+                    hasReadAccessForSecret && <SummaryCounts />}
             </PageSection>
             <Divider component="div" />
             <PageSection variant="light">
@@ -39,12 +48,14 @@ function DashboardPage() {
                         <Title headingLevel="h1">Dashboard</Title>
                         <Text>Review security metrics across all or select resources</Text>
                     </FlexItem>
-                    <FlexItem
-                        grow={{ default: 'grow' }}
-                        className="pf-u-display-flex pf-u-justify-content-flex-end"
-                    >
-                        <ScopeBar />
-                    </FlexItem>
+                    {hasReadAccessForCluster && hasReadAccessForNamespace && (
+                        <FlexItem
+                            grow={{ default: 'grow' }}
+                            className="pf-u-display-flex pf-u-justify-content-flex-end"
+                        >
+                            <ScopeBar />
+                        </FlexItem>
+                    )}
                 </Flex>
             </PageSection>
             <Divider component="div" />


### PR DESCRIPTION
## Description

### Analysis

DashboardPage.tsx renders:

1. `SummaryCounts` element requires READ_ACCESS for all of the following:
    * Alert for count of violations
    * Cluster for count of clusters
    * Deployment for count of deployments
    * Image for count on images
    * Node for count of nodes
    * Secret for count of secrets
2. `ScopeBar` element requires READ_ACCESS for Cluster and Namespace because of `getAllNamespacesByCluster` query

### Solution

1. Conditionally render `SummaryCounts` element.
2. Conditionally render `ScopeBar` element (pending **Residue** item 2).

### Residue

1. Even after the above solution, I still see POST /api/graphql?opname=summary_counts for `clusterCount` on MainPage:

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/MainPage/MainPage.tsx#L56-L62

    Mixing up failures for requests from DashboardPage and MainPage also caused initially incorrect conclusions about resources.

    Investigate whether it is possible to remove need for any resources on `MainPage` by replacing `summary_counts` query:

    * with `useFetchClustersForPermissions` hook

2. Investigate whether it is possible to remove conditional rendering for `ScopeBar` by replacing `getAllNamespacesByCluster` queryto either imitate or reuse improvements that Yann made to cluster and namespace selection for Network Graph. Too bad, so sad, if the style difference becomes a hindrance.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

We might see net decrease after **Residue** item 2.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3759691 - 3759691
        total: 82 = 9936258 - 9936176
    * `ls -al build/static/js/*.js | wc -l`
        0 = 81 - 81 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/dashboard

    * No resources **without** conditional rendering: see explicit evidence of errors for `SummaryCounts` and implicit evidence for `ScopeBar` element.
        ![dashboard_error](https://github.com/stackrox/stackrox/assets/11862657/ebe30759-602a-4837-ac28-bae9890513ef)

    * No resources **with** conditional rendering: see absence of elements.
        ![dashboard_neither](https://github.com/stackrox/stackrox/assets/11862657/dfb4a288-ca2d-44cb-823d-a571c4433ab7)

    * Minimum resources for one element: see `SummaryCounts` element and all widgets except one that requires Compliance resource.
        ![dashboard_SummaryCounts](https://github.com/stackrox/stackrox/assets/11862657/fa3aa5a6-8896-4c2b-b416-753153ef7dc5)

    * Minimum resources for one element: see only `ScopeBar` element.
        ![dashboard_ScopeBar](https://github.com/stackrox/stackrox/assets/11862657/ef4fb42d-796f-4582-99e5-a00d60064abe)

    * Minimum resources for both elements
        ![dashboard_both](https://github.com/stackrox/stackrox/assets/11862657/9cc7f4f6-8932-49ea-84cb-5158d2bf6a4a)

### Unit testing

1. `yarn test` in ui/apps/platform: No tests found related to files changed since last commit
