### PR TITLE
fix(ui): VM Reporting 2.0 last few fixes

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/CheckboxSelect.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/CheckboxSelect.tsx
@@ -17,6 +17,7 @@ export type CheckboxSelectProps = {
     placeholderText?: string;
     toggleIcon?: ReactElement;
     toggleId?: string;
+    menuAppendTo?: () => HTMLElement;
 };
 
 function CheckboxSelect({
@@ -30,6 +31,7 @@ function CheckboxSelect({
     placeholderText = 'Filter by value',
     toggleIcon,
     toggleId,
+    menuAppendTo,
 }: CheckboxSelectProps): ReactElement {
     const [isOpen, setIsOpen] = useState(false);
 
@@ -65,6 +67,7 @@ function CheckboxSelect({
             placeholderText={placeholderText}
             aria-label={ariaLabel}
             toggleId={toggleId}
+            menuAppendTo={menuAppendTo}
         >
             {children}
         </Select>

--- a/ui/apps/platform/src/Components/PatternFly/DayPickerDropdown.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/DayPickerDropdown.tsx
@@ -99,6 +99,7 @@ function DayPickerDropdown({
             isOpen={isDaySelectOpen}
             isDisabled={!isEditable}
             placeholderText={value.length ? 'Selected days' : 'Select days'}
+            menuAppendTo={() => document.body}
         >
             {selectOptions}
         </Select>

--- a/ui/apps/platform/src/Components/PatternFly/RepeatScheduleDropdown.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/RepeatScheduleDropdown.tsx
@@ -23,6 +23,7 @@ function RepeatScheduleDropdown({
             handleSelect={handleSelect}
             isDisabled={!isEditable}
             placeholderText="Select frequency"
+            menuAppendTo={() => document.body}
         >
             <SelectOption isNoResultsOption>None</SelectOption>
             <SelectOption value="WEEKLY">Weekly</SelectOption>

--- a/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
+++ b/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
@@ -14,6 +14,7 @@ export type SelectSingleProps = {
     variant?: 'typeahead' | null;
     placeholderText?: string;
     onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
+    menuAppendTo?: () => HTMLElement;
 };
 
 function SelectSingle({
@@ -29,6 +30,7 @@ function SelectSingle({
     variant = null,
     placeholderText = '',
     onBlur,
+    menuAppendTo,
 }: SelectSingleProps): ReactElement {
     const [isOpen, setIsOpen] = useState(false);
 
@@ -56,6 +58,7 @@ function SelectSingle({
             placeholderText={placeholderText}
             toggleId={id}
             onBlur={onBlur}
+            menuAppendTo={menuAppendTo}
         >
             {children}
         </Select>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
@@ -31,7 +31,7 @@ import ReportFormWizardFooter from './ReportFormWizardFooter';
 
 const wizardStepNames = [
     'Configure report parameters',
-    'Configure delivery destinations (Optional)',
+    'Configure delivery destinations',
     'Review and create',
 ];
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
@@ -31,7 +31,7 @@ import ReportFormWizardFooter from './ReportFormWizardFooter';
 
 const wizardStepNames = [
     'Configure report parameters',
-    'Configure delivery destinations (Optional)',
+    'Configure delivery destinations',
     'Review and save',
 ];
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -239,7 +239,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                                 url: `/api/reports/jobs/download?id=${reportJobId}`,
                                 data: null,
                                 timeout: 300000,
-                                name: `${name}-report.zip`,
+                                name: `${name}.zip`,
                             });
                         }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -198,6 +198,7 @@ function ViewVulnReportPage() {
                                     onClick={() => {
                                         history.push(`${vulnReportPageURL}?action=edit`);
                                     }}
+                                    isDisabled={isReportStatusPending || isRunning}
                                 >
                                     Edit report
                                 </DropdownItem>,
@@ -244,6 +245,7 @@ function ViewVulnReportPage() {
                                     onClick={() => {
                                         openDeleteModal(reportConfiguration.id);
                                     }}
+                                    isDisabled={isReportStatusPending || isRunning}
                                 >
                                     Delete report
                                 </DropdownItem>,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useWatchLastSnapshotForReports.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useWatchLastSnapshotForReports.ts
@@ -7,7 +7,7 @@ import { getRequestQueryString } from './apiUtils';
 import { getErrorMessage } from '../errorUtils';
 
 type Result = {
-    reportSnapshots: Record<string, ReportSnapshot>;
+    reportSnapshots: Record<string, ReportSnapshot | null>;
     isLoading: boolean;
     error: string | null;
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
@@ -140,9 +140,6 @@ function CollectionSelection({
                 direction={{ default: 'row' }}
                 spaceItems={{ default: 'spaceItemsNone' }}
                 alignItems={{ default: 'alignItemsFlexEnd' }}
-                // Workaround to ensure there is enough space for the select menu when opened
-                // at the bottom of a wizard step body (May no longer be needed after upgrade to PF5)
-                className={isOpen ? 'pf-u-mb-3xl' : ''}
             >
                 <FlexItem>
                     <Select
@@ -169,6 +166,7 @@ function CollectionSelection({
                             overflowY: 'auto',
                         }}
                         validated={ValidatedOptions.default}
+                        menuAppendTo={() => document.body}
                     >
                         {sortedCollections.map((collection) => (
                             <SelectOption

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
@@ -176,7 +176,6 @@ function DeliveryDestinationsForm({ title, formik }: DeliveryDestinationsFormPar
                             <Flex direction={{ default: 'row' }}>
                                 <FlexItem>
                                     <FormLabelGroup
-                                        isRequired={formik.values.deliveryDestinations.length !== 0}
                                         label="Repeat every"
                                         fieldId="schedule.intervalType"
                                         errors={formik.errors}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
@@ -115,6 +115,7 @@ function ReportParametersForm({ title, formik }: ReportParametersFormParams): Re
                         onChange={handleCheckboxSelectChange('reportParameters.cveSeverities')}
                         onBlur={formik.handleBlur}
                         placeholderText="CVE severity"
+                        menuAppendTo={() => document.body}
                     >
                         <SelectOption value="CRITICAL_VULNERABILITY_SEVERITY">
                             <Flex
@@ -168,6 +169,7 @@ function ReportParametersForm({ title, formik }: ReportParametersFormParams): Re
                         onChange={handleCheckboxSelectChange('reportParameters.cveStatus')}
                         onBlur={formik.handleBlur}
                         placeholderText="CVE status"
+                        menuAppendTo={() => document.body}
                     >
                         <SelectOption value="FIXABLE">{fixabilityLabels.FIXABLE}</SelectOption>
                         <SelectOption value="NOT_FIXABLE">
@@ -189,6 +191,7 @@ function ReportParametersForm({ title, formik }: ReportParametersFormParams): Re
                         onChange={handleCheckboxSelectChange('reportParameters.imageType')}
                         onBlur={formik.handleBlur}
                         placeholderText="Image type"
+                        menuAppendTo={() => document.body}
                     >
                         <SelectOption value="DEPLOYED">{imageTypeLabelMap.DEPLOYED}</SelectOption>
                         <SelectOption value="WATCHED">{imageTypeLabelMap.WATCHED}</SelectOption>
@@ -205,6 +208,7 @@ function ReportParametersForm({ title, formik }: ReportParametersFormParams): Re
                         value={formik.values.reportParameters.cvesDiscoveredSince}
                         handleSelect={handleSelectChange}
                         onBlur={formik.handleBlur}
+                        menuAppendTo={() => document.body}
                     >
                         <SelectOption
                             value="SINCE_LAST_REPORT"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
@@ -145,22 +145,7 @@ const validationSchema = yup.object().shape({
         })
         .notRequired(),
     schedule: yup.object().shape({
-        intervalType: yup
-            .string()
-            .oneOf(intervalTypes)
-            .strict()
-            .test(
-                'non-empty-delivery-destinations',
-                'A schedule frequency is required',
-                (value, context) => {
-                    const deliveryDestinations = context?.from?.[1].value.deliveryDestinations;
-                    if (deliveryDestinations.length !== 0) {
-                        return value === 'MONTHLY' || value === 'WEEKLY';
-                    }
-                    return true;
-                }
-            )
-            .notRequired(),
+        intervalType: yup.string().oneOf(intervalTypes).nullable(),
         daysOfWeek: yup
             .array()
             .of(yup.string().oneOf(daysOfWeek))


### PR DESCRIPTION
## Description

This PR fixes the following issues:

* Adding a `menuAppendTo` prop to the `Select` components where we append to the body will resolve the cut off issue with the select options
* When editing or cloning a report, the second step should not include the `(Optional)` text
* The download report name should not append a `-report` to the name
* When the last report status is pending, we should disable the edit and delete options in the `Actions` dropdown
* The `schedule` should be optional regardless of whether we set delivery destinations