### PR TITLE
fix(linter): exclude .md in whitespace linter

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -65,6 +65,7 @@ jobs:
 
     - name: Ensure no trailing whitespaces
       if: github.event_name == 'pull_request'
+      # Markdown files aren't checked for trailing whitespaces because it's a valid linebreak there.
       run: git diff --check "${{ github.event.pull_request.base.sha }}" ':(exclude)*.md'
 
     - name: Check PR fixes

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Ensure no trailing whitespaces
       if: github.event_name == 'pull_request'
-      run: git diff --check "${{ github.event.pull_request.base.sha }}"
+      run: git diff --check "${{ github.event.pull_request.base.sha }}" ':(exclude)*.md'
 
     - name: Check PR fixes
       run: scripts/ci/jobs/check-pr-fixes.sh


### PR DESCRIPTION
## Description

Trailing whitespaces are valid markdown, therefore we must exclude markdown files from the linter. See https://www.markdownguide.org/basic-syntax/#line-breaks.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
