### PR TITLE
feat: `pkg/timeutil` time range chunks

### DIFF
--- a/pkg/timeutil/time_chunks.go
+++ b/pkg/timeutil/time_chunks.go
@@ -1,0 +1,37 @@
+package timeutil
+
+import "time"
+
+// TimeRange frames a time range.
+type TimeRange struct {
+	From time.Time
+	To   time.Time
+}
+
+//
+// Next and Done methods allow for iterating over the time range by chunks.
+//
+// Example:
+//	tr = TimeRange{from, to}
+//	for !tr.Done() {
+//		current := tr.Next(time.Hour)
+//	}
+//
+
+// Next returns a new time range for a period of chunk at max.
+func (tr *TimeRange) Next(chunk time.Duration) *TimeRange {
+	result := *tr
+	tr.From = tr.From.Add(chunk)
+	if tr.Done() {
+		result.To = tr.To
+	} else {
+		result.To = tr.From
+	}
+
+	return &result
+}
+
+// Done tells whether the range start is reached the end.
+func (tr *TimeRange) Done() bool {
+	return !tr.From.Before(tr.To)
+}

--- a/pkg/timeutil/time_chunks.go
+++ b/pkg/timeutil/time_chunks.go
@@ -9,12 +9,13 @@ type TimeRange struct {
 }
 
 //
-// Next and Done methods allow for iterating over the time range by chunks.
+// Next and Done methods allow for iterating over a time range by given chunks.
 //
 // Example:
-//	tr = TimeRange{from, to}
+//	tr := TimeRange{From: from, To: to}
 //	for !tr.Done() {
-//		current := tr.Next(time.Hour)
+//		chunk := tr.Next(time.Hour)
+//		// QueryByTime(chunk.From, chunk.To)
 //	}
 //
 
@@ -31,7 +32,7 @@ func (tr *TimeRange) Next(chunk time.Duration) *TimeRange {
 	return &result
 }
 
-// Done tells whether the range start is reached the end.
+// Done tells whether the range start has reached the end.
 func (tr *TimeRange) Done() bool {
 	return !tr.From.Before(tr.To)
 }

--- a/pkg/timeutil/time_chunks_test.go
+++ b/pkg/timeutil/time_chunks_test.go
@@ -1,0 +1,32 @@
+package timeutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeChunks(t *testing.T) {
+	tr := TimeRange{}
+	assert.True(t, tr.Done())
+
+	from := time.Now()
+	to := from.Add(150 * time.Minute)
+
+	chunk := 1 * time.Hour
+
+	chunks := []*TimeRange{}
+
+	tr = TimeRange{from, to}
+	for !tr.Done() {
+		chunks = append(chunks, tr.Next(chunk))
+	}
+
+	expected := []*TimeRange{
+		{from, from.Add(chunk)},                // full chunk.
+		{from.Add(chunk), from.Add(2 * chunk)}, // full chunk.
+		{from.Add(2 * chunk), to},              // half chunk.
+	}
+	assert.Equal(t, expected, chunks)
+}


### PR DESCRIPTION
## Description

A useless utility to iterate over time chunks.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Unit tests.