### PR TITLE
fix(ci): handle the tag before the `-rcd`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -468,6 +468,8 @@ jobs:
       run: |
         git submodule update --init
 
+    - uses: ./.github/actions/handle-tagged-build
+
     - name: Set build tag for prerelease images
       if: matrix.name == 'prerelease'
       run: echo "BUILD_TAG=$(make --quiet --no-print-directory tag)-prerelease" >> "$GITHUB_ENV"
@@ -475,8 +477,6 @@ jobs:
     - name: Set build tag for race condition images
       if: matrix.name == 'race-condition-debug'
       run: echo "BUILD_TAG=$(make --quiet --no-print-directory tag)-rcd" >> "$GITHUB_ENV"
-
-    - uses: ./.github/actions/handle-tagged-build
 
     - name: Build and push manifest lists
       # Skip for external contributions.


### PR DESCRIPTION
## Description

With the current order the `-rcd` gets dropped for the manifest push. The order is correct for the images: https://github.com/stackrox/stackrox/actions/runs/5829094812/job/15808281267#step:26:71

Re: https://issues.redhat.com/browse/ROX-15366?focusedId=22787353&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22787353

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

```
(export GITHUB_ENV=`mktemp`; \
echo "$GITHUB_ENV"; \
export GITHUB_REF=refs/tags/4.1.x-nightly-20230811; \
source scripts/ci/lib.sh; \
handle_gha_tagged_build; \
set -o allexport; \
source "$GITHUB_ENV"; \
echo "BUILD_TAG=$(make --quiet --no-print-directory tag)-rcd" >> "$GITHUB_ENV"; \
source "$GITHUB_ENV"; \
make tag)
```

```
/tmp/nix-shell.SUcG6R/nix-shell.oj2Y0w/tmp.wXWcvhn2D7
GITHUB_REF: refs/tags/4.1.x-nightly-20230811
This is a tagged build: 4.1.x-nightly-20230811
4.1.x-nightly-20230811-rcd
```