### PR TITLE
chore: Remove few obsolete env vars from deployment scripts

### DIFF
--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -6,9 +6,6 @@ echo "DEFAULT_IMAGE_REGISTRY set to $DEFAULT_IMAGE_REGISTRY"
 export MAIN_IMAGE_REPO="${MAIN_IMAGE_REPO:-$DEFAULT_IMAGE_REGISTRY/main}"
 echo "MAIN_IMAGE_REPO set to $MAIN_IMAGE_REPO"
 
-export COLLECTOR_IMAGE_REPO="${COLLECTOR_IMAGE_REPO:-$DEFAULT_IMAGE_REGISTRY/collector}"
-echo "COLLECTOR_IMAGE_REPO set to $COLLECTOR_IMAGE_REPO"
-
 export MAIN_IMAGE_TAG="${MAIN_IMAGE_TAG:-$(make --quiet --no-print-directory -C "$(git rev-parse --show-toplevel)" tag)}"
 echo "StackRox image tag set to $MAIN_IMAGE_TAG"
 

--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export DEFAULT_IMAGE_REGISTRY="${DEFAULT_IMAGE_REGISTRY:-quay.io/stackrox-io}"
+export DEFAULT_IMAGE_REGISTRY="${DEFAULT_IMAGE_REGISTRY:-"$(make --quiet --no-print-directory -C "$(git rev-parse --show-toplevel)" default-image-registry)"}"
 echo "DEFAULT_IMAGE_REGISTRY set to $DEFAULT_IMAGE_REGISTRY"
 
 export MAIN_IMAGE_REPO="${MAIN_IMAGE_REPO:-$DEFAULT_IMAGE_REGISTRY/main}"

--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -39,17 +39,6 @@ echo "Image flavor for roxctl set to $ROXCTL_ROX_IMAGE_FLAVOR"
 export ROX_RESYNC_DISABLED="${ROX_RESYNC_DISABLED:-true}"
 echo "Re-sync disabled for secured cluster set to $ROX_RESYNC_DISABLED"
 
