### PR TITLE
fix(sensor): remove pod monitor

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
@@ -77,31 +77,6 @@ spec:
 
 ---
 
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
-metadata:
-  name: collector-monitor
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "srox.labels" (list . "podmonitor" "collector-monitor") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
-  annotations:
-    {{- include "srox.annotations" (list . "podmonitor" "collector-monitor") | nindent 4 }}
-spec:
-  podMetricsEndpoints:
-  - interval: 30s
-    port: monitoring
-    scheme: http
-    path: metrics
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: collector
-  namespaceSelector:
-    matchNames:
-      - "{{ .Release.Namespace }}"
-
----
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/operator/tests/securedcluster/basic-sc/40-assert.yaml
+++ b/operator/tests/securedcluster/basic-sc/40-assert.yaml
@@ -6,11 +6,6 @@ kind: RoleBinding
 metadata:
   name: secured-cluster-prometheus-k8s
 ---
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
-metadata:
-  name: collector-monitor
----
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:

--- a/operator/tests/securedcluster/basic-sc/41-errors.yaml
+++ b/operator/tests/securedcluster/basic-sc/41-errors.yaml
@@ -2,8 +2,3 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: secured-cluster-prometheus-k8s
----
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
-metadata:
-  name: collector-monitor


### PR DESCRIPTION
## Description

Looks like the pod monitor was copy/pasted from the old implementation. It does not feature authn/z, and we therefore don't want to expose it by default as part of OpenShift monitoring integration.

It is still accessible via `sensor.exposeMonitoring` if one wants to use the unauthenticated monitoring solution.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
