### PR TITLE
ROX-19112: Add to resourceAccessRequirements for Collections

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/permissions.test.js
+++ b/ui/apps/platform/cypress/integration/collections/permissions.test.js
@@ -47,7 +47,12 @@ describe('Collection permission checks', () => {
     it('should not provide mutable UI controls to users with read-only access', () => {
         // Mock a 'READ_ACCESS' permission response
         visitWithStaticResponseForPermissions('/main', {
-            body: { resourceToAccess: { WorkflowAdministration: 'READ_ACCESS' } },
+            body: {
+                resourceToAccess: {
+                    Deployment: 'READ_ACCESS',
+                    WorkflowAdministration: 'READ_ACCESS',
+                },
+            },
         });
         // Ensure the collections link is visible and takes the user to the collections table
         cy.get(`${navSelectors.navExpandable}:contains("Platform Configuration")`).click();
@@ -72,7 +77,12 @@ describe('Collection permission checks', () => {
     it('should provide the full UI to users with read-write access', () => {
         // Mock a 'READ_WRITE_ACCESS' permission response
         visitWithStaticResponseForPermissions('/main', {
-            body: { resourceToAccess: { WorkflowAdministration: 'READ_WRITE_ACCESS' } },
+            body: {
+                resourceToAccess: {
+                    Deployment: 'READ_ACCESS',
+                    WorkflowAdministration: 'READ_WRITE_ACCESS',
+                },
+            },
         });
         // Ensure the collections link is visible and takes the user to the collections table
         cy.get(`${navSelectors.navExpandable}:contains("Platform Configuration")`).click();

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -122,7 +122,7 @@ const routeDescriptionMap: Record<string, RouteDescription> = {
         resourceAccessRequirements: everyResource(['Cluster']),
     },
     [collectionsPath]: {
-        resourceAccessRequirements: everyResource(['WorkflowAdministration']),
+        resourceAccessRequirements: everyResource(['Deployment', 'WorkflowAdministration']),
     },
     [compliancePath]: {
         resourceAccessRequirements: everyResource([


### PR DESCRIPTION
## Description

### Analysis

1. POST /v1/collections/dryrun silently returns no deployments without READ_ACCESS for Deployment resource.
2. **Collection results** dryrun request has inconsistent resource requirements (see **Manual testing** item 2).
3. Bravo, components already have all conditional rendering for read versus write access. Extra credit for explicit props!

### Solution

1. Add `'Deployment'` to `resourceAccessRequirements` in routePaths.ts file because anyone who has access to collections needs to view results.
2. I did not add conditional rendering related to dryrun request, because behavior seems like a backend bug: ROX-19116

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Aha, `'Deployment',` has 13 characters :)

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 13 = 3759794 - 3759781
        total: 13 = 9949148 - 9949135
    * `ls -al build/static/js/*.js | wc -l`
        0 = 81 - 81 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/collections

    * See absence of **Create collection** button and row actions with only READ_ACCESS for WorkflowAdministration resource.
        ![collections_READ_ACCESS](https://github.com/stackrox/stackrox/assets/11862657/fb1d1cf6-1f04-4b99-8667-cd93683a854d)

    * See view form despite action in page address with only READ_ACCESS for WorkflowAdministration resource.

2. View a previously created collection.

    * See absence of **Actions** dropdown with only READ_ACCESS for WorkflowAdministration resource.
        ![collection_READ_ACCESS](https://github.com/stackrox/stackrox/assets/11862657/bfbefc48-ad5b-4c21-b4b2-22afe6fbf3c2)

    * See absence of dry run results **without** READ_ACCESS for Deployment resource (although requests succeeds).
        ![collection_READ_WRITE_ACCESS_without_Deployment](https://github.com/stackrox/stackrox/assets/11862657/aa857ee5-edc0-4b6c-a2b9-28027317836b)

    * See presence of dry run results **with** READ_ACCESS for Deployment.
        ![collection_READ_WRITE_ACCESS_with_deployment](https://github.com/stackrox/stackrox/assets/11862657/085574dc-0484-4a9e-a092-a2cb13c3bf85)

### Integration testing

* collections/collectionsCrudWorkflow.test.js
* collections/collectionsTable.test.js
* collections/deploymentMatching.test.js
* collections/permissions.test.js
