### PR TITLE
ROX-19316: use nginx-unprivileged image

### DIFF
--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -37,6 +37,7 @@ import spock.lang.Unroll
 
 @Tag("BAT")
 class SACTest extends BaseSpecification {
+    static final private String IMAGE = "quay.io/rhacs-eng/qa:nginx-unprivileged-1.25.2"
     static final private String DEPLOYMENTNGINX_NAMESPACE_QA1 = "sac-deploymentnginx-qa1"
     static final private String NAMESPACE_QA1 = "qa-test1"
     static final private String DEPLOYMENTNGINX_NAMESPACE_QA2 = "sac-deploymentnginx-qa2"
@@ -46,7 +47,7 @@ class SACTest extends BaseSpecification {
     static final protected String NOACCESSTOKEN = "noAccess"
     static final protected Deployment DEPLOYMENT_QA1 = new Deployment()
             .setName(DEPLOYMENTNGINX_NAMESPACE_QA1)
-            .setImage(TEST_IMAGE)
+            .setImage(IMAGE)
             .addPort(22, "TCP")
             .addAnnotation("test", "annotation")
             .setEnv(["CLUSTER_NAME": "main"])
@@ -54,7 +55,7 @@ class SACTest extends BaseSpecification {
             .addLabel("app", "test")
     static final protected Deployment DEPLOYMENT_QA2 = new Deployment()
             .setName(DEPLOYMENTNGINX_NAMESPACE_QA2)
-            .setImage(TEST_IMAGE)
+            .setImage(IMAGE)
             .addPort(22, "TCP")
             .addAnnotation("test", "annotation")
             .setEnv(["CLUSTER_NAME": "main"])


### PR DESCRIPTION
## Description

In ROX-19316 the nginx pod did not come up due to the following error:

```
nginx: [warn] the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:2
2023/08/25 15:36:24 [emerg] 1#0: mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
nginx: [emerg] mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
```

I believe the issue is caused by restrictive file permissions for containers on OpenShift. To prevent this issue, there is an unprivileged version of the nginx image `nginx-unprivileged`. This PR switches the qa SACTest to this unprivileged image.

I initially attempted to introduce `nginx-unprivileged` also for other tests, however not all tests - in particular the process baseline tests - work out of the box with it. Since the issue seems to be quite rare, I just introduced it for `SACTest`, where the issue was actually observed. If we see this again with other tests, we can spend the time to make those work with `nginx-unprivileged` as well.

Note that `nginx-unprivileged` is a multi-arch image available for `ppc64le` and `s390x` (see tags in https://hub.docker.com/layers/nginxinc/nginx-unprivileged/1.25.2/images/sha256-fb24255b034e66b36087d7e73828d395b7ca1a7a9a7fd0234f9e99812b216109?context=explore).

## Testing Performed

Various CI runs.