### PR TITLE
test: Remove mock identity in TestGetCentralCapabilities

### DIFF
--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -199,8 +199,7 @@ func (s *serviceImplTestSuite) TestDatabaseBackupStatus() {
 }
 
 func (s *serviceImplTestSuite) TestGetCentralCapabilities() {
-	mockID := mockIdentity.NewMockIdentity(s.mockCtrl)
-	ctx := authn.ContextWithIdentity(sac.WithNoAccess(context.Background()), mockID, s.T())
+	ctx := context.Background()
 
 	s.Run("when managed central", func() {
 		s.T().Setenv("ROX_MANAGED_CENTRAL", "true")


### PR DESCRIPTION
## Description

Since authn/z for `GetCentralCapabilities()` is handled by middleware and no specific permissions are required, remove mock identity from the test.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI run
