### PR TITLE
ROX-19145: Improve RBAC requirements in Policies and System Health

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Detail/ExcludedDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/ExcludedDeployment.tsx
@@ -2,13 +2,13 @@ import React, { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import { Cluster } from 'types/cluster.proto';
+import { ClusterScopeObject } from 'services/RolesService';
 import { PolicyExcludedDeployment } from 'types/policy.proto';
 
 import { getClusterName } from '../policies.utils';
 
 type ExcludedDeploymentProps = {
-    clusters: Cluster[];
+    clusters: ClusterScopeObject[];
     excludedDeployment: PolicyExcludedDeployment;
 };
 

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetailContent.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetailContent.tsx
@@ -2,9 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Formik } from 'formik';
 import { Flex, Title, Divider, Grid } from '@patternfly/react-core';
 
-import { fetchClustersAsArray } from 'services/ClustersService';
 import { fetchNotifierIntegrations } from 'services/NotifierIntegrationsService';
-import { Cluster } from 'types/cluster.proto';
 import { NotifierIntegration } from 'types/notifier.proto';
 import { Policy } from 'types/policy.proto';
 import PolicyOverview from './PolicyOverview';
@@ -21,18 +19,7 @@ function PolicyDetailContent({
     policy,
     isReview = false,
 }: PolicyDetailContentProps): React.ReactElement {
-    const [clusters, setClusters] = useState<Cluster[]>([]);
     const [notifiers, setNotifiers] = useState<NotifierIntegration[]>([]);
-
-    useEffect(() => {
-        fetchClustersAsArray()
-            .then((data) => {
-                setClusters(data as Cluster[]);
-            })
-            .catch(() => {
-                // TODO
-            });
-    }, []);
 
     useEffect(() => {
         fetchNotifierIntegrations()
@@ -78,11 +65,7 @@ function PolicyDetailContent({
                             Policy scope
                         </Title>
                         <Divider component="div" />
-                        <PolicyScopeSection
-                            scope={scope}
-                            exclusions={exclusions}
-                            clusters={clusters}
-                        />
+                        <PolicyScopeSection scope={scope} exclusions={exclusions} />
                     </>
                 )}
             </Flex>

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyScopeSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyScopeSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Title, Grid, GridItem, Card, CardBody, List, ListItem } from '@patternfly/react-core';
 
-import { Cluster } from 'types/cluster.proto';
+import useFetchClustersForPermissions from 'hooks/useFetchClustersForPermissions';
 import { PolicyScope, PolicyExclusion } from 'types/policy.proto';
 import Restriction from './Restriction';
 import ExcludedDeployment from './ExcludedDeployment';
@@ -10,14 +10,11 @@ import { getExcludedDeployments, getExcludedImageNames } from '../policies.utils
 type PolicyScopeSectionProps = {
     scope: PolicyScope[];
     exclusions: PolicyExclusion[];
-    clusters: Cluster[];
 };
 
-function PolicyScopeSection({
-    scope,
-    exclusions,
-    clusters,
-}: PolicyScopeSectionProps): React.ReactElement {
+function PolicyScopeSection({ scope, exclusions }: PolicyScopeSectionProps): React.ReactElement {
+    const { clusters } = useFetchClustersForPermissions(['Deployment']);
+
     const excludedDeploymentScopes = getExcludedDeployments(exclusions);
     const excludedImageNames = getExcludedImageNames(exclusions);
     return (

--- a/ui/apps/platform/src/Containers/Policies/Detail/Restriction.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/Restriction.tsx
@@ -2,13 +2,13 @@ import React, { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import { Cluster } from 'types/cluster.proto';
+import { ClusterScopeObject } from 'services/RolesService';
 import { PolicyScope } from 'types/policy.proto';
 
 import { getClusterName } from '../policies.utils';
 
 type RestrictionProps = {
-    clusters: Cluster[];
+    clusters: ClusterScopeObject[];
     restriction: PolicyScope;
 };
 

--- a/ui/apps/platform/src/Containers/Policies/PoliciesPage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PoliciesPage.tsx
@@ -30,7 +30,8 @@ function PoliciesPage() {
 
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
     const hasReadAccessForPolicy = hasReadAccess('WorkflowAdministration');
-    const hasWriteAccessForPolicy = hasReadWriteAccess('WorkflowAdministration');
+    const hasWriteAccessForPolicy =
+        hasReadWriteAccess('WorkflowAdministration') && hasReadAccess('Alert');
 
     if (!hasReadAccessForPolicy) {
         return <NotFoundMessage title="404: We couldn't find that page" />;

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeCard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeCard.tsx
@@ -18,13 +18,13 @@ import {
 import { TrashIcon } from '@patternfly/react-icons';
 import { useField } from 'formik';
 
-import { Cluster } from 'types/cluster.proto';
+import { ClusterScopeObject } from 'services/RolesService';
 import { ListDeployment } from 'types/deployment.proto';
 
 type PolicyScopeCardProps = {
     type: 'exclusion' | 'inclusion';
     name: string;
-    clusters: Cluster[];
+    clusters: ClusterScopeObject[];
     deployments?: ListDeployment[];
     onDelete: () => void;
     hasAuditLogEventSource: boolean;

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
@@ -17,8 +17,7 @@ import {
 import { ClientPolicy } from 'types/policy.proto';
 import { ListImage } from 'types/image.proto';
 import { ListDeployment } from 'types/deployment.proto';
-import { Cluster } from 'types/cluster.proto';
-import { fetchClustersAsArray } from 'services/ClustersService';
+import useFetchClustersForPermissions from 'hooks/useFetchClustersForPermissions';
 import { getImages } from 'services/imageService';
 import { fetchDeploymentsWithProcessInfoLegacy as fetchDeploymentsWithProcessInfo } from 'services/DeploymentsService';
 import PolicyScopeCard from './PolicyScopeCard';
@@ -27,7 +26,7 @@ function PolicyScopeForm() {
     const [isExcludeImagesOpen, setIsExcludeImagesOpen] = React.useState(false);
     const [images, setImages] = React.useState<ListImage[]>([]);
     const [deployments, setDeployments] = React.useState<ListDeployment[]>([]);
-    const [clusters, setClusters] = React.useState<Cluster[]>([]);
+    const { clusters } = useFetchClustersForPermissions(['Deployment']);
     const { values, setFieldValue } = useFormikContext<ClientPolicy>();
     const { scope, excludedDeploymentScopes, excludedImageNames } = values;
 
@@ -63,16 +62,6 @@ function PolicyScopeForm() {
             setFieldValue('excludedImageNames', [...excludedImageNames, selectedImage]);
         }
     }
-
-    React.useEffect(() => {
-        fetchClustersAsArray()
-            .then((data) => {
-                setClusters(data as Cluster[]);
-            })
-            .catch(() => {
-                // TODO
-            });
-    }, []);
 
     React.useEffect(() => {
         getImages()

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -4,7 +4,7 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import integrationsList from 'Containers/Integrations/utils/integrationsList';
 import { eventSourceLabels, lifecycleStageLabels } from 'messages/common';
-import { Cluster } from 'types/cluster.proto';
+import { ClusterScopeObject } from 'services/RolesService';
 import { NotifierIntegration } from 'types/notifier.proto';
 import {
     EnforcementAction,
@@ -249,7 +249,7 @@ export function getLabelAndNotifierIdsForTypes(
 
 // scope
 
-export function getClusterName(clusters: Cluster[], clusterId: string): string {
+export function getClusterName(clusters: ClusterScopeObject[], clusterId: string): string {
     const cluster = clusters.find(({ id }) => id === clusterId);
     return cluster?.name ?? clusterId;
 }

--- a/ui/apps/platform/src/Containers/SystemHealth/DashboardPage.js
+++ b/ui/apps/platform/src/Containers/SystemHealth/DashboardPage.js
@@ -44,9 +44,11 @@ const SystemHealthDashboardPage = () => {
                     <FlexItem>
                         <Title headingLevel="h1">System Health</Title>
                     </FlexItem>
-                    <FlexItem align={{ default: 'alignRight' }}>
-                        <GenerateDiagnosticBundle />
-                    </FlexItem>
+                    {hasReadAccessForAdministration && (
+                        <FlexItem align={{ default: 'alignRight' }}>
+                            <GenerateDiagnosticBundle />
+                        </FlexItem>
+                    )}
                 </Flex>
             </PageSection>
             <PageSection>

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -181,7 +181,6 @@ const routeDescriptionMap: Record<string, RouteDescription> = {
     },
     [policyManagementBasePath]: {
         resourceAccessRequirements: everyResource([
-            'Cluster',
             'Deployment',
             'Image',
             'Integration',


### PR DESCRIPTION
## Description

### Analysis

#### Policies

1. View policy
    * `PolicyDetailContent` calls `fetchClustersAsArray` for `clusters` prop of `PolicyScopeSection` element, which is conditionally rendered.
    * `PolicyScopeSection` provides `clusters` prop to `Restriction` and `ExcludedDeployment` elements.
    * `Restriction` conditionally renders cluster name for id.
    * `ExcludedDeployment` conditionally renders cluster name for id.

2. Clone, create, or edit policy
    * `PolicyScopeForm` calls `fetchClustersAsArray` for `clusters` prop of `PolicyScopeCard` elements, which are conditionally rendered in `map` methods.
    * `PolicyScopeCard` renders cluster id and name in options of `Select` element.

#### System Health

1. `DiagnosticBundleForm` calls `fetchClustersAsArray` and renders cluster name in options of `Select` element.
    * It is not possible to replace /v1/clusters with /v1/sac/clusters request, because it is not for global resources like Administration.
    * Although it is helpful to be able to filter by cluster, it is possible to download a diagnostic bundles for all clusters.
2. `DashboardPage` renders `GenerateDiagnosticBundle` element unconditionally.

### Solution

#### Policies

1. View policy
    * Replace `useEffect` hook for `getClustersAsArray` call with `useFetchClustersForPermissions` hook and move to `PolicyScopeSection` component.

2. Clone, create, or edit policy
    * Replace `useEffect` hook for `getClustersAsArray` call with `useFetchClustersForPermissions` hook and keep in `PolicyScopeForm` component.
    * There is a `fetchAlertCount` request which requires READ_ACCESS for Alert resource.

#### System Health

1. Conditionally call `getClustersAsArray` function and render `FormGroup` element only if READ_ACCESS for Cluster resource.
    * Cluster for GET /v1/clusters
2. Conditionally render `GenerateDiagnosticBundle` element only if READ_ACCESS for Administration resource.
    * Administration for GET /api/extensions/diagnostics

### Residue

1. Investigate reason for 2 sequences of requests for Policies: mitreattackvectors, clusters, notifiers.
2. Investigate whether Alert resource can become optional for Policies.
3. Rename the only 2 calls of `getClustersAsArray` as `fetchClusters` function because an obsolete function with that name has been deleted.
4. Rename and rewrite in TypeScript: src/Containers/SystemHealth/DashboardPage.js

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: -9 = 3759772 - 3759781
        total: 507 = 9949710 - 9949203
    * `ls -al build/static/js/*.js | wc -l`
        0 = 81 - 81 files
3. `yarn start` in ui

### Manual testing

#### Policies

1. Visit /main/policies and click to visit a policy page with READ_ACCESS for WorkflowAdministration resource.

    * See absence of GET /v1/sac/clusters request if policy **does not have** scope.
        ![policies_view_no_scope](https://github.com/stackrox/stackrox/assets/11862657/c5452527-9ef7-4214-877b-9c1895852ab1)

    * See presence of GET /v1/sac/clusters request if policy **does have** scope.
        ![policies_view_scope](https://github.com/stackrox/stackrox/assets/11862657/1544e4a6-12e0-43f3-9311-d87b5202a404)

2. Click **Actions** and **Edit policy** with READ_WRITE_ACCESS for WorkflowAdministration resource and READ_ACCESS for Alert.

    * On step 4, see GET /v1/sac/clusters request.
        ![policies_edit](https://github.com/stackrox/stackrox/assets/11862657/baa249fb-e61c-470f-bb91-eb1526f12bd8)

#### System Health

1. Visit /main/system-health

    * See absence of **Generate diagnostic bundle** button without READ_ACCESS for Administration.
        ![system-health_absence](https://github.com/stackrox/stackrox/assets/11862657/3a94d0e0-2238-42fd-992f-0f0e3dab10fd)

    * Click **Generate diagnostic bundle** button with READ_ACCESS for Administration resource but **without** READ_ACCESS for Cluster resource.
        See absence of GET /v1/sac/clusters request success and `FormGroup` element.
        ![system-health_without_Cluster](https://github.com/stackrox/stackrox/assets/11862657/fd0a1a0e-f509-44c6-887a-8cb3427c56f1)

    * Click **Generate diagnostic bundle** button with READ_ACCESS for Administration resource and **with** READ_ACCESS for Cluster resource.
        See presence of GET /v1/sac/clusters request success and `FormGroup` element.
        ![system-health_with_Cluster](https://github.com/stackrox/stackrox/assets/11862657/9ffdad0e-46f9-455a-b358-d779f73b3251)

### Integration testing

* policies/policiesTable.test.js
* policies/policyWizardStep3.test.js
* systemHealth/bundle.test.js
* systemHealth/clusters.test.js
* systemHealth/declarativeConfiguration.test.js
* systemHealth/integrations.test.js
* systemHealth/systemHealthGeneral.test.js
* systemHealth/vulnDefinitions.test.js
