### PR TITLE
ROX-18892: increase k8s-client retries

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -142,6 +142,10 @@ class Kubernetes implements OrchestratorMain {
         this.client.configuration.namespace = null
         this.client.configuration.setRequestTimeout(32*1000)
         this.client.configuration.setConnectionTimeout(20*1000)
+        // First retry after 200ms, 12th retry after 410s. The total retry time is
+        // intended to cover a GKE RESIZE_CLUSTER event.
+        this.client.configuration.setRequestRetryBackoffInterval(200)
+        this.client.configuration.setRequestRetryBackoffLimit(12)
         this.deployments = this.client.apps().deployments()
         this.daemonsets = this.client.apps().daemonSets()
         this.statefulsets = this.client.apps().statefulSets()


### PR DESCRIPTION
## Description

In https://issues.redhat.com/browse/ROX-18892 I encountered a test flake due to connection failure.

```
Wrapped by: java.io.IOException: Failed to connect to /34.28.36.43:443
    at orchestratormanager.Kubernetes.ensureNamespaceExists(Kubernetes.groovy:158) [6 skipped]
```

Based on @gavin-stackrox, the root cause is a GKE `CLUSTER_RESIZE`:
```
$ gcloud --project=stackrox-ci container operations list | grep 1696538173041020928
operation-1693321873247-a322b918-4d74-42b4-b71a-9a396906d157  CREATE_CLUSTER  us-central1-b  rox-ci-qa-e2e-test-1696538173041020928                    DONE     2023-08-29T15:11:13.247538598Z  2023-08-29T15:23:38.082118456Z
operation-1693322622916-bf195eb3-0150-4e20-8d31-6e7434ad02db  UPDATE_CLUSTER  us-central1-b  rox-ci-qa-e2e-test-1696538173041020928                    DONE     2023-08-29T15:23:42.916069472Z  2023-08-29T15:23:43.034643792Z
operation-1693327171096-4287b6e6-63b2-4284-b67b-6735cb9e606f  RESIZE_CLUSTER  us-central1-b  rox-ci-qa-e2e-test-1696538173041020928                    DONE     2023-08-29T16:39:31.096328792Z  2023-08-29T16:44:18.497304437Z
operation-1693329499583-13af7fb1-6d93-446e-9276-b7b2baa93e58  DELETE_CLUSTER  us-central1-b  rox-ci-qa-e2e-test-1696538173041020928                    DONE     2023-08-29T17:18:19.583554519Z  2023-08-29T17:23:23.390490672Z
```
 
Therefore increase the k8s-client retries to cover such unavailability events.