### PR TITLE
ROX-19316: add retry to grpc calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ combined_coverage.dat
 /stackrox-secured-cluster-services-chart/
 .vscode
 
+# Used for mounting into the qa e2e-test docker container.
+.gitconfig
+
 # Mac OS hidden file
 .DS_Store
 

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -296,30 +296,34 @@ func (s *serviceImpl) enrichImage(ctx context.Context, img *storage.Image, fetch
 
 // ScanImage scans an image and returns the result
 func (s *serviceImpl) ScanImage(ctx context.Context, request *v1.ScanImageRequest) (*storage.Image, error) {
-	enrichmentCtx := enricher.EnrichmentContext{
-		FetchOpt:  enricher.IgnoreExistingImages,
-		Delegable: true,
-	}
-	if request.GetForce() {
-		enrichmentCtx.FetchOpt = enricher.UseImageNamesRefetchCachedValues
-	}
-	img, err := enricher.EnrichImageByName(ctx, s.enricher, enrichmentCtx, request.GetImageName())
-	if err != nil {
-		return nil, err
-	}
-
-	// Save the image
-	img.Id = utils.GetSHA(img)
-	if img.GetId() != "" {
-		if err := s.saveImage(img); err != nil {
-			return nil, err
-		}
-	}
-	if !request.GetIncludeSnoozed() {
-		utils.FilterSuppressedCVEsNoClone(img)
-	}
-
-	return img, nil
+	log.Errorf("@@@ failed to scan image: %+v", request.GetImageName())
+	return nil, status.New(codes.Internal, "CUSTOM ERROR").Err()
+	// enrichmentCtx := enricher.EnrichmentContext{
+	// 	FetchOpt:  enricher.IgnoreExistingImages,
+	// 	Delegable: true,
+	// }
+	// if request.GetForce() {
+	// 	enrichmentCtx.FetchOpt = enricher.UseImageNamesRefetchCachedValues
+	// }
+	// img, err := enricher.EnrichImageByName(ctx, s.enricher, enrichmentCtx, request.GetImageName())
+	// if err != nil {
+	// 	log.Errorw("failed to enrich image by name", err)
+	// 	return nil, status.New(codes.Internal, err.Error()).Err()
+	// }
+	//
+	// // Save the image
+	// img.Id = utils.GetSHA(img)
+	// if img.GetId() != "" {
+	// 	if err := s.saveImage(img); err != nil {
+	// 		log.Errorw("failed to save image", err)
+	// 		return nil, status.New(codes.Internal, err.Error()).Err()
+	// 	}
+	// }
+	// if !request.GetIncludeSnoozed() {
+	// 	utils.FilterSuppressedCVEsNoClone(img)
+	// }
+	//
+	// return img, nil
 }
 
 // GetImageVulnerabilitiesInternal retrieves the vulnerabilities related to the image

--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -15,11 +15,11 @@ repositories {
     mavenCentral()
 }
 
-def grpcVersion = '1.21.0'
+def grpcVersion = '1.57.2'
 // If the proto versions are changed, be sure it is also changed in make/protogen.mk.
 def protocVersion = '3.23.2'
 def protobufVersion = '3.24.2'
-def nettyTcNativeVersion = '2.0.45.Final'
+def nettyTcNativeVersion = '2.0.61.Final'
 def fabric8Version = '6.8.0'
 def jacksonVersion = '2.14.2'
 

--- a/qa-tests-backend/gradle.properties
+++ b/qa-tests-backend/gradle.properties
@@ -1,2 +1,11 @@
-systemProp.jdk.tls.client.protocols=TLSv1.2
+handlers=java.util.logging.ConsoleHandler
+io.grpc.ChannelLogger.level=FINEST
+io.grpc.level=FINEST
+io.grpc.netty.NettyClientHandler=ALL
+io.grpc.netty.NettyServerHandler=ALL
+io.grpc.xds.XdsLogger.level=FINEST
+io.netty.level=FINEST
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.ConsoleHandler.level=FINEST
 org.gradle.jvmargs=-Xmx4G
+systemProp.jdk.tls.client.protocols=TLSv1.2

--- a/qa-tests-backend/src/main/groovy/services/ImageService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ImageService.groovy
@@ -43,7 +43,8 @@ class ImageService extends BaseService {
                 .setForce(force)
                 .build()
             def response
-            withRetry(1, 15) {
+            withRetry(5, 10) {
+                log.debug("starting scan for image ${image}")
                 response = getImageClient().scanImage(req)
             }
             return response

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -16,6 +16,7 @@ import org.spockframework.runtime.SpockAssertionError
 @Slf4j
 class Helpers {
     static <V> V evaluateWithRetry(int retries, int pauseSecs, Closure<V> closure) {
+        log.debug("Evaluating with retries. maxRetries=${retries}, pauseSecs=${pauseSecs}")
         for (int i = 0; i < retries; i++) {
             try {
                 return closure()

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -78,12 +78,12 @@ class ImageManagementTest extends BaseSpecification {
     def "Verify two consecutive latest tag image have different scans"() {
         given:
         // Scan an ubuntu 14:04 image we're pretending is latest
-        def img = Services.scanImage(
+        def img = ImageService.scanImage(
             "quay.io/rhacs-eng/qa-multi-arch:ubuntu-latest" +
                 "@sha256:64483f3496c1373bfd55348e88694d1c4d0c9b660dee6bfef5e12f43b9933b30") // 14.04
         assert img.scan.componentsList.stream().find { x -> x.name == "eglibc" } != null
 
-        img = Services.scanImage(
+        img = ImageService.scanImage(
             "quay.io/rhacs-eng/qa-multi-arch:ubuntu-latest" +
                 "@sha256:1f1a2d56de1d604801a9671f301190704c25d604a416f59e03c04f5c6ffee0d6") // 16.04
 
@@ -96,7 +96,7 @@ class ImageManagementTest extends BaseSpecification {
     @Tag("BAT")
     def "Verify image scan finds correct base OS - #qaImageTag"() {
         when:
-        def img = Services.scanImage("quay.io/rhacs-eng/qa:$qaImageTag")
+        def img = ImageService.scanImage("quay.io/rhacs-eng/qa:$qaImageTag")
         then:
         assert img.scan.operatingSystem == expected
         where:

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -413,7 +413,7 @@ class ImageScanningTest extends BaseSpecification {
 
         and:
         "Scan Image and verify results"
-        ImageOuterClass.Image img = Services.scanImage(image)
+        ImageOuterClass.Image img = ImageService.scanImage(image)
         assert img.metadata.dataSource.id != ""
         assert img.metadata.dataSource.name != ""
         assert img.scan.dataSource.id != ""
@@ -464,7 +464,7 @@ class ImageScanningTest extends BaseSpecification {
 
         and:
         "Scan Image and verify results"
-        ImageOuterClass.Image img = Services.scanImage(image)
+        ImageOuterClass.Image img = ImageService.scanImage(image)
         assert img.metadata.dataSource.id != ""
         assert img.metadata.dataSource.name != ""
         assert img.scan.dataSource.id != ""
@@ -520,7 +520,7 @@ class ImageScanningTest extends BaseSpecification {
         "Scan image"
         String image = IMAGES_FOR_ERROR_TESTS[scanner.name()][testAspect]
         assert image
-        Services.scanImage(image)
+        ImageService.scanImage(image)
 
         then:
         "Verify image scan outcome"
@@ -649,7 +649,7 @@ class ImageScanningTest extends BaseSpecification {
 
         and:
         "Image is scanned"
-        Services.scanImage(image)
+        ImageService.scanImage(image)
 
         then:
         "get image by name"

--- a/qa-tests-backend/src/test/groovy/RiskTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RiskTest.groovy
@@ -9,6 +9,7 @@ import io.stackrox.proto.storage.ProcessBaselineOuterClass
 import objects.Deployment
 import services.ClusterService
 import services.DeploymentService
+import services.ImageService
 import services.ProcessBaselineService
 import services.ProcessService
 import util.Env
@@ -52,7 +53,7 @@ class RiskTest extends BaseSpecification {
         clusterId = ClusterService.getClusterId()
 
         // ROX-6260: pre scan the image to avoid different risk scores
-        Services.scanImage(TEST_IMAGE)
+        ImageService.scanImage(TEST_IMAGE)
 
         for (int i = 0; i < 2; i++) {
             DEPLOYMENTS.push(

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -91,7 +91,7 @@ class SACTest extends BaseSpecification {
 
     def setupSpec() {
         // Make sure we scan the image initially to make reprocessing faster.
-        def img = Services.scanImage(TEST_IMAGE)
+        def img = ImageService.scanImage(TEST_IMAGE)
         assert img.hasScan()
 
         orchestrator.batchCreateDeployments(DEPLOYMENTS)

--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -225,13 +225,6 @@ class Services extends BaseService {
         return violations == null || violations.isEmpty()
     }
 
-    static scanImage(String image) {
-        return getImageClient().scanImage(
-                ImageServiceOuterClass.ScanImageRequest.newBuilder()
-                        .setImageName(image).build()
-        )
-    }
-
     static String getImageIdByName(String imageName) {
         String id = null
         Timer t = new Timer(10, 1)

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -44,7 +44,7 @@ Options:
     [qa flavor only]
   -s, --spin-cycle=<count> - repeat the test portion until a failure
     occurs or <count> is reached with no failures. [qa flavor only]
-  -w, --spin-wait=<seconds> - delay between tests when running repeat 
+  -w, --spin-wait=<seconds> - delay between tests when running repeat
     tests. default: no wait. [qa flavor only]
   -t <tag> - override 'make tag' which sets the main version to install
     and is used by some tests.
@@ -129,6 +129,7 @@ if [[ ! -f "/i-am-rox-ci-image" ]]; then
     kubeconfig="${KUBECONFIG:-${HOME}/.kube/config}"
     mkdir -p "$QA_TEST_DEBUG_LOGS"
     info "Running in a container..."
+    printf '[safe]\n\tdirectory = "%s"' "${ROOT}" > "$ROOT/.gitconfig"
     docker run \
       -v "$ROOT:$ROOT:z" \
       -w "$ROOT" \
@@ -138,6 +139,7 @@ if [[ ! -f "/i-am-rox-ci-image" ]]; then
       -v "${QA_TEST_DEBUG_LOGS}:${QA_TEST_DEBUG_LOGS}:z" \
       -e "BUILD_TAG=${BUILD_TAG:-}" \
       -v "${ROXCTL_FOR_TEST}:/usr/local/bin/roxctl:z" \
+      -v "${ROOT}/.gitconfig:/etc/gitconfig:ro" \
       -e VAULT_TOKEN \
       --platform linux/amd64 \
       --rm -it \


### PR DESCRIPTION
## Description

While investigating https://issues.redhat.com/browse/ROX-19316 I realized that the gRPC retry probably does not work because it seems that `.enableRetry()` alone is not sufficient. See https://stackoverflow.com/questions/65701091/how-to-get-grpcs-retry-mechanism-to-work-using-grpc-java-in-kubernetes-cluster for a discussion. TLDR: One also needs to supply a serviceConfig to the gRPC channel builder.

The upgrade to `grpcVersion = '1.30.0'` is necessary to specify a default service config without pinning the service names. 

I'm hoping this will significantly reduce the overall number of flakes. I haven't observed any test timeouts caused by the retries.