### PR TITLE
ROX-19335: Add manage watched images button

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -30,4 +30,5 @@ export const selectors = {
     nonZeroCveSeverityCounts: '*[aria-label*="severity cves"i]:not([aria-label^="0"])',
     firstUnwatchedImageRow:
         'tbody tr:not(:has(td[data-label="Image"]:contains("Watched image"))):eq(0)',
+    manageWatchedImagesButton: 'button:contains("Manage watched images")',
 };

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
@@ -39,4 +39,24 @@ describe('Workload CVE watched images flow', () => {
             // TODO - Test that the image appears with a "Watched image" label in the table
         });
     });
+
+    it('should allow management of watched images via the overview page header button', () => {
+        visitWorkloadCveOverview();
+
+        selectEntityTab('Image');
+
+        cy.get(selectors.manageWatchedImagesButton).click();
+
+        // TODO - Test that the image name input is empty
+
+        // TODO - Test for ability to add an image to the watch list by typing the name
+
+        // TODO - Test that the image appears in the table with a "Watched image" label
+
+        // TODO - Test for ability to remove images from the watch list
+
+        // TODO - Test that the image appears in the table without a "Watched image" label
+
+        // TODO - Test that the image is no longer visible in the modal
+    });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -7,6 +7,7 @@ import {
     FlexItem,
     Card,
     CardBody,
+    Button,
 } from '@patternfly/react-core';
 import { useQuery } from '@apollo/client';
 
@@ -57,15 +58,31 @@ function WorkloadCvesOverviewPage() {
             <PageTitle title="Workload CVEs Overview" />
             {/* Default filters are disabled until fixability filters are fixed */}
             <Divider component="div" />
-            <PageSection variant="light" padding={{ default: 'noPadding' }}>
-                <Flex direction={{ default: 'column' }} className="pf-u-py-lg pf-u-pl-lg">
-                    <FlexItem>
-                        <Title headingLevel="h1">Workload CVEs</Title>
-                    </FlexItem>
+            <PageSection
+                className="pf-u-display-flex pf-u-flex-direction-row pf-u-align-items-center"
+                variant="light"
+                padding={{ default: 'noPadding' }}
+            >
+                <Flex
+                    direction={{ default: 'column' }}
+                    className="pf-u-py-lg pf-u-pl-lg pf-u-flex-grow-1"
+                >
+                    <Title headingLevel="h1">Workload CVEs</Title>
                     <FlexItem>
                         Prioritize and manage scanned CVEs across images and deployments
                     </FlexItem>
                 </Flex>
+                <FlexItem className="pf-u-pr-lg">
+                    <Button
+                        variant="secondary"
+                        onClick={() => {
+                            setDefaultWatchedImageName('');
+                            watchedImagesModalToggle.openSelect();
+                        }}
+                    >
+                        Manage watched images
+                    </Button>
+                </FlexItem>
             </PageSection>
             <PageSection padding={{ default: 'noPadding' }}>
                 <PageSection isCenterAligned>


### PR DESCRIPTION
## Description

As titled. Opens the watched images modal with a default empty image name value. Also adds some placeholder Cypress tests until the more interesting pieces of code are implemented.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the Workload CVE overview page. The button will be present for all three entity tabs.
![image](https://github.com/stackrox/stackrox/assets/1292638/4e5491e7-a265-4f9b-b901-f99c10be8023)

Clicking on the button opens the modal.
![image](https://github.com/stackrox/stackrox/assets/1292638/ea0f5d58-d634-45e8-a560-8641e212b5e9)

