### PR TITLE
ROX-18821: Sensor chaos proxy setup

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -682,12 +682,13 @@ function launch_sensor {
 
     # If deploying with chaos proxy enabled, patch sensor to add toxiproxy proxy deployment
     if [[ "$CHAOS_PROXY" == "true" ]]; then
+        original_endpoint=$(kubectl -n stackrox exec -it deploy/sensor -c sensor -- env | grep "ROX_CENTRAL_ENDPOINT" | cut -d'=' -f2)
+
         echo "Patching sensor with toxiproxy container"
         kubectl -n stackrox patch deploy/sensor --type=json -p="$(cat "${common_dir}/sensor-toxiproxy-patch.json")"
-        no_proxy=$(kubectl -n stackrox exec -it deploy/sensor -c sensor -- env | grep "ROX_CENTRAL_ENDPOINT" | cut -d'=' -f2)
         kubectl -n stackrox set env deploy/sensor ROX_CHAOS_PROXY_ENABLED="true"
         kubectl -n stackrox set env deploy/sensor ROX_CHAOS_PROFILE="${CHAOS_PROFILE:-periodicdisconnect}"
-        kubectl -n stackrox set env deploy/sensor ROX_CENTRAL_ENDPOINT_NO_PROXY="$no_proxy"
+        kubectl -n stackrox set env deploy/sensor ROX_CENTRAL_ENDPOINT_NO_PROXY="$original_endpoint"
         kubectl -n stackrox set env deploy/sensor ROX_CENTRAL_ENDPOINT="localhost:8989"
     fi
 

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -686,9 +686,7 @@ function launch_sensor {
 
         echo "Patching sensor with toxiproxy container"
         kubectl -n stackrox patch deploy/sensor --type=json -p="$(cat "${common_dir}/sensor-toxiproxy-patch.json")"
-        kubectl -n stackrox set env deploy/sensor ROX_CHAOS_PROFILE="${CHAOS_PROFILE:-periodicdisconnect}"
-        kubectl -n stackrox set env deploy/sensor ROX_CENTRAL_ENDPOINT_NO_PROXY="$original_endpoint"
-        kubectl -n stackrox set env deploy/sensor ROX_CENTRAL_ENDPOINT="localhost:8989"
+        kubectl -n stackrox set env deploy/sensor -e ROX_CENTRAL_ENDPOINT_NO_PROXY="$original_endpoint" -e ROX_CENTRAL_ENDPOINT="localhost:8989"
     fi
 
     echo

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -682,7 +682,7 @@ function launch_sensor {
 
     # If deploying with chaos proxy enabled, patch sensor to add toxiproxy proxy deployment
     if [[ "$CHAOS_PROXY" == "true" ]]; then
-        original_endpoint=$(kubectl -n stackrox exec -it deploy/sensor -c sensor -- env | grep "ROX_CENTRAL_ENDPOINT" | cut -d'=' -f2)
+        original_endpoint=$(kubectl -n stackrox get deploy/sensor -ojsonpath='{.spec.template.spec.containers[0].env[?(@.name=="ROX_CENTRAL_ENDPOINT")].value}')
 
         echo "Patching sensor with toxiproxy container"
         kubectl -n stackrox patch deploy/sensor --type=json -p="$(cat "${common_dir}/sensor-toxiproxy-patch.json")"

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -686,7 +686,6 @@ function launch_sensor {
 
         echo "Patching sensor with toxiproxy container"
         kubectl -n stackrox patch deploy/sensor --type=json -p="$(cat "${common_dir}/sensor-toxiproxy-patch.json")"
-        kubectl -n stackrox set env deploy/sensor ROX_CHAOS_PROXY_ENABLED="true"
         kubectl -n stackrox set env deploy/sensor ROX_CHAOS_PROFILE="${CHAOS_PROFILE:-periodicdisconnect}"
         kubectl -n stackrox set env deploy/sensor ROX_CENTRAL_ENDPOINT_NO_PROXY="$original_endpoint"
         kubectl -n stackrox set env deploy/sensor ROX_CENTRAL_ENDPOINT="localhost:8989"

--- a/deploy/common/sensor-toxiproxy-patch.json
+++ b/deploy/common/sensor-toxiproxy-patch.json
@@ -1,0 +1,19 @@
+[
+  {
+    "op": "add",
+    "path": "/spec/template/spec/containers/-",
+    "value": {
+      "name": "toxiproxy",
+      "image": "ghcr.io/shopify/toxiproxy:2.5.0",
+      "args": [
+        "-config",
+        "/etc/toxiproxy/config.json"
+      ],
+      "ports": [
+        {
+          "containerPort": 8989
+        }
+      ]
+    }
+  }
+]

--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/russellhaering/goxmldsig v1.4.0
 	github.com/segmentio/analytics-go/v3 v3.2.1
 	github.com/sergi/go-diff v1.3.1
+	github.com/Shopify/toxiproxy/v2 v2.5.0
 	github.com/sigstore/cosign/v2 v2.0.2
 	github.com/sigstore/sigstore v1.6.4
 	github.com/spf13/cobra v1.7.0
@@ -147,8 +148,6 @@ require (
 	sigs.k8s.io/e2e-framework v0.2.0
 	sigs.k8s.io/yaml v1.3.0
 )
-
-require github.com/Shopify/toxiproxy/v2 v2.5.0
 
 require (
 	cloud.google.com/go v0.110.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -148,6 +148,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+require github.com/Shopify/toxiproxy/v2 v2.5.0
+
 require (
 	cloud.google.com/go v0.110.6 // indirect
 	cloud.google.com/go/compute v1.23.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/PagerDuty/go-pagerduty v1.7.0
 	github.com/RoaringBitmap/roaring v1.3.0
+	github.com/Shopify/toxiproxy/v2 v2.5.0
 	github.com/VividCortex/ewma v1.2.0
 	github.com/adhocore/gronx v1.6.5
 	github.com/andygrunwald/go-jira v1.16.0
@@ -93,7 +94,6 @@ require (
 	github.com/russellhaering/goxmldsig v1.4.0
 	github.com/segmentio/analytics-go/v3 v3.2.1
 	github.com/sergi/go-diff v1.3.1
-	github.com/Shopify/toxiproxy/v2 v2.5.0
 	github.com/sigstore/cosign/v2 v2.0.2
 	github.com/sigstore/sigstore v1.6.4
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqR
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/Shopify/toxiproxy/v2 v2.5.0 h1:i4LPT+qrSlKNtQf5QliVjdP08GyAH8+BUIc9gT0eahc=
+github.com/Shopify/toxiproxy/v2 v2.5.0/go.mod h1:yhM2epWtAmel9CB8r2+L+PCmhH6yH2pITaPAo7jxJl0=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=

--- a/sensor/common/chaos/config.go
+++ b/sensor/common/chaos/config.go
@@ -1,0 +1,41 @@
+package chaos
+
+import (
+	"context"
+	"strconv"
+
+	toxiproxy "github.com/Shopify/toxiproxy/v2/client"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/sensor/common/chaos/profile"
+)
+
+var (
+	log = logging.LoggerForModule()
+)
+
+const (
+	toxiproxyEndpoint     = "localhost:8474"
+	toxiproxyCentralProxy = "localhost:8989"
+)
+
+// InitializeChaosConfiguration sets up Toxiproxy to forward requests to real central and control periodic disconnects.
+func InitializeChaosConfiguration(ctx context.Context) {
+	if !HasChaosProxy() || originalCentralEndpoint() == "" {
+		log.Infof("Cannot start chaos proxy configuration (requires ROX_CHAOS_PROXY_ENABLED and ROX_CENTRAL_ENDPOINT_NO_PROXY set). Respectively: %s | %s",
+			strconv.FormatBool(HasChaosProxy()), originalCentralEndpoint())
+		return
+	}
+
+	log.Infof("Running sensor with Chaos Proxy enabled. This could produce disconnects between central and sensor. This should NEVER be enabled in production." +
+		"If you see this message in production, make sure env ROX_CHAOS_PROXY_ENABLED is set to 'false'")
+
+	client := toxiproxy.NewClient(toxiproxyEndpoint)
+	proxy, err := client.CreateProxy("central", toxiproxyCentralProxy, originalCentralEndpoint())
+	if err != nil {
+		log.Warnf("Failed to start chaos client: %s", err)
+		return
+	}
+
+	controller := profile.GetConfig(ctx, chaosProfile())
+	go controller.Run(proxy)
+}

--- a/sensor/common/chaos/config.go
+++ b/sensor/common/chaos/config.go
@@ -2,7 +2,6 @@ package chaos
 
 import (
 	"context"
-	"strconv"
 
 	toxiproxy "github.com/Shopify/toxiproxy/v2/client"
 	"github.com/stackrox/rox/pkg/logging"
@@ -21,18 +20,18 @@ const (
 // InitializeChaosConfiguration sets up Toxiproxy to forward requests to real central and control periodic disconnects.
 func InitializeChaosConfiguration(ctx context.Context) {
 	if !HasChaosProxy() || originalCentralEndpoint() == "" {
-		log.Infof("Cannot start chaos proxy configuration (requires ROX_CHAOS_PROXY_ENABLED and ROX_CENTRAL_ENDPOINT_NO_PROXY set). Respectively: %s | %s",
-			strconv.FormatBool(HasChaosProxy()), originalCentralEndpoint())
+		log.Infof("Cannot start chaos proxy configuration (requires ROX_CHAOS_PROFILE and ROX_CENTRAL_ENDPOINT_NO_PROXY set). Respectively: %s | %s",
+			chaosProfile(), originalCentralEndpoint())
 		return
 	}
 
 	log.Infof("Running sensor with Chaos Proxy enabled. This could produce disconnects between central and sensor. This should NEVER be enabled in production." +
-		"If you see this message in production, make sure env ROX_CHAOS_PROXY_ENABLED is set to 'false'")
+		"If you see this message in production, make sure env ROX_CHAOS_PROFILE is unset")
 
 	client := toxiproxy.NewClient(toxiproxyEndpoint)
 	proxy, err := client.CreateProxy("central", toxiproxyCentralProxy, originalCentralEndpoint())
 	if err != nil {
-		log.Warnf("Failed to start chaos client: %s", err)
+		log.Warnf("Failed to start chaos client: %v", err)
 		return
 	}
 

--- a/sensor/common/chaos/env.go
+++ b/sensor/common/chaos/env.go
@@ -1,6 +1,10 @@
 package chaos
 
-import "github.com/stackrox/rox/pkg/env"
+import (
+	"strings"
+
+	"github.com/stackrox/rox/pkg/env"
+)
 
 var (
 	centralEndpointNoProxyEnv = env.RegisterSetting("ROX_CENTRAL_ENDPOINT_NO_PROXY")
@@ -13,7 +17,8 @@ func chaosProfile() string {
 }
 
 func originalCentralEndpoint() string {
-	return centralEndpointNoProxyEnv.Setting()
+	value := centralEndpointNoProxyEnv.Setting()
+	return strings.TrimRight(value, "\t\n\r")
 }
 
 // HasChaosProxy returns true if running with a chaos proxy between sensor and central.

--- a/sensor/common/chaos/env.go
+++ b/sensor/common/chaos/env.go
@@ -8,7 +8,6 @@ import (
 
 var (
 	centralEndpointNoProxyEnv = env.RegisterSetting("ROX_CENTRAL_ENDPOINT_NO_PROXY")
-	chaosProxyEnabledEnv      = env.RegisterBooleanSetting("ROX_CHAOS_PROXY_ENABLED", false)
 	chaosProfileEnv           = env.RegisterSetting("ROX_CHAOS_PROFILE")
 )
 
@@ -18,10 +17,10 @@ func chaosProfile() string {
 
 func originalCentralEndpoint() string {
 	value := centralEndpointNoProxyEnv.Setting()
-	return strings.TrimRight(value, "\t\n\r")
+	return strings.TrimSpace(value)
 }
 
 // HasChaosProxy returns true if running with a chaos proxy between sensor and central.
 func HasChaosProxy() bool {
-	return chaosProxyEnabledEnv.BooleanSetting()
+	return chaosProfile() != ""
 }

--- a/sensor/common/chaos/env.go
+++ b/sensor/common/chaos/env.go
@@ -1,0 +1,22 @@
+package chaos
+
+import "github.com/stackrox/rox/pkg/env"
+
+var (
+	centralEndpointNoProxyEnv = env.RegisterSetting("ROX_CENTRAL_ENDPOINT_NO_PROXY")
+	chaosProxyEnabledEnv      = env.RegisterBooleanSetting("ROX_CHAOS_PROXY_ENABLED", false)
+	chaosProfileEnv           = env.RegisterSetting("ROX_CHAOS_PROFILE")
+)
+
+func chaosProfile() string {
+	return chaosProfileEnv.Setting()
+}
+
+func originalCentralEndpoint() string {
+	return centralEndpointNoProxyEnv.Setting()
+}
+
+// HasChaosProxy returns true if running with a chaos proxy between sensor and central.
+func HasChaosProxy() bool {
+	return chaosProxyEnabledEnv.BooleanSetting()
+}

--- a/sensor/common/chaos/profile/droppedpackets.go
+++ b/sensor/common/chaos/profile/droppedpackets.go
@@ -25,7 +25,7 @@ func (c *droppedPackets) Run(proxy *toxiproxy.Proxy) {
 	})
 
 	if err != nil {
-		log.Warnf("Failed to create toxic for dropping packets: %s", err)
+		log.Warnf("Failed to create toxic for dropping packets: %v", err)
 		return
 	}
 }

--- a/sensor/common/chaos/profile/droppedpackets.go
+++ b/sensor/common/chaos/profile/droppedpackets.go
@@ -1,0 +1,31 @@
+package profile
+
+import (
+	"context"
+
+	toxiproxy "github.com/Shopify/toxiproxy/v2/client"
+)
+
+type droppedPackets struct {
+	ctx            context.Context
+	percentageLost float32
+}
+
+func newDroppedPackets(ctx context.Context, lost float32) *droppedPackets {
+	return &droppedPackets{
+		ctx:            ctx,
+		percentageLost: lost,
+	}
+}
+
+// Run starts the chaos proxy controller
+func (c *droppedPackets) Run(proxy *toxiproxy.Proxy) {
+	_, err := proxy.AddToxic("unreliable", "timeout", "", c.percentageLost, toxiproxy.Attributes{
+		"timeout": "6000",
+	})
+
+	if err != nil {
+		log.Warnf("Failed to create toxic for dropping packets: %s", err)
+		return
+	}
+}

--- a/sensor/common/chaos/profile/none.go
+++ b/sensor/common/chaos/profile/none.go
@@ -5,4 +5,4 @@ import toxiproxy "github.com/Shopify/toxiproxy/v2/client"
 type none struct{}
 
 // Run starts the chaos proxy controller
-func (_ *none) Run(proxy *toxiproxy.Proxy) {}
+func (*none) Run(_ *toxiproxy.Proxy) {}

--- a/sensor/common/chaos/profile/none.go
+++ b/sensor/common/chaos/profile/none.go
@@ -1,0 +1,8 @@
+package profile
+
+import toxiproxy "github.com/Shopify/toxiproxy/v2/client"
+
+type none struct{}
+
+// Run starts the chaos proxy controller
+func (_ *none) Run(proxy *toxiproxy.Proxy) {}

--- a/sensor/common/chaos/profile/periodicdisconnect.go
+++ b/sensor/common/chaos/profile/periodicdisconnect.go
@@ -43,7 +43,7 @@ func (c *periodicDisconnect) Run(proxy *toxiproxy.Proxy) {
 				log.Warnf("Failed to disable chaos proxy: %s", err)
 				return
 			}
-			log.Debugf("Chaos proxy disabled")
+			log.Info("Periodic timer reached: chaos proxy disabled")
 		}
 
 		select {
@@ -54,7 +54,7 @@ func (c *periodicDisconnect) Run(proxy *toxiproxy.Proxy) {
 				log.Warnf("Failed to re-enable chaos proxy: %s", err)
 				return
 			}
-			log.Debugf("Chaos proxy re-enabled")
+			log.Info("Periodic timer reached: chaos proxy re-enabled")
 		}
 	}
 }

--- a/sensor/common/chaos/profile/periodicdisconnect.go
+++ b/sensor/common/chaos/profile/periodicdisconnect.go
@@ -1,0 +1,60 @@
+package profile
+
+import (
+	"context"
+	"time"
+
+	toxiproxy "github.com/Shopify/toxiproxy/v2/client"
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+var (
+	log = logging.LoggerForModule()
+)
+
+type periodicDisconnect struct {
+	ctx              context.Context
+	disconnectEvery  time.Duration
+	disconnectedTime time.Duration
+}
+
+func newPeriodicDisconnect(ctx context.Context, every, downtime time.Duration) *periodicDisconnect {
+	return &periodicDisconnect{
+		ctx:              ctx,
+		disconnectEvery:  every,
+		disconnectedTime: downtime,
+	}
+}
+
+// Run starts the chaos proxy controller
+func (c *periodicDisconnect) Run(proxy *toxiproxy.Proxy) {
+	defer func() {
+		// If this function early returns, we want to make sure we stop the goroutine
+		// with the proxy enabled (or at least try to).
+		_ = proxy.Enable()
+	}()
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-time.After(c.disconnectEvery):
+			if err := proxy.Disable(); err != nil {
+				log.Warnf("Failed to disable chaos proxy: %s", err)
+				return
+			}
+			log.Debugf("Chaos proxy disabled")
+		}
+
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-time.After(c.disconnectedTime):
+			if err := proxy.Enable(); err != nil {
+				log.Warnf("Failed to re-enable chaos proxy: %s", err)
+				return
+			}
+			log.Debugf("Chaos proxy re-enabled")
+		}
+	}
+}

--- a/sensor/common/chaos/profile/periodicdisconnect.go
+++ b/sensor/common/chaos/profile/periodicdisconnect.go
@@ -40,7 +40,7 @@ func (c *periodicDisconnect) Run(proxy *toxiproxy.Proxy) {
 			return
 		case <-time.After(c.disconnectEvery):
 			if err := proxy.Disable(); err != nil {
-				log.Warnf("Failed to disable chaos proxy: %s", err)
+				log.Warnf("Failed to disable chaos proxy: %v", err)
 				return
 			}
 			log.Info("Periodic timer reached: chaos proxy disabled")
@@ -51,7 +51,7 @@ func (c *periodicDisconnect) Run(proxy *toxiproxy.Proxy) {
 			return
 		case <-time.After(c.disconnectedTime):
 			if err := proxy.Enable(); err != nil {
-				log.Warnf("Failed to re-enable chaos proxy: %s", err)
+				log.Warnf("Failed to re-enable chaos proxy: %v", err)
 				return
 			}
 			log.Info("Periodic timer reached: chaos proxy re-enabled")

--- a/sensor/common/chaos/profile/profile.go
+++ b/sensor/common/chaos/profile/profile.go
@@ -19,8 +19,11 @@ func GetConfig(ctx context.Context, name string) Controller {
 		return newPeriodicDisconnect(ctx, 5*time.Minute, 10*time.Second)
 	case "droppedpackets":
 		return newDroppedPackets(ctx, 0.01)
+	case "none":
+		return &none{}
 	default:
-		return newPeriodicDisconnect(ctx, 5*time.Minute, 10*time.Second)
+		log.Warnf("Profile not set. Chaos proxy profile set to 'none'")
+		return &none{}
 	}
 
 }

--- a/sensor/common/chaos/profile/profile.go
+++ b/sensor/common/chaos/profile/profile.go
@@ -1,0 +1,26 @@
+package profile
+
+import (
+	"context"
+	"time"
+
+	toxiproxy "github.com/Shopify/toxiproxy/v2/client"
+)
+
+// Controller defines a chaos proxy controller, which should be used to introduce network conditions.
+type Controller interface {
+	Run(*toxiproxy.Proxy)
+}
+
+// GetConfig returns a chaos proxy controller given their name.
+func GetConfig(ctx context.Context, name string) Controller {
+	switch name {
+	case "periodicdisconnect":
+		return newPeriodicDisconnect(ctx, 5*time.Minute, 10*time.Second)
+	case "droppedpackets":
+		return newDroppedPackets(ctx, 0.01)
+	default:
+		return newPeriodicDisconnect(ctx, 5*time.Minute, 10*time.Second)
+	}
+
+}

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralclient"
+	"github.com/stackrox/rox/sensor/common/chaos"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/image"
@@ -143,6 +144,9 @@ func createKOCacheSource(centralEndpoint string) (offlineAwareProbeSource, error
 func (s *Sensor) Start() {
 	// Start up connections.
 	log.Infof("Connecting to Central server %s", s.centralEndpoint)
+	if chaos.HasChaosProxy() {
+		chaos.InitializeChaosConfiguration(context.Background())
+	}
 
 	go s.centralConnectionFactory.SetCentralConnectionWithRetries(s.centralConnection)
 


### PR DESCRIPTION
## Description

This PR introduces a chaos testing setup to Sensor. It uses [toxiproxy](github.com/shopify/toxiproxy) as a proxy in between Sensor and Central to introduce bad network conditions.

This is not yet integrated in any automated tests, but you should be able to deploy sensor with toxiproxy by running:

```bash
CHAOS_PROXY="true" ./deploy/k8s/deploy.sh
```

It will patch sensor adding a new container in the same pod that runs `toxiproxy` application. It will also set an environment variable in Sensor `ROX_CHAOS_PROXY_ENABLED` so sensor will do the proxy configurations and add the network conditions. 

So far, I've added two example chaos profiles:
- Periodic disconnects (default): stops the connection for 10 seconds every 5 minutes 
- Random disconnects: 1% of the connection writes should result in disconnects after 6 seconds

We should consider automating QA tests using a chaos proxy, to test if sensor preserves the same behavior (alerts, runtime events and resources transmitted) even through an unreliable network.

## Checklist
- [x ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- [x] Manual testing: deploying ACS with both profiles and testing the application.  

1. Deploy ACS with proxy enabled as explained above
2. (Optional) Port-forward `toxiproxy` API and manipulate the toxics using `toxiproxy-cli` to manually to induce network conditions:
```
$ kubectl -n stackrox port-forward deploy/sensor 8474:8474
```


