### PR TITLE
refactor: enrich schemas with scoping resource for SAC checks

### DIFF
--- a/migrator/migrations/postgreshelper/schema/test_child1.go
+++ b/migrator/migrations/postgreshelper/schema/test_child1.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -23,6 +24,7 @@ var (
 	TestChild1Schema = func() *walker.Schema {
 		schema := walker.Walk(reflect.TypeOf((*storage.TestChild1)(nil)), "test_child1")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(63), "testchild1", (*storage.TestChild1)(nil)))
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_child1_p4.go
+++ b/migrator/migrations/postgreshelper/schema/test_child1_p4.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -34,6 +35,7 @@ var (
 		schema.SetSearchScope([]v1.SearchCategory{
 			v1.SearchCategory(74),
 		}...)
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_child2.go
+++ b/migrator/migrations/postgreshelper/schema/test_child2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -32,6 +33,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(70), "testchild2", (*storage.TestChild2)(nil)))
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_g2_grand_child1.go
+++ b/migrator/migrations/postgreshelper/schema/test_g2_grand_child1.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -32,6 +33,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(66), "testg2grandchild1", (*storage.TestG2GrandChild1)(nil)))
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_g3_grand_child1.go
+++ b/migrator/migrations/postgreshelper/schema/test_g3_grand_child1.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -23,6 +24,7 @@ var (
 	TestG3GrandChild1Schema = func() *walker.Schema {
 		schema := walker.Walk(reflect.TypeOf((*storage.TestG3GrandChild1)(nil)), "test_g3_grand_child1")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(67), "testg3grandchild1", (*storage.TestG3GrandChild1)(nil)))
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_g_grand_child1.go
+++ b/migrator/migrations/postgreshelper/schema/test_g_grand_child1.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -23,6 +24,7 @@ var (
 	TestGGrandChild1Schema = func() *walker.Schema {
 		schema := walker.Walk(reflect.TypeOf((*storage.TestGGrandChild1)(nil)), "test_g_grand_child1")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(65), "testggrandchild1", (*storage.TestGGrandChild1)(nil)))
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_grand_child1.go
+++ b/migrator/migrations/postgreshelper/schema/test_grand_child1.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -32,6 +33,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(64), "testgrandchild1", (*storage.TestGrandChild1)(nil)))
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_grandparents.go
+++ b/migrator/migrations/postgreshelper/schema/test_grandparents.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -33,6 +34,7 @@ var (
 	TestGrandparentsSchema = func() *walker.Schema {
 		schema := walker.Walk(reflect.TypeOf((*storage.TestGrandparent)(nil)), "test_grandparents")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(61), "testgrandparent", (*storage.TestGrandparent)(nil)))
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_parent1.go
+++ b/migrator/migrations/postgreshelper/schema/test_parent1.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -37,6 +38,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(62), "testparent1", (*storage.TestParent1)(nil)))
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_parent2.go
+++ b/migrator/migrations/postgreshelper/schema/test_parent2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -31,6 +32,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(68), "testparent2", (*storage.TestParent2)(nil)))
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_parent3.go
+++ b/migrator/migrations/postgreshelper/schema/test_parent3.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -31,6 +32,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(69), "testparent3", (*storage.TestParent3)(nil)))
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_parent4.go
+++ b/migrator/migrations/postgreshelper/schema/test_parent4.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -35,6 +36,7 @@ var (
 			v1.SearchCategory(61),
 			v1.SearchCategory(74),
 		}...)
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_short_circuits.go
+++ b/migrator/migrations/postgreshelper/schema/test_short_circuits.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -32,6 +33,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(71), "testshortcircuit", (*storage.TestShortCircuit)(nil)))
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_single_key_structs.go
+++ b/migrator/migrations/postgreshelper/schema/test_single_key_structs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -25,6 +26,7 @@ var (
 	TestSingleKeyStructsSchema = func() *walker.Schema {
 		schema := walker.Walk(reflect.TypeOf((*storage.TestSingleKeyStruct)(nil)), "test_single_key_structs")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SEARCH_UNSET, "testsinglekeystruct", (*storage.TestSingleKeyStruct)(nil)))
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_single_uuid_key_structs.go
+++ b/migrator/migrations/postgreshelper/schema/test_single_uuid_key_structs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -25,6 +26,7 @@ var (
 	TestSingleUUIDKeyStructsSchema = func() *walker.Schema {
 		schema := walker.Walk(reflect.TypeOf((*storage.TestSingleUUIDKeyStruct)(nil)), "test_single_uuid_key_structs")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SEARCH_UNSET, "testsingleuuidkeystruct", (*storage.TestSingleUUIDKeyStruct)(nil)))
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/migrator/migrations/postgreshelper/schema/test_structs.go
+++ b/migrator/migrations/postgreshelper/schema/test_structs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -30,6 +31,7 @@ var (
 	TestStructsSchema = func() *walker.Schema {
 		schema := walker.Walk(reflect.TypeOf((*storage.TestStruct)(nil)), "test_structs")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SEARCH_UNSET, "teststruct", (*storage.TestStruct)(nil)))
