### PR TITLE
ROX-19489: Rewrite ClustersPage in TypeScript

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback } from 'react';
-import ReactRouterPropTypes from 'react-router-prop-types';
+import React, { ReactElement, useCallback } from 'react';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 
 import PageHeader from 'Components/PageHeader';
 import LinkShim from 'Components/PatternFly/LinkShim';
@@ -18,16 +18,14 @@ import ClustersTablePanel from './ClustersTablePanel';
 import ClustersSidePanel from './ClustersSidePanel';
 import ManageTokensButton from './Components/ManageTokensButton';
 
-const ClustersPage = ({
-    history,
-    location: { pathname, search },
-    match: {
-        params: { clusterId: selectedClusterId },
-    },
-}) => {
+function ClustersPage(): ReactElement {
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
     const hasReadAccessForDelegatedScanning = hasReadAccess('Administration');
     const hasWriteAccessForIntegration = hasReadWriteAccess('Integration');
+
+    const history = useHistory();
+    const { pathname, search } = useLocation();
+    const { clusterId: selectedClusterId } = useParams(); // see routePaths for parameter
 
     const { searchFilter, setSearchFilter } = useURLSearch();
     const workflowState = parseURL({ pathname, search });
@@ -72,7 +70,7 @@ const ClustersPage = ({
                 {hasReadAccessForDelegatedScanning && (
                     <div className="flex items-center ml-4 mr-1">
                         <Button
-                            variant={ButtonVariant.secondary}
+                            variant="secondary"
                             component={LinkShim}
                             href={clustersDelegatedScanningPath}
                         >
@@ -111,12 +109,6 @@ const ClustersPage = ({
             </section>
         </workflowStateContext.Provider>
     );
-};
-
-ClustersPage.propTypes = {
-    history: ReactRouterPropTypes.history.isRequired,
-    location: ReactRouterPropTypes.location.isRequired,
-    match: ReactRouterPropTypes.match.isRequired,
-};
+}
 
 export default ClustersPage;


### PR DESCRIPTION
## Description

Increase type safety before making functional changes to the page.

1. Replace implicit props from `Route` element in `Body` with explicit hooks.
2. Replace `ButtonVariant` enum in `variant="secondary"` prop because TypeScript verifies according to the string enumeration that PatternFly `Button` element declares. That is, replace JavaScript idiom with fluent TypeScript.

### Residue

1. Move `ManageTokensButton` inline when we change the `href` prop:
    * from **hash** link within Integrations page
    * to link to new route for Cluster init bundles page
2. Distinguish **New** dropdown item in `ClusterTablePanel` as Simon suggested.
3. Compare content of documentation pages:
    * Add cluster prompt: installing/install-ocp-operator.html#adding-a-new-cluster-to-rhacs
    * Install menu: installing/acs-installation-platforms.html

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Replacement of dyamic PropTypes with static types almost offset replacement of implicit props with explicit hooks.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3761772 - 3761772
        total: 12 = 9977177 - 9977165
    * `ls -al build/static/js/*.js | wc -l`
        0 = 80 - 80 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/clusters and click a row to change the address and open the side panel

2. Go to main dashboard, and then paste the address from step 1 to visit and open the side panel.

### Integration testing

* clusters/clusterDeletion.test.js
* clusters/clusters.test.js
* clusters/clustersCertificateExpiration.test.js
* clusters/clustersHealthStatus.test.js
* clusters/clustersManager.test.js
* clusters/delegatedScanning.test.js
* clusters/redirectFromDashboard.test.js