### PR TITLE
ROX-11963: Notifications fail for network flow alerts

### DIFF
--- a/pkg/fixtures/policy.go
+++ b/pkg/fixtures/policy.go
@@ -2,6 +2,7 @@ package fixtures
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
 )
 
 var (
@@ -245,4 +246,30 @@ func GetAuditLogEventSourcePolicy() *storage.Policy {
 		},
 	}
 	return p
+}
+
+// GetNetworkFlowPolicy returns a mock policy with criteria "Unexpected Network Flow Detected"
+func GetNetworkFlowPolicy() *storage.Policy {
+	return &storage.Policy{
+		Id:                 fixtureconsts.NetworkPolicy1,
+		Name:               "Unauthorized Network Flow",
+		Description:        "This policy generates a violation for the network flows that fall outside baselines for which 'alert on anomalous violations' is set.",
+		Rationale:          "The network baseline is a list of flows that are allowed, and once it is frozen, any flow outside that is a concern.",
+		Remediation:        "Evaluate this network flow. If deemed to be okay, add it to the baseline. If not, investigate further as required.",
+		Categories:         []string{"Anomalous Activity"},
+		LifecycleStages:    []storage.LifecycleStage{storage.LifecycleStage_RUNTIME},
+		Severity:           storage.Severity_HIGH_SEVERITY,
+		SORTName:           "Unauthorized Network Flow",
+		SORTLifecycleStage: "RUNTIME",
+		PolicyVersion:      "1.1",
+		PolicySections: []*storage.PolicySection{{
+			PolicyGroups: []*storage.PolicyGroup{{
+				FieldName: "Unexpected Network Flow Detected",
+				Values: []*storage.PolicyValue{{
+					Value: "true",
+				}},
+			}},
+		}},
+		EventSource: storage.EventSource_DEPLOYMENT_EVENT,
+	}
 }

--- a/pkg/notifiers/common.go
+++ b/pkg/notifiers/common.go
@@ -45,7 +45,7 @@ func AlertLink(endpoint string, alert *storage.Alert) string {
 	}
 	var alertPath string
 	switch entity := alert.GetEntity().(type) {
-	case *storage.Alert_Deployment_:
+	case *storage.Alert_Deployment_, *storage.Alert_Resource_:
 		alertPath = fmt.Sprintf(alertLinkPath, alert.GetId())
 	case *storage.Alert_Image:
 		alertPath = fmt.Sprintf(imageLinkPath, entity.Image.GetId())

--- a/pkg/notifiers/format.go
+++ b/pkg/notifiers/format.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Masterminds/sprig/v3"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/images/types"
@@ -40,9 +41,11 @@ const bplPolicyFormat = `
 	{{range .Violations}}
 		{{list .Message}}
 		{{if .MessageAttributes}}
-			{{if .MessageAttributes.KeyValueAttrs}}
-				{{range .MessageAttributes.KeyValueAttrs.Attrs}}
-					{{stringify .Key ":" .Value | nestedList}}
+			{{if kindIs "Alert_Violation_KeyValueAttrs_" .MessageAttributes }}
+				{{if .MessageAttributes.KeyValueAttrs}}
+					{{range .MessageAttributes.KeyValueAttrs.Attrs}}
+						{{stringify .Key ":" .Value | nestedList}}
+					{{end}}
 				{{end}}
 			{{end}}
 		{{end}}
@@ -121,6 +124,7 @@ func FormatAlert(alert *storage.Alert, alertLink string, funcMap template.FuncMa
 	}
 	funcMap["stringify"] = stringify
 	funcMap["default"] = stringutils.OrDefault
+	funcMap["kindIs"] = sprig.GenericFuncMap()["kindIs"]
 	if _, ok := funcMap["valuePrinter"]; !ok {
 		funcMap["valuePrinter"] = valuePrinter
 	}


### PR DESCRIPTION
## Description

Email, Slack and Jira notifications aren't sent for events that have `NetworkFlowInfo` set in the `MessageAttributes` oneof. The reason is because it looks like the oneof doesn't play nicely with the email template. 

This change fixes it by just ignoring any `MessageAttributes` that is not `KeyValueAttrs`. Will file a separate ticket to revisit the template just for network flow alerts at a later time (to see if items from `NetworkFlowInfo` should be rendered or not)

Also fixes a bug with the URL for resource alerts 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~
~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Automated tests and manual

![Screenshot 2023-09-07 at 8 23 54 PM](https://github.com/stackrox/stackrox/assets/1407686/62059ec9-9eb7-4275-ac4e-a617af0de300)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
