### PR TITLE
ROX-19295: Rename fetchClustersAsArray function

### DIFF
--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCards.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCards.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { GridItem } from '@patternfly/react-core';
 
-import { fetchClustersAsArray } from 'services/ClustersService';
+import { fetchClusters } from 'services/ClustersService';
 import { Cluster } from 'types/cluster.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
@@ -22,7 +22,7 @@ const ClustersHealthCards = ({ pollingCount }: ClustersHealthCardsProps): ReactE
 
     useEffect(() => {
         setIsFetching(true);
-        fetchClustersAsArray()
+        fetchClusters()
             .then((clustersFetched) => {
                 setErrorMessageFetching('');
                 // TODO supersede src/Containers/Clusters/clusterTypes.ts with types/cluster.proto.ts

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
@@ -10,7 +10,7 @@ import {
 } from '@patternfly/react-core';
 
 import usePermissions from 'hooks/usePermissions';
-import { fetchClustersAsArray } from 'services/ClustersService';
+import { fetchClusters } from 'services/ClustersService';
 import { DiagnosticBundleRequest } from 'services/DebugService';
 import FilterByStartingTimeValidationMessage from './FilterByStartingTimeValidationMessage';
 
@@ -44,7 +44,7 @@ function DiagnosticBundleForm({
     const hasReadAccessForCluster = hasReadAccess('Cluster');
     useEffect(() => {
         if (hasReadAccessForCluster) {
-            fetchClustersAsArray()
+            fetchClusters()
                 .then((clusters) => {
                     setAvailableClusterOptions(clusters.map(({ name }) => name));
                 })

--- a/ui/apps/platform/src/services/ClustersService.ts
+++ b/ui/apps/platform/src/services/ClustersService.ts
@@ -27,7 +27,7 @@ export type Cluster = {
 /**
  * Fetches list of registered clusters.
  */
-export function fetchClustersAsArray(options?: RestSearchOption[]): Promise<Cluster[]> {
+export function fetchClusters(options?: RestSearchOption[]): Promise<Cluster[]> {
     let queryString = '';
     if (options && options.length !== 0) {
         const query = searchOptionsToQuery(options);


### PR DESCRIPTION
## Description

Follow up task: more consistent name for only 2 calls that remain after deletion of 2 in #7481

The original `fetchClusters` function that called normalizr for sagas was deleted in #6782

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following