### PR TITLE
fix(ui): Fix display of scoped deployments for netpol sim

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -50,6 +50,7 @@ import {
     graphModel,
 } from './utils/modelUtils';
 import getSimulation from './utils/getSimulation';
+import { getSearchFilterFromScopeHierarchy } from './utils/simulatorUtils';
 import CIDRFormModal from './components/CIDRFormModal';
 import NetworkPolicySimulatorSidePanel, {
     clearSimulationQuery,
@@ -130,7 +131,10 @@ function NetworkGraphPage() {
     }
 
     const selectedClusterId = clusterFromUrl.id;
-    const { deploymentCount } = useFetchDeploymentCount(selectedClusterId);
+
+    const { deploymentCount } = useFetchDeploymentCount(
+        getSearchFilterFromScopeHierarchy(scopeHierarchy)
+    );
 
     const [prevEpochCount, setPrevEpochCount] = useState(0);
     const [currentEpochCount, setCurrentEpochCount] = useState(0);
@@ -155,6 +159,7 @@ function NetworkGraphPage() {
         const isQueryFilterComplete = isCompleteSearchFilter(remainingQuery);
 
         // only refresh the graph data from the API if both a cluster and at least one namespace are selected
+        // and the selected scope has at least one deployment
         const isClusterNamespaceSelected =
             clusterFromUrl.name && namespacesFromUrl.length > 0 && deploymentCount;
 
@@ -392,12 +397,7 @@ function NetworkGraphPage() {
                                         simulator={simulator}
                                         setNetworkPolicyModification={setNetworkPolicyModification}
                                         scopeHierarchy={scopeHierarchy}
-                                        networkPolicyGenerationScope={{
-                                            granularity: 'CLUSTER',
-                                            cluster: scopeHierarchy.cluster.name,
-                                            namespaces: [],
-                                            deployments: [],
-                                        }}
+                                        scopeDeploymentCount={deploymentCount ?? 0}
                                     />
                                 </DrawerPanelContent>
                             }

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -15,6 +15,7 @@ import {
 } from '@patternfly/react-topology';
 
 import { networkBasePath } from 'routePaths';
+import useFetchDeploymentCount from 'hooks/useFetchDeploymentCount';
 import DeploymentSideBar from './deployment/DeploymentSideBar';
 import NamespaceSideBar from './namespace/NamespaceSideBar';
 import CidrBlockSideBar from './cidr/CidrBlockSideBar';
@@ -34,7 +35,7 @@ import {
 } from './hooks/useNetworkPolicySimulator';
 import { EdgeState } from './components/EdgeStateSelect';
 import { deploymentTabs } from './utils/deploymentUtils';
-import { getInScopeEntities } from './utils/simulatorUtils';
+import { getSearchFilterFromScopeHierarchy } from './utils/simulatorUtils';
 import { NetworkScopeHierarchy } from './types/networkScopeHierarchy';
 
 // TODO: move these type defs to a central location
@@ -107,6 +108,10 @@ const TopologyComponent = ({
         }
     }
 
+    const { deploymentCount } = useFetchDeploymentCount(
+        getSearchFilterFromScopeHierarchy(scopeHierarchy)
+    );
+
     function onNodeSelect(id: string) {
         onNodeClick([id]);
     }
@@ -170,13 +175,10 @@ const TopologyComponent = ({
                 <TopologySideBar resizable onClose={closeSidebar}>
                     {simulation.isOn && simulation.type === 'networkPolicy' && (
                         <NetworkPolicySimulatorSidePanel
-                            networkPolicyGenerationScope={getInScopeEntities(
-                                model.nodes,
-                                scopeHierarchy
-                            )}
                             simulator={simulator}
                             setNetworkPolicyModification={setNetworkPolicyModification}
                             scopeHierarchy={scopeHierarchy}
+                            scopeDeploymentCount={deploymentCount ?? 0}
                         />
                     )}
                     {selectedNode && selectedNode?.data?.type === 'NAMESPACE' && (

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
@@ -7,6 +7,7 @@ import { NetworkPolicyModification } from 'types/networkPolicy.proto';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { Simulation } from '../utils/getSimulation';
+import { getSearchFilterFromScopeHierarchy } from '../utils/simulatorUtils';
 import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 
 export type NetworkPolicySimulator =
@@ -109,11 +110,9 @@ function useNetworkPolicySimulator({
                 networkService
                     .generateNetworkModification(
                         options.scopeHierarchy.cluster.id,
-                        getRequestQueryStringForSearchFilter({
-                            Namespace: options.scopeHierarchy.namespaces,
-                            Deployment: options.scopeHierarchy.deployments,
-                            ...options.scopeHierarchy.remainingQuery,
-                        }),
+                        getRequestQueryStringForSearchFilter(
+                            getSearchFilterFromScopeHierarchy(scopeHierarchy)
+                        ),
                         options.networkDataSince,
                         options.excludePortsAndProtocols
                     )

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
@@ -17,7 +17,6 @@ import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import useTableSort from 'hooks/patternfly/useTableSort';
 import { SearchFilter } from 'types/search';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 const deploymentQuery = gql`
     query getDeploymentsForPolicyGeneration($query: String!, $pagination: Pagination!) {
@@ -112,7 +111,7 @@ function DeploymentScopeModal({
                         icon={ExclamationCircleIcon}
                         iconClassName="pf-u-danger-color-100"
                     >
-                        {getAxiosErrorMessage(error.message)}
+                        {error.message}
                     </EmptyStateTemplate>
                 </Bullseye>
             )}
@@ -134,8 +133,8 @@ function DeploymentScopeModal({
                         </Tr>
                     </Thead>
                     <Tbody>
-                        {deployments.map(({ name, namespace }) => (
-                            <Tr key={`${namespace}/${name}`}>
+                        {deployments.map(({ id, name, namespace }) => (
+                            <Tr key={id}>
                                 <Td dataLabel="Deployment">{name}</Td>
                                 <Td dataLabel="Namespace">{namespace}</Td>
                             </Tr>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
@@ -1,30 +1,77 @@
-import React from 'react';
-import { Button, Modal } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import {
+    Bullseye,
+    Button,
+    Modal,
+    Pagination,
+    Spinner,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
-import orderBy from 'lodash/orderBy';
+import { gql, useQuery } from '@apollo/client';
 
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import useTableSort from 'hooks/patternfly/useTableSort';
+import { SearchFilter } from 'types/search';
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+const deploymentQuery = gql`
+    query getDeploymentsForPolicyGeneration($query: String!, $pagination: Pagination!) {
+        deployments(query: $query, pagination: $pagination) {
+            id
+            name
+            namespace
+        }
+    }
+`;
+
+const sortFields = ['Deployment', 'Namespace'];
+const defaultSortOption = { field: 'Deployment', direction: 'asc' } as const;
 
 export type DeploymentScopeModalProps = {
-    deployments: {
-        namespace: string;
-        name: string;
-    }[];
+    searchFilter: SearchFilter;
+    scopeDeploymentCount: number;
     isOpen: boolean;
     onClose: () => void;
 };
 
-const sortFields = ['name', 'namespace'];
-const defaultSortOption = { field: 'name', direction: 'asc' } as const;
-
-function DeploymentScopeModal({ deployments, isOpen, onClose }: DeploymentScopeModalProps) {
+function DeploymentScopeModal({
+    searchFilter,
+    scopeDeploymentCount,
+    isOpen,
+    onClose,
+}: DeploymentScopeModalProps) {
     const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
+    const [page, setPage] = useState(1);
+    const [perPage, setPerPage] = useState(20);
 
-    const sortedDeployments = orderBy(
-        deployments,
-        sortOption.field,
-        sortOption.reversed ? 'desc' : 'asc'
-    );
+    const options = {
+        skip: !isOpen,
+        variables: {
+            query: getRequestQueryStringForSearchFilter(searchFilter),
+            pagination: {
+                offset: (page - 1) * perPage,
+                limit: perPage,
+                sortOption,
+            },
+        },
+    };
+    const { data, previousData, loading, error } = useQuery<
+        {
+            deployments: {
+                id: string;
+                name: string;
+                namespace: string;
+            }[];
+        },
+        { query: string }
+    >(deploymentQuery, options);
+
+    const deployments = data?.deployments ?? previousData?.deployments ?? [];
 
     return (
         <Modal
@@ -38,26 +85,64 @@ function DeploymentScopeModal({ deployments, isOpen, onClose }: DeploymentScopeM
                 </Button>,
             ]}
         >
-            <TableComposable variant="compact">
-                <Thead noWrap>
-                    <Tr>
-                        <Th width={50} sort={getSortParams('name')}>
-                            Deployment
-                        </Th>
-                        <Th width={50} sort={getSortParams('namespace')}>
-                            Namespace
-                        </Th>
-                    </Tr>
-                </Thead>
-                <Tbody>
-                    {sortedDeployments.map(({ name, namespace }) => (
-                        <Tr key={`${namespace}/${name}`}>
-                            <Td dataLabel="Deployment">{name}</Td>
-                            <Td dataLabel="Namespace">{namespace}</Td>
+            <Toolbar>
+                <ToolbarContent>
+                    <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
+                        <Pagination
+                            isCompact
+                            itemCount={scopeDeploymentCount}
+                            page={page}
+                            perPage={perPage}
+                            onSetPage={(_, newPage) => setPage(newPage)}
+                            onPerPageSelect={(_, newPerPage) => {
+                                if (scopeDeploymentCount < (page - 1) * newPerPage) {
+                                    setPage(1);
+                                }
+                                setPerPage(newPerPage);
+                            }}
+                        />
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
+            {error && (
+                <Bullseye>
+                    <EmptyStateTemplate
+                        title="There was an error loading deployments"
+                        headingLevel="h2"
+                        icon={ExclamationCircleIcon}
+                        iconClassName="pf-u-danger-color-100"
+                    >
+                        {getAxiosErrorMessage(error.message)}
+                    </EmptyStateTemplate>
+                </Bullseye>
+            )}
+            {loading && deployments.length === 0 && (
+                <Bullseye>
+                    <Spinner aria-label="Loading deployments" />
+                </Bullseye>
+            )}
+            {!error && (
+                <TableComposable variant="compact">
+                    <Thead noWrap>
+                        <Tr>
+                            <Th width={50} sort={getSortParams('Deployment')}>
+                                Deployment
+                            </Th>
+                            <Th width={50} sort={getSortParams('Namespace')}>
+                                Namespace
+                            </Th>
                         </Tr>
-                    ))}
-                </Tbody>
-            </TableComposable>
+                    </Thead>
+                    <Tbody>
+                        {deployments.map(({ name, namespace }) => (
+                            <Tr key={`${namespace}/${name}`}>
+                                <Td dataLabel="Deployment">{name}</Td>
+                                <Td dataLabel="Namespace">{namespace}</Td>
+                            </Tr>
+                        ))}
+                    </Tbody>
+                </TableComposable>
+            )}
         </Modal>
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -35,14 +35,17 @@ import {
     SetNetworkPolicyModification,
 } from '../hooks/useNetworkPolicySimulator';
 import NetworkPoliciesYAML from './NetworkPoliciesYAML';
-import { getDisplayYAMLFromNetworkPolicyModification } from '../utils/simulatorUtils';
+import {
+    getDisplayYAMLFromNetworkPolicyModification,
+    getSearchFilterFromScopeHierarchy,
+} from '../utils/simulatorUtils';
 import UploadYAMLButton from './UploadYAMLButton';
 import NetworkSimulatorActions from './NetworkSimulatorActions';
 import NotifyYAMLModal from './NotifyYAMLModal';
 import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import CompareYAMLModal from './CompareYAMLModal';
 import CodeCompareIcon from './CodeCompareIcon';
-import NetworkPoliciesGenerationScope, { EntityScope } from './NetworkPoliciesGenerationScope';
+import NetworkPoliciesGenerationScope from './NetworkPoliciesGenerationScope';
 
 // @TODO: Consider a better approach to managing the side panel related state (simulation + URL path for entities)
 export function clearSimulationQuery(search: string): string {
@@ -57,11 +60,7 @@ export type NetworkPolicySimulatorSidePanelProps = {
     setNetworkPolicyModification: SetNetworkPolicyModification;
     /** scopeHierarchy is the user's selected scope for the network graph */
     scopeHierarchy: NetworkScopeHierarchy;
-    /**
-     *  `networkPolicyGenerationScope` is the set of entities selected by the `scopeHierarchy`
-     *  that can have network policies generated for them
-     */
-    networkPolicyGenerationScope: EntityScope;
+    scopeDeploymentCount: number;
 };
 
 const tabs = {
@@ -73,7 +72,7 @@ function NetworkPolicySimulatorSidePanel({
     simulator,
     setNetworkPolicyModification,
     scopeHierarchy,
-    networkPolicyGenerationScope,
+    scopeDeploymentCount,
 }: NetworkPolicySimulatorSidePanelProps) {
     const { activeKeyTab, onSelectTab } = useTabs({
         defaultTab: tabs.SIMULATE_NETWORK_POLICIES,
@@ -87,11 +86,9 @@ function NetworkPolicySimulatorSidePanel({
     } | null>(null);
 
     const clusterId = scopeHierarchy.cluster.id;
-    const deploymentQuery = getRequestQueryStringForSearchFilter({
-        Namespace: scopeHierarchy.namespaces,
-        Deployment: scopeHierarchy.deployments,
-        ...scopeHierarchy.remainingQuery,
-    });
+    const deploymentQuery = getRequestQueryStringForSearchFilter(
+        getSearchFilterFromScopeHierarchy(scopeHierarchy)
+    );
 
     const fetchNetworkPolicies = useCallback(
         () =>
@@ -197,7 +194,8 @@ function NetworkPolicySimulatorSidePanel({
                         </TextContent>
                     </FlexItem>
                     <NetworkPoliciesGenerationScope
-                        networkPolicyGenerationScope={networkPolicyGenerationScope}
+                        scopeHierarchy={scopeHierarchy}
+                        scopeDeploymentCount={scopeDeploymentCount}
                     />
                 </Flex>
                 <Flex direction={{ default: 'column' }}>
@@ -393,7 +391,8 @@ function NetworkPolicySimulatorSidePanel({
                         </Text>
                     </TextContent>
                     <NetworkPoliciesGenerationScope
-                        networkPolicyGenerationScope={networkPolicyGenerationScope}
+                        scopeHierarchy={scopeHierarchy}
+                        scopeDeploymentCount={scopeDeploymentCount}
                     />
                 </Flex>
             </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
@@ -1,7 +1,6 @@
 import { NetworkPolicyModification } from 'types/networkPolicy.proto';
-import { EntityScope } from '../simulation/NetworkPoliciesGenerationScope';
+import { SearchFilter } from 'types/search';
 import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
-import { CustomNodeModel } from '../types/topology.type';
 
 export function getDisplayYAMLFromNetworkPolicyModification(
     modification: NetworkPolicyModification | null
@@ -31,60 +30,13 @@ export function getDisplayYAMLFromNetworkPolicyModification(
     return displayYaml;
 }
 
-function getGranularityFromScopeHierarchy(
+export function getSearchFilterFromScopeHierarchy(
     scopeHierarchy: NetworkScopeHierarchy
-): EntityScope['granularity'] {
-    if (scopeHierarchy.namespaces.length === 0 && scopeHierarchy.deployments.length === 0) {
-        // Only a cluster is selected
-        return 'CLUSTER';
-    }
-    if (scopeHierarchy.namespaces.length > 0 && scopeHierarchy.deployments.length === 0) {
-        // A cluster and at least one namespace is selected
-        return 'NAMESPACE';
-    }
-    // A cluster, at least one namespace, and at least one deployment is selected
-    return 'DEPLOYMENT';
-}
-
-/**
- * Given the array of nodeModels returned by the network graph API and the user's
- * current scope hierarchy, return the scope of entities that should be included
- * in the network policy simulation.
- */
-export function getInScopeEntities(
-    nodeModels: CustomNodeModel[],
-    scopeHierarchy: NetworkScopeHierarchy
-): EntityScope {
-    const granularity = getGranularityFromScopeHierarchy(scopeHierarchy);
-
-    // Include all deployments from the model that match a selected namespace and
-    // selected deployment name from the scope hierarchy. This prevents the inclusion
-    // of namespaces and deployments that are visible due to active connections between nodes
-    // and not due to the user's selection.
-    const namespaceNameSet = new Set(scopeHierarchy.namespaces);
-    const deploymentNameSet = new Set(scopeHierarchy.deployments);
-
-    const deploymentScope: EntityScope = {
-        granularity,
-        cluster: scopeHierarchy.cluster.name,
-        namespaces: scopeHierarchy.namespaces,
-        deployments: [],
+): SearchFilter {
+    return {
+        Cluster: scopeHierarchy.cluster.name,
+        Namespace: scopeHierarchy.namespaces,
+        Deployment: scopeHierarchy.deployments,
+        ...scopeHierarchy.remainingQuery,
     };
-
-    nodeModels.forEach((node) => {
-        if (node.data.type !== 'DEPLOYMENT') {
-            return;
-        }
-
-        const inSelectedNamespaces = namespaceNameSet.has(node.data.deployment.namespace);
-        const inSelectedDeployments = deploymentNameSet.has(node.data.deployment.name);
-        if (
-            (granularity === 'NAMESPACE' && inSelectedNamespaces) ||
-            (granularity === 'DEPLOYMENT' && inSelectedNamespaces && inSelectedDeployments)
-        ) {
-            deploymentScope.deployments.push(node.data.deployment);
-        }
-    });
-
-    return deploymentScope;
 }


### PR DESCRIPTION
## Description

_In my opinion this is easier to review in "split" view._

This removes the need for https://github.com/stackrox/stackrox/pull/7386 by querying for the exact deployments in the current scope, including any applied general filters.

This does so with the following changes:

- [Update](https://github.com/stackrox/stackrox/pull/7407/files#diff-c7830fe92be548741538cd230301a23caeae064b01e17134a727da9e69535da3) the `fetchDeploymentCount` hook used in the main page component so that it accepts a full `SearchFilter` instead of just a cluster id
- Reuse the `fetchDeploymentCount` hook result from the main page component to display the count of deployments in the simulator sidebar
- [Remove the previous calculation](https://github.com/stackrox/stackrox/pull/7407/files#diff-9bfc163f430b25882ec0afc38a02cc7875162f24b4cd20149eb18c8cd7d66cf4) of the deployment count that used the result returned from the networkgraph specific API
- Fetch a paginated list of deployments using the page's current `SearchFilter` when the sidebar modal is opened

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the NG and select some namespaces:
![image](https://github.com/stackrox/stackrox/assets/1292638/277d7020-52fc-454b-b4b2-fefb8a2759d0)
![image](https://github.com/stackrox/stackrox/assets/1292638/9e674a52-1671-4fed-87af-d3131bfd1cf9)
![image](https://github.com/stackrox/stackrox/assets/1292638/17c1b31c-4cdb-4cd5-92da-92eb6c6bcd8d)

With the same scope in the header, apply a general filter:
![image](https://github.com/stackrox/stackrox/assets/1292638/6b7fdc50-3894-405b-a65e-eb3ec17c8bc1)
![image](https://github.com/stackrox/stackrox/assets/1292638/def8c66f-75ac-48b4-8186-5a6d5abed132)



