### PR TITLE
fix(ui): Fix bug in delegated regestries path editing

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
@@ -261,6 +261,8 @@ function DelegatedRegistriesTable({
                                 <TextInput
                                     isRequired
                                     type="text"
+                                    id={`${registry.uuid as string}-path-input`}
+                                    name={`${registry.uuid as string}-path-input`}
                                     value={registry.path}
                                     onChange={(value) => handlePathChange(rowIndex, value)}
                                 />

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -38,10 +38,18 @@ const initialDelegatedState: DelegatedRegistryConfig = {
     registries: [],
 };
 
+function getUuid() {
+    const MAX_RANDOM = 1000000;
+
+    // eslint-disable-next-line no-restricted-globals
+    const uuid = self?.crypto?.randomUUID() ?? Math.floor(Math.random() * MAX_RANDOM).toString();
+
+    return uuid;
+}
+
 function addUuidstoRegistries(config: DelegatedRegistryConfig) {
     const newRegistries = config.registries.map((registry) => {
-        // eslint-disable-next-line no-restricted-globals
-        const uuid = self.crypto.randomUUID();
+        const uuid = getUuid();
 
         return {
             path: registry.path,
@@ -140,12 +148,11 @@ function DelegateScanningPage() {
     function addRegistryRow() {
         const newState: DelegatedRegistryConfig = { ...delegatedRegistryConfig };
 
-        // eslint-disable-next-line no-restricted-globals
-        const uuid = self.crypto.randomUUID();
+        const uuid = getUuid();
 
         newState.registries.push({
             path: '',
-            clusterId: delegatedRegistryConfig.defaultClusterId,
+            clusterId: '',
             uuid,
         });
 
@@ -170,6 +177,7 @@ function DelegateScanningPage() {
                 return {
                     path: value,
                     clusterId: registry.clusterId,
+                    uuid: registry.uuid,
                 };
             }
 
@@ -189,6 +197,7 @@ function DelegateScanningPage() {
                 return {
                     path: registry.path,
                     clusterId: value,
+                    uuid: registry.uuid,
                 };
             }
 


### PR DESCRIPTION
## Description

### Problem:
The first character you type in one of the Pathname fields, causes that input to lose focus. Clicking back into it allows you to type as many more characters as you like without losing focus. But if you leave that field (click out, tab out) and then focus it again, then the next character you type also causes it to lose focus.

### Solution:
While trying to add drag and drop to the table (which has been removed for now, due to buggy behavior of the PatternFly component, I had added UUIDs to the table rows. However, I forgot to perpetuate the UUID in the change handler for the path input.

Changes:
- now perpetuate the UUID in the change handler for the path input
- also perpetuate the UUID in the change handler for the row's selected cluster input (provides no obvious benefit in the UX) but keeps the handler pattern consistent

Related changes:
- added a guard for the UUID generation code, on the rare chance that someone tries to use the system in a very old browser, so that page doesn't crash
- added the ID and Name attributes back to the PatternFly text input, because they had been inadvertently deleted

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Validated that path inputs no longer loose focus after typing first character