### PR TITLE
ROX-18875: Poll for status updates in vuln reporting tables

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
@@ -39,7 +39,7 @@ function CloneVulnReportPage() {
     const history = useHistory();
     const { reportId } = useParams();
 
-    const { report, isLoading, error } = useFetchReport(reportId);
+    const { reportConfiguration, isLoading, error } = useFetchReport(reportId);
     const formik = useReportFormValues();
     const {
         isLoading: isCreating,
@@ -54,15 +54,15 @@ function CloneVulnReportPage() {
 
     // We fetch the report configuration for the edittable report and then populate the form values
     useEffect(() => {
-        if (report) {
-            const reportFormValues = getReportFormValuesFromConfiguration(report);
+        if (reportConfiguration) {
+            const reportFormValues = getReportFormValuesFromConfiguration(reportConfiguration);
             // We need to clear the reportId and modify the name
             reportFormValues.reportId = '';
             reportFormValues.reportParameters.reportName = `${reportFormValues.reportParameters.reportName} (copy)`;
             formik.setValues(reportFormValues);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [report, formik.setValues]);
+    }, [reportConfiguration, formik.setValues]);
 
     function onCreate() {
         createReport(formik.values);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
@@ -39,7 +39,7 @@ function EditVulnReportPage() {
     const history = useHistory();
     const { reportId } = useParams();
 
-    const { report, isLoading, error } = useFetchReport(reportId);
+    const { reportConfiguration, isLoading, error } = useFetchReport(reportId);
     const formik = useReportFormValues();
     const { isSaving, saveError, saveReport } = useSaveReport({
         onCompleted: () => {
@@ -50,12 +50,12 @@ function EditVulnReportPage() {
 
     // We fetch the report configuration for the edittable report and then populate the form values
     useEffect(() => {
-        if (report) {
-            const reportFormValues = getReportFormValuesFromConfiguration(report);
+        if (reportConfiguration) {
+            const reportFormValues = getReportFormValuesFromConfiguration(reportConfiguration);
             formik.setValues(reportFormValues);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [report, formik.setValues]);
+    }, [reportConfiguration, formik.setValues]);
 
     function onSave() {
         saveReport(reportId, formik.values);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -23,6 +23,7 @@ import { getDateTime } from 'utils/dateUtils';
 import { getReportFormValuesFromConfiguration } from 'Containers/Vulnerabilities/VulnerablityReporting/utils';
 import useSet from 'hooks/useSet';
 import useURLPagination from 'hooks/useURLPagination';
+import useInterval from 'hooks/useInterval';
 import useFetchReportHistory from 'Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReportHistory';
 import { getRequestQueryString } from 'Containers/Vulnerabilities/VulnerablityReporting/api/apiUtils';
 import useURLSort from 'hooks/useURLSort';
@@ -81,6 +82,8 @@ function ReportJobs({ reportId }: RunHistoryProps) {
     const handleChange = (checked: boolean) => {
         setShowOnlyMyJobs(checked);
     };
+
+    useInterval(fetchReportSnapshots, 10000);
 
     return (
         <>
@@ -147,12 +150,12 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                     </EmptyStateTemplate>
                 </Bullseye>
             )}
-            {isLoading && (
+            {isLoading && !reportSnapshots && (
                 <Bullseye className="pf-u-background-color-100 pf-u-p-lg">
                     <Spinner aria-label="Loading report jobs" />
                 </Bullseye>
             )}
-            {!error && !isLoading && (
+            {reportSnapshots && (
                 <TableComposable aria-label="Simple table" variant="compact">
                     <Thead>
                         <Tr>
@@ -314,7 +317,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                 error={deleteDownloadError}
             >
                 All data in this downloadable report will be deleted. Regenerating a downloadable
-                report will requre the download process to start over.
+                report will require the download process to start over.
             </DeleteModal>
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/apiUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/apiUtils.ts
@@ -1,34 +1,7 @@
-import { fetchReportHistory } from 'services/ReportsService';
-import { ReportConfiguration } from 'services/ReportsService.types';
 import { SearchFilter } from 'types/search';
-
-import { Report } from '../types';
 
 export function getRequestQueryString(searchFilter: SearchFilter): string {
     return Object.entries(searchFilter)
         .map(([key, val]) => `${key}:${Array.isArray(val) ? val.join(',') : val ?? ''}`)
         .join('+');
-}
-
-export async function fetchAndAppendLastReportJobForConfiguration(
-    reportConfiguration: ReportConfiguration
-): Promise<Report> {
-    // Query for the current user's last report job
-    const query = getRequestQueryString({ 'Report state': ['PREPARING', 'WAITING'] });
-
-    const reportSnapshot = await fetchReportHistory({
-        id: reportConfiguration.id,
-        query,
-        page: 1,
-        perPage: 1,
-        showMyHistory: true,
-        sortOption: {
-            field: 'Report Completion Time',
-            reversed: true,
-        },
-    });
-    return {
-        ...reportConfiguration,
-        reportSnapshot: reportSnapshot[0] ?? null,
-    };
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReport.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReport.ts
@@ -2,17 +2,16 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { fetchReportConfiguration } from 'services/ReportsService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { fetchAndAppendLastReportJobForConfiguration } from './apiUtils';
-import { Report } from '../types';
+import { ReportConfiguration } from 'services/ReportsService.types';
 
 type FetchReportResult = {
-    report: Report | null;
+    reportConfiguration: ReportConfiguration | null;
     isLoading: boolean;
     error: string | null;
 };
 
 const defaultResult = {
-    report: null,
+    reportConfiguration: null,
     isLoading: true,
     error: null,
 };
@@ -25,15 +24,14 @@ function useFetchReport(reportId: string): FetchReportResult {
 
         try {
             const reportConfiguration = await fetchReportConfiguration(reportId);
-            const report = await fetchAndAppendLastReportJobForConfiguration(reportConfiguration);
             setResult({
-                report,
+                reportConfiguration,
                 isLoading: false,
                 error: null,
             });
         } catch (error) {
             setResult({
-                report: null,
+                reportConfiguration: null,
                 isLoading: false,
                 error: getAxiosErrorMessage(error),
             });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReportHistory.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReportHistory.ts
@@ -16,7 +16,7 @@ export type UseFetchReportHistory = {
 };
 
 type Result = {
-    reportSnapshots: ReportSnapshot[];
+    reportSnapshots: ReportSnapshot[] | null;
     isLoading: boolean;
     error: string | null;
 };
@@ -26,7 +26,7 @@ export type FetchReportsResult = {
 } & Result;
 
 const defaultResult = {
-    reportSnapshots: [],
+    reportSnapshots: null,
     isLoading: false,
     error: null,
 };
@@ -42,11 +42,11 @@ function useFetchReportHistory({
     const [result, setResult] = useState<Result>(defaultResult);
 
     const fetchReportSnapshots = useCallback(() => {
-        setResult({
-            reportSnapshots: [],
+        setResult((prevResult) => ({
+            reportSnapshots: prevResult.reportSnapshots,
             isLoading: true,
             error: null,
-        });
+        }));
         fetchReportHistory({ id, query, page, perPage, sortOption, showMyHistory })
             .then((reportSnapshots) => {
                 setResult({
@@ -57,7 +57,7 @@ function useFetchReportHistory({
             })
             .catch((error) => {
                 setResult({
-                    reportSnapshots: [],
+                    reportSnapshots: null,
                     isLoading: false,
                     error: getAxiosErrorMessage(error),
                 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useWatchLastSnapshotForReports.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useWatchLastSnapshotForReports.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { fetchReportHistory } from 'services/ReportsService';
+import { ReportConfiguration, ReportSnapshot } from 'services/ReportsService.types';
+import useInterval from 'hooks/useInterval';
+import { getRequestQueryString } from './apiUtils';
+import { getErrorMessage } from '../errorUtils';
+
+type Result = {
+    reportSnapshots: Record<string, ReportSnapshot>;
+    isLoading: boolean;
+    error: string | null;
+};
+
+export type FetchLastSnapshotReturn = Result & {
+    fetchSnapshots: () => void;
+};
+
+async function fetchLastReportJobForConfiguration(
+    reportConfigurationId: string
+): Promise<ReportSnapshot> {
+    // Query for the current user's last report job
+    const query = getRequestQueryString({ 'Report state': ['PREPARING', 'WAITING'] });
+
+    const reportSnapshot = await fetchReportHistory({
+        id: reportConfigurationId,
+        query,
+        page: 1,
+        perPage: 1,
+        showMyHistory: true,
+        sortOption: {
+            field: 'Report Completion Time',
+            reversed: true,
+        },
+    });
+    return reportSnapshot[0] ?? null;
+}
+
+const defaultResult = {
+    reportSnapshots: {},
+    isLoading: false,
+    error: null,
+};
+
+export function useWatchLastSnapshotForReports(
+    reportConfigurations: ReportConfiguration | ReportConfiguration[] | null
+): FetchLastSnapshotReturn {
+    const [result, setResult] = useState<Result>(defaultResult);
+
+    const fetchSnapshots = useCallback(async () => {
+        if (!reportConfigurations) {
+            return;
+        }
+
+        setResult((prevResult) => ({
+            ...prevResult,
+            isLoading: true,
+            error: null,
+        }));
+
+        const configurations = Array.isArray(reportConfigurations)
+            ? reportConfigurations
+            : [reportConfigurations];
+
+        try {
+            const snapshots = await Promise.all(
+                configurations.map(({ id }) => fetchLastReportJobForConfiguration(id))
+            );
+            setResult({
+                reportSnapshots: configurations.reduce(
+                    (acc, { id }, index) => ({ ...acc, [id]: snapshots[index] }),
+                    {}
+                ),
+                isLoading: false,
+                error: null,
+            });
+        } catch (error) {
+            setResult({
+                reportSnapshots: {},
+                isLoading: false,
+                error: getErrorMessage(error),
+            });
+        }
+    }, [reportConfigurations]);
+
+    useInterval(fetchSnapshots, 10000);
+
+    useEffect(() => {
+        // eslint-disable-next-line no-void
+        void fetchSnapshots();
+        // Clear out statuses when report configurations change to avoid stale renders across pages
+        setResult(defaultResult);
+    }, [fetchSnapshots]);
+
+    return {
+        ...result,
+        fetchSnapshots,
+    };
+}


### PR DESCRIPTION
## Description

Polls the last status report history for report configurations on the list page.

Polls the last status for the report config on the details page. (Used to toggle `isDisabled` state in the menu.)

Polls the list of report jobs on the details page.

## Implementation notes

- In order to poll only the statuses, I decoupled the request for the configuration from the requests for the job history. This led to some renaming/type changes again from `Report` -> `ReportConfiguration`.
- To avoid entire tables being replaced with a loading spinner when data was updating, or a page was changing, I added a `null` type to the data from the `useFetchReport` and `useFetchReports` hooks as well as retaining the previous state during a re-fetch. This required a bit of a logic change in the components. e.g) [Here](https://github.com/stackrox/stackrox/pull/7471/files#diff-bc7ec4f5f79173ce6409f4a2e058587fa8c6a57c074e979730f9208d4a8434a7R43-R48) and [here](https://github.com/stackrox/stackrox/pull/7471/files#diff-67796c13ee0900c75cc29280a99a91f1039267a882846b9be7b61c45186c60e2R126-R195) for the list page
- The [api util ](ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/apiUtils.ts) added in the previous PR was moved yet again. This time to a new hook in order to make it easier to automatically poll for updates. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed


Load the report list page and open the network tab. Kick off a "Generate download" for one or more reports:
![image](https://github.com/stackrox/stackrox/assets/1292638/64b8e15b-b116-4226-8915-bde017c9967c)

See that requests for updated statuses are sent every 10 seconds and an update changes the status once the jobs are completed.
![image](https://github.com/stackrox/stackrox/assets/1292638/7b3d47f1-8f6f-41da-bb4b-59e358d19c58)
![image](https://github.com/stackrox/stackrox/assets/1292638/2e71a7a9-5fd0-4609-8641-8d87c0021a59)

Open the detail view for a report configuration in two tabs. Start a job in one tab and view the "All report jobs" tab in the second tab. Once the job has completed, the "All report jobs" table should update with the new data:
![image](https://github.com/stackrox/stackrox/assets/1292638/5dbf4eb9-5a7e-468e-a3cc-e79b592313e9)
![image](https://github.com/stackrox/stackrox/assets/1292638/7ee746d7-11fc-4b33-bb30-f0763c64a1ca)



