### PR TITLE
ROX-18992: Add conditional RBAC in Risk

### DIFF
--- a/ui/apps/platform/cypress/integration/risk/Risk.selectors.js
+++ b/ui/apps/platform/cypress/integration/risk/Risk.selectors.js
@@ -52,8 +52,7 @@ export const selectors = {
         searchModifier: '.react-select__multi-value__label:first',
         searchWord: '.react-select__multi-value__label:eq(1)',
     },
-    createPolicyButton:
-        '[data-testid="panel-button-create-policy-from-search"]:contains("Create Policy")',
+    createPolicyButton: 'button:contains("Create olicy")',
     imageLink: 'div:contains("Image Name") + a',
     table: scopeSelectors('[data-testid="panel"]:first', tableSelectors),
     eventTimeline: eventTimelineSelectors,

--- a/ui/apps/platform/cypress/integration/risk/Risk.selectors.js
+++ b/ui/apps/platform/cypress/integration/risk/Risk.selectors.js
@@ -52,7 +52,7 @@ export const selectors = {
         searchModifier: '.react-select__multi-value__label:first',
         searchWord: '.react-select__multi-value__label:eq(1)',
     },
-    createPolicyButton: 'button:contains("Create olicy")',
+    createPolicyButton: 'button:contains("Create policy")',
     imageLink: 'div:contains("Image Name") + a',
     table: scopeSelectors('[data-testid="panel"]:first', tableSelectors),
     eventTimeline: eventTimelineSelectors,

--- a/ui/apps/platform/src/Containers/Risk/CreatePolicyFromSearch.js
+++ b/ui/apps/platform/src/Containers/Risk/CreatePolicyFromSearch.js
@@ -2,10 +2,9 @@ import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { Plus } from 'react-feather';
+import { Button } from '@patternfly/react-core';
 
 import workflowStateContext from 'Containers/workflowStateContext';
-import PanelButton from 'Components/PanelButton';
 import { actions as formMessageActions } from 'reducers/formMessages';
 import { actions as notificationActions } from 'reducers/notifications';
 import { actions as wizardActions } from 'reducers/policies/wizard';
@@ -77,16 +76,14 @@ function CreatePolicyFromSearch({
     const isPolicyBtnDisabled = !policySearchOptions?.length;
 
     return (
-        <PanelButton
-            icon={<Plus className="h-4 w-4" />}
-            className="btn-icon btn-tertiary whitespace-nowrap h-10 ml-4"
+        <Button
+            variant="secondary"
+            className="ml-4"
             onClick={createPolicyFromSearch}
-            disabled={isPolicyBtnDisabled}
-            tooltip="Create Policy from Current Search"
-            dataTestId="panel-button-create-policy-from-search"
+            isDisabled={isPolicyBtnDisabled}
         >
-            Create Policy
-        </PanelButton>
+            Create policy
+        </Button>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Risk/RiskPageHeader.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskPageHeader.js
@@ -8,11 +8,24 @@ import {
     orchestratorComponentsOption,
 } from 'utils/orchestratorComponents';
 import SearchFilterInput from 'Components/SearchFilterInput';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import usePermissions from 'hooks/usePermissions';
 import useURLSearch from 'hooks/useURLSearch';
 import searchOptionsToQuery from 'services/searchOptionsToQuery';
+import { isRouteEnabled, policyManagementBasePath } from 'routePaths';
+
 import CreatePolicyFromSearch from './CreatePolicyFromSearch';
 
 function RiskPageHeader({ isViewFiltered, searchOptions }) {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const { hasReadAccess, hasReadWriteAccess } = usePermissions();
+
+    // Although request requires only WorkflowAdministration,
+    // also require require resources for Policies route.
+    const hasWriteAccessForCreatePolicy =
+        hasReadWriteAccess('WorkflowAdministration') &&
+        isRouteEnabled({ hasReadAccess, isFeatureFlagEnabled }, policyManagementBasePath);
+
     const { searchFilter, setSearchFilter } = useURLSearch();
     const subHeader = isViewFiltered ? 'Filtered view' : 'Default view';
     const autoCompleteCategory = searchCategories[entityTypes.DEPLOYMENT];
@@ -31,7 +44,7 @@ function RiskPageHeader({ isViewFiltered, searchOptions }) {
                 handleChangeSearchFilter={(filter) => setSearchFilter(filter, 'push')}
                 autocompleteQueryPrefix={searchOptionsToQuery(prependAutocompleteQuery)}
             />
-            <CreatePolicyFromSearch />
+            {hasWriteAccessForCreatePolicy && <CreatePolicyFromSearch />}
         </PageHeader>
     );
 }

--- a/ui/apps/platform/src/Containers/Risk/RiskPageHeader.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskPageHeader.js
@@ -20,8 +20,7 @@ function RiskPageHeader({ isViewFiltered, searchOptions }) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
 
-    // Although request requires only WorkflowAdministration,
-    // also require require resources for Policies route.
+    // Require READ_WRITE_ACCESS to create plus READ_ACCESS to other resources for Policies route.
     const hasWriteAccessForCreatePolicy =
         hasReadWriteAccess('WorkflowAdministration') &&
         isRouteEnabled({ hasReadAccess, isFeatureFlagEnabled }, policyManagementBasePath);


### PR DESCRIPTION
## Description

### Analysis

1. **Create policy** requires READ_WRITE_ACCESS for WorkflowAdministration resource.

### Solution

1. Render `CreatePolicyFromSearch` element conditionally
    * READ_WRITE_ACCESS for WorkflowAdministration resource.
    * Resources for Policy Management route. Call `isRouteEnabled` to encapsulate which resources are required. For example, if we can replace /v1/clusters with /v1/sac/clusters endpoint, then Cluster resource will not be required.
2. Replace classic `PanelButton` with PatternFly `Button` element.
3. Replace title case with sentence case.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

It looks like replacement of button might have rearranged bundles to more than balance addition of conditional rendering.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3759688 - 3759688
        total: -756 = 9945509 - 9946265
    * `ls -al build/static/js/*.js | wc -l`
        0 = 81 - 81 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/risk

    * See absence of **Create policy** button with only resources for Risk route.
        Ditto with addition of only READ_WRITE_ACCESS for WorkflowAdmistration (which is necessary, but not sufficient).
        ![risk_without_button](https://github.com/stackrox/stackrox/assets/11862657/544002d5-77b6-4d2a-9e0d-316886f46ba7)

    * See presence of disabled **Create policy** button with routes for Risk and Policy Management routes, plus READ_WRITE_ACCESS for WorkflowAdmistration.
        ![risk_with_button_disabled](https://github.com/stackrox/stackrox/assets/11862657/513f1bbf-8862-42fb-88f3-61a665b6768c)

    * See presence of enabled **Create policy** button for non-empty search filter.
        ![risk_with_button_enabled](https://github.com/stackrox/stackrox/assets/11862657/2fa3ebd2-632a-4be7-a5cc-2ce90b38d719)

### Integration testing

Not applicable, because relevant tests are skipped pending update from classic to PatternFly policies.
