### PR TITLE
ROX-19109: Use v1.26 to get a more stable GKE clusters

### DIFF
--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -86,6 +86,10 @@ choose_cluster_version() {
         gcloud container get-server-config --format json | jq .validMasterVersions
         unset GKE_CLUSTER_VERSION
     fi
+    # ROX-19109: Use v1.26 to get a more stable GKE clusters
+    if [[ -z "${GKE_CLUSTER_VERSION:-}" ]]; then
+        GKE_CLUSTER_VERSION="1.26"
+    fi
 }
 
 create_cluster() {


### PR DESCRIPTION
## Description

Since the GKE update to k8s 1.27 CI has started to flake due to cluster API unavailability. Google support has not provided a workaround: "Cluster operations such as resizing cannot be excluded from the maintenance exclusions".

## Checklist
- [x] Investigated and inspected CI test results. Failures are known flakes.

## Testing Performed

All GKE flavors. 16x runs without cluster issues.
