### PR TITLE
ROX-19088: Remove unneeded conditional RBAC in Risk Acceptance 1.0

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/RiskAcceptancePage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/RiskAcceptancePage.tsx
@@ -14,9 +14,7 @@ import {
 } from '@patternfly/react-core';
 import { Switch, Route, useHistory, useLocation, Redirect } from 'react-router-dom';
 
-import { dashboardPath, vulnManagementPath } from 'routePaths';
-import usePermissions from 'hooks/usePermissions';
-import NotFoundMessage from 'Components/NotFoundMessage';
+import { dashboardPath } from 'routePaths';
 import PageTitle from 'Components/PageTitle';
 
 import {
@@ -82,23 +80,8 @@ function TabContentList({ activeKeyTab }): ReactElement {
 }
 
 function RiskAcceptancePage(): ReactElement {
-    const { hasReadAccess } = usePermissions();
     const history = useHistory();
     const location = useLocation();
-
-    if (
-        !hasReadAccess('VulnerabilityManagementRequests') ||
-        !hasReadAccess('VulnerabilityManagementApprovals')
-    ) {
-        return (
-            <NotFoundMessage
-                title="404: Not found"
-                message="This page doesn't exist, return to Vulnerability Management"
-                actionText="Go to Vulnerability Management"
-                url={vulnManagementPath}
-            />
-        );
-    }
 
     const activeKeyTab = getActiveKeyTab(location.pathname);
 


### PR DESCRIPTION
## Description

### Analysis

1. RiskAcceptancePage has conditional rendering of 404 Not Found page that is now generic in Body.
2. Table components have conditional rendering for READ_WRITE_ACCESS to VulnerabilityManagementApprovals or VulnerabilityManagementRequests resources.

### Solution

1. Delete obsolete conditional rendering.

### Lessons

1. Some of the conditional rendering conflates whether action items:
    * are disabled because of current selection or user
    * are unavailable because of user role
2. Seen here again, as discovered recently elsewhere:
    * `Select` element does not support conditional rendering of `SelectOption` but is not first choice for imperative actions.
    * `Dropdown` element better supports conditional push of items into `dropdownItems` array but `BulkActionsDropdown` does not because it emulates child composition.

### Residue

1. Because of **Lessons** item 2 and because it is used only in container which is counting down to deprecation, move `BulkActionsDropdown` from src/Components/PatternFly folder.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Even webpack cannot delete unreachable conditional rendering in components.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3759688 - 3759688
        total: -299 = 9948717 - 9949016
    * `ls -al build/static/js/*.js | wc -l`
        0 = 81 - 81 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/vulnerability-management/risk-acceptance and verify route resource access requirements.

### Integration testing

* vulnmanagement/riskAcceptance/observedCVEs.test.js is skipped