### PR TITLE
ROX-19220: Remove `namespaces` from anti-affinity.

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -96,7 +96,6 @@ admissionControl:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 60
           podAffinityTerm:
-            namespaces: ["stackrox"]
             topologyKey: "kubernetes.io/hostname"
             labelSelector:
               matchLabels:

--- a/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
@@ -239,7 +239,6 @@
 #       preferredDuringSchedulingIgnoredDuringExecution:
 #         - weight: 60
 #           podAffinityTerm:
-#             namespaces: ["stackrox"]
 #             topologyKey: "kubernetes.io/hostname"
 #             labelSelector:
 #               matchLabels:


### PR DESCRIPTION
## Description

[K8s docs say](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#an-example-of-a-pod-that-uses-pod-affinity):
> If omitted or empty, `namespaces` defaults to the namespace of the Pod where the affinity/anti-affinity definition appears.

This is simpler and more robust than hardcoding `stackrox` - which caused the anti-affinity rule to be ignored when admission controller is installed into a custom-named namespace.


## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI should be sufficient, but in addition I manually installed ACS in the non-default namespace and validated that the admission controller pods are dispersed despite lack of the `namespaces` field:

```
[mowsiany@mowsiany stackrox]$ kubectl -n $NAMESPACE get pods -o wide -l app=admission-control
NAME                                 READY   STATUS    RESTARTS      AGE    IP           NODE                                                  NOMINATED NODE   READINESS GATES
admission-control-7c48dc876f-kxwmc   1/1     Running   0             110s   10.84.0.12   gke-mo-08-23-utter-frog--default-pool-6d666c11-sw61   <none>           <none>
admission-control-7c48dc876f-q6ph6   1/1     Running   0             111s   10.84.3.10   gke-mo-08-23-utter-frog--default-pool-6d666c11-2knk   <none>           <none>
admission-control-7c48dc876f-s2cvb   1/1     Running   1 (59s ago)   110s   10.84.1.13   gke-mo-08-23-utter-frog--default-pool-6d666c11-pmj0   <none>           <none>
[mowsiany@mowsiany stackrox]$ kubectl -n $NAMESPACE get pod -o yaml admission-control-7c48dc876f-kxwmc|grep -A20 affinity:
  affinity:
    nodeAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
      - preference:
          matchExpressions:
          - key: node-role.kubernetes.io/master
            operator: Exists
        weight: 50
      - preference:
          matchExpressions:
          - key: node-role.kubernetes.io/control-plane
            operator: Exists
        weight: 50
    podAntiAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
      - podAffinityTerm:
          labelSelector:
            matchLabels:
              app: admission-control
          topologyKey: kubernetes.io/hostname
        weight: 60
```

This is not a hard proof, but at least shows that the situation is no worse than it was.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
