### PR TITLE
fix(qa-tests): add timeout and retry to diag bundle call

### DIFF
--- a/qa-tests-backend/src/test/groovy/DiagnosticBundleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DiagnosticBundleTest.groovy
@@ -1,4 +1,5 @@
 import static io.restassured.RestAssured.given
+import static util.Helpers.evaluateWithRetry
 
 import java.time.Instant
 import java.util.zip.ZipEntry
@@ -6,12 +7,7 @@ import java.util.zip.ZipInputStream
 
 import io.restassured.RestAssured
 import io.restassured.config.HttpClientConfig
-import io.restassured.config.HttpClientConfig.HttpClientFactory
 import io.restassured.config.SSLConfig
-
-import org.apache.http.client.HttpClient
-import org.apache.http.impl.client.StandardHttpRequestRetryHandler
-import org.apache.http.impl.client.SystemDefaultHttpClient
 
 import io.stackrox.proto.api.v1.ApiTokenService.GenerateTokenResponse
 import io.stackrox.proto.storage.RoleOuterClass
@@ -106,32 +102,24 @@ class DiagnosticBundleTest extends BaseSpecification {
             headers.put("Authorization", "Bearer " + token)
         }
 
-        def response = given()
-            .config(RestAssured.config()
-                .httpClient(HttpClientConfig.httpClientConfig()
-                    .httpClientFactory(new HttpClientFactory() {
-            @Override
-            HttpClient createHttpClient() {
-                HttpClient httpClient = new SystemDefaultHttpClient()
-                // Retry 10 times on [InterruptedIOException, UnknownHostException, ConnectException,
-                // SSLException].
-                httpClient.setHttpRequestRetryHandler(new StandardHttpRequestRetryHandler(10, true))
-                return httpClient
-            }
-                    })
-                    // Times out after 1 minute of trying to establish a connection.
-                    .setParam("http.connection.timeout", 60000)
-                    // Times out after 5 minutes of connection inactivity.
-                    .setParam("http.socket.timeout", 300000)
+        def response = evaluateWithRetry(10, 10) {
+            return given()
+                .config(RestAssured.config()
+                    .httpClient(HttpClientConfig.httpClientConfig()
+                        // Times out after 1 minute of trying to establish a connection.
+                        .setParam("http.connection.timeout", 60000)
+                        // Times out after 5 minutes of connection inactivity.
+                        .setParam("http.socket.timeout", 300000)
+                    )
+                    .sslConfig(SSLConfig.sslConfig()
+                        .relaxedHTTPSValidation()
+                        .allowAllHostnames()
+                    )
                 )
-                .sslConfig(SSLConfig.sslConfig()
-                    .relaxedHTTPSValidation()
-                    .allowAllHostnames()
-                )
-            )
-            .headers(headers)
-            .when()
-            .get("https://${Env.mustGetHostname()}:${Env.mustGetPort()}/api/extensions/diagnostics")
+                .headers(headers)
+                .when()
+                .get("https://${Env.mustGetHostname()}:${Env.mustGetPort()}/api/extensions/diagnostics")
+        }
 
         then:
         "Check that response is as expected"


### PR DESCRIPTION
## Description

In https://issues.redhat.com/browse/ROX-19182 we observed the generic test timeout (`800s`) being hit. Upon investigation, I realized that the http client in the test has no timeouts and does not retry on connection issues. Therefore this PR adds:

* connection and read timeouts to indicate the type of issue more clearly.
* a retry handler for retry-able errors.