### PR TITLE
chore(cleanup): Audit panic usage and be more lenient

### DIFF
--- a/central/cluster/datastore/datastore_test_constructors.go
+++ b/central/cluster/datastore/datastore_test_constructors.go
@@ -68,10 +68,7 @@ func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) (DataStore, error)
 		return nil, err
 	}
 	k8sRoleStore := roleDataStore.GetTestPostgresDataStore(t, pool)
-	k8sRoleBindingStore, err := roleBindingDataStore.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
+	k8sRoleBindingStore := roleBindingDataStore.GetTestPostgresDataStore(t, pool)
 	networkBaselineManager, err := networkBaselineManager.GetTestPostgresManager(t, pool)
 	if err != nil {
 		return nil, err

--- a/central/detection/buildtime/singleton.go
+++ b/central/detection/buildtime/singleton.go
@@ -42,7 +42,7 @@ func initialize() {
 
 	for _, policy := range policies {
 		if policyUtils.AppliesAtBuildTime(policy) {
-			utils.Must(policySet.UpsertPolicy(policy))
+			utils.Should(policySet.UpsertPolicy(policy))
 		}
 	}
 

--- a/central/graphql/resolvers/search_test.go
+++ b/central/graphql/resolvers/search_test.go
@@ -357,14 +357,12 @@ func TestSubjectAutocompleteSearch(t *testing.T) {
 	defer pgtest.CloseGormDB(t, testGormDB)
 	defer testDB.Teardown(t)
 
-	roleBindingDatastore, err := k8sRoleBindingDataStore.GetTestPostgresDataStore(t, testDB.DB)
-	require.NoError(t, err)
+	roleBindingDatastore := k8sRoleBindingDataStore.GetTestPostgresDataStore(t, testDB.DB)
 
 	ctx := loaders.WithLoaderContext(sac.WithAllAccess(context.Background()))
 	roleBindings := fixtures.GetMultipleK8sRoleBindings(2, 3)
 	for _, roleBinding := range roleBindings {
-		err = roleBindingDatastore.UpsertRoleBinding(ctx, roleBinding)
-		require.NoError(t, err)
+		require.NoError(t, roleBindingDatastore.UpsertRoleBinding(ctx, roleBinding))
 	}
 
 	resolver, _ := SetupTestResolver(t, roleBindingDatastore)

--- a/central/imageintegration/datastore/singleton.go
+++ b/central/imageintegration/datastore/singleton.go
@@ -28,7 +28,7 @@ func initializeIntegrations(storage store.Store) {
 	if !env.OfflineModeEnv.BooleanSetting() && len(iis) == 0 {
 		// Add default integrations
 		for _, ii := range store.DefaultImageIntegrations {
-			utils.Must(storage.Upsert(ctx, ii))
+			utils.Should(storage.Upsert(ctx, ii))
 		}
 	}
 

--- a/central/policy/datastore/singleton.go
+++ b/central/policy/datastore/singleton.go
@@ -76,10 +76,10 @@ func addDefaults(s policyStore.Store, categoriesDS categoriesDS.DataStore) {
 		policyCategories := p.GetCategories()
 		p.Categories = []string{}
 		if err := s.Upsert(workflowAdministrationCtx, p); err != nil {
-			utils.CrashOnError(err)
+			utils.Must(err)
 		}
 		if err := categoriesDS.SetPolicyCategoriesForPolicy(sac.WithAllAccess(context.Background()), p.GetId(), policyCategories); err != nil {
-			utils.CrashOnError(err)
+			utils.Should(err)
 		}
 
 	}

--- a/central/postgres/report_pruning_test.go
+++ b/central/postgres/report_pruning_test.go
@@ -56,8 +56,7 @@ func (s *ReportHistoryPruningSuite) SetupSuite() {
 	s.testDB = pgtest.ForT(s.T())
 	s.ctx = sac.WithAllAccess(context.Background())
 
-	configDS, err := configDatastore.GetTestPostgresDataStore(s.T(), s.testDB)
-	s.Require().NoError(err)
+	configDS := configDatastore.GetTestPostgresDataStore(s.T(), s.testDB)
 	s.configDS = configDS
 	s.historyDS = historyDatastore.GetTestPostgresDataStore(s.T(), s.testDB)
 	s.blobDS = blobDatastore.NewTestDatastore(s.T(), s.testDB)

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -1871,8 +1871,7 @@ func (s *PruningTestSuite) TestRemoveOrphanedRBACObjects() {
 			serviceAccounts, err := serviceAccountDataStore.GetTestPostgresDataStore(t, s.pool)
 			assert.NoError(t, err)
 			k8sRoles := k8sRoleDataStore.GetTestPostgresDataStore(t, s.pool)
-			k8sRoleBindings, err := k8sRoleBindingDataStore.GetTestPostgresDataStore(t, s.pool)
-			assert.NoError(t, err)
+			k8sRoleBindings := k8sRoleBindingDataStore.GetTestPostgresDataStore(t, s.pool)
 
 			for _, sa := range c.serviceAccts {
 				assert.NoError(t, serviceAccounts.UpsertServiceAccount(pruningCtx, sa))

--- a/central/rbac/k8srolebinding/datastore/datastore.go
+++ b/central/rbac/k8srolebinding/datastore/datastore.go
@@ -29,16 +29,15 @@ type DataStore interface {
 }
 
 // New returns a new instance of DataStore using the input store, and searcher.
-func New(k8sRoleBindingStore store.Store, searcher search.Searcher) (DataStore, error) {
-	d := &datastoreImpl{
+func New(k8sRoleBindingStore store.Store, searcher search.Searcher) DataStore {
+	return &datastoreImpl{
 		storage:  k8sRoleBindingStore,
 		searcher: searcher,
 	}
-	return d, nil
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	dbstore := pgStore.New(pool)
 	indexer := pgStore.NewIndexer(pool)
 	searcher := search.New(dbstore, indexer)

--- a/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
@@ -35,11 +35,8 @@ type k8sRoleBindingSACSuite struct {
 }
 
 func (s *k8sRoleBindingSACSuite) SetupSuite() {
-	var err error
-
 	s.testPostgres = pgtest.ForT(s.T())
-	s.datastore, err = GetTestPostgresDataStore(s.T(), s.testPostgres.DB)
-	s.Require().NoError(err)
+	s.datastore = GetTestPostgresDataStore(s.T(), s.testPostgres.DB)
 	s.optionsMap = schema.RoleBindingsSchema.OptionsMap
 
 	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),

--- a/central/rbac/k8srolebinding/datastore/singleton.go
+++ b/central/rbac/k8srolebinding/datastore/singleton.go
@@ -18,11 +18,7 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	var err error
-	ad, err = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
-	if err != nil {
-		log.Panicf("Failed to initialize secrets datastore: %s", err)
-	}
+	ad = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
 }
 
 // Singleton provides the interface for non-service external interaction.

--- a/central/rbac/utils/cluster_permission_evaluator_test.go
+++ b/central/rbac/utils/cluster_permission_evaluator_test.go
@@ -117,8 +117,7 @@ func TestIsClusterAdmin(t *testing.T) {
 
 	pool := pgtest.ForT(t)
 	roleStore := roleDS.GetTestPostgresDataStore(t, pool)
-	bindingStore, err := roleBindingDS.GetTestPostgresDataStore(t, pool)
-	require.NoError(t, err)
+	bindingStore := roleBindingDS.GetTestPostgresDataStore(t, pool)
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -208,8 +207,7 @@ func TestClusterPermissionsForSubject(t *testing.T) {
 
 	pool := pgtest.ForT(t)
 	roleStore := roleDS.GetTestPostgresDataStore(t, pool)
-	bindingStore, err := roleBindingDS.GetTestPostgresDataStore(t, pool)
-	require.NoError(t, err)
+	bindingStore := roleBindingDS.GetTestPostgresDataStore(t, pool)
 
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/rbac/utils/namespace_permission_evaluator_test.go
+++ b/central/rbac/utils/namespace_permission_evaluator_test.go
@@ -170,8 +170,7 @@ func TestNamespacePermissionsForSubject(t *testing.T) {
 
 	pool := pgtest.ForT(t)
 	roleStore := roleDS.GetTestPostgresDataStore(t, pool)
-	bindingStore, err := roleBindingDS.GetTestPostgresDataStore(t, pool)
-	require.NoError(t, err)
+	bindingStore := roleBindingDS.GetTestPostgresDataStore(t, pool)
 	for _, role := range testRoles {
 		require.NoError(t, roleStore.UpsertRole(ctx, role))
 	}
@@ -200,8 +199,7 @@ func BenchmarkGetBindingsAndRoles(b *testing.B) {
 	pool := pgtest.ForT(b)
 
 	roleStore := roleDS.GetTestPostgresDataStore(b, pool)
-	bindingStore, err := roleBindingDS.GetTestPostgresDataStore(b, pool)
-	require.NoError(b, err)
+	bindingStore := roleBindingDS.GetTestPostgresDataStore(b, pool)
 
 	roles := fixtures.GetMultipleK8SRoles(10000)
 	bindings := fixtures.GetMultipleK8sRoleBindingsWithRole(10000, 10, roles)

--- a/central/reports/config/datastore/datastore.go
+++ b/central/reports/config/datastore/datastore.go
@@ -30,16 +30,15 @@ type DataStore interface {
 }
 
 // New returns a new DataStore instance.
-func New(reportConfigStore store.Store, searcher search.Searcher) (DataStore, error) {
-	d := &dataStoreImpl{
+func New(reportConfigStore store.Store, searcher search.Searcher) DataStore {
+	return &dataStoreImpl{
 		reportConfigStore: reportConfigStore,
 		searcher:          searcher,
 	}
-	return d, nil
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
 	store := pgStore.New(pool)
 	indexer := pgStore.NewIndexer(pool)
 	searcher := search.New(store, indexer)

--- a/central/reports/config/datastore/datastore_impl_postgres_test.go
+++ b/central/reports/config/datastore/datastore_impl_postgres_test.go
@@ -31,12 +31,8 @@ type ReportConfigurationPostgresDatastoreTests struct {
 }
 
 func (s *ReportConfigurationPostgresDatastoreTests) SetupSuite() {
-
-	var err error
 	s.testDB = pgtest.ForT(s.T())
-	s.datastore, err = GetTestPostgresDataStore(s.T(), s.testDB.DB)
-	s.NoError(err)
-
+	s.datastore = GetTestPostgresDataStore(s.T(), s.testDB.DB)
 	s.ctx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),

--- a/central/reports/config/datastore/datastore_impl_v2_test.go
+++ b/central/reports/config/datastore/datastore_impl_v2_test.go
@@ -39,10 +39,8 @@ func (s *ReportConfigurationDatastoreV2Tests) SetupSuite() {
 		s.T().SkipNow()
 	}
 
-	var err error
 	s.testDB = pgtest.ForT(s.T())
-	s.datastore, err = GetTestPostgresDataStore(s.T(), s.testDB.DB)
-	s.NoError(err)
+	s.datastore = GetTestPostgresDataStore(s.T(), s.testDB.DB)
 	s.reportSnapshotStore = reportSnapshotDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
 
 	s.ctx = sac.WithGlobalAccessScopeChecker(context.Background(),

--- a/central/reports/config/datastore/singleton.go
+++ b/central/reports/config/datastore/singleton.go
@@ -15,13 +15,8 @@ var (
 // Singleton creates a singleton for the report configuration datastore and loads the plugin client config
 func Singleton() DataStore {
 	once.Do(func() {
-		var err error
 		storage := pgStore.New(globaldb.GetPostgres())
-
-		ds, err = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
-		if err != nil {
-			log.Panicf("Failed to initialize report configurations datastore: %s", err)
-		}
+		ds = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
 	})
 	return ds
 }

--- a/central/reports/snapshot/datastore/datastore_impl_test.go
+++ b/central/reports/snapshot/datastore/datastore_impl_test.go
@@ -37,11 +37,9 @@ func (s *ReportMetadataDatastoreTestSuite) SetupSuite() {
 		s.T().SkipNow()
 	}
 
-	var err error
 	s.testDB = pgtest.ForT(s.T())
 	s.datastore = GetTestPostgresDataStore(s.T(), s.testDB.DB)
-	s.reportConfigStore, err = reportConfigDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
-	s.NoError(err)
+	s.reportConfigStore = reportConfigDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
 
 	s.ctx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(

--- a/central/resourcecollection/service/service_impl_test.go
+++ b/central/resourcecollection/service/service_impl_test.go
@@ -44,10 +44,8 @@ func (suite *CollectionServiceTestSuite) SetupSuite() {
 	suite.queryResolver = datastoreMocks.NewMockQueryResolver(suite.mockCtrl)
 	suite.deploymentDS = deploymentDSMocks.NewMockDataStore(suite.mockCtrl)
 
-	var err error
 	suite.testDB = pgtest.ForT(suite.T())
-	suite.resourceConfigDS, err = reportConfigurationDS.GetTestPostgresDataStore(suite.T(), suite.testDB.DB)
-	suite.NoError(err)
+	suite.resourceConfigDS = reportConfigurationDS.GetTestPostgresDataStore(suite.T(), suite.testDB.DB)
 	suite.collectionService = New(suite.dataStore, suite.queryResolver, suite.deploymentDS, suite.resourceConfigDS)
 
 	testutils.SetExampleVersion(suite.T())


### PR DESCRIPTION
## Description

Be more lenient in some panic scenarios and removed a bit of dead code related to panic-able spots

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI, but we won't hit the failure spots
