### PR TITLE
fix(metrics): use DNS k8sutil client

### DIFF
--- a/pkg/metrics/tls.go
+++ b/pkg/metrics/tls.go
@@ -11,13 +11,13 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/k8scfgwatch"
+	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/mtls/certwatch"
 	"github.com/stackrox/rox/pkg/mtls/verifier"
 	"github.com/stackrox/rox/pkg/sync"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 func certFilePath() string {
@@ -91,7 +91,7 @@ func NewTLSConfigurerFromEnv() verifier.TLSConfigurer {
 		return &nilTLSConfigurer{}
 	}
 
-	config, err := rest.InClusterConfig()
+	config, err := k8sutil.GetK8sInClusterConfig()
 	if err != nil {
 		log.Errorw("Failed to get in-cluster config", zap.Error(err))
 		return &nilTLSConfigurer{}


### PR DESCRIPTION
## Description

Use `k8sutils` to construct the client config to make sure we bypass the proxy on cloud-service Centrals.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested on OpenShift cluster.