### PR TITLE
ROX-19201: Add conditional RBAC for global search links

### DIFF
--- a/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
@@ -7,18 +7,20 @@ import { SearchFilter } from 'types/search';
 import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 
 import NotApplicable from './NotApplicable';
-import { searchResultCategoryMap } from './searchCategories';
+import { SearchResultCategoryMap } from './searchCategories';
 
 type FilterLinksProps = {
     filterValue: string;
     resultCategory: SearchResultCategory;
     searchFilter: SearchFilter;
+    searchResultCategoryMap: SearchResultCategoryMap;
 };
 
 function FilterLinks({
     filterValue,
     resultCategory,
     searchFilter,
+    searchResultCategoryMap,
 }: FilterLinksProps): ReactElement {
     const { filterOn } = searchResultCategoryMap[resultCategory] ?? {};
 

--- a/ui/apps/platform/src/Containers/Search/SearchNavAndTable.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchNavAndTable.tsx
@@ -2,13 +2,12 @@ import React, { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import { Flex, FlexItem, Nav, NavItem, NavList, Split, SplitItem } from '@patternfly/react-core';
 
-import usePermissions from 'hooks/usePermissions';
 import { SearchResponse } from 'services/SearchService';
 import { SearchFilter } from 'types/search';
 import { searchPath } from 'routePaths';
 
 import SearchTable from './SearchTable';
-import { SearchNavCategory, searchResultCategoryMap, searchNavMap } from './searchCategories';
+import { SearchNavCategory, searchNavMap } from './searchCategories';
 import { stringifyQueryObject } from './searchQuery';
 
 type SearchNavAndTableProps = {
@@ -22,8 +21,6 @@ function SearchNavAndTable({
     searchFilter,
     searchResponse,
 }: SearchNavAndTableProps): ReactElement {
-    const { hasReadAccess } = usePermissions();
-
     const { counts, results } = searchResponse;
 
     function getNavCategoryCount(navCategory: SearchNavCategory) {
@@ -32,18 +29,12 @@ function SearchNavAndTable({
             : counts.find(({ category }) => category === navCategory)?.count ?? 0;
     }
 
-    const searchNavEntriesFiltered = Object.entries(searchNavMap).filter(
-        ([navCategory]) =>
-            navCategory === 'SEARCH_UNSET' ||
-            hasReadAccess(searchResultCategoryMap[navCategory].resourceName)
-    );
-
     return (
         <Split hasGutter>
             <SplitItem>
                 <Nav aria-label="Categories" theme="light">
                     <NavList>
-                        {searchNavEntriesFiltered.map(([navCategory, text]) => (
+                        {Object.entries(searchNavMap).map(([navCategory, text]) => (
                             <NavItem key={navCategory} isActive={navCategory === activeNavCategory}>
                                 <Link
                                     to={`${searchPath}${stringifyQueryObject({

--- a/ui/apps/platform/src/Containers/Search/SearchTable.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchTable.tsx
@@ -9,8 +9,8 @@ import FilterLinks from './FilterLinks';
 import ViewLinks from './ViewLinks';
 import {
     SearchNavCategory,
-    searchResultCategoryMapFilteredIsRouteEnabled,
     searchNavMap,
+    searchResultCategoryMapFilteredIsRouteEnabled,
 } from './searchCategories';
 
 function getLocationTextForCategory(location: string, category: SearchResultCategory) {

--- a/ui/apps/platform/src/Containers/Search/SearchTable.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchTable.tsx
@@ -1,12 +1,17 @@
 import React, { ReactElement } from 'react';
 import { TableComposable, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
+import useIsRouteEnabled from 'hooks/useIsRouteEnabled';
 import { SearchResult, SearchResultCategory } from 'services/SearchService';
 import { SearchFilter } from 'types/search';
 
 import FilterLinks from './FilterLinks';
 import ViewLinks from './ViewLinks';
-import { SearchNavCategory, searchResultCategoryMap, searchNavMap } from './searchCategories';
+import {
+    SearchNavCategory,
+    searchResultCategoryMapFilteredIsRouteEnabled,
+    searchNavMap,
+} from './searchCategories';
 
 function getLocationTextForCategory(location: string, category: SearchResultCategory) {
     return category === 'DEPLOYMENTS' ? location.replace(/^\//, '') : location.replace(/\/.+/, '');
@@ -23,6 +28,9 @@ type SearchTableProps = {
 };
 
 function SearchTable({ navCategory, searchFilter, searchResults }: SearchTableProps): ReactElement {
+    const isRouteEnabled = useIsRouteEnabled();
+    const searchResultCategoryMap = searchResultCategoryMapFilteredIsRouteEnabled(isRouteEnabled);
+
     const firstColumnHeading = searchNavMap[navCategory];
     const hasLocationColumn =
         navCategory === 'DEPLOYMENTS' || navCategory === 'NAMESPACES' || navCategory === 'NODES';
@@ -105,7 +113,11 @@ function SearchTable({ navCategory, searchFilter, searchResults }: SearchTablePr
                             )}
                             {hasViewLinkColumn && (
                                 <Td dataLabel="View on">
-                                    <ViewLinks id={id} resultCategory={category} />
+                                    <ViewLinks
+                                        id={id}
+                                        resultCategory={category}
+                                        searchResultCategoryMap={searchResultCategoryMap}
+                                    />
                                 </Td>
                             )}
                             {hasFilterLinkColumn && (
@@ -114,6 +126,7 @@ function SearchTable({ navCategory, searchFilter, searchResults }: SearchTablePr
                                         filterValue={name}
                                         resultCategory={category}
                                         searchFilter={searchFilter}
+                                        searchResultCategoryMap={searchResultCategoryMap}
                                     />
                                 </Td>
                             )}

--- a/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
@@ -5,14 +5,15 @@ import LinkShim from 'Components/PatternFly/LinkShim';
 import { SearchResultCategory } from 'services/SearchService';
 
 import NotApplicable from './NotApplicable';
-import { searchResultCategoryMap } from './searchCategories';
+import { SearchResultCategoryMap } from './searchCategories';
 
 type ViewLinksProps = {
     id: string;
     resultCategory: SearchResultCategory;
+    searchResultCategoryMap: SearchResultCategoryMap;
 };
 
-function ViewLinks({ id, resultCategory }: ViewLinksProps): ReactElement {
+function ViewLinks({ id, resultCategory, searchResultCategoryMap }: ViewLinksProps): ReactElement {
     const { viewLinks } = searchResultCategoryMap[resultCategory] ?? {};
 
     if (viewLinks?.length) {

--- a/ui/apps/platform/src/Containers/Search/searchCategories.ts
+++ b/ui/apps/platform/src/Containers/Search/searchCategories.ts
@@ -196,11 +196,14 @@ export function searchResultCategoryMapFilteredIsRouteEnabled(
         const value = searchResultCategoryMapFiltered[searchResultKey];
 
         if (value.filterOn) {
-            const { filterLinks } = value.filterOn;
+            const filterLinks = value.filterOn.filterLinks.filter(({ routeKey }) =>
+                isRouteEnabled(routeKey)
+            );
+
             if (filterLinks.length !== 0) {
-                value.filterOn.filterLinks = filterLinks.filter(({ routeKey }) =>
-                    isRouteEnabled(routeKey)
-                );
+                value.filterOn.filterLinks = filterLinks;
+            } else {
+                value.filterOn = null;
             }
         }
 

--- a/ui/apps/platform/src/Containers/Search/searchCategories.ts
+++ b/ui/apps/platform/src/Containers/Search/searchCategories.ts
@@ -58,7 +58,7 @@ export type SearchResultCategoryMap = Record<SearchResultCategory, SearchResultC
 // Therefore update that property if response ever adds search categories.
 
 // prettier-ignore
-export const searchResultCategoryMap: SearchResultCategoryMap = {
+const searchResultCategoryMap: SearchResultCategoryMap = {
     ALERTS: {
         filterOn: null,
         viewLinks: [

--- a/ui/apps/platform/src/hooks/useIsRouteEnabled.ts
+++ b/ui/apps/platform/src/hooks/useIsRouteEnabled.ts
@@ -3,7 +3,9 @@ import { RouteKey, isRouteEnabled } from 'routePaths';
 import useFeatureFlags from './useFeatureFlags';
 import usePermissions from './usePermissions';
 
-function useIsRouteEnabled() {
+export type IsRouteEnabled = (routeKey: RouteKey) => boolean;
+
+function useIsRouteEnabled(): IsRouteEnabled {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const { hasReadAccess } = usePermissions();
 

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -61,17 +61,9 @@ export const vulnerabilitiesBasePath = `${mainPath}/vulnerabilities`;
 export const vulnerabilitiesWorkloadCvesPath = `${vulnerabilitiesBasePath}/workload-cves`;
 export const vulnerabilityReportsPath = `${vulnerabilitiesBasePath}/reports`;
 
-// Configuration Management paths for links from Search:
-
-export const configManagementRolesPath = `${configManagementPath}/roles`;
-export const configManagementSecretsPath = `${configManagementPath}/secrets`;
-export const configManagementServiceAccountsPath = `${configManagementPath}/serviceaccounts`;
-
-// Vulnerability Management 1.0 paths for links from Dashboard or Search:
+// Vulnerability Management 1.0 path for links from Dashboard:
 
 export const vulnManagementImagesPath = `${vulnManagementPath}/images`;
-export const vulnManagementNamespacesPath = `${vulnManagementPath}/namespaces`;
-export const vulnManagementNodesPath = `${vulnManagementPath}/nodes`;
 
 // Compose resourceAccessRequirements from resource names and predicates.
 


### PR DESCRIPTION
## Description

### Analysis and solution

1. Add conditional rendering of links according to `routeKey` property added in #7524
    * Delete filtering for individual resources from `SearchNavAndTable` because it assumes all are specified as `resourceAccessRequirements` in routePaths.
    * Delete `resourceName` property from `searchResultCategoryMap` and write comment.
    * Replace direct import of `searchResultCategoryMap` in `SearchTable` with filtered copy from `searchResultCategoryMapFilteredIsRouteEnabled` function call.
    * Replace direct import of `searchResultCategoryMap` in `FilterLinks` and `ViewLinks` with prop for filtered copy from `SearchTable` component.

### Residue

1. Add optional `featureFlagDependency` property for situations in the future like policy categories in the past.
2. Add id to page address for policy categories. It is only in page state because someone scoffed: why would we need a page address :(

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: -170 = 3761645 - 3761815
        total: -44 = 9967878 - 9967922
    * `ls -al build/static/js/*.js | wc -l`
        0 = 80 - 80 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/dashboard with minimum resources for global search route, click **Search**, and then enter **Namespace: stackrox** search filter.

    * **Clusters** does render **View** links because `clusters` route is enabled.
    * **Deployments** does not render **View** links because `risk` route is not enabled but does render **Filter** links because `violations` route is enabled.
    * **Images** does not render **View** links because `'vulnerability-management'` is not enabled but does render **Filter** links because `violations` route is enabled although `risk` route is not enabled.
    * **Namespaces** does not render **View** links because `'vulnerability-management'` route is not enabled.
    * **Nodes** has no results. It would not render **View** links because `'vulnerability-management'` route is not enabled.
    * **Policies** has no results. It would render **View** links because `'policy-management'` route is enabled and would render **Filter** links because `violations` route is enabled.
    * **Policy categories** has no results. It cannot render **View** links because of **Residue** item 2.
    * **Roles** does not render **View** links because `configmanagement` route is not enabled. It would be, except for Compliance.
    * **Role bindings** does not have links in the map.
    * **Secrets** does not render **View** links because `configmanagement` route is not enabled and does not render **Filter** links because `risk` route is not enabled.
    * **Service accounts** does not render **View** links because `configmanagement` route is not enabled.
    * **Users and groups** has no results. It does not have links in the map.
    * **Violations** does render **View** links because `violations` route is enabled.

    ![search](https://github.com/stackrox/stackrox/assets/11862657/3a0dbdbb-5808-4ec6-ace0-83753d4c1554)
