### PR TITLE
ROX-19337: Add watch image functionality to workload cve modal

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -31,4 +31,5 @@ export const selectors = {
     firstUnwatchedImageRow:
         'tbody tr:not(:has(td[data-label="Image"]:contains("Watched image"))):eq(0)',
     manageWatchedImagesButton: 'button:contains("Manage watched images")',
+    addWatchedImageNameInput: '*[role="dialog"] input[id="imageName"]',
 };

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
@@ -32,7 +32,7 @@ describe('Workload CVE watched images flow', () => {
             cy.get('button:contains("Watch image")').click();
 
             // Verify that the selected image is pre-populated in the modal
-            cy.get(`*[role="dialog"] *:contains("${fullName}")`);
+            cy.get(`${selectors.addWatchedImageNameInput}[value="${fullName}"]`);
 
             // TODO - Test for ability to add the selected image to the watch list
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesForm.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Button, Form, FormGroup, TextInput } from '@patternfly/react-core';
+import { FormikHelpers, useFormik } from 'formik';
+import * as yup from 'yup';
+
+import { UseRestMutationReturn } from 'hooks/useRestMutation';
+
+const validationSchema = yup.object({
+    imageName: yup.string().required('A valid image name is required'),
+});
+
+type FormData = yup.InferType<typeof validationSchema>;
+
+export type WatchedImagesFormProps = {
+    defaultWatchedImageName: string;
+    watchImage: UseRestMutationReturn<string, string>['mutate'];
+};
+
+function WatchedImagesForm({ defaultWatchedImageName, watchImage }: WatchedImagesFormProps) {
+    const {
+        values,
+        errors,
+        touched,
+        handleChange,
+        handleBlur,
+        handleSubmit,
+        submitForm,
+        isSubmitting,
+    } = useFormik({
+        initialValues: { imageName: defaultWatchedImageName },
+        validationSchema,
+        onSubmit: addToWatchedImages,
+    });
+    const isNameFieldInvalid = !!(errors.imageName && touched.imageName);
+    const nameFieldValidated = isNameFieldInvalid ? 'error' : 'default';
+
+    function addToWatchedImages(formValues: FormData, { setSubmitting }: FormikHelpers<FormData>) {
+        watchImage(formValues.imageName, {
+            onSettled: () => setSubmitting(false),
+        });
+    }
+
+    return (
+        <Form onSubmit={handleSubmit}>
+            <FormGroup
+                label="Image name"
+                fieldId="imageName"
+                isRequired
+                validated={nameFieldValidated}
+                helperText="The fully-qualified image name, beginning with the registry, and ending with the tag."
+                helperTextInvalid={errors.imageName}
+            >
+                <TextInput
+                    id="imageName"
+                    type="text"
+                    value={values.imageName}
+                    validated={nameFieldValidated}
+                    onChange={(_, e) => handleChange(e)}
+                    onBlur={handleBlur}
+                    isDisabled={isSubmitting}
+                    placeholder="registry.example.com/namespace/image-name:tag"
+                    isRequired
+                />
+            </FormGroup>
+            <div>
+                <Button
+                    variant="secondary"
+                    onClick={submitForm}
+                    isDisabled={isSubmitting || isNameFieldInvalid}
+                    isLoading={isSubmitting}
+                >
+                    Add image to watch list
+                </Button>
+            </div>
+        </Form>
+    );
+}
+
+export default WatchedImagesForm;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { Button, Modal } from '@patternfly/react-core';
+import { Alert, Button, Flex, Modal } from '@patternfly/react-core';
+import noop from 'lodash/noop';
+
+import { watchImage } from 'services/imageService';
+import useRestMutation from 'hooks/useRestMutation';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+import WatchedImagesForm from './WatchedImagesForm';
 
 export type WatchedImagesModalProps = {
     defaultWatchedImageName: string;
@@ -8,19 +15,53 @@ export type WatchedImagesModalProps = {
 };
 
 function WatchedImagesModal({ defaultWatchedImageName, isOpen, onClose }: WatchedImagesModalProps) {
+    const { data, mutate, isSuccess, isLoading, isError, error, reset } = useRestMutation(
+        (name: string) => watchImage(name)
+    );
+
+    function onCloseModal() {
+        onClose();
+        reset();
+    }
+
     return (
         <Modal
             title="Manage watched images"
             isOpen={isOpen}
-            onClose={onClose}
+            onClose={onCloseModal}
             variant="medium"
+            showClose={!isLoading}
+            onEscapePress={isLoading ? noop : onCloseModal}
             actions={[
-                <Button key="Close" onClick={onClose}>
+                <Button key="Close" onClick={onCloseModal} isDisabled={isLoading}>
                     Close
                 </Button>,
             ]}
         >
-            <div>Image name: {defaultWatchedImageName}</div>
+            <Flex direction={{ default: 'column' }}>
+                {isSuccess && (
+                    <Alert
+                        variant="success"
+                        isInline
+                        title="The image was successfully added to the watch list"
+                    >
+                        {data ?? ''}
+                    </Alert>
+                )}
+                {isError && (
+                    <Alert
+                        variant="danger"
+                        isInline
+                        title="There was an error adding the image to the watch list"
+                    >
+                        {getAxiosErrorMessage(error)}
+                    </Alert>
+                )}
+                <WatchedImagesForm
+                    defaultWatchedImageName={defaultWatchedImageName}
+                    watchImage={mutate}
+                />
+            </Flex>
         </Modal>
     );
 }

--- a/ui/apps/platform/src/hooks/useRestMutation.test.ts
+++ b/ui/apps/platform/src/hooks/useRestMutation.test.ts
@@ -1,0 +1,154 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useRestMutation from './useRestMutation';
+
+// Utility function to track the order of callbacks as the hook transitions
+// through its lifecycle.
+function trackCallbacksInArray(array: string[], scope: 'global' | 'local') {
+    return {
+        onSuccess: (data: string) => {
+            array.push(`${scope} success: ${data}`);
+        },
+        onError: (error: unknown) => {
+            array.push(`${scope} error: ${error as string}`);
+        },
+        onSettled: (data: string | undefined, error: unknown) => {
+            array.push(`${scope} settled: [${String(data)}, ${error as string}]`);
+        },
+    };
+}
+
+describe('useRestMutation hook', () => {
+    it('should correctly handle success lifecycle statuses and data', async () => {
+        jest.useFakeTimers();
+
+        const requestFn = (arg: string) =>
+            new Promise<string>((resolve) =>
+                setTimeout(() => resolve(`called with "${arg}"`), 1000)
+            );
+
+        const callbackResults: string[] = [];
+
+        const { result, waitForNextUpdate } = renderHook(() =>
+            useRestMutation(requestFn, trackCallbacksInArray(callbackResults, 'global'))
+        );
+
+        // Check initial state
+        expect(result.current.isIdle).toBe(true);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.isSuccess).toBe(false);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.data).toBe(undefined);
+        expect(result.current.error).toBe(undefined);
+
+        act(() => {
+            result.current.mutate('test', trackCallbacksInArray(callbackResults, 'local'));
+        });
+
+        // Check loading state
+        expect(result.current.isIdle).toBe(false);
+        expect(result.current.isLoading).toBe(true);
+        expect(result.current.isSuccess).toBe(false);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.data).toBe(undefined);
+        expect(result.current.error).toBe(undefined);
+
+        // Expire timeout timer and wait for state to change
+        jest.runAllTimers();
+        await waitForNextUpdate();
+
+        // Check success state
+        expect(result.current.isIdle).toBe(false);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.isSuccess).toBe(true);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.data).toBe('called with "test"');
+        expect(result.current.error).toBe(undefined);
+
+        expect(callbackResults).toEqual([
+            'global success: called with "test"',
+            'local success: called with "test"',
+            'global settled: [called with "test", undefined]',
+            'local settled: [called with "test", undefined]',
+        ]);
+
+        act(() => {
+            result.current.reset();
+        });
+
+        // Check reset state
+        expect(result.current.isIdle).toBe(true);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.isSuccess).toBe(false);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.data).toBe(undefined);
+        expect(result.current.error).toBe(undefined);
+    });
+
+    it('should correctly handle failure lifecycle statuses and data', async () => {
+        jest.useFakeTimers();
+
+        const requestFn = (arg: string) =>
+            new Promise<string>((resolve, reject) =>
+                // Using a 'string' instead of `Error` for simplicity
+                // eslint-disable-next-line prefer-promise-reject-errors
+                setTimeout(() => reject(`error with "${arg}"`), 1000)
+            );
+
+        const callbackResults: string[] = [];
+
+        const { result, waitForNextUpdate } = renderHook(() =>
+            useRestMutation(requestFn, trackCallbacksInArray(callbackResults, 'global'))
+        );
+
+        // Check initial state
+        expect(result.current.isIdle).toBe(true);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.isSuccess).toBe(false);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.data).toBe(undefined);
+        expect(result.current.error).toBe(undefined);
+
+        act(() => {
+            result.current.mutate('test', trackCallbacksInArray(callbackResults, 'local'));
+        });
+
+        // Check loading state
+        expect(result.current.isIdle).toBe(false);
+        expect(result.current.isLoading).toBe(true);
+        expect(result.current.isSuccess).toBe(false);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.data).toBe(undefined);
+        expect(result.current.error).toBe(undefined);
+
+        // Expire timeout timer and wait for state to change
+        jest.runAllTimers();
+        await waitForNextUpdate();
+
+        // Check failure state
+        expect(result.current.isIdle).toBe(false);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.isSuccess).toBe(false);
+        expect(result.current.isError).toBe(true);
+        expect(result.current.data).toBe(undefined);
+        expect(result.current.error as string).toBe('error with "test"');
+
+        expect(callbackResults).toEqual([
+            'global error: error with "test"',
+            'local error: error with "test"',
+            'global settled: [undefined, error with "test"]',
+            'local settled: [undefined, error with "test"]',
+        ]);
+
+        act(() => {
+            result.current.reset();
+        });
+
+        // Check reset state
+        expect(result.current.isIdle).toBe(true);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.isSuccess).toBe(false);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.data).toBe(undefined);
+    });
+});

