### PR TITLE
fix(race): Fix race conditions by cloning the sort option

### DIFF
--- a/pkg/search/paginated/paginated.go
+++ b/pkg/search/paginated/paginated.go
@@ -13,7 +13,7 @@ func WithDefaultSortOption(searcher search.Searcher, defaultSortOption *v1.Query
 	return search.FuncSearcher{
 		SearchFunc: func(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 			// Add pagination sort order if needed.
-			local := FillDefaultSortOption(q, defaultSortOption)
+			local := FillDefaultSortOption(q, defaultSortOption.Clone())
 			return searcher.Search(ctx, local)
 		},
 		CountFunc: func(ctx context.Context, q *v1.Query) (int, error) {


### PR DESCRIPTION
## Description

https://issues.redhat.com/browse/ROX-19082 and https://issues.redhat.com/browse/ROX-18863 are examples of this. Basically we mark the sort option field as to lower but the default sort option is only declared once

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Race condition change

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
