### PR TITLE
fix(roxctl): increase retry attempts

### DIFF
--- a/roxctl/common/connection.go
+++ b/roxctl/common/connection.go
@@ -61,7 +61,8 @@ func createGRPCConn(c grpcConfig) (*grpc.ClientConn, error) {
 	const initialBackoffDuration = 100 * time.Millisecond
 	retryOpts := []grpc_retry.CallOption{
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(initialBackoffDuration)),
-		grpc_retry.WithMax(3),
+		// First retry after 100ms, last retry after 51.2s.
+		grpc_retry.WithMax(10),
 	}
 
 	grpcDialOpts := []grpc.DialOption{


### PR DESCRIPTION
## Description

We have consistently observed that `roxctl` calls fail tests due to connectivity issues. The currently configured 3 retries with a maximum backoff of 0.4s might be inadequate. This will not solve all our problems because some of the failures are due to `DeadlineExceeded`, which is not retried at all by gRPC. However, I'm hoping it will reduce the number of `Unavailable` failures. Note that the total retry time is still bounded by the parent context timeout.