+		schema.ScopingResource = resources.Namespace
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/active_components.go
+++ b/pkg/postgres/schema/active_components.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -42,6 +43,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_ACTIVE_COMPONENT, "activecomponent", (*storage.ActiveComponent)(nil)))
+		schema.ScopingResource = resources.Deployment
 		RegisterTable(schema, CreateTableActiveComponentsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_ACTIVE_COMPONENT, schema)
 		return schema

--- a/pkg/postgres/schema/alerts.go
+++ b/pkg/postgres/schema/alerts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -30,6 +31,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Alert)(nil)), "alerts")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_ALERTS, "alert", (*storage.Alert)(nil)))
+		schema.ScopingResource = resources.Alert
 		RegisterTable(schema, CreateTableAlertsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_ALERTS, schema)
 		return schema

--- a/pkg/postgres/schema/api_tokens.go
+++ b/pkg/postgres/schema/api_tokens.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -29,6 +30,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TokenMetadata)(nil)), "api_tokens")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_API_TOKEN, "tokenmetadata", (*storage.TokenMetadata)(nil)))
+		schema.ScopingResource = resources.Integration
 		RegisterTable(schema, CreateTableAPITokensStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_API_TOKEN, schema)
 		return schema

--- a/pkg/postgres/schema/auth_providers.go
+++ b/pkg/postgres/schema/auth_providers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.AuthProvider)(nil)), "auth_providers")
+		schema.ScopingResource = resources.Access
 		RegisterTable(schema, CreateTableAuthProvidersStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/blobs.go
+++ b/pkg/postgres/schema/blobs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -29,6 +30,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Blob)(nil)), "blobs")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_BLOB, "blob", (*storage.Blob)(nil)))
+		schema.ScopingResource = resources.Administration
 		RegisterTable(schema, CreateTableBlobsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_BLOB, schema)
 		return schema

--- a/pkg/postgres/schema/cluster_cve_edges.go
+++ b/pkg/postgres/schema/cluster_cve_edges.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -42,6 +43,7 @@ var (
 			v1.SearchCategory_CLUSTER_VULN_EDGE,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Cluster
 		RegisterTable(schema, CreateTableClusterCveEdgesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTER_VULN_EDGE, schema)
 		return schema

--- a/pkg/postgres/schema/cluster_cves.go
+++ b/pkg/postgres/schema/cluster_cves.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -34,6 +35,7 @@ var (
 			v1.SearchCategory_CLUSTER_VULN_EDGE,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Cluster
 		RegisterTable(schema, CreateTableClusterCvesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTER_VULNERABILITIES, schema)
 		return schema

--- a/pkg/postgres/schema/cluster_health_statuses.go
+++ b/pkg/postgres/schema/cluster_health_statuses.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -37,6 +38,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_CLUSTER_HEALTH, "clusterhealthstatus", (*storage.ClusterHealthStatus)(nil)))
+		schema.ScopingResource = resources.Cluster
 		RegisterTable(schema, CreateTableClusterHealthStatusesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTER_HEALTH, schema)
 		return schema

--- a/pkg/postgres/schema/clusters.go
+++ b/pkg/postgres/schema/clusters.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -28,6 +29,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Cluster)(nil)), "clusters")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_CLUSTERS, "cluster", (*storage.Cluster)(nil)))
+		schema.ScopingResource = resources.Cluster
 		RegisterTable(schema, CreateTableClustersStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTERS, schema)
 		return schema

--- a/pkg/postgres/schema/collections.go
+++ b/pkg/postgres/schema/collections.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -33,6 +34,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ResourceCollection)(nil)), "collections")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_COLLECTIONS, "resourcecollection", (*storage.ResourceCollection)(nil)))
+		schema.ScopingResource = resources.WorkflowAdministration
 		RegisterTable(schema, CreateTableCollectionsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_COLLECTIONS, schema)
 		return schema

--- a/pkg/postgres/schema/compliance_configs.go
+++ b/pkg/postgres/schema/compliance_configs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceConfig)(nil)), "compliance_configs")
+		schema.ScopingResource = resources.Compliance
 		RegisterTable(schema, CreateTableComplianceConfigsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/compliance_domains.go
+++ b/pkg/postgres/schema/compliance_domains.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -28,6 +29,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceDomain)(nil)), "compliance_domains")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_COMPLIANCE_DOMAIN, "compliancedomain", (*storage.ComplianceDomain)(nil)))
+		schema.ScopingResource = resources.Compliance
 		RegisterTable(schema, CreateTableComplianceDomainsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_COMPLIANCE_DOMAIN, schema)
 		return schema

--- a/pkg/postgres/schema/compliance_integrations.go
+++ b/pkg/postgres/schema/compliance_integrations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -41,6 +42,7 @@ var (
 			v1.SearchCategory_NAMESPACES,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Integration
 		RegisterTable(schema, CreateTableComplianceIntegrationsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_COMPLIANCE_INTEGRATIONS, schema)
 		return schema

--- a/pkg/postgres/schema/compliance_operator_check_result_v2.go
+++ b/pkg/postgres/schema/compliance_operator_check_result_v2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -38,6 +39,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_COMPLIANCE_CHECK_RESULTS, "complianceoperatorcheckresultv2", (*storage.ComplianceOperatorCheckResultV2)(nil)))
+		schema.ScopingResource = resources.ComplianceOperator
 		RegisterTable(schema, CreateTableComplianceOperatorCheckResultV2Stmt, features.ComplianceEnhancements.Enabled)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_COMPLIANCE_CHECK_RESULTS, schema)
 		return schema

