### PR TITLE
chore(e2e): Update cypress 13.0.0 devDependencies in ui

### DIFF
--- a/ui/apps/platform/cypress.config.js
+++ b/ui/apps/platform/cypress.config.js
@@ -11,6 +11,8 @@ module.exports = {
     chromeWebSecurity: false, // Browser options
     numTestsKeptInMemory: 0, // Global options
     requestTimeout: 10000, // Timeouts options
+    video: true, // Videos options
+    videoCompression: 32, // Videos options
     viewportHeight: 850, // Viewport options
     viewportWidth: 1440, // Viewport options
 

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -126,7 +126,7 @@
         "@types/segment-analytics": "^0.0.34",
         "autoprefixer": "^10.2.5",
         "babel-eslint": "^10.1.0",
-        "cypress": "^12.17.4",
+        "cypress": "^13.0.0",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-airbnb-typescript": "12.3.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1770,10 +1770,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz#1bfafe4b7ed0f3e4105837e056e0a89b108ebe36"
   integrity sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==
 
-"@cypress/request@2.88.12":
-  version "2.88.12"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.12.tgz#ba4911431738494a85e93fb04498cb38bc55d590"
-  integrity sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==
+"@cypress/request@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.0.tgz#7f58dfda087615ed4e6aab1b25fffe7630d6dd85"
+  integrity sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -7318,12 +7318,12 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^12.17.4:
-  version "12.17.4"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.17.4.tgz#b4dadf41673058493fa0d2362faa3da1f6ae2e6c"
-  integrity sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==
+cypress@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.0.0.tgz#8fe8f13dbb46f76ad30fa2d47be1c3489de625d2"
+  integrity sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==
   dependencies:
-    "@cypress/request" "2.88.12"
+    "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"
     "@types/node" "^16.18.39"
     "@types/sinonjs__fake-timers" "8.1.1"


### PR DESCRIPTION
## Description

https://docs.cypress.io/guides/references/changelog#13-0-0

Although Test Replay for Cypress Cloud is not relevant for us, it does affect some configuration.

1. Automation performance is now improved by switching away from websockets to direct CDP calls for Chrome and Electron browsers.
2. Edge cases where `cy.intercept` would not properly intercept have been addressed.
3. Node 14 support has been removed and Node 16 support has been deprecated. Node 16 may continue to work with Cypress v13, but will not be supported moving forward to closer coincide with Node 16's end-of-life schedule. It is recommended that users update to at least Node 18.
    * CI currently uses 18.16.0
    * I am currently using 16.13.0 and tested locally that this upgrade version works.
4. The minimum supported Typescript version is 4.x
    * UI currently uses TypeScript 5.1.5 although irrelevant because integration tests are JavaScript.
5. Upgraded (at) cypress/request from ^2.88.11 to ^3.0.0 to address the CVE-2023-28155 security vulnerability.

https://docs.cypress.io/guides/references/migration-guide#Video-updates

1. `video` is set to `false` by default.
2. `videoCompression` is set to `false` by default.

Explicitly set previous default values in ui/apps/platform/cypress.config.js

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test configuration

## Testing Performed

1. `yarn` in ui
2. `yarn start` in ui
4. `yarn cypress-open` in ui/apps/platform
    * compliance/hideScanResults.test.js
