### PR TITLE
ROX-19159 Added report config name to report csv name

### DIFF
--- a/central/reports/common/report_formatter.go
+++ b/central/reports/common/report_formatter.go
@@ -152,11 +152,10 @@ func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults [
 
 	var zipBuf bytes.Buffer
 	zipWriter := zip.NewWriter(&zipBuf)
-	reportName := fmt.Sprintf("RHACS_Vulnerability_Report_%s.csv", time.Now().Format("02_January_2006"))
-	log.Infof("configName %s", configName)
-	if configName != "" {
-		reportName = fmt.Sprintf("RHACS_Vulnerability_Report_Config_%s_%s.csv", configName, time.Now().Format("02_January_2006"))
+	if len(configName) > 80 {
+		configName = configName[0:80] + "..."
 	}
+	reportName := fmt.Sprintf("RHACS_Vulnerability_Report_%s_%s.csv", configName, time.Now().Format("02_January_2006"))
 	zipFile, err := zipWriter.Create(reportName)
 	if err != nil {
 		return nil, true, errors.Wrap(err, "unable to create a zip file of the vuln report")

--- a/central/reports/common/report_formatter.go
+++ b/central/reports/common/report_formatter.go
@@ -83,7 +83,7 @@ type WatchedImagesResult struct {
 }
 
 // Format takes in the results of vuln report query, converts to CSV and returns zipped CSV data and
-// a flag if the report is empty or not
+// a flag if the report is empty or not. For v1 config pass an empty string.
 func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults []WatchedImagesResult, configName string) (*bytes.Buffer, bool, error) {
 	csvWriter := csv.NewGenericWriter(csvHeader, true)
 	for _, r := range deployedImagesResults {
@@ -152,10 +152,16 @@ func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults [
 
 	var zipBuf bytes.Buffer
 	zipWriter := zip.NewWriter(&zipBuf)
+	var reportName string
 	if len(configName) > 80 {
 		configName = configName[0:80] + "..."
+		reportName = fmt.Sprintf("RHACS_Vulnerability_Report_%s_%s.csv", configName, time.Now().Format("02_January_2006"))
+	} else if configName == "" {
+		reportName = fmt.Sprintf("RHACS_Vulnerability_Report_%s.csv", time.Now().Format("02_January_2006"))
+	} else {
+		reportName = fmt.Sprintf("RHACS_Vulnerability_Report_%s_%s.csv", configName, time.Now().Format("02_January_2006"))
 	}
-	reportName := fmt.Sprintf("RHACS_Vulnerability_Report_%s_%s.csv", configName, time.Now().Format("02_January_2006"))
+
 	zipFile, err := zipWriter.Create(reportName)
 	if err != nil {
 		return nil, true, errors.Wrap(err, "unable to create a zip file of the vuln report")

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -277,7 +277,7 @@ func (s *scheduler) sendReportResults(req *ReportRequest) error {
 		return err
 	}
 	// Format results into CSV
-	zippedCSVData, empty, err := common.Format(reportData, nil)
+	zippedCSVData, empty, err := common.Format(reportData, nil, req.ReportConfig.GetName())
 	if err != nil {
 		return errors.Wrap(err, "error formatting the report data")
 	}

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -277,7 +277,7 @@ func (s *scheduler) sendReportResults(req *ReportRequest) error {
 		return err
 	}
 	// Format results into CSV
-	zippedCSVData, empty, err := common.Format(reportData, nil, req.ReportConfig.GetName())
+	zippedCSVData, empty, err := common.Format(reportData, nil, "")
 	if err != nil {
 		return errors.Wrap(err, "error formatting the report data")
 	}

--- a/central/reports/scheduler/v2/reportgenerator/report_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen.go
@@ -6,6 +6,7 @@ import (
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
 	deploymentDS "github.com/stackrox/rox/central/deployment/datastore"
 	namespaceDS "github.com/stackrox/rox/central/namespace/datastore"
+	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
 	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	watchedImageDS "github.com/stackrox/rox/central/watchedimage/datastore"
@@ -32,6 +33,7 @@ func New(
 	blobDatastore blobDS.Datastore,
 	clusterDatastore clusterDS.DataStore,
 	namespaceDatastore namespaceDS.DataStore,
+	configDatastore reportConfigDS.DataStore,
 	schema *graphql.Schema,
 ) ReportGenerator {
 	return newReportGeneratorImpl(
@@ -43,6 +45,7 @@ func New(
 		blobDatastore,
 		clusterDatastore,
 		namespaceDatastore,
+		configDatastore,
 		schema,
 	)
 }
@@ -56,6 +59,7 @@ func newReportGeneratorImpl(
 	blobStore blobDS.Datastore,
 	clusterDatastore clusterDS.DataStore,
 	namespaceDatastore namespaceDS.DataStore,
+	configDatastore reportConfigDS.DataStore,
 	schema *graphql.Schema,
 ) *reportGeneratorImpl {
 	return &reportGeneratorImpl{
@@ -67,7 +71,7 @@ func newReportGeneratorImpl(
 		clusterDatastore:        clusterDatastore,
 		namespaceDatastore:      namespaceDatastore,
 		blobStore:               blobStore,
-
-		Schema: schema,
+		configDatastore:         configDatastore,
+		Schema:                  schema,
 	}
 }

--- a/central/reports/scheduler/v2/reportgenerator/report_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen.go
@@ -6,7 +6,6 @@ import (
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
 	deploymentDS "github.com/stackrox/rox/central/deployment/datastore"
 	namespaceDS "github.com/stackrox/rox/central/namespace/datastore"
-	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
 	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	watchedImageDS "github.com/stackrox/rox/central/watchedimage/datastore"
@@ -33,7 +32,6 @@ func New(
 	blobDatastore blobDS.Datastore,
 	clusterDatastore clusterDS.DataStore,
 	namespaceDatastore namespaceDS.DataStore,
-	configDatastore reportConfigDS.DataStore,
 	schema *graphql.Schema,
 ) ReportGenerator {
 	return newReportGeneratorImpl(
@@ -45,7 +43,6 @@ func New(
 		blobDatastore,
 		clusterDatastore,
 		namespaceDatastore,
-		configDatastore,
 		schema,
 	)
 }
@@ -59,7 +56,6 @@ func newReportGeneratorImpl(
 	blobStore blobDS.Datastore,
 	clusterDatastore clusterDS.DataStore,
 	namespaceDatastore namespaceDS.DataStore,
-	configDatastore reportConfigDS.DataStore,
 	schema *graphql.Schema,
 ) *reportGeneratorImpl {
 	return &reportGeneratorImpl{
@@ -71,7 +67,6 @@ func newReportGeneratorImpl(
 		clusterDatastore:        clusterDatastore,
 		namespaceDatastore:      namespaceDatastore,
 		blobStore:               blobStore,
-		configDatastore:         configDatastore,
 		Schema:                  schema,
 	}
 }

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
 	namespaceDS "github.com/stackrox/rox/central/namespace/datastore"
 	"github.com/stackrox/rox/central/reports/common"
-	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
 	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	watchedImageDS "github.com/stackrox/rox/central/watchedimage/datastore"
@@ -28,7 +27,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/branding"
 	"github.com/stackrox/rox/pkg/errorhelpers"
-	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mathutil"
@@ -57,7 +55,6 @@ type reportGeneratorImpl struct {
 	blobStore               blobDS.Datastore
 	clusterDatastore        clusterDS.DataStore
 	namespaceDatastore      namespaceDS.DataStore
-	configDatastore         reportConfigDS.DataStore
 
 	Schema *graphql.Schema
 }
@@ -110,14 +107,7 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 	}
 
 	// Format results into CSV
-	reportConfig, found, err := rg.configDatastore.GetReportConfiguration(reportGenCtx, req.ReportSnapshot.GetReportConfigurationId())
-	if !found {
-		return errors.Wrapf(errox.NotFound, "Report configuration id %s not found", req.ReportSnapshot.GetReportConfigurationId())
-	}
-	if err != nil {
-		return err
-	}
-	zippedCSVData, empty, err := common.Format(deployedImgData, watchedImgData, reportConfig.GetName())
+	zippedCSVData, empty, err := common.Format(deployedImgData, watchedImgData, req.ReportSnapshot.Name)
 	if err != nil {
 		return err
 	}

--- a/central/reports/scheduler/v2/reportgenerator/singleton.go
+++ b/central/reports/scheduler/v2/reportgenerator/singleton.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stackrox/rox/central/graphql/resolvers"
 	namespaceDS "github.com/stackrox/rox/central/namespace/datastore"
 	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
-	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
 	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	watchedImageDS "github.com/stackrox/rox/central/watchedimage/datastore"
@@ -34,7 +33,6 @@ func initialize() {
 		blobDS.Singleton(),
 		clusterDS.Singleton(),
 		namespaceDS.Singleton(),
-		reportConfigDS.Singleton(),
 
 		schema,
 	)

--- a/central/reports/scheduler/v2/reportgenerator/singleton.go
+++ b/central/reports/scheduler/v2/reportgenerator/singleton.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/central/graphql/resolvers"
 	namespaceDS "github.com/stackrox/rox/central/namespace/datastore"
 	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
+	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
 	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	watchedImageDS "github.com/stackrox/rox/central/watchedimage/datastore"
@@ -33,6 +34,8 @@ func initialize() {
 		blobDS.Singleton(),
 		clusterDS.Singleton(),
 		namespaceDS.Singleton(),
+		reportConfigDS.Singleton(),
+
 		schema,
 	)
 }


### PR DESCRIPTION
This includes report config name in report csv name. 

## Testing Performed
Manually verified that when user downloads a report , report config is included in csv name
example - RHACS_Vulnerability_Report_Config_Test_07_September_2023.csv for report config called Test