### PR TITLE
fix(GHA): cut-rc - github.event.inputs is empty for closed milestones

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -51,7 +51,7 @@ run-name: >-
     format('Cut {0}{1}{2}',
       github.event.milestone.title,
       inputs.version,
-      fromJSON('[" (dry-run)", ""]')[inputs.dry-run != true]
+      fromJSON('[" (dry-run)", ""]')[github.event.inputs.dry-run != 'true']
     )
   }}
 
@@ -97,9 +97,10 @@ jobs:
     name: Check Jira tickets for release
     needs: [variables, properties]
     runs-on: ubuntu-latest
+    # Checking unequal with "false" because closed milestones have unset input values.
+    if: github.event.inputs.check-jira-issues != 'false'
     steps:
       - name: Query JIRA
-        if: github.event.inputs.check-jira-issues == 'true'
         env:
           JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
         run: |
@@ -305,16 +306,16 @@ jobs:
     secrets: inherit
     needs: [variables, cut-rc]
     uses: stackrox/actions/.github/workflows/create-demo-clusters.yml@v1
-    if: >- # Skip if no clusters are going to be created.
+    if: >- # Skip if no clusters are going to be created. Checking unequal with "false" because closed milestones have unset input values.
       github.event.inputs.create-k8s-cluster != 'false' ||
       github.event.inputs.create-os4-cluster != 'false' ||
       needs.variables.outputs.rc == '1' &&
       github.event.inputs.create-long-cluster != 'false'
     with:
       version: ${{needs.variables.outputs.milestone}}
-      create-k8s-cluster: ${{github.event.inputs.create-k8s-cluster == 'true'}}
-      create-os4-cluster: ${{github.event.inputs.create-os4-cluster == 'true'}}
-      create-long-cluster: ${{needs.variables.outputs.rc == '1' && github.event.inputs.create-long-cluster == 'true'}}
+      create-k8s-cluster: ${{github.event.inputs.create-k8s-cluster != 'false'}}
+      create-os4-cluster: ${{github.event.inputs.create-os4-cluster != 'false'}}
+      create-long-cluster: ${{needs.variables.outputs.rc == '1' && github.event.inputs.create-long-cluster != 'false'}}
       dry-run: ${{github.event.inputs.dry-run == 'true'}}
       workflow-ref: v1
       kube-burner-config-ref: ${{needs.variables.outputs.milestone}}


### PR DESCRIPTION
Auto-generated PR to update the upstream GHA automation

Tested in https://github.com/stackrox/test-gh-actions/pull/125