### PR TITLE
ROX-19524: add debug logs to diag bundle

### DIFF
--- a/central/debug/service/diagnostics.go
+++ b/central/debug/service/diagnostics.go
@@ -216,6 +216,7 @@ func (s *serviceImpl) pullSensorMetrics(ctx context.Context, zipWriter *zip.Writ
 			return ctx.Err()
 		case file, ok := <-filesC:
 			if !ok {
+				log.Info("finished writing Sensor data to diagnostic bundle")
 				return nil
 			}
 			err := writePrefixedFileToZip(zipWriter, "sensor-metrics", file)
@@ -285,6 +286,7 @@ func (s *serviceImpl) getK8sDiagnostics(ctx context.Context, zipWriter *zip.Writ
 			return ctx.Err()
 		case file, ok := <-filesC:
 			if !ok {
+				log.Info("finished writing Kubernetes data to diagnostic bundle")
 				return nil
 			}
 			err := writePrefixedFileToZip(zipWriter, "kubernetes", file)

--- a/central/debug/service/diagnostics.go
+++ b/central/debug/service/diagnostics.go
@@ -216,7 +216,7 @@ func (s *serviceImpl) pullSensorMetrics(ctx context.Context, zipWriter *zip.Writ
 			return ctx.Err()
 		case file, ok := <-filesC:
 			if !ok {
-				log.Info("finished writing Sensor data to diagnostic bundle")
+				log.Info("Finished writing Sensor data to diagnostic bundle")
 				return nil
 			}
 			err := writePrefixedFileToZip(zipWriter, "sensor-metrics", file)
@@ -286,7 +286,7 @@ func (s *serviceImpl) getK8sDiagnostics(ctx context.Context, zipWriter *zip.Writ
 			return ctx.Err()
 		case file, ok := <-filesC:
 			if !ok {
-				log.Info("finished writing Kubernetes data to diagnostic bundle")
+				log.Info("Finished writing Kubernetes data to diagnostic bundle")
 				return nil
 			}
 			err := writePrefixedFileToZip(zipWriter, "kubernetes", file)

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -582,16 +582,16 @@ func (s *serviceImpl) writeZippedDebugDump(ctx context.Context, w http.ResponseW
 			log.Error(err)
 		}
 
-		log.Info("finished writing Central data to diagnostic bundle")
+		log.Info("Finished writing Central data to diagnostic bundle")
 	}
 
 	if opts.logs == fullK8sIntrospectionData {
 		if err := s.getK8sDiagnostics(debugDumpCtx, zipWriter, opts); err != nil {
-			log.Errorf("could not get K8s diagnostics: %+q", err)
+			log.Errorf("Could not get K8s diagnostics: %+q", err)
 			opts.logs = localLogs // fallback to local logs
 		}
 		if err := s.pullSensorMetrics(debugDumpCtx, zipWriter, opts); err != nil {
-			log.Errorf("could not get sensor metrics: %+q", err)
+			log.Errorf("Could not get sensor metrics: %+q", err)
 		}
 	}
 
@@ -705,8 +705,6 @@ func (s *serviceImpl) getDiagnosticDump(w http.ResponseWriter, r *http.Request) 
 func (s *serviceImpl) getDiagnosticDumpWithCentral(w http.ResponseWriter, r *http.Request, withCentral bool) {
 	filename := time.Now().Format("stackrox_diagnostic_2006_01_02_15_04_05.zip")
 
-	log.Infof("started writing diagnostic bundle %s; withCentral = %t", filename, withCentral)
-
 	opts := debugDumpOptions{
 		logs:              fullK8sIntrospectionData,
 		telemetryMode:     telemetryCentralAndSensors,
@@ -723,6 +721,7 @@ func (s *serviceImpl) getDiagnosticDumpWithCentral(w http.ResponseWriter, r *htt
 		fmt.Fprint(w, err.Error())
 		return
 	}
+	log.Infof("Started writing diagnostic bundle %q with options: %+v", filename, opts)
 
 	s.writeZippedDebugDump(r.Context(), w, filename, opts)
 }

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -581,6 +581,8 @@ func (s *serviceImpl) writeZippedDebugDump(ctx context.Context, w http.ResponseW
 		if err := getCentralDBData(ctx, zipWriter); err != nil {
 			log.Error(err)
 		}
+
+		log.Info("finished writing Central data to diagnostic bundle")
 	}
 
 	if opts.logs == fullK8sIntrospectionData {
@@ -702,6 +704,8 @@ func (s *serviceImpl) getDiagnosticDump(w http.ResponseWriter, r *http.Request) 
 
 func (s *serviceImpl) getDiagnosticDumpWithCentral(w http.ResponseWriter, r *http.Request, withCentral bool) {
 	filename := time.Now().Format("stackrox_diagnostic_2006_01_02_15_04_05.zip")
+
+	log.Infof("started writing diagnostic bundle %s; withCentral = %t", filename, withCentral)
 
 	opts := debugDumpOptions{
 		logs:              fullK8sIntrospectionData,


### PR DESCRIPTION
## Description

We have seen repeated timeouts in the qa-tests when requesting a diagnostic bundle (timeout=5min):
```
    11:10:36 | INFO  | DiagnosticBundleTest      | DiagnosticBundleTest      | Starting testcase: Test that diagnostic bundle download succeeds with admin access token
    11:15:41 | DEBUG | DiagnosticBundleTest      | Helpers                   | Caught exception. Retrying in 10s (attempt 0 of 10): io.restassured.internal.http.ResponseParseException: status code: 200, reason phrase: OK
    11:20:56 | DEBUG | DiagnosticBundleTest      | Helpers                   | Caught exception. Retrying in 10s (attempt 1 of 10): io.restassured.internal.http.ResponseParseException: status code: 200, reason phrase: OK
```

There is no apparent cause and it's unclear where in Central the diag bundle request handler is stuck. It is possible that under some conditions the Central diagnostic bundle handler deadlocks. Unfortunately I was unable to reproduce the issue while running `DiagnosticBundleTest` several hundred times both locally and in CI.

The info logs are intended to locate the problem if it ever re-appears, while keeping the log volume at bay at the same time.