### PR TITLE
chore: Remove prevent.stackrox.com from deploy.sh

### DIFF
--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -278,7 +278,7 @@ function setup_auth0() {
 		"client_secret": "${LOCAL_CLIENT_SECRET}",
 		"mode": "post"
 	},
-	"extraUiEndpoints": ["localhost:8000", "localhost:3000", "localhost:8001", "prevent.stackrox.com"]
+	"extraUiEndpoints": ["localhost:8000", "localhost:3000", "localhost:8001"]
 }
 EOF
     )


### PR DESCRIPTION
## Description

`prevent.stackrox.com` was introduced long time ago as a test domain name that you would add via `/etc/hosts` to access Central in UI. There is strong evidence that it is ancient history as no one mentioned it since 2019, and all references to it are limited to `setup_auth0`, which itself is becoming obsolete.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

1. CI is sufficient

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
