### PR TITLE
ROX-19527: Rewrite ClusterDeployment in TypeScript

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { ReactElement } from 'react';
 import { Alert, Button } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
 import { CheckCircle } from 'react-feather';
@@ -7,10 +6,21 @@ import { ClipLoader } from 'react-spinners';
 
 import CollapsibleCard from 'Components/CollapsibleCard';
 import ToggleSwitch from 'Components/ToggleSwitch';
+import { ClusterManagerType } from 'types/cluster.proto';
 
 const baseClass = 'py-6';
 
-const ClusterDeploymentPage = ({
+export type ClusterDeploymentProps = {
+    clusterCheckedIn: boolean;
+    createUpgraderSA: boolean;
+    editing: boolean;
+    isDownloadingBundle: boolean;
+    managerType: ClusterManagerType;
+    onFileDownload: () => void;
+    toggleSA: () => void;
+};
+
+function ClusterDeployment({
     onFileDownload,
     isDownloadingBundle,
     clusterCheckedIn,
@@ -18,7 +28,7 @@ const ClusterDeploymentPage = ({
     createUpgraderSA,
     toggleSA,
     managerType,
-}) => {
+}: ClusterDeploymentProps): ReactElement {
     let managerTypeTitle = 'Dynamic configurations are automatically applied';
     let managerTypeText =
         'If you edited static configurations or you need to redeploy, download a new bundle.';
@@ -54,7 +64,6 @@ const ClusterDeploymentPage = ({
                                     </label>
                                     <ToggleSwitch
                                         id="createUpgraderSA"
-                                        name="createUpgraderSA"
                                         toggleHandler={toggleSA}
                                         enabled={createUpgraderSA}
                                     />
@@ -113,16 +122,6 @@ const ClusterDeploymentPage = ({
             )}
         </div>
     );
-};
+}
 
-ClusterDeploymentPage.propTypes = {
-    onFileDownload: PropTypes.func.isRequired,
-    isDownloadingBundle: PropTypes.bool.isRequired,
-    clusterCheckedIn: PropTypes.bool.isRequired,
-    editing: PropTypes.bool.isRequired,
-    createUpgraderSA: PropTypes.bool.isRequired,
-    toggleSA: PropTypes.func.isRequired,
-    managerType: PropTypes.string.isRequired,
-};
-
-export default ClusterDeploymentPage;
+export default ClusterDeployment;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterEditForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterEditForm.tsx
@@ -2,13 +2,14 @@ import React, { ReactElement } from 'react';
 
 import Loader from 'Components/Loader';
 import { labelClassName } from 'constants/form.constants';
+import { Cluster, ClusterManagerType } from 'types/cluster.proto';
 import { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
 
 import ClusterSummary from './Components/ClusterSummary';
 import StaticConfigurationSection from './StaticConfigurationSection';
 import DynamicConfigurationSection from './DynamicConfigurationSection';
 import ClusterLabelsTable from './ClusterLabelsTable';
-import { CentralEnv, Cluster, ClusterManagerType } from './clusterTypes';
+import { CentralEnv } from './clusterTypes'; // augmented with successfullyFetched
 
 type ClusterEditFormProps = {
     centralEnv: CentralEnv;

--- a/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
@@ -18,7 +18,7 @@ import {
     downloadClusterYaml,
     getClusterDefaults,
 } from 'services/ClustersService';
-import { Cluster } from 'types/cluster.proto';
+import { Cluster, ClusterManagerType } from 'types/cluster.proto';
 import { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useAnalytics, { CLUSTER_CREATED } from 'hooks/useAnalytics';
@@ -31,7 +31,7 @@ import {
     newClusterDefault,
     centralEnvDefault,
 } from './cluster.helpers';
-import { CentralEnv, ClusterManagerType } from './clusterTypes';
+import { CentralEnv } from './clusterTypes'; // augmented with successfullyFetched
 
 const requiredKeys = ['name', 'type', 'mainImage', 'centralApiEndpoint'];
 

--- a/ui/apps/platform/src/Containers/Clusters/clusterTypes.ts
+++ b/ui/apps/platform/src/Containers/Clusters/clusterTypes.ts
@@ -1,7 +1,3 @@
-import { Cluster } from 'types/cluster.proto';
-
-export type { Cluster }; // TODO replace all imports from this file with imports from types/cluster.proto file
-
 export type SensorHealthStatus = 'HEALTHY' | 'UNHEALTHY' | 'DEGRADED' | 'UNINITIALIZED';
 
 export type ClusterHealthItemStatus =
@@ -66,10 +62,6 @@ export type DynamicConfig = {
     };
 };
 
-export type HelmConfig = {
-    dynamicConfig: DynamicConfig;
-};
-
 export type CentralEnv = {
     kernelSupportAvailable?: boolean;
     successfullyFetched?: boolean;
@@ -92,9 +84,3 @@ export type ClusterStatus = {
     upgradeStatus: SensorUpgradeStatus;
     certExpiryStatus: CertExpiryStatus;
 };
-
-export type ClusterManagerType =
-    | 'MANAGER_TYPE_UNKNOWN'
-    | 'MANAGER_TYPE_MANUAL'
-    | 'MANAGER_TYPE_HELM_CHART'
-    | 'MANAGER_TYPE_KUBERNETES_OPERATOR';


### PR DESCRIPTION
## Description

Increase type safety before making functional changes to the page.

### Residue

1. Replace import from container clusterTypes.ts with src/types/cluster.proto.ts file.
    * 23 results in 16 files within Clusters container.
    * Separate chore for cluster types and helpers for credential expiration in SystemHealth container.
2. Investigate how to represent request status for `kernelSupportAvailable` property.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3761772 - 3761772
        total: -18 = 9977206 - 9977224
    * `ls -al build/static/js/*.js | wc -l`
        0 = 80 - 80 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/clusters and create an unavailable cluster.
    ![ClusterDeployment](https://github.com/stackrox/stackrox/assets/11862657/9ac3e5e2-0d94-4624-b8c0-ba4ade848a60)

### Integration testing

* clusters/clusterDeletion.test.js
* clusters/clusters.test.js
* clusters/clustersCertificateExpiration.test.js
* clusters/clustersHealthStatus.test.js
* clusters/clustersManager.test.js
* clusters/delegatedScanning.test.js 1 test fails see what happens on CI
* clusters/redirectFromDashboard.test.js
