### PR TITLE
fix: invert if to exit early from func

### DIFF
--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -903,68 +903,69 @@ func enrichImage(image *storage.Image, scan *storage.ImageScan, dataSource *stor
 
 // FillScanStats fills in the higher level stats from the scan data.
 func FillScanStats(i *storage.Image) {
-	if i.GetScan() != nil {
-		i.SetComponents = &storage.Image_Components{
-			Components: int32(len(i.GetScan().GetComponents())),
-		}
+	if i.GetScan() == nil {
+		return
+	}
+	i.SetComponents = &storage.Image_Components{
+		Components: int32(len(i.GetScan().GetComponents())),
+	}
 
-		var fixedByProvided bool
-		var imageTopCVSS float32
-		vulns := make(map[string]bool)
-		for _, c := range i.GetScan().GetComponents() {
-			var componentTopCVSS float32
-			var hasVulns bool
-			for _, v := range c.GetVulns() {
-				hasVulns = true
-				if _, ok := vulns[v.GetCve()]; !ok {
-					vulns[v.GetCve()] = false
-				}
-
-				if v.GetCvss() > componentTopCVSS {
-					componentTopCVSS = v.GetCvss()
-				}
-
-				if v.GetSetFixedBy() == nil {
-					continue
-				}
-
-				fixedByProvided = true
-				if v.GetFixedBy() != "" {
-					vulns[v.GetCve()] = true
-				}
+	var fixedByProvided bool
+	var imageTopCVSS float32
+	vulns := make(map[string]bool)
+	for _, c := range i.GetScan().GetComponents() {
+		var componentTopCVSS float32
+		var hasVulns bool
+		for _, v := range c.GetVulns() {
+			hasVulns = true
+			if _, ok := vulns[v.GetCve()]; !ok {
+				vulns[v.GetCve()] = false
 			}
 
-			if hasVulns {
-				c.SetTopCvss = &storage.EmbeddedImageScanComponent_TopCvss{
-					TopCvss: componentTopCVSS,
-				}
+			if v.GetCvss() > componentTopCVSS {
+				componentTopCVSS = v.GetCvss()
 			}
 
-			if componentTopCVSS > imageTopCVSS {
-				imageTopCVSS = componentTopCVSS
+			if v.GetSetFixedBy() == nil {
+				continue
+			}
+
+			fixedByProvided = true
+			if v.GetFixedBy() != "" {
+				vulns[v.GetCve()] = true
 			}
 		}
 
-		i.SetCves = &storage.Image_Cves{
-			Cves: int32(len(vulns)),
-		}
-
-		if len(vulns) > 0 {
-			i.SetTopCvss = &storage.Image_TopCvss{
-				TopCvss: imageTopCVSS,
+		if hasVulns {
+			c.SetTopCvss = &storage.EmbeddedImageScanComponent_TopCvss{
+				TopCvss: componentTopCVSS,
 			}
 		}
 
-		if int32(len(vulns)) == 0 || fixedByProvided {
-			var numFixableVulns int32
-			for _, fixable := range vulns {
-				if fixable {
-					numFixableVulns++
-				}
+		if componentTopCVSS > imageTopCVSS {
+			imageTopCVSS = componentTopCVSS
+		}
+	}
+
+	i.SetCves = &storage.Image_Cves{
+		Cves: int32(len(vulns)),
+	}
+
+	if len(vulns) > 0 {
+		i.SetTopCvss = &storage.Image_TopCvss{
+			TopCvss: imageTopCVSS,
+		}
+	}
+
+	if int32(len(vulns)) == 0 || fixedByProvided {
+		var numFixableVulns int32
+		for _, fixable := range vulns {
+			if fixable {
+				numFixableVulns++
 			}
-			i.SetFixable = &storage.Image_FixableCves{
-				FixableCves: numFixableVulns,
-			}
+		}
+		i.SetFixable = &storage.Image_FixableCves{
+			FixableCves: numFixableVulns,
 		}
 	}
 }


### PR DESCRIPTION
## Description

This is just a style change to use less indentation after inverting condition and exiting early.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
