### PR TITLE
fix(test): wait longer for central readiness

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -401,7 +401,7 @@ function launch_central {
     # On some systems there's a race condition when port-forward connects to central but its pod then gets deleted due
     # to ongoing modifications to the central deployment. This port-forward dies and the script hangs "Waiting for
     # Central to respond" until it times out. Waiting for rollout status should help not get into such situation.
-    rollout_wait_timeout="3m"
+    rollout_wait_timeout="4m"
     if [[ "${IS_RACE_BUILD:-}" == "true" ]]; then
       rollout_wait_timeout="9m"
     fi


### PR DESCRIPTION
## Description

Per the failure in https://issues.redhat.com/browse/ROX-19022, deploy.sh may not wait long enough for central rollout readiness. This PR bump the wait a little.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

/test aks-qa-e2e-tests
