### PR TITLE
fix(test): provide more oomph for compat-test

### DIFF
--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -19,7 +19,7 @@ logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 chart_versions = get_latest_helm_chart_versions("stackrox-secured-cluster-services")
 
-gkecluster = GKECluster("compat-test")
+gkecluster = GKECluster("compat-test", machine_type="e2-standard-8", num_nodes=2)
 
 failing_sensor_versions = []
 for version in chart_versions:


### PR DESCRIPTION
## Description

Switch to e2-standard-8 x 2 for this test (was e2-standard-4 x 3) to avoid unscheduled collectors that have appeared since GKE switched v1.26->1.27.  
- https://search.ci.openshift.org/chart?search=Timed+out+after+10m&maxAge=336h&context=1&type=build-log&name=stackrox.*compat.*&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job
- https://issues.redhat.com/browse/ROX-19023

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

/test gke-version-compatibility-tests