### PR TITLE
feat(telemetry): set install method

### DIFF
--- a/image/templates/helm/stackrox-central/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-central/internal/config-shape.yaml
@@ -8,6 +8,7 @@ imagePullSecrets:
 image:
   registry: null # string
 env:
+  installMethod: null # string
   openshift: null # bool
   istio: null # bool
   platform: null # string

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -109,6 +109,8 @@ spec:
         - name: ROX_ENABLE_SECURE_METRICS
           value: "true"
         {{- end }}
+        - name: ROX_INSTALL_METHOD
+          value: {{ ._rox.env.installMethod | quote }}
         {{- include "srox.envVars" (list . "deployment" "central" "central") | nindent 8 }}
         volumeMounts:
         - name: varlog

--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -139,6 +139,14 @@
 {{ include "srox.autoSensePodSecurityPolicies" (list $) }}
 [<- end >]
 
+[< if .Operator >]
+{{ $_ := set $env "installMethod" "rhacs-operator" }}
+[< else if not .KubectlOutput >]
+{{ $_ := set $env "installMethod" "helm" }}
+[< else >]
+{{ $_ := set $env "installMethod" "manifest" }}
+[< end >]
+
 {{/* Apply defaults */}}
 {{ $defaultsCfg := dict }}
 {{ $platformCfgFile := dict }}

--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -140,11 +140,11 @@
 [<- end >]
 
 [< if .Operator >]
-{{ $_ := set $env "installMethod" "rhacs-operator" }}
-[< else if not .KubectlOutput >]
-{{ $_ := set $env "installMethod" "helm" }}
-[< else >]
+{{ $_ := set $env "installMethod" "operator" }}
+[< else if .KubectlOutput >]
 {{ $_ := set $env "installMethod" "manifest" }}
+[< else >]
+{{ $_ := set $env "installMethod" "helm" }}
 [< end >]
 
 {{/* Apply defaults */}}

--- a/operator/tests/central/basic-central/80-assert.yaml
+++ b/operator/tests/central/basic-central/80-assert.yaml
@@ -39,7 +39,7 @@ spec:
             - name: ROX_OPENSHIFT
               value: "true"
             - name: ROX_INSTALL_METHOD
-              value: "rhacs-operator"
+              value: "operator"
             - name: NO_PROXY
               valueFrom:
                 secretKeyRef:

--- a/operator/tests/central/basic-central/80-assert.yaml
+++ b/operator/tests/central/basic-central/80-assert.yaml
@@ -38,6 +38,8 @@ spec:
               value: "true"
             - name: ROX_OPENSHIFT
               value: "true"
+            - name: ROX_INSTALL_METHOD
+              value: "rhacs-operator"
             - name: NO_PROXY
               valueFrom:
                 secretKeyRef:

--- a/operator/tests/central/basic-central/81-assert.yaml
+++ b/operator/tests/central/basic-central/81-assert.yaml
@@ -34,6 +34,8 @@ spec:
               value: "true"
             - name: ROX_OPENSHIFT
               value: "true"
+            - name: ROX_INSTALL_METHOD
+              value: "rhacs-operator"
             - name: NO_PROXY
               valueFrom:
                 secretKeyRef:

--- a/operator/tests/central/basic-central/81-assert.yaml
+++ b/operator/tests/central/basic-central/81-assert.yaml
@@ -35,7 +35,7 @@ spec:
             - name: ROX_OPENSHIFT
               value: "true"
             - name: ROX_INSTALL_METHOD
-              value: "rhacs-operator"
+              value: "operator"
             - name: NO_PROXY
               valueFrom:
                 secretKeyRef:

--- a/sensor/common/installmethod/install.go
+++ b/sensor/common/installmethod/install.go
@@ -1,0 +1,34 @@
+package installmethod
+
+import (
+	storage "github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	installMethod string
+	mutex         sync.RWMutex
+)
+
+// Get returns the installation method.
+func Get() string {
+	mutex.RLock()
+	defer mutex.RUnlock()
+
+	return installMethod
+}
+
+// Set sets the installation method based on the managedBy property.
+func Set(value storage.ManagerType) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	switch value {
+	case storage.ManagerType_MANAGER_TYPE_MANUAL:
+		installMethod = "manifest"
+	case storage.ManagerType_MANAGER_TYPE_HELM_CHART:
+		installMethod = "helm"
+	case storage.ManagerType_MANAGER_TYPE_KUBERNETES_OPERATOR:
+		installMethod = "rhacs-operator"
+	}
+}

