### PR TITLE
ROX-18482: Add structured logs to reprocessor

### DIFF
--- a/central/tlsconfig/tlsconfig.go
+++ b/central/tlsconfig/tlsconfig.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/fileutils"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/x509utils"
@@ -149,7 +150,7 @@ func MaybeGetDefaultTLSCertificateFromDirectory(dir string) (*tls.Certificate, e
 
 	if exists, err := fileutils.Exists(certFile); err != nil || !exists {
 		if err != nil {
-			log.Warnw("Error checking if default TLS certificate file exists", zap.Error(err))
+			log.Warnw("Error checking if default TLS certificate file exists", logging.Err(err))
 			return nil, err
 		}
 		log.Infof("Default TLS certificate file %q does not exist. Skipping", certFile)
@@ -158,7 +159,7 @@ func MaybeGetDefaultTLSCertificateFromDirectory(dir string) (*tls.Certificate, e
 
 	if exists, err := fileutils.Exists(keyFile); err != nil || !exists {
 		if err != nil {
-			log.Warnw("Error checking if default TLS key file exists", zap.Error(err))
+			log.Warnw("Error checking if default TLS key file exists", logging.Err(err))
 			return nil, err
 		}
 		log.Infof("Default TLS key file %q does not exist. Skipping", keyFile)

--- a/pkg/k8scfgwatch/cfg_watcher.go
+++ b/pkg/k8scfgwatch/cfg_watcher.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/contextutil"
 	"github.com/stackrox/rox/pkg/logging"
-	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -40,7 +39,7 @@ func NewConfigMapWatcher(k8sClient kubernetes.Interface, modifiedFunc func(*v1.C
 func (w *ConfigMapWatcher) Watch(ctx concurrency.Waitable, namespace string, name string) {
 	err := w.init(ctx, namespace, name)
 	if err != nil {
-		log.Errorw(fmt.Sprintf("Failed initial get of config map %s/%s", name, namespace), zap.Error(err))
+		log.Errorw(fmt.Sprintf("Failed initial get of config map %s/%s", name, namespace), logging.Err(err))
 	}
 	go w.run(ctx, namespace, name)
 }
@@ -74,7 +73,7 @@ func (w *ConfigMapWatcher) startWatcher(ctx concurrency.Waitable, namespace stri
 		metav1.SingleObject(metav1.ObjectMeta{Name: name, Namespace: namespace}),
 	)
 	if err != nil {
-		log.Errorw(fmt.Sprintf("Unable to start watching config map %s/%s", name, namespace), zap.Error(err))
+		log.Errorw(fmt.Sprintf("Unable to start watching config map %s/%s", name, namespace), logging.Err(err))
 		return
 	}
 	defer watcher.Stop()

--- a/pkg/logging/fields.go
+++ b/pkg/logging/fields.go
@@ -6,3 +6,23 @@ import "go.uber.org/zap"
 func Err(err error) zap.Field {
 	return zap.Error(err)
 }
+
+// ImageName provides the image name as a structured log field.
+func ImageName(name string) zap.Field {
+	return zap.String("image", name)
+}
+
+// ClusterID provides the cluster ID as a structured log field.
+func ClusterID(id string) zap.Field {
+	return zap.String("cluster_id", id)
+}
+
+// ImageID provides the image ID as a structured log field.
+func ImageID(id string) zap.Field {
+	return zap.String("image_id", id)
+}
+
+// NodeID provides the node ID as a structured log field.
+func NodeID(id string) zap.Field {
+	return zap.String("node_id", id)
+}

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls/verifier"
 	"github.com/stackrox/rox/pkg/utils"
-	"go.uber.org/zap"
 )
 
 const (
@@ -103,19 +102,19 @@ func (s *Server) Stop(ctx context.Context) {
 
 	if metricsEnabled() {
 		if err := s.metricsServer.Shutdown(ctx); err != nil {
-			log.Errorw("Failed to shutdown metrics server", zap.Error(err))
+			log.Errorw("Failed to shutdown metrics server", logging.Err(err))
 			err := s.metricsServer.Close()
 			if err != nil {
-				log.Errorw("Failed to close metrics server", zap.Error(err))
+				log.Errorw("Failed to close metrics server", logging.Err(err))
 			}
 		}
 	}
 	if secureMetricsEnabled() {
 		if err := s.secureMetricsServer.Shutdown(ctx); err != nil {
-			log.Errorw("Failed to shutdown secure metrics server", zap.Error(err))
+			log.Errorw("Failed to shutdown secure metrics server", logging.Err(err))
 			err := s.secureMetricsServer.Close()
 			if err != nil {
-				log.Errorw("Failed to close metrics server", zap.Error(err))
+				log.Errorw("Failed to close metrics server", logging.Err(err))
 			}
 		}
 	}

--- a/pkg/metrics/tls.go
+++ b/pkg/metrics/tls.go
@@ -12,10 +12,10 @@ import (
 	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/k8scfgwatch"
 	"github.com/stackrox/rox/pkg/k8sutil"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls/certwatch"
 	"github.com/stackrox/rox/pkg/mtls/verifier"
 	"github.com/stackrox/rox/pkg/sync"
-	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -93,12 +93,12 @@ func NewTLSConfigurerFromEnv() verifier.TLSConfigurer {
 
 	config, err := k8sutil.GetK8sInClusterConfig()
 	if err != nil {
-		log.Errorw("Failed to get in-cluster config", zap.Error(err))
+		log.Errorw("Failed to get in-cluster config", logging.Err(err))
 		return &nilTLSConfigurer{}
 	}
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.Errorw("Failed to create Kubernetes client", zap.Error(err))
+		log.Errorw("Failed to create Kubernetes client", logging.Err(err))
 		return &nilTLSConfigurer{}
 	}
 	certDir := env.SecureMetricsCertDir.Setting()
@@ -129,7 +129,7 @@ func (t *tlsConfigurerImpl) getCertificateFromDirectory(dir string) (*tls.Certif
 	certFile := filepath.Join(dir, env.TLSCertFileName)
 	if exists, err := fileutils.Exists(certFile); err != nil || !exists {
 		if err != nil {
-			log.Errorw("Error checking if monitoring TLS certificate file exists", zap.Error(err))
+			log.Errorw("Error checking if monitoring TLS certificate file exists", logging.Err(err))
 			return nil, err
 		}
 		log.Infof("Monitoring TLS certificate file %q does not exist. Skipping TLS watcher cycle.", certFile)
@@ -139,7 +139,7 @@ func (t *tlsConfigurerImpl) getCertificateFromDirectory(dir string) (*tls.Certif
 	keyFile := filepath.Join(dir, env.TLSKeyFileName)
 	if exists, err := fileutils.Exists(keyFile); err != nil || !exists {
 		if err != nil {
-			log.Errorw("Error checking if monitoring TLS key file exists", zap.Error(err))
+			log.Errorw("Error checking if monitoring TLS key file exists", logging.Err(err))
 			return nil, err
 		}
 		log.Infof("Monitoring TLS key file %q does not exist. Skipping TLS watcher cycle.", keyFile)
@@ -176,7 +176,7 @@ func (t *tlsConfigurerImpl) updateClientCA(cm *v1.ConfigMap) {
 		log.Infof("Updating secure metrics client CAs based on %s/%s", t.clientCANamespace, t.clientCAConfigMap)
 		signerCAs, err := helpers.ParseCertificatesPEM([]byte(caFile))
 		if err != nil {
-			log.Errorw("Unable to parse client CAs", zap.Error(err))
+			log.Errorw("Unable to parse client CAs", logging.Err(err))
 			return
 		}
 		if len(signerCAs) == 0 {

--- a/sensor/upgrader/runner/runner.go
+++ b/sensor/upgrader/runner/runner.go
@@ -25,7 +25,7 @@ type Runner interface {
 	// Err() is guaranteed to be non-nil.
 	MostRecentStage() sensorupgrader.Stage
 	// RunNextStage runs the next stage of the runner.
-	// Callers MUST check r.Finished() and r.Err() before calling this.
+	// Callers MUST check r.Finished() and r.Error() before calling this.
 	RunNextStage()
 }
 


### PR DESCRIPTION
## Description

This PR adds structured logs to the reprocessor. The reprocessor will be the first package that will be moved to structured logs to later enable it to send the log entry to the notification service.
The reason for choosing the reprocessor is that it currently does expose probably the most interesting async info for customers: whether there's trouble scanning images or not.

The existing `Errorw/Warnw` were used. We may think about adding `Infow` as well, I personally do not mind adding it in this PR.

As a caveat:
Introduced multiple wrappers for common fields we want to have in structured logs: `image, image_id, cluster_id, node_id`.

Additionally, also refactored existing usages of `zap.Error` to use `logging.Err` instead. Reason for this is that the wrapper (both the one for `zap.Error` as well as our own `Logger` interface for `zap.SugaredLogger`) is to avoid other clients to directly import `zap`, if not necessary.
While client packages _may_ still import `zap` to e.g. introduce their own, package-specific fields, we should reduce the imports of `zap` as much as possible.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

N/A
