### PR TITLE
[ROX-19037] : Allow reporting v1 and v2 to coexist

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -407,7 +407,7 @@ func servicesToRegister() []pkgGRPC.APIService {
 	}
 
 	if env.VulnReportingEnhancements.BooleanSetting() {
-		// TODO Remove (deprecated) v1 report configuration service when Reporting enhancements are enabled by default.
+		// TODO Remove (deprecated) v1 report configuration service when Reporting 2.0 is GA.
 		servicesToRegister = append(servicesToRegister, reportServiceV2.Singleton())
 	}
 
@@ -845,12 +845,11 @@ func waitForTerminationSignal() {
 		{centralclient.InstanceConfig().Gatherer(), "telemetry gatherer"},
 		{centralclient.InstanceConfig().Telemeter(), "telemetry client"},
 		{obj: apiTokenExpiration.Singleton(), name: "api token expiration notifier"},
+		{vulnReportScheduleManager.Singleton(), "vuln reports v1 schedule manager"},
 	}
 
 	if env.VulnReportingEnhancements.BooleanSetting() {
 		stoppables = append(stoppables, stoppableWithName{vulnReportV2Scheduler.Singleton(), "vuln reports v2 scheduler"})
-	} else {
-		stoppables = append(stoppables, stoppableWithName{vulnReportScheduleManager.Singleton(), "vuln reports schedule manager"})
 	}
 
 	var wg sync.WaitGroup

--- a/central/reports/common/testutils.go
+++ b/central/reports/common/testutils.go
@@ -8,34 +8,34 @@ import (
 )
 
 // GetTestReportConfigsV1 returns v1 configs for testing
-func GetTestReportConfigsV1(_ *testing.T, notifierId, collectionId string) []*storage.ReportConfiguration {
+func GetTestReportConfigsV1(_ *testing.T, notifierID, collectionID string) []*storage.ReportConfiguration {
 	v1Config1 := fixtures.GetValidReportConfigWithMultipleNotifiersV1()
 	v1Config1.Id = ""
 	v1Config1.Name = "Report Config - 1"
-	v1Config1.GetEmailConfig().NotifierId = notifierId
-	v1Config1.ScopeId = collectionId
+	v1Config1.GetEmailConfig().NotifierId = notifierID
+	v1Config1.ScopeId = collectionID
 
 	v1Config2 := fixtures.GetValidReportConfigWithMultipleNotifiersV1()
 	v1Config2.Id = ""
 	v1Config2.Name = "Report Config - 2"
-	v1Config2.GetEmailConfig().NotifierId = notifierId
-	v1Config2.ScopeId = collectionId
+	v1Config2.GetEmailConfig().NotifierId = notifierID
+	v1Config2.ScopeId = collectionID
 
 	return []*storage.ReportConfiguration{v1Config1, v1Config2}
 }
 
 // GetTestReportConfigsV2 returns v2 configs for testing
-func GetTestReportConfigsV2(_ *testing.T, notifierId, collectionId string) []*storage.ReportConfiguration {
+func GetTestReportConfigsV2(_ *testing.T, notifierID, collectionID string) []*storage.ReportConfiguration {
 	v2Config1 := fixtures.GetValidReportConfigWithMultipleNotifiersV2()
 	v2Config1.Id = ""
 	v2Config1.Name = "Report Config - 1"
 	for _, notifierConf := range v2Config1.GetNotifiers() {
 		notifierConf.Ref = &storage.NotifierConfiguration_Id{
-			Id: notifierId,
+			Id: notifierID,
 		}
 	}
 	v2Config1.ResourceScope.ScopeReference = &storage.ResourceScope_CollectionId{
-		CollectionId: collectionId,
+		CollectionId: collectionID,
 	}
 
 	v2Config2 := fixtures.GetValidReportConfigWithMultipleNotifiersV2()
@@ -43,11 +43,11 @@ func GetTestReportConfigsV2(_ *testing.T, notifierId, collectionId string) []*st
 	v2Config2.Name = "Report Config - 2"
 	for _, notifierConf := range v2Config2.GetNotifiers() {
 		notifierConf.Ref = &storage.NotifierConfiguration_Id{
-			Id: notifierId,
+			Id: notifierID,
 		}
 	}
 	v2Config2.ResourceScope.ScopeReference = &storage.ResourceScope_CollectionId{
-		CollectionId: collectionId,
+		CollectionId: collectionID,
 	}
 
 	return []*storage.ReportConfiguration{v2Config1, v2Config2}

--- a/central/reports/common/testutils.go
+++ b/central/reports/common/testutils.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/fixtures"
+)
+
+// GetTestReportConfigsV1 returns v1 configs for testing
+func GetTestReportConfigsV1(_ *testing.T, notifierId, collectionId string) []*storage.ReportConfiguration {
+	v1Config1 := fixtures.GetValidReportConfigWithMultipleNotifiersV1()
+	v1Config1.Id = ""
+	v1Config1.Name = "Report Config - 1"
+	v1Config1.GetEmailConfig().NotifierId = notifierId
+	v1Config1.ScopeId = collectionId
+
+	v1Config2 := fixtures.GetValidReportConfigWithMultipleNotifiersV1()
+	v1Config2.Id = ""
+	v1Config2.Name = "Report Config - 2"
+	v1Config2.GetEmailConfig().NotifierId = notifierId
+	v1Config2.ScopeId = collectionId
+
+	return []*storage.ReportConfiguration{v1Config1, v1Config2}
+}
+
+// GetTestReportConfigsV2 returns v2 configs for testing
+func GetTestReportConfigsV2(_ *testing.T, notifierId, collectionId string) []*storage.ReportConfiguration {
+	v2Config1 := fixtures.GetValidReportConfigWithMultipleNotifiersV2()
+	v2Config1.Id = ""
+	v2Config1.Name = "Report Config - 1"
+	for _, notifierConf := range v2Config1.GetNotifiers() {
+		notifierConf.Ref = &storage.NotifierConfiguration_Id{
+			Id: notifierId,
+		}
+	}
+	v2Config1.ResourceScope.ScopeReference = &storage.ResourceScope_CollectionId{
+		CollectionId: collectionId,
+	}
+
+	v2Config2 := fixtures.GetValidReportConfigWithMultipleNotifiersV2()
+	v2Config2.Id = ""
+	v2Config2.Name = "Report Config - 2"
+	for _, notifierConf := range v2Config2.GetNotifiers() {
+		notifierConf.Ref = &storage.NotifierConfiguration_Id{
+			Id: notifierId,
+		}
+	}
+	v2Config2.ResourceScope.ScopeReference = &storage.ResourceScope_CollectionId{
+		CollectionId: collectionId,
+	}
+
+	return []*storage.ReportConfiguration{v2Config1, v2Config2}
+}

--- a/central/reports/common/utils.go
+++ b/central/reports/common/utils.go
@@ -2,8 +2,10 @@ package common
 
 import (
 	rolePkg "github.com/stackrox/rox/central/role"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/grpc/authn"
+	"github.com/stackrox/rox/pkg/search"
 )
 
 // ExtractAccessScopeRules extracts simple access scope rules from the given authenticated user identity
@@ -33,4 +35,28 @@ func ExtractAccessScopeRules(identity authn.Identity) []*storage.SimpleAccessSco
 		accessScopeRulesList = append(accessScopeRulesList, rolePkg.AccessScopeExcludeAll.GetRules())
 	}
 	return accessScopeRulesList
+}
+
+// IsV1ReportConfig returns true if the given config belongs to reporting version 1.0
+func IsV1ReportConfig(config *storage.ReportConfiguration) bool {
+	return config.GetResourceScope() == nil
+}
+
+// IsV2ReportConfig returns true if the given config belongs to reporting version 2.0
+func IsV2ReportConfig(config *storage.ReportConfiguration) bool {
+	return config.GetResourceScope() != nil
+}
+
+// WithoutV2ReportConfigs adds a conjunction query to exclude v2 report configs
+func WithoutV2ReportConfigs(query *v1.Query) *v1.Query {
+	return search.ConjunctionQuery(
+		query,
+		search.NewQueryBuilder().AddExactMatches(search.CollectionID, "").ProtoQuery())
+}
+
+// WithoutV1ReportConfigs adds a conjunction query to exclude v1 report configs
+func WithoutV1ReportConfigs(query *v1.Query) *v1.Query {
+	return search.ConjunctionQuery(
+		query,
+		search.NewQueryBuilder().AddExactMatches(search.EmbeddedCollectionID, "").ProtoQuery())
 }

