### PR TITLE
ROX-18750: Protect delegated scanning config route

### DIFF
--- a/ui/apps/platform/cypress/fixtures/auth/mypermissionsNoAdminAccess.json
+++ b/ui/apps/platform/cypress/fixtures/auth/mypermissionsNoAdminAccess.json
@@ -1,0 +1,28 @@
+{
+    "resourceToAccess": {
+        "Access": "READ_WRITE_ACCESS",
+        "Administration": "NO_ACCESS",
+        "Alert": "READ_WRITE_ACCESS",
+        "CVE": "READ_WRITE_ACCESS",
+        "Cluster": "READ_WRITE_ACCESS",
+        "Compliance": "READ_WRITE_ACCESS",
+        "Deployment": "READ_WRITE_ACCESS",
+        "DeploymentExtension": "READ_WRITE_ACCESS",
+        "Detection": "READ_WRITE_ACCESS",
+        "Image": "READ_WRITE_ACCESS",
+        "Integration": "READ_WRITE_ACCESS",
+        "K8sRole": "READ_WRITE_ACCESS",
+        "K8sRoleBinding": "READ_WRITE_ACCESS",
+        "K8sSubject": "READ_WRITE_ACCESS",
+        "Namespace": "READ_WRITE_ACCESS",
+        "NetworkGraph": "READ_WRITE_ACCESS",
+        "NetworkPolicy": "READ_WRITE_ACCESS",
+        "Node": "READ_WRITE_ACCESS",
+        "Secret": "READ_WRITE_ACCESS",
+        "ServiceAccount": "READ_WRITE_ACCESS",
+        "VulnerabilityManagementApprovals": "READ_WRITE_ACCESS",
+        "VulnerabilityManagementRequests": "READ_WRITE_ACCESS",
+        "WatchedImage": "READ_WRITE_ACCESS",
+        "WorkflowAdministration": "READ_WRITE_ACCESS"
+    }
+}

--- a/ui/apps/platform/cypress/integration/clusters/Clusters.helpers.js
+++ b/ui/apps/platform/cypress/integration/clusters/Clusters.helpers.js
@@ -43,7 +43,7 @@ const routeMatcherMapForDelegateScanning = {
 };
 
 const basePath = '/main/clusters';
-const delegateScanningPath = `${basePath}/delegate-scanning`;
+export const delegatedScanningPath = `${basePath}/delegated-image-scanning`;
 
 const title = 'Clusters';
 
