### PR TITLE
fix(auth): make api docs require authn only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-18477: Fixed an issue that breaks operator installations if a `Central` or `SecuredCluster` CR configures egress proxy environment variables while openshift cluster-wide proxy is enabled.
 - ROX-15969: The column `Component Upgrade` in vulnerability reports has been renamed to `CVE Fixed In`.
 - The removal of `/v1/report` APIs in this release, that was communicated in release 4.0.0, has been postponed by one release. Consequently, the `/v1/report` APIs will continue to be available in this release.
+- The `/api/docs/swagger` API previously required read on the resource `Integration`.
+  Now it only requires users to be authenticated to via the API docs.
 
 ## [4.1.0]
 

--- a/central/main.go
+++ b/central/main.go
@@ -648,7 +648,7 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 		},
 		{
 			Route:         "/api/docs/swagger",
-			Authorizer:    user.With(permissions.View(resources.Integration)),
+			Authorizer:    user.Authenticated(),
 			ServerHandler: docs.Swagger(),
 			Compression:   true,
 		},


### PR DESCRIPTION
## Description

This PR changes the permission required to view the API docs, i.e. the `api/docs/swagger` path.

Previously this required `READ Integration`, before the resource migration and simplification this was `READ APIToken`. This dates back to a long time, when the feature was first introduced.

Now, this can pose as a challenge for users interested in APIs (e.g. the report config or CVE / Image related ones) where they do not necessarily have `READ Integration`).

Thus, this PR lowers the access barrier for the API docs, and only requires users to be authenticated.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- N/A, `user.Authenticated()` has been covered previously.