--- a/pkg/postgres/schema/compliance_operator_check_results.go
+++ b/pkg/postgres/schema/compliance_operator_check_results.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceOperatorCheckResult)(nil)), "compliance_operator_check_results")
+		schema.ScopingResource = resources.ComplianceOperator
 		RegisterTable(schema, CreateTableComplianceOperatorCheckResultsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/compliance_operator_profile_v2.go
+++ b/pkg/postgres/schema/compliance_operator_profile_v2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
+		schema.ScopingResource = resources.ComplianceOperator
 		RegisterTable(schema, CreateTableComplianceOperatorProfileV2Stmt, features.ComplianceEnhancements.Enabled)
 		return schema
 	}()

--- a/pkg/postgres/schema/compliance_operator_profiles.go
+++ b/pkg/postgres/schema/compliance_operator_profiles.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceOperatorProfile)(nil)), "compliance_operator_profiles")
+		schema.ScopingResource = resources.ComplianceOperator
 		RegisterTable(schema, CreateTableComplianceOperatorProfilesStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/compliance_operator_rule_v2.go
+++ b/pkg/postgres/schema/compliance_operator_rule_v2.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -25,6 +26,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceOperatorRuleV2)(nil)), "compliance_operator_rule_v2")
+		schema.ScopingResource = resources.ComplianceOperator
 		RegisterTable(schema, CreateTableComplianceOperatorRuleV2Stmt, features.ComplianceEnhancements.Enabled)
 		return schema
 	}()

--- a/pkg/postgres/schema/compliance_operator_rules.go
+++ b/pkg/postgres/schema/compliance_operator_rules.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceOperatorRule)(nil)), "compliance_operator_rules")
+		schema.ScopingResource = resources.ComplianceOperator
 		RegisterTable(schema, CreateTableComplianceOperatorRulesStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/compliance_operator_scan_setting_bindings.go
+++ b/pkg/postgres/schema/compliance_operator_scan_setting_bindings.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceOperatorScanSettingBinding)(nil)), "compliance_operator_scan_setting_bindings")
+		schema.ScopingResource = resources.ComplianceOperator
 		RegisterTable(schema, CreateTableComplianceOperatorScanSettingBindingsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/compliance_operator_scan_setting_v2.go
+++ b/pkg/postgres/schema/compliance_operator_scan_setting_v2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -47,6 +48,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_COMPLIANCE_SCAN_SETTINGS, "complianceoperatorscansettingv2", (*storage.ComplianceOperatorScanSettingV2)(nil)))
+		schema.ScopingResource = resources.ComplianceOperator
 		RegisterTable(schema, CreateTableComplianceOperatorScanSettingV2Stmt, features.ComplianceEnhancements.Enabled)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_COMPLIANCE_SCAN_SETTINGS, schema)
 		return schema

--- a/pkg/postgres/schema/compliance_operator_scan_v2.go
+++ b/pkg/postgres/schema/compliance_operator_scan_v2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -44,6 +45,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_COMPLIANCE_SCAN, "complianceoperatorscanv2", (*storage.ComplianceOperatorScanV2)(nil)))
+		schema.ScopingResource = resources.ComplianceOperator
 		RegisterTable(schema, CreateTableComplianceOperatorScanV2Stmt, features.ComplianceEnhancements.Enabled)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_COMPLIANCE_SCAN, schema)
 		return schema

--- a/pkg/postgres/schema/compliance_operator_scans.go
+++ b/pkg/postgres/schema/compliance_operator_scans.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceOperatorScan)(nil)), "compliance_operator_scans")
+		schema.ScopingResource = resources.ComplianceOperator
 		RegisterTable(schema, CreateTableComplianceOperatorScansStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/compliance_run_metadata.go
+++ b/pkg/postgres/schema/compliance_run_metadata.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -29,6 +30,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceRunMetadata)(nil)), "compliance_run_metadata")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_COMPLIANCE_METADATA, "compliancerunmetadata", (*storage.ComplianceRunMetadata)(nil)))
+		schema.ScopingResource = resources.Compliance
 		RegisterTable(schema, CreateTableComplianceRunMetadataStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_COMPLIANCE_METADATA, schema)
 		return schema

--- a/pkg/postgres/schema/compliance_run_results.go
+++ b/pkg/postgres/schema/compliance_run_results.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -29,6 +30,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceRunResults)(nil)), "compliance_run_results")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_COMPLIANCE_RESULTS, "compliancerunresults", (*storage.ComplianceRunResults)(nil)))
+		schema.ScopingResource = resources.Compliance
 		RegisterTable(schema, CreateTableComplianceRunResultsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_COMPLIANCE_RESULTS, schema)
 		return schema

