### PR TITLE
ROX-19215: Fix operator index deployment on OCP 4.14

### DIFF
--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -50,7 +50,9 @@ function apply_operator_manifests() {
   local catalog_source_crd
   catalog_source_crd="$(kubectl get customresourcedefinitions.apiextensions.k8s.io catalogsources.operators.coreos.com -o yaml)"
   local disable_security_context_config="# "
-  if [[ "$(yq eval '[.. | select(key == "grpcPodConfig")].[].properties | has("securityContextConfig")' - <<< "$catalog_source_crd")" == "true" ]]; then
+  local has_scc_key
+  has_scc_key="$(yq eval '[.. | select(key == "grpcPodConfig")].[].properties | has("securityContextConfig")' - <<< "$catalog_source_crd")"
+  if [[ "$has_scc_key" == "true" ]]; then
       disable_security_context_config=""
   fi
 

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -47,7 +47,7 @@ function apply_operator_manifests() {
   local catalog_source_crd
   catalog_source_crd="$(kubectl get customresourcedefinitions.apiextensions.k8s.io catalogsources.operators.coreos.com -o yaml)"
   local disable_security_context_config="# "
-  if [[ "$catalog_source_crd" == *"securityContextConfig:"* ]]; then
+  if [[ "$(yq '[.. | select(key == "grpcPodConfig")].[].properties | has("securityContextConfig")' <<< "$catalog_source_crd")" == "true" ]]; then
       disable_security_context_config=""
   fi
 

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -39,6 +39,9 @@ function apply_operator_manifests() {
   local -r index_version="$3"
   local -r operator_version="$4"
 
+  # TODO: remove me before merging
+  yq --version
+
   # OCP starting from v4.14 requires either spec.grpcPodConfig.securityContextConfig attribute to be set on the
   # CatalogSource resource or the namespace of the CatalogSource to have relaxed PSA enforcement, otherwise the
   # CatalogSource pod does not get deployed with PodSecurity errors.

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -50,7 +50,7 @@ function apply_operator_manifests() {
   local catalog_source_crd
   catalog_source_crd="$(kubectl get customresourcedefinitions.apiextensions.k8s.io catalogsources.operators.coreos.com -o yaml)"
   local disable_security_context_config="# "
-  if [[ "$(yq '[.. | select(key == "grpcPodConfig")].[].properties | has("securityContextConfig")' <<< "$catalog_source_crd")" == "true" ]]; then
+  if [[ "$(yq eval '[.. | select(key == "grpcPodConfig")].[].properties | has("securityContextConfig")' <<< "$catalog_source_crd")" == "true" ]]; then
       disable_security_context_config=""
   fi
 

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -39,9 +39,6 @@ function apply_operator_manifests() {
   local -r index_version="$3"
   local -r operator_version="$4"
 
-  # TODO: remove me before merging
-  yq --version
-
   # OCP starting from v4.14 requires either spec.grpcPodConfig.securityContextConfig attribute to be set on the
   # CatalogSource resource or the namespace of the CatalogSource to have relaxed PSA enforcement, otherwise the
   # CatalogSource pod does not get deployed with PodSecurity errors.

--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -50,7 +50,7 @@ function apply_operator_manifests() {
   local catalog_source_crd
   catalog_source_crd="$(kubectl get customresourcedefinitions.apiextensions.k8s.io catalogsources.operators.coreos.com -o yaml)"
   local disable_security_context_config="# "
-  if [[ "$(yq eval '[.. | select(key == "grpcPodConfig")].[].properties | has("securityContextConfig")' <<< "$catalog_source_crd")" == "true" ]]; then
+  if [[ "$(yq eval '[.. | select(key == "grpcPodConfig")].[].properties | has("securityContextConfig")' - <<< "$catalog_source_crd")" == "true" ]]; then
       disable_security_context_config=""
   fi
 

--- a/operator/hack/operator.envsubst.yaml
+++ b/operator/hack/operator.envsubst.yaml
@@ -9,7 +9,7 @@ spec:
   image: ${IMAGE_TAG_BASE}-index:v${INDEX_VERSION}
   displayName: StackRox Operator Test index
   grpcPodConfig:
-    securityContextConfig: restricted
+    ${DISABLE_SECURITY_CONTEXT_CONFIG}securityContextConfig: restricted
 ---
 apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup

--- a/operator/hack/operator.envsubst.yaml
+++ b/operator/hack/operator.envsubst.yaml
@@ -8,6 +8,8 @@ spec:
   - operator-pull-secret
   image: ${IMAGE_TAG_BASE}-index:v${INDEX_VERSION}
   displayName: StackRox Operator Test index
+  grpcPodConfig:
+    securityContextConfig: restricted
 ---
 apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup


### PR DESCRIPTION
## Description

Per my research in the related ticket, the only required thing is the presence of `spec.grpcPodConfig.securityContextConfig` attribute on the operator `CatalogSource` resource.

This should make manifests for deploying our upstream-built operator index deployable on OCP 4.14.

## Checklist
- [x] Investigated and inspected CI test results

Not doing these:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

- [x] CatalogSource resource created on OCP 4.10 in CI doesn't have `securityContextConfig` attribute.
- [x] CatalogSource resource created on OCP 4.13 in CI has `securityContextConfig` attribute.
- [x] Can deploy operator locally with `make olm-install` and `ROX_PRODUCT_BRANDING=RHACS_BRANDING make deploy-via-olm` on minikube.
- [x] Can deploy operator to OCP 4.14 with `ROX_PRODUCT_BRANDING=RHACS_BRANDING make deploy-via-olm`.

I haven't tested further operands deployment on 4.14. Any issues there (if present) would be separate from this one which blocks the deployment of the operator.

Not creating automated tests because the changed code is part of automated tests itself.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