@@ -172,7 +172,7 @@ export function visitClusterByNameWithFixtureMetadataDatetime(
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function visitDelegateScanning(staticResponseMap) {
-    visit(delegateScanningPath, routeMatcherMapForDelegateScanning, staticResponseMap);
+    visit(delegatedScanningPath, routeMatcherMapForDelegateScanning, staticResponseMap);
 }
 
 /**

--- a/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
@@ -1,18 +1,23 @@
 import withAuth from '../../helpers/basicAuth';
 
 import { getInputByLabel } from '../../helpers/formHelpers';
+import { visitWithStaticResponseForPermissions } from '../../helpers/visit';
 
-import { visitDelegateScanning, saveDelegatedRegistryConfig } from './Clusters.helpers';
+import {
+    visitDelegateScanning,
+    saveDelegatedRegistryConfig,
+    delegatedScanningPath,
+} from './Clusters.helpers';
 
 // There is some overlap between tests for Certificate Expiration and Health Status.
-describe('Delegate Image Scanning', () => {
+describe('Delegated Image Scanning', () => {
     withAuth();
 
     it(`should load the page in the cluster hierarchy`, () => {
         visitDelegateScanning();
 
         // make sure the static page loads
-        cy.get('h1:contains("Delegate Image Scanning")');
+        cy.get('h1:contains("Delegated Image Scanning")');
 
         cy.get('.pf-c-breadcrumb__item a:contains("Clusters")').should(
             'have.attr',
@@ -20,7 +25,7 @@ describe('Delegate Image Scanning', () => {
             '/main/clusters'
         );
 
-        cy.get('.pf-c-breadcrumb__item:contains("Delegate Image Scanning")');
+        cy.get('.pf-c-breadcrumb__item:contains("Delegated Image Scanning")');
 
         // check the initial state of the delegate config
         getInputByLabel('Enable delegated image scanning').should('not.be.checked');
@@ -62,5 +67,25 @@ describe('Delegate Image Scanning', () => {
         cy.get(
             '.pf-c-alert.pf-m-success .pf-c-alert__title:contains("Delegated scanning configuration saved successfully")'
         );
+    });
+
+    describe('when user does not have permission to see page', () => {
+        it(`should not show the page`, () => {
+            cy.fixture('auth/mypermissionsNoAdminAccess.json').then(({ resourceToAccess }) => {
+                const staticResponseForPermissions = {
+                    body: {
+                        resourceToAccess: { ...resourceToAccess },
+                    },
+                };
+
+                visitWithStaticResponseForPermissions(
+                    delegatedScanningPath,
+                    staticResponseForPermissions
+                );
+
+                // make sure page does not load
+                cy.get('h1:contains("Delegated Image Scanning")').should('not.exist');
+            });
+        });
     });
 });

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -39,7 +39,7 @@ const initialDelegatedState: DelegatedRegistryConfig = {
 };
 
 function DelegateScanningPage() {
-    const displayedPageTitle = 'Delegate Image Scanning';
+    const displayedPageTitle = 'Delegated Image Scanning';
     const [delegatedRegistryConfig, setDedicatedRegistryConfig] =
         useState<DelegatedRegistryConfig>(initialDelegatedState);
     const [delegatedRegistryClusters, setDelegatedRegistryClusters] = useState<

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -7,7 +7,7 @@ import {
     isRouteEnabled, // predicate function
     accessControlPath,
     apidocsPath,
-    clustersDelegateScanningPath,
+    clustersDelegatedScanningPath,
     clustersPathWithParam,
     collectionsPath,
     complianceEnhancedBasePath,
@@ -58,7 +58,7 @@ function NotFoundPage(): ReactElement {
 const routeComponentMap: Record<string, ElementType> = {
     [accessControlPath]: asyncComponent(() => import('Containers/AccessControl/AccessControl')),
     [apidocsPath]: asyncComponent(() => import('Containers/Docs/ApiPage')),
-    [clustersDelegateScanningPath]: asyncComponent(
+    [clustersDelegatedScanningPath]: asyncComponent(
         () => import('Containers/Clusters/DelegateScanning/DelegateScanningPage')
     ),
     [clustersPathWithParam]: asyncComponent(() => import('Containers/Clusters/ClustersPage')),

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -21,7 +21,7 @@ export const apidocsPath = `${mainPath}/apidocs`;
 export const clustersBasePath = `${mainPath}/clusters`;
 export const clustersPathWithParam = `${clustersBasePath}/:clusterId?`;
 export const clustersListPath = `${mainPath}/clusters-pf`;
-export const clustersDelegateScanningPath = `${clustersBasePath}/delegate-scanning`;
+export const clustersDelegatedScanningPath = `${clustersBasePath}/delegated-image-scanning`;
 export const collectionsBasePath = `${mainPath}/collections`;
 export const collectionsPath = `${mainPath}/collections/:collectionId?`;
 export const complianceBasePath = `${mainPath}/compliance`;
@@ -115,7 +115,7 @@ const routeDescriptionMap: Record<string, RouteDescription> = {
     [apidocsPath]: {
         resourceAccessRequirements: everyResource([]),
     },
-    [clustersDelegateScanningPath]: {
+    [clustersDelegatedScanningPath]: {
         resourceAccessRequirements: everyResource(['Administration']),
     },
     [clustersPathWithParam]: {


### PR DESCRIPTION
## Description

As part of his work to clean up permissions gating in the app, @pedrottimark had already added a basic route gate to this page's route.

This PR follows up on that gating:

1. Updated the URL to use be "resource-noun" style of `delegated-image-scanning`, rather than the original "verb-like" `delegate-scanning`
2. Updated the page title, header, and breadcrumb to match the "noun" style
3. Added a test for reduced permission 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added


## Testing Performed

Updated the ui-e2e tests, and added one with permissions mocked to not allow visiting the route.