### PR TITLE
ROX-16345: Fix graphQL error navigating from node_compoenent to nodes

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.js
@@ -30,7 +30,7 @@ function VulnMgmtComponentOverview({ data, entityContext }) {
     const currentEntityType = workflowState.getCurrentEntityType();
 
     const vulnType =
-        currentEntityType === entityTypes.NODE_COMPONENT
+        currentEntityType === entityTypes.NODE_COMPONENT || entityTypes.NODE
             ? entityTypes.NODE_CVE
             : entityTypes.IMAGE_CVE;
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.js
@@ -49,7 +49,10 @@ const TableWidgetFixableCves = ({
 
     const displayedEntityType = entityNounOrdinaryCaseSingular[entityType];
 
-    const queryFieldName = queryFieldNames[entityType];
+    const queryFieldName =
+        vulnType === entityTypes.NODE_CVE
+            ? queryFieldNames[entityTypes.NODE_COMPONENT] // fix for React state transition
+            : queryFieldNames[entityType];
     let queryVulnCounterFieldName = 'imageVulnerabilityCounter';
     let queryVulnsFieldName = 'imageVulnerabilities';
     let queryCVEFieldsName = 'imageCVEFields';


### PR DESCRIPTION
## Description

### Repro steps
1) From VM dashboard, open Node CVEs and then click on a single Node CVE.
2) Click on the 'Open externally' button on the top right corner (left of close button) to open the CVE in its own view.
3) Click components from the related entities.
4) Click any component.
5) Click Nodes under component's related entities.

Result: graphQL error in the API network call response, but no visible effect on UI

### Analysis
The React component update cycle tries to re-render the ComponentOverview component one last time before navigating away from it, but with the new entityType of "NODE". Due to a missing path in the conditional that calculates the dynamic query for TableFixableCves, it tries to make a new query for node CVEs, but with an `imageVulnerabilityCounter`.

### Fix
Add a check for entityType of "NODE" when calculating CVE type, in addition to the check for NODE_COMPONENT.

This fix has the added benefit that the graphQL client sees that this is the same query that ran when the Node Component view loaded, and and returns the cached query results and doesn't make a new network request. (Which would never be displayed anyway.)

## Checklist
- [x] Investigated and inspected CI test results (failure in one flavor of ui-e2e-tests run is known random flake "Compliance hideScanResults")


## Testing Performed

### Here I tell how I validated my change

Manual testing

Before the change:
Observed the extra graphQL API call return errors, and step through the code to see the cause of the incorrect query params.

After the change:
Observe that no extraneous API call is made, and thus no error. Step through the code and see that the function call to the graphQL client library now passes the correct type of CVE.


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
