### PR TITLE
feat(roxvet): add analyzer for structured logs

### DIFF
--- a/tools/roxvet/analyzers/needlessformat/analyzer.go
+++ b/tools/roxvet/analyzers/needlessformat/analyzer.go
@@ -34,12 +34,12 @@ var (
 			"(*ErrorList).AddStringf": "AddString",
 		},
 		"github.com/stackrox/rox/pkg/logging": {
-			"Logger.Infof":  "Info",
-			"Logger.Warnf":  "Warn",
-			"Logger.Debugf": "Debug",
-			"Logger.Errorf": "Error",
-			"Logger.Panicf": "Panic",
-			"Logger.Fatalf": "Fatal",
+			"(*Logger).Infof":  "Info",
+			"(*Logger).Warnf":  "Warn",
+			"(*Logger).Debugf": "Debug",
+			"(*Logger).Errorf": "Error",
+			"(*Logger).Panicf": "Panic",
+			"(*Logger).Fatalf": "Fatal",
 		},
 		"github.com/pkg/errors": {
 			"Errorf": "New",

--- a/tools/roxvet/analyzers/structuredlogs/analyzer.go
+++ b/tools/roxvet/analyzers/structuredlogs/analyzer.go
@@ -1,0 +1,107 @@
+package structuredlogs
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"regexp"
+
+	"github.com/stackrox/rox/tools/roxvet/common"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/ast/inspector"
+	"golang.org/x/tools/go/types/typeutil"
+)
+
+// Analyzer is the analyzer.
+var Analyzer = &analysis.Analyzer{
+	Name:     "structuredlogs",
+	Doc:      "check for structured logs usage and flag non-structured logs",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+var replacements = map[string]map[string]string{
+	"github.com/stackrox/rox/pkg/logging": {
+		"Logger.Warnf":  "Warnw",
+		"Logger.Errorf": "Errorw",
+		"Logger.Fatalf": "Fatalw",
+	},
+}
+
+// List of the linted package paths. Since structured logs aren't being rolled out immediately to all packages,
+// we will gradually increase the list here. Ultimately, all logs should be moved to structured logs.
+var packagesToLint = []*regexp.Regexp{
+	regexp.MustCompile(`^github\.com/stackrox/rox/central/reprocessor(/|$)`),
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	if !matchesPackagePattern(pass.Pkg.Path()) {
+		return nil, nil
+	}
+
+	inspectResult := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{
+		(*ast.CallExpr)(nil),
+	}
+
+	fileFilter := common.And(common.Not(common.IsTestFile), common.Not(common.IsGeneratedFile))
+
+	common.FilteredPreorder(inspectResult, fileFilter, nodeFilter, func(n ast.Node) {
+		checkCall(pass, n.(*ast.CallExpr))
+	})
+
+	return nil, nil
+}
+
+func checkCall(pass *analysis.Pass, call *ast.CallExpr) {
+	fn := astutil.Unparen(call.Fun)
+
+	// Skip type conversions and built-in functions.
+	if pass.TypesInfo.Types[fn].IsType() || pass.TypesInfo.Types[fn].IsBuiltin() {
+		return
+	}
+
+	namedFn, _ := typeutil.Callee(pass.TypesInfo, call).(*types.Func)
+	if namedFn == nil {
+		return
+	}
+
+	if match, name, replacement := isNonStructuredLogFunction(namedFn); match {
+		pass.Reportf(call.Fun.Pos(), "Logging function %s used without structured context; use %s instead",
+			name, replacement)
+	}
+}
+
+func isNonStructuredLogFunction(fn *types.Func) (bool, string, string) {
+	sig := fn.Type().(*types.Signature)
+	if sig == nil {
+		return false, "", ""
+	}
+
+	logReplacements, isLogFunction := replacements[fn.Pkg().Path()]
+	if !isLogFunction {
+		return false, "", ""
+	}
+
+	name := fn.Name()
+
+	if sig.Recv() != nil {
+		receiverType := sig.Recv().Type()
+		qualifier := types.RelativeTo(fn.Pkg())
+		name = fmt.Sprintf("%s.%s", types.TypeString(receiverType, qualifier), name)
+	}
+	replacement, match := logReplacements[name]
+	return match, fmt.Sprintf("\"%s\".%s", fn.Pkg().Path(), name), replacement
+}
+
+func matchesPackagePattern(path string) bool {
+	for _, regex := range packagesToLint {
+		if regex.MatchString(path) {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/roxvet/roxvet.go
+++ b/tools/roxvet/roxvet.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/tools/roxvet/analyzers/protoptrs"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/regexes"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/storeinterface"
+	"github.com/stackrox/rox/tools/roxvet/analyzers/structuredlogs"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/uncheckederrors"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/uncheckedifassign"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/unusedroxctlargs"
@@ -32,5 +33,6 @@ func main() {
 		filepathwalk.Analyzer,
 		validateimports.Analyzer,
 		importpackagenames.Analyzer,
+		structuredlogs.Analyzer,
 	)
 }


### PR DESCRIPTION
## Description

This PR adds an analyzer for roxvet which verifies structured log usage. Currently it simply flags calls of `Warnf/Errorf` to use `Warnw/Errorw` instead.

In the future, we might sophisticate this further, as well as extend the scope of linted packages (for the time being, only the `reprocessor` package is being linted).

Split out of this PR is #7462 which fixes the `Logger` expression for the `needlessformat` anaylzer and all occurrences.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI succeeding.
- run the linter locally via `go vet -vettools ./.gotools/bin/roxvet github.com/stackrox/rox/central/reprocessor`. Introduced changes locally to ensure that the check flags them correctly.
