### PR TITLE
ROX-19485: Change create button into a dropdown footer

### DIFF
--- a/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
+++ b/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
@@ -15,6 +15,7 @@ export type SelectSingleProps = {
     placeholderText?: string;
     onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
     menuAppendTo?: () => HTMLElement;
+    footer?: React.ReactNode;
 };
 
 function SelectSingle({
@@ -31,6 +32,7 @@ function SelectSingle({
     placeholderText = '',
     onBlur,
     menuAppendTo,
+    footer,
 }: SelectSingleProps): ReactElement {
     const [isOpen, setIsOpen] = useState(false);
 
@@ -59,6 +61,7 @@ function SelectSingle({
             toggleId={id}
             onBlur={onBlur}
             menuAppendTo={menuAppendTo}
+            footer={footer}
         >
             {children}
         </Select>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
@@ -114,6 +114,7 @@ function CollectionSelection({
     }
 
     function onOpenCreateCollectionModal() {
+        onToggle(false);
         setModalAction({ type: 'create' });
         setIsCollectionModalOpen((current) => !current);
     }
@@ -171,7 +172,20 @@ function CollectionSelection({
                             overflowY: 'auto',
                         }}
                         validated={ValidatedOptions.default}
+                        footer={
+                            hasWriteAccessForCollections &&
+                            isRouteEnabledForCollections && (
+                                <Button
+                                    variant="link"
+                                    isInline
+                                    onClick={onOpenCreateCollectionModal}
+                                >
+                                    Create collection
+                                </Button>
+                            )
+                        }
                         menuAppendTo={() => document.body}
+                        direction="up"
                     >
                         {sortedCollections.map((collection) => (
                             <SelectOption
@@ -192,16 +206,6 @@ function CollectionSelection({
                             isDisabled={!selectedScope}
                         >
                             View
-                        </Button>
-                    </FlexItem>
-                )}
-                {hasWriteAccessForCollections && isRouteEnabledForCollections && (
-                    <FlexItem>
-                        <Button
-                            variant={ButtonVariant.secondary}
-                            onClick={onOpenCreateCollectionModal}
-                        >
-                            Create collection
                         </Button>
                     </FlexItem>
                 )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/NotifierSelection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/NotifierSelection.tsx
@@ -1,13 +1,6 @@
 import React, { useState, useEffect, ReactElement } from 'react';
 
-import {
-    Button,
-    ButtonVariant,
-    Flex,
-    FlexItem,
-    SelectOption,
-    TextInput,
-} from '@patternfly/react-core';
+import { Button, Flex, FlexItem, SelectOption, TextInput } from '@patternfly/react-core';
 import { FormikProps } from 'formik';
 
 import SelectSingle from 'Components/SelectSingle';
@@ -98,6 +91,17 @@ function NotifierSelection({
                             handleSelect={onNotifierChange}
                             placeholderText="Select a notifier"
                             isDisabled={notifiers.length === 0}
+                            footer={
+                                allowCreate && (
+                                    <Button
+                                        variant="link"
+                                        isInline
+                                        onClick={onToggleEmailNotifierModal}
+                                    >
+                                        Create email notifier
+                                    </Button>
+                                )
+                            }
                         >
                             {notifiers.map(({ id, name }) => (
                                 <SelectOption key={id} value={id}>
@@ -106,16 +110,6 @@ function NotifierSelection({
                             ))}
                         </SelectSingle>
                     </FlexItem>
-                    {allowCreate && (
-                        <FlexItem>
-                            <Button
-                                variant={ButtonVariant.secondary}
-                                onClick={onToggleEmailNotifierModal}
-                            >
-                                Create email notifier
-                            </Button>
-                        </FlexItem>
-                    )}
                 </Flex>
             </FormLabelGroup>
             <FormLabelGroup


### PR DESCRIPTION
## Description

This change includes removing the "Create" buttons for the Collection and Notifier in the VM 2.0 Reports Form and placing them inside the dropdown select as a footer action. See included screenshots

<img width="319" alt="Screenshot 2023-08-31 at 4 49 38 PM" src="https://github.com/stackrox/stackrox/assets/4805485/191c0fc6-7887-4134-98d2-386ea4432021">
<img width="358" alt="Screenshot 2023-08-31 at 4 49 43 PM" src="https://github.com/stackrox/stackrox/assets/4805485/d6275029-f40a-4614-b1cb-92dcb71938fa">
<img width="219" alt="Screenshot 2023-08-31 at 4 53 48 PM" src="https://github.com/stackrox/stackrox/assets/4805485/1679459b-ca0b-4f02-b34e-1c0019749454">
<img width="233" alt="Screenshot 2023-08-31 at 4 53 52 PM" src="https://github.com/stackrox/stackrox/assets/4805485/f4104929-e3bb-4965-ac6e-e6d7f63c92e1">


