### PR TITLE
ROX-19072: Minimize conditional RBAC in MainPage

### DIFF
--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -82,16 +82,27 @@ export function visitMainDashboard(staticResponseMap) {
 }
 
 /**
- * @param {{data: Record<string, number>}} staticResponseForSummaryCounts
+ * @param {{data: Record<string, number>}} staticResponseForClustersForPermissions
  */
-export function visitMainDashboardWithStaticResponseForSummaryCounts(
-    staticResponseForSummaryCounts
+export function visitMainDashboardWithStaticResponseForClustersForPermission(
+    staticResponseForClustersForPermissions
 ) {
     // Omit requests for widgets because Dashboard redirects to Clusters page.
-    const staticResponseMapForSummaryCounts = {
-        [summaryCountsOpname]: staticResponseForSummaryCounts,
+    const clustersForPermissionsAlias = 'sac/clusters';
+    const routeMatcherMapForClustersForPermissions = {
+        [clustersForPermissionsAlias]: {
+            method: 'GET',
+            url: '/v1/sac/clusters?',
+        },
     };
-    visit(basePath, routeMatcherMapForSummaryCounts, staticResponseMapForSummaryCounts);
+    const staticResponseMapForClustersForPermissions = {
+        [clustersForPermissionsAlias]: staticResponseForClustersForPermissions,
+    };
+    visit(
+        basePath,
+        routeMatcherMapForClustersForPermissions,
+        staticResponseMapForClustersForPermissions
+    );
 
     // Omit assertion for Dashboard heading.
 }

--- a/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
@@ -1,5 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
-import { visitMainDashboardWithStaticResponseForSummaryCounts } from '../../helpers/main';
+import { visitMainDashboardWithStaticResponseForClustersForPermission } from '../../helpers/main';
 
 import { clustersAlias, interactAndVisitClusters } from './Clusters.helpers';
 
@@ -16,19 +16,14 @@ describe('Clusters', () => {
         };
 
         interactAndVisitClusters(() => {
-            const staticResponseForSummaryCounts = {
+            const staticResponseForClustersForPermissions = {
                 body: {
-                    data: {
-                        clusterCount: 0, // no secured clusters
-                        nodeCount: 3,
-                        violationCount: 20,
-                        deploymentCount: 35,
-                        imageCount: 31,
-                        secretCount: 15,
-                    },
+                    clusters: [], // no secured clusters
                 },
             };
-            visitMainDashboardWithStaticResponseForSummaryCounts(staticResponseForSummaryCounts);
+            visitMainDashboardWithStaticResponseForClustersForPermission(
+                staticResponseForClustersForPermissions
+            );
         }, staticResponseMapForClusters);
 
         cy.get(


### PR DESCRIPTION
## Description

### Analysis

1. For redirect to /main/clusters, CLUSTER_COUNT query requires READ_ACCESS to Cluster resource.
    * The count is relevant only if READ_WRITE_ACCESS to Cluster resource.
    * Because hook cannot be conditional, it is not possible to omit the request if the answer is not relevant.

### Solution

1. Replace `useQuery` with `useEffect` and call `getClustersForPermissions` only if READ_WRITE_ACCESS for Cluster resource.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed

Slight increase probably from `isLoadingClustersCount` because replacement of query with request was probable about even exchange.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 44 = 3759732 - 3759688
        total: 44 = 9949060 - 9949016
    * `ls -al build/static/js/*.js | wc -l`
        0 = 81 - 81 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/dashboard

    * See summary_counts failure with NO_ACCESS for Cluster resource.
        ![summary_counts_without_Cluster](https://github.com/stackrox/stackrox/assets/11862657/305f921e-ecea-4e94-a246-8a75a1e170c5)

    * See summary_counts success with READ_ACCESS for Cluster resource.
        ![summary_counts_with_Cluster](https://github.com/stackrox/stackrox/assets/11862657/118e6ad5-8ee1-459c-965c-7649b543e91d)

    * See absence of /v1/sac/clusters request with NO_ACCESS or READ_ACCESS for Cluster resource.

    * See presence of /v1/sac/clusters request with READ_WRITE_ACCESS for Cluster resource.
        ![sac_clusters](https://github.com/stackrox/stackrox/assets/11862657/eebd4776-1dcd-44a4-9ad0-4472a632a666)

### Integration testing

* clusters/redirectFromDashboard.test.js