### PR TITLE
refactor: Move Delete SAC checks to query generator

### DIFF
--- a/migrator/migrations/m_183_to_m_184_move_declarative_config_health/migration.go
+++ b/migrator/migrations/m_183_to_m_184_move_declarative_config_health/migration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/utils"
 	"gorm.io/gorm"
 )
@@ -31,7 +32,7 @@ func init() {
 }
 
 func moveDeclarativeConfigHealthToNewStore(db postgres.DB, gormDB *gorm.DB) error {
-	ctx := context.Background()
+	ctx := sac.WithAllAccess(context.Background())
 	pgutils.CreateTableFromModel(ctx, gormDB, schema.CreateTableDeclarativeConfigHealthsStmt)
 
 	configStore := declarativeConfigStore.New(db)

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/random"
+	"github.com/stackrox/rox/pkg/sac"
 	searchPkg "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/aggregatefunc"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
@@ -325,8 +326,56 @@ func (p *parsedPaginationQuery) AsSQL() string {
 	return paginationSB.String()
 }
 
-func standardizeQueryAndPopulatePath(q *v1.Query, schema *walker.Schema, queryType QueryType) (*query, error) {
+func enrichQueryWithSACFilter(ctx context.Context, q *v1.Query, schema *walker.Schema, queryType QueryType) (*v1.Query, error) {
+	switch queryType {
+	case DELETE:
+		if schema.PermissionChecker != nil {
+			if ok, err := schema.PermissionChecker.WriteAllowed(ctx); err != nil {
+				return nil, err
+			} else if !ok {
+				return nil, sac.ErrResourceAccessDenied
+			}
+			return q, nil
+		}
+		sacFilter, err := GetReadWriteSACQuery(ctx, schema.ScopingResource)
+		if err != nil {
+			return nil, err
+		}
+		pagination := q.GetPagination()
+		query := searchPkg.ConjunctionQuery(sacFilter, q)
+		query.Pagination = pagination
+		return query, nil
+		/*
+			case GET:
+				if schema.PermissionChecker != nil {
+					if ok, err := schema.PermissionChecker.ReadAllowed(ctx); err != nil {
+						return nil, err
+					} else if !ok {
+						return getMatchNoneQuery(), nil
+					}
+					return q, nil
+				} else {
+					sacFilter, err := GetReadSACQuery(ctx, schema.ScopingResource)
+					if err != nil {
+						return nil, err
+					}
+					pagination := q.GetPagination()
+					query := searchPkg.ConjunctionQuery(sacFilter, q)
+					query.Pagination = pagination
+					return query, nil
+				}
+
+		*/
+	}
+	return q, nil
+}
+
+func standardizeQueryAndPopulatePath(ctx context.Context, q *v1.Query, schema *walker.Schema, queryType QueryType) (*query, error) {
 	nowForQuery := time.Now()
+	q, sacErr := enrichQueryWithSACFilter(ctx, q, schema, queryType)
+	if sacErr != nil {
+		return nil, sacErr
+	}
 	standardizeFieldNamesInQuery(q)
 	innerJoins, dbFields := getJoinsAndFields(schema, q)
 
@@ -700,7 +749,7 @@ func RunSearchRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1
 		}
 	}()
 
-	query, err = standardizeQueryAndPopulatePath(q, schema, SEARCH)
+	query, err = standardizeQueryAndPopulatePath(ctx, q, schema, SEARCH)
 	if err != nil {
 		return nil, err
 	}
@@ -726,7 +775,7 @@ func RunCountRequest(ctx context.Context, category v1.SearchCategory, q *v1.Quer
 
 // RunCountRequestForSchema executes a request for just the count against the database
 func RunCountRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1.Query, db postgres.DB) (int, error) {
-	query, err := standardizeQueryAndPopulatePath(q, schema, COUNT)
+	query, err := standardizeQueryAndPopulatePath(ctx, q, schema, COUNT)
 	if err != nil || query == nil {
 		return 0, err
 	}
@@ -749,7 +798,7 @@ type unmarshaler[T any] interface {
 
 // RunGetQueryForSchema executes a request for just the search against the database
 func RunGetQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, schema *walker.Schema, q *v1.Query, db postgres.DB) (*T, error) {
-	query, err := standardizeQueryAndPopulatePath(q, schema, GET)
+	query, err := standardizeQueryAndPopulatePath(ctx, q, schema, GET)
 	if err != nil {
 		return nil, err
 	}
@@ -778,7 +827,7 @@ func retryableRunGetManyQueryForSchema[T any, PT unmarshaler[T]](ctx context.Con
 
 // RunGetManyQueryForSchema executes a request for just the search against the database and unmarshal it to given type.
 func RunGetManyQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, schema *walker.Schema, q *v1.Query, db postgres.DB) ([]*T, error) {
-	query, err := standardizeQueryAndPopulatePath(q, schema, GET)
+	query, err := standardizeQueryAndPopulatePath(ctx, q, schema, GET)
 	if err != nil {
 		return nil, err
 	}
@@ -794,7 +843,7 @@ func RunGetManyQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, sch
 
 // RunCursorQueryForSchema creates a cursor against the database
 func RunCursorQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, schema *walker.Schema, q *v1.Query, db postgres.DB) (fetcher func(n int) ([]*T, error), closer func(), err error) {
-	query, err := standardizeQueryAndPopulatePath(q, schema, GET)
+	query, err := standardizeQueryAndPopulatePath(ctx, q, schema, GET)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error creating query")
 	}
@@ -842,7 +891,7 @@ func RunCursorQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, sche
 
 // RunDeleteRequestForSchema executes a request for just the delete against the database
 func RunDeleteRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1.Query, db postgres.DB) error {
-	query, err := standardizeQueryAndPopulatePath(q, schema, DELETE)
+	query, err := standardizeQueryAndPopulatePath(ctx, q, schema, DELETE)
 	if err != nil || query == nil {
 		return err
 	}

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -345,27 +345,6 @@ func enrichQueryWithSACFilter(ctx context.Context, q *v1.Query, schema *walker.S
 		query := searchPkg.ConjunctionQuery(sacFilter, q)
 		query.Pagination = pagination
 		return query, nil
-		/*
-			case GET:
-				if schema.PermissionChecker != nil {
-					if ok, err := schema.PermissionChecker.ReadAllowed(ctx); err != nil {
-						return nil, err
-					} else if !ok {
-						return getMatchNoneQuery(), nil
-					}
-					return q, nil
-				} else {
-					sacFilter, err := GetReadSACQuery(ctx, schema.ScopingResource)
-					if err != nil {
-						return nil, err
-					}
-					pagination := q.GetPagination()
-					query := searchPkg.ConjunctionQuery(sacFilter, q)
-					query.Pagination = pagination
-					return query, nil
-				}
-
-		*/
 	}
 	return q, nil
 }

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	mappings "github.com/stackrox/rox/pkg/search/options/deployments"
 	"github.com/stackrox/rox/pkg/search/postgres/aggregatefunc"
@@ -207,7 +208,8 @@ func TestMultiTableQueries(t *testing.T) {
 		},
 	} {
 		t.Run(c.desc, func(t *testing.T) {
-			actual, err := standardizeQueryAndPopulatePath(c.q, deploymentBaseSchema, SEARCH)
+			ctx := sac.WithAllAccess(context.Background())
+			actual, err := standardizeQueryAndPopulatePath(ctx, c.q, deploymentBaseSchema, SEARCH)
 			if c.expectedError != "" {
 				assert.Error(t, err, c.expectedError)
 			} else {


### PR DESCRIPTION
## Description

SAC checks are currently done in generic store code, which imposes use of the generated/generic store for data access.
The goal here is to allow implementation of other data access patterns while still enforcing Scoped Access Control and data filtering.

PR stack:
+- #7466 
| +- #7475 
| | +- #7479
| | | +- #7480
| | | | +- #7494 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
