### PR TITLE
chore: Set `target="_blank"` on links rendered in OSCI

### DIFF
--- a/qa-tests-backend/scripts/lib.sh
+++ b/qa-tests-backend/scripts/lib.sh
@@ -74,7 +74,7 @@ HEAD
         classname="${classname%.log}"
         url="$(get_spec_log_url "${log}")"
         cat >> "$artifact_file" << DETAILS
-        <li><a target=_blank href="${url}">${classname}</a></li>
+        <li><a target="_blank" href="${url}">${classname}</a></li>
 DETAILS
     done
 

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -369,7 +369,7 @@ HEAD
     project="$(gcloud config get project --quiet)"
 
     for authUser in {0..2}; do
-    cat >> "$artifact_file" << LINK
+    cat << LINK |
       <li>
         <a href="https://console.cloud.google.com/logs/query
 ;query=
@@ -383,6 +383,7 @@ resource.labels.namespace_name%3D%22stackrox%22%0A
 &orgonly=true&supportedpurview=organizationId" target="_blank">authUser $authUser</a>
       </li>
 LINK
+tr -d '\n' >> "$artifact_file"
     done
 
     cat >> "$artifact_file" <<- FOOT

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -357,7 +357,7 @@ create_log_explorer_links() {
         </style>
     </head>
     <body>
-    <p>(These links require a 'right-click -> open in new tab'. The authUser is the number for your @stackrox.com account.)</p>
+    <p>(The authUser is the number for your @stackrox.com account.)</p>
     <ul style="padding-bottom: 28px; padding-left: 30px; font-family: Roboto,Helvetica,Arial,sans-serif;">
 HEAD
 
@@ -380,7 +380,7 @@ resource.labels.namespace_name%3D%22stackrox%22%0A
 ;cursorTimestamp=$start_ts
 ?authuser=$authUser
 &project=$project
-&orgonly=true&supportedpurview=organizationId">authUser $authUser</a>
+&orgonly=true&supportedpurview=organizationId" target="_blank">authUser $authUser</a>
       </li>
 LINK
     done

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -371,7 +371,8 @@ HEAD
     for authUser in {0..2}; do
     cat << LINK |
       <li>
-        <a target="_blank" href="https://console.cloud.google.com/logs/query
+        <a onclick="window.open(this.href,'_blank');return false;" target="_blank"
+           href="https://console.cloud.google.com/logs/query
 ;query=
 resource.type%3D%22k8s_container%22%0A
 resource.labels.cluster_name%3D%22${CLUSTER_NAME}%22%0A

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -371,7 +371,7 @@ HEAD
     for authUser in {0..2}; do
     cat << LINK |
       <li>
-        <a href="https://console.cloud.google.com/logs/query
+        <a target="_blank" href="https://console.cloud.google.com/logs/query
 ;query=
 resource.type%3D%22k8s_container%22%0A
 resource.labels.cluster_name%3D%22${CLUSTER_NAME}%22%0A
@@ -381,7 +381,7 @@ resource.labels.namespace_name%3D%22stackrox%22%0A
 ?authuser=${authUser}
 &amp;project=${project}
 &amp;orgonly=true
-&amp;supportedpurview=organizationId" target="_blank">authUser $authUser</a>
+&amp;supportedpurview=organizationId">authUser $authUser</a>
       </li>
 LINK
 tr -d '\n' >> "$artifact_file"

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -373,14 +373,15 @@ HEAD
       <li>
         <a href="https://console.cloud.google.com/logs/query
 ;query=
-resource.type=%22k8s_container%22%0A
-resource.labels.cluster_name%3D%22$CLUSTER_NAME%22%0A
+resource.type%3D%22k8s_container%22%0A
+resource.labels.cluster_name%3D%22${CLUSTER_NAME}%22%0A
 resource.labels.namespace_name%3D%22stackrox%22%0A
-;timeRange=$start_ts%2F$end_ts
-;cursorTimestamp=$start_ts
-?authuser=$authUser
-&project=$project
-&orgonly=true&supportedpurview=organizationId" target="_blank">authUser $authUser</a>
+;timeRange=${start_ts}%2F${end_ts}
+;cursorTimestamp=${start_ts}
+?authuser=${authUser}
+&amp;project=${project}
+&amp;orgonly=true
+&amp;supportedpurview=organizationId" target="_blank">authUser $authUser</a>
       </li>
 LINK
 tr -d '\n' >> "$artifact_file"

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -357,7 +357,7 @@ create_log_explorer_links() {
         </style>
     </head>
     <body>
-    <p>(The authUser is the number for your @stackrox.com account.)</p>
+    <p>(These links require a 'right-click -> open in new tab'. The authUser is the number for your @stackrox.com account.)</p>
     <ul style="padding-bottom: 28px; padding-left: 30px; font-family: Roboto,Helvetica,Arial,sans-serif;">
 HEAD
 
@@ -371,8 +371,7 @@ HEAD
     for authUser in {0..2}; do
     cat << LINK |
       <li>
-        <a onclick="window.open(this.href,'_blank');return false;" target="_blank"
-           href="https://console.cloud.google.com/logs/query
+        <a target="_blank" href="https://console.cloud.google.com/logs/query
 ;query=
 resource.type%3D%22k8s_container%22%0A
 resource.labels.cluster_name%3D%22${CLUSTER_NAME}%22%0A

--- a/scripts/ci/store-artifacts.sh
+++ b/scripts/ci/store-artifacts.sh
@@ -177,9 +177,9 @@ make_artifacts_help() {
         You can check this by clicking on the user avatar in the top right corner of Google Cloud Console page
         after following the link.</p>
 
-        <a href="$browser_job_url?authuser=0">authuser=0</a><br>
-        <a href="$browser_job_url?authuser=1">authuser=1</a><br>
-        <a href="$browser_job_url?authuser=2">authuser=2</a><br>
+        <a href="$browser_job_url?authuser=0" target="_blank">authuser=0</a><br>
+        <a href="$browser_job_url?authuser=1" target="_blank">authuser=1</a><br>
+        <a href="$browser_job_url?authuser=2" target="_blank">authuser=2</a><br>
 
         <br><br>
 

--- a/scripts/ci/store-artifacts.sh
+++ b/scripts/ci/store-artifacts.sh
@@ -177,9 +177,9 @@ make_artifacts_help() {
         You can check this by clicking on the user avatar in the top right corner of Google Cloud Console page
         after following the link.</p>
 
-        <a href="$browser_job_url?authuser=0" target="_blank">authuser=0</a><br>
-        <a href="$browser_job_url?authuser=1" target="_blank">authuser=1</a><br>
-        <a href="$browser_job_url?authuser=2" target="_blank">authuser=2</a><br>
+        <a target="_blank" href="$browser_job_url?authuser=0">authuser=0</a><br>
+        <a target="_blank" href="$browser_job_url?authuser=2">authuser=2</a><br>
+        <a target="_blank" href="$browser_job_url?authuser=1">authuser=1</a><br>
 
         <br><br>
 

--- a/scripts/ci/store-artifacts.sh
+++ b/scripts/ci/store-artifacts.sh
@@ -178,8 +178,8 @@ make_artifacts_help() {
         after following the link.</p>
 
         <a target="_blank" href="$browser_job_url?authuser=0">authuser=0</a><br>
-        <a target="_blank" href="$browser_job_url?authuser=2">authuser=2</a><br>
         <a target="_blank" href="$browser_job_url?authuser=1">authuser=1</a><br>
+        <a target="_blank" href="$browser_job_url?authuser=2">authuser=2</a><br>
 
         <br><br>
 


### PR DESCRIPTION
## Description

I wanted to make it for a long time.

## Checklist
- [x] Investigated and inspected CI test results

Won't do these:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

- [x] `Additional StackRox e2e artifacts` links are left-clickable.
- [x] `Groovy Test Logs` links are left-clickable.
- ~~[ ] `GKE Logs Explorer` links are left-clickable~~ - no, they aren't and I could not make them work.

Not creating tests for this change because it's change in tests tooling.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
