### PR TITLE
Make Report State:SUCCESS filter replacement in queries case insensitive

### DIFF
--- a/central/reports/common/searcher.go
+++ b/central/reports/common/searcher.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/gogo/protobuf/proto"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -73,7 +74,7 @@ func replaceSearchBySuccess(q *v1.Query) {
 		if !ok {
 			return
 		}
-		if mfQ.MatchFieldQuery.GetField() == search.ReportState.String() &&
+		if strings.ToLower(mfQ.MatchFieldQuery.GetField()) == strings.ToLower(search.ReportState.String()) &&
 			doesValueMatchSuccess(mfQ.MatchFieldQuery.GetValue()) {
 			*q = *search.NewQueryBuilder().
 				AddExactMatches(search.ReportState, storage.ReportStatus_GENERATED.String(), storage.ReportStatus_DELIVERED.String()).
@@ -85,6 +86,6 @@ func replaceSearchBySuccess(q *v1.Query) {
 }
 
 func doesValueMatchSuccess(val string) bool {
-	return val == apiV2.ReportStatus_SUCCESS.String() ||
-		val == search.ExactMatchString(apiV2.ReportStatus_SUCCESS.String())
+	return strings.ToLower(val) == strings.ToLower(apiV2.ReportStatus_SUCCESS.String()) ||
+		strings.ToLower(val) == strings.ToLower(search.ExactMatchString(apiV2.ReportStatus_SUCCESS.String()))
 }

--- a/central/reports/common/searcher_test.go
+++ b/central/reports/common/searcher_test.go
@@ -93,6 +93,19 @@ func TestReplaceSearchBySuccess(t *testing.T) {
 			),
 		},
 		{
+			name: "Simple query with Report state = sUCCEsS (case insensitive replacement)",
+			query: search.NewQueryBuilder().
+				AddStrings(search.ReportState, storage.ReportStatus_PREPARING.String(), "sUCCEsS").ProtoQuery(),
+			expectedQ: search.DisjunctionQuery(
+				search.NewQueryBuilder().
+					AddStrings(search.ReportState, storage.ReportStatus_PREPARING.String()).
+					ProtoQuery(),
+				search.NewQueryBuilder().
+					AddExactMatches(search.ReportState, storage.ReportStatus_GENERATED.String(), storage.ReportStatus_DELIVERED.String()).
+					ProtoQuery(),
+			),
+		},
+		{
 			name: "Complex query with Report state = SUCCESS",
 			query: search.ConjunctionQuery(
 				search.NewQueryBuilder().
@@ -101,6 +114,32 @@ func TestReplaceSearchBySuccess(t *testing.T) {
 					AddExactMatches(search.ReportNotificationMethod, storage.ReportStatus_DOWNLOAD.String()).ProtoQuery(),
 				search.NewQueryBuilder().
 					AddExactMatches(search.ReportState, storage.ReportStatus_PREPARING.String(), "SUCCESS").
+					ProtoQuery(),
+			),
+			expectedQ: search.ConjunctionQuery(
+				search.NewQueryBuilder().
+					AddExactMatches(search.ReportRequestType, storage.ReportStatus_ON_DEMAND.String()).ProtoQuery(),
+				search.NewQueryBuilder().
+					AddExactMatches(search.ReportNotificationMethod, storage.ReportStatus_DOWNLOAD.String()).ProtoQuery(),
+				search.DisjunctionQuery(
+					search.NewQueryBuilder().
+						AddExactMatches(search.ReportState, storage.ReportStatus_PREPARING.String()).
+						ProtoQuery(),
+					search.NewQueryBuilder().
+						AddExactMatches(search.ReportState, storage.ReportStatus_GENERATED.String(), storage.ReportStatus_DELIVERED.String()).
+						ProtoQuery(),
+				),
+			),
+		},
+		{
+			name: "Complex query with Report state = sUCCEsS (case insensitive replacement)",
+			query: search.ConjunctionQuery(
+				search.NewQueryBuilder().
+					AddExactMatches(search.ReportRequestType, storage.ReportStatus_ON_DEMAND.String()).ProtoQuery(),
+				search.NewQueryBuilder().
+					AddExactMatches(search.ReportNotificationMethod, storage.ReportStatus_DOWNLOAD.String()).ProtoQuery(),
+				search.NewQueryBuilder().
+					AddExactMatches(search.ReportState, storage.ReportStatus_PREPARING.String(), "sUCCEsS").
 					ProtoQuery(),
 			),
 			expectedQ: search.ConjunctionQuery(


### PR DESCRIPTION
## Description

Currently we are only able to replace `Report State:SUCCESS` queries but the incoming queries can have any case like `rePort stAte:sUCCeSS`. The query replacement replaces it with `Report State:GENERATED OR Report State:DELIVERED` should be case insensitive.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Unit tests

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
