### PR TITLE
ROX-15146: Disable certgen API for managed Central

### DIFF
--- a/central/certgen/service.go
+++ b/central/certgen/service.go
@@ -37,13 +37,13 @@ func (s *serviceImpl) CustomRoutes() []routes.CustomRoute {
 		{
 			Route:         "/api/extensions/certgen/central",
 			Authorizer:    user.With(permissions.Modify(resources.Administration)),
-			ServerHandler: http.HandlerFunc(s.centralHandler),
+			ServerHandler: routes.NotImplementedOnManagedServices(http.HandlerFunc(s.centralHandler)),
 			Compression:   false,
 		},
 		{
 			Route:         "/api/extensions/certgen/scanner",
 			Authorizer:    user.With(permissions.Modify(resources.Administration)),
-			ServerHandler: http.HandlerFunc(s.scannerHandler),
+			ServerHandler: routes.NotImplementedOnManagedServices(http.HandlerFunc(s.scannerHandler)),
 			Compression:   false,
 		},
 


### PR DESCRIPTION
## Description

Restrict certgen API for managed centrals. A small refactoring has been made in order to reuse the existing helper methods.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Testing performed manually on a local cluster with helm installation method.

### Here I tell how I validated my change
1. Generate chart
  ```
  docker run -it --rm -v "$(pwd):/usr/src/stackrox" quay.io/stackrox-io/roxctl:4.1.x-842-g944704de24 helm output central-services --image-defaults opensource --output-dir /usr/src/stackrox/stackrox-central-services-chart --remove
  ```
2. Install central
  ```
  helm upgrade -i --namespace=stackrox stackrox-central-services ./stackrox-central-services-chart --values ./tmp/helm/values/values-central-dev.yaml --set env.managedServices=true --create-namespace
  ```
3. Open UI
4. Ensure that certificate download fails

