### PR TITLE
ROX-19163: VM Reporting 2.0 fixes

### DIFF
--- a/ui/apps/platform/src/Components/TechPreviewBanner.tsx
+++ b/ui/apps/platform/src/Components/TechPreviewBanner.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Alert } from '@patternfly/react-core';
+
+export type TechPreviewBannerProps = {
+    featureURL: string;
+    featureName: string;
+};
+
+function TechPreviewBanner({ featureURL, featureName }: TechPreviewBannerProps) {
+    return (
+        <Alert
+            variant="warning"
+            isInline
+            title={
+                <span>
+                    This feature is in its Technology Preview phase. For optimal production
+                    performance, please rely on <Link to={featureURL}>{featureName}</Link>.
+                </span>
+            }
+        />
+    );
+}
+
+export default TechPreviewBanner;

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -150,7 +150,11 @@ const navDescriptions: NavDescription[] = [
             },
             {
                 type: 'child',
-                content: 'Vulnerability Reporting',
+                content: (
+                    <NavigationContent variant="TechPreview">
+                        Vulnerability Reporting
+                    </NavigationContent>
+                ),
                 path: vulnerabilityReportsPath,
             },
         ],

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/JobDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/JobDetails.tsx
@@ -10,14 +10,15 @@ import {
 } from '@patternfly/react-core';
 
 import { getDateTime } from 'utils/dateUtils';
-import { ReportStatus } from 'services/ReportsService.types';
+import { ReportSnapshot } from 'services/ReportsService.types';
 import { getReportStatusText } from '../utils';
 
 export type JobDetailsProps = {
-    reportStatus: ReportStatus;
+    reportSnapshot: ReportSnapshot;
 };
 
