### PR TITLE
ROX-18660: Added SecuredCluster CR param registryOverride

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ configure paths for this plugin. See <https://github.com/jvolkman/intellij-proto
 
 </details>
 
-#### Running `sql_integration` tests
+#### Running sql_integration tests
 
 <details><summary>Click to expand</summary>
 

--- a/generated/api/v1/cluster_service.swagger.json
+++ b/generated/api/v1/cluster_service.swagger.json
@@ -662,7 +662,8 @@
         "disableAuditLogs": {
           "type": "boolean"
         }
-      }
+      },
+      "description": "The difference between Static and Dynamic cluster config is that Dynamic values are sent over the Central to Sensor gRPC connection. This has the benefit of allowing for \"hot reloading\" of values without restarting Secured cluster components."
     },
     "storageGoogleProviderMetadata": {
       "type": "object",
@@ -815,7 +816,8 @@
         "admissionControllerEvents": {
           "type": "boolean"
         }
-      }
+      },
+      "description": "The difference between Static and Dynamic cluster config is that Static values are not sent over the Central to Sensor gRPC connection. They are used, for example, to generate manifests that can be used to set up the Secured Cluster's k8s components. They are *not* dynamically reloaded."
     },
     "storageTolerationsConfig": {
       "type": "object",

--- a/generated/storage/cluster.pb.go
+++ b/generated/storage/cluster.pb.go
@@ -930,6 +930,7 @@ func (m *TolerationsConfig) Clone() *TolerationsConfig {
 	return cloned
 }
 
+// The difference between Static and Dynamic cluster config is that Static values are not sent over the Central to Sensor gRPC connection. They are used, for example, to generate manifests that can be used to set up the Secured Cluster's k8s components. They are *not* dynamically reloaded.
 type StaticClusterConfig struct {
 	Type                       ClusterType        `protobuf:"varint,1,opt,name=type,proto3,enum=storage.ClusterType" json:"type,omitempty"`
 	MainImage                  string             `protobuf:"bytes,2,opt,name=main_image,json=mainImage,proto3" json:"main_image,omitempty"`
@@ -1063,6 +1064,7 @@ func (m *StaticClusterConfig) Clone() *StaticClusterConfig {
 	return cloned
 }
 
+// The difference between Static and Dynamic cluster config is that Dynamic values are sent over the Central to Sensor gRPC connection. This has the benefit of allowing for "hot reloading" of values without restarting Secured cluster components.
 type DynamicClusterConfig struct {
 	AdmissionControllerConfig *AdmissionControllerConfig `protobuf:"bytes,1,opt,name=admission_controller_config,json=admissionControllerConfig,proto3" json:"admission_controller_config,omitempty"`
 	RegistryOverride          string                     `protobuf:"bytes,2,opt,name=registry_override,json=registryOverride,proto3" json:"registry_override,omitempty"`

--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -91,6 +91,10 @@ type SecuredClusterSpec struct {
 	// Monitoring configuration.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=13,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	Monitoring *GlobalMonitoring `json:"monitoring,omitempty"`
+
+	// Set this parameter to override the default registry in images. For example, nginx:latest -> <registry override>/library/nginx:latest
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Custom Default Image Registry",order=14,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	RegistryOverride string `json:"registryOverride,omitempty"`
 }
 
 // SensorComponentSpec defines settings for sensor.

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -664,6 +664,10 @@ spec:
                     - AvoidTaints
                     type: string
                 type: object
+              registryOverride:
+                description: Set this parameter to override the default registry in
+                  images. For example, nginx:latest -> <registry override>/library/nginx:latest
+                type: string
               scanner:
                 description: Settings for the Scanner component, which is responsible
                   for vulnerability scanning of container images stored in a cluster-local

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -586,6 +586,12 @@ spec:
         path: monitoring
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Set this parameter to override the default registry in images.
+          For example, nginx:latest -> <registry override>/library/nginx:latest
+        displayName: Custom Default Image Registry
+        path: registryOverride
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Set this to 'true' to enable preventive policy enforcement for
           object creations.
         displayName: Listen On Creates

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -664,6 +664,10 @@ spec:
                     - AvoidTaints
                     type: string
                 type: object
+              registryOverride:
+                description: Set this parameter to override the default registry in
+                  images. For example, nginx:latest -> <registry override>/library/nginx:latest
+                type: string
               scanner:
                 description: Settings for the Scanner component, which is responsible
                   for vulnerability scanning of container images stored in a cluster-local

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -720,6 +720,12 @@ spec:
         path: monitoring
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Set this parameter to override the default registry in images.
+          For example, nginx:latest -> <registry override>/library/nginx:latest
+        displayName: Custom Default Image Registry
+        path: registryOverride
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Allows overriding the default resource settings for this component.
           Please consult the documentation for an overview of default resource requirements
           and a sizing guide.

--- a/operator/pkg/securedcluster/values/translation/translation.go
+++ b/operator/pkg/securedcluster/values/translation/translation.go
@@ -122,6 +122,10 @@ func (t Translator) translate(ctx context.Context, sc platform.SecuredCluster) (
 
 	v.AddChild("monitoring", translation.GetGlobalMonitoring(sc.Spec.Monitoring))
 
+	if sc.Spec.RegistryOverride != "" {
+		v.SetStringValue("registryOverride", sc.Spec.RegistryOverride)
+	}
+
 	return v.Build()
 }
 

--- a/operator/pkg/securedcluster/values/translation/translation_test.go
+++ b/operator/pkg/securedcluster/values/translation/translation_test.go
@@ -377,6 +377,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 						Misc: &platform.MiscSpec{
 							CreateSCCs: pointer.Bool(true),
 						},
+						RegistryOverride: "my.registry.override.com",
 					},
 				},
 			},