--- a/pkg/postgres/schema/compliance_strings.go
+++ b/pkg/postgres/schema/compliance_strings.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceStrings)(nil)), "compliance_strings")
+		schema.ScopingResource = resources.Compliance
 		RegisterTable(schema, CreateTableComplianceStringsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/configs.go
+++ b/pkg/postgres/schema/configs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Config)(nil)), "configs")
+		schema.ScopingResource = resources.Administration
 		RegisterTable(schema, CreateTableConfigsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/declarative_config_healths.go
+++ b/pkg/postgres/schema/declarative_config_healths.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.DeclarativeConfigHealth)(nil)), "declarative_config_healths")
+		schema.ScopingResource = resources.Integration
 		RegisterTable(schema, CreateTableDeclarativeConfigHealthsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/delegated_registry_configs.go
+++ b/pkg/postgres/schema/delegated_registry_configs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.DelegatedRegistryConfig)(nil)), "delegated_registry_configs")
+		schema.ScopingResource = resources.Administration
 		RegisterTable(schema, CreateTableDelegatedRegistryConfigsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/deployments.go
+++ b/pkg/postgres/schema/deployments.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -78,6 +79,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 			v1.SearchCategory_PROCESS_INDICATORS,
 		}...)
+		schema.ScopingResource = resources.Deployment
 		RegisterTable(schema, CreateTableDeploymentsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_DEPLOYMENTS, schema)
 		return schema

--- a/pkg/postgres/schema/external_backups.go
+++ b/pkg/postgres/schema/external_backups.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ExternalBackup)(nil)), "external_backups")
+		schema.ScopingResource = resources.Integration
 		RegisterTable(schema, CreateTableExternalBackupsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/groups.go
+++ b/pkg/postgres/schema/groups.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Group)(nil)), "groups")
+		schema.ScopingResource = resources.Access
 		RegisterTable(schema, CreateTableGroupsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/hashes.go
+++ b/pkg/postgres/schema/hashes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -25,6 +26,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Hash)(nil)), "hashes")
+		schema.ScopingResource = resources.Hash
 		RegisterTable(schema, CreateTableHashesStmt, features.StoreEventHashes.Enabled)
 		return schema
 	}()

--- a/pkg/postgres/schema/image_component_cve_edges.go
+++ b/pkg/postgres/schema/image_component_cve_edges.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -48,6 +49,7 @@ var (
 			v1.SearchCategory_NAMESPACES,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Image
 		RegisterTable(schema, CreateTableImageComponentCveEdgesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_COMPONENT_VULN_EDGE, schema)
 		return schema

--- a/pkg/postgres/schema/image_component_edges.go
+++ b/pkg/postgres/schema/image_component_edges.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -48,6 +49,7 @@ var (
 			v1.SearchCategory_NAMESPACES,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Image
 		RegisterTable(schema, CreateTableImageComponentEdgesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_COMPONENT_EDGE, schema)
 		return schema

--- a/pkg/postgres/schema/image_components.go
+++ b/pkg/postgres/schema/image_components.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -39,6 +40,7 @@ var (
 			v1.SearchCategory_NAMESPACES,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Image
 		RegisterTable(schema, CreateTableImageComponentsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_COMPONENTS, schema)
 		return schema

--- a/pkg/postgres/schema/image_cve_edges.go
+++ b/pkg/postgres/schema/image_cve_edges.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -49,6 +50,7 @@ var (
 			v1.SearchCategory_NAMESPACES,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Image
 		RegisterTable(schema, CreateTableImageCveEdgesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_VULN_EDGE, schema)
 		return schema

--- a/pkg/postgres/schema/image_cves.go
+++ b/pkg/postgres/schema/image_cves.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -40,6 +41,7 @@ var (
 			v1.SearchCategory_NAMESPACES,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Image
 		RegisterTable(schema, CreateTableImageCvesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_VULNERABILITIES, schema)
 		return schema

--- a/pkg/postgres/schema/image_integrations.go
+++ b/pkg/postgres/schema/image_integrations.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -28,6 +29,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ImageIntegration)(nil)), "image_integrations")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_IMAGE_INTEGRATIONS, "imageintegration", (*storage.ImageIntegration)(nil)))
+		schema.ScopingResource = resources.Integration
 		RegisterTable(schema, CreateTableImageIntegrationsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_INTEGRATIONS, schema)
 		return schema

--- a/pkg/postgres/schema/images.go
+++ b/pkg/postgres/schema/images.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -46,6 +47,7 @@ var (
 			v1.SearchCategory_NAMESPACES,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Image
 		RegisterTable(schema, CreateTableImagesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGES, schema)
 		return schema

--- a/pkg/postgres/schema/installation_infos.go
+++ b/pkg/postgres/schema/installation_infos.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.InstallationInfo)(nil)), "installation_infos")
+		schema.ScopingResource = resources.InstallationInfo
 		RegisterTable(schema, CreateTableInstallationInfosStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/integration_healths.go
+++ b/pkg/postgres/schema/integration_healths.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.IntegrationHealth)(nil)), "integration_healths")
+		schema.ScopingResource = resources.Integration
 		RegisterTable(schema, CreateTableIntegrationHealthsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/k8s_roles.go
+++ b/pkg/postgres/schema/k8s_roles.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -28,6 +29,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.K8SRole)(nil)), "k8s_roles")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_ROLES, "k8srole", (*storage.K8SRole)(nil)))
+		schema.ScopingResource = resources.K8sRole
 		RegisterTable(schema, CreateTableK8sRolesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_ROLES, schema)
 		return schema

