### PR TITLE
chore(log): fix migration sequence number check 

### DIFF
--- a/migrator/runner/runner.go
+++ b/migrator/runner/runner.go
@@ -58,7 +58,7 @@ func Run(databases *types.Databases) error {
 		log.WriteToStderrf("DB sequence number %d is greater than the latest one we have (%d). This means "+
 			"we are in a rollback.", dbSeqNum, currSeqNum)
 	}
-	if dbSeqNum <= currSeqNum {
+	if dbSeqNum < currSeqNum {
 		log.WriteToStderrf("Found DB at version %d, which is less than what we expect (%d). Running migrations...", dbSeqNum, currSeqNum)
 		if err := runMigrations(databases, dbSeqNum); err != nil {
 			return err


### PR DESCRIPTION
## Description

The sequence number check condition was `<=`.  This lead to a misleading log statement that we were executing migrations in cases where the database sequence number was = to the software sequence number.  No migrations were executed in this case as the logic would fall through the loop that ran the migrations.  But it left a misleading statement in the logs.  Simple fix here to resolve that so the log statement is not written in the case the sequences are equal.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran from 4.1.1 up to this version saw migrations execute as expected.
Bounced central with this version and saw that the log statement `DB is up to date at version %d. Nothing to do here.` was no printed.


