### PR TITLE
chore(docs): ACS API guidelines - Part 1: Naming convention

### DIFF
--- a/.github/api_best_practices.md
+++ b/.github/api_best_practices.md
@@ -8,26 +8,28 @@ in slack channel [#forum-acs-api-design](https://redhat-internal.slack.com/archi
 ## Table of Contents
 
 - [Naming Guidelines](#naming-guidelines)
-  - [Service Name](#service-name)
-  - [RPC Method Name](#rpc-method-name)
-  - [RPC Message Name](#rpc-message-name)
+  - [gRPC Service Name](#grpc-service-name)
+  - [gRPC Method Name](#grpc-method-name)
+  - [gRPC Message Name](#grpc-message-name)
 
 ## Naming Guidelines
 
-### Service Name
+### gRPC Service Name
 Service name **must** be unique and should use a noun that generally refers to a resource or product component 
 e.g. `DeploymentService`, `ReportService`, `ComplianceService`. Intuitive and well-known short forms or 
 abbreviations may be used in some cases (and could even be preferable) for succinctness 
 e.g. `ReportConfigService`, `RbacService`. 
-All RPC methods grouped into a single service must generally pertain to the primary resource of the service.
+All gRPC methods grouped into a single service must generally pertain to the primary resource of the service.
 
-All service defined in versioned package [/proto/api/v2](https://github.com/stackrox/stackrox/blob/master/proto/v2)
+Note:
+- All service defined in versioned package [/proto/api/v2](https://github.com/stackrox/stackrox/blob/master/proto/v2)
 **must not** import from [/proto/storage](https://github.com/stackrox/stackrox/blob/master/proto/storage) and
 [/proto/internalapi](https://github.com/stackrox/stackrox/blob/master/proto/internalapi) packages.
-All new RPC methods defined in versioned package [/proto/api/v1](https://github.com/stackrox/stackrox/blob/master/proto/v1) **must not** import from
-`/proto/storage` and `/proto/internalapi` packages.
+- All new gRPC methods defined in versioned package [/proto/api/v1](https://github.com/stackrox/stackrox/blob/master/proto/v1) 
+**must not** import from `/proto/storage` and `/proto/internalapi` packages.
+- All services of the type `APIServiceWithCustomRoutes` **must not** import from `/proto/storage` and `/proto/internalapi` packages.
 
-### RPC Method Name
+### gRPC Method Name
 Methods should be named such that they provide insights into the functionality. Typically, the method 
 name should follow the _VerbNoun_ convention. For example, `StartComplianceScan`, `RunComplianceScan`, 
 and `GetComplianceScan` are not the same. `StartComplianceScan` must return without waiting for the compliance 
@@ -142,7 +144,7 @@ GetBaselineNetworkPolicyRequest {
 </tr>
 </table>
 
-### RPC Message Name
+### gRPC Message Name
 The request and response messages **must** be named after method names with suffix `Request` and `Response` unless 
 the request/response type is an empty message. Generally, resource type as response message should be avoided 
 e.g. use `GetDeploymentResponse` response instead of `Deployment`. This allows augmenting the response with 

--- a/.github/api_best_practices.md
+++ b/.github/api_best_practices.md
@@ -1,0 +1,196 @@
+# ACS API Guidelines
+An overview of the set of standardized guidelines and practices to ensure that the APIs across different 
+projects and teams adhere to a common structure and design. This consistency simplifies the process of understanding 
+and maintaining APIs. The guidelines helps identify potential pitfalls and design choices that could lead to issues to 
+help developers avoid common mistakes and build more robust APIs. When in doubt, It is encouraged to seek resolution
+in slack channel [#forum-acs-api-design](https://redhat-internal.slack.com/archives/C05MMG2PP8A).
+
+## Table of Contents
+- [Naming Guidelines](#Naming Guidelines)
+  - [Service Name](Service Name)
+  - [Method Name](Method Name)
+  - [Message Name](Message Name)
+
+##Naming Guidelines
+### Service Name
+Service name **must** be unique and should use a noun that generally refers to a resource or product component 
+e.g. `DeploymentService`, `ReportService`, `ComplianceService`. Intuitive and well-known short forms or 
+abbreviations may be used in some cases (and could even be preferable) for succinctness 
+e.g. `ReportConfigService`, `RbacService`. 
+All RPC methods grouped into a single service must generally pertain to the primary resource of the service.
+
+All service defined in versioned package `/proto/api/v2` **must not** import from 
+`/proto/storage` and `/proto/internalapi` packages.
+All new RPC methods defined in versioned package `/proto/api/v1` **must not** import from
+`/proto/storage` and `/proto/internalapi` packages.
+
+### Method Name
+Methods (and URLs) should be named such that they provide insights into the functionality. Typically, the method 
+name should follow the _VerbNoun_ convention. For example, `StartComplianceScan`, `RunComplianceScan`, 
+and `GetComplianceScan` are not the same. `StartComplianceScan` must return without waiting for the compliance 
+scan to complete. `RunComplianceScan` may or may not wait for a compliance scan; the method name is ambiguous 
+and should be avoided if it starts a process and returns without waiting. `GetComplianceScan` should not run 
+a compliance scan but only fetches a stored one.
+
+| Verb   | Noun           | Method name         |
+|--------|----------------|---------------------|
+| List   | Deployment     | `ListDeployments`   |
+| Get    | Deployment     | `GetDeployment`     |
+| Update | Deployment     | `UpdateDeployment`  |
+| Delete | Deployment     | `DeleteDeployment`  |
+| Notify | Violation      | `NotifyViolation`   |
+| Run    | ComplianceScan | `RunComplianceScan` |
+
+It is **recommended** that the verbs be imperative instead of inquisitive. Generally, the noun should be the resource type. 
+In some cases, the noun portion could be composed of multiple nouns e.g. `GetVulnerabilityDeferralState`, `RunPolicyScan`.
+
+| Inquisitive               | Imperative                      |
+|---------------------------|---------------------------------|
+| `IsRunComplete`           | `GetRunStatus`                  |
+| `IsAdmin`                 | `GetUserRole`                   |
+| `IsVulnerabilityDeferred` | `GetVulnerabilityDeferralState` |
+
+The noun portion of methods that act on a single resource **must** be singular e.g. `GetDeployment`. Those methods that 
+act on the collection of resources **must** be plural e.g. `ListDeployments`, `DeleteDeployments`. Avoid prepositions 
+(e.g. for, by) in method names as much as possible. Typically, this can be addressed by using a distinct verb, 
+adding a field to the request message, or restructuring _VerbNoun_.
+
+<table>
+<tr>
+<td><b>Instead of</b></td><td><b>Use</b></td>
+</tr>
+<tr>
+<td>
+
+`GetBaselineGeneratedNetworkPolicyForDeployment`
+
+</td>
+
+<td>
+
+```
+GenerateDeploymentNetworkPolicy
+
+GenerateDeploymentNetworkPolicyRequest {
+  bool from_baseline;  
+  bool from_network_flows;
+}
+```
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`RunPolicyScanForDeployment`  
+
+</td>
+<td>
+
+`RunDeploymentPolicyScan`
+
+</td>
+</tr>
+
+<tr>
+
+<td>
+
+`DeleteDeploymentsByQuery`
+
+</td>
+<td>
+
+```
+DeleteDeployments
+
+DeleteDeploymentsRequest {
+  string query; 
+}
+```
+
+</td>
+</tr>
+</table>
+
+### Message Name
+The request and response messages **must** be named after method names with suffix `Request` and `Response` unless 
+the request/response type is an empty message. Generally, resource type as response message should be avoided 
+e.g. use `GetDeploymentResponse` response instead of `Deployment`. This allows augmenting the response with 
+supplemental information in the future.
+
+| Verb                      | Noun           | Method name         | Request message            | Response message            |
+|---------------------------|----------------|---------------------|----------------------------|-----------------------------|
+| List                      | Deployment     | `ListDeployments`   | `ListDeploymentRequest`    | `ListDeploymentResponse`    |
+| Get                       | Deployment     | `GetDeployment`     | `GetDeploymentRequest`     | `GetDeploymentResponse`     |   
+| Update                    | Deployment     | `UpdateDeployment`  | `UpdateDeploymentRequest`  | `UpdateDeploymentResponse`  |  
+| Delete                    | Deployment     | `DeleteDeployment`  | `DeleteDeploymentRequest`  | `google.protobuf.Empty`     |     
+| Get                       | ReportStatus   | `GetReportStatus`   | `GetReportStatusRequest`   | `GetReportStatusResponse`   |  
+| Run                       | ComplianceScan | `RunComplianceScan` | `RunComplianceScanRequest` | `RunComplianceScanResponse` | 
+
+Avoid prepositions as much as possible (e.g. “for”, “with”; `DeploymentWithProcessInfo`, `DeploymentWithImageScan`).
+In case such a need arises, add a field to the request message and response message.
+
+<table>
+<tr>
+<td><b>Instead of</b></td><td><b>Use</b></td>
+</tr>
+<tr>
+<td>
+
+`GetDeploymentWithImageScanRequest`
+
+</td>
+<td>
+
+```
+GetDeploymentRequest {
+  bool with_image_scan;
+}
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+`GetDeploymentWithImageScanResponse`
+
+</td>
+<td>
+
+```
+GetDeploymentWithImageScanResponse
+GetDeploymentResponse {
+  Deployment deployment;
+  Image image;
+}
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+`RunPolicyScanForDeploymentRequest`
+
+</td>
+<td>
+
+`RunDeploymentPolicyScanRequest`
+
+</td>
+</tr>
+</table>
+
+All fields in the message **must** be lowercase and underscore separated names. The JSON names for the fields are 
+autogenerated by the proto compiler. By default, field names are converted to camel case notation.
+
+| Proto field name           | JSON field name        |
+|----------------------------|------------------------|
+| `network_data_start_time`  | `networkDataStartTime` |
+| `expiry_date`              | `expiryDate`           |
+
+Be explicit about conveying the specific purpose of fields e.g. instead of `expires_on`
+use `expiry_date`(/`timestamp`), instead of `network_data_since` use `network_data_start_time`.

--- a/.github/api_best_practices.md
+++ b/.github/api_best_practices.md
@@ -9,8 +9,8 @@ in slack channel [#forum-acs-api-design](https://redhat-internal.slack.com/archi
 
 - [Naming Guidelines](#naming-guidelines)
   - [Service Name](#service-name)
-  - [Method Name](#method-name)
-  - [Message Name](#message-name)
+  - [RPC Method Name](#rpc-method-name)
+  - [RPC Message Name](#rpc-message-name)
 
 ## Naming Guidelines
 
@@ -21,13 +21,14 @@ abbreviations may be used in some cases (and could even be preferable) for succi
 e.g. `ReportConfigService`, `RbacService`. 
 All RPC methods grouped into a single service must generally pertain to the primary resource of the service.
 
-All service defined in versioned package `/proto/api/v2` **must not** import from 
-`/proto/storage` and `/proto/internalapi` packages.
-All new RPC methods defined in versioned package `/proto/api/v1` **must not** import from
+All service defined in versioned package [/proto/api/v2](https://github.com/stackrox/stackrox/blob/master/proto/v2)
+**must not** import from [/proto/storage](https://github.com/stackrox/stackrox/blob/master/proto/storage) and
+[/proto/internalapi](https://github.com/stackrox/stackrox/blob/master/proto/internalapi) packages.
+All new RPC methods defined in versioned package [/proto/api/v1](https://github.com/stackrox/stackrox/blob/master/proto/v1) **must not** import from
 `/proto/storage` and `/proto/internalapi` packages.
 
-### Method Name
-Methods (and URLs) should be named such that they provide insights into the functionality. Typically, the method 
+### RPC Method Name
+Methods should be named such that they provide insights into the functionality. Typically, the method 
 name should follow the _VerbNoun_ convention. For example, `StartComplianceScan`, `RunComplianceScan`, 
 and `GetComplianceScan` are not the same. `StartComplianceScan` must return without waiting for the compliance 
 scan to complete. `RunComplianceScan` may or may not wait for a compliance scan; the method name is ambiguous 
@@ -67,7 +68,6 @@ adding a field to the request message, or restructuring _VerbNoun_.
 `GetBaselineGeneratedNetworkPolicyForDeployment`
 
 </td>
-
 <td>
 
 ```
@@ -81,7 +81,6 @@ GenerateDeploymentNetworkPolicyRequest {
 
 </td>
 </tr>
-
 <tr>
 <td>
 
@@ -94,9 +93,7 @@ GenerateDeploymentNetworkPolicyRequest {
 
 </td>
 </tr>
-
 <tr>
-
 <td>
 
 `DeleteDeploymentsByQuery`
@@ -114,9 +111,38 @@ DeleteDeploymentsRequest {
 
 </td>
 </tr>
+<tr>
+<td>
+
+```
+GetBaselineGeneratedNetworkPolicyForDeployment
+```
+
+</td>
+<td>
+
+`GetDeploymentBaselineNetworkPolicy` or merely `GetBaselineNetworkPolicy` if the concept of baselines applies
+to deployments only.
+
+The following example demonstrates design if that concept of baselines may apply to resource types other than deployments.
+
+```
+GetBaselineNetworkPolicy
+
+GetBaselineNetworkPolicyRequest {
+  oneof resource {
+    string deployment_id;
+    string cluster_id;
+  }
+}
+
+```
+
+</td>
+</tr>
 </table>
 
-### Message Name
+### RPC Message Name
 The request and response messages **must** be named after method names with suffix `Request` and `Response` unless 
 the request/response type is an empty message. Generally, resource type as response message should be avoided 
 e.g. use `GetDeploymentResponse` response instead of `Deployment`. This allows augmenting the response with 
@@ -163,9 +189,14 @@ GetDeploymentRequest {
 <td>
 
 ```
-GetDeploymentWithImageScanResponse
 GetDeploymentResponse {
   Deployment deployment;
+  Image image;
+}
+
+Or,
+
+GetDeploymentImageScanResponse {
   Image image;
 }
 ```

--- a/.github/api_best_practices.md
+++ b/.github/api_best_practices.md
@@ -6,10 +6,11 @@ help developers avoid common mistakes and build more robust APIs. When in doubt,
 in slack channel [#forum-acs-api-design](https://redhat-internal.slack.com/archives/C05MMG2PP8A).
 
 ## Table of Contents
-- [Naming Guidelines](#Naming Guidelines)
-  - [Service Name](Service Name)
-  - [Method Name](Method Name)
-  - [Message Name](Message Name)
+
+- [Naming Guidelines](#naming-guidelines)
+  - [Service Name](#service-name)
+  - [Method Name](#method-name)
+  - [Message Name](#message-name)
 
 ##Naming Guidelines
 ### Service Name

--- a/.github/api_best_practices.md
+++ b/.github/api_best_practices.md
@@ -12,7 +12,8 @@ in slack channel [#forum-acs-api-design](https://redhat-internal.slack.com/archi
   - [Method Name](#method-name)
   - [Message Name](#message-name)
 
-##Naming Guidelines
+## Naming Guidelines
+
 ### Service Name
 Service name **must** be unique and should use a noun that generally refers to a resource or product component 
 e.g. `DeploymentService`, `ReportService`, `ComplianceService`. Intuitive and well-known short forms or 

--- a/.github/api_best_practices.md
+++ b/.github/api_best_practices.md
@@ -1,7 +1,7 @@
 # ACS API Guidelines
 An overview of the set of standardized guidelines and practices to ensure that the APIs across different 
 projects and teams adhere to a common structure and design. This consistency simplifies the process of understanding 
-and maintaining APIs. The guidelines helps identify potential pitfalls and design choices that could lead to issues to 
+and maintaining APIs. These guidelines help identify potential pitfalls and design choices that could lead to issues to 
 help developers avoid common mistakes and build more robust APIs. When in doubt, It is encouraged to seek resolution
 in slack channel [#forum-acs-api-design](https://redhat-internal.slack.com/archives/C05MMG2PP8A).
 
@@ -15,27 +15,27 @@ in slack channel [#forum-acs-api-design](https://redhat-internal.slack.com/archi
 ## Naming Guidelines
 
 ### gRPC Service Name
-Service name **must** be unique and should use a noun that generally refers to a resource or product component 
-e.g. `DeploymentService`, `ReportService`, `ComplianceService`. Intuitive and well-known short forms or 
-abbreviations may be used in some cases (and could even be preferable) for succinctness 
+The service name **must** be unique and use a noun that generally refers to a resource or product component and 
+**must** end with **Service** e.g. `DeploymentService`, `ReportService`, `ComplianceService`. Intuitive and well-known 
+short forms or abbreviations **may** be used in some cases (and could even be preferable) for succinctness 
 e.g. `ReportConfigService`, `RbacService`. 
-All gRPC methods grouped into a single service must generally pertain to the primary resource of the service.
-
-Note:
-- All service defined in versioned package [/proto/api/v2](https://github.com/stackrox/stackrox/blob/master/proto/v2)
-**must not** import from [/proto/storage](https://github.com/stackrox/stackrox/blob/master/proto/storage) and
-[/proto/internalapi](https://github.com/stackrox/stackrox/blob/master/proto/internalapi) packages.
-- All new gRPC methods defined in versioned package [/proto/api/v1](https://github.com/stackrox/stackrox/blob/master/proto/v1) 
-**must not** import from `/proto/storage` and `/proto/internalapi` packages.
-- All services of the type `APIServiceWithCustomRoutes` **must not** import from `/proto/storage` and `/proto/internalapi` packages.
+All gRPC methods grouped into a single service **must** generally pertain to the primary resource of the service.
 
 ### gRPC Method Name
-Methods should be named such that they provide insights into the functionality. Typically, the method 
-name should follow the _VerbNoun_ convention. For example, `StartComplianceScan`, `RunComplianceScan`, 
-and `GetComplianceScan` are not the same. `StartComplianceScan` must return without waiting for the compliance 
-scan to complete. `RunComplianceScan` may or may not wait for a compliance scan; the method name is ambiguous 
-and should be avoided if it starts a process and returns without waiting. `GetComplianceScan` should not run 
-a compliance scan but only fetches a stored one.
+Methods **should** be named such that they provide insights into the functionality.
+
+Let us look at a few examples.`StartComplianceScan`, `RunComplianceScan`, and `GetComplianceScan` are not the same. 
+
+- `StartComplianceScan` **should** return without waiting for the compliance scan to complete. 
+- `RunComplianceScan` is ambiguous because it is unclear if the call waits for the scan to complete. 
+The ambiguity can be removed by adding a field to the request that helps clarify the expectation 
+e.g. `bool wait_for_scan_completion` if set to `true` informs the method to wait for the compliance 
+scan to complete. However, for long-running processes, it is **recommended** to create a job that 
+finishes the process asynchronously and return the job ID to the users which can be tracked via 
+dedicated job tracking method.
+- `GetComplianceScan` **should** not run a compliance scan but only fetches a stored one.
+
+Typically, the method name **should** follow the _VerbNoun_ convention.
 
 | Verb   | Noun           | Method name         |
 |--------|----------------|---------------------|
@@ -46,7 +46,7 @@ a compliance scan but only fetches a stored one.
 | Notify | Violation      | `NotifyViolation`   |
 | Run    | ComplianceScan | `RunComplianceScan` |
 
-It is **recommended** that the verbs be imperative instead of inquisitive. Generally, the noun should be the resource type. 
+It is **recommended** that the verbs be imperative instead of inquisitive. Generally, the noun **should** be the resource type. 
 In some cases, the noun portion could be composed of multiple nouns e.g. `GetVulnerabilityDeferralState`, `RunPolicyScan`.
 
 | Inquisitive               | Imperative                      |
@@ -126,7 +126,7 @@ GetBaselineGeneratedNetworkPolicyForDeployment
 `GetDeploymentBaselineNetworkPolicy` or merely `GetBaselineNetworkPolicy` if the concept of baselines applies
 to deployments only.
 
-The following example demonstrates design if that concept of baselines may apply to resource types other than deployments.
+The following example demonstrates design if that concept of baselines could apply to multiple resource types.
 
 ```
 GetBaselineNetworkPolicy
@@ -146,7 +146,7 @@ GetBaselineNetworkPolicyRequest {
 
 ### gRPC Message Name
 The request and response messages **must** be named after method names with suffix `Request` and `Response` unless 
-the request/response type is an empty message. Generally, resource type as response message should be avoided 
+the request/response type is an empty message. Generally, resource type as response message **should** be avoided 
 e.g. use `GetDeploymentResponse` response instead of `Deployment`. This allows augmenting the response with 
 supplemental information in the future.
 


### PR DESCRIPTION
## Description

This PR is the first in the series of PRs to document general ACS API best practices. This PR exclusively focuses on the naming conventions recommendations.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
n/a
