### PR TITLE
fix(ci): allow missing dir in artifact store

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -431,7 +431,7 @@ function launch_central {
     # On some systems there's a race condition when port-forward connects to central but its pod then gets deleted due
     # to ongoing modifications to the central deployment. This port-forward dies and the script hangs "Waiting for
     # Central to respond" until it times out. Waiting for rollout status should help not get into such situation.
-    rollout_wait_timeout="4m"
+    rollout_wait_timeout="10s"
     if [[ "${IS_RACE_BUILD:-}" == "true" ]]; then
       rollout_wait_timeout="9m"
     fi

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -431,7 +431,7 @@ function launch_central {
     # On some systems there's a race condition when port-forward connects to central but its pod then gets deleted due
     # to ongoing modifications to the central deployment. This port-forward dies and the script hangs "Waiting for
     # Central to respond" until it times out. Waiting for rollout status should help not get into such situation.
-    rollout_wait_timeout="10s"
+    rollout_wait_timeout="4m"
     if [[ "${IS_RACE_BUILD:-}" == "true" ]]; then
       rollout_wait_timeout="9m"
     fi


### PR DESCRIPTION
## Description

Per title. The recent change to store some artifacts in OSCI storage (versus GCS) did not follow the same semantics as the other post scripts i.e. `run_with_best_effort()`. This change only copies when the source dir exists and changes the overall handling to follow that best effort approach.

This PR stems from failures like [this](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-qa-e2e-tests/1695115680392679424) where the post process gets short circuited by this bug and the full suite of debug logs are not gathered.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] cause a failure similar to [this](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-qa-e2e-tests/1695115680392679424) and verify artifacts are available.
- [x] happy path