### PR TITLE
ROX-19047: Add more specific error messages to sensor integration test

### DIFF
--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -621,6 +621,24 @@ func (c *TestContext) LastViolationStateWithTimeout(t *testing.T, name string, a
 	}
 }
 
+// NoViolationForDeployment checks that no alerts are raised for deployment name.
+func (c *TestContext) NoViolationForDeployment(t *testing.T, name string, message string) {
+	timer := time.NewTimer(defaultWaitTimeout)
+	ticker := time.NewTicker(defaultTicker)
+	for {
+		select {
+		case <-timer.C:
+			return
+		case <-ticker.C:
+			messages := c.GetFakeCentral().GetAllMessages()
+			alerts := GetAllAlertsForDeploymentName(messages, name)
+			if len(alerts) > 0 {
+				t.Fatalf("alerts found for deployment %s: %s", name, message)
+			}
+		}
+	}
+}
+
 // LastViolationStateByID checks the violation state by deployment ID
 func (c *TestContext) LastViolationStateByID(t *testing.T, id string, assertion AlertAssertFunc, message string, checkEmptyAlertResults bool) {
 	c.LastViolationStateByIDWithTimeout(t, id, assertion, message, checkEmptyAlertResults, defaultWaitTimeout)

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -598,7 +598,7 @@ func (c *TestContext) LastViolationState(t *testing.T, name string, assertion Al
 func (c *TestContext) LastViolationStateWithTimeout(t *testing.T, name string, assertion AlertAssertFunc, message string, timeout time.Duration) {
 	timer := time.NewTimer(timeout)
 	ticker := time.NewTicker(defaultTicker)
-	var lastErr error
+	lastErr := errors.Errorf("no alerts found for deployment %s", name)
 	for {
 		select {
 		case <-timer.C:
@@ -607,6 +607,9 @@ func (c *TestContext) LastViolationStateWithTimeout(t *testing.T, name string, a
 			messages := c.GetFakeCentral().GetAllMessages()
 			alerts := GetAllAlertsForDeploymentName(messages, name)
 			var lastViolationState *central.AlertResults
+			if len(alerts) == 0 {
+				continue
+			}
 			if len(alerts) > 0 {
 				lastViolationState = alerts[len(alerts)-1].GetEvent().GetAlertResults()
 			}

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -621,22 +621,12 @@ func (c *TestContext) LastViolationStateWithTimeout(t *testing.T, name string, a
 	}
 }
 
-// NoViolationForDeployment checks that no alerts are raised for deployment name.
-func (c *TestContext) NoViolationForDeployment(t *testing.T, name string, message string) {
-	timer := time.NewTimer(defaultWaitTimeout)
-	ticker := time.NewTicker(defaultTicker)
-	for {
-		select {
-		case <-timer.C:
-			return
-		case <-ticker.C:
-			messages := c.GetFakeCentral().GetAllMessages()
-			alerts := GetAllAlertsForDeploymentName(messages, name)
-			if len(alerts) > 0 {
-				t.Fatalf("alerts found for deployment %s (%+v): %s", name, alerts, message)
-			}
-		}
-	}
+// NoViolations checks that no alerts are raised for deployment after timer.
+func (c *TestContext) NoViolations(t *testing.T, name string, message string) {
+	<-time.After(defaultWaitTimeout)
+	messages := c.GetFakeCentral().GetAllMessages()
+	alerts := GetAllAlertsForDeploymentName(messages, name)
+	assert.Len(t, alerts, 0, fmt.Sprintf("%s: violations found [%+v]", message, alerts))
 }
 
 // LastViolationStateByID checks the violation state by deployment ID

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -633,7 +633,7 @@ func (c *TestContext) NoViolationForDeployment(t *testing.T, name string, messag
 			messages := c.GetFakeCentral().GetAllMessages()
 			alerts := GetAllAlertsForDeploymentName(messages, name)
 			if len(alerts) > 0 {
-				t.Fatalf("alerts found for deployment %s: %s", name, message)
+				t.Fatalf("alerts found for deployment %s (%+v): %s", name, alerts, message)
 			}
 		}
 	}

--- a/sensor/tests/resource/imagescan/imagescan_test.go
+++ b/sensor/tests/resource/imagescan/imagescan_test.go
@@ -95,13 +95,7 @@ func (s *ImageScanSuite) Test_AlertsUpdatedOnImageUpdate() {
 			}, "myapp should have started the container and have an imageID", 2*time.Minute)
 
 			// There should be no violation yet, because there are no components provided for this image
-			tc.LastViolationState(t, "myapp", func(result *central.AlertResults) error {
-				if checkIfAlertsHaveViolation(result, Policies[0].GetName()) {
-					return errors.New("violation found for deployment")
-				}
-				return nil
-			}, "Should not have violation")
-
+			tc.NoViolationForDeployment(t, "myapp", "violation found for deployment")
 			tc.GetFakeCentral().StubMessage(&central.MsgToSensor{
 				Msg: &central.MsgToSensor_UpdatedImage{
 					UpdatedImage: &storage.Image{

--- a/sensor/tests/resource/imagescan/imagescan_test.go
+++ b/sensor/tests/resource/imagescan/imagescan_test.go
@@ -95,7 +95,7 @@ func (s *ImageScanSuite) Test_AlertsUpdatedOnImageUpdate() {
 			}, "myapp should have started the container and have an imageID", 2*time.Minute)
 
 			// There should be no violation yet, because there are no components provided for this image
-			tc.NoViolationForDeployment(t, "myapp", "violation found for deployment")
+			tc.NoViolations(t, "myapp", "violation found for deployment")
 			tc.GetFakeCentral().StubMessage(&central.MsgToSensor{
 				Msg: &central.MsgToSensor_UpdatedImage{
 					UpdatedImage: &storage.Image{

--- a/sensor/tests/resource/networkpolicy/data/policies.json
+++ b/sensor/tests/resource/networkpolicy/data/policies.json
@@ -1,3 +1,96 @@
-{"policies":[
-  {"id":"38bf79e7-48bf-4ab1-b72f-38e8ad8b4ec3","name":"Deployments should have at least one ingress Network Policy","description":"Alerts if deployments are missing an ingress Network Policy","rationale":"","remediation":"","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-apiserver namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-apiserver","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-scheduler namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-scheduler","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-controller-manager namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-controller-manager","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-sdn namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-sdn","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-network-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-network-operator","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-multus namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-multus","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-cluster-version namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-version","label":null}},"image":null,"expiration":null},{"name":"Don't alert on node-ca DaemonSet in the openshift-image-registry namespace","deployment":{"name":"node-ca","scope":{"cluster":"","namespace":"openshift-image-registry","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-etcd namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-etcd","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-machine-config-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-machine-config-operator","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-monitoring namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-monitoring","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-machine-api namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-machine-api","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-cluster-node-tuning-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-node-tuning-operator","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.578090548Z","SORTName":"Deployments should have at least one ingress Network Policy","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"Alert on missing ingres Network Policy","policyGroups":[{"fieldName":"Has Ingress Network Policy","booleanOperator":"OR","negate":false,"values":[{"value":"false"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-  {"id":"32d770b9-c6ba-4398-b48a-0c3e807644ed","name":"Deployments should have at least one egress Network Policy","description":"Alerts if deployments are missing an egress Network Policy","rationale":"","remediation":"","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-apiserver namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-apiserver","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-scheduler namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-scheduler","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-controller-manager namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-controller-manager","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-sdn namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-sdn","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-network-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-network-operator","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-multus namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-multus","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-cluster-version namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-version","label":null}},"image":null,"expiration":null},{"name":"Don't alert on node-ca DaemonSet in the openshift-image-registry namespace","deployment":{"name":"node-ca","scope":{"cluster":"","namespace":"openshift-image-registry","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-etcd namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-etcd","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-machine-config-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-machine-config-operator","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-monitoring namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-monitoring","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-machine-api namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-machine-api","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-cluster-node-tuning-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-node-tuning-operator","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.578090548Z","SORTName":"Deployments should have at least one ingress Network Policy","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"Alert on missing ingres Network Policy","policyGroups":[{"fieldName":"Has Ingress Network Policy","booleanOperator":"OR","negate":false,"values":[{"value":"false"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true}]}
+{
+  "policies": [
+    {
+      "id": "38bf79e7-48bf-4ab1-b72f-38e8ad8b4ec3",
+      "name": "Deployments should have at least one ingress Network Policy",
+      "description": "Alerts if deployments are missing an ingress Network Policy",
+      "rationale": "",
+      "remediation": "",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.578090548Z",
+      "SORTName": "Deployments should have at least one ingress Network Policy",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "Alert on missing ingres Network Policy",
+          "policyGroups": [
+            {
+              "fieldName": "Has Ingress Network Policy",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "false"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "32d770b9-c6ba-4398-b48a-0c3e807644ed",
+      "name": "Deployments should have at least one egress Network Policy",
+      "description": "Alerts if deployments are missing an egress Network Policy",
+      "rationale": "",
+      "remediation": "",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.578090548Z",
+      "SORTName": "Deployments should have at least one ingress Network Policy",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "Alert on missing egress Network Policy",
+          "policyGroups": [
+            {
+              "fieldName": "Has Egress Network Policy",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "false"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    }
+  ]
+}

--- a/sensor/tests/resource/networkpolicy/networkpolicy_test.go
+++ b/sensor/tests/resource/networkpolicy/networkpolicy_test.go
@@ -100,7 +100,7 @@ func (s *NetworkPolicySuite) Test_Deployment_NetpolViolations() {
 				helper.WithResources(resourcesToApply),
 				helper.WithTestCase(func(t *testing.T, tc *helper.TestContext, objects map[string]k8s.Object) {
 					if len(testCase.violationsExpected) == 0 {
-						tc.NoViolationForDeployment(t, "nginx-deployment", "no violations for deployment")
+						tc.NoViolations(t, "nginx-deployment", "no violations for deployment")
 					} else {
 						tc.LastViolationState(t, "nginx-deployment", checkViolations(testCase.violationsExpected), name)
 					}

--- a/sensor/tests/resource/networkpolicy/networkpolicy_test.go
+++ b/sensor/tests/resource/networkpolicy/networkpolicy_test.go
@@ -1,15 +1,15 @@
 package networkpolicy
 
 import (
+	"context"
 	"log"
 	"testing"
 
-	"github.com/pkg/errors"
-	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/sensor/tests/helper"
 	"github.com/stackrox/rox/sensor/testutils"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 )
 
@@ -56,56 +56,26 @@ var (
 	egressNetpolViolationName  = "Deployments should have at least one egress Network Policy"
 )
 
-func checkViolations(violations []string) func(result *central.AlertResults) error {
-	return func(result *central.AlertResults) error {
-		missing := set.NewStringSet(violations...)
-		for _, alertMessage := range result.GetAlerts() {
-			missing.Remove(alertMessage.GetPolicy().GetName())
-		}
+func (s *NetworkPolicySuite) Test_NetworkPolicyViolations() {
+	s.testContext.RunTest(s.T(),
+		helper.WithTestCase(func(t *testing.T, tc *helper.TestContext, objects map[string]k8s.Object) {
+			ctx := context.Background()
+			k8sDeployment := &appsv1.Deployment{}
+			_, err := tc.ApplyResourceAndWait(ctx, t, helper.DefaultNamespace, &NginxDeployment, k8sDeployment, nil)
+			require.NoError(t, err)
 
-		if len(missing) != 0 {
-			return errors.Errorf("expected violations not found: %v", missing.AsSlice())
-		}
-		return nil
-	}
-}
+			deploymentID := string(k8sDeployment.GetUID())
 
-func (s *NetworkPolicySuite) Test_Deployment_NetpolViolations() {
-	testCases := map[string]struct {
-		netpolsApplied     []helper.K8sResourceInfo
-		violationsExpected []string
-	}{
-		"No policies applied: should have two violations": {
-			netpolsApplied:     []helper.K8sResourceInfo{},
-			violationsExpected: []string{ingressNetpolViolationName, egressNetpolViolationName},
-		},
-		"Both policies applied: should have no violations": {
-			netpolsApplied:     []helper.K8sResourceInfo{IngressPolicyAllow443, EgressPolicyBlockAllEgress},
-			violationsExpected: []string{},
-		},
-		"Ingress applied: egress violation": {
-			netpolsApplied:     []helper.K8sResourceInfo{IngressPolicyAllow443},
-			violationsExpected: []string{egressNetpolViolationName},
-		},
-		"Egress applied: ingress violation": {
-			netpolsApplied:     []helper.K8sResourceInfo{EgressPolicyBlockAllEgress},
-			violationsExpected: []string{ingressNetpolViolationName},
-		},
-	}
+			tc.LastViolationStateByID(t, deploymentID, helper.AssertViolationsMatch(egressNetpolViolationName, ingressNetpolViolationName), "", true)
 
-	for name, testCase := range testCases {
-		s.T().Run(name, func(t *testing.T) {
-			resourcesToApply := append(testCase.netpolsApplied, NginxDeployment)
-			s.testContext.RunTest(t,
-				helper.WithResources(resourcesToApply),
-				helper.WithTestCase(func(t *testing.T, tc *helper.TestContext, objects map[string]k8s.Object) {
-					if len(testCase.violationsExpected) == 0 {
-						tc.NoViolations(t, "nginx-deployment", "no violations for deployment")
-					} else {
-						tc.LastViolationState(t, "nginx-deployment", checkViolations(testCase.violationsExpected), name)
-					}
-				}))
-		})
+			_, err = tc.ApplyResourceAndWaitNoObject(ctx, t, helper.DefaultNamespace, EgressPolicyBlockAllEgress, nil)
+			require.NoError(t, err)
 
-	}
+			tc.LastViolationStateByID(t, deploymentID, helper.AssertViolationsMatch(ingressNetpolViolationName), "", true)
+
+			_, err = tc.ApplyResourceAndWaitNoObject(ctx, t, helper.DefaultNamespace, IngressPolicyAllow443, nil)
+			require.NoError(t, err)
+
+			tc.LastViolationStateByID(t, deploymentID, helper.AssertNoViolations(), "", true)
+		}))
 }

--- a/sensor/tests/resource/networkpolicy/networkpolicy_test.go
+++ b/sensor/tests/resource/networkpolicy/networkpolicy_test.go
@@ -99,7 +99,11 @@ func (s *NetworkPolicySuite) Test_Deployment_NetpolViolations() {
 			s.testContext.RunTest(t,
 				helper.WithResources(resourcesToApply),
 				helper.WithTestCase(func(t *testing.T, tc *helper.TestContext, objects map[string]k8s.Object) {
-					tc.LastViolationState(t, "nginx-deployment", checkViolations(testCase.violationsExpected), name)
+					if len(testCase.violationsExpected) == 0 {
+						tc.NoViolationForDeployment(t, "nginx-deployment", "no violations for deployment")
+					} else {
+						tc.LastViolationState(t, "nginx-deployment", checkViolations(testCase.violationsExpected), name)
+					}
 				}))
 		})
 

--- a/sensor/tests/resource/networkpolicy/yaml/netpol-allow-443.yaml
+++ b/sensor/tests/resource/networkpolicy/yaml/netpol-allow-443.yaml
@@ -11,4 +11,3 @@ spec:
     - port: 443
   policyTypes:
   - Ingress
-

--- a/sensor/tests/resource/networkpolicy/yaml/netpol-allow-443.yaml
+++ b/sensor/tests/resource/networkpolicy/yaml/netpol-allow-443.yaml
@@ -9,3 +9,6 @@ spec:
   ingress:
   - ports:
     - port: 443
+  policyTypes:
+  - Ingress
+

--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -51,15 +51,6 @@ func assertAlertTriggered(alert *storage.Alert) helper.AlertAssertFunc {
 	}
 }
 
-func assertAlertNotTriggered(alert *storage.Alert) helper.AlertAssertFunc {
-	return func(results *central.AlertResults) error {
-		if err := checkAlert(alert, results); err != nil {
-			return nil
-		}
-		return errors.Errorf("alert '%s' should not be triggered", alert.GetPolicy().GetName())
-	}
-}
-
 func checkPortConfig(deployment *storage.Deployment, ports []*storage.PortConfig) error {
 	for _, expectedPort := range ports {
 		foundPortConfig := false
@@ -171,16 +162,7 @@ func (s *DeploymentExposureSuite) Test_ClusterIpPermutation() {
 			),
 			"'PortConfig' for Cluster IP service test not found",
 		)
-		testC.LastViolationState(t, nginxDeploymentName,
-			assertAlertNotTriggered(
-				&storage.Alert{
-					Policy: &storage.Policy{
-						Name: servicePolicyName,
-					},
-					State: storage.ViolationState_ACTIVE,
-				},
-			),
-			fmt.Sprintf("Alert '%s' should not be triggered", servicePolicyName))
+		testC.NoViolations(t, nginxDeploymentName, fmt.Sprintf("Alert '%s' should not be triggered", servicePolicyName))
 		testC.GetFakeCentral().ClearReceivedBuffer()
 	}))
 }
@@ -341,16 +323,7 @@ func (s *DeploymentExposureSuite) Test_NoExposure() {
 				),
 				"PortConfig",
 			)
-			testC.LastViolationState(t, nginxDeploymentName,
-				assertAlertNotTriggered(
-					&storage.Alert{
-						Policy: &storage.Policy{
-							Name: servicePolicyName,
-						},
-						State: storage.ViolationState_ACTIVE,
-					},
-				),
-				fmt.Sprintf("Alert '%s' should not be triggered", servicePolicyName))
+			testC.NoViolations(t, nginxDeploymentName, fmt.Sprintf("Alert '%s' should not be triggered", servicePolicyName))
 			testC.GetFakeCentral().ClearReceivedBuffer()
 		}),
 	)
@@ -443,16 +416,7 @@ func (s *DeploymentExposureSuite) Test_MultipleDeploymentUpdates() {
 			),
 			"'PortConfig' for Multiple Deployment Updates test found",
 		)
-		testC.LastViolationState(t, nginxDeploymentName,
-			assertAlertNotTriggered(
-				&storage.Alert{
-					Policy: &storage.Policy{
-						Name: servicePolicyName,
-					},
-					State: storage.ViolationState_RESOLVED,
-				},
-			),
-			fmt.Sprintf("Alert '%s' should not be triggered", servicePolicyName))
+		testC.NoViolations(t, nginxDeploymentName, fmt.Sprintf("Alert '%s' should not be triggered", servicePolicyName))
 		testC.GetFakeCentral().ClearReceivedBuffer()
 	}))
 }


### PR DESCRIPTION
## Description

Show an error message that no alert results were found if fake central doesn't have alerts for requested deployment. Right now, this integration test will fail with the assertion message, which is misleading. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

- CI