--- a/central/reports/config/service/config_separation_test.go
+++ b/central/reports/config/service/config_separation_test.go
@@ -56,21 +56,21 @@ func (s *ServiceLevelConfigSeparationSuite) SetupSuite() {
 	s.ctx = sac.WithAllAccess(context.Background())
 
 	// Add notifier
-	notifierId, err := s.notifierDatastore.AddNotifier(s.ctx, &storage.Notifier{Name: "notifier"})
+	notifierID, err := s.notifierDatastore.AddNotifier(s.ctx, &storage.Notifier{Name: "notifier"})
 	s.Require().NoError(err)
 
 	// Add collection
-	collectionId, err := s.collectionDatastore.AddCollection(s.ctx, &storage.ResourceCollection{Name: "collection"})
+	collectionID, err := s.collectionDatastore.AddCollection(s.ctx, &storage.ResourceCollection{Name: "collection"})
 	s.Require().NoError(err)
 
 	// Add report configs
-	s.v1Configs = common.GetTestReportConfigsV1(s.T(), notifierId, collectionId)
+	s.v1Configs = common.GetTestReportConfigsV1(s.T(), notifierID, collectionID)
 	for _, conf := range s.v1Configs {
 		conf.Id, err = s.reportConfigDatastore.AddReportConfiguration(s.ctx, conf)
 		s.Require().NoError(err)
 	}
 
-	s.v2Configs = common.GetTestReportConfigsV2(s.T(), notifierId, collectionId)
+	s.v2Configs = common.GetTestReportConfigsV2(s.T(), notifierID, collectionID)
 	for _, conf := range s.v2Configs {
 		conf.Id, err = s.reportConfigDatastore.AddReportConfiguration(s.ctx, conf)
 		s.Require().NoError(err)

--- a/central/reports/config/service/config_separation_test.go
+++ b/central/reports/config/service/config_separation_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package service
 
 import (

--- a/central/reports/config/service/config_separation_test.go
+++ b/central/reports/config/service/config_separation_test.go
@@ -1,0 +1,169 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
+	"github.com/stackrox/rox/central/reports/common"
+	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
+	managerMocks "github.com/stackrox/rox/central/reports/manager/mocks"
+	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
+	apiV1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+func TestServiceLevelConfigSeparation(t *testing.T) {
+	suite.Run(t, new(ServiceLevelConfigSeparationSuite))
+}
+
+type ServiceLevelConfigSeparationSuite struct {
+	suite.Suite
+	service Service
+
+	testDB                *pgtest.TestPostgres
+	ctx                   context.Context
+	reportConfigDatastore reportConfigDS.DataStore
+	notifierDatastore     notifierDS.DataStore
+	collectionDatastore   collectionDS.DataStore
+	manager               *managerMocks.MockManager
+	mockCtrl              *gomock.Controller
+
+	v1Configs []*storage.ReportConfiguration
+	v2Configs []*storage.ReportConfiguration
+}
+
+func (s *ServiceLevelConfigSeparationSuite) SetupSuite() {
+	s.testDB = pgtest.ForT(s.T())
+	s.reportConfigDatastore = reportConfigDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
+	s.notifierDatastore = notifierDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
+
+	var err error
+	s.collectionDatastore, _, err = collectionDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
+	s.Require().NoError(err)
+
+	s.mockCtrl = gomock.NewController(s.T())
+	s.manager = managerMocks.NewMockManager(s.mockCtrl)
+	s.service = New(s.reportConfigDatastore, s.notifierDatastore, s.collectionDatastore, s.manager)
+
+	s.ctx = sac.WithAllAccess(context.Background())
+
+	// Add notifier
+	notifierId, err := s.notifierDatastore.AddNotifier(s.ctx, &storage.Notifier{Name: "notifier"})
+	s.Require().NoError(err)
+
+	// Add collection
+	collectionId, err := s.collectionDatastore.AddCollection(s.ctx, &storage.ResourceCollection{Name: "collection"})
+	s.Require().NoError(err)
+
+	// Add report configs
+	s.v1Configs = common.GetTestReportConfigsV1(s.T(), notifierId, collectionId)
+	for _, conf := range s.v1Configs {
+		conf.Id, err = s.reportConfigDatastore.AddReportConfiguration(s.ctx, conf)
+		s.Require().NoError(err)
+	}
+
+	s.v2Configs = common.GetTestReportConfigsV2(s.T(), notifierId, collectionId)
+	for _, conf := range s.v2Configs {
+		conf.Id, err = s.reportConfigDatastore.AddReportConfiguration(s.ctx, conf)
+		s.Require().NoError(err)
+	}
+}
+
+func (s *ServiceLevelConfigSeparationSuite) TearDownSuite() {
+	s.mockCtrl.Finish()
+	s.testDB.Teardown(s.T())
+}
+
+func (s *ServiceLevelConfigSeparationSuite) TestGetReportConfigurations() {
+	// Empty Query
+	res, err := s.service.GetReportConfigurations(s.ctx, &apiV1.RawQuery{Query: ""})
+	s.Require().NoError(err)
+	s.Require().ElementsMatch(s.v1Configs, res.ReportConfigs)
+
+	// Non empty query
+	res, err = s.service.GetReportConfigurations(s.ctx,
+		&apiV1.RawQuery{Query: fmt.Sprintf("Report Name:%s", s.v1Configs[0].Name)})
+	s.Require().NoError(err)
+	s.Require().Equal(1, len(res.ReportConfigs))
+	s.Require().Equal(s.v1Configs[0], res.ReportConfigs[0])
+}
+
+func (s *ServiceLevelConfigSeparationSuite) TestGetReportConfiguration() {
+	// returns v1 config
+	res, err := s.service.GetReportConfiguration(s.ctx, &apiV1.ResourceByID{Id: s.v1Configs[0].Id})
+	s.Require().NoError(err)
+	s.Require().Equal(s.v1Configs[0], res.ReportConfig)
+
+	// error on requesting v2 config
+	_, err = s.service.GetReportConfiguration(s.ctx, &apiV1.ResourceByID{Id: s.v2Configs[0].Id})
+	s.Require().Error(err)
+}
+
+func (s *ServiceLevelConfigSeparationSuite) TestCountReportConfigurations() {
+	// Empty query
+	res, err := s.service.CountReportConfigurations(s.ctx, &apiV1.RawQuery{Query: ""})
+	s.Require().NoError(err)
+	s.Require().Equal(int32(len(s.v1Configs)), res.Count)
+
+	// Non empty query
+	res, err = s.service.CountReportConfigurations(s.ctx,
+		&apiV1.RawQuery{Query: fmt.Sprintf("Report Name:%s", s.v1Configs[0].Name)})
+	s.Require().NoError(err)
+	s.Require().Equal(int32(1), res.Count)
+}
+
+func (s *ServiceLevelConfigSeparationSuite) TestPostReportConfiguration() {
+	// Error on v2 config
+	config := s.v2Configs[0].Clone()
+	config.Id = ""
+	config.NotifierConfig = s.v1Configs[0].NotifierConfig
+	_, err := s.service.PostReportConfiguration(s.ctx, &apiV1.PostReportConfigurationRequest{ReportConfig: config})
+	s.Require().Error(err)
+
+	// No error on v1 config
+	s.manager.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	config = s.v1Configs[0].Clone()
+	config.Id = ""
+	res, err := s.service.PostReportConfiguration(s.ctx, &apiV1.PostReportConfigurationRequest{ReportConfig: config})
+	s.Require().NoError(err)
+
+	err = s.reportConfigDatastore.RemoveReportConfiguration(s.ctx, res.ReportConfig.Id)
+	s.Require().NoError(err)
+}
+
+func (s *ServiceLevelConfigSeparationSuite) TestUpdateReportConfiguration() {
+	// Error on v2 config
+	config := s.v2Configs[0].Clone()
+	config.NotifierConfig = s.v1Configs[0].NotifierConfig
+	config.GetVulnReportFilters().SinceLastReport = true
+	_, err := s.service.UpdateReportConfiguration(s.ctx, &apiV1.UpdateReportConfigurationRequest{ReportConfig: config})
+	s.Require().Error(err)
+
+	// No error on v1 config
+	s.manager.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	s.v1Configs[0].GetVulnReportFilters().SinceLastReport = true
+	_, err = s.service.UpdateReportConfiguration(s.ctx, &apiV1.UpdateReportConfigurationRequest{ReportConfig: s.v1Configs[0]})
+	s.Require().NoError(err)
+}
+
+func (s *ServiceLevelConfigSeparationSuite) TestDeleteReportConfiguration() {
+	// Error on v2 config ID
+	_, err := s.service.DeleteReportConfiguration(s.ctx, &apiV1.ResourceByID{Id: s.v2Configs[0].Id})
+	s.Require().Error(err)
+
+	// No error on v1 config ID
+	s.manager.EXPECT().Remove(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	config := s.v1Configs[0].Clone()
+	config.Id = ""
+	config.Name = "Delete report config"
+	config.Id, err = s.reportConfigDatastore.AddReportConfiguration(s.ctx, config)
+	s.Require().NoError(err)
+	_, err = s.service.DeleteReportConfiguration(s.ctx, &apiV1.ResourceByID{Id: config.Id})
+	s.Require().NoError(err)
+}

--- a/central/reports/config/service/validate.go
+++ b/central/reports/config/service/validate.go
@@ -99,7 +99,7 @@ func (s *serviceImpl) validateEmailConfig(ctx context.Context, emailConfig *stor
 func (s *serviceImpl) validateResourceScope(ctx context.Context, config *storage.ReportConfiguration) error {
 	if !common.IsV1ReportConfig(config) {
 		return errors.Wrap(errox.InvalidArgs, "Report configuration belonging to reporting version 1.0 should not set the 'resourceScope' field."+
-			"Instead, set the 'scopeID' field to the desired collection ID.")
+			"Instead, set the 'scopeId' field to the desired collection ID.")
 	}
 	if config.GetScopeId() == "" {
 		return errors.Wrap(errox.InvalidArgs, "Report configuration must specify a valid collection ID in the 'scopeId' field")

--- a/central/reports/config/service/validate.go
+++ b/central/reports/config/service/validate.go
@@ -5,6 +5,7 @@ import (
 	"net/mail"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/reports/common"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
@@ -96,6 +97,10 @@ func (s *serviceImpl) validateEmailConfig(ctx context.Context, emailConfig *stor
 }
 
 func (s *serviceImpl) validateResourceScope(ctx context.Context, config *storage.ReportConfiguration) error {
+	if !common.IsV1ReportConfig(config) {
+		return errors.Wrap(errox.InvalidArgs, "Report configuration belonging to reporting version 1.0 should not set the 'resourceScope' field."+
+			"Instead, set the 'scopeID' field to the desired collection ID.")
+	}
 	if config.GetScopeId() == "" {
 		return errors.Wrap(errox.InvalidArgs, "Report configuration must specify a valid collection ID in the 'scopeId' field")
 	}

--- a/central/reports/manager/manager_impl.go
+++ b/central/reports/manager/manager_impl.go
@@ -2,13 +2,15 @@ package manager
 
 import (
 	"context"
-	"errors"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
+	"github.com/stackrox/rox/central/reports/common"
 	"github.com/stackrox/rox/central/reports/scheduler"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/contextutil"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 )
@@ -38,6 +40,9 @@ func (m *managerImpl) Upsert(ctx context.Context, reportConfig *storage.ReportCo
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+	if !common.IsV1ReportConfig(reportConfig) {
+		return errors.Wrap(errox.InvalidArgs, "report configuration does not belong to reporting version 1.0")
+	}
 	if err := m.scheduler.UpsertReportSchedule(reportConfig); err != nil {
 		return err
 	}
@@ -50,6 +55,9 @@ func (m *managerImpl) RunReport(ctx context.Context, reportConfig *storage.Repor
 	 * An on demand report may be submitted while other scheduled reports are being run and will be
 	 * executed in FIFO order (in case multiple scheduled reports are already queued up).
 	 */
+	if !common.IsV1ReportConfig(reportConfig) {
+		return errors.Wrap(errox.InvalidArgs, "report configuration does not belong to reporting version 1.0")
+	}
 	if m.inProgress.TestAndSet(true) {
 		return errors.New("report generation already in progress, please try again later")
 	}

--- a/central/reports/manager/manager_impl.go
+++ b/central/reports/manager/manager_impl.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/contextutil"
-	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 )
@@ -24,9 +23,6 @@ type managerImpl struct {
 }
 
 func (m *managerImpl) Remove(ctx context.Context, id string) error {
-	if env.VulnReportingEnhancements.BooleanSetting() {
-		return nil
-	}
 	if ok, err := reportsSAC.WriteAllowed(ctx); err != nil {
 		return err
 	} else if !ok {
@@ -37,9 +33,6 @@ func (m *managerImpl) Remove(ctx context.Context, id string) error {
 }
 
 func (m *managerImpl) Upsert(ctx context.Context, reportConfig *storage.ReportConfiguration) error {
-	if env.VulnReportingEnhancements.BooleanSetting() {
-		return nil
-	}
 	if ok, err := reportsSAC.WriteAllowed(ctx); err != nil {
 		return err
 	} else if !ok {
@@ -52,9 +45,6 @@ func (m *managerImpl) Upsert(ctx context.Context, reportConfig *storage.ReportCo
 }
 
 func (m *managerImpl) RunReport(ctx context.Context, reportConfig *storage.ReportConfiguration) error {
-	if env.VulnReportingEnhancements.BooleanSetting() {
-		return nil
-	}
 	/*
 	 * Multiple on demand reports cannot be executed concurrently.
 	 * An on demand report may be submitted while other scheduled reports are being run and will be
@@ -74,15 +64,9 @@ func (m *managerImpl) RunReport(ctx context.Context, reportConfig *storage.Repor
 }
 
 func (m *managerImpl) Start() {
-	if env.VulnReportingEnhancements.BooleanSetting() {
-		return
-	}
 	m.scheduler.Start()
 }
 
 func (m *managerImpl) Stop() {
-	if env.VulnReportingEnhancements.BooleanSetting() {
-		return
-	}
 	m.scheduler.Stop()
 }

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/graphql/resolvers"
 	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
+	"github.com/stackrox/rox/central/reports/common"
 	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
 	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
 	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
@@ -359,7 +360,8 @@ func (s *scheduler) queueScheduledReports() {
 	query := search.NewQueryBuilder().
 		AddExactMatches(search.ReportType, storage.ReportConfiguration_VULNERABILITY.String()).
 		ProtoQuery()
-	reportConfigs, err := s.reportConfigDatastore.GetReportConfigurations(scheduledCtx, query)
+	filteredQ := common.WithoutV1ReportConfigs(query)
+	reportConfigs, err := s.reportConfigDatastore.GetReportConfigurations(scheduledCtx, filteredQ)
 	if err != nil {
 		log.Errorf("Error finding scheduled reports: %s", err)
 		return

--- a/central/reports/service/service_impl.go
+++ b/central/reports/service/service_impl.go
@@ -6,10 +6,12 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
+	"github.com/stackrox/rox/central/reports/common"
 	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
 	"github.com/stackrox/rox/central/reports/manager"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
@@ -21,7 +23,7 @@ import (
 var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
 		user.With(permissions.View(resources.WorkflowAdministration), permissions.View(resources.Integration),
-			permissions.View(resources.Access), permissions.View(resources.Image)): {
+			permissions.View(resources.Image)): {
 			"/v1.ReportService/RunReport",
 		},
 	})
@@ -57,7 +59,10 @@ func (s *serviceImpl) RunReport(ctx context.Context, id *v1.ResourceByID) (*v1.E
 		return &v1.Empty{}, errors.Wrapf(err, "error finding report configuration %s", id)
 	}
 	if !found {
-		return &v1.Empty{}, errors.Errorf("unable to find report configuration %s", id)
+		return &v1.Empty{}, errors.Wrapf(errox.NotFound, "unable to find report configuration %s", id)
+	}
+	if !common.IsV1ReportConfig(rc) {
+		return &v1.Empty{}, errors.Wrap(errox.InvalidArgs, "report configuration does not belong to reporting version 1.0")
 	}
 
 	if err := s.manager.RunReport(ctx, rc); err != nil {

--- a/central/reports/service/service_impl_test.go
+++ b/central/reports/service/service_impl_test.go
@@ -1,1 +1,34 @@
 package service
+
+import (
+	"context"
+	"testing"
+
+	reportConfigDSMocks "github.com/stackrox/rox/central/reports/config/datastore/mocks"
+	managerMocks "github.com/stackrox/rox/central/reports/manager/mocks"
+	apiV1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestConfigSeparation(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	reportConfigStore := reportConfigDSMocks.NewMockDataStore(mockCtrl)
+	manager := managerMocks.NewMockManager(mockCtrl)
+	service := New(reportConfigStore, nil, manager)
+	ctx := context.Background()
+
+	// Error on v2 config
+	configV2 := fixtures.GetValidReportConfigWithMultipleNotifiersV2()
+	reportConfigStore.EXPECT().GetReportConfiguration(gomock.Any(), configV2.Id).Return(configV2, true, nil).Times(1)
+	_, err := service.RunReport(ctx, &apiV1.ResourceByID{Id: configV2.Id})
+	assert.Error(t, err)
+
+	// No error on v1 config
+	configV1 := fixtures.GetValidReportConfigWithMultipleNotifiersV1()
+	reportConfigStore.EXPECT().GetReportConfiguration(gomock.Any(), configV1.Id).Return(configV1, true, nil).Times(1)
+	manager.EXPECT().RunReport(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	_, err = service.RunReport(ctx, &apiV1.ResourceByID{Id: configV1.Id})
+	assert.NoError(t, err)
+}

--- a/central/reports/service/service_impl_test.go
+++ b/central/reports/service/service_impl_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestConfigSeparation(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
 	reportConfigStore := reportConfigDSMocks.NewMockDataStore(mockCtrl)
 	manager := managerMocks.NewMockManager(mockCtrl)
 	service := New(reportConfigStore, nil, manager)

--- a/central/reports/service/singleton.go
+++ b/central/reports/service/singleton.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
+	"github.com/stackrox/rox/central/reports/common"
 	"github.com/stackrox/rox/central/reports/config/datastore"
 	"github.com/stackrox/rox/central/reports/manager"
 	"github.com/stackrox/rox/generated/storage"
@@ -31,7 +32,9 @@ func initializeManager() manager.Manager {
 			sac.ResourceScopeKeys(resources.WorkflowAdministration)))
 
 	query := search.NewQueryBuilder().AddExactMatches(search.ReportType, storage.ReportConfiguration_VULNERABILITY.String()).ProtoQuery()
-	reportConfigs, err := datastore.Singleton().GetReportConfigurations(ctx, query)
+	filteredQ := common.WithoutV2ReportConfigs(query)
+
+	reportConfigs, err := datastore.Singleton().GetReportConfigurations(ctx, filteredQ)
 	mgr := manager.Singleton()
 	if err != nil {
 		log.Errorf("Error finding scheduled reports: %s", err)

--- a/central/reports/service/v2/config_separation_test.go
+++ b/central/reports/service/v2/config_separation_test.go
@@ -1,0 +1,175 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
+	"github.com/stackrox/rox/central/reports/common"
+	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
+	schedulerMocks "github.com/stackrox/rox/central/reports/scheduler/v2/mocks"
+	"github.com/stackrox/rox/central/reports/validation"
+	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
+	apiV2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+func TestServiceLevelConfigSeparationV2(t *testing.T) {
+	suite.Run(t, new(ServiceLevelConfigSeparationSuiteV2))
+}
+
+type ServiceLevelConfigSeparationSuiteV2 struct {
+	suite.Suite
+	service *serviceImpl
+
+	testDB                *pgtest.TestPostgres
+	ctx                   context.Context
+	reportConfigDatastore reportConfigDS.DataStore
+	notifierDatastore     notifierDS.DataStore
+	collectionDatastore   collectionDS.DataStore
+	scheduler             *schedulerMocks.MockScheduler
+
+	mockCtrl *gomock.Controller
+
+	v1Configs []*storage.ReportConfiguration
+	v2Configs []*storage.ReportConfiguration
+}
+
+func (s *ServiceLevelConfigSeparationSuiteV2) SetupSuite() {
+	s.T().Setenv(env.VulnReportingEnhancements.EnvVar(), "true")
+	if !env.VulnReportingEnhancements.BooleanSetting() {
+		s.T().Skip("Skip test when reporting enhancements are disabled")
+		s.T().SkipNow()
+	}
+
+	s.testDB = pgtest.ForT(s.T())
+	s.reportConfigDatastore = reportConfigDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
+	s.notifierDatastore = notifierDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
+
+	var err error
+	s.collectionDatastore, _, err = collectionDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
+	s.Require().NoError(err)
+
+	s.mockCtrl = gomock.NewController(s.T())
+	s.scheduler = schedulerMocks.NewMockScheduler(s.mockCtrl)
+
+	validator := validation.New(s.reportConfigDatastore, nil, s.collectionDatastore, s.notifierDatastore)
+	s.service = &serviceImpl{
+		reportConfigStore:   s.reportConfigDatastore,
+		collectionDatastore: s.collectionDatastore,
+		notifierDatastore:   s.notifierDatastore,
+		scheduler:           s.scheduler,
+		validator:           validator,
+	}
+
+	s.ctx = sac.WithAllAccess(context.Background())
+
+	// Add notifier
+	notifierId, err := s.notifierDatastore.AddNotifier(s.ctx, &storage.Notifier{Name: "notifier"})
+	s.Require().NoError(err)
+
+	// Add collection
+	collectionId, err := s.collectionDatastore.AddCollection(s.ctx, &storage.ResourceCollection{Name: "collection"})
+	s.Require().NoError(err)
+
+	// Add report configs
+	s.v1Configs = common.GetTestReportConfigsV1(s.T(), notifierId, collectionId)
+	for _, conf := range s.v1Configs {
+		conf.Id, err = s.reportConfigDatastore.AddReportConfiguration(s.ctx, conf)
+		s.Require().NoError(err)
+	}
+
+	s.v2Configs = common.GetTestReportConfigsV2(s.T(), notifierId, collectionId)
+	for _, conf := range s.v2Configs {
+		conf.Id, err = s.reportConfigDatastore.AddReportConfiguration(s.ctx, conf)
+		s.Require().NoError(err)
+	}
+}
+
+func (s *ServiceLevelConfigSeparationSuiteV2) TearDownSuite() {
+	s.mockCtrl.Finish()
+	s.testDB.Teardown(s.T())
+}
+
+func (s *ServiceLevelConfigSeparationSuiteV2) TestListReportConfigurations() {
+	apiV2Configs := s.convertConfigs(s.v2Configs)
+
+	// Empty Query
+	res, err := s.service.ListReportConfigurations(s.ctx, &apiV2.RawQuery{Query: ""})
+	s.Require().NoError(err)
+	s.Require().ElementsMatch(apiV2Configs, res.ReportConfigs)
+
+	// Non empty query
+	res, err = s.service.ListReportConfigurations(s.ctx,
+		&apiV2.RawQuery{Query: fmt.Sprintf("Report Name:%s", s.v2Configs[0].Name)})
+	s.Require().NoError(err)
+	s.Require().Equal(1, len(res.ReportConfigs))
+	s.Require().Equal(apiV2Configs[0], res.ReportConfigs[0])
+}
+
+func (s *ServiceLevelConfigSeparationSuiteV2) TestGetReportConfiguration() {
+	apiV2Configs := s.convertConfigs(s.v2Configs)
+
+	// returns v2 config
+	res, err := s.service.GetReportConfiguration(s.ctx, &apiV2.ResourceByID{Id: s.v2Configs[0].Id})
+	s.Require().NoError(err)
+	s.Require().Equal(apiV2Configs[0], res)
+
+	// error on requesting v1 config
+	_, err = s.service.GetReportConfiguration(s.ctx, &apiV2.ResourceByID{Id: s.v1Configs[0].Id})
+	s.Require().Error(err)
+}
+
+func (s *ServiceLevelConfigSeparationSuiteV2) TestCountReportConfigurations() {
+	// Empty query
+	res, err := s.service.CountReportConfigurations(s.ctx, &apiV2.RawQuery{Query: ""})
+	s.Require().NoError(err)
+	s.Require().Equal(int32(len(s.v2Configs)), res.Count)
+
+	// Non empty query
+	res, err = s.service.CountReportConfigurations(s.ctx,
+		&apiV2.RawQuery{Query: fmt.Sprintf("Report Name:%s", s.v2Configs[0].Name)})
+	s.Require().NoError(err)
+	s.Require().Equal(int32(1), res.Count)
+}
+
+func (s *ServiceLevelConfigSeparationSuiteV2) TestDeleteReportConfiguration() {
+	// Error on v1 config ID
+	_, err := s.service.DeleteReportConfiguration(s.ctx, &apiV2.ResourceByID{Id: s.v1Configs[0].Id})
+	s.Require().Error(err)
+
+	// No error on v2 config ID
+	s.scheduler.EXPECT().RemoveReportSchedule(gomock.Any()).Return().Times(1)
+	config := s.v2Configs[0].Clone()
+	config.Id = ""
+	config.Name = "Delete report config"
+	config.Id, err = s.reportConfigDatastore.AddReportConfiguration(s.ctx, config)
+	s.Require().NoError(err)
+	_, err = s.service.DeleteReportConfiguration(s.ctx, &apiV2.ResourceByID{Id: config.Id})
+	s.Require().NoError(err)
+}
+
+func (s *ServiceLevelConfigSeparationSuiteV2) TestRunReport() {
+	// Error on v1 config
+	_, err := s.service.RunReport(s.ctx, &apiV2.RunReportRequest{
+		ReportConfigId:           s.v1Configs[0].Id,
+		ReportNotificationMethod: apiV2.NotificationMethod_EMAIL,
+	})
+	s.Require().Error(err)
+}
+
+func (s *ServiceLevelConfigSeparationSuiteV2) convertConfigs(configs []*storage.ReportConfiguration) []*apiV2.ReportConfiguration {
+	apiV2Configs := make([]*apiV2.ReportConfiguration, 0, len(configs))
+	for _, conf := range configs {
+		c, err := convertProtoReportConfigurationToV2(conf, s.collectionDatastore, s.notifierDatastore)
+		s.Require().NoError(err)
+		apiV2Configs = append(apiV2Configs, c)
+	}
+	return apiV2Configs
+}

--- a/central/reports/service/v2/config_separation_test.go
+++ b/central/reports/service/v2/config_separation_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package v2
 
 import (

--- a/central/reports/service/v2/config_separation_test.go
+++ b/central/reports/service/v2/config_separation_test.go
@@ -169,7 +169,7 @@ func (s *ServiceLevelConfigSeparationSuiteV2) TestRunReport() {
 func (s *ServiceLevelConfigSeparationSuiteV2) convertConfigs(configs []*storage.ReportConfiguration) []*apiV2.ReportConfiguration {
 	apiV2Configs := make([]*apiV2.ReportConfiguration, 0, len(configs))
 	for _, conf := range configs {
-		c, err := convertProtoReportConfigurationToV2(conf, s.collectionDatastore, s.notifierDatastore)
+		c, err := s.service.convertProtoReportConfigurationToV2(conf)
 		s.Require().NoError(err)
 		apiV2Configs = append(apiV2Configs, c)
 	}

--- a/central/reports/service/v2/config_separation_test.go
+++ b/central/reports/service/v2/config_separation_test.go
@@ -73,21 +73,21 @@ func (s *ServiceLevelConfigSeparationSuiteV2) SetupSuite() {
 	s.ctx = sac.WithAllAccess(context.Background())
 
 	// Add notifier
-	notifierId, err := s.notifierDatastore.AddNotifier(s.ctx, &storage.Notifier{Name: "notifier"})
+	notifierID, err := s.notifierDatastore.AddNotifier(s.ctx, &storage.Notifier{Name: "notifier"})
 	s.Require().NoError(err)
 
 	// Add collection
-	collectionId, err := s.collectionDatastore.AddCollection(s.ctx, &storage.ResourceCollection{Name: "collection"})
+	collectionID, err := s.collectionDatastore.AddCollection(s.ctx, &storage.ResourceCollection{Name: "collection"})
 	s.Require().NoError(err)
 
 	// Add report configs
-	s.v1Configs = common.GetTestReportConfigsV1(s.T(), notifierId, collectionId)
+	s.v1Configs = common.GetTestReportConfigsV1(s.T(), notifierID, collectionID)
 	for _, conf := range s.v1Configs {
 		conf.Id, err = s.reportConfigDatastore.AddReportConfiguration(s.ctx, conf)
 		s.Require().NoError(err)
 	}
 
-	s.v2Configs = common.GetTestReportConfigsV2(s.T(), notifierId, collectionId)
+	s.v2Configs = common.GetTestReportConfigsV2(s.T(), notifierID, collectionID)
 	for _, conf := range s.v2Configs {
 		conf.Id, err = s.reportConfigDatastore.AddReportConfiguration(s.ctx, conf)
 		s.Require().NoError(err)

--- a/central/reports/service/v2/download.go
+++ b/central/reports/service/v2/download.go
@@ -133,7 +133,7 @@ func (h *downloadHandler) handle(w http.ResponseWriter, r *http.Request) {
 			sac.AccessModeScopeKeys(storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.WorkflowAdministration)),
 	)
-	if err != nil && status.GetRunState() == storage.ReportStatus_GENERATED {
+	if err == nil && status.GetRunState() == storage.ReportStatus_GENERATED {
 		rep.ReportStatus.RunState = storage.ReportStatus_DELIVERED
 		err = h.snapshotStore.UpdateReportSnapshot(writeSnapshotCtx, rep)
 		if err != nil {

--- a/central/reports/service/v2/download_test.go
+++ b/central/reports/service/v2/download_test.go
@@ -157,6 +157,10 @@ func (s *handlerTestSuite) TestDownloadReport() {
 			mockGen: func() {
 				s.reportSnapshotDataStore.EXPECT().Get(gomock.Any(), reportSnapshot.GetReportId()).
 					Return(reportSnapshot, true, nil).Times(1)
+				snap := reportSnapshot.Clone()
+				snap.ReportStatus.RunState = storage.ReportStatus_DELIVERED
+				s.reportSnapshotDataStore.EXPECT().UpdateReportSnapshot(gomock.Any(), snap).
+					Return(nil).Times(1)
 				s.blobStore.EXPECT().Get(gomock.Any(), blobName, gomock.Any()).Times(1).DoAndReturn(
 					func(_ context.Context, _ string, writer io.Writer) (*storage.Blob, bool, error) {
 						c, err := writer.Write(blobData.Bytes())

--- a/central/reports/validation/validate.go
+++ b/central/reports/validation/validate.go
@@ -188,6 +188,9 @@ func (v *Validator) ValidateAndGenerateReportRequest(
 	if !found {
 		return nil, errors.Wrapf(errox.NotFound, "Report configuration id not found %s", configID)
 	}
+	if !common.IsV2ReportConfig(config) {
+		return nil, errors.Wrap(errox.InvalidArgs, "report configuration does not belong to reporting version 2.0")
+	}
 
 	collection, found, err := v.collectionDatastore.Get(allAccessCtx, config.GetResourceScope().GetCollectionId())
 	if err != nil {


### PR DESCRIPTION
## Description

- v1 reporting APIs will not accept/return report configs that have the `resourceScope` field set.
- v2 reporting APIs will not accept/return report configs that have the `scopeId` field set.
- v1 scheduler will only run jobs for v1 report configs, v2 scheduler will only run jobs for v2 report configs.

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Unit tests

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
