### PR TITLE
fix: monitoring in manifest download

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/.helmtplignore.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/.helmtplignore.htpl
@@ -1,6 +1,5 @@
 [<- if .KubectlOutput >]
 templates/cluster-config.yaml
-templates/openshift-monitoring.yaml
 templates/00-injected-ca-bundle.yaml
 internal/cluster-config.yaml.tpl
 sensor-chart-upgrade.md

--- a/image/templates/sensor/openshift/delete-sensor.sh
+++ b/image/templates/sensor/openshift/delete-sensor.sh
@@ -2,6 +2,9 @@
 
 oc -n stackrox delete cm,secret,sa,svc,validatingwebhookconfigurations,ds,deploy,netpol,clusterrole,clusterrolebinding,role,rolebinding -l auto-upgrade.stackrox.io/component=sensor --wait
 
+oc -n kube-system delete rolebinding -l auto-upgrade.stackrox.io/component=sensor --wait
+oc -n openshift-monitoring delete prometheusrule,servicemonitor -l auto-upgrade.stackrox.io/component=sensor --wait
+
 SUPPORTS_PSP=$(oc api-resources | grep "podsecuritypolicies" -c || true)
 
 if [[ "${SUPPORTS_PSP}" -ne 0 ]]; then

--- a/image/templates/sensor/openshift/sensor.sh
+++ b/image/templates/sensor/openshift/sensor.sh
@@ -46,6 +46,11 @@ if [[ -f "$DIR/sensor-pod-security.yaml" ]]; then
   fi
 fi
 
+if [[ -f "$DIR/openshift-monitoring.yaml" ]]; then
+    echo "Creating OpenShift monitoring configuration..."
+    ${KUBE_COMMAND} apply -f "$DIR/openshift-monitoring.yaml"
+fi
+
 # OpenShift roles can be delayed to be added
 sleep 5
 


### PR DESCRIPTION
## Description

Unfortunately I found a bug w/ OpenShift monitoring in the secured cluster manifest download. It applies only when secured clusters are installed via manifest download, and causes the monitoring resources to not be created and applied. As a result, Sensor does not show up in OpenShift monitoring.

## Testing Performed

Tested manifest download w/ and w/out this change.