--- a/sensor/common/installmethod/install.go
+++ b/sensor/common/installmethod/install.go
@@ -29,6 +29,6 @@ func Set(value storage.ManagerType) {
 	case storage.ManagerType_MANAGER_TYPE_HELM_CHART:
 		installMethod = "helm"
 	case storage.ManagerType_MANAGER_TYPE_KUBERNETES_OPERATOR:
-		installMethod = "rhacs-operator"
+		installMethod = "operator"
 	}
 }

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -4,11 +4,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/branding"
-	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/version"
 	"github.com/stackrox/rox/sensor/common/centralid"
 	"github.com/stackrox/rox/sensor/common/clusterid"
+	"github.com/stackrox/rox/sensor/common/installmethod"
 )
 
 var (
@@ -152,9 +152,9 @@ var (
 		"branding":       branding.GetProductNameShort(),
 		"build":          metrics.GetBuildType(),
 		"hosting":        getHosting(),
-		"install_method": env.InstallMethod.Setting(),
 		"sensor_version": version.GetMainVersion(),
 	}
+
 	telemetrySecuredNodes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace:   metrics.PrometheusNamespace,
@@ -163,7 +163,7 @@ var (
 			Help:        "The number of nodes secured by Sensor",
 			ConstLabels: telemetryLabels,
 		},
-		[]string{"central_id", "sensor_id"},
+		[]string{"central_id", "install_method", "sensor_id"},
 	)
 
 	telemetrySecuredVCPU = prometheus.NewGaugeVec(
@@ -174,7 +174,7 @@ var (
 			Help:        "The number of vCPUs secured by Sensor",
 			ConstLabels: telemetryLabels,
 		},
-		[]string{"central_id", "sensor_id"},
+		[]string{"central_id", "install_method", "sensor_id"},
 	)
 )
 
@@ -281,11 +281,13 @@ func SetTelemetryMetrics(cm *central.ClusterMetrics) {
 	telemetrySecuredNodes.Reset()
 	telemetrySecuredNodes.WithLabelValues(
 		centralid.Get(),
+		installmethod.Get(),
 		clusterid.GetNoWait(),
 	).Set(float64(cm.GetNodeCount()))
 	telemetrySecuredVCPU.Reset()
 	telemetrySecuredVCPU.WithLabelValues(
 		centralid.Get(),
+		installmethod.Get(),
 		clusterid.GetNoWait(),
 	).Set(float64(cm.GetCpuCapacity()))
 }

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/externalsrcs"
 	"github.com/stackrox/rox/sensor/common/image"
+	"github.com/stackrox/rox/sensor/common/installmethod"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/networkflow/manager"
 	"github.com/stackrox/rox/sensor/common/networkflow/service"
@@ -95,6 +96,8 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 			return nil, errors.New("a sensor that uses certificates from an init bundle must have a cluster name specified")
 		}
 	}
+
+	installmethod.Set(helmManagedConfig.GetManagedBy())
 
 	deploymentIdentification := fetchDeploymentIdentification(context.Background(), cfg.k8sClient.Kubernetes())
 	log.Infof("Determined deployment identification: %s", protoutils.NewWrapper(deploymentIdentification))


### PR DESCRIPTION
## Description

Set the `install_method={rhacs-operator, manifest, helm}` label for the telemetry metrics. The install method is determined based on available fields in the Helm chart:
* `.Operator` -> Helm chart was rendered by the RHACS operator.
* `.KubectlOutput` -> Helm chart was rendered by manifest renderer.
* otherwise it's a plain Helm chart.

In Central, this information is based in via an env variable `ROX_INSTALL_METHOD`. Sensor already knows about it via its `managedBy` property, so we just need to expose it to the telemetry metric.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
