### PR TITLE
fix(sensor): set hosting at later point

### DIFF
--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -151,7 +151,6 @@ var (
 	telemetryLabels = prometheus.Labels{
 		"branding":       branding.GetProductNameShort(),
 		"build":          metrics.GetBuildType(),
-		"hosting":        getHosting(),
 		"sensor_version": version.GetMainVersion(),
 	}
 
@@ -163,7 +162,7 @@ var (
 			Help:        "The number of nodes secured by Sensor",
 			ConstLabels: telemetryLabels,
 		},
-		[]string{"central_id", "install_method", "sensor_id"},
+		[]string{"central_id", "hosting", "install_method", "sensor_id"},
 	)
 
 	telemetrySecuredVCPU = prometheus.NewGaugeVec(
@@ -174,7 +173,7 @@ var (
 			Help:        "The number of vCPUs secured by Sensor",
 			ConstLabels: telemetryLabels,
 		},
-		[]string{"central_id", "install_method", "sensor_id"},
+		[]string{"central_id", "hosting", "install_method", "sensor_id"},
 	)
 )
 
@@ -281,12 +280,14 @@ func SetTelemetryMetrics(cm *central.ClusterMetrics) {
 	telemetrySecuredNodes.Reset()
 	telemetrySecuredNodes.WithLabelValues(
 		centralid.Get(),
+		getHosting(),
 		installmethod.Get(),
 		clusterid.GetNoWait(),
 	).Set(float64(cm.GetNodeCount()))
 	telemetrySecuredVCPU.Reset()
 	telemetrySecuredVCPU.WithLabelValues(
 		centralid.Get(),
+		getHosting(),
 		installmethod.Get(),
 		clusterid.GetNoWait(),
 	).Set(float64(cm.GetCpuCapacity()))


### PR DESCRIPTION
## Description

The hosting information for Sensor needs to be set up runtime based on information passed by Central. Therefore when first running the metrics registration this information may not yet be available. For this reason, set the hosting label later during runtime when other dynamic labels are set.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Tested on OpenShift cluster.