--- a/pkg/postgres/schema/listening_endpoints.go
+++ b/pkg/postgres/schema/listening_endpoints.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -37,6 +38,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PROCESS_LISTENING_ON_PORT, "processlisteningonportstorage", (*storage.ProcessListeningOnPortStorage)(nil)))
+		schema.ScopingResource = resources.DeploymentExtension
 		RegisterTable(schema, CreateTableListeningEndpointsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_LISTENING_ON_PORT, schema)
 		return schema

--- a/pkg/postgres/schema/log_imbues.go
+++ b/pkg/postgres/schema/log_imbues.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.LogImbue)(nil)), "log_imbues")
+		schema.ScopingResource = resources.Administration
 		RegisterTable(schema, CreateTableLogImbuesStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/namespaces.go
+++ b/pkg/postgres/schema/namespaces.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -47,6 +48,7 @@ var (
 			v1.SearchCategory_NAMESPACES,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableNamespacesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_NAMESPACES, schema)
 		return schema

--- a/pkg/postgres/schema/network_baselines.go
+++ b/pkg/postgres/schema/network_baselines.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -28,6 +29,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.NetworkBaseline)(nil)), "network_baselines")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NETWORK_BASELINE, "networkbaseline", (*storage.NetworkBaseline)(nil)))
+		schema.ScopingResource = resources.DeploymentExtension
 		RegisterTable(schema, CreateTableNetworkBaselinesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_NETWORK_BASELINE, schema)
 		return schema

--- a/pkg/postgres/schema/network_graph_configs.go
+++ b/pkg/postgres/schema/network_graph_configs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.NetworkGraphConfig)(nil)), "network_graph_configs")
+		schema.ScopingResource = resources.Administration
 		RegisterTable(schema, CreateTableNetworkGraphConfigsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/networkpolicies.go
+++ b/pkg/postgres/schema/networkpolicies.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -28,6 +29,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.NetworkPolicy)(nil)), "networkpolicies")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NETWORK_POLICIES, "networkpolicy", (*storage.NetworkPolicy)(nil)))
+		schema.ScopingResource = resources.NetworkPolicy
 		RegisterTable(schema, CreateTableNetworkpoliciesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_NETWORK_POLICIES, schema)
 		return schema

--- a/pkg/postgres/schema/networkpoliciesundodeployments.go
+++ b/pkg/postgres/schema/networkpoliciesundodeployments.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.NetworkPolicyApplicationUndoDeploymentRecord)(nil)), "networkpoliciesundodeployments")
+		schema.ScopingResource = resources.NetworkPolicy
 		RegisterTable(schema, CreateTableNetworkpoliciesundodeploymentsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/networkpolicyapplicationundorecords.go
+++ b/pkg/postgres/schema/networkpolicyapplicationundorecords.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.NetworkPolicyApplicationUndoRecord)(nil)), "networkpolicyapplicationundorecords")
+		schema.ScopingResource = resources.NetworkPolicy
 		RegisterTable(schema, CreateTableNetworkpolicyapplicationundorecordsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/node_component_edges.go
+++ b/pkg/postgres/schema/node_component_edges.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -45,6 +46,7 @@ var (
 			v1.SearchCategory_NODES,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Node
 		RegisterTable(schema, CreateTableNodeComponentEdgesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_NODE_COMPONENT_EDGE, schema)
 		return schema

--- a/pkg/postgres/schema/node_components.go
+++ b/pkg/postgres/schema/node_components.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -36,6 +37,7 @@ var (
 			v1.SearchCategory_NODES,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Node
 		RegisterTable(schema, CreateTableNodeComponentsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_NODE_COMPONENTS, schema)
 		return schema

--- a/pkg/postgres/schema/node_components_cves_edges.go
+++ b/pkg/postgres/schema/node_components_cves_edges.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -45,6 +46,7 @@ var (
 			v1.SearchCategory_NODES,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Node
 		RegisterTable(schema, CreateTableNodeComponentsCvesEdgesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_NODE_COMPONENT_CVE_EDGE, schema)
 		return schema

--- a/pkg/postgres/schema/node_cves.go
+++ b/pkg/postgres/schema/node_cves.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -37,6 +38,7 @@ var (
 			v1.SearchCategory_NODES,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Node
 		RegisterTable(schema, CreateTableNodeCvesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_NODE_VULNERABILITIES, schema)
 		return schema

--- a/pkg/postgres/schema/nodes.go
+++ b/pkg/postgres/schema/nodes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -50,6 +51,7 @@ var (
 			v1.SearchCategory_NODES,
 			v1.SearchCategory_CLUSTERS,
 		}...)
+		schema.ScopingResource = resources.Node
 		RegisterTable(schema, CreateTableNodesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_NODES, schema)
 		return schema

--- a/pkg/postgres/schema/notification_schedules.go
+++ b/pkg/postgres/schema/notification_schedules.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.NotificationSchedule)(nil)), "notification_schedules")
+		schema.ScopingResource = resources.Notifications
 		RegisterTable(schema, CreateTableNotificationSchedulesStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/notifiers.go
+++ b/pkg/postgres/schema/notifiers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Notifier)(nil)), "notifiers")
+		schema.ScopingResource = resources.Integration
 		RegisterTable(schema, CreateTableNotifiersStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/permission_sets.go
+++ b/pkg/postgres/schema/permission_sets.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.PermissionSet)(nil)), "permission_sets")
+		schema.ScopingResource = resources.Access
 		RegisterTable(schema, CreateTablePermissionSetsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/pods.go
+++ b/pkg/postgres/schema/pods.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -41,6 +42,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PODS, "pod", (*storage.Pod)(nil)))
+		schema.ScopingResource = resources.Deployment
 		RegisterTable(schema, CreateTablePodsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_PODS, schema)
 		return schema

