### PR TITLE
fix: Show declarative marker near group only when group is declarative

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
@@ -161,7 +161,7 @@ function RuleGroups({
                                         </SelectSingle>
                                     </FormGroup>
                                 </FlexItem>
-                                {!isDisabled(group) ? (
+                                {!isDisabled(group) && (
                                     <FlexItem>
                                         <Button
                                             variant="plain"
@@ -172,7 +172,8 @@ function RuleGroups({
                                             <TrashIcon />
                                         </Button>
                                     </FlexItem>
-                                ) : (
+                                )}
+                                {!isUserResource(group?.props?.traits) && (
                                     <FlexItem>
                                         <Tooltip content="This rule is managed declaratively and can only be edited declaratively.">
                                             <Button


### PR DESCRIPTION
## Description

We shouldn't show `This rule is managed declaratively and can only be edited declaratively.` information message when user resource is in view mode.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Before:
<img width="1018" alt="Screenshot 2023-08-17 at 13 57 03" src="https://github.com/stackrox/stackrox/assets/78353299/53136694-73d0-4e09-a5b8-8cdfcd1428f4">
After:
<img width="928" alt="Screenshot 2023-08-17 at 13 56 28" src="https://github.com/stackrox/stackrox/assets/78353299/cb6a9c37-3993-42c9-881d-8590c9f24182">