--- a/ui/apps/platform/src/hooks/useRestMutation.ts
+++ b/ui/apps/platform/src/hooks/useRestMutation.ts
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+
+export type RequestStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export type MutationOptions<Result> = {
+    /** A function to call when the mutation is successful */
+    onSuccess?: (data: Result) => void;
+    /** A function to call when the mutation fails */
+    onError?: (error: unknown) => void;
+    /** A function to call after the mutation is successful or fails */
+    onSettled?: (data: Result | undefined, error: unknown) => void;
+};
+
+export type UseRestMutationReturn<Payload, Result> = {
+    /** The result of the mutation. */
+    data: Result | undefined;
+    /** Whether the mutation is currently idle, i.e. before the mutation is first triggered */
+    isIdle: boolean;
+    /** Whether the mutation is currently loading */
+    isLoading: boolean;
+    /** Whether the mutation was successful */
+    isSuccess: boolean;
+    /** Whether the mutation failed */
+    isError: boolean;
+    /** The current status of the mutation lifecycle */
+    status: RequestStatus;
+    /** The error that occurred during the mutation */
+    error: unknown;
+    /**
+     * A function to trigger the mutation. Accepts an optional object to run callbacks for
+     * this specific mutation.
+     */
+    mutate: (payload: Payload, localOptions?: MutationOptions<Result>) => void;
+    /** A function to reset the mutation to its initial state and clear any data or error */
+    reset: () => void;
+};
+
+const defaultState = { data: undefined, status: 'idle', error: undefined } as const;
+
+/**
+ * A hook used for general purpose REST mutations. The API is a subset of the one provided by
+ * `react-query`'s `useMutation` hook.
+ *
+ * @param requestFn The function that will be called when the mutation is triggered.
+ * @param options Options for the mutation to run callbacks globally each time the mutation is triggered. These will
+ *                be called before the local callbacks passed to the `mutate` function.
+ * @returns An object containing the current status of the mutation, the result of the mutation,
+ *          and a function to trigger the mutation.
+ */
+export default function useRestMutation<Payload, Result>(
+    requestFn: (payload: Payload) => Promise<Result>,
+    options: MutationOptions<Result> = {}
+): UseRestMutationReturn<Payload, Result> {
+    const [state, setState] = useState<{
+        data: Result | undefined;
+        status: RequestStatus;
+        error: unknown;
+    }>(defaultState);
+    const { status } = state;
+
+    const mutate = (payload: Payload, localOptions: MutationOptions<Result> = {}) => {
+        const request = requestFn(payload);
+
+        setState((prevState) => ({ ...prevState, status: 'loading', error: undefined }));
+
+        // Store the result of the request callbacks in local variables so that we can
+        // call the `onSettled` callback with the correct data or error.
+        let mutationData: Result | undefined;
+        let mutationError: unknown;
+
+        request
+            .then((data: Result) => {
+                mutationData = data;
+                setState({ data, status: 'success', error: undefined });
+                options.onSuccess?.(data);
+                localOptions.onSuccess?.(data);
+            })
+            .catch((error: unknown) => {
+                mutationError = error;
+                setState({ data: undefined, status: 'error', error });
+                options.onError?.(error);
+                localOptions.onError?.(error);
+            })
+            .finally(() => {
+                options.onSettled?.(mutationData, mutationError);
+                localOptions.onSettled?.(mutationData, mutationError);
+            });
+    };
+
+    function reset() {
+        setState(defaultState);
+    }
+
+    return {
+        ...state,
+        isIdle: status === 'idle',
+        isLoading: status === 'loading',
+        isSuccess: status === 'success',
+        isError: status === 'error',
+        mutate,
+        reset,
+    };
+}


