### PR TITLE
fix: Disable offline_access checkbox when auth provider is declarative

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -441,7 +441,8 @@ function AuthProviderForm({
                             onBlur={handleBlur}
                             configErrors={errors.config}
                             configTouched={touched.config}
-                            disabled={values.active || getIsAuthProviderImmutable(values)}
+                            isAuthProviderActive={values.active}
+                            isAuthProviderDeclarative={getIsAuthProviderImmutable(values)}
                         />
                     </Grid>
                 </FormSection>

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/ConfigurationFormFields.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/ConfigurationFormFields.tsx
@@ -30,7 +30,7 @@ export type ConfigurationFormFieldsProps = {
     configErrors?: FormikErrors<Record<string, string>>;
     configTouched?: FormikTouched<Record<string, string>>;
     isAuthProviderActive: boolean | undefined;
-    isAuthProviderDeclarative: boolean | undefined;
+    isAuthProviderDeclarative: boolean;
 };
 
 const baseURL = `${window.location.protocol}//${window.location.host}`;
@@ -69,9 +69,9 @@ function ConfigurationFormFields({
     const clientSecretMandatory = config.mode === 'query';
 
     const clientSecretHelperText = getClientSecretHelperText(config, clientSecretSupported);
-    const activeModificationsDisabled = isAuthProviderActive || isAuthProviderDeclarative;
+    const isActiveModificationsDisabled = isAuthProviderActive || isAuthProviderDeclarative;
     const doNotUseClientSecretDisabled =
-        activeModificationsDisabled || !clientSecretSupported || clientSecretMandatory;
+        isActiveModificationsDisabled || !clientSecretSupported || clientSecretMandatory;
 
     const showIssuerError = Boolean(configErrors?.issuer && configTouched?.issuer);
     const showClientIdError = Boolean(configErrors?.client_id && configTouched?.client_id);
@@ -122,7 +122,7 @@ function ConfigurationFormFields({
                                 id="config.issuer"
                                 value={(config.issuer as string) || ''}
                                 onChange={onChange}
-                                isDisabled={isViewing || activeModificationsDisabled}
+                                isDisabled={isViewing || isActiveModificationsDisabled}
                                 isRequired
                                 onBlur={onBlur}
                                 validated={showIssuerError ? ValidatedOptions.error : 'default'}
@@ -142,7 +142,7 @@ function ConfigurationFormFields({
                                 id="config.client_id"
                                 value={(config.client_id as string) || ''}
                                 onChange={onChange}
-                                isDisabled={isViewing || activeModificationsDisabled}
+                                isDisabled={isViewing || isActiveModificationsDisabled}
                                 isRequired
                                 onBlur={onBlur}
                                 validated={showClientIdError ? ValidatedOptions.error : 'default'}
@@ -172,7 +172,7 @@ function ConfigurationFormFields({
                                 id="config.mode"
                                 value={config.mode as string}
                                 handleSelect={updateClientSecretFlagOnChange}
-                                isDisabled={isViewing || activeModificationsDisabled}
+                                isDisabled={isViewing || isActiveModificationsDisabled}
                             >
                                 {oidcCallbackModes.map(({ value, label }) => (
                                     <SelectOption key={value} value={value}>
@@ -203,7 +203,7 @@ function ConfigurationFormFields({
                                 id="config.issuer"
                                 value={(config.issuer as string) || ''}
                                 onChange={onChange}
-                                isDisabled={isViewing || activeModificationsDisabled}
+                                isDisabled={isViewing || isActiveModificationsDisabled}
                                 isRequired
                                 onBlur={onBlur}
                                 validated={showIssuerError ? ValidatedOptions.error : 'default'}
@@ -223,7 +223,7 @@ function ConfigurationFormFields({
                                 id="config.client_id"
                                 value={(config.client_id as string) || ''}
                                 onChange={onChange}
-                                isDisabled={isViewing || activeModificationsDisabled}
+                                isDisabled={isViewing || isActiveModificationsDisabled}
                                 isRequired
                                 onBlur={onBlur}
                                 validated={showClientIdError ? ValidatedOptions.error : 'default'}
@@ -254,7 +254,7 @@ function ConfigurationFormFields({
                                 onChange={onChange}
                                 isDisabled={
                                     isViewing ||
-                                    activeModificationsDisabled ||
+                                    isActiveModificationsDisabled ||
                                     config.mode === 'fragment' ||
                                     !!config.do_not_use_client_secret
                                 }
@@ -347,7 +347,7 @@ function ConfigurationFormFields({
                                 id="config.sp_issuer"
                                 value={(config.sp_issuer as string) || ''}
                                 onChange={onChange}
-                                isDisabled={isViewing || activeModificationsDisabled}
+                                isDisabled={isViewing || isActiveModificationsDisabled}
                                 isRequired
                                 onBlur={onBlur}
                                 validated={showSpIssuerError ? ValidatedOptions.error : 'default'}
@@ -364,7 +364,7 @@ function ConfigurationFormFields({
                                 id="config.configurationType"
                                 value={config.configurationType as string}
                                 handleSelect={setFieldValue}
-                                isDisabled={isViewing || activeModificationsDisabled}
+                                isDisabled={isViewing || isActiveModificationsDisabled}
                             >
                                 <SelectOption value="dynamic">
                                     Option 1: Dynamic configuration
@@ -400,7 +400,7 @@ function ConfigurationFormFields({
                                         id="config.idp_metadata_url"
                                         value={(config.idp_metadata_url as string) || ''}
                                         onChange={onChange}
-                                        isDisabled={isViewing || activeModificationsDisabled}
+                                        isDisabled={isViewing || isActiveModificationsDisabled}
                                         isRequired
                                         onBlur={onBlur}
                                         validated={
@@ -443,7 +443,7 @@ function ConfigurationFormFields({
                                         id="config.idp_issuer"
                                         value={(config.idp_issuer as string) || ''}
                                         onChange={onChange}
-                                        isDisabled={isViewing || activeModificationsDisabled}
+                                        isDisabled={isViewing || isActiveModificationsDisabled}
                                         isRequired={config.configurationType === 'static'}
                                         onBlur={onBlur}
                                         validated={
@@ -475,7 +475,7 @@ function ConfigurationFormFields({
                                         id="config.idp_sso_url"
                                         value={(config.idp_sso_url as string) || ''}
                                         onChange={onChange}
-                                        isDisabled={isViewing || activeModificationsDisabled}
+                                        isDisabled={isViewing || isActiveModificationsDisabled}
                                         isRequired={config.configurationType === 'static'}
                                         onBlur={onBlur}
                                         validated={
@@ -502,7 +502,7 @@ function ConfigurationFormFields({
                                         id="config.idp_nameid_format"
                                         value={(config.idp_nameid_format as string) || ''}
                                         onChange={onChange}
-                                        isDisabled={isViewing || activeModificationsDisabled}
+                                        isDisabled={isViewing || isActiveModificationsDisabled}
                                         onBlur={onBlur}
                                     />
                                 </FormGroup>
@@ -524,7 +524,7 @@ function ConfigurationFormFields({
                                         id="config.idp_cert_pem"
                                         value={(config.idp_cert_pem as string) || ''}
                                         onChange={onChange}
-                                        isDisabled={isViewing || activeModificationsDisabled}
+                                        isDisabled={isViewing || isActiveModificationsDisabled}
                                         isRequired={config.configurationType === 'static'}
                                         placeholder={
                                             '-----BEGIN CERTIFICATE-----\nYour certificate data\n-----END CERTIFICATE-----'
@@ -570,7 +570,7 @@ function ConfigurationFormFields({
                             id="config.keys"
                             value={(config.keys as string) || ''}
                             onChange={onChange}
-                            isDisabled={isViewing || activeModificationsDisabled}
+                            isDisabled={isViewing || isActiveModificationsDisabled}
                             isRequired
                             placeholder={
                                 '-----BEGIN CERTIFICATE-----\nAuthority certificate data\n-----END CERTIFICATE-----'
@@ -603,7 +603,7 @@ function ConfigurationFormFields({
                             id="config.audience"
                             value={(config.audience as string) || ''}
                             onChange={onChange}
-                            isDisabled={isViewing || activeModificationsDisabled}
+                            isDisabled={isViewing || isActiveModificationsDisabled}
                             isRequired
                             onBlur={onBlur}
                             validated={showAudienceError ? ValidatedOptions.error : 'default'}

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/ConfigurationFormFields.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/ConfigurationFormFields.tsx
@@ -29,7 +29,8 @@ export type ConfigurationFormFieldsProps = {
     type: AuthProviderType;
     configErrors?: FormikErrors<Record<string, string>>;
     configTouched?: FormikTouched<Record<string, string>>;
-    disabled: boolean | undefined;
+    isAuthProviderActive: boolean | undefined;
+    isAuthProviderDeclarative: boolean | undefined;
 };
 
 const baseURL = `${window.location.protocol}//${window.location.host}`;
@@ -61,14 +62,16 @@ function ConfigurationFormFields({
     type,
     configErrors,
     configTouched,
-    disabled = false,
+    isAuthProviderActive = false,
+    isAuthProviderDeclarative = false,
 }: ConfigurationFormFieldsProps): ReactElement {
     const clientSecretSupported = config.mode !== 'fragment';
     const clientSecretMandatory = config.mode === 'query';
 
     const clientSecretHelperText = getClientSecretHelperText(config, clientSecretSupported);
+    const activeModificationsDisabled = isAuthProviderActive || isAuthProviderDeclarative;
     const doNotUseClientSecretDisabled =
-        disabled || !clientSecretSupported || clientSecretMandatory;
+        activeModificationsDisabled || !clientSecretSupported || clientSecretMandatory;
 
     const showIssuerError = Boolean(configErrors?.issuer && configTouched?.issuer);
     const showClientIdError = Boolean(configErrors?.client_id && configTouched?.client_id);
@@ -119,7 +122,7 @@ function ConfigurationFormFields({
                                 id="config.issuer"
                                 value={(config.issuer as string) || ''}
                                 onChange={onChange}
-                                isDisabled={isViewing || disabled}
+                                isDisabled={isViewing || activeModificationsDisabled}
                                 isRequired
                                 onBlur={onBlur}
                                 validated={showIssuerError ? ValidatedOptions.error : 'default'}
@@ -139,7 +142,7 @@ function ConfigurationFormFields({
                                 id="config.client_id"
                                 value={(config.client_id as string) || ''}
                                 onChange={onChange}
-                                isDisabled={isViewing || disabled}
+                                isDisabled={isViewing || activeModificationsDisabled}
                                 isRequired
                                 onBlur={onBlur}
                                 validated={showClientIdError ? ValidatedOptions.error : 'default'}
@@ -169,7 +172,7 @@ function ConfigurationFormFields({
                                 id="config.mode"
                                 value={config.mode as string}
                                 handleSelect={updateClientSecretFlagOnChange}
-                                isDisabled={isViewing || disabled}
+                                isDisabled={isViewing || activeModificationsDisabled}
                             >
                                 {oidcCallbackModes.map(({ value, label }) => (
                                     <SelectOption key={value} value={value}>
@@ -200,7 +203,7 @@ function ConfigurationFormFields({
                                 id="config.issuer"
                                 value={(config.issuer as string) || ''}
                                 onChange={onChange}
-                                isDisabled={isViewing || disabled}
+                                isDisabled={isViewing || activeModificationsDisabled}
                                 isRequired
                                 onBlur={onBlur}
                                 validated={showIssuerError ? ValidatedOptions.error : 'default'}
@@ -220,7 +223,7 @@ function ConfigurationFormFields({
                                 id="config.client_id"
                                 value={(config.client_id as string) || ''}
                                 onChange={onChange}
-                                isDisabled={isViewing || disabled}
+                                isDisabled={isViewing || activeModificationsDisabled}
                                 isRequired
                                 onBlur={onBlur}
                                 validated={showClientIdError ? ValidatedOptions.error : 'default'}
@@ -251,7 +254,7 @@ function ConfigurationFormFields({
                                 onChange={onChange}
                                 isDisabled={
                                     isViewing ||
-                                    disabled ||
+                                    activeModificationsDisabled ||
                                     config.mode === 'fragment' ||
                                     !!config.do_not_use_client_secret
                                 }
@@ -302,7 +305,7 @@ function ConfigurationFormFields({
                                 onChange={(checked) => {
                                     setFieldValue('config.disable_offline_access_scope', checked);
                                 }}
-                                isDisabled={isViewing}
+                                isDisabled={isViewing || isAuthProviderDeclarative}
                             />
                         </FormGroup>
                     </GridItem>
@@ -344,7 +347,7 @@ function ConfigurationFormFields({
                                 id="config.sp_issuer"
                                 value={(config.sp_issuer as string) || ''}
                                 onChange={onChange}
-                                isDisabled={isViewing || disabled}
+                                isDisabled={isViewing || activeModificationsDisabled}
                                 isRequired
                                 onBlur={onBlur}
                                 validated={showSpIssuerError ? ValidatedOptions.error : 'default'}
@@ -361,7 +364,7 @@ function ConfigurationFormFields({
                                 id="config.configurationType"
                                 value={config.configurationType as string}
                                 handleSelect={setFieldValue}
-                                isDisabled={isViewing || disabled}
+                                isDisabled={isViewing || activeModificationsDisabled}
                             >
                                 <SelectOption value="dynamic">
                                     Option 1: Dynamic configuration
@@ -397,7 +400,7 @@ function ConfigurationFormFields({
                                         id="config.idp_metadata_url"
                                         value={(config.idp_metadata_url as string) || ''}
                                         onChange={onChange}
-                                        isDisabled={isViewing || disabled}
+                                        isDisabled={isViewing || activeModificationsDisabled}
                                         isRequired
                                         onBlur={onBlur}
                                         validated={
@@ -440,7 +443,7 @@ function ConfigurationFormFields({
                                         id="config.idp_issuer"
                                         value={(config.idp_issuer as string) || ''}
                                         onChange={onChange}
-                                        isDisabled={isViewing || disabled}
+                                        isDisabled={isViewing || activeModificationsDisabled}
                                         isRequired={config.configurationType === 'static'}
                                         onBlur={onBlur}
                                         validated={
@@ -472,7 +475,7 @@ function ConfigurationFormFields({
                                         id="config.idp_sso_url"
                                         value={(config.idp_sso_url as string) || ''}
                                         onChange={onChange}
-                                        isDisabled={isViewing || disabled}
+                                        isDisabled={isViewing || activeModificationsDisabled}
                                         isRequired={config.configurationType === 'static'}
                                         onBlur={onBlur}
                                         validated={
@@ -499,7 +502,7 @@ function ConfigurationFormFields({
                                         id="config.idp_nameid_format"
                                         value={(config.idp_nameid_format as string) || ''}
                                         onChange={onChange}
-                                        isDisabled={isViewing || disabled}
+                                        isDisabled={isViewing || activeModificationsDisabled}
                                         onBlur={onBlur}
                                     />
                                 </FormGroup>
@@ -521,7 +524,7 @@ function ConfigurationFormFields({
                                         id="config.idp_cert_pem"
                                         value={(config.idp_cert_pem as string) || ''}
                                         onChange={onChange}
-                                        isDisabled={isViewing || disabled}
+                                        isDisabled={isViewing || activeModificationsDisabled}
                                         isRequired={config.configurationType === 'static'}
                                         placeholder={
                                             '-----BEGIN CERTIFICATE-----\nYour certificate data\n-----END CERTIFICATE-----'
@@ -567,7 +570,7 @@ function ConfigurationFormFields({
                             id="config.keys"
                             value={(config.keys as string) || ''}
                             onChange={onChange}
-                            isDisabled={isViewing || disabled}
+                            isDisabled={isViewing || activeModificationsDisabled}
                             isRequired
                             placeholder={
                                 '-----BEGIN CERTIFICATE-----\nAuthority certificate data\n-----END CERTIFICATE-----'
@@ -600,7 +603,7 @@ function ConfigurationFormFields({
                             id="config.audience"
                             value={(config.audience as string) || ''}
                             onChange={onChange}
-                            isDisabled={isViewing || disabled}
+                            isDisabled={isViewing || activeModificationsDisabled}
                             isRequired
                             onBlur={onBlur}
                             validated={showAudienceError ? ValidatedOptions.error : 'default'}


### PR DESCRIPTION
## Description

Even though this checkbox does not change anything, it's still better to disable it so that UI would be consistent.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Manually tested 
<img width="1784" alt="Screenshot 2023-08-25 at 17 08 05" src="https://github.com/stackrox/stackrox/assets/78353299/3646dce8-a78b-4517-9114-f7c6b7327bfa">


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
