### PR TITLE
ROX-19089: Add conditional RBAC in Network Graph

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -23,6 +23,7 @@ import { networkBasePath } from 'routePaths';
 import { timeWindows } from 'constants/timeWindows';
 import useFetchClustersForPermissions from 'hooks/useFetchClustersForPermissions';
 import useFetchDeploymentCount from 'hooks/useFetchDeploymentCount';
+import usePermissions from 'hooks/usePermissions';
 import useURLSearch from 'hooks/useURLSearch';
 import { fetchNetworkFlowGraph, fetchNodeUpdates } from 'services/NetworkService';
 import queryService from 'utils/queryService';
@@ -75,6 +76,11 @@ const INCLUDE_POLICIES = true;
 const clusterPermissions = ['NetworkGraph', 'Deployment'];
 
 function NetworkGraphPage() {
+    const { hasReadAccess, hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForBlocks =
+        hasReadAccess('Administration') && hasReadWriteAccess('NetworkGraph');
+    const hasReadAccessForGenerator = hasReadAccess('Integration');
+
     const history = useHistory();
     const [edgeState, setEdgeState] = useState<EdgeState>('active');
     const [displayOptions, setDisplayOptions] = useState<DisplayOption[]>([
@@ -286,23 +292,32 @@ function NetworkGraphPage() {
                                 selectedDeployments={deploymentsFromUrl}
                             />
                         </ToolbarGroup>
-                        <ToolbarGroup variant="button-group" alignment={{ default: 'alignRight' }}>
-                            <ToolbarItem spacer={{ default: 'spacerMd' }}>
-                                <Button
-                                    variant="secondary"
-                                    onClick={toggleCIDRBlockForm}
-                                    isDisabled={!selectedClusterId}
-                                >
-                                    Manage CIDR blocks
-                                </Button>
-                            </ToolbarItem>
-                            <ToolbarItem spacer={{ default: 'spacerNone' }}>
-                                <SimulateNetworkPolicyButton
-                                    simulation={simulation}
-                                    isDisabled={scopeHierarchy.cluster.id === ''}
-                                />
-                            </ToolbarItem>
-                        </ToolbarGroup>
+                        {(hasWriteAccessForBlocks || hasReadAccessForGenerator) && (
+                            <ToolbarGroup
+                                variant="button-group"
+                                alignment={{ default: 'alignRight' }}
+                            >
+                                {hasWriteAccessForBlocks && (
+                                    <ToolbarItem spacer={{ default: 'spacerMd' }}>
+                                        <Button
+                                            variant="secondary"
+                                            onClick={toggleCIDRBlockForm}
+                                            isDisabled={!selectedClusterId}
+                                        >
+                                            Manage CIDR blocks
+                                        </Button>
+                                    </ToolbarItem>
+                                )}
+                                {hasReadAccessForGenerator && (
+                                    <ToolbarItem spacer={{ default: 'spacerNone' }}>
+                                        <SimulateNetworkPolicyButton
+                                            simulation={simulation}
+                                            isDisabled={scopeHierarchy.cluster.id === ''}
+                                        />
+                                    </ToolbarItem>
+                                )}
+                            </ToolbarGroup>
+                        )}
                     </ToolbarContent>
                 </Toolbar>
             </PageSection>

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -172,7 +172,12 @@ const routeDescriptionMap: Record<string, RouteDescription> = {
         resourceAccessRequirements: everyResource(['Deployment', 'DeploymentExtension']),
     },
     [networkPath]: {
-        resourceAccessRequirements: everyResource(['NetworkGraph', 'NetworkPolicy']),
+        resourceAccessRequirements: everyResource([
+            'Deployment',
+            'DeploymentExtension',
+            'NetworkGraph',
+            'NetworkPolicy',
+        ]),
     },
     [policyManagementBasePath]: {
         resourceAccessRequirements: everyResource([


### PR DESCRIPTION
## Description

### Analysis

1. `DeploymentSelector` requires READ_ACCESS for Deployment resource.
2. Side panel requires READ_ACCESS for DeploymentExtension resource.
3. **Manage CIDR blocks** has asymmetrical requirements
    * requires READ_ACCESS for Administration resource to open the modal
    * requires READ_WRITE_ACCESS for NetworkGraph to click **Update configuration**
        Usually I would require only READ_ACCESS to open and conditionally render **Update** button, but **Manage** verb sets an expection to touch with your hands, not just see with your eyes.
4. **Network policy generator**
    * requires READ_ACCESS for Notifier resource, probably for **Share YAML with notifiers**

### Solution

1. Add resources to `resourceAccessRequirements` in routePaths.ts file.
2. Add conditional rendering in `NetworkGraphPage` component.

### Residue

1. Investigate correctness of asymmetric requirements for **Manage CIDR blocks**
2. Brainstorm with Dave whether conditional rendering for Integration resource is possible in **Network policy generator**
3. Brainstorm with Dave about errors in developer console especially when generator/simulator is open.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 35 = 3759767 - 3759732
        total: 194 = 9949254 - 9949060
    * `ls -al build/static/js/*.js | wc -l`
        0 = 81 - 81 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/network-graph

    * See neither button at upper right of Network Graph
        ![neither](https://github.com/stackrox/stackrox/assets/11862657/ac1a2cc9-01d9-4fc9-ba81-4fe293573d7a)

    * See only **Manage CIDR blocks** button
        ![only_Manage_CIDR_blocks](https://github.com/stackrox/stackrox/assets/11862657/a6391096-e1a8-4689-950a-262e5dc5f87f)

    * See only **Network policy generator** button
        ![only_Network_policy_generator](https://github.com/stackrox/stackrox/assets/11862657/3c2a6757-af34-4b15-91fa-94e48e349253)

    * See both buttons
        ![both](https://github.com/stackrox/stackrox/assets/11862657/67eb9509-bfa8-40d5-84a8-57b5e905bafb)

### Integration testing

* networkGraph/networkDeploymentSidebar.test.js
* networkGraph/networkGraph.test.js