### PR DESCRIPTION
## Description

Adds the "Watch image" modal form and formik validation to the Workload CVE page.

Adds a general purpose `useRestMutation` hook that is API compatible with the react-query equivalent to avoid boilerplate when making destructive async calls.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests for new hook.

Visit the workload CVE page and open the modal via header button. The default value in the form is empty. Click into the text input and then click out, the form will present an error and submitting will be disabled.
![image](https://github.com/stackrox/stackrox/assets/1292638/d5580a5a-ce98-41fd-b197-9d860c1aa204)
![image](https://github.com/stackrox/stackrox/assets/1292638/ab619aff-302c-4f29-bb45-28d2ac237853)

Close the modal and open the modal via a table row action. The text input should have the value of the image in the row that was selected. Click "Add image to watch list" and watch the form go through the loading state to the success state, showing an inline alert.
![image](https://github.com/stackrox/stackrox/assets/1292638/72e58015-26ed-4cff-ac71-b570b88d4af8)
![image](https://github.com/stackrox/stackrox/assets/1292638/620c9b59-c2e7-41ec-8053-df80ae9185fc)
![image](https://github.com/stackrox/stackrox/assets/1292638/1888f461-ce23-47b3-87b4-5d0a5c3ae5fa)

Close the modal and open via a different table row action. The alert will be cleared and the text input should have the correct, new value. Clear the value of the input and add an invalid image name. Attempt to add the image to the watch list and watch the form go through the loading state to the error state, showing an inline alert.
![image](https://github.com/stackrox/stackrox/assets/1292638/4ab3e2c1-e6ee-48cb-89f2-c9b4705a4479)
![image](https://github.com/stackrox/stackrox/assets/1292638/e1f31c9c-3fb0-49c1-9a27-9cac4bc8904b)
![image](https://github.com/stackrox/stackrox/assets/1292638/4151ae21-74a7-4054-9f70-03f9374eb9d8)

Close the modal and open the modal again via any action to verify that the error is cleared.
![image](https://github.com/stackrox/stackrox/assets/1292638/25131bcb-afc7-4ffc-8246-36135b052ad8)



