### PR TITLE
ROX-18772: use quay registry

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -197,20 +197,20 @@ class ImageManagementTest extends BaseSpecification {
                 .addScope(ScopeOuterClass.Scope.newBuilder().setNamespace(TEST_NAMESPACE))
                 .build()
         policy = PolicyService.createAndFetchPolicy(policy)
-        def scanResults = Services.requestBuildImageScan("docker.io", "docker/kube-compose-controller", "v0.4.23")
+        def scanResults = Services.requestBuildImageScan("quay.io", "rhacs-eng/qa", "kube-compose-controller-v0.4.23")
         assert scanResults.alertsList.find { x -> x.policy.id == policy.id } != null
 
         when:
         "Suppress CVE and check that it violates"
         def cve = "CVE-2019-14697"
         CVEService.suppressImageCVE(cve)
-        scanResults = Services.requestBuildImageScan("docker.io", "docker/kube-compose-controller", "v0.4.23")
+        scanResults = Services.requestBuildImageScan("quay.io", "rhacs-eng/qa", "kube-compose-controller-v0.4.23")
         assert scanResults.alertsList.find { y -> y.policy.id == policy.id } == null
 
         and:
         "Unsuppress CVE"
         CVEService.unsuppressImageCVE(cve)
-        scanResults = Services.requestBuildImageScan("docker.io", "docker/kube-compose-controller", "v0.4.23")
+        scanResults = Services.requestBuildImageScan("quay.io", "rhacs-eng/qa", "kube-compose-controller-v0.4.23")
 
         then:
         "Verify unsuppressing lets the CVE show up again"
@@ -340,7 +340,7 @@ class ImageManagementTest extends BaseSpecification {
 
         and:
         "Request Image Scan with sendNotifications"
-        def scanResults = Services.requestBuildImageScan("docker.io", "library/busybox", "latest", true)
+        def scanResults = Services.requestBuildImageScan("quay.io", "quay/busybox", "latest", true)
 
         then:
         "verify violation matches expected violation status and notification sent"
@@ -353,9 +353,9 @@ class ImageManagementTest extends BaseSpecification {
             assert alert["policy"]["name"] == clone.name
             assert alert["image"] != null
             assert alert["deployment"] == null
-            assert alert["image"]["name"]["fullName"] == "docker.io/library/busybox:latest"
-            assert alert["image"]["name"]["registry"] == "docker.io"
-            assert alert["image"]["name"]["remote"] == "library/busybox"
+            assert alert["image"]["name"]["fullName"] == "quay.io/quay/busybox:latest"
+            assert alert["image"]["name"]["registry"] == "quay.io"
+            assert alert["image"]["name"]["remote"] == "quay/busybox"
             assert alert["image"]["name"]["tag"] == "latest"
         }
 


### PR DESCRIPTION
## Description

Dockerhub frequently returns errors like
```
io.grpc.StatusRuntimeException: INTERNAL: image enrichment error: error getting metadata for image: docker.io/docker/kube-compose-controller:v0.4.23 errors: [getting metadata from registry: &#34;Public DockerHub&#34;: failed to get the manifest digest: Head &#34;https://registry-1.docker.io/v2/docker/kube-compose-controller/manifests/v0.4.23&#34;: http: non-successful response (status=401 body=&#34;&#34;), getting metadata from registry: &#34;Autogenerated https://registry-1.docker.io for cluster remote&#34;: failed to get the manifest digest: Head &#34;https://registry-1.docker.io/v2/docker/kube-compose-controller/manifests/v0.4.23&#34;: http: non-successful response (status=401 body=&#34;&#34;)
```
leading to test flakes.

Therefore, switch the image registry from `docker.io` to `quay.io` to avoid rate limiting and hopefully achieve greater qa test stability. Also increases consistency with other tests, which mostly already use `quay.io`. Since `quay.io` sometimes fails as well, working on retries in https://github.com/stackrox/stackrox/pull/7636.

Note that the images are merely scanned and not deployed, so no multi-arch images are needed.
`kube-compose-controller:v0.4.23` has been copied over from `docker.io` to `quay.io/rhacs-eng/qa`. `quay.io/quay/busybox` is used instead of `quay.io/rhacs-eng/qa:busybox` because we rely on a `:latest` tag in the test.

## Testing Performed

CI