### PR TITLE
fix(ui): Fix VM reporting config API pagination

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReports.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReports.ts
@@ -57,11 +57,9 @@ function useFetchReports({
                 page,
                 perPage,
             });
-            const { count: totalReports } = await fetchReportConfigurationsCount({
-                query: getRequestQueryString(searchFilter),
-                page,
-                perPage,
-            });
+            const { count: totalReports } = await fetchReportConfigurationsCount(
+                getRequestQueryString(searchFilter)
+            );
             const reports: Report[] = await Promise.all(
                 reportConfigurations.map(async (reportConfiguration): Promise<Report> => {
                     const PAGE = 1;

--- a/ui/apps/platform/src/services/ReportsService.ts
+++ b/ui/apps/platform/src/services/ReportsService.ts
@@ -98,26 +98,8 @@ export function runReport(reportId: string): Promise<Empty> {
 
 // The following functions are built around the new VM Reporting Enhancements
 
-// @TODO: Same logic is used in fetchReportConfigurations. Maybe consider something more DRY
-export function fetchReportConfigurationsCount({
-    query,
-    page,
-    perPage,
-}: {
-    query: string;
-    page: number;
-    perPage: number;
-}): Promise<{ count: number }> {
-    const params = queryString.stringify(
-        {
-            query,
-            pagination: {
-                limit: perPage,
-                offset: page - 1,
-            },
-        },
-        { arrayFormat: 'repeat', allowDots: true }
-    );
+export function fetchReportConfigurationsCount(query: string): Promise<{ count: number }> {
+    const params = queryString.stringify({ query }, { arrayFormat: 'repeat', allowDots: true });
     return axios
         .get<{ count: number }>(`/v2/reports/configuration-count?${params}`)
         .then((response) => {
@@ -139,7 +121,7 @@ export function fetchReportConfigurations({
             query,
             pagination: {
                 limit: perPage,
-                offset: page - 1,
+                offset: (page - 1) * perPage,
             },
         },
         { arrayFormat: 'repeat', allowDots: true }


### PR DESCRIPTION
## Description

Quick pagination fixes I noticed. There was an issue where switching between pages caused the offset to advance by one across each page, instead of advancing by the current `pageSize`. This also makes it impossible for the user to view the tail end of the report list.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Create 5 report configs and manually set `perPage=2` in the URL.

Page forward/backward:

![image](https://github.com/stackrox/stackrox/assets/1292638/acf158dc-0438-4c23-b702-da67329d516c)
![image](https://github.com/stackrox/stackrox/assets/1292638/5f7a361a-5757-4005-a734-2cb5a6d2f021)
![image](https://github.com/stackrox/stackrox/assets/1292638/f1ed229d-c713-49b1-b420-1a0ca0451148)
![image](https://github.com/stackrox/stackrox/assets/1292638/011d166e-2b82-4800-ae7d-9c53e901c441)
![image](https://github.com/stackrox/stackrox/assets/1292638/21e85f69-f0fa-4071-97d1-77e8c986adf6)

