### PR TITLE
fix(roxctl): increase sensor timeouts

### DIFF
--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -244,6 +244,8 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c.PersistentFlags().BoolVar(&ac.Enabled, "admission-controller-enforce-on-creates", false, "dynamic enable for enforcing on object creates in the admission controller")
 	c.PersistentFlags().BoolVar(&ac.EnforceOnUpdates, "admission-controller-enforce-on-updates", false, "dynamic enable for enforcing on object updates in the admission controller")
 
+	flags.AddTimeoutWithDefault(c, 5*time.Minute)
+
 	c.AddCommand(k8s(generateCmd))
 	c.AddCommand(openshift(generateCmd))
 

--- a/roxctl/sensor/getbundle/get_bundle.go
+++ b/roxctl/sensor/getbundle/get_bundle.go
@@ -109,6 +109,8 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 			"Generate deployment files supporting the given Istio version. Valid versions: %s",
 			strings.Join(istioutils.ListKnownIstioVersions(), ", ")))
 
+	flags.AddTimeoutWithDefault(c, 5*time.Minute)
+
 	autobool.NewFlag(c.PersistentFlags(), &slimCollector, "slim-collector", "Use slim collector in deployment bundle")
 
 	return c


### PR DESCRIPTION
## Description

`roxctl sensor generate`/`roxctl sensor get-bundle` involve downloading K8s manifests from Central, which has been observed to time out in tests with a `DeadlineExceeded`. See https://issues.redhat.com/browse/ROX-19204 for an example. To reduce the probability of exceeding the deadline, increase the timeout for this command from the global 1m default to 5m.