### PR TITLE
ROX-14550: UI for configuring auth provider required attributes

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -262,9 +262,7 @@ function AuthProviderForm({
 
     const ruleAttributes = getRuleAttributes(selectedAuthProvider.type, availableProviderTypes);
 
-    function isDisabled() {
-        return isViewing || values.active || getIsAuthProviderImmutable(values);
-    }
+    const isDisabled = isViewing || values.active || getIsAuthProviderImmutable(values);
 
     return (
         <Form>
@@ -409,7 +407,7 @@ function AuthProviderForm({
                                     id="name"
                                     value={values.name}
                                     onChange={onChange}
-                                    isDisabled={isDisabled()}
+                                    isDisabled={isDisabled}
                                     isRequired
                                     onBlur={handleBlur}
                                     validated={
@@ -472,11 +470,12 @@ function AuthProviderForm({
                         </SelectSingle>
                     </FormGroup>
                     <div id="minimum-access-role-description">
-                        <Alert isInline variant="info" title="">
-                            <p>
-                                The minimum access role is granted to all users who sign in with
-                                this authentication provider.
-                            </p>
+                        <Alert
+                            isInline
+                            variant="info"
+                            title="Note: the minimum access role is granted to all users who sign in with
+                                this authentication provider."
+                        >
                             <p>
                                 To give users different roles, add rules. Users are granted all
                                 matching roles.
@@ -492,20 +491,20 @@ function AuthProviderForm({
                             title="Required attributes for the authentication provider"
                             titleElement="h3"
                         >
-                            <div id="required-attributes-description">
-                                <Alert isInline variant="info" title="">
-                                    <p>
-                                        The required attributes are used to require attributes being
-                                        returned from the authentication provider.
-                                    </p>
-                                    <p>
-                                        In case a required attribute is not returned from the
-                                        authentication provider, the login attempt will fail and no
-                                        role will be assigned to the user.
-                                    </p>
-                                </Alert>
-                            </div>
-                            {values.requiredAttributes.length === 0 && (
+                            <Alert
+                                isInline
+                                variant="info"
+                                title="Note: the required attributes are used to require attributes being
+                                    returned from the authentication provider."
+                            >
+                                <p>
+                                    In case a required attribute is not returned from the
+                                    authentication provider, the login attempt will fail and no role
+                                    will be assigned to the user.
+                                </p>
+                            </Alert>
+                            {(!values.requiredAttributes ||
+                                values.requiredAttributes.length === 0) && (
                                 <p>No required attributes defined</p>
                             )}
                             <FieldArray
@@ -525,7 +524,7 @@ function AuthProviderForm({
                                                                 id={`requiredAttributes[${index}].attributeKey`}
                                                                 value={attribute.attributeKey}
                                                                 onChange={onChange}
-                                                                isDisabled={isDisabled()}
+                                                                isDisabled={isDisabled}
                                                             />
                                                         </FormGroup>
                                                         <FormGroup
@@ -537,10 +536,10 @@ function AuthProviderForm({
                                                                 id={`requiredAttributes[${index}].attributeValue`}
                                                                 value={attribute.attributeValue}
                                                                 onChange={onChange}
-                                                                isDisabled={isDisabled()}
+                                                                isDisabled={isDisabled}
                                                             />
                                                         </FormGroup>
-                                                        {!isDisabled() && (
+                                                        {!isDisabled && (
                                                             <FlexItem>
                                                                 <Button
                                                                     variant="plain"
@@ -578,7 +577,7 @@ function AuthProviderForm({
                                                     </Flex>
                                                 )
                                             )}
-                                        {!isDisabled() && (
+                                        {!isDisabled && (
                                             <Flex>
                                                 <FlexItem>
                                                     <Button

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -499,11 +499,15 @@ function AuthProviderForm({
                                         returned from the authentication provider.
                                     </p>
                                     <p>
-                                        In case a required attribute is not returned from the authentication provider, the login
-                                        attempt will fail and no role will be assigned to the user.
+                                        In case a required attribute is not returned from the
+                                        authentication provider, the login attempt will fail and no
+                                        role will be assigned to the user.
                                     </p>
                                 </Alert>
                             </div>
+                            {values.requiredAttributes.length === 0 && (
+                                <p>No required attributes defined</p>
+                            )}
                             <FieldArray
                                 name="requiredAttributes"
                                 render={(arrayHelpers) => (

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -499,8 +499,8 @@ function AuthProviderForm({
                                         returned from the authentication provider.
                                     </p>
                                     <p>
-                                        In case a required attribute is not set, the login will fail
-                                        and no role will be set to the user.
+                                        In case a required attribute is not returned from the authentication provider, the login
+                                        attempt will fail and no role will be assigned to the user.
                                     </p>
                                 </Alert>
                             </div>

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -121,6 +121,12 @@ function AuthProviderForm({
                 }),
             })
         ),
+        requiredAttributes: yup.array().of(
+            yup.object().shape({
+                attributeKey: yup.string().required('Key is a required field'),
+                attributeValue: yup.string().required('Value is a required field'),
+            })
+        ),
         /* eslint-disable @typescript-eslint/no-unsafe-return */
         config: yup
             .object()

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -25,13 +25,13 @@ import {
     Tooltip,
     ValidatedOptions,
 } from '@patternfly/react-core';
+import { InfoCircleIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 
 import SelectSingle from 'Components/SelectSingle'; // TODO import from where?
 import { selectors } from 'reducers';
 import { actions as authActions } from 'reducers/auth';
 
 import { AuthProvider, getIsAuthProviderImmutable } from 'services/AuthService';
-import { InfoCircleIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import ConfigurationFormFields from './ConfigurationFormFields';
 import RuleGroups, { RuleGroupErrors } from './RuleGroups';
 import {


### PR DESCRIPTION
## Description

Required attributes can be already set up via API and declaratively. This PR allows to do that via UI.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

#### How to test manually
1. Deploy code changes(for example, on infra)
2. Create auth provider of OIDC type
3. In create form, specify required attributed(see screenshot)
4. After `Save` reload the page to force UI to pull data from the backend and check that required attributes are present

After save: 
<img width="1784" alt="Screenshot 2023-08-17 at 15 49 22" src="https://github.com/stackrox/stackrox/assets/78353299/09ef5dd0-a32c-4d61-8e26-6af9a94885b9">
Before save: 
<img width="1784" alt="Screenshot 2023-08-17 at 15 49 09" src="https://github.com/stackrox/stackrox/assets/78353299/39fb3d24-1f64-41ed-9ca1-2a3b62c747c1">
No attributes edit mode: 
<img width="1783" alt="Screenshot 2023-08-17 at 15 48 41" src="https://github.com/stackrox/stackrox/assets/78353299/2a772ed6-1312-4fc6-aca3-95316049cea2">
No attributes view mode: 
<img width="1783" alt="Screenshot 2023-08-17 at 15 48 30" src="https://github.com/stackrox/stackrox/assets/78353299/b011f91d-98c5-4cd1-b7c4-2591428ec4ed">

