### PR TITLE
feat(notifications): notification interface

### DIFF
--- a/pkg/env/notifications.go
+++ b/pkg/env/notifications.go
@@ -1,0 +1,4 @@
+package env
+
+// NotificationsStreamBufferSize is the buffer size of the notifications stream.
+var NotificationsStreamBufferSize = RegisterIntegerSetting("ROX_NOTIFICATIONS_STREAM_BUFFER_SIZE", 100)

--- a/pkg/notifications/singleton.go
+++ b/pkg/notifications/singleton.go
@@ -1,0 +1,23 @@
+package notifications
+
+import (
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	once sync.Once
+
+	stream Stream
+)
+
+// Singleton returns an instance of the notification stream.
+func Singleton() Stream {
+	if !features.CentralEvents.Enabled() {
+		return nil
+	}
+	once.Do(func() {
+		stream = newStream()
+	})
+	return stream
+}

--- a/pkg/notifications/stream.go
+++ b/pkg/notifications/stream.go
@@ -1,0 +1,40 @@
+package notifications
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/stackrox/rox/generated/storage"
+)
+
+const bufferSize = 100
+
+// Stream is an interface for the notifications stream.
+type Stream interface {
+	Consume() <-chan *storage.Notification
+	Produce(event *storage.Notification) error
+}
+
+func newStream() Stream {
+	return &streamImpl{notificationChan: make(chan *storage.Notification, bufferSize)}
+}
+
+type streamImpl struct {
+	notificationChan chan *storage.Notification
+}
+
+// Consume returns the channel to retrieve notifications.
+func (s *streamImpl) Consume() <-chan *storage.Notification {
+	return s.notificationChan
+}
+
+// Produce adds a notification to the stream.
+//
+// Should be retried if an error is returned.
+func (s *streamImpl) Produce(notification *storage.Notification) error {
+	select {
+	case s.notificationChan <- notification:
+		return nil
+	default:
+		return errors.New("failed to add notification to the stream")
+	}
+}


### PR DESCRIPTION
## Description

Create an interface to write and consume notifications. The corresponding service and datastore will be created in follow up PRs.

The first use case of the notification stream is adding notifications from log packages in chosen modules.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

-