### PR TITLE
ROX-18291: Add environment variable to configure GRPC message size

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -55,6 +55,7 @@ func init() {
 var (
 	log = logging.LoggerForModule()
 
+	maxMsgSizeSetting         = env.RegisterIntegerSetting("ROX_GRPC_MAX_MESSAGE_SIZE", maxMsgSize)
 	maxResponseMsgSizeSetting = env.RegisterIntegerSetting("ROX_GRPC_MAX_RESPONSE_SIZE", defaultMaxResponseMsgSize)
 	enableRequestTracing      = env.RegisterBooleanSetting("ROX_GRPC_ENABLE_REQUEST_TRACING", false)
 )
@@ -378,7 +379,7 @@ func (a *apiImpl) run(startedSig *concurrency.ErrorSignal) {
 		grpc.UnaryInterceptor(
 			grpc_middleware.ChainUnaryServer(a.unaryInterceptors()...),
 		),
-		grpc.MaxRecvMsgSize(maxMsgSize),
+		grpc.MaxRecvMsgSize(maxMsgSizeSetting.IntegerSetting()),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			Time: 40 * time.Second,
 		}),


### PR DESCRIPTION
## Description

This can cause sensor's connection to restart if any message is larger than the hardcoded limit. We have observed some scenarios where the reconciliation fails with `RESOURCE_EXHAUSTED` error. This leads to the gRPC stream being closed. 

This PR allows users to increase the value if sensor's are not able to come up due to large payloads during the reconciliation.  

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] ~~Determined and documented upgrade steps~~
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed


