### PR TITLE
ROX-16856: watch certs for openshift auth provider

### DIFF
--- a/pkg/auth/authproviders/openshift/watcher.go
+++ b/pkg/auth/authproviders/openshift/watcher.go
@@ -58,8 +58,10 @@ func (h *handler) OnStableUpdate(val interface{}, err error) {
 }
 
 func (h *handler) OnWatchError(err error) {
-	log.Errorw("Failed watching CAs. Not updating any CAs for Openshift auth providers",
-		logging.Err(err))
+	if !os.IsNotExist(err) {
+		log.Errorw("Failed watching CAs.",
+			logging.Err(err))
+	}
 }
 
 func internalCAs() ([][]byte, error) {

--- a/pkg/auth/authproviders/openshift/watcher.go
+++ b/pkg/auth/authproviders/openshift/watcher.go
@@ -1,0 +1,104 @@
+package openshift
+
+import (
+	"context"
+	"os"
+	"path"
+	"time"
+
+	"github.com/stackrox/rox/pkg/k8scfgwatch"
+	"github.com/stackrox/rox/pkg/logging"
+	"go.uber.org/zap"
+)
+
+var (
+	log = logging.LoggerForModule()
+
+	_ k8scfgwatch.Handler = (*handler)(nil)
+)
+
+type notifyOnCertPoolUpdate = func()
+
+func watchCertPool(n notifyOnCertPoolUpdate) {
+	opts := k8scfgwatch.Options{
+		Interval: 5 * time.Second,
+		Force:    true,
+	}
+
+	_ = k8scfgwatch.WatchConfigMountDir(context.Background(), path.Dir(serviceOperatorCAPath),
+		k8scfgwatch.DeduplicateWatchErrors(&handler{readCAs: internalCAs, notifyBackend: n}), opts)
+	_ = k8scfgwatch.WatchConfigMountDir(context.Background(), path.Dir(injectedCAPath),
+		k8scfgwatch.DeduplicateWatchErrors(&handler{readCAs: injectedCAs, notifyBackend: n}), opts)
+}
+
+type handler struct {
+	notifyBackend func()
+	readCAs       func() ([][]byte, error)
+}
+
+func (h *handler) OnChange(_ string) (interface{}, error) {
+	return h.readCAs()
+}
+
+func (h *handler) OnStableUpdate(val interface{}, err error) {
+	// Ignore errors and nil values.
+	if err != nil || val == nil {
+		return
+	}
+
+	// Expect always a [][]byte.
+	caBytes := val.([][]byte)
+	if caBytes == nil {
+		log.Info("No updated CA bytes found, using the default system CA cert pool.")
+		return
+	}
+	h.notifyBackend()
+}
+
+func (h *handler) OnWatchError(err error) {
+	log.Errorw("Failed watching CAs. Not updating any CAs for Openshift auth providers",
+		logging.Err(err))
+}
+
+func internalCAs() ([][]byte, error) {
+	var caBytes [][]byte
+	ca, exists, err := readCA(serviceOperatorCAPath)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		caBytes = append(caBytes, ca)
+	}
+	ca, exists, err = readCA(internalServicesCAPath)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		caBytes = append(caBytes, ca)
+	}
+	return caBytes, nil
+}
+
+func injectedCAs() ([][]byte, error) {
+	caBytes, exists, err := readCA(injectedCAPath)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return [][]byte{caBytes}, nil
+	}
+	return nil, nil
+}
+
+func readCA(file string) ([]byte, bool, error) {
+	caBytes, err := os.ReadFile(file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		log.Errorw("Reading CA file", logging.Err(err), zap.String("file", file))
+		return nil, false, err
+	}
+
+	return caBytes, true, nil
+}

--- a/pkg/auth/authproviders/openshift/watcher.go
+++ b/pkg/auth/authproviders/openshift/watcher.go
@@ -52,6 +52,8 @@ func (h *handler) OnStableUpdate(val interface{}, err error) {
 		log.Info("No updated CA bytes found, using the default system CA cert pool.")
 		return
 	}
+
+	log.Info("Found an update to the root CAs for Openshift auth providers. Updating the providers.")
 	h.notifyBackend()
 }
 


### PR DESCRIPTION
## Description

This PR introduces the capability to watch the certificates injected within the openshift connector for the openshift auth provider.

We had reportst that after some certificates have been rotated, the central pod would have to be restarted. Additionally, the injected CA bundle, which _can_ be updated during runtime, also does not get propagated to existing instances of OpenShift auth without a restart.

Hence, added the capability to reload the certpool injected into the openshift connector.

Caveats:
- Decided _not_ to adjust the openshift connector interface to introduce a separate method allowing to reload the cert pool but instead opted into re-creating the openshift connector instead.
- Currently for each connector a two k8scfgwatch handlers will be started. They will then propagate to each backend in case changes are found. The expectation is that currently openshift auth will be a single instance, but if required we can change the logic to only start watch handlers once and then register 
the notify functions there instead.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see unit tests

Manually tested the changes by:
```
1. Create an Openshift cluster.

2. optional: Configure Openshift auth for the cluster (configure a cluster IdP, in this example [the HTPasswd IdP was used](https://docs.openshift.com/container-platform/4.13/authentication/identity_providers/configuring-htpasswd-identity-provider.html)).

3. Create the auth provider within Central. Ensure that login works successfully and no error logs are printed.

4. Update the injected CA bundle (this depends on the installation method). Add a dummy certificate to it.

5. Verify that update works by observing the logs.

6. Verify that login still works.

7. Removing the CA triggers the change again.
```
