### PR TITLE
ROX-9350: Enable HostToContainer mount propagation

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -67,20 +67,25 @@ spec:
         - mountPath: /host/proc
           name: proc-ro
           readOnly: true
+          mountPropagation: HostToContainer
         - mountPath: /module
           name: tmpfs-module
         - mountPath: /host/etc
           name: etc-ro
           readOnly: true
+          mountPropagation: HostToContainer
         - mountPath: /host/usr/lib
           name: usr-lib-ro
           readOnly: true
+          mountPropagation: HostToContainer
         - mountPath: /host/sys
           name: sys-ro
           readOnly: true
+          mountPropagation: HostToContainer
         - mountPath: /host/dev
           name: dev-ro
           readOnly: true
+          mountPropagation: HostToContainer
         - mountPath: /run/secrets/stackrox.io/certs/
           name: certs
           readOnly: true
@@ -139,9 +144,7 @@ spec:
         - mountPath: /host
           name: host-root-ro
           readOnly: true
-          {{- if ._rox.env.openshift }}
           mountPropagation: HostToContainer
-          {{- end }}
         - mountPath: /run/secrets/stackrox.io/certs/
           name: certs
           readOnly: true
@@ -166,9 +169,7 @@ spec:
          - mountPath: /host
            name: host-root-ro
            readOnly: true
-           {{- if ._rox.env.openshift }}
            mountPropagation: HostToContainer
-           {{- end }}
          - mountPath: /tmp/
            name: tmp-volume
          - mountPath: /cache

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -139,6 +139,9 @@ spec:
         - mountPath: /host
           name: host-root-ro
           readOnly: true
+          {{- if eq ._rox.env.openshift }}
+          mountPropagation: HostToContainer
+          {{- end }}
         - mountPath: /run/secrets/stackrox.io/certs/
           name: certs
           readOnly: true
@@ -163,6 +166,9 @@ spec:
          - mountPath: /host
            name: host-root-ro
            readOnly: true
+           {{- if eq ._rox.env.openshift }}
+           mountPropagation: HostToContainer
+           {{- end }}
          - mountPath: /tmp/
            name: tmp-volume
          - mountPath: /cache

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -139,7 +139,7 @@ spec:
         - mountPath: /host
           name: host-root-ro
           readOnly: true
-          {{- if eq ._rox.env.openshift }}
+          {{- if ._rox.env.openshift }}
           mountPropagation: HostToContainer
           {{- end }}
         - mountPath: /run/secrets/stackrox.io/certs/
@@ -166,7 +166,7 @@ spec:
          - mountPath: /host
            name: host-root-ro
            readOnly: true
-           {{- if eq ._rox.env.openshift }}
+           {{- if ._rox.env.openshift }}
            mountPropagation: HostToContainer
            {{- end }}
          - mountPath: /tmp/


### PR DESCRIPTION
## Description

**Change**
Set the mount propagation setting to `HostToContainer` for volumes in the collector daemonset on the root directory mount. By default, the k8s/ocp setting is `none,` equivalent to `rprivate` in Linux. Using this mount propagation fixes a customer/OCP issue and is also more correct for ACS, if a host mount is added after the pod is created, with the existing mount propagation, the volume mount will not have access to the new mount.

**Fixes**
Changing the mount propagation allows the pod to receive `unmount` events, which will fix [ROX-9350](https://issues.redhat.com/browse/ROX-9350) and is based on guidance in this ticket, [OCPBUGS-14351](https://issues.redhat.com/browse/OCPBUGS-14351)

Openshift 3.15 will enable this by default for any HostPath volume. For now, other OCP operators that use a HostPath volume are changing the mount propagation.

* https://github.com/ComplianceAsCode/compliance-operator/pull/377 
* https://github.com/openshift/file-integrity-operator/pull/424
* https://github.com/openshift/cluster-node-tuning-operator/pull/705


## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

CI testing is sufficent.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
