### PR TITLE
Add link on Clusters page to Delegated Scanning

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/Clusters.helpers.js
+++ b/ui/apps/platform/cypress/integration/clusters/Clusters.helpers.js
@@ -42,8 +42,8 @@ const routeMatcherMapForDelegateScanning = {
     },
 };
 
-const basePath = '/main/clusters';
-export const delegatedScanningPath = `${basePath}/delegated-image-scanning`;
+export const clustersPath = '/main/clusters';
+export const delegatedScanningPath = `${clustersPath}/delegated-image-scanning`;
 
 const title = 'Clusters';
 
@@ -67,7 +67,7 @@ export function interactAndVisitClusters(interactionCallback, staticResponseMap)
 
     interactionCallback();
 
-    cy.location('pathname').should('eq', basePath);
+    cy.location('pathname').should('eq', clustersPath);
     cy.get(`h1:contains("${title}")`);
 
     waitForResponses(routeMatcherMapForClusters);
@@ -76,7 +76,7 @@ export function interactAndVisitClusters(interactionCallback, staticResponseMap)
 export function visitClustersFromLeftNav() {
     visitFromLeftNavExpandable('Platform Configuration', title, routeMatcherMapForClusters);
 
-    cy.location('pathname').should('eq', basePath);
+    cy.location('pathname').should('eq', clustersPath);
     cy.get(`h1:contains("${title}")`);
 }
 
@@ -84,7 +84,7 @@ export function visitClustersFromLeftNav() {
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function visitClusters(staticResponseMap) {
-    visit(basePath, routeMatcherMapForClusters, staticResponseMap);
+    visit(clustersPath, routeMatcherMapForClusters, staticResponseMap);
 
     cy.get(`h1:contains("${title}")`);
 }
@@ -109,7 +109,7 @@ export function visitClusterById(clusterId, staticResponseMap) {
             url: `/v1/clusters/${clusterId}`,
         },
     };
-    visit(`${basePath}/${clusterId}`, routeMatcherMapForClusterById, staticResponseMap);
+    visit(`${clustersPath}/${clusterId}`, routeMatcherMapForClusterById, staticResponseMap);
 
     cy.get(`h1:contains("${title}")`);
 }

--- a/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
@@ -4,14 +4,24 @@ import { getInputByLabel } from '../../helpers/formHelpers';
 import { visitWithStaticResponseForPermissions } from '../../helpers/visit';
 
 import {
+    visitClusters,
     visitDelegateScanning,
     saveDelegatedRegistryConfig,
     delegatedScanningPath,
+    clustersPath,
 } from './Clusters.helpers';
 
 // There is some overlap between tests for Certificate Expiration and Health Status.
 describe('Delegated Image Scanning', () => {
     withAuth();
+
+    it(`should have a link on the clusters main page`, () => {
+        visitClusters();
+
+        cy.get('a:contains("Manage delegated scanning")').click();
+
+        cy.location('pathname').should('eq', '/main/clusters/delegated-image-scanning');
+    });
 
     it(`should load the page in the cluster hierarchy`, () => {
         visitDelegateScanning();
@@ -85,6 +95,21 @@ describe('Delegated Image Scanning', () => {
 
                 // make sure page does not load
                 cy.get('h1:contains("Delegated Image Scanning")').should('not.exist');
+            });
+        });
+
+        it(`should not have a link on the Clusters page`, () => {
+            cy.fixture('auth/mypermissionsNoAdminAccess.json').then(({ resourceToAccess }) => {
+                const staticResponseForPermissions = {
+                    body: {
+                        resourceToAccess: { ...resourceToAccess },
+                    },
+                };
+
+                visitWithStaticResponseForPermissions(clustersPath, staticResponseForPermissions);
+
+                // make sure link is not present
+                cy.get('a:contains("Manage delegated scanning")').should('not.exist');
             });
         });
     });

--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
@@ -1,14 +1,17 @@
 import React, { useCallback } from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { useQuery } from '@apollo/client';
+import { Button, ButtonVariant } from '@patternfly/react-core';
 
 import PageHeader from 'Components/PageHeader';
+import LinkShim from 'Components/PatternFly/LinkShim';
 import SearchFilterInput from 'Components/SearchFilterInput';
 import entityTypes, { searchCategories } from 'constants/entityTypes';
 import workflowStateContext from 'Containers/workflowStateContext';
 import { SEARCH_OPTIONS_QUERY } from 'queries/search';
 import usePermissions from 'hooks/usePermissions';
 import useURLSearch from 'hooks/useURLSearch';
+import { clustersDelegatedScanningPath } from 'routePaths';
 import parseURL from 'utils/URLParser';
 
 import ClustersTablePanel from './ClustersTablePanel';
@@ -22,7 +25,8 @@ const ClustersPage = ({
         params: { clusterId: selectedClusterId },
     },
 }) => {
-    const { hasReadWriteAccess } = usePermissions();
+    const { hasReadAccess, hasReadWriteAccess } = usePermissions();
+    const hasReadAccessForDelegatedScanning = hasReadAccess('Administration');
     const hasWriteAccessForIntegration = hasReadWriteAccess('Integration');
 
     const { searchFilter, setSearchFilter } = useURLSearch();
@@ -65,9 +69,22 @@ const ClustersPage = ({
                     placeholder="Filter clusters"
                     handleChangeSearchFilter={setSearchFilter}
                 />
+                {hasReadAccessForDelegatedScanning && (
+                    <div className="flex items-center ml-4 mr-1">
+                        <Button
+                            variant={ButtonVariant.secondary}
+                            component={LinkShim}
+                            href={clustersDelegatedScanningPath}
+                        >
+                            Manage delegated scanning
+                        </Button>
+                    </div>
+                )}
                 {hasWriteAccessForIntegration && (
-                    <div className="flex items-center ml-4 mr-3">
-                        <ManageTokensButton />
+                    <div className="flex items-center ml-1">
+                        <Button variant="tertiary">
+                            <ManageTokensButton />
+                        </Button>
                     </div>
                 )}
             </div>

--- a/ui/apps/platform/src/Containers/Clusters/Components/ManageTokensButton.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ManageTokensButton.tsx
@@ -5,7 +5,7 @@ import { HashLink } from 'react-router-hash-link';
 const ManageTokensButton = () => (
     <HashLink
         to={`${integrationsPath}#token-integrations`}
-        className="no-underline btn btn-base flex-shrink-0"
+        className="no-underline flex-shrink-0"
         data-testid="manageTokens"
     >
         Manage Tokens


### PR DESCRIPTION
## Description

Besides adding a link on Clusters page to Delegated Scanning, I also refactored the "buttons" in the header to be more PatternFly-like.

Also did a little bit of refactoring of the test helpers and constants, to make the ui-e2e tests more straightforward.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added

## Testing Performed

* New CI tests
* Manual testing

![Screen Shot 2023-08-20 at 1 25 42 PM](https://github.com/stackrox/stackrox/assets/715729/2ab0b259-735d-4fd4-b9a2-84199dd006ae)
