### PR TITLE
refactor: Move Walk and Get* SAC checks to query generator

### DIFF
--- a/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission/migration.go
+++ b/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission/migration.go
@@ -9,6 +9,7 @@ import (
 	permissionSetPostgresStore "github.com/stackrox/rox/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission/permissionsetpostgresstore"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/sac"
 )
 
 const (
@@ -52,7 +53,7 @@ func propagateAccessForPermission(permission string, accessLevel storage.Access,
 }
 
 func cleanupPermissionSets(db postgres.DB) error {
-	ctx := context.Background()
+	ctx := sac.WithAllAccess(context.Background())
 	permissionSetStore := permissionSetPostgresStore.New(db)
 	permissionSetsToInsert := make([]*storage.PermissionSet, 0, batchSize)
 	err := permissionSetStore.Walk(ctx, func(obj *storage.PermissionSet) error {

--- a/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission/migration_test.go
+++ b/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission/migration_test.go
@@ -12,6 +12,7 @@ import (
 	pghelper "github.com/stackrox/rox/migrator/migrations/postgreshelper"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -98,7 +99,7 @@ func (s *psMigrationTestSuite) TearDownTest() {
 }
 
 func (s *psMigrationTestSuite) TestMigration() {
-	ctx := context.Background()
+	ctx := sac.WithAllAccess(context.Background())
 	var psToUpsert []*storage.PermissionSet
 	psToUpsert = append(psToUpsert, unmigratedPSs...)
 	psToUpsert = append(psToUpsert, alreadyMigratedPSs...)

--- a/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/migration_test.go
+++ b/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/migration_test.go
@@ -12,6 +12,7 @@ import (
 	pghelper "github.com/stackrox/rox/migrator/migrations/postgreshelper"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -101,7 +102,7 @@ func (s *psMigrationTestSuite) TearDownTest() {
 }
 
 func (s *psMigrationTestSuite) TestMigration() {
-	ctx := context.Background()
+	ctx := sac.WithAllAccess(context.Background())
 	var psToUpsert []*storage.PermissionSet
 	psToUpsert = append(psToUpsert, unmigratedPSs...)
 	psToUpsert = append(psToUpsert, alreadyMigratedPSs...)

--- a/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/migration.go
+++ b/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/migration.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/uuid"
 	"gorm.io/gorm"
@@ -223,7 +224,7 @@ func createCollectionsForScope(ctx context.Context, scopeID string,
 }
 
 func moveScopesInReportsToCollections(gormDB *gorm.DB, db postgres.DB) error {
-	ctx := context.Background()
+	ctx := sac.WithAllAccess(context.Background())
 	pgutils.CreateTableFromModel(ctx, gormDB, frozenSchema.CreateTableCollectionsStmt)
 	reportConfigStore := reportConfigurationPostgres.New(db)
 	accessScopeStore := accessScopePostgres.New(db)

--- a/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/migration_test.go
+++ b/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/migration_test.go
@@ -14,6 +14,7 @@ import (
 	pghelper "github.com/stackrox/rox/migrator/migrations/postgreshelper"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/suite"
 )
@@ -402,7 +403,7 @@ func (s *reportConfigsMigrationTestSuite) TearDownTest() {
 }
 
 func (s *reportConfigsMigrationTestSuite) TestMigration() {
-	ctx := context.Background()
+	ctx := sac.WithAllAccess(context.Background())
 	s.NoError(s.accessScopeStore.UpsertMany(ctx, accessScopes))
 	s.NoError(s.reportConfigStore.UpsertMany(ctx, configSliceFromMap(configIDToReportConfig)))
 

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/migration.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/migration.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/uuid"
 	"gorm.io/gorm"
 )
@@ -38,7 +39,7 @@ var (
 
 // MigrateToPartitions updates the btree network flow indexes to be hash
 func MigrateToPartitions(gormDB *gorm.DB, db postgres.DB) error {
-	ctx := context.Background()
+	ctx := sac.WithAllAccess(context.Background())
 
 	err := analyzeOldTable(ctx, db)
 	if err != nil {

--- a/migrator/migrations/m_174_to_m_175_enable_search_on_api_tokens/migration.go
+++ b/migrator/migrations/m_174_to_m_175_enable_search_on_api_tokens/migration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stackrox/rox/pkg/sac"
 	"gorm.io/gorm"
 )
 
@@ -35,7 +36,7 @@ func init() {
 }
 
 func migrateAPITokens(postgresDB postgres.DB, gormDB *gorm.DB) error {
-	ctx := context.Background()
+	ctx := sac.WithAllAccess(context.Background())
 	oldStore := oldAPITokenStore.New(postgresDB)
 	pgutils.CreateTableFromModel(ctx, gormDB, frozenSchema.CreateTableAPITokensStmt)
 	newStore := newAPITokenStore.New(postgresDB)

--- a/migrator/migrations/m_175_to_m_176_create_notification_schedule_table/migration.go
+++ b/migrator/migrations/m_175_to_m_176_create_notification_schedule_table/migration.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stackrox/rox/pkg/sac"
 	"gorm.io/gorm"
 )
 
@@ -28,7 +29,7 @@ func init() {
 }
 
 func createNotificationScheduleTable(_ postgres.DB, gormDB *gorm.DB) error {
-	ctx := context.Background()
+	ctx := sac.WithAllAccess(context.Background())
 	pgutils.CreateTableFromModel(ctx, gormDB, frozenSchema.CreateTableNotificationSchedulesStmt)
 	return nil
 }

--- a/migrator/migrations/m_176_to_m_177_network_baselines_cidr/migration.go
+++ b/migrator/migrations/m_176_to_m_177_network_baselines_cidr/migration.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/migrator/migrations/m_176_to_m_177_network_baselines_cidr/networkentitystore"
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/sac"
 )
 
 const (
@@ -77,7 +78,7 @@ func updatePeer(
 }
 
 func addCIDRBlockToBaselines(postgresDB postgres.DB) error {
-	ctx := context.Background()
+	ctx := sac.WithAllAccess(context.Background())
 	networkBaselineStore := networkbaselinestore.New(postgresDB)
 	networkEntityStore := networkentitystore.New(postgresDB)
 

--- a/migrator/migrations/m_178_to_m_179_embedded_collections_search_label/migration.go
+++ b/migrator/migrations/m_178_to_m_179_embedded_collections_search_label/migration.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/migrator/types"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stackrox/rox/pkg/sac"
 	"gorm.io/gorm"
 )
 
@@ -34,7 +35,7 @@ func init() {
 }
 
 func migrateReportConfigs(postgresDB postgres.DB, gormDB *gorm.DB) error {
-	ctx := context.Background()
+	ctx := sac.WithAllAccess(context.Background())
 	pgutils.CreateTableFromModel(ctx, gormDB, frozenSchema.CreateTableReportConfigurationsStmt)
 	newReportStore := newStore.New(postgresDB)
 

--- a/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
+++ b/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/migrator/migrations/policymigrationhelper/policypostgresstorefortest/schema"
 	pghelper "github.com/stackrox/rox/migrator/migrations/postgreshelper"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -31,7 +32,7 @@ type postgresPolicyMigratorTestSuite struct {
 
 func (s *postgresPolicyMigratorTestSuite) SetupTest() {
 	s.db = pghelper.ForT(s.T(), false)
-	s.ctx = context.Background()
+	s.ctx = sac.WithAllAccess(context.Background())
 	pgutils.CreateTableFromModel(s.ctx, s.db.GetGormDB(), schema.CreateTablePoliciesStmt)
 	s.store = policypostgresstore.New(s.db, s.T())
 }


### PR DESCRIPTION
## Description

SAC checks are currently done in generic store code, which imposes use of the generated/generic store for data access.
The goal here is to allow implementation of other data access patterns while still enforcing Scoped Access Control and data filtering.

PR stack:
+- #7466 
| +- #7475 
| | +- #7479
| | | +- #7480
| | | | +- #7494 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
