### PR TITLE
refactor(csv): Use same constants in both CSV writers

### DIFF
--- a/pkg/csv/http_writer.go
+++ b/pkg/csv/http_writer.go
@@ -15,13 +15,6 @@ var (
 	errSendBody    = errox.ServerError.New("failed to send body")
 )
 
-const (
-	// contentType is the Content-Type HTTP header value.
-	contentType = "text/csv; charset=utf-8"
-	// utf8BOM is the UTF-8 BOM byte sequence.
-	utf8BOM = "\uFEFF"
-)
-
 // Row is type to hold a CSV line.
 type Row = []string
 

--- a/pkg/csv/http_writer_test.go
+++ b/pkg/csv/http_writer_test.go
@@ -52,7 +52,7 @@ func TestHTTPCSVWriter(t *testing.T) {
 			break
 		}
 	}
-	assert.Equal(t, contentType, httpWriterMock.header["Content-Type"][0])
+	assert.Contains(t, httpWriterMock.header["Content-Type"][0], "text/csv")
 	assert.NoError(t, err)
 	w.Flush()
 	assert.Equal(t, "\uFEFFa,b\r\na1,b1\r\na2,b2\r\n", buf.String())
@@ -78,7 +78,7 @@ func TestHTTPCSVWriterError(t *testing.T) {
 			break
 		}
 	}
-	assert.Equal(t, "text/plain; charset=utf-8", httpWriterMock.header["Content-Type"][0])
+	assert.Contains(t, httpWriterMock.header["Content-Type"][0], "text/plain")
 	assert.ErrorIs(t, err, errSendHeaders)
 	w.Flush()
 	assert.Equal(t, "", buf.String())
@@ -126,7 +126,7 @@ func TestHTTPCSVWriterLateError(t *testing.T) {
 			break
 		}
 	}
-	assert.Equal(t, contentType, httpWriterMock.header["Content-Type"][0])
+	assert.Contains(t, httpWriterMock.header["Content-Type"][0], "text/csv")
 	assert.NoError(t, err)
 	w.Flush()
 	assert.Equal(t, utf8BOM, buf.String())

--- a/pkg/csv/utils.go
+++ b/pkg/csv/utils.go
@@ -10,6 +10,11 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/errors"
 )
 
+const (
+	// utf8BOM is the UTF-8 BOM byte sequence.
+	utf8BOM = "\uFEFF"
+)
+
 // Utility functions to be used for CSV exporting.
 
 // WriteError responds with the error message and HTTP status code deduced from

--- a/pkg/csv/writer.go
+++ b/pkg/csv/writer.go
@@ -84,7 +84,7 @@ func (c *GenericWriter) Write(w http.ResponseWriter, filename string) {
 		})
 	}
 
-	_, _ = w.Write([]byte("\uFEFF")) // UTF-8 BOM.
+	_, _ = w.Write([]byte(utf8BOM))
 	cw := csv.NewWriter(w)
 	cw.UseCRLF = true
 	_ = cw.Write(c.header)


### PR DESCRIPTION
## Description

Also relax string eq checks in a test and removed one constant as a side bonus.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI run

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
