### PR TITLE
fix: Apply stackrox-central-diagnostics role in ACSCS

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-03-diagnostics-rbac.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-03-diagnostics-rbac.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: stackrox-central-diagnostics
-  namespace: {{.Release.Namespace}}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "srox.labels" (list . "role" "stackrox-central-diagnostics") | nindent 4 }}
   annotations:
@@ -30,7 +30,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: stackrox-central-diagnostics
-  namespace: {{.Release.Namespace}}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "srox.labels" (list . "rolebinding" "stackrox-central-diagnostics") | nindent 4 }}
   annotations:
@@ -42,4 +42,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: central
-    namespace: {{.Release.Namespace}}
+    namespace: {{ .Release.Namespace }}

--- a/image/templates/helm/stackrox-central/templates/01-central-03-diagnostics-rbac.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-03-diagnostics-rbac.yaml
@@ -1,11 +1,10 @@
 {{- include "srox.init" . -}}
 
-{{- if not ._rox.env.managedServices }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: stackrox-central-diagnostics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{.Release.Namespace}}
   labels:
     {{- include "srox.labels" (list . "role" "stackrox-central-diagnostics") | nindent 4 }}
   annotations:
@@ -31,7 +30,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: stackrox-central-diagnostics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{.Release.Namespace}}
   labels:
     {{- include "srox.labels" (list . "rolebinding" "stackrox-central-diagnostics") | nindent 4 }}
   annotations:
@@ -43,5 +42,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: central
-    namespace: {{ .Release.Namespace }}
-{{- end }}
+    namespace: {{.Release.Namespace}}


### PR DESCRIPTION
## Description

Since ACSCS central diagnostics are re-enabled in https://issues.redhat.com/browse/ROX-12125, we need corresponding role to collect data via k8s API.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. CI
