### PR TITLE
ROX-19183: Add ImageManagementTest to the parallel set

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/PolicyService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/PolicyService.groovy
@@ -74,6 +74,17 @@ class PolicyService extends BaseService {
         }
     }
 
+    static Policy clonePolicy(String name, String newPolicyName) {
+        Policy policy = getPolicyClient().getPolicy(getResourceByID(
+                getPolicies().find { it.name == name }.id
+        ))
+        Policy cloned = policy.toBuilder()
+            .clearId()
+            .setName(newPolicyName)
+            .build()
+        return createAndFetchPolicy(cloned)
+    }
+
     static Policy clonePolicyAndScopeByNamespace(String name, String namespace) {
         Policy policy = getPolicyClient().getPolicy(getResourceByID(
                 getPolicies().find { it.name == name }.id

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -262,9 +262,6 @@ class BaseSpecification extends Specification {
             LOG.warn "Could not create the core image integration."
             LOG.warn "Check that REGISTRY_USERNAME and REGISTRY_PASSWORD are valid for quay.io."
         }
-        // This sleep is required due to tests that can execute before the
-        // product has fully digested the integration.
-        sleep(5 * 1000)
     }
 
     private static void recordResourcesAtRunStart(OrchestratorMain orchestrator) {

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -262,6 +262,9 @@ class BaseSpecification extends Specification {
             LOG.warn "Could not create the core image integration."
             LOG.warn "Check that REGISTRY_USERNAME and REGISTRY_PASSWORD are valid for quay.io."
         }
+        // This sleep is required due to tests that can execute before the
+        // product has fully digested the integration.
+        sleep(5 * 1000)
     }
 
     private static void recordResourcesAtRunStart(OrchestratorMain orchestrator) {

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -1,7 +1,5 @@
 import static util.Helpers.withRetry
 
-import io.stackrox.proto.api.v1.Common
-import io.stackrox.proto.api.v1.PolicyServiceOuterClass
 import io.stackrox.proto.storage.PolicyOuterClass
 import io.stackrox.proto.storage.PolicyOuterClass.LifecycleStage
 import io.stackrox.proto.storage.PolicyOuterClass.Policy

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -18,6 +18,7 @@ import spock.lang.Unroll
 import spock.lang.IgnoreIf
 import util.Env
 
+@Tag("Parallel")
 class ImageManagementTest extends BaseSpecification {
 
     private static final String TEST_NAMESPACE = "qa-image-management"

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -321,7 +321,7 @@ class ImageManagementTest extends BaseSpecification {
     def "Verify CI/CD Integration Endpoint with notifications"() {
         when:
         "Clone and scope the policy for test"
-        Policy clone = PolicyService.clonePolicyAndScopeByNamespace("Latest tag", TEST_NAMESPACE)
+        Policy clone = PolicyService.clonePolicy("Latest tag", "Latest tag - ${TEST_NAMESPACE}")
 
         and:
         "Create a notifier"
@@ -336,6 +336,7 @@ class ImageManagementTest extends BaseSpecification {
             .addLifecycleStages(LifecycleStage.BUILD)
             .addNotifiers(notifier.id)
             .addCategories("DevOps Best Practices") // required for putPolicy
+            .clearExclusions()
             .build()
         Services.updatePolicy(update)
 

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -119,7 +119,7 @@ class ImageManagementTest extends BaseSpecification {
     @Unroll
     @Tag("BAT")
     @Tag("Integration")
-    def "Verify CI/CD Integration Endpoint excluded scopes - #policy - #excludedscopes"() {
+    def "Verify CI/CD Integration Endpoint excluded scopes - #policyName - #excludedscopes"() {
         when:
         "Clone and scope the policy for test"
         Policy clone = PolicyService.clonePolicyAndScopeByNamespace(policyName, TEST_NAMESPACE)

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -135,6 +135,7 @@ class ProcessBaselinesTest extends BaseSpecification {
 
     def cleanupSpec() {
         PolicyService.deletePolicy(unauthorizedProcessExecution.getId())
+        orchestrator.deleteNamespace(TEST_NAMESPACE)
     }
 
     @Unroll


### PR DESCRIPTION
## Description

This PR adds `ImageManagementTest.groovy` to the set of tests that run concurrently. This is achieved with a standard pattern: clone and scope policies to a test namespace and create deployments in that same namespace.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

50x runs:
- testParallel - [out43.txt](https://github.com/stackrox/stackrox/files/12412001/out43.txt)
- testParallelBAT - [out42.txt](https://github.com/stackrox/stackrox/files/12411998/out42.txt)
