### PR TITLE
fix(sensor): add sensor auto-upgrade labels

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "srox.labels" (list . "role" "secured-cluster-prometheus-k8s") | nindent 4 }}
+    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "role" "secured-cluster-prometheus-k8s") | nindent 4 }}
 rules:
@@ -32,6 +33,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "srox.labels" (list . "rolebinding" "secured-cluster-prometheus-k8s") | nindent 4 }}
+    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "rolebinding" "secured-cluster-prometheus-k8s") | nindent 4 }}
 roleRef:
@@ -52,6 +54,7 @@ metadata:
   namespace: openshift-monitoring
   labels:
     {{- include "srox.labels" (list . "servicemonitor" (print "sensor-monitor-" .Release.Namespace)) | nindent 4 }}
+    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "servicemonitor" (print "sensor-monitor-" .Release.Namespace)) | nindent 4 }}
 spec:
@@ -81,6 +84,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "srox.labels" (list . "podmonitor" "collector-monitor") | nindent 4 }}
+    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "podmonitor" "collector-monitor") | nindent 4 }}
 spec:
@@ -105,6 +109,7 @@ metadata:
   namespace: kube-system
   labels:
     {{- include "srox.labels" (list . "rolebinding" (print "rhacs-sensor-auth-reader-" .Release.Namespace)) | nindent 4 }}
+    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "rolebinding" (print "rhacs-sensor-auth-reader-" .Release.Namespace)) | nindent 4 }}
 roleRef:
@@ -125,6 +130,7 @@ metadata:
   namespace: openshift-monitoring
   labels:
     {{- include "srox.labels" (list . "prometheusrule" (print "sensor-telemeter-" .Release.Namespace )) | nindent 4 }}
+    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "prometheusrule" (print "sensor-telemeter-" .Release.Namespace )) | nindent 4 }}
 spec:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-netpol.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-netpol.yaml
@@ -72,6 +72,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "sensor-monitoring-tls") | nindent 4 }}
+    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "networkpolicy" "sensor-monitoring-tls") | nindent 4 }}
 spec:

--- a/sensor/upgrader/common/bundle_resources.go
+++ b/sensor/upgrader/common/bundle_resources.go
@@ -22,6 +22,8 @@ var OrderedBundleResourceTypes = []schema.GroupVersionKind{
 	{Group: "policy", Version: "v1beta1", Kind: "PodSecurityPolicy"},
 	{Group: "security.openshift.io", Version: "v1", Kind: "SecurityContextConstraints"},
 	{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
+	{Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor"},
+	{Group: "monitoring.coreos.com", Version: "v1", Kind: "PrometheusRule"},
 
 	// Might depend on objects above (e.g., referencing podsecuritypolicies)
 	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"},

--- a/sensor/upgrader/common/bundle_resources_test.go
+++ b/sensor/upgrader/common/bundle_resources_test.go
@@ -29,5 +29,7 @@ func TestEnsureBundleResourcesTypesAreCorrect(t *testing.T) {
 		{Group: "policy", Version: "v1beta1", Kind: "PodSecurityPolicy"},
 		{Group: "apps", Version: "v1", Kind: "DaemonSet"},
 		{Group: "apps", Version: "v1", Kind: "Deployment"},
+		{Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor"},
+		{Group: "monitoring.coreos.com", Version: "v1", Kind: "PrometheusRule"},
 	})
 }


### PR DESCRIPTION
## Description

Openshift monitoring resources are missing the auto-upgrade label that other Sensor resources have. This seems to break the nightly upgrader tests, see https://issues.redhat.com/browse/ROX-18895.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
