### PR TITLE
chore(ci): Add collection of init container logs in CI

### DIFF
--- a/scripts/ci/collect-service-logs.sh
+++ b/scripts/ci/collect-service-logs.sh
@@ -21,6 +21,19 @@ usage() {
     echo "e.g. ./scripts/ci/collect-service-logs.sh stackrox"
 }
 
+dump_logs() {
+    for ctr in $(kubectl -n "${namespace}" get "${object}" "${item}" -o jsonpath="{${jpath}[*].name}"); do
+        kubectl -n "${namespace}" logs "${object}/${item}" -c "${ctr}" > "${log_dir}/${object}/${item}-${ctr}.log"
+        prev_log_file="${log_dir}/${object}/${item}-${ctr}-previous.log"
+        if kubectl -n "${namespace}" logs "${object}/${item}" -p -c "${ctr}" > "${prev_log_file}"; then
+            exit_code="$(kubectl -n "${namespace}" get "${object}/${item}" -o jsonpath="{${jpath}}" | jq --arg ctr "$ctr" '.[] | select(.name == $ctr) | .lastState.terminated.exitCode')"
+            if [ "$exit_code" -eq "0" ]; then
+            mv "${prev_log_file}" "${log_dir}/${object}/${item}-${ctr}-prev-success.log"
+            fi
+        fi
+    done
+}
+
 main() {
     namespace="$1"
     if [ -z "${namespace}" ]; then
@@ -68,16 +81,12 @@ main() {
               echo '# Full YAML definition'
               kubectl get "${object}" "${item}" -n "${namespace}" -o yaml 2>&1
             } > "${log_dir}/${object}/${item}_describe.log"
-            for ctr in $(kubectl -n "${namespace}" get "${object}" "${item}" -o jsonpath='{.status.containerStatuses[*].name}'); do
-                kubectl -n "${namespace}" logs "${object}/${item}" -c "${ctr}" > "${log_dir}/${object}/${item}-${ctr}.log"
-                prev_log_file="${log_dir}/${object}/${item}-${ctr}-previous.log"
-                if kubectl -n "${namespace}" logs "${object}/${item}" -p -c "${ctr}" > "${prev_log_file}"; then
-                  exit_code="$(kubectl -n "${namespace}" get "${object}/${item}" -o jsonpath='{.status.containerStatuses}' | jq --arg ctr "$ctr" '.[] | select(.name == $ctr) | .lastState.terminated.exitCode')"
-                  if [ "$exit_code" -eq "0" ]; then
-                    mv "${prev_log_file}" "${log_dir}/${object}/${item}-${ctr}-prev-success.log"
-                  fi
-                fi
-            done
+
+            jpath='.status.containerStatuses'
+            dump_logs
+
+            jpath='.status.initContainerStatuses'
+            dump_logs
         done
     done
 

--- a/scripts/ci/collect-service-logs.sh
+++ b/scripts/ci/collect-service-logs.sh
@@ -28,7 +28,7 @@ dump_logs() {
         if kubectl -n "${namespace}" logs "${object}/${item}" -p -c "${ctr}" > "${prev_log_file}"; then
             exit_code="$(kubectl -n "${namespace}" get "${object}/${item}" -o jsonpath="{${jpath}}" | jq --arg ctr "$ctr" '.[] | select(.name == $ctr) | .lastState.terminated.exitCode')"
             if [ "$exit_code" -eq "0" ]; then
-            mv "${prev_log_file}" "${log_dir}/${object}/${item}-${ctr}-prev-success.log"
+                mv "${prev_log_file}" "${log_dir}/${object}/${item}-${ctr}-prev-success.log"
             fi
         fi
     done


### PR DESCRIPTION
## Description

Adds init container logs to the CI log dumps.

Intent is to aid in troubleshooting init-container issues (i.e. this one ROX-19213)

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
Installed ACS v4.1.2 on an OCP 4.13 infra cluster, and did the following:

```sh
# collect logs before the change was made
$ ./scripts/ci/collect-service-logs.sh stackrox ./dignore-before

# collect logs after the change was made
$ ./scripts/ci/collect-service-logs.sh stackrox ./dignore-after

# create a list of files from before the change
$ path=dignore-before
$ find $path -type f | sed "s/$path//g" > files-$path

# create a list of files from after the change
$ path=dignore-after
$ find $path -type f | sed "s/$path//g" > files-$path

# compare the file lists, notice the only difference is two new files for init containers
$ diff files-dignore-before files-dignore-after
109a110
> /stackrox/pods/central-db-5cfd969ff-xxmjb-init-db.log
135a137
> /stackrox/pods/scanner-db-6c7494ff46-ldf7f-init-db.log

# confirm the file lists contain more than just those two files
$ cat files-dignore-before | wc -l
     203

$ cat files-dignore-after | wc -l
     205
```
Also did spot check on a few non-init log files (that don't change often) to ensure they are still populated:

```
$ cat dignore-before/stackrox/pods/central-db-5cfd969ff-xxmjb-central-db.log | wc -l
      21

$ diff dignore-before/stackrox/pods/central-db-5cfd969ff-xxmjb-central-db.log dignore-after/stackrox/pods/central-db-5cfd969ff-xxmjb-central-db.log

$ echo $?
0

$ cat dignore-before/stackrox/pods/scanner-db-6c7494ff46-ldf7f-db.log  | wc -l
      10

$ diff dignore-before/stackrox/pods/scanner-db-6c7494ff46-ldf7f-db.log dignore-after/stackrox/pods/scanner-db-6c7494ff46-ldf7f-db.log

$ echo $?
0
```
Via [this CI job](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/7532/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1693758949620191232), can see init container logs being captured:

![image](https://github.com/stackrox/stackrox/assets/119438707/ce8076d5-8d0a-44da-9d9a-32ca7c3dd439)

