### PR TITLE
ROX-15277: Fix table output

### DIFF
--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -290,10 +290,10 @@ func printCVESummary(image string, cveSummary map[string]int, out logger.Logger)
 	out.PrintfLn("(%s: %d, %s: %d, %s: %d, %s: %d, %s: %d, %s: %d)\n",
 		totalComponentsMapKey, cveSummary[totalComponentsMapKey],
 		totalVulnerabilitiesMapKey, cveSummary[totalVulnerabilitiesMapKey],
-		lowCVESeverity, cveSummary["LOW"],
-		moderateCVESeverity, cveSummary["MEDIUM"],
-		importantCVESeverity, cveSummary["IMPORTANT"],
-		criticalCVESeverity, cveSummary["CRITICAL"])
+		lowCVESeverity, cveSummary[lowCVESeverity.String()],
+		moderateCVESeverity, cveSummary[moderateCVESeverity.String()],
+		importantCVESeverity, cveSummary[importantCVESeverity.String()],
+		criticalCVESeverity, cveSummary[criticalCVESeverity.String()])
 }
 
 // print warning with amount of CVEs found in components

--- a/roxctl/image/scan/testdata/color_testComponents.txt
+++ b/roxctl/image/scan/testdata/color_testComponents.txt
@@ -1,5 +1,5 @@
 Scan results for image: nginx:test
-(TOTAL-COMPONENTS: 5, TOTAL-VULNERABILITIES: 11, [34;2mLOW[0m: 2, MODERATE: 0, [31mIMPORTANT[0m: 3, [31;1mCRITICAL[0m: 3)
+(TOTAL-COMPONENTS: 5, TOTAL-VULNERABILITIES: 11, [34;2mLOW[0m: 2, MODERATE: 3, [31mIMPORTANT[0m: 3, [31;1mCRITICAL[0m: 3)
 
 +-----------+------------+--------------+-----------+--------------------+
 | COMPONENT |  VERSION   |     CVE      | SEVERITY  |        LINK        |

--- a/roxctl/image/scan/testdata/testComponents.txt
+++ b/roxctl/image/scan/testdata/testComponents.txt
@@ -1,5 +1,5 @@
 Scan results for image: nginx:test
-(TOTAL-COMPONENTS: 5, TOTAL-VULNERABILITIES: 11, LOW: 2, MODERATE: 0, IMPORTANT: 3, CRITICAL: 3)
+(TOTAL-COMPONENTS: 5, TOTAL-VULNERABILITIES: 11, LOW: 2, MODERATE: 3, IMPORTANT: 3, CRITICAL: 3)
 
 +-----------+------------+--------------+-----------+--------------------+
 | COMPONENT |  VERSION   |     CVE      | SEVERITY  |        LINK        |


### PR DESCRIPTION
## Description

The table output summary line previously was missing the number of moderate CVEs.

This is due to us using the wrong key, sadly this has existed for quite some time.

The PR fixes this by using the constants to get the correct string.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see the adjusted unit tests in CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
