### PR TITLE
ROX-19233: Fix verify connections from external sources

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -497,7 +497,7 @@ class NetworkFlowTest extends BaseSpecification {
             throw new RuntimeException("Unexpected OrchestratorType")
         }
 
-        when:
+        expect:
         "Check for edge in network graph"
         withRetry(5, 20) {
             log.info "Generate traffic to the target deployment ${NGINXCONNECTIONTARGET}"

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -1,8 +1,6 @@
 import static io.restassured.RestAssured.given
 import static util.Helpers.withRetry
 
-import java.util.concurrent.TimeUnit
-
 import io.grpc.StatusRuntimeException
 import io.restassured.response.Response
 import orchestratormanager.OrchestratorTypes
@@ -34,8 +32,6 @@ import util.NetworkGraphUtil
 import util.Timer
 
 import org.junit.Assume
-import org.junit.Rule
-import org.junit.rules.Timeout
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Shared
@@ -209,11 +205,6 @@ class NetworkFlowTest extends BaseSpecification {
         DEPLOYMENTS.add(icmp)
         */
     }
-
-    // Overwrite the default timeout, as these tests may take longer than 800 seconds to finish.
-    @Rule
-    @SuppressWarnings(["JUnitPublicProperty"])
-    Timeout globalTimeout = new Timeout(1600, TimeUnit.SECONDS)
 
     def setupSpec() {
         orchestrator.createNamespace(OTHER_NAMESPACE)

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -533,7 +533,7 @@ class NetworkFlowTest extends BaseSpecification {
                 }
                 log.warn("Edge coming from OpenShift ingress router to ${deploymentUid} not found")
                 // Debug dump of all router edges
-                currentGraph = NetworkGraphService.getNetworkGraph()
+                def currentGraph = NetworkGraphService.getNetworkGraph()
                 def index = currentGraph.nodesList.findIndexOf { node -> node.deploymentName == defaultRouterId }
                 List<NetworkNode> outNodesRouter = currentGraph.nodesList.findAll { node ->
                     node.outEdgesMap.containsKey(index)
@@ -546,7 +546,7 @@ class NetworkFlowTest extends BaseSpecification {
                     NetworkGraphUtil.checkForEdge(Constants.INTERNET_EXTERNAL_SOURCE_ID, deploymentUid, null, 180)
             if (edges == null || edges.size() == 0) {
                 // Debug dump of all INTERNET_EXTERNAL_SOURCE_ID edges
-                currentGraph = NetworkGraphService.getNetworkGraph()
+                def currentGraph = NetworkGraphService.getNetworkGraph()
                 def index = currentGraph.nodesList.findIndexOf {
                     node -> node.deploymentName == Constants.INTERNET_EXTERNAL_SOURCE_ID
                 }

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -539,7 +539,6 @@ class NetworkFlowTest extends BaseSpecification {
                     node.outEdgesMap.containsKey(index)
                 }
                 log.debug("All edges of 'router-default' ${defaultRouterId}: ${outNodesRouter}")
-
             }
             log.info("Searching for edge coming from INTERNET_EXTERNAL_SOURCE_ID " +
                 "(${Constants.INTERNET_EXTERNAL_SOURCE_ID}) to ${deploymentUid}")

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -554,7 +554,7 @@ class NetworkFlowTest extends BaseSpecification {
                 "(${Constants.INTERNET_EXTERNAL_SOURCE_ID}) to ${deploymentUid}")
             List<Edge> edges =
                     NetworkGraphUtil.checkForEdge(Constants.INTERNET_EXTERNAL_SOURCE_ID, deploymentUid, null, 180)
-            if (edges == null && edges.size() == 0) {
+            if (edges == null || edges.size() == 0) {
                 // Debug dump of all INTERNET_EXTERNAL_SOURCE_ID edges
                 currentGraph = NetworkGraphService.getNetworkGraph()
                 def index = currentGraph.nodesList.findIndexOf {

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -497,24 +497,23 @@ class NetworkFlowTest extends BaseSpecification {
             throw new RuntimeException("Unexpected OrchestratorType")
         }
 
-        when:
-        "ping the target deployment"
-        Response response = null
-        Timer t = new Timer(12, 5)
-        while (response?.statusCode() != 200 && t.IsValid()) {
-            try {
-                log.info "trying ${targetUrl}..."
-                response = given().get(targetUrl)
-            } catch (Exception e) {
-                log.warn("Failure calling ${targetUrl}. Trying again in 5 sec...", e)
-            }
-        }
-        assert response?.getStatusCode() == 200
-        log.info response.asString()
-
         then:
         "Check for edge in network graph"
         withRetry(5, 20) {
+            log.info "Generate traffic to the target deployment ${NGINXCONNECTIONTARGET}"
+            Response response = null
+            Timer t = new Timer(12, 5)
+            while (response?.statusCode() != 200 && t.IsValid()) {
+                try {
+                    log.info "trying ${targetUrl}..."
+                    response = given().get(targetUrl)
+                } catch (Exception e) {
+                    log.warn("Failure calling ${targetUrl}. Trying again in 5 sec...", e)
+                }
+            }
+            assert response?.getStatusCode() == 200
+            log.info response.asString()
+
             log.info "Checking for edge from external to ${NGINXCONNECTIONTARGET}"
 
             // Only on OpenShift 4.12, the edge will not show from EXTERNAL_SOURCE, but instead from

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -32,6 +32,7 @@ import util.NetworkGraphUtil
 import util.Timer
 
 import org.junit.Assume
+import org.junit.Rule
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Shared

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -478,6 +478,10 @@ class NetworkFlowTest extends BaseSpecification {
         assert edges
     }
 
+    // Overwrite the default timeout, as these tests may take longer than 800 seconds to finish.
+    @Rule
+    @SuppressWarnings(["JUnitPublicProperty"])
+    org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(1600, TimeUnit.SECONDS)
     @Tag("NetworkFlowVisualization")
     def "Verify connections from external sources"() {
         given:
@@ -521,6 +525,7 @@ class NetworkFlowTest extends BaseSpecification {
             // router-default deployment in openshift-ingress namespace.
             List<Edge> routerDefaultEdges = null
             if (ClusterService.isOpenShift4()) {
+                log.info("Searching for edge coming from OpenShift ingress router to ${deploymentUid}")
                 SearchServiceOuterClass.RawQuery query = SearchServiceOuterClass.RawQuery.newBuilder()
                         .setQuery("Namespace:openshift-ingress")
                         .build()
@@ -530,11 +535,29 @@ class NetworkFlowTest extends BaseSpecification {
                 if (routerDefaultEdges != null) {
                     log.info("Found edge coming from OpenShift ingress router")
                     return
+                } else {
+                    log.warn("Edge coming from OpenShift ingress router to ${deploymentUid} not found")
+                    // Debug dump of all router edges
+                    currentGraph = NetworkGraphService.getNetworkGraph()
+                    def index = currentGraph.nodesList.findIndexOf { node -> node.deploymentName == defaultRouterId }
+                    List<NetworkNode> outNodesRouter = currentGraph.nodesList.findAll { node ->
+                        node.outEdgesMap.containsKey(index)
+                    }
+                    log.debug("All edges of 'router-default' ${defaultRouterId}: ${outNodesRouter}")
                 }
             }
+            log.info("Searching for edge coming from INTERNET_EXTERNAL_SOURCE_ID (${Constants.INTERNET_EXTERNAL_SOURCE_ID}) to ${deploymentUid}")
             List<Edge> edges =
                     NetworkGraphUtil.checkForEdge(Constants.INTERNET_EXTERNAL_SOURCE_ID, deploymentUid, null, 180)
-
+            if (edges == null && edges.size() == 0) {
+                // Debug dump of all INTERNET_EXTERNAL_SOURCE_ID edges
+                currentGraph = NetworkGraphService.getNetworkGraph()
+                def index = currentGraph.nodesList.findIndexOf { node -> node.deploymentName == Constants.INTERNET_EXTERNAL_SOURCE_ID }
+                List<NetworkNode> outNodes = currentGraph.nodesList.findAll { node ->
+                    node.outEdgesMap.containsKey(index)
+                }
+                log.debug("All edges of 'INTERNET_EXTERNAL_SOURCE_ID' ${Constants.INTERNET_EXTERNAL_SOURCE_ID}: ${outNodes}")
+            }
             assert edges
         }
     }

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -499,14 +499,14 @@ class NetworkFlowTest extends BaseSpecification {
 
         when:
         log.info "Generate initial traffic to the target deployment ${NGINXCONNECTIONTARGET}"
-        def initialResponse = doHTTPGetExpectCode(targetUrl,200)
+        def initialResponse = doHTTPGetExpectCode(targetUrl, 200)
         assert initialResponse?.getStatusCode() == 200
 
         then:
         "Check for edge in network graph"
         withRetry(5, 20) {
             log.info "Retry traffic to the target deployment ${NGINXCONNECTIONTARGET}"
-            def response = doHTTPGetExpectCode(targetUrl,200)
+            def response = doHTTPGetExpectCode(targetUrl, 200)
             assert response?.getStatusCode() == 200
 
             log.info "Checking for edge from external to ${NGINXCONNECTIONTARGET}"

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -535,32 +535,36 @@ class NetworkFlowTest extends BaseSpecification {
                         .build()
                 def ingressDeployments = DeploymentService.listDeploymentsSearch(query).deploymentsList
                 def defaultRouterId = ingressDeployments.find { it.getName() == "router-default" }.id
-                List<Edge> routerDefaultEdges = NetworkGraphUtil.checkForEdge(defaultRouterId, deploymentUid, null, 180)
-                if (routerDefaultEdges != null) {
+                def rEdges = NetworkGraphUtil.checkForEdge(defaultRouterId, deploymentUid, null, 180)
+                if (rEdges != null) {
                     log.info("Found edge coming from OpenShift ingress router")
                     return
-                } else {
-                    log.warn("Edge coming from OpenShift ingress router to ${deploymentUid} not found")
-                    // Debug dump of all router edges
-                    currentGraph = NetworkGraphService.getNetworkGraph()
-                    def index = currentGraph.nodesList.findIndexOf { node -> node.deploymentName == defaultRouterId }
-                    List<NetworkNode> outNodesRouter = currentGraph.nodesList.findAll { node ->
-                        node.outEdgesMap.containsKey(index)
-                    }
-                    log.debug("All edges of 'router-default' ${defaultRouterId}: ${outNodesRouter}")
                 }
+                log.warn("Edge coming from OpenShift ingress router to ${deploymentUid} not found")
+                // Debug dump of all router edges
+                currentGraph = NetworkGraphService.getNetworkGraph()
+                def index = currentGraph.nodesList.findIndexOf { node -> node.deploymentName == defaultRouterId }
+                List<NetworkNode> outNodesRouter = currentGraph.nodesList.findAll { node ->
+                    node.outEdgesMap.containsKey(index)
+                }
+                log.debug("All edges of 'router-default' ${defaultRouterId}: ${outNodesRouter}")
+
             }
-            log.info("Searching for edge coming from INTERNET_EXTERNAL_SOURCE_ID (${Constants.INTERNET_EXTERNAL_SOURCE_ID}) to ${deploymentUid}")
+            log.info("Searching for edge coming from INTERNET_EXTERNAL_SOURCE_ID " +
+                "(${Constants.INTERNET_EXTERNAL_SOURCE_ID}) to ${deploymentUid}")
             List<Edge> edges =
                     NetworkGraphUtil.checkForEdge(Constants.INTERNET_EXTERNAL_SOURCE_ID, deploymentUid, null, 180)
             if (edges == null && edges.size() == 0) {
                 // Debug dump of all INTERNET_EXTERNAL_SOURCE_ID edges
                 currentGraph = NetworkGraphService.getNetworkGraph()
-                def index = currentGraph.nodesList.findIndexOf { node -> node.deploymentName == Constants.INTERNET_EXTERNAL_SOURCE_ID }
+                def index = currentGraph.nodesList.findIndexOf {
+                    node -> node.deploymentName == Constants.INTERNET_EXTERNAL_SOURCE_ID
+                }
                 List<NetworkNode> outNodes = currentGraph.nodesList.findAll { node ->
                     node.outEdgesMap.containsKey(index)
                 }
-                log.debug("All edges of 'INTERNET_EXTERNAL_SOURCE_ID' ${Constants.INTERNET_EXTERNAL_SOURCE_ID}: ${outNodes}")
+                log.debug("All edges of 'INTERNET_EXTERNAL_SOURCE_ID' " +
+                    "${Constants.INTERNET_EXTERNAL_SOURCE_ID}: ${outNodes}")
             }
             assert edges
         }

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -497,7 +497,7 @@ class NetworkFlowTest extends BaseSpecification {
             throw new RuntimeException("Unexpected OrchestratorType")
         }
 
-        then:
+        when:
         "Check for edge in network graph"
         withRetry(5, 20) {
             log.info "Generate traffic to the target deployment ${NGINXCONNECTIONTARGET}"

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -1,6 +1,8 @@
 import static io.restassured.RestAssured.given
 import static util.Helpers.withRetry
 
+import java.util.concurrent.TimeUnit
+
 import io.grpc.StatusRuntimeException
 import io.restassured.response.Response
 import orchestratormanager.OrchestratorTypes
@@ -207,6 +209,11 @@ class NetworkFlowTest extends BaseSpecification {
         DEPLOYMENTS.add(icmp)
         */
     }
+
+    // Overwrite the default timeout, as these tests may take longer than 800 seconds to finish.
+    @Rule
+    @SuppressWarnings(["JUnitPublicProperty"])
+    Timeout globalTimeout = new Timeout(1600, TimeUnit.SECONDS)
 
     def setupSpec() {
         orchestrator.createNamespace(OTHER_NAMESPACE)
@@ -480,10 +487,6 @@ class NetworkFlowTest extends BaseSpecification {
         assert edges
     }
 
-    // Overwrite the default timeout, as these tests may take longer than 800 seconds to finish.
-    @Rule
-    @SuppressWarnings(["JUnitPublicProperty"])
-    Timeout globalTimeout = new Timeout(1600, TimeUnit.SECONDS)
     @Tag("NetworkFlowVisualization")
     def "Verify connections from external sources"() {
         given:


### PR DESCRIPTION
## Description

Not yet sure how to fix that flake, as I am still trying to reproduce it... This description will be updated once a solution is found.

### So far I tried/observed the following

1. Was unable to increase the timeout of 800s to 1600s - the solution using `Timeout globalTimeout = new Timeout(1600, TimeUnit.SECONDS)` does not help.

[CI log](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/7600/pull-ci-stackrox-stackrox-master-ocp-4-13-qa-e2e-tests/1696188892962623488)
```
18:28:17 | DEBUG | NetworkFlowTest           | NetworkGraphUtil          | Checking for edge between deployments: sourceId 104a577f-c658-4212-bdfa-b8e2b75bbfbf, targetId 81bb672b-541f-4165-9836-a08be4289b8c
18:28:17 | DEBUG | NetworkFlowTest           | NetworkGraphUtil          | Looking at edges for 1 source node(s)
18:28:18 | DEBUG | NetworkFlowTest           | NetworkGraphUtil          | Checking for edge between deployments: sourceId 104a577f-c658-4212-bdfa-b8e2b75bbfbf, targetId 81bb672b-541f-4165-9836-a08be4289b8c
18:28:18 | DEBUG | NetworkFlowTest           | NetworkGraphUtil          | Looking at edges for 1 source node(s)
18:28:20 | DEBUG | NetworkFlowTest           | NetworkGraphUtil          | Checking for edge between deployments: sourceId 104a577f-c658-4212-bdfa-b8e2b75bbfbf, targetId 81bb672b-541f-4165-9836-a08be4289b8c
18:28:20 | DEBUG | NetworkFlowTest           | NetworkGraphUtil          | Looking at edges for 1 source node(s)
18:28:20 | WARN  | NetworkFlowTest           | NetworkGraphUtil          | SR did not detect the edge in Network Flow graph
18:28:20 | WARN  | NetworkFlowTest           | NetworkFlowTest           | Edge coming from OpenShift ingress router to 81bb672b-541f-4165-9836-a08be4289b8c not found
18:28:20 | ERROR | NetworkFlowTest           | Helpers                   | An exception occurred in test
(...)
18:31:38 | INFO  | NetworkFlowTest           | NetworkFlowTest           | Ending testcase
NetworkFlowTest > Verify connections from external sources FAILED
org.junit.runners.model.TestTimedOutException: test timed out after 1600 seconds
```

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- This is a CI flake, so I will try to demonstrate that it does not happens again. This will happen through rerunning the affected test (`ocp-4-13-qa-e2e-tests` or `ocp-4-10-qa-e2e-tests`) several times and looking if the test got executed and passed.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
