### PR TITLE
fix: Scanner NetworkPolicy only allow traffic from Central to select …

### DIFF
--- a/image/templates/helm/shared/templates/02-scanner-05-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-05-network-policy.yaml
@@ -20,17 +20,22 @@ spec:
     - podSelector:
         matchLabels:
           app: central
-{{ if or (eq ._rox.scanner.mode "slim") ._rox.env.openshift }}
-  - from:
-    - podSelector:
-        matchLabels:
-          app: sensor
-{{ end }}
     ports:
     - port: 8080
       protocol: TCP
     - port: 8443
       protocol: TCP
+{{ if or (eq ._rox.scanner.mode "slim") ._rox.env.openshift }}
+  - from:
+    - podSelector:
+        matchLabels:
+          app: sensor
+    ports:
+    - port: 8080
+      protocol: TCP
+    - port: 8443
+      protocol: TCP
+{{ end }}
   policyTypes:
     - Ingress
 

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
@@ -115,7 +115,9 @@ tests:
     verifyNodeAffinities(.deployments["scanner"])
     verifyNodeAffinities(.deployments["scanner-db"])
     .networkpolicys["scanner"].spec.ingress | assertThat(length == 2)
+    .networkpolicys["scanner"].spec.ingress[0] | .ports | assertThat(length == 2)
     .networkpolicys["scanner"].spec.ingress[1] | .from[0].podSelector.matchLabels.app | assertThat(. == "sensor")
+    .networkpolicys["scanner"].spec.ingress[1] | .ports | assertThat(length == 2)
 
 - name: "scanner with OpenShift 4 and disabled SCCs"
   server:
@@ -137,7 +139,9 @@ tests:
     verifyNodeAffinities(.deployments["scanner"])
     verifyNodeAffinities(.deployments["scanner-db"])
     .networkpolicys["scanner"].spec.ingress | assertThat(length == 2)
+    .networkpolicys["scanner"].spec.ingress[0] | .ports | assertThat(length == 2)
     .networkpolicys["scanner"].spec.ingress[1] | .from[0].podSelector.matchLabels.app | assertThat(. == "sensor")
+    .networkpolicys["scanner"].spec.ingress[1] | .ports | assertThat(length == 2)
 
 - name: "Installation fails with slim mode"
   values:


### PR DESCRIPTION
…ports

## Description

[A previous change opened up traffic from Central to any port in the Scanner image.](https://github.com/stackrox/stackrox/pull/746/files) This PR reverts it back to only allow traffic to select ports. This also only allows traffic from Sensor to the gRPC port, and not the HTTP port, as only the gRPC port should be used by Sensor.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

CI
