### PR TITLE
fix(ui): Replace resource icon colors which had insufficient contrast

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/ResourceIcon/ResourceIcon.css
+++ b/ui/apps/platform/src/Components/PatternFly/ResourceIcon/ResourceIcon.css
@@ -1,5 +1,4 @@
 .resource-icon {
-  background-color: var(--color-resource-default);
   display: inline-block;
   color: var(--pf-global--palette--white);
   border-radius: 20px;
@@ -9,28 +8,3 @@
   margin-right: var(--pf-global--spacer--xs);
   font-size: var(--pf-global--FontSize--xs);
 }
-
-.resource-icon-cluster {
-  background-color: var(--color-resource-cluster);
-}
-
-.resource-icon-namespace {
-  background-color: var(--color-resource-namespace);
-}
-
-.resource-icon-deployment {
-  background-color: var(--color-resource-deployment);
-}
-
-.resource-icon-configmap {
-  background-color: var(--color-resource-configmap);
-}
-
-.resource-icon-secret {
-  background-color: var(--color-resource-secret);
-}
-
-.resource-icon-unknown {
-  background-color: var(--color-resource-unknown);
-}
-

--- a/ui/apps/platform/src/Components/PatternFly/ResourceIcon/ResourceIcon.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/ResourceIcon/ResourceIcon.tsx
@@ -9,13 +9,13 @@ export type ResourceIconProps = {
     kind: K8sResourceKind;
 };
 
-const IconAttributes: Record<K8sResourceKind, { text: string; classNameSuffix: string }> = {
-    Cluster: { text: 'CL', classNameSuffix: 'cluster' },
-    ConfigMap: { text: 'CM', classNameSuffix: 'configmap' },
-    Deployment: { text: 'D', classNameSuffix: 'deployment' },
-    Namespace: { text: 'NS', classNameSuffix: 'namespace' },
-    Secret: { text: 'S', classNameSuffix: 'secret' },
-    Unknown: { text: '?', classNameSuffix: 'unknown' },
+const IconAttributes: Record<K8sResourceKind, { text: string; backgroundColor: string }> = {
+    Cluster: { text: 'CL', backgroundColor: 'var(--pf-global--palette--purple-500)' },
+    ConfigMap: { text: 'CM', backgroundColor: 'var(--pf-global--palette--purple-600)' },
+    Deployment: { text: 'D', backgroundColor: 'var(--pf-global--palette--blue-500)' },
+    Namespace: { text: 'NS', backgroundColor: 'var(--pf-global--palette--green-500)' },
+    Secret: { text: 'S', backgroundColor: 'var(--pf-global--palette--orange-600)' },
+    Unknown: { text: '?', backgroundColor: 'var(--pf-global--palette--black-700)' },
 } as const;
 
 /**
@@ -27,11 +27,12 @@ const IconAttributes: Record<K8sResourceKind, { text: string; classNameSuffix: s
  *
  */
 function ResourceIcon(props: ResourceIconProps) {
-    const { text, classNameSuffix } = IconAttributes[props.kind];
+    const { text, backgroundColor } = IconAttributes[props.kind];
     return (
         <span
             title={props.kind}
-            className={`resource-icon resource-icon-${classNameSuffix} ${props.className ?? ''}`}
+            className={`resource-icon ${props.className ?? ''}`}
+            style={{ backgroundColor }}
         >
             {text}
         </span>

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkGraphIcons.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkGraphIcons.tsx
@@ -7,11 +7,11 @@ export const deploymentBadgeText = 'D';
 export const cidrBlockBadgeText = 'CB';
 export const externalEntitiesBadgeText = 'E';
 
-export const clusterBadgeColor = '#8476d1';
-export const namespaceBadgeColor = '#35842C';
-export const deploymentBadgeColor = '#0566CA';
-export const cidrBlockBadgeColor = '#008DAB';
-export const externalEntitiesBadgeColor = '#000000';
+export const clusterBadgeColor = 'var(--pf-global--palette--purple-500)';
+export const namespaceBadgeColor = 'var(--pf-global--palette--green-500)';
+export const deploymentBadgeColor = 'var(--pf-global--palette--blue-500)';
+export const cidrBlockBadgeColor = 'var(--pf-global--palette--light-blue-600)';
+export const externalEntitiesBadgeColor = 'var(--pf-global--palette--black-850)';
 
 export function DeploymentIcon(props) {
     return (

--- a/ui/apps/platform/src/css/acs.css
+++ b/ui/apps/platform/src/css/acs.css
@@ -1,21 +1,3 @@
-:root {
-    /*
-    * Global color variables for resource icons based on openshift console styles.
-    * An incomplete list, but should track colors defined in
-    * https://github.com/openshift/console/blob/b3cf77721f1c588fbbb6c795423958c9bd92325b/frontend/public/style/_vars.scss and
-    * https://github.com/openshift/console/blob/7f866284272db0d5898384ff116cea18351c9957/frontend/public/components/_resource.scss
-    * until we are able to share code across projects.
-    */
-    --color-resource-default: var(--pf-global--palette--blue-300);
-    --color-resource-cluster: var(--pf-global--palette--purple-600);
-    --color-resource-namespace: var(--pf-global--palette--green-600);
-    --color-resource-deployment: var(--pf-global--palette--blue-500);
-    --color-resource-secret: var(--pf-global--palette--orange-400);
-    --color-resource-configmap: var(--pf-global--palette--purple-600);
-    /* unknown has no openshift equivalent */
-    --color-resource-unknown: var(--pf-global--palette--black-500);
-}
-
 /*
  * A button with small font size like `isSmall` and reduced padding:
  * 4px instead of 6px vertical


### PR DESCRIPTION
## Description

Thanks to Zhenpeng for selecting colors which have sufficient contrast.

### Residue

1. Refactor the two separate implementations into one.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

**Residue** item 1 aims for decrease in js bundles.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/css/*.css`
        main.css: -447 = 797293 - 797740
        total: -2363 = 1637043 - 1639406
    * `ls -al build/static/css/*.css | wc -l`
        0 = 30 - 30 files
    * `wc build/static/js/*.js`
        main.css: 0 = 3761815 - 3761815
        total: 504 = 9969952 - 9969448
    * `ls -al build/static/js/*.js | wc -l`
        0 = 80 - 80 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/network-graph

    * See insufficient color contrast for CL resource icon before changes.
        ![network-graph_insufficient](https://github.com/stackrox/stackrox/assets/11862657/ec855e95-71f2-4075-8ff1-4f40c2e72a85)

    * See sufficient color contrast for CL resource icon after changes.
        ![network-graph_sufficient](https://github.com/stackrox/stackrox/assets/11862657/d87ec3fd-0993-41d3-8d1f-ae3894e67a88)

    * See **CL** resource icon with `style` attribute.
        ![network-graph_CL](https://github.com/stackrox/stackrox/assets/11862657/335139c9-16be-4da6-96c2-52e4e5cf6c4f)

    * See **CB** resource icon with `style` attribute.
        ![network-graph_CB](https://github.com/stackrox/stackrox/assets/11862657/2f94d0f0-3740-4332-9115-7c7df31a53da)

2. Visit /main/collections and click a click to open a collection page.

    * See **D** resource icon with `style` attribute.
        ![collection_D](https://github.com/stackrox/stackrox/assets/11862657/cf23abf7-3cec-4781-91f3-055109105f70)
