### PR TITLE
ROX-17867: Prepared downloadable vuln report days

### DIFF
--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
@@ -13,18 +13,20 @@ type DataRetentionValueProps = {
     value: number | undefined;
     suffix: string;
     shouldPluralize?: boolean;
+    canRetainForever?: boolean;
 };
 
 function DataRetentionValue({
     value,
     suffix,
+    canRetainForever = true,
     shouldPluralize = true,
 }: DataRetentionValueProps): ReactElement {
     let content = 'Unknown';
 
     if (typeof value === 'number') {
         if (value === 0) {
-            content = 'Never deleted';
+            content = canRetainForever ? 'Never deleted' : 'Deleted in every pruning cycle';
         } else if (value > 0) {
             content = `${value} ${shouldPluralize ? pluralize(suffix, value) : suffix}`;
         }
@@ -132,13 +134,31 @@ const PrivateConfigDataRetentionDetails = ({
                                 privateConfig?.reportRetentionConfig?.historyRetentionDurationDays
                             }
                             suffix="day"
+                            canRetainForever={false}
                         />
                     </CardBody>
                 </Card>
             </GridItem>
             <GridItem>
                 <Card isFlat>
-                    <CardTitle>Vulnerability report run history retention</CardTitle>
+                    <CardTitle>
+                        Prepared downloadable vulnerability reports retention days
+                    </CardTitle>
+                    <CardBody>
+                        <DataRetentionValue
+                            value={
+                                privateConfig?.reportRetentionConfig
+                                    ?.downloadableReportRetentionDays
+                            }
+                            suffix="day"
+                            canRetainForever={false}
+                        />
+                    </CardBody>
+                </Card>
+            </GridItem>
+            <GridItem>
+                <Card isFlat>
+                    <CardTitle>Prepared downloadable vulnerability reports limit</CardTitle>
                     <CardBody>
                         Set a total limit for all prepared downloadable vulnerability reports. Once
                         the limit is reached, the oldest report in download queue will be removed.

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
@@ -335,6 +335,26 @@ const SystemConfigForm = ({
                 </GridItem>
                 <GridItem>
                     <FormGroup
+                        label="Prepared downloadable vulnerability reports retention days"
+                        isRequired
+                        fieldId="privateConfig.reportRetentionConfig.downloadableReportRetentionDays"
+                    >
+                        <TextInput
+                            isRequired
+                            type="number"
+                            id="privateConfig.reportRetentionConfig.downloadableReportRetentionDays"
+                            name="privateConfig.reportRetentionConfig.downloadableReportRetentionDays"
+                            value={
+                                values?.privateConfig?.reportRetentionConfig
+                                    ?.downloadableReportRetentionDays
+                            }
+                            onChange={onChange}
+                            min={0}
+                        />
+                    </FormGroup>
+                </GridItem>
+                <GridItem>
+                    <FormGroup
                         label="Prepared downloadable vulnerability reports limit"
                         isRequired
                         fieldId="privateConfig.reportRetentionConfig.downloadableReportGlobalRetentionBytes"

--- a/ui/apps/platform/src/types/config.proto.ts
+++ b/ui/apps/platform/src/types/config.proto.ts
@@ -43,8 +43,9 @@ export type DecommissionedClusterRetentionConfig = {
 };
 
 export type ReportRetentionConfig = {
-    historyRetentionDurationDays: number; // int32
-    downloadableReportGlobalRetentionBytes: number; // int64
+    historyRetentionDurationDays: number; // uint32
+    downloadableReportGlobalRetentionBytes: number; // uint32
+    downloadableReportRetentionDays: number; // uint32
 };
 
 export type PrivateConfig = {


### PR DESCRIPTION
## Description

Add `downloadableReportRetentionDays` to system config

Additionally, for `downloadableReportRetentionDays` and `historyRetentionDurationDays` a 0 value would mean delete whenever the next garbage collection runs. Since reports can consume lot of storage, we do not want to provide option to never delete.  

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
![Screenshot 2023-08-21 at 4 42 50 PM](https://github.com/stackrox/stackrox/assets/61400697/cb283377-7539-403b-a0a6-7c52ada8705a)



![Screenshot 2023-08-21 at 4 43 01 PM](https://github.com/stackrox/stackrox/assets/61400697/d7002988-645e-4327-9759-32e4ea5f8f36)

