### PR TITLE
ROX-18276: adapt telemetry metrics to Telemeter feedback

### DIFF
--- a/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
@@ -109,19 +109,19 @@ spec:
       rules:
         - expr: |
             max by (build, central_id, central_version, hosting, install_method) (
-              rox_central_secured_clusters{branding="RHACS"}
+              rox_central_secured_clusters{branding=~"rhacs|RHACS"}
             )
           record: rhacs:telemetry:rox_central_secured_clusters
 
         - expr: |
             max by (build, central_id, central_version, hosting, install_method) (
-              rox_central_secured_nodes{branding="RHACS"}
+              rox_central_secured_nodes{branding=~"rhacs|RHACS"}
             )
           record: rhacs:telemetry:rox_central_secured_nodes
 
         - expr: |
             max by (build, central_id, central_version, hosting, install_method) (
-              rox_central_secured_vcpu{branding="RHACS"}
+              rox_central_secured_vcpu{branding=~"rhacs|RHACS"}
             )
           record: rhacs:telemetry:rox_central_secured_vcpu
 

--- a/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
@@ -108,20 +108,20 @@ spec:
     - name: rhacs.telemeter
       rules:
         - expr: |
-            max by (branding, build, central_id, central_version, hosting, install_method) (
-              rox_central_secured_clusters
+            max by (build, central_id, central_version, hosting, install_method) (
+              rox_central_secured_clusters{branding="RHACS"}
             )
           record: rhacs:telemetry:rox_central_secured_clusters
 
         - expr: |
-            max by (branding, build, central_id, central_version, hosting, install_method) (
-              rox_central_secured_nodes
+            max by (build, central_id, central_version, hosting, install_method) (
+              rox_central_secured_nodes{branding="RHACS"}
             )
           record: rhacs:telemetry:rox_central_secured_nodes
 
         - expr: |
-            max by (branding, build, central_id, central_version, hosting, install_method) (
-              rox_central_secured_vcpu
+            max by (build, central_id, central_version, hosting, install_method) (
+              rox_central_secured_vcpu{branding="RHACS"}
             )
           record: rhacs:telemetry:rox_central_secured_vcpu
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
@@ -114,7 +114,7 @@ spec:
       rules:
         - expr: |
             max by (build, central_id, hosting, install_method, sensor_id, sensor_version) (
-              rox_sensor_secured_nodes{branding="RHACS"} > bool 0
+              rox_sensor_secured_nodes{branding=~"rhacs|RHACS"} > bool 0
             )
           record: rhacs:telemetry:rox_sensor_info
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
@@ -113,15 +113,9 @@ spec:
     - name: rhacs.telemeter
       rules:
         - expr: |
-            max by (branding, build, central_id, hosting, install_method, sensor_id, sensor_version) (
-              rox_sensor_secured_nodes
+            max by (build, central_id, hosting, install_method, sensor_id, sensor_version) (
+              rox_sensor_secured_nodes{branding="RHACS"} > bool 0
             )
-          record: rhacs:telemetry:rox_sensor_secured_nodes
-
-        - expr: |
-            max by (branding, build, central_id, hosting, install_method, sensor_id, sensor_version) (
-              rox_sensor_secured_vcpu
-            )
-          record: rhacs:telemetry:rox_sensor_secured_vcpu
+          record: rhacs:telemetry:rox_sensor_info
 
 {{- end -}}


### PR DESCRIPTION
## Description

Based on feedback in https://github.com/openshift/cluster-monitoring-operator/pull/2062, change the telemetry metrics in the following ways:

* `rhacs:telemetry:rox_sensor_secured_nodes` and `rhacs:telemetry:rox_sensor_secured_vcpu` -> `rhacs:telemetry:rox_sensor_info`. The reason for this change is that Telemeter already includes the node count and cpu count in their metrics. We keep the info metric for the remaining information.
* remove `branding` label from all recording rules and filter directly for `RHACS` branding.

~~I also realized that `ROX_PRODUCT_BRANDING` is not set consistently in the container environment. Therefore, switch to the image flavor name `ROX_IMAGE_FLAVOR`, which serves essentially the same purpose. We may switch back to `ROX_PRODUCT_BRANDING` at a later time once we figured out the env problem.~~

~~From https://github.com/stackrox/stackrox/blob/b522f6257b837102c6a32cc5e4fd1138751127ce/pkg/images/defaults/env.go, we assume that `ROX_IMAGE_FLAVOR` having `"rhacs"` string in its value is a solid indication of a production RHACS build.~~

The above bug will be fixed independently, no need for the workaround.

## Testing Performed

Tested the metrics in an OpenShift cluster.