### PR TITLE
ROX-18829: switch gke ebpf race condition qa e2e tests to core bpf

### DIFF
--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -129,7 +129,9 @@ function get_cluster_zip {
     EXTRA_JSON="$8"
 
     COLLECTION_METHOD_ENUM="default"
-    if [[ "$COLLECTION_METHOD" == "ebpf" ]]; then
+    if [[ "$COLLECTION_METHOD" == "core_bpf" ]]; then
+       COLLECTION_METHOD_ENUM="CORE_BPF"
+    elif [[ "$COLLECTION_METHOD" == "ebpf" ]]; then
       COLLECTION_METHOD_ENUM="EBPF"
     elif [[ "$COLLECTION_METHOD" == "none" ]]; then
       COLLECTION_METHOD_ENUM="NO_COLLECTION"


### PR DESCRIPTION
## Description

We have recently added core_bpf as a new collection method for collector as tech preview. It will soon become GA. This PR adds core_bpf as a collection method to deploy/common/deploy.sh. It was noticed that it had not been added previously when the gke-race-condition-qa-e2e-tests failed when run with the core_bpf collection method.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Race condition tests running in openshift/release PR with core_bpf 
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Ran race condition tests in openshift/release PR with core_bpf 

See https://github.com/openshift/release/pull/42327