### PR TITLE
ROX-18772: fix scanImage retry

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/ImageService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ImageService.groovy
@@ -3,7 +3,9 @@ package services
 import static util.Helpers.evaluateWithRetry
 import static util.Helpers.withRetry
 
+import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+
 import io.stackrox.proto.api.v1.EmptyOuterClass
 import io.stackrox.proto.api.v1.ImageServiceGrpc
 import io.stackrox.proto.api.v1.ImageServiceOuterClass
@@ -11,6 +13,7 @@ import io.stackrox.proto.api.v1.SearchServiceOuterClass.RawQuery
 import io.stackrox.proto.storage.ImageOuterClass
 
 @Slf4j
+@CompileStatic
 class ImageService extends BaseService {
     static ImageServiceGrpc.ImageServiceBlockingStub getImageClient() {
         return ImageServiceGrpc.newBlockingStub(getChannel())
@@ -20,7 +23,7 @@ class ImageService extends BaseService {
         return getImageClient().listImages(request).imagesList
     }
 
-    static getImage(String digest, Boolean includeSnoozed = true) {
+    static ImageOuterClass.Image getImage(String digest, Boolean includeSnoozed = true) {
         if (digest == null) {
             return null
         }

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -78,14 +78,14 @@ class ImageManagementTest extends BaseSpecification {
     def "Verify two consecutive latest tag image have different scans"() {
         given:
         // Scan an ubuntu 14:04 image we're pretending is latest
-        def img = Services.scanImage(
+        def img = ImageService.scanImage(
             "quay.io/rhacs-eng/qa-multi-arch:ubuntu-latest" +
-                "@sha256:64483f3496c1373bfd55348e88694d1c4d0c9b660dee6bfef5e12f43b9933b30") // 14.04
+                "@sha256:64483f3496c1373bfd55348e88694d1c4d0c9b660dee6bfef5e12f43b9933b30", false) // 14.04
         assert img.scan.componentsList.stream().find { x -> x.name == "eglibc" } != null
 
-        img = Services.scanImage(
+        img = ImageService.scanImage(
             "quay.io/rhacs-eng/qa-multi-arch:ubuntu-latest" +
-                "@sha256:1f1a2d56de1d604801a9671f301190704c25d604a416f59e03c04f5c6ffee0d6") // 16.04
+                "@sha256:1f1a2d56de1d604801a9671f301190704c25d604a416f59e03c04f5c6ffee0d6", false) // 16.04
 
         expect:
         assert img.scan != null
@@ -96,7 +96,7 @@ class ImageManagementTest extends BaseSpecification {
     @Tag("BAT")
     def "Verify image scan finds correct base OS - #qaImageTag"() {
         when:
-        def img = Services.scanImage("quay.io/rhacs-eng/qa:$qaImageTag")
+        def img = ImageService.scanImage("quay.io/rhacs-eng/qa:$qaImageTag")
         then:
         assert img.scan.operatingSystem == expected
         where:

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -96,7 +96,7 @@ class ImageManagementTest extends BaseSpecification {
     @Tag("BAT")
     def "Verify image scan finds correct base OS - #qaImageTag"() {
         when:
-        def img = ImageService.scanImage("quay.io/rhacs-eng/qa:$qaImageTag")
+        def img = ImageService.scanImage("quay.io/rhacs-eng/qa:$qaImageTag", false)
         then:
         assert img.scan.operatingSystem == expected
         where:

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -413,7 +413,7 @@ class ImageScanningTest extends BaseSpecification {
 
         and:
         "Scan Image and verify results"
-        ImageOuterClass.Image img = ImageService.scanImageNoRetry(image, false)
+        ImageOuterClass.Image img = ImageService.scanImage(image, false)
         assert img.metadata.dataSource.id != ""
         assert img.metadata.dataSource.name != ""
         assert img.scan.dataSource.id != ""
@@ -464,7 +464,7 @@ class ImageScanningTest extends BaseSpecification {
 
         and:
         "Scan Image and verify results"
-        ImageOuterClass.Image img = ImageService.scanImageNoRetry(image, false)
+        ImageOuterClass.Image img = ImageService.scanImage(image, false)
         assert img.metadata.dataSource.id != ""
         assert img.metadata.dataSource.name != ""
         assert img.scan.dataSource.id != ""
@@ -649,7 +649,7 @@ class ImageScanningTest extends BaseSpecification {
 
         and:
         "Image is scanned"
-        ImageService.scanImageNoRetry(image, false)
+        ImageService.scanImage(image, false)
 
         then:
         "get image by name"

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -413,7 +413,7 @@ class ImageScanningTest extends BaseSpecification {
 
         and:
         "Scan Image and verify results"
-        ImageOuterClass.Image img = Services.scanImage(image)
+        ImageOuterClass.Image img = ImageService.scanImageNoRetry(image, false)
         assert img.metadata.dataSource.id != ""
         assert img.metadata.dataSource.name != ""
         assert img.scan.dataSource.id != ""
@@ -464,7 +464,7 @@ class ImageScanningTest extends BaseSpecification {
 
         and:
         "Scan Image and verify results"
-        ImageOuterClass.Image img = Services.scanImage(image)
+        ImageOuterClass.Image img = ImageService.scanImageNoRetry(image, false)
         assert img.metadata.dataSource.id != ""
         assert img.metadata.dataSource.name != ""
         assert img.scan.dataSource.id != ""
@@ -520,7 +520,7 @@ class ImageScanningTest extends BaseSpecification {
         "Scan image"
         String image = IMAGES_FOR_ERROR_TESTS[scanner.name()][testAspect]
         assert image
-        Services.scanImage(image)
+        ImageService.scanImageNoRetry(image, false)
 
         then:
         "Verify image scan outcome"
@@ -649,7 +649,7 @@ class ImageScanningTest extends BaseSpecification {
 
         and:
         "Image is scanned"
-        Services.scanImage(image)
+        ImageService.scanImageNoRetry(image, false)
 
         then:
         "get image by name"

--- a/qa-tests-backend/src/test/groovy/RiskTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RiskTest.groovy
@@ -9,6 +9,7 @@ import io.stackrox.proto.storage.ProcessBaselineOuterClass
 import objects.Deployment
 import services.ClusterService
 import services.DeploymentService
+import services.ImageService
 import services.ProcessBaselineService
 import services.ProcessService
 import util.Env
@@ -52,7 +53,7 @@ class RiskTest extends BaseSpecification {
         clusterId = ClusterService.getClusterId()
 
         // ROX-6260: pre scan the image to avoid different risk scores
-        Services.scanImage(TEST_IMAGE)
+        ImageService.scanImage(TEST_IMAGE, false)
 
         for (int i = 0; i < 2; i++) {
             DEPLOYMENTS.push(

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -92,7 +92,7 @@ class SACTest extends BaseSpecification {
 
     def setupSpec() {
         // Make sure we scan the image initially to make reprocessing faster.
-        def img = Services.scanImage(TEST_IMAGE)
+        def img = ImageService.scanImage(TEST_IMAGE, false)
         assert img.hasScan()
 
         orchestrator.batchCreateDeployments(DEPLOYMENTS)

--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -242,20 +242,19 @@ class Services extends BaseService {
 
     static requestBuildImageScan(String registry, String remote, String tag, Boolean sendNotifications = false) {
         LOG.info "Request scan of ${registry}/${remote}:${tag} with sendNotifications=${sendNotifications}"
-        return evaluateWithRetry(10, 15) {
-            return getDetectionClient().detectBuildTime(
-                BuildDetectionRequest.newBuilder()
-                    .setImage(ContainerImage.newBuilder()
-                        .setName(ImageOuterClass.ImageName.newBuilder()
-                            .setRegistry(registry)
-                            .setRemote(remote)
-                            .setTag(tag)
-                            .build()
-                        )
-                    )
-                    .setSendNotifications(sendNotifications)
+        def request = BuildDetectionRequest.newBuilder()
+            .setImage(ContainerImage.newBuilder()
+                .setName(ImageOuterClass.ImageName.newBuilder()
+                    .setRegistry(registry)
+                    .setRemote(remote)
+                    .setTag(tag)
                     .build()
+                )
             )
+            .setSendNotifications(sendNotifications)
+            .build()
+        return evaluateWithRetry(10, 15) {
+            return getDetectionClient().detectBuildTime(request)
         }
     }
 


### PR DESCRIPTION
## Description

We have seen `scanImage` and `detectBuildTime` flaking repeatedly when image registries respond with throttling or `5xx` status codes. See https://issues.redhat.com/browse/ROX-18772 and related tickets for some examples.

Fix retries by doing the following:

* Consolidate use of `scanImage`.
* Fix the retry in `ImageService.scanImage` by increasing the attempts from 1 to 10.
* Add retry to `requestBuildImageScan`.

I believe this should fix many of the CI flakes we've been seeing around `scanImage`.

## Testing Performed

CI