### PR TITLE
ROX-19069: 4.1.3 to verify backward compatiblity

### DIFF
--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -84,9 +84,7 @@ test_upgrade_paths() {
     EARLIER_SHA="fe924fce30bbec4dbd37d731ccd505837a2c2575"
     EARLIER_TAG="3.74.0-1-gfe924fce30"
     # To test we remain backwards compatible rollback to 4.1.x
-    # TODO(ROX-18861): Replace the rollback version to next 4.1 release
-    # We use an engineering build for now until it is available
-    FORCE_ROLLBACK_VERSION="4.1.2-5-gaf845e72a2"
+    FORCE_ROLLBACK_VERSION="4.1.3"
 
     cd "$REPO_FOR_TIME_TRAVEL"
     git checkout "$EARLIER_SHA"


### PR DESCRIPTION
## Description

A policy validation change that broke backwards compatibility to 4.1.2 was back ported to 4.1.3.  So the upgrade test needs to be updated to check backwards compatibility to 4.1.3.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Change is CI, CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
