### PR TITLE
fix(ui): Fix dropdown not closing with duplicate notifier

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
@@ -25,6 +25,7 @@ import usePermissions from 'hooks/usePermissions';
 import RepeatScheduleDropdown from 'Components/PatternFly/RepeatScheduleDropdown';
 import DayPickerDropdown from 'Components/PatternFly/DayPickerDropdown';
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+import useIndexKey from 'hooks/useIndexKey';
 import NotifierSelection from './NotifierSelection';
 
 export type DeliveryDestinationsFormParams = {
@@ -35,6 +36,7 @@ export type DeliveryDestinationsFormParams = {
 function DeliveryDestinationsForm({ title, formik }: DeliveryDestinationsFormParams): ReactElement {
     const { hasReadWriteAccess } = usePermissions();
     const hasNotifierWriteAccess = hasReadWriteAccess('Integration');
+    const { keyFor } = useIndexKey();
 
     function addDeliveryDestination() {
         const newDeliveryDestination: DeliveryDestination = { notifier: null, mailingLists: [] };
@@ -106,10 +108,7 @@ function DeliveryDestinationsForm({ title, formik }: DeliveryDestinationsFormPar
                                 {formik.values.deliveryDestinations.map(
                                     (deliveryDestination, index) => {
                                         return (
-                                            <li
-                                                key={deliveryDestination.notifier?.id}
-                                                className="pf-u-mb-md"
-                                            >
+                                            <li key={keyFor(index)} className="pf-u-mb-md">
                                                 <Card>
                                                     <CardTitle>
                                                         <Flex


### PR DESCRIPTION
## Description

This fixes an issue where the delivery destination dropdowns would freeze if multiple delivery destinations were added using the same notifier.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Test adding and deleting multiple delivery destinations, including duplicate notifiers throughout. All dropdowns should successfully open and close as expected, and the value of the notifiers should remain consistent when values are deleted.

Performing similar actions against staging causes the UI to break almost immediately.

https://github.com/stackrox/stackrox/assets/1292638/6aa1f0d0-ef31-4ec4-ba37-3e01fd37d608

