### PR TITLE
ROX-18892: Fix Network Baseline timeout in JUnit

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -1,5 +1,7 @@
 import static util.Helpers.evaluateWithRetry
 
+import java.util.concurrent.TimeUnit
+
 import com.google.protobuf.Timestamp
 
 import io.stackrox.proto.storage.NetworkBaselineOuterClass
@@ -10,6 +12,7 @@ import services.NetworkBaselineService
 import util.NetworkGraphUtil
 import util.Timer
 
+import org.junit.Rule
 import spock.lang.Tag
 import spock.lang.Timeout
 
@@ -168,8 +171,12 @@ class NetworkBaselineTest extends BaseSpecification {
         }
     }
 
+    // Overwrite the default timeout, as these tests may take longer than 800 seconds to finish.
+    @Rule
+    @SuppressWarnings(["JUnitPublicProperty"])
+    org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(1600, TimeUnit.SECONDS)
+
     @Tag("NetworkBaseline")
-    @Timeout(1600)
     def "Verify network baseline functionality"() {
         when:
         "Create initial set of deployments, wait for baseline to populate"


### PR DESCRIPTION
## Description

The `@timeout` annotation used was from `Spock` framework which couldn't overwrite the JUnit default test timeout of 800s. In order to allow a test to run longer than 800s we need to overwrite JUnit's global timeout variable:

```groovy
    @Rule
    @SuppressWarnings(["JUnitPublicProperty"])
    org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(1600, TimeUnit.SECONDS)
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- [ ] CI Test