### PR TITLE
fix(ui): Clarify impact of applied filters on netpol simulator scope

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -50,6 +50,7 @@ import {
     graphModel,
 } from './utils/modelUtils';
 import getSimulation from './utils/getSimulation';
+import { getInScopeEntities } from './utils/simulatorUtils';
 import CIDRFormModal from './components/CIDRFormModal';
 import NetworkPolicySimulatorSidePanel, {
     clearSimulationQuery,
@@ -392,12 +393,10 @@ function NetworkGraphPage() {
                                         simulator={simulator}
                                         setNetworkPolicyModification={setNetworkPolicyModification}
                                         scopeHierarchy={scopeHierarchy}
-                                        networkPolicyGenerationScope={{
-                                            granularity: 'CLUSTER',
-                                            cluster: scopeHierarchy.cluster.name,
-                                            namespaces: [],
-                                            deployments: [],
-                                        }}
+                                        networkPolicyGenerationScope={getInScopeEntities(
+                                            [],
+                                            scopeHierarchy
+                                        )}
                                     />
                                 </DrawerPanelContent>
                             }

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
-import { Button, Modal } from '@patternfly/react-core';
+import { Alert, Button, Modal } from '@patternfly/react-core';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import orderBy from 'lodash/orderBy';
 
 import useTableSort from 'hooks/patternfly/useTableSort';
+import { EntityScope } from '../utils/simulatorUtils';
 
 export type DeploymentScopeModalProps = {
-    deployments: {
-        namespace: string;
-        name: string;
-    }[];
+    entityScope: EntityScope;
     isOpen: boolean;
     onClose: () => void;
 };
@@ -17,11 +15,11 @@ export type DeploymentScopeModalProps = {
 const sortFields = ['name', 'namespace'];
 const defaultSortOption = { field: 'name', direction: 'asc' } as const;
 
-function DeploymentScopeModal({ deployments, isOpen, onClose }: DeploymentScopeModalProps) {
+function DeploymentScopeModal({ entityScope, isOpen, onClose }: DeploymentScopeModalProps) {
     const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
 
     const sortedDeployments = orderBy(
-        deployments,
+        entityScope.deployments,
         sortOption.field,
         sortOption.reversed ? 'desc' : 'asc'
     );
@@ -38,6 +36,13 @@ function DeploymentScopeModal({ deployments, isOpen, onClose }: DeploymentScopeM
                 </Button>,
             ]}
         >
+            {entityScope.hasAppliedDeploymentFilters && (
+                <Alert
+                    isInline
+                    variant="info"
+                    title="The deployment scope for generated policies may be further reduced by filters applied on this page"
+                />
+            )}
             <TableComposable variant="compact">
                 <Thead noWrap>
                     <Tr>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
@@ -1,22 +1,13 @@
 import React from 'react';
-import { Button, Flex } from '@patternfly/react-core';
+import { Button, Flex, Label } from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons';
 import uniq from 'lodash/uniq';
 
 import { ClusterIcon, DeploymentIcon, NamespaceIcon } from '../common/NetworkGraphIcons';
 
 import './NetworkPoliciesGenerationScope.css';
 import DeploymentScopeModal from './DeploymentScopeModal';
-
-export type EntityScope = {
-    // `granularity` refers to the most specific entity type that has been selected by the user.
-    granularity: 'CLUSTER' | 'NAMESPACE' | 'DEPLOYMENT';
-    cluster: string;
-    namespaces: string[];
-    deployments: {
-        namespace: string;
-        name: string;
-    }[];
-};
+import { EntityScope } from '../utils/simulatorUtils';
 
 export type NetworkPoliciesGenerationScopeProps = {
     networkPolicyGenerationScope: EntityScope;
@@ -25,10 +16,9 @@ export type NetworkPoliciesGenerationScopeProps = {
 function NetworkPoliciesGenerationScope({
     networkPolicyGenerationScope,
 }: NetworkPoliciesGenerationScopeProps) {
-    const { granularity, cluster, deployments } = networkPolicyGenerationScope;
-    const [modalDeployments, setModalDeployments] = React.useState<
-        { namespace: string; name: string }[] | null
-    >(null);
+    const { granularity, cluster, deployments, hasAppliedDeploymentFilters } =
+        networkPolicyGenerationScope;
+    const [modalEntityScope, setModalEntityScope] = React.useState<EntityScope | null>(null);
 
     let deploymentElement = <span>All deployments</span>;
     let namespaceElement = <span>All namespaces</span>;
@@ -47,7 +37,7 @@ function NetworkPoliciesGenerationScope({
             <Button
                 variant="link"
                 isInline
-                onClick={() => setModalDeployments(networkPolicyGenerationScope.deployments)}
+                onClick={() => setModalEntityScope(networkPolicyGenerationScope)}
             >
                 {deploymentText}
             </Button>
@@ -56,11 +46,11 @@ function NetworkPoliciesGenerationScope({
 
     return (
         <>
-            {modalDeployments && (
+            {modalEntityScope && (
                 <DeploymentScopeModal
-                    deployments={modalDeployments}
-                    isOpen={modalDeployments !== null}
-                    onClose={() => setModalDeployments(null)}
+                    entityScope={networkPolicyGenerationScope}
+                    isOpen={modalEntityScope !== null}
+                    onClose={() => setModalEntityScope(null)}
                 />
             )}
             <div className="network-policies-generation-scope">
@@ -70,6 +60,11 @@ function NetworkPoliciesGenerationScope({
                 >
                     <DeploymentIcon aria-label="Deployment" />
                     {deploymentElement}
+                    {hasAppliedDeploymentFilters && (
+                        <Label isCompact icon={<FilterIcon />} color="grey">
+                            Filter applied
+                        </Label>
+                    )}
                 </Flex>
 
                 <Flex

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -35,14 +35,14 @@ import {
     SetNetworkPolicyModification,
 } from '../hooks/useNetworkPolicySimulator';
 import NetworkPoliciesYAML from './NetworkPoliciesYAML';
-import { getDisplayYAMLFromNetworkPolicyModification } from '../utils/simulatorUtils';
+import { EntityScope, getDisplayYAMLFromNetworkPolicyModification } from '../utils/simulatorUtils';
 import UploadYAMLButton from './UploadYAMLButton';
 import NetworkSimulatorActions from './NetworkSimulatorActions';
 import NotifyYAMLModal from './NotifyYAMLModal';
 import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import CompareYAMLModal from './CompareYAMLModal';
 import CodeCompareIcon from './CodeCompareIcon';
-import NetworkPoliciesGenerationScope, { EntityScope } from './NetworkPoliciesGenerationScope';
+import NetworkPoliciesGenerationScope from './NetworkPoliciesGenerationScope';
 
 // @TODO: Consider a better approach to managing the side panel related state (simulation + URL path for entities)
 export function clearSimulationQuery(search: string): string {

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
@@ -1,5 +1,4 @@
 import { NetworkPolicyModification } from 'types/networkPolicy.proto';
-import { EntityScope } from '../simulation/NetworkPoliciesGenerationScope';
 import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import { CustomNodeModel } from '../types/topology.type';
 
@@ -46,6 +45,18 @@ function getGranularityFromScopeHierarchy(
     return 'DEPLOYMENT';
 }
 
+export type EntityScope = {
+    // `granularity` refers to the most specific entity type that has been selected by the user.
+    granularity: 'CLUSTER' | 'NAMESPACE' | 'DEPLOYMENT';
+    cluster: string;
+    namespaces: string[];
+    deployments: {
+        namespace: string;
+        name: string;
+    }[];
+    hasAppliedDeploymentFilters: boolean;
+};
+
 /**
  * Given the array of nodeModels returned by the network graph API and the user's
  * current scope hierarchy, return the scope of entities that should be included
@@ -64,11 +75,14 @@ export function getInScopeEntities(
     const namespaceNameSet = new Set(scopeHierarchy.namespaces);
     const deploymentNameSet = new Set(scopeHierarchy.deployments);
 
+    const hasAppliedDeploymentFilters = Object.keys(scopeHierarchy.remainingQuery).length > 0;
+
     const deploymentScope: EntityScope = {
         granularity,
         cluster: scopeHierarchy.cluster.name,
         namespaces: scopeHierarchy.namespaces,
         deployments: [],
+        hasAppliedDeploymentFilters,
     };
 
     nodeModels.forEach((node) => {


### PR DESCRIPTION
## Description

There is an edge case when listing the deployments that will have generated policies in the network policy simulator. If a general filter is applied, we cannot accurately filter the resulting deployments without the addition of a new API.

The workaround for this case is to add a "Filters applied" label next to the scope in the sidebar. Additionally, when the modal is opened, if filters could reduce the scope an alert is shown in the modal as well.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the NG and apply different scopes to the simulator. The "Filters applied" label and alert should not be visible.
![image](https://github.com/stackrox/stackrox/assets/1292638/9faeb599-ad59-4971-beff-37dcec149abf)
![image](https://github.com/stackrox/stackrox/assets/1292638/cb2a794b-ccc2-4ac5-9a3e-5a9d3000cd0c)

Add any general filter - the label will appear in the sidebar and the alert will appear in the modal.
![image](https://github.com/stackrox/stackrox/assets/1292638/39c9993f-98d0-4946-90fc-080507fa2721)
![image](https://github.com/stackrox/stackrox/assets/1292638/78c5a0e8-80ae-4fc7-b452-0936a8f96953)

