### PR TITLE
ROX-19541: Rewrite IntegrationTilesPage in TypeScript

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTilesPage/IntegrationTile.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTilesPage/IntegrationTile.tsx
@@ -2,22 +2,18 @@ import React, { ReactElement, CSSProperties } from 'react';
 import {
     Badge,
     Card,
+    CardActions,
+    CardFooter,
     CardHeader,
     CardHeaderMain,
     CardTitle,
-    CardFooter,
-    CardActions,
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 
-type IntegrationType = {
-    label: string;
-    image: string;
-    categories: string;
-};
+import { IntegrationDescriptor } from '../utils/integrationsList';
 
 type IntegrationTileProps = {
-    integration: IntegrationType;
+    integration: IntegrationDescriptor;
     numIntegrations: number;
     linkTo: string;
 };
@@ -28,10 +24,10 @@ const styleCard = {
 
 function IntegrationTile({
     integration,
-    numIntegrations = 0,
+    numIntegrations,
     linkTo,
 }: IntegrationTileProps): ReactElement {
-    const { image, label, categories } = integration;
+    const { image, label } = integration;
 
     return (
         <Link to={linkTo} data-testid="integration-tile">
@@ -45,8 +41,8 @@ function IntegrationTile({
                     </CardActions>
                 </CardHeader>
                 <CardTitle className="pf-u-color-100">{label}</CardTitle>
-                {categories !== '' && categories !== undefined && (
-                    <CardFooter className="pf-u-color-200">{categories}</CardFooter>
+                {'categories' in integration && integration.categories && (
+                    <CardFooter className="pf-u-color-200">{integration.categories}</CardFooter>
                 )}
             </Card>
         </Link>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTilesPage/IntegrationTilesPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTilesPage/IntegrationTilesPage.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import React, { ReactElement } from 'react';
+import { useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { PageSection, Title } from '@patternfly/react-core';
 
@@ -8,19 +7,40 @@ import useCentralCapabilities from 'hooks/useCentralCapabilities';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import { integrationsPath } from 'routePaths';
 import { selectors } from 'reducers';
-import integrationsList from '../utils/integrationsList';
+import { ClusterInitBundle } from 'services/ClustersService';
+import { ApiToken } from 'types/apiToken.proto';
+import { BackupIntegration } from 'types/externalBackup.proto';
+import { ImageIntegration } from 'types/imageIntegration.proto';
+import { NotifierIntegration } from 'types/notifier.proto';
+import { SignatureIntegration } from 'types/signatureIntegration.proto';
+
+import integrationsList, { IntegrationDescriptor } from '../utils/integrationsList';
 
 import IntegrationTile from './IntegrationTile';
 import IntegrationsSection from './IntegrationsSection';
 
-const IntegrationTilesPage = ({
-    apiTokens,
-    clusterInitBundles,
-    backups,
-    imageIntegrations,
-    notifiers,
-    signatureIntegrations,
-}) => {
+type IntegrationSource = keyof typeof integrationsList;
+
+// Although unnecessary for reducers in TypeScript, we intend to replace reducers and sagas with requests.
+type IntegrationsSelector = {
+    apiTokens: ApiToken[];
+    backups: BackupIntegration[];
+    clusterInitBundles: ClusterInitBundle[];
+    imageIntegrations: ImageIntegration[];
+    notifiers: NotifierIntegration[];
+    signatureIntegrations: SignatureIntegration[];
+};
+
+const integrationsSelector = createStructuredSelector<IntegrationsSelector>({
+    apiTokens: selectors.getAPITokens,
+    backups: selectors.getBackups,
+    clusterInitBundles: selectors.getClusterInitBundles,
+    imageIntegrations: selectors.getImageIntegrations,
+    notifiers: selectors.getNotifiers,
+    signatureIntegrations: selectors.getSignatureIntegrations,
+});
+
+function IntegrationTilesPage(): ReactElement {
     const { isFeatureFlagEnabled } = useFeatureFlags();
 
     const { isCentralCapabilityAvailable } = useCentralCapabilities();
@@ -28,7 +48,16 @@ const IntegrationTilesPage = ({
         'centralCanUseCloudBackupIntegrations'
     );
 
-    function findIntegrations(source, type) {
+    const {
+        apiTokens,
+        clusterInitBundles,
+        backups,
+        imageIntegrations,
+        notifiers,
+        signatureIntegrations,
+    } = useSelector(integrationsSelector);
+
+    function countIntegrations(source: IntegrationSource, type): number {
         const typeLowerMatches = (integration) =>
             integration.type.toLowerCase() === type.toLowerCase();
 
@@ -36,35 +65,40 @@ const IntegrationTilesPage = ({
             case 'authProviders': {
                 // Integrations Authentication Tokens differ from Access Control Auth providers.
                 if (type === 'apitoken') {
-                    return apiTokens;
+                    return apiTokens.length;
                 }
                 if (type === 'clusterInitBundle') {
-                    return clusterInitBundles;
+                    return clusterInitBundles.length;
                 }
-                return [];
+                return 0;
             }
             case 'notifiers': {
-                return notifiers.filter(typeLowerMatches);
+                return notifiers.filter(typeLowerMatches).length;
             }
             case 'backups': {
-                return backups.filter(typeLowerMatches);
+                return backups.filter(typeLowerMatches).length;
             }
             case 'imageIntegrations': {
-                return imageIntegrations.filter(typeLowerMatches);
+                return imageIntegrations.filter(typeLowerMatches).length;
             }
             case 'signatureIntegrations': {
-                return signatureIntegrations;
+                return signatureIntegrations.length;
             }
             default: {
-                throw new Error(`Unknown source ${source}`);
+                return 0;
             }
         }
     }
 
-    function renderIntegrationTiles(source) {
+    // Maybe caused by TypeScript error below.
+    /* eslint-disable @typescript-eslint/no-unsafe-return */
+    function renderIntegrationTiles(source: IntegrationSource): ReactElement[] {
         return (
             integrationsList[source]
                 // filter out non-visible integrations
+                // TypeScript 5.2 fixes the error: This expression is not callable
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore TS2349
                 .filter((integration) => {
                     if (typeof integration.featureFlagDependency === 'string') {
                         if (!isFeatureFlagEnabled(integration.featureFlagDependency)) {
@@ -74,11 +108,8 @@ const IntegrationTilesPage = ({
                     return true;
                 })
                 // get a list of rendered integration tiles
-                .map((integration) => {
-                    const numIntegrations = findIntegrations(
-                        integration.source,
-                        integration.type
-                    ).length;
+                .map((integration: IntegrationDescriptor) => {
+                    const numIntegrations = countIntegrations(integration.source, integration.type);
                     const linkTo = `${integrationsPath}/${integration.source}/${integration.type}`;
 
                     return (
@@ -92,11 +123,11 @@ const IntegrationTilesPage = ({
                 })
         );
     }
+    /* eslint-enable @typescript-eslint/no-unsafe-return */
 
     const imageIntegrationTiles = renderIntegrationTiles('imageIntegrations');
     const notifierTiles = renderIntegrationTiles('notifiers');
     const authProviderTiles = renderIntegrationTiles('authProviders');
-    const backupTiles = renderIntegrationTiles('backups');
     const signatureTiles = renderIntegrationTiles('signatureIntegrations');
 
     return (
@@ -105,66 +136,29 @@ const IntegrationTilesPage = ({
                 <Title headingLevel="h1">Integrations</Title>
             </PageSection>
             <PageSection>
-                <IntegrationsSection headerName="Image Integrations" testId="image-integrations">
+                <IntegrationsSection headerName="Image Integrations" id="image-integrations">
                     {imageIntegrationTiles}
                 </IntegrationsSection>
                 <IntegrationsSection
                     headerName="Signature Integrations"
-                    testId="signature-integrations"
+                    id="signature-integrations"
                 >
                     {signatureTiles}
                 </IntegrationsSection>
-                <IntegrationsSection
-                    headerName="Notifier Integrations"
-                    testId="notifier-integrations"
-                >
+                <IntegrationsSection headerName="Notifier Integrations" id="notifier-integrations">
                     {notifierTiles}
                 </IntegrationsSection>
                 {canUseCloudBackupIntegrations && (
-                    <IntegrationsSection
-                        headerName="Backup Integrations"
-                        testId="backup-integrations"
-                    >
-                        {backupTiles}
+                    <IntegrationsSection headerName="Backup Integrations" id="backup-integrations">
+                        {renderIntegrationTiles('backups')}
                     </IntegrationsSection>
                 )}
-                <IntegrationsSection headerName="Authentication Tokens" testId="token-integrations">
+                <IntegrationsSection headerName="Authentication Tokens" id="token-integrations">
                     {authProviderTiles}
                 </IntegrationsSection>
             </PageSection>
         </>
     );
-};
+}
 
-IntegrationTilesPage.propTypes = {
-    apiTokens: PropTypes.arrayOf(
-        PropTypes.shape({
-            name: PropTypes.string.isRequired,
-            role: PropTypes.string.isRequired,
-        })
-    ).isRequired,
-    clusterInitBundles: PropTypes.arrayOf(
-        PropTypes.shape({
-            name: PropTypes.string.isRequired,
-        })
-    ).isRequired,
-    backups: PropTypes.arrayOf(
-        PropTypes.shape({
-            name: PropTypes.string.isRequired,
-        })
-    ).isRequired,
-    notifiers: PropTypes.arrayOf(PropTypes.object).isRequired,
-    imageIntegrations: PropTypes.arrayOf(PropTypes.object).isRequired,
-    signatureIntegrations: PropTypes.arrayOf(PropTypes.object).isRequired,
-};
-
-const mapStateToProps = createStructuredSelector({
-    apiTokens: selectors.getAPITokens,
-    clusterInitBundles: selectors.getClusterInitBundles,
-    notifiers: selectors.getNotifiers,
-    imageIntegrations: selectors.getImageIntegrations,
-    backups: selectors.getBackups,
-    signatureIntegrations: selectors.getSignatureIntegrations,
-});
-
-export default connect(mapStateToProps)(IntegrationTilesPage);
+export default IntegrationTilesPage;

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTilesPage/IntegrationsSection.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTilesPage/IntegrationsSection.tsx
@@ -4,19 +4,19 @@ import { PageSection, Title, Gallery, GalleryItem } from '@patternfly/react-core
 type IntegrationsSectionProps = {
     headerName: string;
     children: ReactElement[];
-    testId: string;
+    id: string;
 };
 
 const IntegrationsSection = ({
     headerName,
     children,
-    testId,
+    id,
 }: IntegrationsSectionProps): ReactElement => {
     const galleryItems = React.Children.map(children, (child) => {
         return <GalleryItem>{child}</GalleryItem>;
     });
     return (
-        <PageSection variant="light" id={testId} className="pf-u-mb-xl">
+        <PageSection variant="light" id={id} className="pf-u-mb-xl">
             <div className="pf-u-mb-md">
                 <Title headingLevel="h2">{headerName}</Title>
             </div>

--- a/ui/apps/platform/src/services/IntegrationsService.ts
+++ b/ui/apps/platform/src/services/IntegrationsService.ts
@@ -1,7 +1,7 @@
 import axios from './instance';
 import { Empty } from './types';
 
-type IntegrationSource =
+export type IntegrationSource =
     | 'authProviders'
     | 'backups'
     | 'imageIntegrations'


### PR DESCRIPTION
## Description

Increase type safety before making functional changes to the page (see **Residue**).

1. Replace `mapStateToProps` with `useSelector` hook.
2. Replace `PropTypes` with type for structured selector.
3. Simplify `countIntegrations` function.
4. Replace `testId` with `id` prop.

### Residue

1. Provide conditional rendering for **Cluster Init Bundles** tile according to permissions.
    * Encapsulate request to prevent 403 Forbidden status.
    * Prepare for link to clusters instead of integrations.
2. Possibly encapsulate requests for counts of other sections to remove dependency on reducers and sagas.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Replace dynamic with static types offsets replace JavaScript with TypeScript conditional code like: `'categories' in integration && integration.categories`

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3763438 - 3763438
        total: -4 = 9982137 - 9982143
    * `ls -al build/static/js/*.js | wc -l`
        0 = 80 - 80 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/integrations
    * See expected requests.
    * See expected tiles with counts and categories for image integrations.

![integrations_1](https://github.com/stackrox/stackrox/assets/11862657/48436d2e-cf14-4bde-973f-20887c22a94c)
![integrations_2](https://github.com/stackrox/stackrox/assets/11862657/3ed95cc1-595f-46ee-af9c-e1bda8b11f4a)

### Integration testing

* integrations/general.test.js
