### PR TITLE
refactor(csv): Rely on `http.Error` in 'pkg/csv'

### DIFF
--- a/central/compliance/handlers/csv.go
+++ b/central/compliance/handlers/csv.go
@@ -123,7 +123,7 @@ func CSVHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		options, err := parseOptions(r)
 		if err != nil {
-			csv.WriteError(w, http.StatusBadRequest, err)
+			csv.WriteErrorWithCode(w, http.StatusBadRequest, err)
 			return
 		}
 
@@ -134,7 +134,7 @@ func CSVHandler() http.HandlerFunc {
 			var unsupported []string
 			options.standardIDs, unsupported = standards.FilterSupported(options.standardIDs)
 			if len(unsupported) > 0 {
-				csv.WriteError(w, http.StatusBadRequest, standards.UnSupportedStandardsErr(unsupported...))
+				csv.WriteError(w, standards.UnSupportedStandardsErr(unsupported...))
 				return
 			}
 		}
@@ -142,7 +142,7 @@ func CSVHandler() http.HandlerFunc {
 		if len(options.clusterIDs) == 0 {
 			clusterIDs, err := getClusterIDs(r.Context())
 			if err != nil {
-				csv.WriteError(w, http.StatusInternalServerError, err)
+				csv.WriteErrorWithCode(w, http.StatusInternalServerError, err)
 				return
 			}
 			options.clusterIDs = clusterIDs
@@ -150,7 +150,7 @@ func CSVHandler() http.HandlerFunc {
 
 		data, err := complianceDS.GetLatestRunResultsBatch(r.Context(), options.clusterIDs, options.standardIDs, complianceDSTypes.WithMessageStrings)
 		if err != nil {
-			csv.WriteError(w, http.StatusInternalServerError, err)
+			csv.WriteErrorWithCode(w, http.StatusInternalServerError, err)
 			return
 		}
 		validResults, _ := datastore.ValidResultsAndSources(data)

--- a/central/cve/cluster/csv/handler.go
+++ b/central/cve/cluster/csv/handler.go
@@ -105,14 +105,14 @@ func ClusterCVECSVHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		query, rQuery, err := parser.ParseURLQuery(r.URL.Query())
 		if err != nil {
-			csv.WriteError(w, http.StatusBadRequest, err)
+			csv.WriteErrorWithCode(w, http.StatusBadRequest, err)
 			return
 		}
 		rawQuery, paginatedQuery := resolvers.V1RawQueryAsResolverQuery(rQuery)
 
 		cveRows, err := ClusterCVECSVRows(loaders.WithLoaderContext(r.Context()), query, rawQuery, paginatedQuery)
 		if err != nil {
-			csv.WriteError(w, http.StatusInternalServerError, err)
+			csv.WriteErrorWithCode(w, http.StatusInternalServerError, err)
 			return
 		}
 

--- a/central/cve/cluster/csv/handler.go
+++ b/central/cve/cluster/csv/handler.go
@@ -15,6 +15,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/csv"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/search"
@@ -105,14 +106,14 @@ func ClusterCVECSVHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		query, rQuery, err := parser.ParseURLQuery(r.URL.Query())
 		if err != nil {
-			csv.WriteErrorWithCode(w, http.StatusBadRequest, err)
+			csv.WriteError(w, errox.InvalidArgs.CausedBy(err))
 			return
 		}
 		rawQuery, paginatedQuery := resolvers.V1RawQueryAsResolverQuery(rQuery)
 
 		cveRows, err := ClusterCVECSVRows(loaders.WithLoaderContext(r.Context()), query, rawQuery, paginatedQuery)
 		if err != nil {
-			csv.WriteErrorWithCode(w, http.StatusInternalServerError, err)
+			csv.WriteError(w, errox.ServerError.CausedBy(err))
 			return
 		}
 

--- a/central/cve/csv/handler.go
+++ b/central/cve/csv/handler.go
@@ -15,6 +15,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/csv"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/search"
@@ -120,14 +121,14 @@ func CVECSVHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		query, rQuery, err := parser.ParseURLQuery(r.URL.Query())
 		if err != nil {
-			csv.WriteErrorWithCode(w, http.StatusBadRequest, err)
+			csv.WriteError(w, errox.InvalidArgs.CausedBy(err))
 			return
 		}
 		rawQuery, paginatedQuery := resolvers.V1RawQueryAsResolverQuery(rQuery)
 
 		cveRows, err := cveCSVRows(loaders.WithLoaderContext(r.Context()), query, rawQuery, paginatedQuery)
 		if err != nil {
-			csv.WriteErrorWithCode(w, http.StatusInternalServerError, err)
+			csv.WriteError(w, errox.ServerError.CausedBy(err))
 			return
 		}
 

--- a/central/cve/csv/handler.go
+++ b/central/cve/csv/handler.go
@@ -120,14 +120,14 @@ func CVECSVHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		query, rQuery, err := parser.ParseURLQuery(r.URL.Query())
 		if err != nil {
-			csv.WriteError(w, http.StatusBadRequest, err)
+			csv.WriteErrorWithCode(w, http.StatusBadRequest, err)
 			return
 		}
 		rawQuery, paginatedQuery := resolvers.V1RawQueryAsResolverQuery(rQuery)
 
 		cveRows, err := cveCSVRows(loaders.WithLoaderContext(r.Context()), query, rawQuery, paginatedQuery)
 		if err != nil {
-			csv.WriteError(w, http.StatusInternalServerError, err)
+			csv.WriteErrorWithCode(w, http.StatusInternalServerError, err)
 			return
 		}
 

--- a/central/cve/image/csv/handler.go
+++ b/central/cve/image/csv/handler.go
@@ -14,6 +14,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/csv"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/search"
@@ -111,14 +112,14 @@ func ImageCVECSVHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		query, rQuery, err := parser.ParseURLQuery(r.URL.Query())
 		if err != nil {
-			csv.WriteErrorWithCode(w, http.StatusBadRequest, err)
+			csv.WriteError(w, errox.InvalidArgs.CausedBy(err))
 			return
 		}
 		rawQuery, paginatedQuery := resolvers.V1RawQueryAsResolverQuery(rQuery)
 
 		cveRows, err := ImageCVECSVRows(loaders.WithLoaderContext(r.Context()), query, rawQuery, paginatedQuery)
 		if err != nil {
-			csv.WriteErrorWithCode(w, http.StatusInternalServerError, err)
+			csv.WriteError(w, errox.ServerError.CausedBy(err))
 			return
 		}
 

--- a/central/cve/image/csv/handler.go
+++ b/central/cve/image/csv/handler.go
@@ -111,14 +111,14 @@ func ImageCVECSVHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		query, rQuery, err := parser.ParseURLQuery(r.URL.Query())
 		if err != nil {
-			csv.WriteError(w, http.StatusBadRequest, err)
+			csv.WriteErrorWithCode(w, http.StatusBadRequest, err)
 			return
 		}
 		rawQuery, paginatedQuery := resolvers.V1RawQueryAsResolverQuery(rQuery)
 
 		cveRows, err := ImageCVECSVRows(loaders.WithLoaderContext(r.Context()), query, rawQuery, paginatedQuery)
 		if err != nil {
-			csv.WriteError(w, http.StatusInternalServerError, err)
+			csv.WriteErrorWithCode(w, http.StatusInternalServerError, err)
 			return
 		}
 

--- a/central/cve/node/csv/handler.go
+++ b/central/cve/node/csv/handler.go
@@ -106,14 +106,14 @@ func NodeCVECSVHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		query, rQuery, err := parser.ParseURLQuery(r.URL.Query())
 		if err != nil {
-			csv.WriteError(w, http.StatusBadRequest, err)
+			csv.WriteErrorWithCode(w, http.StatusBadRequest, err)
 			return
 		}
 		rawQuery, paginatedQuery := resolvers.V1RawQueryAsResolverQuery(rQuery)
 
 		cveRows, err := NodeCVECSVRows(loaders.WithLoaderContext(r.Context()), query, rawQuery, paginatedQuery)
 		if err != nil {
-			csv.WriteError(w, http.StatusInternalServerError, err)
+			csv.WriteErrorWithCode(w, http.StatusInternalServerError, err)
 			return
 		}
 

--- a/central/cve/node/csv/handler.go
+++ b/central/cve/node/csv/handler.go
@@ -14,6 +14,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/csv"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/search"
@@ -106,14 +107,14 @@ func NodeCVECSVHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		query, rQuery, err := parser.ParseURLQuery(r.URL.Query())
 		if err != nil {
-			csv.WriteErrorWithCode(w, http.StatusBadRequest, err)
+			csv.WriteError(w, errox.InvalidArgs.CausedBy(err))
 			return
 		}
 		rawQuery, paginatedQuery := resolvers.V1RawQueryAsResolverQuery(rQuery)
 
 		cveRows, err := NodeCVECSVRows(loaders.WithLoaderContext(r.Context()), query, rawQuery, paginatedQuery)
 		if err != nil {
-			csv.WriteErrorWithCode(w, http.StatusInternalServerError, err)
+			csv.WriteError(w, errox.ServerError.CausedBy(err))
 			return
 		}
 

--- a/central/risk/handlers/timeline/csv.go
+++ b/central/risk/handlers/timeline/csv.go
@@ -147,12 +147,12 @@ func CSVHandler() http.HandlerFunc {
 		resolver := resolvers.New()
 		podResolvers, err := resolver.Pods(ctx, resolvers.PaginatedQuery{Query: &rawQuery})
 		if err != nil {
-			csv.WriteError(w, http.StatusInternalServerError, err)
+			csv.WriteErrorWithCode(w, http.StatusInternalServerError, err)
 			return
 		}
 		containerResolvers, err := resolver.GroupedContainerInstances(ctx, resolvers.RawQuery{Query: &rawQuery})
 		if err != nil {
-			csv.WriteError(w, http.StatusInternalServerError, err)
+			csv.WriteErrorWithCode(w, http.StatusInternalServerError, err)
 			return
 		}
 

--- a/central/risk/handlers/timeline/csv.go
+++ b/central/risk/handlers/timeline/csv.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/central/graphql/resolvers"
 	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
 	"github.com/stackrox/rox/pkg/csv"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
 	podUtils "github.com/stackrox/rox/pkg/pods/utils"
 	"github.com/stackrox/rox/pkg/stringutils"
@@ -147,12 +148,12 @@ func CSVHandler() http.HandlerFunc {
 		resolver := resolvers.New()
 		podResolvers, err := resolver.Pods(ctx, resolvers.PaginatedQuery{Query: &rawQuery})
 		if err != nil {
-			csv.WriteErrorWithCode(w, http.StatusInternalServerError, err)
+			csv.WriteError(w, errox.ServerError.CausedBy(err))
 			return
 		}
 		containerResolvers, err := resolver.GroupedContainerInstances(ctx, resolvers.RawQuery{Query: &rawQuery})
 		if err != nil {
-			csv.WriteErrorWithCode(w, http.StatusInternalServerError, err)
+			csv.WriteError(w, errox.ServerError.CausedBy(err))
 			return
 		}
 

--- a/pkg/csv/http_writer.go
+++ b/pkg/csv/http_writer.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/stackrox/rox/pkg/errox"
-	"github.com/stackrox/rox/pkg/grpc/errors"
 	"github.com/stackrox/rox/pkg/logging"
 )
 
@@ -94,7 +93,7 @@ func (w *httpWriterImpl[Record]) SetHTTPError(err error) error {
 		// Too late to change the HTTP headers and status.
 		return nil
 	}
-	http.Error(w.writer, err.Error(), errors.ErrToHTTPStatus(err))
+	WriteError(w.writer, err)
 	return err
 }
 

--- a/pkg/csv/utils.go
+++ b/pkg/csv/utils.go
@@ -12,16 +12,12 @@ import (
 // Utility functions to be used for CSV exporting.
 
 // WriteError responds with the error message and HTTP status code deduced from
-// the error class. Appropriate response headers are set.
+// the error class. Appropriate response headers are set. Note that once data
+// have been written to ResponseWriter, depending on its implementation, headers
+// and the status code might have already been sent over HTTP. In such case,
+// calling WriteError will not have the desired effect.
 func WriteError(w http.ResponseWriter, err error) {
-	WriteErrorWithCode(w, errors.ErrToHTTPStatus(err), err)
-}
-
-// WriteErrorWithCode is similar to WriteError but uses the provided HTTP status
-// code. If err is a known internal error, use WriteError to ensure consistency
-// of HTTP status codes.
-func WriteErrorWithCode(w http.ResponseWriter, code int, err error) {
-	http.Error(w, err.Error(), code)
+	http.Error(w, err.Error(), errors.ErrToHTTPStatus(err))
 }
 
 // FromTimestamp creates a string representation of the given timestamp.

--- a/pkg/csv/utils.go
+++ b/pkg/csv/utils.go
@@ -1,7 +1,6 @@
 package csv
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 

--- a/pkg/csv/utils.go
+++ b/pkg/csv/utils.go
@@ -7,15 +7,22 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/graph-gophers/graphql-go"
+	"github.com/stackrox/rox/pkg/grpc/errors"
 )
 
 // Utility functions to be used for CSV exporting.
 
-// WriteError Writes the given error to the given http.ResponseWriter.
-func WriteError(w http.ResponseWriter, code int, err error) {
-	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(code)
-	_, _ = fmt.Fprint(w, err)
+// WriteError responds with the error message and HTTP status code deduced from
+// the error class. Appropriate response headers are set.
+func WriteError(w http.ResponseWriter, err error) {
+	WriteErrorWithCode(w, errors.ErrToHTTPStatus(err), err)
+}
+
+// WriteErrorWithCode is similar to WriteError but uses the provided HTTP status
+// code. If err is a known internal error, use WriteError to ensure consistency
+// of HTTP status codes.
+func WriteErrorWithCode(w http.ResponseWriter, code int, err error) {
+	http.Error(w, err.Error(), code)
 }
 
 // FromTimestamp creates a string representation of the given timestamp.

--- a/pkg/csv/utils_test.go
+++ b/pkg/csv/utils_test.go
@@ -1,0 +1,79 @@
+package csv
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockResponseWriter struct {
+	header http.Header
+	status int
+}
+
+func (m *mockResponseWriter) Header() (h http.Header)           { return m.header }
+func (m *mockResponseWriter) Write(p []byte) (n int, err error) { return len(p), nil }
+func (m *mockResponseWriter) WriteHeader(statusCode int)        { m.status = statusCode }
+
+func TestWriteError(t *testing.T) {
+	type testCase struct {
+		desc         string
+		err          error
+		expectedCode int
+	}
+
+	testCases := []testCase{
+		{
+			"Known error maps to the appropriate HTTP code",
+			errox.InvalidArgs,
+			400,
+		},
+		{
+			"Unknown error maps to default HTTP code",
+			errors.New("bigbadabum"),
+			500,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			w := &mockResponseWriter{header: http.Header{}}
+			WriteError(w, tc.err)
+			assert.Equal(t, tc.expectedCode, w.status)
+			assert.Contains(t, w.header["Content-Type"][0], "text/plain")
+		})
+	}
+}
+
+func TestWriteErrorWithCode(t *testing.T) {
+	type testCase struct {
+		desc string
+		err  error
+		code int
+	}
+
+	testCases := []testCase{
+		{
+			"Known error maps to the provided HTTP code",
+			errox.InvalidArgs,
+			200,
+		},
+		{
+			"Unknown error maps to the provided HTTP code",
+			errors.New("bigbadabum"),
+			200,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			w := &mockResponseWriter{header: http.Header{}}
+			WriteErrorWithCode(w, tc.code, tc.err)
+			assert.Equal(t, tc.code, w.status)
+			assert.Contains(t, w.header["Content-Type"][0], "text/plain")
+		})
+	}
+}

--- a/pkg/csv/utils_test.go
+++ b/pkg/csv/utils_test.go
@@ -32,7 +32,7 @@ func TestWriteError(t *testing.T) {
 			400,
 		},
 		{
-			"Unknown error maps to default HTTP code",
+			"Unknown error maps to the default HTTP code",
 			errors.New("bigbadabum"),
 			500,
 		},
@@ -43,36 +43,6 @@ func TestWriteError(t *testing.T) {
 			w := &mockResponseWriter{header: http.Header{}}
 			WriteError(w, tc.err)
 			assert.Equal(t, tc.expectedCode, w.status)
-			assert.Contains(t, w.header["Content-Type"][0], "text/plain")
-		})
-	}
-}
-
-func TestWriteErrorWithCode(t *testing.T) {
-	type testCase struct {
-		desc string
-		err  error
-		code int
-	}
-
-	testCases := []testCase{
-		{
-			"Known error maps to the provided HTTP code",
-			errox.InvalidArgs,
-			200,
-		},
-		{
-			"Unknown error maps to the provided HTTP code",
-			errors.New("bigbadabum"),
-			200,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			w := &mockResponseWriter{header: http.Header{}}
-			WriteErrorWithCode(w, tc.code, tc.err)
-			assert.Equal(t, tc.code, w.status)
 			assert.Contains(t, w.header["Content-Type"][0], "text/plain")
 		})
 	}


### PR DESCRIPTION
## Description

This PR teaches `csv.WriteError()` to deduce the status code from the error class und ensures appropriate HTTP headers are set.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Unit tests and CI run.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