-function JobDetails({ reportStatus }: JobDetailsProps): ReactElement {
+function JobDetails({ reportSnapshot }: JobDetailsProps): ReactElement {
+    const { isDownloadAvailable, reportStatus } = reportSnapshot;
     const { reportRequestType, completedAt } = reportStatus;
     return (
         <Flex direction={{ default: 'column' }}>
@@ -36,7 +37,7 @@ function JobDetails({ reportStatus }: JobDetailsProps): ReactElement {
                     <DescriptionListGroup>
                         <DescriptionListTerm>Status</DescriptionListTerm>
                         <DescriptionListDescription>
-                            {getReportStatusText(reportStatus)}
+                            {getReportStatusText(reportStatus, isDownloadAvailable)}
                         </DescriptionListDescription>
                     </DescriptionListGroup>
                     <DescriptionListGroup>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobStatus.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobStatus.tsx
@@ -68,16 +68,10 @@ function ReportJobStatus({
         isDownloadAvailable &&
         !areDownloadActionsDisabled
     ) {
-        statusColorClass = 'pf-u-info-color-100';
+        statusColorClass = 'pf-u-primary-color-100';
         statusIcon = <DownloadIcon title="Report download was successfully prepared" />;
         statusText = (
-            <Button
-                variant="link"
-                color="info"
-                isInline
-                className={statusColorClass}
-                onClick={onDownload}
-            >
+            <Button variant="link" isInline className={statusColorClass} onClick={onDownload}>
                 Ready for download
             </Button>
         );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobStatus.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobStatus.tsx
@@ -7,18 +7,24 @@ import {
     InProgressIcon,
     PendingIcon,
 } from '@patternfly/react-icons';
-import { Flex, FlexItem, Tooltip } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Tooltip } from '@patternfly/react-core';
 
 import { ReportSnapshot } from 'services/ReportsService.types';
 
 export type ReportJobStatusProps = {
     reportSnapshot: ReportSnapshot;
+    areDownloadActionsDisabled: boolean;
+    onDownload: () => void;
 };
 
 const genericMsg =
     'An issue was encountered. Please try again later. If the issue persists, please contact support';
 
-function ReportJobStatus({ reportSnapshot }: ReportJobStatusProps): ReactElement {
+function ReportJobStatus({
+    reportSnapshot,
+    areDownloadActionsDisabled,
+    onDownload,
+}: ReportJobStatusProps): ReactElement {
     const { reportStatus, isDownloadAvailable } = reportSnapshot;
 
     let statusColorClass = '';
@@ -28,11 +34,53 @@ function ReportJobStatus({ reportSnapshot }: ReportJobStatusProps): ReactElement
     if (
         reportStatus.runState === 'SUCCESS' &&
         reportStatus.reportNotificationMethod === 'DOWNLOAD' &&
-        isDownloadAvailable
+        isDownloadAvailable &&
+        areDownloadActionsDisabled
+    ) {
+        statusColorClass = 'pf-u-disabled-color-100';
+        statusIcon = <DownloadIcon title="Report download was successfully prepared" />;
+        statusText = (
+            <Flex
+                direction={{ default: 'row' }}
+                spaceItems={{ default: 'spaceItemsSm' }}
+                alignItems={{ default: 'alignItemsCenter' }}
+            >
+                <FlexItem>
+                    <p>Ready for download</p>
+                </FlexItem>
+                <FlexItem>
+                    <Tooltip
+                        content={
+                            <div>
+                                Only the requestor of the download has the authority to access or
+                                remove it.
+                            </div>
+                        }
+                    >
+                        <HelpIcon />
+                    </Tooltip>
+                </FlexItem>
+            </Flex>
+        );
+    } else if (
+        reportStatus.runState === 'SUCCESS' &&
+        reportStatus.reportNotificationMethod === 'DOWNLOAD' &&
+        isDownloadAvailable &&
+        !areDownloadActionsDisabled
     ) {
         statusColorClass = 'pf-u-info-color-100';
         statusIcon = <DownloadIcon title="Report download was successfully prepared" />;
-        statusText = <p>Ready for download</p>;
+        statusText = (
+            <Button
+                variant="link"
+                color="info"
+                isInline
+                className={statusColorClass}
+                onClick={onDownload}
+            >
+                Ready for download
+            </Button>
+        );
     } else if (
         reportStatus.runState === 'SUCCESS' &&
         reportStatus.reportNotificationMethod === 'DOWNLOAD' &&
@@ -47,7 +95,7 @@ function ReportJobStatus({ reportSnapshot }: ReportJobStatusProps): ReactElement
                 alignItems={{ default: 'alignItemsCenter' }}
             >
                 <FlexItem>
-                    <p>Ready for download</p>
+                    <p>Download deleted</p>
                 </FlexItem>
                 <FlexItem>
                     <Tooltip

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -28,6 +28,7 @@ import { getRequestQueryString } from 'Containers/Vulnerabilities/VulnerablityRe
 import useURLSort from 'hooks/useURLSort';
 import { saveFile } from 'services/DownloadService';
 import useDeleteDownloadModal from 'Containers/Vulnerabilities/VulnerablityReporting/hooks/useDeleteDownloadModal';
+import useAuthStatus from 'hooks/useAuthStatus';
 
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate/EmptyStateTemplate';
 import CheckboxSelect from 'Components/PatternFly/CheckboxSelect';
@@ -48,6 +49,7 @@ const sortOptions = {
 };
 
 function ReportJobs({ reportId }: RunHistoryProps) {
+    const { currentUser } = useAuthStatus();
     const { page, perPage, setPage, setPerPage } = useURLPagination(10);
     const { sortOption, getSortParams } = useURLSort(sortOptions);
     const [filteredStatuses, setFilteredStatuses] = useState<RunState[]>([]);
@@ -223,20 +225,19 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                             isDownloadAvailable &&
                             reportStatus.runState === 'SUCCESS' &&
                             reportStatus.reportNotificationMethod === 'DOWNLOAD';
+                        const areDownloadActionsDisabled = currentUser.userId !== user.id;
+
+                        function onDownload() {
+                            return saveFile({
+                                method: 'get',
+                                url: `/api/reports/jobs/download?id=${reportJobId}`,
+                                data: null,
+                                timeout: 300000,
+                                name: `${name}-report.zip`,
+                            });
+                        }
+
                         const rowActions = [
-                            {
-                                title: 'Download report',
-                                onClick: (event) => {
-                                    event.preventDefault();
-                                    return saveFile({
-                                        method: 'get',
-                                        url: `/api/reports/jobs/download?id=${reportJobId}`,
-                                        data: null,
-                                        timeout: 300000,
-                                        name: `${name}-report.zip`,
-                                    });
-                                },
-                            },
                             {
                                 title: (
                                     <span className="pf-u-danger-color-100">Delete download</span>
@@ -264,12 +265,19 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                                             : '-'}
                                     </Td>
                                     <Td dataLabel="Status">
-                                        <ReportJobStatus reportSnapshot={reportSnapshot} />
+                                        <ReportJobStatus
+                                            reportSnapshot={reportSnapshot}
+                                            areDownloadActionsDisabled={!areDownloadActionsDisabled}
+                                            onDownload={onDownload}
+                                        />
                                     </Td>
                                     <Td dataLabel="Requester">{user.name}</Td>
                                     <Td isActionCell>
                                         {hasDownloadableReport && (
-                                            <ActionsColumn items={rowActions} />
+                                            <ActionsColumn
+                                                items={rowActions}
+                                                isDisabled={!areDownloadActionsDisabled}
+                                            />
                                         )}
                                     </Td>
                                 </Tr>
@@ -278,7 +286,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                                         <Card className="pf-u-m-md pf-u-p-md" isFlat>
                                             <Flex>
                                                 <FlexItem>
-                                                    <JobDetails reportStatus={reportStatus} />
+                                                    <JobDetails reportSnapshot={reportSnapshot} />
                                                 </FlexItem>
                                                 <Divider component="div" className="pf-u-my-md" />
                                                 <FlexItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -267,7 +267,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                                     <Td dataLabel="Status">
                                         <ReportJobStatus
                                             reportSnapshot={reportSnapshot}
-                                            areDownloadActionsDisabled={!areDownloadActionsDisabled}
+                                            areDownloadActionsDisabled={areDownloadActionsDisabled}
                                             onDownload={onDownload}
                                         />
                                     </Td>
@@ -276,7 +276,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                                         {hasDownloadableReport && (
                                             <ActionsColumn
                                                 items={rowActions}
-                                                isDisabled={!areDownloadActionsDisabled}
+                                                isDisabled={areDownloadActionsDisabled}
                                             />
                                         )}
                                     </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -3,8 +3,9 @@ import { Route, Switch, Redirect } from 'react-router-dom';
 
 import usePageAction from 'Containers/Vulnerabilities/VulnerablityReporting/hooks/usePageAction';
 import usePermissions from 'hooks/usePermissions';
-import { vulnerabilityReportsPath } from 'routePaths';
+import { vulnManagementReportsPath, vulnerabilityReportsPath } from 'routePaths';
 
+import TechPreviewBanner from 'Components/TechPreviewBanner';
 import VulnReportsPage from './VulnReports/VulnReportsPage';
 import CreateVulnReportPage from './ModifyVulnReport/CreateVulnReportPage';
 import EditVulnReportPage from './ModifyVulnReport/EditVulnReportPage';
@@ -32,34 +33,40 @@ function VulnReportingPage() {
         hasNotifierIntegrationReadAccess;
 
     return (
-        <Switch>
-            <Route
-                exact
-                path={vulnerabilityReportsPath}
-                render={(props) => {
-                    if (pageAction === 'create' && canReadWriteReports) {
-                        return <CreateVulnReportPage {...props} />;
-                    }
-                    if (pageAction === undefined) {
-                        return <VulnReportsPage {...props} />;
-                    }
-                    return <Redirect to={vulnerabilityReportsPath} />;
-                }}
+        <>
+            <TechPreviewBanner
+                featureURL={vulnManagementReportsPath}
+                featureName="Vulnerability Management (1.0) Reporting"
             />
-            <Route
-                exact
-                path={vulnerabilityReportPath}
-                render={(props) => {
-                    if (pageAction === 'edit' && canReadWriteReports) {
-                        return <EditVulnReportPage {...props} />;
-                    }
-                    if (pageAction === 'clone' && canReadWriteReports) {
-                        return <CloneVulnReportPage {...props} />;
-                    }
-                    return <ViewVulnReportPage {...props} />;
-                }}
-            />
-        </Switch>
+            <Switch>
+                <Route
+                    exact
+                    path={vulnerabilityReportsPath}
+                    render={(props) => {
+                        if (pageAction === 'create' && canReadWriteReports) {
+                            return <CreateVulnReportPage {...props} />;
+                        }
+                        if (pageAction === undefined) {
+                            return <VulnReportsPage {...props} />;
+                        }
+                        return <Redirect to={vulnerabilityReportsPath} />;
+                    }}
+                />
+                <Route
+                    exact
+                    path={vulnerabilityReportPath}
+                    render={(props) => {
+                        if (pageAction === 'edit' && canReadWriteReports) {
+                            return <EditVulnReportPage {...props} />;
+                        }
+                        if (pageAction === 'clone' && canReadWriteReports) {
+                            return <CloneVulnReportPage {...props} />;
+                        }
+                        return <ViewVulnReportPage {...props} />;
+                    }}
+                />
+            </Switch>
+        </>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/utils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/utils.test.ts
@@ -1,0 +1,79 @@
+import { ReportStatus } from 'services/ReportsService.types';
+import { getReportStatusText } from './utils';
+
+// @TODO: Consider making a more unique name for general utils file under Vulnerability Reporting
+describe('utils', () => {
+    describe('getReportStatusText', () => {
+        it('should show the correct text for different report statuses', () => {
+            const reportStatus: ReportStatus = {
+                runState: 'SUCCESS',
+                completedAt: '2023-06-20T10:59:46.383433891Z',
+                errorMsg: '',
+                reportRequestType: 'ON_DEMAND',
+                reportNotificationMethod: 'EMAIL',
+            };
+            let isDownloadAvailable = false;
+            expect(getReportStatusText(reportStatus, isDownloadAvailable)).toEqual('Emailed');
+
+            reportStatus.runState = 'SUCCESS';
+            reportStatus.reportNotificationMethod = 'DOWNLOAD';
+            isDownloadAvailable = true;
+
+            expect(getReportStatusText(reportStatus, isDownloadAvailable)).toEqual(
+                'Download prepared'
+            );
+
+            reportStatus.runState = 'SUCCESS';
+            reportStatus.reportNotificationMethod = 'DOWNLOAD';
+            isDownloadAvailable = false;
+
+            expect(getReportStatusText(reportStatus, isDownloadAvailable)).toEqual(
+                'Download deleted'
+            );
+
+            reportStatus.runState = 'FAILURE';
+            reportStatus.reportNotificationMethod = 'EMAIL';
+
+            expect(getReportStatusText(reportStatus, isDownloadAvailable)).toEqual(
+                'Email attempted'
+            );
+
+            reportStatus.runState = 'FAILURE';
+            reportStatus.reportNotificationMethod = 'DOWNLOAD';
+
+            expect(getReportStatusText(reportStatus, isDownloadAvailable)).toEqual(
+                'Failed to generate download'
+            );
+
+            reportStatus.runState = 'SUCCESS';
+            reportStatus.reportNotificationMethod = 'UNSET';
+
+            expect(getReportStatusText(reportStatus, isDownloadAvailable)).toEqual('Success');
+
+            reportStatus.runState = 'FAILURE';
+            reportStatus.reportNotificationMethod = 'UNSET';
+
+            expect(getReportStatusText(reportStatus, isDownloadAvailable)).toEqual('Error');
+
+            reportStatus.runState = 'PREPARING';
+            reportStatus.reportNotificationMethod = 'DOWNLOAD';
+
+            expect(getReportStatusText(reportStatus, isDownloadAvailable)).toEqual('Preparing');
+
+            reportStatus.runState = 'PREPARING';
+            reportStatus.reportNotificationMethod = 'EMAIL';
+
+            expect(getReportStatusText(reportStatus, isDownloadAvailable)).toEqual('Preparing');
+
+            reportStatus.runState = 'WAITING';
+            reportStatus.reportNotificationMethod = 'DOWNLOAD';
+
+            expect(getReportStatusText(reportStatus, isDownloadAvailable)).toEqual('Waiting');
+
+            reportStatus.runState = 'WAITING';
+            reportStatus.reportNotificationMethod = 'EMAIL';
+
+            expect(getReportStatusText(reportStatus, isDownloadAvailable)).toEqual('Waiting');
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/utils.ts
@@ -213,7 +213,10 @@ export function getReportFormValuesFromConfiguration(
     return reportFormValues;
 }
 
-export function getReportStatusText(reportStatus: ReportStatus | null): string {
+export function getReportStatusText(
+    reportStatus: ReportStatus | null,
+    isDownloadAvailable: boolean
+): string {
     let statusText = '-';
 
     if (
@@ -223,9 +226,16 @@ export function getReportStatusText(reportStatus: ReportStatus | null): string {
         statusText = 'Emailed';
     } else if (
         reportStatus?.runState === 'SUCCESS' &&
-        reportStatus?.reportNotificationMethod === 'DOWNLOAD'
+        reportStatus?.reportNotificationMethod === 'DOWNLOAD' &&
+        isDownloadAvailable
     ) {
         statusText = 'Download prepared';
+    } else if (
+        reportStatus?.runState === 'SUCCESS' &&
+        reportStatus?.reportNotificationMethod === 'DOWNLOAD' &&
+        !isDownloadAvailable
+    ) {
+        statusText = 'Download deleted';
     } else if (
         reportStatus?.runState === 'FAILURE' &&
         reportStatus?.reportNotificationMethod === 'EMAIL'

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Link, Route, Switch } from 'react-router-dom';
-import { Alert, PageSection } from '@patternfly/react-core';
+import { Route, Switch } from 'react-router-dom';
+import { PageSection } from '@patternfly/react-core';
 
 import PageNotFound from 'Components/PageNotFound';
 import PageTitle from 'Components/PageTitle';
 
 import { vulnManagementPath, vulnerabilitiesWorkloadCvesPath } from 'routePaths';
+import TechPreviewBanner from 'Components/TechPreviewBanner';
 import DeploymentPage from './Deployment/DeploymentPage';
 import ImagePage from './Image/ImagePage';
 import WorkloadCvesOverviewPage from './Overview/WorkloadCvesOverviewPage';
@@ -20,16 +21,9 @@ const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesWorkloa
 function WorkloadCvesPage() {
     return (
         <>
-            <Alert
-                variant="warning"
-                isInline
-                title={
-                    <span>
-                        This is a Technology Preview of this feature. For all production
-                        requirements we recommend using{' '}
-                        <Link to={vulnManagementPath}>Vulnerability Management (1.0)</Link>
-                    </span>
-                }
+            <TechPreviewBanner
+                featureURL={vulnManagementPath}
+                featureName="Vulnerability Management (1.0)"
             />
             <Switch>
                 <Route path={vulnerabilitiesWorkloadCveSinglePath} component={ImageCvePage} />


### PR DESCRIPTION
## Description

This PR includes the following fixes:
1. Adds a "Tech preview" label for the Vulnerability Reporting 2.0 feature
2. When expanding a report job, the details should show that the download was deleted if it was (not saying it's prepared)
3. The table row actions should be disabled if you weren't the user who generated the download
4. If a download is ready, you should be able to download by clicking on the "Ready for download"
5. If you aren't allowed to download (not the user who generated the download) you shouldn't be able to click on the "Ready for download"
6. If a download was deleted, we should say "Download deleted"

<img width="281" alt="Screenshot 2023-08-17 at 10 24 41 AM" src="https://github.com/stackrox/stackrox/assets/4805485/add39513-7668-4791-885a-838a17f5c484">
<img width="587" alt="Screenshot 2023-08-17 at 10 24 14 AM" src="https://github.com/stackrox/stackrox/assets/4805485/ac40e663-8c4f-4696-91bf-f6b8d6e358aa">
<img width="1163" alt="Screenshot 2023-08-17 at 11 08 36 AM" src="https://github.com/stackrox/stackrox/assets/4805485/5d650803-5ea3-4592-a6f5-3b6b5aa933ad">
<img width="587" alt="Screenshot 2023-08-17 at 11 09 43 AM" src="https://github.com/stackrox/stackrox/assets/4805485/dc8ab98e-2835-4c39-8aad-cd2a2b87ac10">
