### PR TITLE
chore: Ask before deploying on top of an existing central

### DIFF
--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -108,6 +108,34 @@ function wait_for_central {
     echo
 }
 
+# Checks if central already exists in this cluster.
+# If yes, the user is asked if they want to continue. If they answer no, then the script is terminated.
+function check_central_exists() {
+    central_pod="$("${ORCH_CMD}" -n stackrox get pods -l app=central -ojsonpath='{.items[0].metadata.name}')"
+    if [[ -n "$central_pod" ]]; then
+        yes_no_prompt "Detected there is already a central running on this cluster. Are you sure you want to proceed with this deploy?" || { echo >&2 "Exiting as requested"; exit 1; }
+    fi
+}
+
+# yes_no_prompt "<message>" displays the given message and prompts the user to
+# input 'yes' or 'no'. The return value is 0 if the user has entered 'yes', 1
+# if they answered 'no', and 2 if the read was aborted (^C/^D) or no valid
+# answer was given after three tries.
+function yes_no_prompt() {
+  local prompt="$1"
+  local tries=0
+  [[ -z "$prompt" ]] || echo >&2 "$prompt"
+  local answer=""
+  while (( tries < 3 )) && { echo -n "Type 'yes' or 'no': "; read answer; } ; do
+    answer="$(echo "$answer" | tr '[:upper:]' '[:lower:]')"
+    [[ "$answer" == "yes" ]] && return 0
+    [[ "$answer" == "no" ]] && return 1
+    tries=$((tries + 1))
+  done
+  echo "Aborted."
+  return 2
+}
+
 # get_cluster_zip
 # arguments:
 #   - central API server endpoint reachable from this host

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -91,6 +91,7 @@ function launch_central {
     local common_dir="${k8s_dir}/../common"
 
     verify_orch
+    check_central_exists
 
     echo "Generating central config..."
 


### PR DESCRIPTION
## Description

I keep getting burnt by deploying on top of staging..

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
