### PR TITLE
fix(k8sutils): use FQDN for managed Central

### DIFF
--- a/pkg/k8sutil/client_config.go
+++ b/pkg/k8sutil/client_config.go
@@ -20,7 +20,7 @@ func GetK8sInClusterConfig() (*rest.Config, error) {
 	// allows for easier proxy configuration.
 	if env.ManagedCentral.BooleanSetting() {
 		port := os.Getenv("KUBERNETES_SERVICE_PORT")
-		restCfg.Host = "https://" + net.JoinHostPort("kubernetes.default.svc", port)
+		restCfg.Host = "https://" + net.JoinHostPort("kubernetes.default.svc.cluster.local.", port)
 	}
 	return restCfg, nil
 }


### PR DESCRIPTION
## Description

Use FQDN to prevent unnecessary DNS lookups. See https://github.com/stackrox/acs-fleet-manager/pull/1208 for the corresponding `NO_PROXY` env var definition.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested on OpenShift cluster.