### PR TITLE
ROX-18881: Add extra margin below dropdown in reporting form

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
@@ -134,6 +134,9 @@ function CollectionSelection({
                 fieldId="scopeId"
                 touched={{}}
                 errors={{}}
+                // Workaround to ensure there is enough space for the select menu when opened
+                // at the bottom of a wizard step body (May no longer be needed after upgrade to PF5)
+                className={isOpen ? 'pf-u-mb-3xl' : ''}
             >
                 <Flex
                     direction={{ default: 'row' }}


### PR DESCRIPTION
## Description

Small UX improvement for the collections menu in reporting 2.0. This makes the space in the wizard container expand slightly when the menu is opened.

In either case, this makes the body of the wizard component scrollable, but after this change it is more apparent that the menu has expanded by exposing content.

An alternative implementation that would be simple is to add `direction="up"` to the Select component, but the UX felt a bit out of place. Setting the behavior to flip automatically only works if we set a non-default parent for the dropdown list component. I tested this a bit but found it was fixing the issue at hand while introducing others.

Note that it appears that the interaction between these components is fixed in PF5, so this may not be needed after upgrade:
![image](https://github.com/stackrox/stackrox/assets/1292638/f2586bcc-c3c3-45ce-bfbc-60518844ca48)


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Before change:
One item:
![image](https://github.com/stackrox/stackrox/assets/1292638/fb07d4fa-f24c-4f45-99ea-d5c3604fbb67)
![image](https://github.com/stackrox/stackrox/assets/1292638/1911dc00-dbb8-4949-a5eb-521577753913)
Many items:
![image](https://github.com/stackrox/stackrox/assets/1292638/c4551cc3-62f9-4a2e-bcd9-4e672c738d58)
![image](https://github.com/stackrox/stackrox/assets/1292638/c53a8d45-643f-4775-bc64-549fb840ea24)
![image](https://github.com/stackrox/stackrox/assets/1292638/3a6901b3-32cf-4268-a92a-e35cf31230c7)


After change:
One item:
![image](https://github.com/stackrox/stackrox/assets/1292638/83b1a318-7f8f-4cb9-9e00-15f5d46d1872)
![image](https://github.com/stackrox/stackrox/assets/1292638/c3db6294-86ae-4890-9388-787beee605f7)
Many items:
![image](https://github.com/stackrox/stackrox/assets/1292638/cdb1a939-4cf4-488e-ac46-98098791546c)
![image](https://github.com/stackrox/stackrox/assets/1292638/dd31ebdb-f819-4413-9459-e651d8c5b466)
![image](https://github.com/stackrox/stackrox/assets/1292638/9c32e0fa-8d14-4387-b655-74e6e23ff969)