--- a/pkg/postgres/schema/policies.go
+++ b/pkg/postgres/schema/policies.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -30,6 +31,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Policy)(nil)), "policies")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_POLICIES, "policy", (*storage.Policy)(nil)))
+		schema.ScopingResource = resources.WorkflowAdministration
 		RegisterTable(schema, CreateTablePoliciesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_POLICIES, schema)
 		return schema

--- a/pkg/postgres/schema/policy_categories.go
+++ b/pkg/postgres/schema/policy_categories.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -28,6 +29,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.PolicyCategory)(nil)), "policy_categories")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_POLICY_CATEGORIES, "policycategory", (*storage.PolicyCategory)(nil)))
+		schema.ScopingResource = resources.WorkflowAdministration
 		RegisterTable(schema, CreateTablePolicyCategoriesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_POLICY_CATEGORIES, schema)
 		return schema

--- a/pkg/postgres/schema/policy_category_edges.go
+++ b/pkg/postgres/schema/policy_category_edges.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -41,6 +42,7 @@ var (
 			v1.SearchCategory_POLICY_CATEGORY_EDGE,
 			v1.SearchCategory_POLICY_CATEGORIES,
 		}...)
+		schema.ScopingResource = resources.WorkflowAdministration
 		RegisterTable(schema, CreateTablePolicyCategoryEdgesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_POLICY_CATEGORY_EDGE, schema)
 		return schema

--- a/pkg/postgres/schema/process_baseline_results.go
+++ b/pkg/postgres/schema/process_baseline_results.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -28,6 +29,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ProcessBaselineResults)(nil)), "process_baseline_results")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PROCESS_BASELINE_RESULTS, "processbaselineresults", (*storage.ProcessBaselineResults)(nil)))
+		schema.ScopingResource = resources.DeploymentExtension
 		RegisterTable(schema, CreateTableProcessBaselineResultsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_BASELINE_RESULTS, schema)
 		return schema

--- a/pkg/postgres/schema/process_baselines.go
+++ b/pkg/postgres/schema/process_baselines.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -28,6 +29,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ProcessBaseline)(nil)), "process_baselines")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PROCESS_BASELINES, "processbaseline", (*storage.ProcessBaseline)(nil)))
+		schema.ScopingResource = resources.DeploymentExtension
 		RegisterTable(schema, CreateTableProcessBaselinesStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_BASELINES, schema)
 		return schema

--- a/pkg/postgres/schema/process_indicators.go
+++ b/pkg/postgres/schema/process_indicators.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -37,6 +38,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PROCESS_INDICATORS, "processindicator", (*storage.ProcessIndicator)(nil)))
+		schema.ScopingResource = resources.DeploymentExtension
 		RegisterTable(schema, CreateTableProcessIndicatorsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_INDICATORS, schema)
 		return schema

--- a/pkg/postgres/schema/report_configurations.go
+++ b/pkg/postgres/schema/report_configurations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -44,6 +45,7 @@ var (
 		schema.SetSearchScope([]v1.SearchCategory{
 			v1.SearchCategory_REPORT_SNAPSHOT,
 		}...)
+		schema.ScopingResource = resources.WorkflowAdministration
 		RegisterTable(schema, CreateTableReportConfigurationsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_REPORT_CONFIGURATIONS, schema)
 		return schema

--- a/pkg/postgres/schema/report_snapshots.go
+++ b/pkg/postgres/schema/report_snapshots.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -37,6 +38,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_REPORT_SNAPSHOT, "reportsnapshot", (*storage.ReportSnapshot)(nil)))
+		schema.ScopingResource = resources.WorkflowAdministration
 		RegisterTable(schema, CreateTableReportSnapshotsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_REPORT_SNAPSHOT, schema)
 		return schema

--- a/pkg/postgres/schema/risks.go
+++ b/pkg/postgres/schema/risks.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -28,6 +29,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Risk)(nil)), "risks")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_RISKS, "risk", (*storage.Risk)(nil)))
+		schema.ScopingResource = resources.DeploymentExtension
 		RegisterTable(schema, CreateTableRisksStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_RISKS, schema)
 		return schema

--- a/pkg/postgres/schema/role_bindings.go
+++ b/pkg/postgres/schema/role_bindings.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -33,6 +34,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.K8SRoleBinding)(nil)), "role_bindings")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_ROLEBINDINGS, "k8srolebinding", (*storage.K8SRoleBinding)(nil)))
+		schema.ScopingResource = resources.K8sRoleBinding
 		RegisterTable(schema, CreateTableRoleBindingsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_ROLEBINDINGS, schema)
 		return schema

