### PR TITLE
ROX-18810: Remove ImageScanningTest from the parallel test set

### DIFF
--- a/qa-tests-backend/src/main/groovy/common/Constants.groovy
+++ b/qa-tests-backend/src/main/groovy/common/Constants.groovy
@@ -46,16 +46,6 @@ class Constants {
     // tests fail.
     static final TEST_FEATURE_TIMEOUT_PAD = 360
 
-    // Used for @Tag("Parallel") tests to gate their requirements for scanner
-    // configuration.
-    // A ResourceAccessMode.READ_WRITE @ResourceLock means the test will modify
-    // scanner integrations and other tests that require a READ or READ_WRITE
-    // lock are blocked.
-    // A ResourceAccessMode.READ @ResourceLock means the test relies on the
-    // default scanner configuration (currently Stackrox Scanner). Other READ
-    // tests will run. READ_WRITE tests are blocked.
-    static final String RESOURCE_SCANNER_INTEGRATION = "RESOURCE_SCANNER_INTEGRATION"
-
     /*
         StackRox Product Feature Flags
 

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -8,7 +8,6 @@ import io.stackrox.proto.storage.PolicyOuterClass.PolicySection
 import io.stackrox.proto.storage.PolicyOuterClass.PolicyValue
 import io.stackrox.proto.storage.ScopeOuterClass
 
-import common.Constants
 import objects.Deployment
 import services.CVEService
 import services.ClusterService
@@ -19,16 +18,11 @@ import util.ApplicationHealth
 import util.ChaosMonkey
 import util.Timer
 
-import org.spockframework.runtime.model.parallel.ResourceAccessMode
-import spock.lang.ResourceLock
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Timeout
 import spock.lang.Unroll
 
-// @ResourceLock() - Ensures that no tests that modify scanner integrations run
-// in parallel with this test.
-@ResourceLock(value = Constants.RESOURCE_SCANNER_INTEGRATION, mode = ResourceAccessMode.READ)
 class AdmissionControllerTest extends BaseSpecification {
     @Shared
     private String clusterId

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -31,15 +31,10 @@ import util.Timer
 
 import org.junit.Assume
 import org.junit.AssumptionViolatedException
-import org.spockframework.runtime.model.parallel.ResourceAccessMode
-import spock.lang.ResourceLock
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Unroll
 
-// @ResourceLock() - Block other tests that rely on a default scanner configuration.
-@ResourceLock(value = Constants.RESOURCE_SCANNER_INTEGRATION, mode = ResourceAccessMode.READ_WRITE)
-@Tag("Parallel")
 class ImageScanningTest extends BaseSpecification {
     static final private String TEST_NAMESPACE = "qa-image-scanning-test"
     private final static String CLONED_POLICY_SUFFIX = "(${TEST_NAMESPACE})"

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -11,7 +11,6 @@ import io.stackrox.proto.storage.PolicyOuterClass.Policy
 import io.stackrox.proto.storage.ScopeOuterClass.Scope
 import io.stackrox.proto.storage.Vulnerability
 
-import common.Constants
 import objects.AzureRegistryIntegration
 import objects.ClairScannerIntegration
 import objects.ClairV4ScannerIntegration


### PR DESCRIPTION
## Description

Per title. PR #7289  was a bit premature. Other tests create registry secrets (when they create a per test namespace that duplicates secrets from the `qa` namespace for example). These in turn can create autogenerated registry integrations which can effect ImageScanningTest.

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

CI is sufficient.
