### PR TITLE
fix: write UTF-8 BOM to the stream before CSV headers

### DIFF
--- a/pkg/csv/writer.go
+++ b/pkg/csv/writer.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
-
-	"github.com/stackrox/rox/pkg/sliceutils"
 )
 
 // Header represents a CSV's header line.
@@ -88,11 +86,10 @@ func (c *GenericWriter) Write(w http.ResponseWriter, filename string) {
 		})
 	}
 
-	header := sliceutils.ShallowClone(c.header)
-	header[0] = "\uFEFF" + header[0]
+	_, _ = w.Write([]byte("\uFEFF")) // UTF-8 BOM.
 	cw := csv.NewWriter(w)
 	cw.UseCRLF = true
-	_ = cw.Write(header)
+	_ = cw.Write(c.header)
 	for _, v := range c.values {
 		_ = cw.Write(v)
 	}


### PR DESCRIPTION
## Description

Fix UTF-8 BOM write in CSV writer.

When UTF-8 BOM is added to a CSV header, the header may be wrapped in double quotes, with the BOM. The BOM should be put directly to the stream instead.

Bug demonstration: https://play.golang.com/p/8Q34s_jlsD-

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Tested in #7403.