### PR TITLE
ROX-19320: Use quay.io instead of docker

### DIFF
--- a/qa-tests-backend/src/test/groovy/Enforcement.groovy
+++ b/qa-tests-backend/src/test/groovy/Enforcement.groovy
@@ -462,8 +462,8 @@ class Enforcement extends BaseSpecification {
         and:
         "Request Image Scan"
         def scanResults = Services.requestBuildImageScan(
-                "docker.io",
-                "library/nginx",
+                "quay.io",
+                "rhacs-eng/qa",
                 "latest"
         )
 


### PR DESCRIPTION
## Description

docker.io is rate limited. We should switch to quay.io where possible.

- https://github.com/stackrox/stackrox/commit/01e52f7ed35acefa36f1d82ba6ad9eacb6250475#diff-9dcde8ab453f7c9b245fc4376c28fd3914a380a7cc995d93c0f29bc1003ed625R369-R370

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
