### PR TITLE
fix: Use DNS in k8s client for ACSCS

### DIFF
--- a/central/debug/service/diagnostics.go
+++ b/central/debug/service/diagnostics.go
@@ -5,8 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net"
-	"os"
 	"path"
 	"regexp"
 	"time"
@@ -16,11 +14,10 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
-	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/k8sintrospect"
+	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sliceutils"
-	"k8s.io/client-go/rest"
 )
 
 var (
@@ -128,7 +125,7 @@ func addMissingClustersInfo(ctx context.Context, remainingClusterNameMap map[str
 func pullCentralClusterDiagnostics(ctx context.Context, filesC chan<- k8sintrospect.File, wg *concurrency.WaitGroup, since time.Time) {
 	defer wg.Add(-1)
 
-	restCfg, err := getK8sInClusterConfig()
+	restCfg, err := k8sutil.GetK8sInClusterConfig()
 	if err == nil {
 		err = k8sintrospect.Collect(ctx, mainClusterConfig, restCfg, k8sintrospect.SendToChan(filesC), since)
 	}
@@ -142,20 +139,6 @@ func pullCentralClusterDiagnostics(ctx context.Context, filesC chan<- k8sintrosp
 		case <-ctx.Done():
 		}
 	}
-}
-
-func getK8sInClusterConfig() (*rest.Config, error) {
-	restCfg, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-	// Replacing raw IP address with kubernetes.default.svc
-	// allows for easier proxy configuration.
-	if env.ManagedCentral.BooleanSetting() {
-		port := os.Getenv("KUBERNETES_SERVICE_PORT")
-		restCfg.Host = "https://" + net.JoinHostPort("kubernetes.default.svc", port)
-	}
-	return restCfg, nil
 }
 
 func (s *serviceImpl) getClusterNameMap(ctx context.Context) (map[string]string, error) {

--- a/pkg/k8sutil/client_config.go
+++ b/pkg/k8sutil/client_config.go
@@ -10,6 +10,7 @@ import (
 
 // GetK8sInClusterConfig returns k8s client config that can be used from within cluster.
 // It is adjusted to use DNS record instead of raw IP as API host in certain cases.
+// This can be used to more conveniently bypass the proxy.
 func GetK8sInClusterConfig() (*rest.Config, error) {
 	restCfg, err := rest.InClusterConfig()
 	if err != nil {

--- a/pkg/k8sutil/client_config.go
+++ b/pkg/k8sutil/client_config.go
@@ -1,0 +1,25 @@
+package k8sutil
+
+import (
+	"net"
+	"os"
+
+	"github.com/stackrox/rox/pkg/env"
+	"k8s.io/client-go/rest"
+)
+
+// GetK8sInClusterConfig returns k8s client config that can be used from within cluster.
+// It is adjusted to use DNS record instead of raw IP as API host in certain cases.
+func GetK8sInClusterConfig() (*rest.Config, error) {
+	restCfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	// Replacing raw IP address with kubernetes.default.svc
+	// allows for easier proxy configuration.
+	if env.ManagedCentral.BooleanSetting() {
+		port := os.Getenv("KUBERNETES_SERVICE_PORT")
+		restCfg.Host = "https://" + net.JoinHostPort("kubernetes.default.svc", port)
+	}
+	return restCfg, nil
+}


### PR DESCRIPTION
## Description

Since ACSCS central diagnostics are re-enabled in [issues.redhat.com/browse/ROX-12125](https://issues.redhat.com/browse/ROX-12125), we need to allow ACS to connect to k8s API.

To allow that connection, we need to add an exception for the kubernetes API server in ACSCS data plane cluster. This change makes the k8s client use DNS record as a host instead of raw IP, which allows for easier configuration of the ACSCS data plane cluster, see https://github.com/stackrox/acs-fleet-manager/pull/1200

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Manually tested by downloading diagnostic bundle