--- a/pkg/postgres/schema/roles.go
+++ b/pkg/postgres/schema/roles.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Role)(nil)), "roles")
+		schema.ScopingResource = resources.Access
 		RegisterTable(schema, CreateTableRolesStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/secrets.go
+++ b/pkg/postgres/schema/secrets.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -39,6 +40,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Secret)(nil)), "secrets")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SECRETS, "secret", (*storage.Secret)(nil)))
+		schema.ScopingResource = resources.Secret
 		RegisterTable(schema, CreateTableSecretsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_SECRETS, schema)
 		return schema

--- a/pkg/postgres/schema/sensor_upgrade_configs.go
+++ b/pkg/postgres/schema/sensor_upgrade_configs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.SensorUpgradeConfig)(nil)), "sensor_upgrade_configs")
+		schema.ScopingResource = resources.Administration
 		RegisterTable(schema, CreateTableSensorUpgradeConfigsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/service_accounts.go
+++ b/pkg/postgres/schema/service_accounts.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -28,6 +29,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ServiceAccount)(nil)), "service_accounts")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SERVICE_ACCOUNTS, "serviceaccount", (*storage.ServiceAccount)(nil)))
+		schema.ScopingResource = resources.ServiceAccount
 		RegisterTable(schema, CreateTableServiceAccountsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_SERVICE_ACCOUNTS, schema)
 		return schema

--- a/pkg/postgres/schema/service_identities.go
+++ b/pkg/postgres/schema/service_identities.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ServiceIdentity)(nil)), "service_identities")
+		schema.ScopingResource = resources.Administration
 		RegisterTable(schema, CreateTableServiceIdentitiesStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/signature_integrations.go
+++ b/pkg/postgres/schema/signature_integrations.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.SignatureIntegration)(nil)), "signature_integrations")
+		schema.ScopingResource = resources.Integration
 		RegisterTable(schema, CreateTableSignatureIntegrationsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/simple_access_scopes.go
+++ b/pkg/postgres/schema/simple_access_scopes.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.SimpleAccessScope)(nil)), "simple_access_scopes")
+		schema.ScopingResource = resources.Access
 		RegisterTable(schema, CreateTableSimpleAccessScopesStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/system_infos.go
+++ b/pkg/postgres/schema/system_infos.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.SystemInfo)(nil)), "system_infos")
+		schema.ScopingResource = resources.Administration
 		RegisterTable(schema, CreateTableSystemInfosStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/test_child1.go
+++ b/pkg/postgres/schema/test_child1.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -28,6 +29,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestChild1)(nil)), "test_child1")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(102), "testchild1", (*storage.TestChild1)(nil)))
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestChild1Stmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(102), schema)
 		return schema

--- a/pkg/postgres/schema/test_child1_p4.go
+++ b/pkg/postgres/schema/test_child1_p4.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -39,6 +40,7 @@ var (
 		schema.SetSearchScope([]v1.SearchCategory{
 			v1.SearchCategory(103),
 		}...)
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestChild1P4Stmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(103), schema)
 		return schema

--- a/pkg/postgres/schema/test_child2.go
+++ b/pkg/postgres/schema/test_child2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -37,6 +38,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(104), "testchild2", (*storage.TestChild2)(nil)))
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestChild2Stmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(104), schema)
 		return schema

--- a/pkg/postgres/schema/test_g2_grand_child1.go
+++ b/pkg/postgres/schema/test_g2_grand_child1.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -37,6 +38,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(105), "testg2grandchild1", (*storage.TestG2GrandChild1)(nil)))
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestG2GrandChild1Stmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(105), schema)
 		return schema

--- a/pkg/postgres/schema/test_g3_grand_child1.go
+++ b/pkg/postgres/schema/test_g3_grand_child1.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -28,6 +29,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestG3GrandChild1)(nil)), "test_g3_grand_child1")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(106), "testg3grandchild1", (*storage.TestG3GrandChild1)(nil)))
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestG3GrandChild1Stmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(106), schema)
 		return schema

--- a/pkg/postgres/schema/test_g_grand_child1.go
+++ b/pkg/postgres/schema/test_g_grand_child1.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -28,6 +29,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestGGrandChild1)(nil)), "test_g_grand_child1")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(107), "testggrandchild1", (*storage.TestGGrandChild1)(nil)))
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestGGrandChild1Stmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(107), schema)
 		return schema

--- a/pkg/postgres/schema/test_grand_child1.go
+++ b/pkg/postgres/schema/test_grand_child1.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -37,6 +38,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(108), "testgrandchild1", (*storage.TestGrandChild1)(nil)))
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestGrandChild1Stmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(108), schema)
 		return schema

--- a/pkg/postgres/schema/test_grandparents.go
+++ b/pkg/postgres/schema/test_grandparents.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -38,6 +39,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestGrandparent)(nil)), "test_grandparents")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(109), "testgrandparent", (*storage.TestGrandparent)(nil)))
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestGrandparentsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(109), schema)
 		return schema

--- a/pkg/postgres/schema/test_parent1.go
+++ b/pkg/postgres/schema/test_parent1.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -42,6 +43,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(110), "testparent1", (*storage.TestParent1)(nil)))
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestParent1Stmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(110), schema)
 		return schema

--- a/pkg/postgres/schema/test_parent2.go
+++ b/pkg/postgres/schema/test_parent2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -36,6 +37,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(111), "testparent2", (*storage.TestParent2)(nil)))
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestParent2Stmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(111), schema)
 		return schema

