### PR TITLE
ROX-19453: Add logchecker exception for deprecated DeploymentConfigs

### DIFF
--- a/pkg/protoconv/resources/resources.go
+++ b/pkg/protoconv/resources/resources.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 
 	ptypes "github.com/gogo/protobuf/types"
-	openshift_appsv1 "github.com/openshift/api/apps/v1"
+	openshiftAppsV1 "github.com/openshift/api/apps/v1"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	imageUtils "github.com/stackrox/rox/pkg/images/utils"
@@ -229,7 +229,7 @@ func (w *DeploymentWrap) populateFields(obj interface{}) {
 	var podSpec v1.PodSpec
 
 	switch o := obj.(type) {
-	case *openshift_appsv1.DeploymentConfig:
+	case *openshiftAppsV1.DeploymentConfig:
 		if o.Spec.Template == nil {
 			log.Errorf("Spec obj %+v does not have a Template field or is not a pointer pod spec", spec)
 			return

--- a/scripts/ci/logcheck/allowlist-patterns
+++ b/scripts/ci/logcheck/allowlist-patterns
@@ -20,7 +20,7 @@ unexpected owner for certificate secrets
 # We detect if they are not supported and in that case do not apply them, so these warnings are not useful at this point.
 # See ROX-17796 ROX-17766 ROX-17734 for related work.
 policy/v1beta1 PodSecurityPolicy is deprecated in v1.21., unavailable in v1.25.
-# This is to unlock testing on OCP 4.14.
-# DeploymentConfigs are planned to be removed in 4.17 - see:
-# https://issues.redhat.com/browse/OCPSTRAT-118 (comment from: Gaurav Singh 2023/05/22 4:18 PM)
+# This prevents false-positives whin testing on OCP 4.14.
+# DeploymentConfigs are deprecated but there are no plans to remove them as this is written.
+# See: https://issues.redhat.com/browse/OCPSTRAT-118
 apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+

--- a/scripts/ci/logcheck/allowlist-patterns
+++ b/scripts/ci/logcheck/allowlist-patterns
@@ -20,3 +20,7 @@ unexpected owner for certificate secrets
 # We detect if they are not supported and in that case do not apply them, so these warnings are not useful at this point.
 # See ROX-17796 ROX-17766 ROX-17734 for related work.
 policy/v1beta1 PodSecurityPolicy is deprecated in v1.21., unavailable in v1.25.
+# This is to unlock testing on OCP 4.14.
+# DeploymentConfigs are planned to be removed in 4.17 - see:
+# https://issues.redhat.com/browse/OCPSTRAT-118 (comment from: Gaurav Singh 2023/05/22 4:18 PM)
+apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+

--- a/scripts/ci/logcheck/allowlist-patterns
+++ b/scripts/ci/logcheck/allowlist-patterns
@@ -20,7 +20,7 @@ unexpected owner for certificate secrets
 # We detect if they are not supported and in that case do not apply them, so these warnings are not useful at this point.
 # See ROX-17796 ROX-17766 ROX-17734 for related work.
 policy/v1beta1 PodSecurityPolicy is deprecated in v1.21., unavailable in v1.25.
-# This prevents false-positives whin testing on OCP 4.14.
+# This prevents false-positives when testing on OCP 4.14.
 # DeploymentConfigs are deprecated but there are no plans to remove them as this is written.
 # See: https://issues.redhat.com/browse/OCPSTRAT-118
-apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
+apps\.openshift\.io\/v1 DeploymentConfig is deprecated in v4\.14\+, unavailable in v4\.10000\+

--- a/sensor/admission-control/manager/k8s_object.go
+++ b/sensor/admission-control/manager/k8s_object.go
@@ -1,7 +1,7 @@
 package manager
 
 import (
-	openshift_appsv1 "github.com/openshift/api/apps/v1"
+	openshiftAppsV1 "github.com/openshift/api/apps/v1"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/kubernetes"
@@ -42,7 +42,7 @@ func unmarshalK8sObject(gvk metav1.GroupVersionKind, raw []byte) (k8sutil.Object
 	case kubernetes.Job:
 		obj = &batchV1.Job{}
 	case kubernetes.DeploymentConfig:
-		obj = &openshift_appsv1.DeploymentConfig{}
+		obj = &openshiftAppsV1.DeploymentConfig{}
 	default:
 		return nil, errors.Errorf("currently do not recognize kind %q in admission controller", gvk.Kind)
 	}

--- a/sensor/kubernetes/listener/resources/convert.go
+++ b/sensor/kubernetes/listener/resources/convert.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 
 	"github.com/mitchellh/hashstructure/v2"
-	openshift_appsv1 "github.com/openshift/api/apps/v1"
+	openshiftAppsV1 "github.com/openshift/api/apps/v1"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -176,7 +176,7 @@ func (w *deploymentWrap) populateNonStaticFields(obj interface{}, action *centra
 	)
 
 	switch o := obj.(type) {
-	case *openshift_appsv1.DeploymentConfig:
+	case *openshiftAppsV1.DeploymentConfig:
 		if o.Spec.Template == nil {
 			return false, fmt.Errorf("spec obj %+v does not have a Template field or is not a pointer pod spec", spec)
 		}


### PR DESCRIPTION
## Description

This PR adds an ignore-regexp to the log checker to tolerate deprecation warning in form of: `apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+`

We do not have any references to [/oapi/v1.DeploymentConfig](https://docs.openshift.com/container-platform/3.10/rest_api/oapi/v1.AppliedClusterResourceQuota.html) which is gone since OCP 3.10.

We do support [apps.openshift.io/v1/DeploymentConfig ](http://apps.openshift.io/v1) as long as they exist. They were originally planned to be removed in 4.17, but apparently this plan was dropped and the removal date is unknown. For more details see https://issues.redhat.com/browse/OCPSTRAT-118.

## Checklist
- [ ] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))


## Testing Performed

### Here I tell how I validated my change

- [ ] Run `ocp-4-14-ebpf-qa-e2e-tests` against this branch as done in: https://github.com/openshift/release/pull/42477
- [x] Locally as follows:

Testing this on Mac requires to change all occurrences of `grep` in `scripts/ci/logcheck/check.sh` to `ggrep`

```shell
$ cat test.txt 
deprecated
apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000000000000000
apps.openshift.io/v1 DeploymentConfig is deprecated in v4X14+, unavailable in v4X10000+
apps\.openshift\.io\/v1 DeploymentConfig is deprecated in v4\.14\+, unavailable in v4\.10000\+

# Expecting to see all lines but the second 

$ ./scripts/ci/logcheck/check.sh test.txt
INFO:  Allow list file: /Users/prygiels/go/src/github.com/stackrox/stackrox2/scripts/ci/logcheck/allowlist-patterns
deprecated
apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000000000000000
apps.openshift.io/v1 DeploymentConfig is deprecated in v4X14+, unavailable in v4X10000+
apps\.openshift\.io\/v1 DeploymentConfig is deprecated in v4\.14\+, unavailable in v4\.10000\+
``` 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
