### PR TITLE
ROX-18436: update mock-grpc-server container to be multi-arch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -609,11 +609,6 @@ jobs:
       run: |
         echo "TAG=$(make --quiet --no-print-directory tag)" >> "$GITHUB_OUTPUT"
 
-    - name: Build binaries
-      env:
-        PLATFORM: "linux/amd64,linux/s390x,linux/ppc64le"
-      run: make mock-grpc-server-build
-
     - name: Set up Docker Buildx
       # Skip for external contributions.
       if: |
@@ -635,6 +630,7 @@ jobs:
         github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       env:
         TAG: ${{ steps.tag.outputs.TAG }}
+        PLATFORM: "linux/amd64,linux/s390x,linux/ppc64le"
       run: make mock-grpc-server-image-push
 
   scan-images-with-roxctl:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -609,8 +609,10 @@ jobs:
       run: |
         echo "TAG=$(make --quiet --no-print-directory tag)" >> "$GITHUB_OUTPUT"
 
-    - name: Build image
-      run: make mock-grpc-server-image
+    - name: Build binaries
+      env:
+        PLATFORM: "linux/amd64,linux/s390x,linux/ppc64le"
+      run: make mock-grpc-server-build
 
     - name: Set up Docker Buildx
       # Skip for external contributions.
@@ -629,14 +631,11 @@ jobs:
         password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
     - name: Push to quay.io/rhacs-eng
-      uses: docker/build-push-action@v4
       if: |
         github.event_name == 'push' || !github.event.pull_request.head.repo.fork
-      with:
-        push: true
-        context: integration-tests/mock-grpc-server/image
-        tags: |
-          quay.io/rhacs-eng/grpc-server:${{ steps.tag.outputs.TAG }}
+      env:
+        TAG: ${{ steps.tag.outputs.TAG }}
+      run: make mock-grpc-server-image-push
 
   scan-images-with-roxctl:
     if: github.event_name == 'push'

--- a/Makefile
+++ b/Makefile
@@ -647,19 +647,17 @@ syslog-image: syslog-build
 
 .PHONY: mock-grpc-server-image
 mock-grpc-server-image: mock-grpc-server-build clean-image
-	find bin -type f -name mock-grpc-server -exec install -D  "{}" "integration-tests/mock-grpc-server/image/{}" \;
+	cp -R bin integration-tests/mock-grpc-server/image
 	docker buildx build --platform $(PLATFORM) --load \
 		-t stackrox/grpc-server:$(TAG) \
 		-t quay.io/rhacs-eng/grpc-server:$(TAG) \
-		-f integration-tests/mock-grpc-server/image/Dockerfile \
 		integration-tests/mock-grpc-server/image
 
 .PHONY: mock-grpc-server-image-push
 mock-grpc-server-image-push:
-	find bin -type f -name mock-grpc-server -exec install -D  "{}" "integration-tests/mock-grpc-server/image/{}" \;
+	cp -R bin integration-tests/mock-grpc-server/image
 	docker buildx build --platform $(PLATFORM) --push \
 		-t quay.io/rhacs-eng/grpc-server:$(TAG) \
-		-f integration-tests/mock-grpc-server/image/Dockerfile \
 		integration-tests/mock-grpc-server/image
 
 .PHONY: central-db-image

--- a/Makefile
+++ b/Makefile
@@ -654,7 +654,7 @@ mock-grpc-server-image: mock-grpc-server-build clean-image
 		integration-tests/mock-grpc-server/image
 
 .PHONY: mock-grpc-server-image-push
-mock-grpc-server-image-push:
+mock-grpc-server-image-push: mock-grpc-server-build
 	cp -R bin integration-tests/mock-grpc-server/image
 	docker buildx build --platform $(PLATFORM) --push \
 		-t quay.io/rhacs-eng/grpc-server:$(TAG) \

--- a/integration-tests/mock-grpc-server/image/Dockerfile
+++ b/integration-tests/mock-grpc-server/image/Dockerfile
@@ -1,7 +1,9 @@
 FROM scratch
 MAINTAINER StackRox <support@stackrox.com>
+ARG TARGETARCH
+ARG TARGETOS
 
-COPY ./bin/mock-grpc-server /
+COPY ./bin/${TARGETOS}_${TARGETARCH}/mock-grpc-server /
 EXPOSE 9090
 USER 1000:1000
 ENTRYPOINT ["/mock-grpc-server"]


### PR DESCRIPTION
## Description

update mock-grpc-server to support multiple architectures.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Build and pushed to personal quay repo
