### PR TITLE
build: Disable SELinux separation for podman containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,10 +407,6 @@ build-volumes:
 	$(SILENT)mkdir -p $(CURDIR)/linux-gocache
 	$(SILENT)docker volume inspect $(GOPATH_VOLUME_NAME) >/dev/null 2>&1 || docker volume create $(GOPATH_VOLUME_NAME)
 	$(SILENT)docker volume inspect $(GOCACHE_VOLUME_NAME) >/dev/null 2>&1 || docker volume create $(GOCACHE_VOLUME_NAME)
-ifneq ($(DOCKER_USER),)
-	@echo "Restoring user's ownership of linux-gocache and go directories after previous runs which could set it to root..."
-	$(SILENT)docker run --rm $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) chown -R "$(shell id -u)" /linux-gocache /go
-endif
 
 .PHONY: main-builder-image
 main-builder-image: build-volumes

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ BENCHCOUNT ?= 1
 ifeq (,$(findstring podman,$(shell docker --version 2>/dev/null)))
 # Podman DTRT by running processes unprivileged in containers,
 # but it's UID mapping is more nuanced. Only set user for vanilla docker.
-DOCKER_USER=--user "$(shell id -u)"
+DOCKER_OPTS=--user "$(shell id -u)"
+else
+DOCKER_OPTS=--security-opt label=disable
 endif
 
 # Set to empty string to echo some command lines which are hidden by default.
@@ -216,7 +218,7 @@ central-build-nodeps:
 .PHONY: fast-central
 fast-central: deps
 	@echo "+ $@"
-	docker run $(DOCKER_USER) -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make fast-central-build
+	docker run $(DOCKER_OPTS) -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make fast-central-build
 	$(SILENT)$(BASE_DIR)/scripts/k8s/kill-pod.sh central
 
 # fast is a dev mode options when using local dev
@@ -234,7 +236,7 @@ fast-sensor-kubernetes: sensor-kubernetes-build-dockerized
 .PHONY: fast-migrator
 fast-migrator:
 	@echo "+ $@"
-	docker run $(DOCKER_USER) -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make fast-migrator-build
+	docker run $(DOCKER_OPTS) -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make fast-migrator-build
 
 .PHONY: fast-migrator-build
 fast-migrator-build: migrator-build-nodeps
@@ -422,12 +424,12 @@ main-build: build-prep main-build-dockerized
 .PHONY: sensor-build-dockerized
 sensor-build-dockerized: main-builder-image
 	@echo "+ $@"
-	docker run $(DOCKER_USER) --rm -e CI -e BUILD_TAG -e GOTAGS -e DEBUG_BUILD $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make sensor-build
+	docker run $(DOCKER_OPTS) --rm -e CI -e BUILD_TAG -e GOTAGS -e DEBUG_BUILD $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make sensor-build
 
 .PHONY: sensor-kubernetes-build-dockerized
 sensor-kubernetes-build-dockerized: main-builder-image
 	@echo "+ $@"
-	docker run $(DOCKER_USER) -e CI -e BUILD_TAG -e GOTAGS -e DEBUG_BUILD $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make sensor-kubernetes-build
+	docker run $(DOCKER_OPTS) -e CI -e BUILD_TAG -e GOTAGS -e DEBUG_BUILD $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make sensor-kubernetes-build
 
 .PHONY: sensor-build
 sensor-build:
@@ -441,7 +443,7 @@ sensor-kubernetes-build:
 .PHONY: main-build-dockerized
 main-build-dockerized: main-builder-image
 	@echo "+ $@"
-	docker run $(DOCKER_USER) -i -e RACE -e CI -e BUILD_TAG -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make main-build-nodeps
+	docker run $(DOCKER_OPTS) -i -e RACE -e CI -e BUILD_TAG -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make main-build-nodeps
 
 .PHONY: main-build-nodeps
 main-build-nodeps: central-build-nodeps migrator-build-nodeps

--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -258,7 +258,7 @@ $(MERGED_API_SWAGGER_SPEC_V2): $(BASE_PATH)/scripts/mergeswag.sh $(GENERATED_API
 # Generate the docs from the merged swagger specs.
 $(GENERATED_API_DOCS): $(MERGED_API_SWAGGER_SPEC) $(PROTOC_GEN_GRPC_GATEWAY)
 	@echo "+ $@"
-	docker run $(DOCKER_USER) --rm -v $(CURDIR)/$(GENERATED_DOC_PATH):/tmp/$(GENERATED_DOC_PATH) swaggerapi/swagger-codegen-cli generate -l html2 -i /tmp/$< -o /tmp/$@
+	docker run $(DOCKER_OPTS) --rm -v $(CURDIR)/$(GENERATED_DOC_PATH):/tmp/$(GENERATED_DOC_PATH) swaggerapi/swagger-codegen-cli generate -l html2 -i /tmp/$< -o /tmp/$@
 
 # Nukes pretty much everything that goes into building protos.
 # You should not have to run this day-to-day, but it occasionally is useful


### PR DESCRIPTION
## Description                                                                                                                                        

Without this change, this is the error I get when running a dockerized build with podman:

```
$ make main-build-dockerized
[ ... ]
docker run  -i -e RACE -e CI -e BUILD_TAG -e GOTAGS -e DEBUG_BUILD --rm -w /src \
    -e GOPATH=/go -e GOCACHE=/linux-gocache -e GIT_CONFIG_COUNT=1 -e GIT_CONFIG_KEY \
    _0=safe.directory -e GIT_CONFIG_VALUE_0='/src' \
    -v/home/klape/src/stackrox:/src:delegated \
    -v /home/klape/src/stackrox/linux-gocache:/linux-gocache:delegated \
    -v /home/klape/go:/go:delegated \
    quay.io/stackrox-io/apollo-ci:stackrox-build-0.3.59 \
    make main-build-nodeps
make: stat: Makefile: Permission denied
make: *** No rule to make target 'main-build-nodeps'.  Stop.
make: *** [Makefile:421: main-build-dockerized] Error 2
```

Since podman maps the uid in the container, the user in the container does not have access to anything in the /src dir.  Note that I get the same error even with the `--user $(id -u)` option.

The `podman-run` man page explains an option to disable SELinux separation:

> Note: Do not relabel system files and directories. Relabeling system content might cause other confined services on the machine to fail. For  these types  of containers  we  recommend disabling SELinux separation.  The option --security-opt label=disable disables SELinux separation for the container.  For example if a user wanted to volume mount their entire home directory into a container, they need to disable SELinux separation.
>
>        $ podman run --security-opt label=disable -v $HOME:/home/user fedora touch /home/user/file

Since modifying file SELinux labels seems risky (particularly for the go path mount), the safer (and simpler) option seems to just disable the SELinux separation altogether for these particular containers (since we can reasonably trust stackrox builder containers).

## Testing Performed

### Here I tell how I validated my change

I ran `make main-build-dockerized` with podman installed, and it ran without error.

I also made sure the `--user` option was still set with docker by modifying the `podman` string in the `ifeq` on line 8 to take the different code path.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the performed testing and you are satisfied with it.