@@ -549,6 +550,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 						"enabled": true,
 					},
 				},
+				"registryOverride": "my.registry.override.com",
 			},
 		},
 	}

--- a/proto/storage/cluster.proto
+++ b/proto/storage/cluster.proto
@@ -73,6 +73,7 @@ message TolerationsConfig {
         bool  disabled  = 1;
 }
 
+// The difference between Static and Dynamic cluster config is that Static values are not sent over the Central to Sensor gRPC connection. They are used, for example, to generate manifests that can be used to set up the Secured Cluster's k8s components. They are *not* dynamically reloaded.
 message StaticClusterConfig {
     ClusterType               type                         = 1;
     string                    main_image                   = 2;
@@ -86,6 +87,7 @@ message StaticClusterConfig {
     bool                      admission_controller_events  = 10;
 }
 
+// The difference between Static and Dynamic cluster config is that Dynamic values are sent over the Central to Sensor gRPC connection. This has the benefit of allowing for "hot reloading" of values without restarting Secured cluster components.
 message DynamicClusterConfig {
     AdmissionControllerConfig admission_controller_config = 1;
     string registry_override                              = 2;


### PR DESCRIPTION
## Description

Adds the registry override parameter to the SecuredCluster CR, pipes it through to the Helm chart.

## Checklist
- [Not yet - creating PR] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [Not yet - unsure if required] Evaluated and added CHANGELOG entry if required
- ~~[ ] Determined and documented upgrade steps~~
- [Not yet - unsure if required] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

Unit tests.

Tested: Ran a kind cluster, installed CentralCluster and SecuredCluster CRs, ran the Operator locally, confirmed that the value is piped through when set in the SecuredCluster CR (visible in Central UI means value is set in the backend -> downstream pipe doesn't need testing).

For my own reference:
operator/EXTENDING_CRDS.md (code)
operator/README.md (test)

Example debug configuration in GoLand:
```
Package path: github.com/stackrox/rox/operator
Environment: ENABLE_WEBHOOKS=false
Go tool arguments: '-ldflags=-X "github.com/stackrox/rox/pkg/version/internal.MainVersion=4.1.x-865-gb1013f262d" -X "github.com/stackrox/rox/pkg/version/internal.CollectorVersion=3.15.x-170-g83d1210386" -X "github.com/stackrox/rox/pkg/version/internal.ScannerVersion=2.30.x-30-gd3e2a58a13" -X "github.com/stackrox/rox/pkg/version/internal.GitShortSha=b1013f262d" -linkmode=external'
```
