### PR TITLE
fix(ci): allow roxctl image check to be disabled (4.1)

### DIFF
--- a/release/scripts/scan-images-with-roxctl.sh
+++ b/release/scripts/scan-images-with-roxctl.sh
@@ -7,6 +7,15 @@ source "$ROOT/scripts/ci/lib.sh"
 set -euo pipefail
 
 scan_images_with_roxctl() {
+    if [[ "${STACKROX_CI_INSTANCE_CENTRAL_HOST}" == "disabled" ]]; then
+        if is_GITHUB_ACTIONS; then
+            echo "::warning ::Image scan with roxctl is disabled"
+        else
+            info "Image scan with roxctl is disabled"
+        fi
+        return 0
+    fi
+
     info "Will scan anticipated release images with roxctl"
 
     local images=()


### PR DESCRIPTION
## Description

Backport from main branch.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.