### PR TITLE
feat(ui): Add toasts when running a report from the list page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
@@ -106,7 +106,10 @@ function DeliveryDestinationsForm({ title, formik }: DeliveryDestinationsFormPar
                                 {formik.values.deliveryDestinations.map(
                                     (deliveryDestination, index) => {
                                         return (
-                                            <li className="pf-u-mb-md">
+                                            <li
+                                                key={deliveryDestination.notifier?.id}
+                                                className="pf-u-mb-md"
+                                            >
                                                 <Card>
                                                     <CardTitle>
                                                         <Flex


### PR DESCRIPTION
## Description

As titled.

Also adds a `key` prop for notifiers in the form.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Send report:
![image](https://github.com/stackrox/stackrox/assets/1292638/52ffd134-fd10-4270-8fee-d34c9226ba97)

Generate download:
![image](https://github.com/stackrox/stackrox/assets/1292638/b1ef697b-997c-451f-b5b4-4b7ffafc4e19)