-export SCANNER_IMAGE="${SCANNER_IMAGE:-}"
-if [[ -z "${SCANNER_IMAGE}" ]]; then
-  SCANNER_IMAGE="$DEFAULT_IMAGE_REGISTRY/scanner:$(cat "$(git rev-parse --show-toplevel)/SCANNER_VERSION")"
-fi
-export SCANNER_DB_IMAGE="${SCANNER_DB_IMAGE:-}"
-if [[ -z "${SCANNER_DB_IMAGE}" ]]; then
-  SCANNER_DB_IMAGE="$DEFAULT_IMAGE_REGISTRY/scanner-db:$(cat "$(git rev-parse --show-toplevel)/SCANNER_VERSION")"
-  export SCANNER_DB_IMAGE
-fi
-echo "StackRox scanner image set to $SCANNER_IMAGE"
-
 function curl_central() {
 	cmd=(curl -k)
 	local admin_user="${ROX_ADMIN_USER:-admin}"

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -528,12 +528,6 @@ function launch_sensor {
     	extra_helm_config+=(--set "admissionControl.listenOnEvents=${bool_val}")
     fi
 
-    if [[ -n "$COLLECTOR_IMAGE_REPO" && ${DISABLE_RHACS_IMAGE_REPOSITORY_PARAMS:-false} != "true" ]]; then
-        extra_config+=("--collector-image-repository=${COLLECTOR_IMAGE_REPO}")
-        extra_json_config+=", \"collectorImage\": \"${COLLECTOR_IMAGE_REPO}\""
-        extra_helm_config+=(--set "image.collector.repository=${COLLECTOR_IMAGE_REPO}")
-    fi
-
     if [[ -n "$ROXCTL_TIMEOUT" ]]; then
       echo "Extending roxctl timeout to $ROXCTL_TIMEOUT"
       extra_config+=("--timeout=$ROXCTL_TIMEOUT")

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -240,16 +240,12 @@ function launch_central {
     rm -rf "${unzip_dir}"
     if ! (( use_docker )); then
         rm -rf central-bundle "${k8s_dir}/central-bundle"
-        set -x
         roxctl central generate "${ORCH}" "${EXTRA_ARGS[@]}" --output-dir="central-bundle" "${STORAGE}" "${STORAGE_ARGS[@]}"
-        set +x
         cp -R central-bundle/ "${unzip_dir}/"
         rm -rf central-bundle
     else
-        set -x
         docker run --rm "${EXTRA_DOCKER_ARGS[@]}" --env-file <(env | grep '^ROX_') "$ROXCTL_IMAGE" \
           central generate "${ORCH}" "${EXTRA_ARGS[@]}" "${STORAGE}" "${STORAGE_ARGS[@]}" > "${k8s_dir}/central.zip"
-        set +x
         unzip "${k8s_dir}/central.zip" -d "${unzip_dir}"
     fi
 
@@ -282,9 +278,7 @@ function launch_central {
 
         helm dependency update "${COMMON_DIR}/../charts/monitoring"
         envsubst < "${COMMON_DIR}/../charts/monitoring/values.yaml" > "${COMMON_DIR}/../charts/monitoring/values_substituted.yaml"
-        set -x
         helm upgrade -n stackrox --install --create-namespace stackrox-monitoring "${COMMON_DIR}/../charts/monitoring" --values "${COMMON_DIR}/../charts/monitoring/values_substituted.yaml" "${helm_args[@]}"
-        set +x
         rm "${COMMON_DIR}/../charts/monitoring/values_substituted.yaml"
         echo "Deployed Monitoring..."
     fi
@@ -374,10 +368,8 @@ function launch_central {
         helm lint "${helm_chart}" -n stackrox "${helm_args[@]}"
       fi
 
-      set -x
       helm upgrade --install -n stackrox stackrox-central-services "$helm_chart" \
           "${helm_args[@]}"
-      set +x
     else
       if [[ -n "${REGISTRY_USERNAME}" ]]; then
         $unzip_dir/central/scripts/setup.sh
@@ -631,24 +623,18 @@ function launch_sensor {
         kubectl -n "$sensor_namespace" get secret stackrox &>/dev/null || kubectl -n "$sensor_namespace" create -f - < <("${common_dir}/pull-secret.sh" stackrox docker.io)
       fi
 
-      set -x
       helm upgrade --install -n "$sensor_namespace" --create-namespace stackrox-secured-cluster-services "$helm_chart" \
           "${helm_args[@]}" "${extra_helm_config[@]}"
-      set +x
     else
       if [[ -x "$(command -v roxctl)" && "$(roxctl version)" == "$MAIN_IMAGE_TAG" ]]; then
         [[ -n "${ROX_ADMIN_PASSWORD}" ]] || { echo >&2 "ROX_ADMIN_PASSWORD not found! Cannot launch sensor."; return 1; }
-        set -x
         roxctl -p ${ROX_ADMIN_PASSWORD} --endpoint "${API_ENDPOINT}" sensor generate --main-image-repository="${MAIN_IMAGE_REPO}" --central="$CLUSTER_API_ENDPOINT" --name="$CLUSTER" \
              --collection-method="$COLLECTION_METHOD" \
              "${ORCH}" \
              "${extra_config[@]+"${extra_config[@]}"}"
-        set +x
         mv "sensor-${CLUSTER}" "$k8s_dir/sensor-deploy"
       else
-        set -x
         get_cluster_zip "$API_ENDPOINT" "$CLUSTER" ${CLUSTER_TYPE} "${MAIN_IMAGE_REPO}" "$CLUSTER_API_ENDPOINT" "$k8s_dir" "$COLLECTION_METHOD" "$extra_json_config"
-        set +x
         unzip "$k8s_dir/sensor-deploy.zip" -d "$k8s_dir/sensor-deploy"
         rm "$k8s_dir/sensor-deploy.zip"
       fi

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -165,14 +165,6 @@ function launch_central {
 
     add_args "--offline=$OFFLINE_MODE"
 
-    if [[ -n "$SCANNER_IMAGE" ]]; then
-        add_args "--scanner-image=$SCANNER_IMAGE"
-    fi
-
-    if [[ -n "$SCANNER_DB_IMAGE" ]]; then
-        add_args "--scanner-db-image=${SCANNER_DB_IMAGE}"
-    fi
-
     if [[ -n "$ROX_DEFAULT_TLS_CERT_FILE" ]]; then
     	add_args "--default-tls-cert"
     	add_file_arg "$ROX_DEFAULT_TLS_CERT_FILE"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -119,10 +119,7 @@ setup_deployment_env() {
         ci_export MAIN_IMAGE_TAG "$(make --quiet --no-print-directory tag)"
     fi
 
-    REPO=rhacs-eng
-    ci_export MAIN_IMAGE_REPO "quay.io/$REPO/main"
-    ci_export CENTRAL_DB_IMAGE_REPO "quay.io/$REPO/central-db"
-    ci_export COLLECTOR_IMAGE_REPO "quay.io/$REPO/collector"
+    ci_export ROX_PRODUCT_BRANDING "RHACS_BRANDING"
 }
 
 get_central_debug_dump() {

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -49,7 +49,6 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
     fi
     ci_export DEPLOY_STACKROX_VIA_OPERATOR "false"
     ci_export OUTPUT_FORMAT "helm"
-    ci_export DISABLE_RHACS_IMAGE_REPOSITORY_PARAMS "true"
 
     # Repo name can't be too long or `helm search repo [REPO_NAME] -l` cuts off part of the name and the regex below fails.
     helm_repo_name="tmp-srox-compat"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -93,14 +93,6 @@ test_preamble() {
 
     export ROX_PLAINTEXT_ENDPOINTS="8080,grpc@8081"
     export ROXDEPLOY_CONFIG_FILE_MAP="$ROOT/scripts/ci/endpoints/endpoints.yaml"
-
-    local registry="quay.io/rhacs-eng"
-
-    SCANNER_IMAGE="$registry/scanner:$(cat "$ROOT"/SCANNER_VERSION)"
-    export SCANNER_IMAGE
-    SCANNER_DB_IMAGE="$registry/scanner-db:$(cat "$ROOT"/SCANNER_VERSION)"
-    export SCANNER_DB_IMAGE
-
     export TRUSTED_CA_FILE="$ROOT/tests/bad-ca/untrusted-root-badssl-com.pem"
 }
 

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -193,8 +193,6 @@ test_upgrader() {
 
     rm -rf sensor-remote-new
     "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/roxctl" -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor generate k8s \
-        --main-image-repository "${MAIN_IMAGE_REPO:-$REGISTRY/main}" \
-        --collector-image-repository "${COLLECTOR_IMAGE_REPO:-$REGISTRY/collector}" \
         --name remote-new \
         --create-admission-controller
 


### PR DESCRIPTION
## Description

Triggered by
* https://github.com/stackrox/stackrox/pull/5795#discussion_r1294379793
* https://github.com/stackrox/stackrox/pull/5795#discussion_r1294383119

This change removes `COLLECTOR_IMAGE_REPO`, `SCANNER_IMAGE`, `SCANNER_DB_IMAGE` env vars from dev-deployment scripts and e2e tests. These vars are redundant at this point as everything about images to be deployed must be derived from the image flavor.

Unfortunately, race condition images bypass image flavor and so I could not easily eliminate other parts of the setup like `MAIN_IMAGE` env var. This remains for the future.

This change also makes `deploy/k8s|openshift/deploy*.sh` receptive to `ROX_PRODUCT_BRANDING` environment variable so one can deploy `quay.io/rhacs-eng` images with the following command: `ROX_PRODUCT_BRANDING=RHACS_BRANDING deploy/openshift/deploy.sh`.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ - this is a change to development scripts that are also used in tests. Not adding automated tests as this feels complicated.

Won't do these as this change doesn't impact commercial users:
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

1. Ran extra `/test` commands for areas which I think might be affected.
2. Did [image-diff](#issuecomment-1697309327) as suggested by Jan.
3. Used `set -x` around roxctl/helm commands to visually check sanity of arguments. (This isn't the ultimate proof but was useful in development.)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