--- a/pkg/postgres/schema/test_parent3.go
+++ b/pkg/postgres/schema/test_parent3.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -36,6 +37,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(112), "testparent3", (*storage.TestParent3)(nil)))
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestParent3Stmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(112), schema)
 		return schema

--- a/pkg/postgres/schema/test_parent4.go
+++ b/pkg/postgres/schema/test_parent4.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -40,6 +41,7 @@ var (
 			v1.SearchCategory(109),
 			v1.SearchCategory(103),
 		}...)
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestParent4Stmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(113), schema)
 		return schema

--- a/pkg/postgres/schema/test_short_circuits.go
+++ b/pkg/postgres/schema/test_short_circuits.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -37,6 +38,7 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(114), "testshortcircuit", (*storage.TestShortCircuit)(nil)))
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestShortCircuitsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(114), schema)
 		return schema

--- a/pkg/postgres/schema/test_single_key_structs.go
+++ b/pkg/postgres/schema/test_single_key_structs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -30,6 +31,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestSingleKeyStruct)(nil)), "test_single_key_structs")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(100), "testsinglekeystruct", (*storage.TestSingleKeyStruct)(nil)))
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestSingleKeyStructsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(100), schema)
 		return schema

--- a/pkg/postgres/schema/test_single_uuid_key_structs.go
+++ b/pkg/postgres/schema/test_single_uuid_key_structs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -30,6 +31,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestSingleUUIDKeyStruct)(nil)), "test_single_uuid_key_structs")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(115), "testsingleuuidkeystruct", (*storage.TestSingleUUIDKeyStruct)(nil)))
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestSingleUUIDKeyStructsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(115), schema)
 		return schema

--- a/pkg/postgres/schema/test_structs.go
+++ b/pkg/postgres/schema/test_structs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
@@ -35,6 +36,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestStruct)(nil)), "test_structs")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(101), "teststruct", (*storage.TestStruct)(nil)))
+		schema.ScopingResource = resources.Namespace
 		RegisterTable(schema, CreateTableTestStructsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(101), schema)
 		return schema

--- a/pkg/postgres/schema/versions.go
+++ b/pkg/postgres/schema/versions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -25,6 +26,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.Version)(nil)), "versions")
+		schema.ScopingResource = resources.Version
 		RegisterTable(schema, CreateTableVersionsStmt)
 		return schema
 	}()

--- a/pkg/postgres/schema/watched_images.go
+++ b/pkg/postgres/schema/watched_images.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.WatchedImage)(nil)), "watched_images")
+		schema.ScopingResource = resources.WatchedImage
 		RegisterTable(schema, CreateTableWatchedImagesStmt)
 		return schema
 	}()

--- a/pkg/postgres/walker/schema.go
+++ b/pkg/postgres/walker/schema.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/search"
@@ -128,6 +129,8 @@ type Schema struct {
 	// some categories in cases of overlapping search fields.
 	// This is optional.
 	SearchScope map[v1.SearchCategory]struct{}
+
+	ScopingResource permissions.ResourceMetadata
 }
 
 // TableFieldsGroup is the group of table fields. A slice of this struct can be used where the table order is essential,

--- a/tools/generate-helpers/pg-table-bindings/list.go
+++ b/tools/generate-helpers/pg-table-bindings/list.go
@@ -88,6 +88,7 @@ func init() {
 		&storage.SignatureIntegration{}:                         resources.Integration,
 		&storage.SimpleAccessScope{}:                            resources.Access,
 		&storage.StoredLicenseKey{}:                             resources.Access,
+		&storage.SystemInfo{}:                                   resources.Administration,
 		&storage.TelemetryConfiguration{}:                       resources.Administration,
 		&storage.TokenMetadata{}:                                resources.Integration,
 		&storage.User{}:                                         resources.Access,

--- a/tools/generate-helpers/pg-table-bindings/schema.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/schema.go.tpl
@@ -16,6 +16,7 @@ import (
     "github.com/stackrox/rox/pkg/features"{{- end }}
     "github.com/stackrox/rox/pkg/postgres"
     "github.com/stackrox/rox/pkg/postgres/walker"
+    "github.com/stackrox/rox/pkg/sac/resources"
     "github.com/stackrox/rox/pkg/search"
     "github.com/stackrox/rox/pkg/search/postgres/mapping"
     "github.com/stackrox/rox/pkg/uuid"
@@ -70,6 +71,9 @@ var (
             {{- end}}
             }...)
             {{- end }}
+        {{- end }}
+        {{- if or (.Obj.IsGloballyScoped) (.Obj.IsDirectlyScoped) (.Obj.IsIndirectlyScoped) }}
+            schema.ScopingResource = resources.{{.Type | storageToResource}}
         {{- end }}
         {{- if .RegisterSchema }}
         RegisterTable(schema, {{template "createTableStmtVar" .Schema }}{{ if .FeatureFlag }}, features.{{.FeatureFlag}}.Enabled {{ end }})


### PR DESCRIPTION
## Description

This PR enriches the datastore schemas with SAC resources or SAC permission checker in order to later be able to move the SAC checks deeper in the code framework.

PR stack:
+- #7466 
| +- #7475 
| | +- #7479
| | | +- #7480
| | | | +- #7494 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
