### PR TITLE
fix(ci): normalize stackrox scanner config

### DIFF
--- a/qa-tests-backend/src/main/groovy/objects/ImageIntegration.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/ImageIntegration.groovy
@@ -37,7 +37,7 @@ class StackroxScannerIntegration implements ImageIntegration {
     static ImageIntegrationOuterClass.ImageIntegration.Builder getCustomBuilder(Map customArgs = [:]) {
         Map defaultArgs = [
                 name: Constants.AUTO_REGISTERED_STACKROX_SCANNER_INTEGRATION,
-                endpoint: "https://scanner.stackrox:8080",
+                endpoint: "https://scanner.stackrox.svc:8080",
         ]
         Map args = defaultArgs + customArgs
 

--- a/qa-tests-backend/src/main/groovy/services/ImageIntegrationService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ImageIntegrationService.groovy
@@ -161,6 +161,7 @@ class ImageIntegrationService extends BaseService {
         ImageIntegrationOuterClass.ImageIntegration existing =
             getImageIntegrationByName(Constants.AUTO_REGISTERED_STACKROX_SCANNER_INTEGRATION)
         if (existing) {
+            log.debug("${Constants.AUTO_REGISTERED_STACKROX_SCANNER_INTEGRATION} already exists")
             return existing.id
         }
         return StackroxScannerIntegration.createDefaultIntegration()

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -11,7 +11,6 @@ import io.stackrox.proto.storage.ScopeOuterClass
 import objects.Deployment
 import services.CVEService
 import services.ClusterService
-import services.ImageIntegrationService
 import services.ImageService
 import services.PolicyService
 import util.ApplicationHealth

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -98,7 +98,6 @@ class AdmissionControllerTest extends BaseSpecification {
         sleep(10000 * (ClusterService.isOpenShift4() ? 4 : 1))
 
         // Pre run scan to avoid timeouts with inline scans in the tests below
-        ImageIntegrationService.addStackroxScannerIntegration()
         ImageService.scanImage(NGINX_IMAGE)
 
         orchestrator.ensureNamespaceExists(TEST_NAMESPACE)

--- a/qa-tests-backend/src/test/groovy/VulnMgmtSACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtSACTest.groovy
@@ -6,7 +6,6 @@ import io.stackrox.proto.storage.RoleOuterClass
 import services.ApiTokenService
 import services.BaseService
 import services.GraphQLService
-import services.ImageIntegrationService
 import services.ImageService
 import services.RoleService
 

--- a/qa-tests-backend/src/test/groovy/VulnMgmtSACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtSACTest.groovy
@@ -130,7 +130,6 @@ class VulnMgmtSACTest extends BaseSpecification {
     def setupSpec() {
         // Purposefully add an image (centos7-base) that is not running to check the case
         // where an image is orphaned. The image is actually part of the re-scanned image set.
-        ImageIntegrationService.addStackroxScannerIntegration()
         // Re-scan the images used in previous test cases to ensure pruning did not leave orphan CVEs.
         for ( imageToScan in IMAGES_TO_RESCAN ) {
             ImageService.scanImage(imageToScan)
@@ -145,7 +144,6 @@ class VulnMgmtSACTest extends BaseSpecification {
 
     def cleanupSpec() {
         BaseService.useBasicAuth()
-        ImageIntegrationService.deleteStackRoxScannerIntegrationIfExists()
         RoleService.deleteRole(NODE_ROLE)
         RoleService.deleteRole(IMAGE_ROLE)
         RoleService.deleteRole(NODE_IMAGE_ROLE)

--- a/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
@@ -208,13 +208,8 @@ fragment cveFields on ImageVulnerability {
 """
 
     def setupSpec() {
-        ImageIntegrationService.addStackroxScannerIntegration()
         ImageService.scanImage(RHEL_IMAGE)
         ImageService.scanImage(UBUNTU_IMAGE)
-    }
-
-    def cleanupSpec() {
-        ImageIntegrationService.deleteStackRoxScannerIntegrationIfExists()
     }
 
     def getEmbeddedImageQuery() {

--- a/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
@@ -1,7 +1,6 @@
 import io.stackrox.proto.storage.Cve.VulnerabilitySeverity
 
 import services.GraphQLService
-import services.ImageIntegrationService
 import services.ImageService
 
 import spock.lang.Tag


### PR DESCRIPTION
## Description

While implementing https://github.com/stackrox/stackrox/pull/7497 I ran into numerous race failures around the presence and absence of Stackrox Scanner. This PR removes cases where Stackrox Scanner is deleted by some tests and added by others to rely instead on Stackrox Scanner being a default integration.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] CI + OCP flavors.
- [x] `ci-all-qa-tests`.
