### PR TITLE
ROX-19034: Add conditional RBAC in Violations

### DIFF
--- a/ui/apps/platform/cypress/integration/violations/Violations.selectors.js
+++ b/ui/apps/platform/cypress/integration/violations/Violations.selectors.js
@@ -1,6 +1,6 @@
 export const selectors = {
     actions: {
-        btn: 'td.pf-c-table__action button[aria-label="Actions"]',
+        btn: 'td .pf-c-dropdown button[aria-label="Actions"]', // via ActionsColumn element
         excludeDeploymentBtn: 'button:contains("Exclude deployment")',
         resolveBtn: 'button:contains("Mark as resolved")',
         resolveAndAddToBaselineBtn: 'button:contains("Resolve and add to process baseline")',
@@ -19,13 +19,11 @@ export const selectors = {
         explanationMessage: '[aria-label="Enforcement explanation message"]',
     },
     deployment: {
-        overview: '[aria-label="Deployment details"] [aria-label="Deployment overview"]',
-        containerConfiguration:
-            '[aria-label="Deployment details"] [aria-label="Container configuration"]',
-        securityContext: '[aria-label="Deployment details"] [aria-label="Security context"]',
-        portConfiguration: '[aria-label="Deployment details"] [aria-label="Port configuration"]',
-        networkPolicy:
-            '[aria-label="Deployment details"] [aria-label="Network policies in namespace"]',
-        networkPolicyModal: "[role='dialog']:contains('Network policy details')",
+        overview: `[aria-label="Deployment details"] article:has('h3:contains("Deployment overview")')`,
+        containerConfiguration: `[aria-label="Deployment details"] article:has('h3:contains("Container configuration")')`,
+        securityContext: `[aria-label="Deployment details"] article:has('h3:contains("Security context")')`,
+        portConfiguration: `[aria-label="Deployment details"] article:has('h3:contains("Port configuration")')`,
+        networkPolicy: `[aria-label="Deployment details"] article:has('h3:contains("Network policies")')`,
+        networkPolicyModal: '[role="dialog"]:contains("Network policy details")',
     },
 };

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentDetails.tsx
@@ -1,30 +1,16 @@
-import React, { useEffect, useState } from 'react';
-import {
-    Alert,
-    Button,
-    Flex,
-    FlexItem,
-    Card,
-    CardBody,
-    Title,
-    Divider,
-} from '@patternfly/react-core';
-import { TableComposable, Caption, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import React, { ReactElement } from 'react';
+import { Alert, Card, CardBody, CardTitle, Flex, FlexItem, Title } from '@patternfly/react-core';
 
-import { fetchNetworkPoliciesInNamespace } from 'services/NetworkService';
 import useFetchDeployment from 'hooks/useFetchDeployment';
+import usePermissions from 'hooks/usePermissions';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { NetworkPolicy } from 'types/networkPolicy.proto';
-import { Alert as AlertViolation } from '../../types/violationTypes';
-import DeploymentOverview from './DeploymentOverview';
-import SecurityContext from './SecurityContext';
-import ContainerConfiguration from './ContainerConfiguration';
-import NetworkPolicyModal from './NetworkPolicyModal';
-import PortDescriptionList from './PortDescriptionList';
 
-const compareNetworkPolicies = (a: NetworkPolicy, b: NetworkPolicy): number => {
-    return a.name.localeCompare(b.name);
-};
+import { Alert as AlertViolation } from '../../types/violationTypes'; // TODO
+import ContainerConfiguration from './ContainerConfiguration';
+import DeploymentOverview from './DeploymentOverview';
+import NetworkPoliciesCard from './NetworkPoliciesCard';
+import PortDescriptionList from './PortDescriptionList';
+import SecurityContext from './SecurityContext';
 
 export type DeploymentDetailsProps = {
     alertDeployment: Pick<
@@ -33,21 +19,13 @@ export type DeploymentDetailsProps = {
     >;
 };
 
-const DeploymentDetails = ({ alertDeployment }: DeploymentDetailsProps) => {
-    const [namespacePolicies, setNamespacePolicies] = useState<NetworkPolicy[]>([]);
-    const [selectedNetworkPolicy, setSelectedNetworkPolicy] = useState<NetworkPolicy | null>(null);
+function DeploymentDetails({ alertDeployment }: DeploymentDetailsProps): ReactElement {
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForNetworkPolicy = hasReadAccess('NetworkPolicy');
 
     // attempt to fetch related deployment to selected alert
     const { deployment: relatedDeployment, error: relatedDeploymentFetchError } =
         useFetchDeployment(alertDeployment.id);
-
-    useEffect(() => {
-        fetchNetworkPoliciesInNamespace(alertDeployment.clusterId, alertDeployment.namespace).then(
-            // TODO Infer type from response once NetworkService.js is typed
-            (policies: NetworkPolicy[]) => setNamespacePolicies(policies ?? []),
-            () => setNamespacePolicies([])
-        );
-    }, [alertDeployment.namespace, alertDeployment.clusterId, setNamespacePolicies]);
 
     const relatedDeploymentPorts = relatedDeployment?.ports || [];
 
@@ -69,13 +47,8 @@ const DeploymentDetails = ({ alertDeployment }: DeploymentDetailsProps) => {
             <Flex flex={{ default: 'flex_1' }}>
                 <Flex direction={{ default: 'column' }} flex={{ default: 'flex_1' }}>
                     <FlexItem>
-                        <Title headingLevel="h3" className="pf-u-mb-md">
-                            Overview
-                        </Title>
-                        <Divider component="div" />
-                    </FlexItem>
-                    <FlexItem>
-                        <Card isFlat aria-label="Deployment overview">
+                        <Card isFlat>
+                            <CardTitle component="h3">Deployment overview</CardTitle>
                             <CardBody>
                                 {relatedDeployment && (
                                     <DeploymentOverview deployment={relatedDeployment} />
@@ -84,13 +57,8 @@ const DeploymentDetails = ({ alertDeployment }: DeploymentDetailsProps) => {
                         </Card>
                     </FlexItem>
                     <FlexItem>
-                        <Title headingLevel="h3" className="pf-u-my-md">
-                            Port configuration
-                        </Title>
-                        <Divider component="div" />
-                    </FlexItem>
-                    <FlexItem>
-                        <Card isFlat aria-label="Port configuration">
+                        <Card isFlat>
+                            <CardTitle component="h3">Port configuration</CardTitle>
                             <CardBody>
                                 {relatedDeploymentPorts.length === 0
                                     ? 'None'
@@ -111,79 +79,21 @@ const DeploymentDetails = ({ alertDeployment }: DeploymentDetailsProps) => {
                         </Card>
                     </FlexItem>
                     <FlexItem>
-                        <Title headingLevel="h3" className="pf-u-my-md">
-                            Security context
-                        </Title>
-                        <Divider component="div" />
-                    </FlexItem>
-                    <FlexItem>
                         <SecurityContext deployment={relatedDeployment} />
                     </FlexItem>
-                    <FlexItem>
-                        <Title headingLevel="h3" className="pf-u-my-md">
-                            Network policy
-                        </Title>
-                        <Divider component="div" />
-                    </FlexItem>
-                    <FlexItem>
-                        <Card isFlat aria-label="Network policies in namespace">
-                            <CardBody>
-                                {namespacePolicies.length > 0 ? (
-                                    <TableComposable variant="compact">
-                                        <Caption>
-                                            <Title headingLevel="h3">All network policies</Title>
-                                            in &quot;{alertDeployment.namespace}&quot; namespace
-                                        </Caption>
-                                        <Thead>
-                                            <Tr>
-                                                <Th>Name</Th>
-                                            </Tr>
-                                        </Thead>
-                                        <Tbody>
-                                            {selectedNetworkPolicy && (
-                                                <NetworkPolicyModal
-                                                    networkPolicy={selectedNetworkPolicy}
-                                                    isOpen={selectedNetworkPolicy !== null}
-                                                    onClose={() => setSelectedNetworkPolicy(null)}
-                                                />
-                                            )}
-                                            {namespacePolicies
-                                                .sort(compareNetworkPolicies)
-                                                .map((netpol: NetworkPolicy) => (
-                                                    <Tr key={netpol.id}>
-                                                        <Td dataLabel="Name">
-                                                            <Button
-                                                                variant="link"
-                                                                onClick={() =>
-                                                                    setSelectedNetworkPolicy(netpol)
-                                                                }
-                                                            >
-                                                                {netpol.name}
-                                                            </Button>
-                                                        </Td>
-                                                    </Tr>
-                                                ))}
-                                        </Tbody>
-                                    </TableComposable>
-                                ) : (
-                                    <>
-                                        No network policies found in &quot;
-                                        {alertDeployment.namespace}&quot; namespace
-                                    </>
-                                )}
-                            </CardBody>
-                        </Card>
-                    </FlexItem>
+                    {hasReadAccessForNetworkPolicy && (
+                        <FlexItem>
+                            <NetworkPoliciesCard
+                                clusterId={alertDeployment.clusterId}
+                                namespaceName={alertDeployment.namespace}
+                            />
+                        </FlexItem>
+                    )}
                 </Flex>
                 <Flex direction={{ default: 'column' }} flex={{ default: 'flex_1' }}>
                     <FlexItem>
-                        <Title headingLevel="h3" className="pf-u-mb-md">
-                            Container configuration
-                        </Title>
-                        <Divider component="div" />
-                    </FlexItem>
-                    <FlexItem>
-                        <Card isFlat aria-label="Container configuration">
+                        <Card isFlat>
+                            <CardTitle component="h3">Container configuration</CardTitle>
                             <CardBody>
                                 {Array.isArray(relatedDeployment?.containers) &&
                                 relatedDeployment?.containers.length !== 0
@@ -207,6 +117,6 @@ const DeploymentDetails = ({ alertDeployment }: DeploymentDetailsProps) => {
             </Flex>
         </Flex>
     );
-};
+}
 
 export default DeploymentDetails;

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/NetworkPoliciesCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/NetworkPoliciesCard.tsx
@@ -1,0 +1,68 @@
+import React, { ReactElement, useEffect, useState } from 'react';
+import { Button, Card, CardBody, CardTitle, List, ListItem } from '@patternfly/react-core';
+
+import { fetchNetworkPoliciesInNamespace } from 'services/NetworkService';
+import { NetworkPolicy } from 'types/networkPolicy.proto';
+
+import NetworkPolicyModal from './NetworkPolicyModal';
+
+const compareNetworkPolicies = (a: NetworkPolicy, b: NetworkPolicy): number => {
+    return a.name.localeCompare(b.name);
+};
+
+export type NetworkPoliciesCardProps = {
+    clusterId: string;
+    namespaceName: string;
+};
+
+function NetworkPoliciesCard({ clusterId, namespaceName }: NetworkPoliciesCardProps): ReactElement {
+    const [selectedNetworkPolicy, setSelectedNetworkPolicy] = useState<NetworkPolicy | null>(null);
+    const [namespacePolicies, setNamespacePolicies] = useState<NetworkPolicy[]>([]);
+
+    useEffect(() => {
+        fetchNetworkPoliciesInNamespace(clusterId, namespaceName).then(
+            // TODO Infer type from response once NetworkService.js is typed
+            (policies: NetworkPolicy[]) => setNamespacePolicies(policies ?? []),
+            () => setNamespacePolicies([])
+        );
+    }, [clusterId, namespaceName, setNamespacePolicies]);
+
+    return (
+        <Card isFlat>
+            <CardTitle component="h3">Network policies</CardTitle>
+            <CardBody>
+                <div className="pf-u-mb-md">{`Namespace: ${namespaceName}`}</div>
+                {namespacePolicies.length > 0 ? (
+                    <>
+                        {selectedNetworkPolicy && (
+                            <NetworkPolicyModal
+                                networkPolicy={selectedNetworkPolicy}
+                                isOpen={selectedNetworkPolicy !== null}
+                                onClose={() => setSelectedNetworkPolicy(null)}
+                            />
+                        )}
+                        <List component="ol">
+                            {namespacePolicies
+                                .sort(compareNetworkPolicies)
+                                .map((netpol: NetworkPolicy) => (
+                                    <ListItem>
+                                        <Button
+                                            key={netpol.id}
+                                            variant="link"
+                                            onClick={() => setSelectedNetworkPolicy(netpol)}
+                                        >
+                                            {netpol.name}
+                                        </Button>
+                                    </ListItem>
+                                ))}
+                        </List>
+                    </>
+                ) : (
+                    <>Namespace has no network policies</>
+                )}
+            </CardBody>
+        </Card>
+    );
+}
+
+export default NetworkPoliciesCard;

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/SecurityContext.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/SecurityContext.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Card, CardBody, DescriptionList } from '@patternfly/react-core';
+import { Card, CardBody, CardTitle, DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
 import { Deployment } from 'types/deployment.proto';
@@ -19,7 +19,8 @@ function SecurityContext({ deployment }: SecurityContextProps): ReactElement {
                 )
         ) ?? [];
     return (
-        <Card isFlat aria-label="Security context">
+        <Card isFlat>
+            <CardTitle component="h3">Security context</CardTitle>
             <CardBody>
                 {securityContextContainers?.length > 0
                     ? securityContextContainers.map((container, idx) => {

--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
@@ -31,7 +31,7 @@ function ViolationDetailsPage(): ReactElement {
 
     const hasReadAccessForDeployment = hasReadAccess('Deployment');
 
-    const hasReadAccessForPolicyManagement = isRouteEnabled(
+    const hasReadAccessForPolicy = isRouteEnabled(
         { isFeatureFlagEnabled, hasReadAccess },
         policyManagementBasePath
     );
@@ -114,7 +114,7 @@ function ViolationDetailsPage(): ReactElement {
                             </PageSection>
                         </Tab>
                     )}
-                    {hasReadAccessForPolicyManagement && (
+                    {hasReadAccessForPolicy && (
                         <Tab eventKey={3} title={<TabTitleText>Policy</TabTitleText>}>
                             <PageSection variant="default">
                                 <>

--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
@@ -14,6 +14,10 @@ import {
 import { fetchAlert } from 'services/AlertsService';
 import PolicyDetailContent from 'Containers/Policies/Detail/PolicyDetailContent';
 import { getClientWizardPolicy } from 'Containers/Policies/policies.utils';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import usePermissions from 'hooks/usePermissions';
+import { isRouteEnabled, policyManagementBasePath } from 'routePaths';
+
 import DeploymentDetails from './Deployment/DeploymentDetails';
 import EnforcementDetails from './EnforcementDetails';
 import { Alert } from '../types/violationTypes';
@@ -22,6 +26,16 @@ import ViolationDetails from './ViolationDetails';
 import ViolationsBreadcrumbs from '../ViolationsBreadcrumbs';
 
 function ViolationDetailsPage(): ReactElement {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const { hasReadAccess } = usePermissions();
+
+    const hasReadAccessForDeployment = hasReadAccess('Deployment');
+
+    const hasReadAccessForPolicyManagement = isRouteEnabled(
+        { isFeatureFlagEnabled, hasReadAccess },
+        policyManagementBasePath
+    );
+
     const [activeTabKey, setActiveTabKey] = useState(0);
     const [alert, setAlert] = useState<Alert>();
     const [isFetchingSelectedAlert, setIsFetchingSelectedAlert] = useState(false);
@@ -93,24 +107,26 @@ function ViolationDetailsPage(): ReactElement {
                             </PageSection>
                         </Tab>
                     )}
-                    {deployment && (
+                    {hasReadAccessForDeployment && deployment && (
                         <Tab eventKey={2} title={<TabTitleText>Deployment</TabTitleText>}>
                             <PageSection variant="default">
                                 <DeploymentDetails alertDeployment={deployment} />
                             </PageSection>
                         </Tab>
                     )}
-                    <Tab eventKey={3} title={<TabTitleText>Policy</TabTitleText>}>
-                        <PageSection variant="default">
-                            <>
-                                <Title headingLevel="h3" className="pf-u-mb-md">
-                                    Policy overview
-                                </Title>
-                                <Divider component="div" className="pf-u-pb-md" />
-                                <PolicyDetailContent policy={getClientWizardPolicy(policy)} />
-                            </>
-                        </PageSection>
-                    </Tab>
+                    {hasReadAccessForPolicyManagement && (
+                        <Tab eventKey={3} title={<TabTitleText>Policy</TabTitleText>}>
+                            <PageSection variant="default">
+                                <>
+                                    <Title headingLevel="h3" className="pf-u-mb-md">
+                                        Policy overview
+                                    </Title>
+                                    <Divider component="div" className="pf-u-pb-md" />
+                                    <PolicyDetailContent policy={getClientWizardPolicy(policy)} />
+                                </>
+                            </PageSection>
+                        </Tab>
+                    )}
                 </Tabs>
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -10,17 +10,21 @@ import {
     SelectOption,
     pluralize,
 } from '@patternfly/react-core';
-import { TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { ActionsColumn, TableComposable, Tbody, Thead, Td, Th, Tr } from '@patternfly/react-table';
 
-import useTableSelection from 'hooks/useTableSelection';
-import { resolveAlert } from 'services/AlertsService';
-import { excludeDeployments } from 'services/PoliciesService';
 import { ENFORCEMENT_ACTIONS } from 'constants/enforcementActions';
 import VIOLATION_STATES from 'constants/violationStates';
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';
 import TableCell from 'Components/PatternFly/TableCell';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import usePermissions from 'hooks/usePermissions';
+import useTableSelection from 'hooks/useTableSelection';
 import { GetSortParams } from 'hooks/useURLSort';
+import { resolveAlert } from 'services/AlertsService';
+import { excludeDeployments } from 'services/PoliciesService';
 import { TableColumn } from 'types/table';
+import { isRouteEnabled, policyManagementBasePath } from 'routePaths';
+
 import ResolveConfirmation from './Modals/ResolveConfirmation';
 import ExcludeConfirmation from './Modals/ExcludeConfirmation';
 import { ListAlert } from './types/violationTypes';
@@ -57,6 +61,15 @@ function ViolationsTablePanel({
     getSortParams,
     columns,
 }: ViolationsTablePanelProps): ReactElement {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const { hasReadAccess, hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForAlert = hasReadWriteAccess('Alert');
+    // Require READ_WRITE_ACCESS to exclude plus READ_ACCESS to other resources for Policies route.
+    const hasWriteAccessForExcludeDeploymentsFromPolicy =
+        hasReadWriteAccess('WorkflowAdministration') &&
+        isRouteEnabled({ hasReadAccess, isFeatureFlagEnabled }, policyManagementBasePath);
+    const hasActions = hasWriteAccessForAlert || hasWriteAccessForExcludeDeploymentsFromPolicy;
+
     // Handle confirmation modal being open.
     const [modalType, setModalType] = useState<ModalType>();
 
@@ -140,28 +153,33 @@ function ViolationsTablePanel({
                         {pluralize(violationsCount, 'result')} found
                     </Title>
                 </FlexItem>
-                <FlexItem>
-                    <Select
-                        onToggle={onToggleSelect}
-                        isOpen={isSelectOpen}
-                        placeholderText="Row Actions"
-                        onSelect={closeSelect}
-                        isDisabled={!hasSelections}
-                    >
-                        <SelectOption
-                            key="1"
-                            value={`Mark as resolved (${numResolveable})`}
-                            isDisabled={numResolveable === 0}
-                            onClick={showResolveConfirmationDialog}
-                        />
-                        <SelectOption
-                            key="2"
-                            value={`Exclude deployments from policy (${numScopesToExclude})`}
-                            isDisabled={numScopesToExclude === 0}
-                            onClick={showExcludeConfirmationDialog}
-                        />
-                    </Select>
-                </FlexItem>
+                {hasActions && (
+                    <FlexItem>
+                        <Select
+                            onToggle={onToggleSelect}
+                            isOpen={isSelectOpen}
+                            placeholderText="Row actions"
+                            onSelect={closeSelect}
+                            isDisabled={!hasSelections}
+                        >
+                            <SelectOption
+                                key="1"
+                                value={`Mark as resolved (${numResolveable})`}
+                                isDisabled={!hasWriteAccessForAlert || numResolveable === 0}
+                                onClick={showResolveConfirmationDialog}
+                            />
+                            <SelectOption
+                                key="2"
+                                value={`Exclude deployments from policy (${numScopesToExclude})`}
+                                isDisabled={
+                                    !hasWriteAccessForExcludeDeploymentsFromPolicy ||
+                                    numScopesToExclude === 0
+                                }
+                                onClick={showExcludeConfirmationDialog}
+                            />
+                        </Select>
+                    </FlexItem>
+                )}
                 <FlexItem align={{ default: 'alignRight' }}>
                     <Pagination
                         itemCount={violationsCount}
@@ -193,7 +211,7 @@ function ViolationsTablePanel({
                                     </Th>
                                 );
                             })}
-                            <Td />
+                            {hasActions && <Td />}
                         </Tr>
                     </Thead>
                     <Tbody>
@@ -207,8 +225,13 @@ function ViolationsTablePanel({
                                 enforcementAction ===
                                 ENFORCEMENT_ACTIONS.FAIL_DEPLOYMENT_CREATE_ENFORCEMENT;
 
+                            // Instead of items prop of Td element, render ActionsColumn element
+                            // so every cell has vertical ellipsis (also known as kabob)
+                            // even if its items array is empty. For example:
+                            // hasWriteAccessForAlert but alert is not Runtime lifecycle.
+                            // !hasWriteAccessForWorkflowAdministration
                             const actionItems: ActionItem[] = [];
-                            if (!isResolved) {
+                            if (hasWriteAccessForAlert && !isResolved) {
                                 if (isRuntimeAlert) {
                                     actionItems.push({
                                         title: 'Resolve and add to process baseline',
@@ -222,7 +245,11 @@ function ViolationsTablePanel({
                                     });
                                 }
                             }
-                            if (!isDeployCreateAttemptedAlert && 'deployment' in violation) {
+                            if (
+                                hasWriteAccessForExcludeDeploymentsFromPolicy &&
+                                !isDeployCreateAttemptedAlert &&
+                                'deployment' in violation
+                            ) {
                                 actionItems.push({
                                     title: 'Exclude deployment from policy',
                                     onClick: () =>
@@ -249,11 +276,14 @@ function ViolationsTablePanel({
                                             />
                                         );
                                     })}
-                                    <Td
-                                        actions={{
-                                            items: actionItems,
-                                        }}
-                                    />
+                                    {hasActions && (
+                                        <Td>
+                                            <ActionsColumn
+                                                isDisabled={actionItems.length === 0}
+                                                items={actionItems}
+                                            />
+                                        </Td>
+                                    )}
                                 </Tr>
                             );
                         })}


### PR DESCRIPTION
## Description

### Analysis

1. ViolationsTablePanel
    * **Resolve and add to process baseline** requires READ_WRITE_ACCESS for Alert resource.
    * **Mark as resolved** requires READ_WRITE_ACCESS for Alert resource.
    * **Exclude deployment from policy** requires READ_WRITE_ACCESS for WorkflowAdministration resource.

2. ViolationDetailsPage
    * **Violation** and **Enforcement** tabs render information from `alert` object.
    * **Deployment** tab requires READ_ACCESS for Deployment resource.
    * **Policy** tab requires READ_ACCESS for Policy Management route.
        * Because `PolicyDetailContent` element makes additional requests like GET /v1/notifiers which requires READ_ACCESS for Integration resource.
        * Even if this context does not require all the resources of the route, breaking encapsulation for Violations to make assumptions about Policies component is a risky invisible inter-container coupling, but more important, it is counter-intuitive if Policy Management is not enabled. Also more consistent for card about a policy to have same conditional render requirement as a link to a policy.

3. DeploymentDetails
    * **Network policies** card requires READ_ACCESS for NetworkPolicy resource.

### Solution

1. ViolationsTablePanel
    * Conditionally render actions. See **Residue** item 1 for **Row actions** element.

2. ViolationDetailsPage
    * Conditionally render `DeploymentDetails` only if READ_ACCESS for Deployment resource
    * Conditionally render `PolicyDetailContent` only if READ_ACCESS for Policy Management route resources.

3. DeploymentDetails
    * Move `h3` elements into cards both for accessibility but also for conditional rendering.
    * Factor out `NetworkPoliciesCard` so it makes request only if READ_ACCESS for NetworkPolicy resource.

### Residue

1. Because PatternFly `Select` does not support conditional rendering for `SelectOption` elements:
    * Use `disabled` prop for this pull request, even though that displays an unavailable option.
    * Replace with `Dropdown` element, intended for imperative actions, which has `dropdownItems` prop for similar conditional `push` logic as `actionItems` in table rows.
2. Replace imports from src/Containers/Violations/types/violationTypes.ts with imports from src/types/alert.proto.ts and so on.
3. Investigate whether DeploymentDetails can render a meaningful subset of information with only `alertDeployment` data from /v1/alerts response.
4. Replace /v1/clusters with /v1/sac/clusters in Policies so route does not require Cluster resource.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

It looks like deletion of separated headings and replacement of policies table with list more than balanced additions.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3759688 - 3759688
        total: -362 = 9945877 - 9946239
    * `ls -al build/static/js/*.js | wc -l`
        0 = 81 - 81 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/violations

    * See no actions
        ![violations_without_actions](https://github.com/stackrox/stackrox/assets/11862657/ae2f94be-52a4-4fe7-8daf-260ee476ca63)

    * See only actions for Alert resource (although confusing because of **Residue** item 1)
        ![violations_actions_only_Alert](https://github.com/stackrox/stackrox/assets/11862657/4401c097-eab9-4c26-a9ae-b90c97189c2c)

    * See only actions for WorkflowAdministration resource (although confusing because of **Residue** item 1)
        ![violations_actions_only_WorkflowAdministration](https://github.com/stackrox/stackrox/assets/11862657/e142e08e-f6d6-48ac-a63b-4ebf5afc9f50)

    * See actions for both resources (although confusing because of **Residue** item 1)
        ![violations_actions_both](https://github.com/stackrox/stackrox/assets/11862657/7cff1f25-75f6-4246-892e-b9bfc59beb31)

2. Click a violation link

    * See only **Violation** tab
        ![violations_Violation_tab](https://github.com/stackrox/stackrox/assets/11862657/6cacaa2b-adda-4b5d-a675-3a2c5cd44159)

    * See **Deployment** tab without **Network policies** card
![violations_Deployment_tab_without_Network_policies](https://github.com/stackrox/stackrox/assets/11862657/dcddacdc-da15-459f-acb4-9e136bd45de2)

    * See **Deployment** tab with **Network policies** card
        ![violations_Deployment_tab_with_Network_policies](https://github.com/stackrox/stackrox/assets/11862657/47fb0026-4856-4530-9fcd-1bbe90fa04f8)

    * See **Policy** tab
        ![violations_Policy_tab](https://github.com/stackrox/stackrox/assets/11862657/5aeac2f1-b257-4a1e-8e85-30e0122a4b3d)

### Integration testing

* violations/violations.test.js
