### PR TITLE
ROX-19168,ROX-19167,ROX-19164: VM 2.0 Report fixes

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -80,6 +80,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
 
     const handleChange = (checked: boolean) => {
         setShowOnlyMyJobs(checked);
+        setPage(1);
     };
 
     return (
@@ -97,6 +98,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                                     (val) => runStates[val] !== undefined
                                 ) as RunState[];
                                 setFilteredStatuses(newRunStates);
+                                setPage(1);
                             }}
                             placeholderText="Filter by status"
                         >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -179,6 +179,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                                                 variant="link"
                                                 onClick={() => {
                                                     setFilteredStatuses([]);
+                                                    setPage(1);
                                                 }}
                                             >
                                                 Clear filters

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -40,6 +40,7 @@ import useURLSort from 'hooks/useURLSort';
 import PageTitle from 'Components/PageTitle';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate/EmptyStateTemplate';
 import useFeatureFlags from 'hooks/useFeatureFlags';
+import CollectionsFormModal from 'Containers/Collections/CollectionFormModal';
 import HelpIconTh from './HelpIconTh';
 import MyActiveJobStatus from './MyActiveJobStatus';
 import DeleteModal from '../components/DeleteModal';
@@ -85,6 +86,7 @@ function VulnReportsPage() {
     const [searchValue, setSearchValue] = useState(() => {
         return (searchFilter?.[reportNameSearchKey] as string) || '';
     });
+    const [collectionModalId, setCollectionModalId] = useState<string | null>(null);
 
     const {
         reports,
@@ -431,13 +433,16 @@ function VulnReportsPage() {
                                                     </Td>
                                                     <Td>
                                                         {isCollectionsRouteEnabled ? (
-                                                            <Link
-                                                                to={generatePath(collectionsPath, {
-                                                                    collectionId,
-                                                                })}
+                                                            <Button
+                                                                variant="link"
+                                                                onClick={() =>
+                                                                    setCollectionModalId(
+                                                                        collectionId
+                                                                    )
+                                                                }
                                                             >
                                                                 {collectionName}
-                                                            </Link>
+                                                            </Button>
                                                         ) : (
                                                             collectionName
                                                         )}
@@ -477,6 +482,13 @@ function VulnReportsPage() {
                 This report and any attached downloadable reports will be permanently deleted. The
                 action cannot be undone.
             </DeleteModal>
+            {collectionModalId && (
+                <CollectionsFormModal
+                    hasWriteAccessForCollections={false}
+                    modalAction={{ type: 'view', collectionId: collectionModalId }}
+                    onClose={() => setCollectionModalId(null)}
+                />
+            )}
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -27,7 +27,7 @@ import { Link, generatePath, useHistory } from 'react-router-dom';
 import { ExclamationCircleIcon, FileIcon, SearchIcon } from '@patternfly/react-icons';
 import isEmpty from 'lodash/isEmpty';
 
-import { vulnerabilityReportsPath } from 'routePaths';
+import { collectionsPath, isRouteEnabled, vulnerabilityReportsPath } from 'routePaths';
 import { vulnerabilityReportPath } from 'Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting';
 import useFetchReports from 'Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReports';
 import usePermissions from 'hooks/usePermissions';
@@ -39,6 +39,7 @@ import useURLSort from 'hooks/useURLSort';
 
 import PageTitle from 'Components/PageTitle';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate/EmptyStateTemplate';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import HelpIconTh from './HelpIconTh';
 import MyActiveJobStatus from './MyActiveJobStatus';
 import DeleteModal from '../components/DeleteModal';
@@ -61,6 +62,7 @@ const sortOptions = {
 function VulnReportsPage() {
     const history = useHistory();
 
+    const { isFeatureFlagEnabled } = useFeatureFlags();
     const { hasReadWriteAccess, hasReadAccess } = usePermissions();
     const hasWorkflowAdministrationWriteAccess = hasReadWriteAccess('WorkflowAdministration');
     const hasImageReadAccess = hasReadAccess('Image');
@@ -71,6 +73,11 @@ function VulnReportsPage() {
         hasImageReadAccess &&
         hasAccessScopeReadAccess &&
         hasNotifierIntegrationReadAccess;
+
+    const isCollectionsRouteEnabled = isRouteEnabled(
+        { hasReadAccess, isFeatureFlagEnabled },
+        collectionsPath
+    );
 
     const { page, perPage, setPage, setPerPage } = useURLPagination(10);
     const { sortOption, getSortParams } = useURLSort(sortOptions);
@@ -404,6 +411,8 @@ function VulnReportsPage() {
                                                 isDisabled: isReportStatusPending,
                                             },
                                         ];
+                                        const { collectionName, collectionId } =
+                                            report.resourceScope.collectionScope;
                                         return (
                                             <Tbody
                                                 key={report.id}
@@ -419,10 +428,17 @@ function VulnReportsPage() {
                                                         </Link>
                                                     </Td>
                                                     <Td>
-                                                        {
-                                                            report.resourceScope.collectionScope
-                                                                .collectionName
-                                                        }
+                                                        {isCollectionsRouteEnabled ? (
+                                                            <Link
+                                                                to={generatePath(collectionsPath, {
+                                                                    collectionId,
+                                                                })}
+                                                            >
+                                                                {collectionName}
+                                                            </Link>
+                                                        ) : (
+                                                            collectionName
+                                                        )}
                                                     </Td>
                                                     <Td>{report.description || '-'}</Td>
                                                     <Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -160,10 +160,12 @@ function VulnReportsPage() {
                                             onSearch={(_event, value) => {
                                                 setSearchValue(value);
                                                 setSearchFilter({ [reportNameSearchKey]: value });
+                                                setPage(1);
                                             }}
                                             onClear={() => {
                                                 setSearchValue('');
                                                 setSearchFilter({});
+                                                setPage(1);
                                             }}
                                         />
                                     </ToolbarItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/exampleReportsCSVData.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/exampleReportsCSVData.ts
@@ -1,3 +1,5 @@
+import { VulnerabilitySeverity } from 'types/cve.proto';
+
 export type ExampleReportCSVData = {
     cluster: string;
     namespace: string;
@@ -7,7 +9,8 @@ export type ExampleReportCSVData = {
     cve: string;
     fixable: string;
     componentUpgrade: string;
-    severity: string;
+    severity: VulnerabilitySeverity;
+    cvss: number;
     discoveredAt: string;
     reference: string;
 };
@@ -23,6 +26,7 @@ const exampleReportsCSVData: ExampleReportCSVData[] = [
         fixable: 'false',
         componentUpgrade: '',
         severity: 'LOW_VULNERABILITY_SEVERITY',
+        cvss: 3.3,
         discoveredAt: 'January 26, 2022',
         reference: 'https://access.redhat.com/security/cve/CVE-2019-12900',
     },
@@ -36,6 +40,7 @@ const exampleReportsCSVData: ExampleReportCSVData[] = [
         fixable: 'false',
         componentUpgrade: '',
         severity: 'MODERATE_VULNERABILITY_SEVERITY',
+        cvss: 5.5,
         discoveredAt: 'January 26, 2022',
         reference: 'https://access.redhat.com/security/cve/CVE-2021-4122',
     },
@@ -49,6 +54,7 @@ const exampleReportsCSVData: ExampleReportCSVData[] = [
         fixable: 'true',
         componentUpgrade: '0:7.61.1-22.el8',
         severity: 'MODERATE_VULNERABILITY_SEVERITY',
+        cvss: 5.8,
         discoveredAt: 'January 26, 2022',
         reference: 'https://access.redhat.com/errata/RHSA-2021:4511',
     },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportReviewForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportReviewForm.tsx
@@ -17,7 +17,6 @@ import {
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import exampleReportsCSVData from 'Containers/Vulnerabilities/VulnerablityReporting/exampleReportsCSVData';
-import { VulnerabilitySeverity } from 'types/cve.proto';
 
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
 import ReportParametersDetails from '../components/ReportParametersDetails';
@@ -80,6 +79,7 @@ function ReportReviewForm({ title, formValues }: ReportReviewFormParams): ReactE
                                         <Th>Fixable</Th>
                                         <Th>Component Upgrade</Th>
                                         <Th>Severity</Th>
+                                        <Th>CVSS</Th>
                                         <Th>Discovered At</Th>
                                         <Th>Reference</Th>
                                     </Tr>
@@ -96,6 +96,7 @@ function ReportReviewForm({ title, formValues }: ReportReviewFormParams): ReactE
                                             fixable,
                                             componentUpgrade,
                                             severity,
+                                            cvss,
                                             discoveredAt,
                                             reference,
                                         }) => {
@@ -115,11 +116,10 @@ function ReportReviewForm({ title, formValues }: ReportReviewFormParams): ReactE
                                                     </Td>
                                                     <Td dataLabel="Severity">
                                                         <VulnerabilitySeverityIconText
-                                                            severity={
-                                                                severity as VulnerabilitySeverity
-                                                            }
+                                                            severity={severity}
                                                         />
                                                     </Td>
+                                                    <Td dataLabel="CVSS">{cvss}</Td>
                                                     <Td dataLabel="Discovered At">
                                                         {discoveredAt}
                                                     </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/utils.ts
@@ -150,7 +150,8 @@ export function getReportFormValuesFromConfiguration(
         cvesDiscoveredSince = 'SINCE_LAST_REPORT';
     } else if ('sinceStartDate' in vulnReportFilters) {
         cvesDiscoveredSince = 'START_DATE';
-        cvesDiscoveredStartDate = vulnReportFilters.sinceStartDate;
+        // Strip off the google.protobuf.Timestamp time portion of the date string
+        cvesDiscoveredStartDate = vulnReportFilters.sinceStartDate.substring(0, 10);
     } else {
         // we'll default to this if none of these fields are present
         cvesDiscoveredSince = 'ALL_VULN';


### PR DESCRIPTION
## Description

1. If the user can visit the collections page, the collection name in the reports table will link to the appropriate page.
2. Incoming Dates are formatted correctly for the report form
3. Add CVSS column to report table preview
4. Sets the current page to `1` when a filter is applied or cleared

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. 
Load VM reporting and see that the collections link is visible and opens the collection modal:
![image](https://github.com/stackrox/stackrox/assets/1292638/67cb9749-f2a7-465c-823e-ba7ce95f090b)
![image](https://github.com/stackrox/stackrox/assets/1292638/99069c9e-c77f-4a8a-8c88-cab91763fe32)


If the user does not have the appropriate access, only the collection name will be displayed instead. (Currently this is only possible if the user has read access to "WorkflowAdministration" but no access to "Deployment".)
![image](https://github.com/stackrox/stackrox/assets/1292638/0cafac9a-db22-4474-b918-2eeba702b47a)

2. Edit a report config with a custom date set and ensure the date is correctly displayed in the YYYY-MM-DD format without time information.
![image](https://github.com/stackrox/stackrox/assets/1292638/76f2ef39-8f26-4eb0-bde4-d9f68b7e398e)

3. View the report review step and see the CVSS score:
![image](https://github.com/stackrox/stackrox/assets/1292638/eac42455-a420-4656-b81b-6144edf610f7)

4. On the list page, move to a page beyond the first and apply a filter:
![image](https://github.com/stackrox/stackrox/assets/1292638/f3da0bda-68bc-4aed-b63f-a50ea02e9d95)
![image](https://github.com/stackrox/stackrox/assets/1292638/837a1cfc-83e4-4d4f-b724-e37319993c9f)
Move to a page beyond the first and clear the filter:
![image](https://github.com/stackrox/stackrox/assets/1292638/0d3b446c-56f4-4f00-8397-d23eaaa6624b)
![image](https://github.com/stackrox/stackrox/assets/1292638/909c8668-b2d5-4845-b95c-eb278bf78469)

Do the same with the filters on the report jobs table for the "Filter by status" dropdown, "View only my jobs" switch, and "Clear filters" button within the table.



