### PR TITLE
ROX-18882: Enable actions on report view page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
@@ -39,7 +39,7 @@ function CloneVulnReportPage() {
     const history = useHistory();
     const { reportId } = useParams();
 
-    const { reportConfiguration, isLoading, error } = useFetchReport(reportId);
+    const { report, isLoading, error } = useFetchReport(reportId);
     const formik = useReportFormValues();
     const {
         isLoading: isCreating,
@@ -54,15 +54,15 @@ function CloneVulnReportPage() {
 
     // We fetch the report configuration for the edittable report and then populate the form values
     useEffect(() => {
-        if (reportConfiguration) {
-            const reportFormValues = getReportFormValuesFromConfiguration(reportConfiguration);
+        if (report) {
+            const reportFormValues = getReportFormValuesFromConfiguration(report);
             // We need to clear the reportId and modify the name
             reportFormValues.reportId = '';
             reportFormValues.reportParameters.reportName = `${reportFormValues.reportParameters.reportName} (copy)`;
             formik.setValues(reportFormValues);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [reportConfiguration, formik.setValues]);
+    }, [report, formik.setValues]);
 
     function onCreate() {
         createReport(formik.values);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
@@ -39,7 +39,7 @@ function EditVulnReportPage() {
     const history = useHistory();
     const { reportId } = useParams();
 
-    const { reportConfiguration, isLoading, error } = useFetchReport(reportId);
+    const { report, isLoading, error } = useFetchReport(reportId);
     const formik = useReportFormValues();
     const { isSaving, saveError, saveReport } = useSaveReport({
         onCompleted: () => {
@@ -50,12 +50,12 @@ function EditVulnReportPage() {
 
     // We fetch the report configuration for the edittable report and then populate the form values
     useEffect(() => {
-        if (reportConfiguration) {
-            const reportFormValues = getReportFormValuesFromConfiguration(reportConfiguration);
+        if (report) {
+            const reportFormValues = getReportFormValuesFromConfiguration(report);
             formik.setValues(reportFormValues);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [reportConfiguration, formik.setValues]);
+    }, [report, formik.setValues]);
 
     function onSave() {
         saveReport(reportId, formik.values);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/apiUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/apiUtils.ts
@@ -1,7 +1,33 @@
+import { fetchReportHistory } from 'services/ReportsService';
+import { ReportConfiguration } from 'services/ReportsService.types';
 import { SearchFilter } from 'types/search';
+
+import { Report } from '../types';
 
 export function getRequestQueryString(searchFilter: SearchFilter): string {
     return Object.entries(searchFilter)
         .map(([key, val]) => `${key}:${Array.isArray(val) ? val.join(',') : val ?? ''}`)
         .join('+');
+}
+
+export async function fetchAndAppendLastReportJobForConfiguration(
+    reportConfiguration: ReportConfiguration
+): Promise<Report> {
+    const PAGE = 1;
+    const PER_PAGE = 1;
+    const SHOW_MY_HISTORY = true;
+    // Query for the current user's last report job
+    const query = getRequestQueryString({ 'Report state': ['PREPARING', 'WAITING'] });
+
+    const reportSnapshot = await fetchReportHistory(
+        reportConfiguration.id,
+        query,
+        PAGE,
+        PER_PAGE,
+        SHOW_MY_HISTORY
+    );
+    return {
+        ...reportConfiguration,
+        reportSnapshot: reportSnapshot[0] ?? null,
+    };
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReports.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReports.ts
@@ -1,16 +1,12 @@
 /* eslint-disable no-void */
 import { useCallback, useEffect, useState } from 'react';
 
-import {
-    fetchReportConfigurations,
-    fetchReportConfigurationsCount,
-    fetchReportHistory,
-} from 'services/ReportsService';
+import { fetchReportConfigurations, fetchReportConfigurationsCount } from 'services/ReportsService';
 
 import { SearchFilter } from 'types/search';
 import { Report } from '../types';
 import { getErrorMessage } from '../errorUtils';
-import { getRequestQueryString } from './apiUtils';
+import { fetchAndAppendLastReportJobForConfiguration, getRequestQueryString } from './apiUtils';
 
 export type UseFetchReportsProps = {
     searchFilter: SearchFilter;
@@ -63,26 +59,7 @@ function useFetchReports({
                 perPage,
             });
             const reports: Report[] = await Promise.all(
-                reportConfigurations.map(async (reportConfiguration): Promise<Report> => {
-                    const PAGE = 1;
-                    const PER_PAGE = 1;
-                    const SHOW_MY_HISTORY = true;
-                    // Query for the current user's last report job
-                    const query = getRequestQueryString({
-                        'Report state': ['PREPARING', 'WAITING'],
-                    });
-                    const reportSnapshot = await fetchReportHistory(
-                        reportConfiguration.id,
-                        query,
-                        PAGE,
-                        PER_PAGE,
-                        SHOW_MY_HISTORY
-                    );
-                    return {
-                        ...reportConfiguration,
-                        reportSnapshot: reportSnapshot?.[0] || null,
-                    };
-                })
+                reportConfigurations.map(fetchAndAppendLastReportJobForConfiguration)
             );
             setResult({
                 reports,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useRunReport.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useRunReport.ts
@@ -5,7 +5,7 @@ import { ReportNotificationMethod } from 'services/ReportsService.types';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 export type UseSaveReportProps = {
-    onCompleted: () => void;
+    onCompleted: (context: { reportNotificationMethod: ReportNotificationMethod }) => void;
 };
 
 type Result = {
@@ -42,7 +42,7 @@ function useRunReport({ onCompleted }: UseSaveReportProps): SaveReportResult {
                         isRunning: false,
                         runError: null,
                     });
-                    onCompleted();
+                    onCompleted({ reportNotificationMethod });
                 })
                 .catch((err) => {
                     setResult({


### PR DESCRIPTION
## Description

Enables "Run report" and "Generate download" menu items on View Report page, adds toasts when actions complete.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Open menu and select "Send report now" from the list:
![image](https://github.com/stackrox/stackrox/assets/1292638/452fcc5a-7026-4b2e-96af-281e9f074f4d)

Open menu and select "Generate download" from the list:
![image](https://github.com/stackrox/stackrox/assets/1292638/a3800fd4-4c47-41f9-8620-267c2e542074)

Simulated failure for either of the above cases:
![image](https://github.com/stackrox/stackrox/assets/1292638/ad619e2d-9f6f-4a45-aeaa-18c45e7efeba)

Menu item disabled when no notifiers:
![image](https://github.com/stackrox/stackrox/assets/1292638/364f1526-498a-4491-988d-7c765b555338)

