### PR TITLE
debug(ci): collect logs from splunk

### DIFF
--- a/qa-tests-backend/src/main/groovy/common/Constants.groovy
+++ b/qa-tests-backend/src/main/groovy/common/Constants.groovy
@@ -45,6 +45,7 @@ class Constants {
     // common functionality that occurs for all tests such as debug gathering when
     // tests fail.
     static final TEST_FEATURE_TIMEOUT_PAD = 360
+    static final String SPLUNK_TEST_NAMESPACE = "qa-splunk"
 
     /*
         StackRox Product Feature Flags

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -105,6 +105,7 @@ class Helpers {
             shellCmd("./scripts/ci/collect-service-logs.sh stackrox ${collectionDir}/stackrox-k8s-logs")
             shellCmd("./scripts/ci/collect-service-logs.sh kube-system ${collectionDir}/kube-system-k8s-logs")
             shellCmd("./scripts/ci/collect-qa-service-logs.sh ${collectionDir}/qa-k8s-logs")
+            shellCmd("./scripts/ci/collect-splunk-logs.sh ${Constants.SPLUNK_TEST_NAMESPACE} ${collectionDir}/splunk-logs")
             shellCmd("./scripts/grab-data-from-central.sh ${collectionDir}/central-data")
         }
         catch (Exception e) {

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -42,7 +42,7 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
     "splunk-common-information-model-cim_511.tgz")
     private static final String STACKROX_REMOTE_LOCATION = "/tmp/stackrox.spl"
     private static final String CIM_REMOTE_LOCATION = "/tmp/cim.tgz"
-    private static final String TEST_NAMESPACE = "qa-splunk-violation"
+    private static final String TEST_NAMESPACE = Constants.SPLUNK_TEST_NAMESPACE
     private static final String SPLUNK_INPUT_NAME = "stackrox-violations-input"
 
     private SplunkDeployment splunkDeployment

--- a/scripts/ci/collect-splunk-logs.sh
+++ b/scripts/ci/collect-splunk-logs.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Collect logs from as splunk pod daemon
+#
+# Usage:
+#   collect-splunk-logs.sh NAMESPACE DIR
+
+usage() {
+    echo "./scripts/ci/collect-splunk-logs.sh <namespace> <output-dir>"
+}
+
+main() {
+    if [[ "$#" -lt 2 ]]; then
+        usage
+        exit 1
+    fi
+
+    namespace="$1"
+    log_dir="$2"
+
+    if ! kubectl get ns "${namespace}"; then
+        echo "Collection is skipped when the splunk namespace is missing: ${namespace}"
+        exit 0
+    fi
+
+    mkdir -p "${log_dir}"
+
+    splunk_pod="$(kubectl -n "${namespace}" get pods -o json \
+      | jq -r '.items[] | select(.metadata.labels["app"]? | match("^splunk")) | .metadata.name')"
+
+    kubectl -n "${namespace}" exec "${splunk_pod}" -- \
+      sudo tar cf - --warning=no-file-changed /opt/splunk/var/log/splunk | \
+      tar xf - --strip 5 -C "${log_dir}"
+
+    echo "Splunk logs saved to ${log_dir}"
+}
+
+main "$@"


### PR DESCRIPTION
## Description

Per title. For splunk test failure it might be useful to have the splunkd logs. @ivan-degtiarenko @Maddosaurus let me know if this would be useful. I created it as part of #7343 and it works well but #7343 will not be merged.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Tested on #7343.