### PR TITLE
feat(ui): Add updated 'watched image' label to workload cve table

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -14,6 +14,8 @@ import { defaultImageSortFields, imagesDefaultSort } from '../sortUtils';
 import { DefaultFilters, VulnerabilitySeverityLabel, CveStatusTab } from '../types';
 import TableEntityToolbar from '../components/TableEntityToolbar';
 
+export { imageListQuery } from '../Tables/ImagesTable';
+
 type ImagesTableContainerProps = {
     defaultFilters: DefaultFilters;
     countsData: EntityCounts;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -9,7 +9,7 @@ import {
     CardBody,
     Button,
 } from '@patternfly/react-core';
-import { useQuery } from '@apollo/client';
+import { useApolloClient, useQuery } from '@apollo/client';
 
 import useURLSearch from 'hooks/useURLSearch';
 import useURLStringUnion from 'hooks/useURLStringUnion';
@@ -21,7 +21,7 @@ import { parseQuerySearchFilter, getCveStatusScopedQueryString } from '../search
 import { entityTypeCountsQuery } from '../components/EntityTypeToggleGroup';
 import CVEsTableContainer from './CVEsTableContainer';
 import DeploymentsTableContainer from './DeploymentsTableContainer';
-import ImagesTableContainer from './ImagesTableContainer';
+import ImagesTableContainer, { imageListQuery } from './ImagesTableContainer';
 import WatchedImagesModal from '../WatchedImages/WatchedImagesModal';
 
 const emptyStorage: VulnMgmtLocalStorage = {
@@ -35,6 +35,8 @@ const emptyStorage: VulnMgmtLocalStorage = {
 };
 
 function WorkloadCvesOverviewPage() {
+    const apolloClient = useApolloClient();
+
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const [activeEntityTabKey] = useURLStringUnion('entityTab', entityTabValues);
@@ -124,6 +126,9 @@ function WorkloadCvesOverviewPage() {
                     setDefaultWatchedImageName('');
                     watchedImagesModalToggle.closeSelect();
                 }}
+                onWatchedImagesChange={() =>
+                    apolloClient.refetchQueries({ include: [imageListQuery] })
+                }
             />
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -2,16 +2,17 @@ import React from 'react';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 import { ActionsColumn, TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { Flex } from '@patternfly/react-core';
+import { Flex, Label } from '@patternfly/react-core';
 
 import { UseURLSortResult } from 'hooks/useURLSort';
+import { EyeIcon } from '@patternfly/react-icons';
 import ImageNameTd from '../components/ImageNameTd';
 import SeverityCountLabels from '../components/SeverityCountLabels';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
 import EmptyTableResults from '../components/EmptyTableResults';
 import DateDistanceTd from '../components/DatePhraseTd';
 import TooltipTh from '../components/TooltipTh';
-import { VulnerabilitySeverityLabel, watchStatusLabel, WatchStatus } from '../types';
+import { VulnerabilitySeverityLabel, WatchStatus } from '../types';
 
 export const imageListQuery = gql`
     query getImageList($query: String, $pagination: Pagination) {
@@ -134,7 +135,19 @@ function ImagesTable({
                             <Tr>
                                 <Td dataLabel="Image">
                                     {name ? (
-                                        <ImageNameTd name={name} id={id} />
+                                        <ImageNameTd name={name} id={id}>
+                                            {watchStatus === 'WATCHED' && (
+                                                <Label
+                                                    isCompact
+                                                    variant="outline"
+                                                    color="grey"
+                                                    className="pf-u-mt-xs"
+                                                    icon={<EyeIcon />}
+                                                >
+                                                    Watched Image
+                                                </Label>
+                                            )}
+                                        </ImageNameTd>
                                     ) : (
                                         'Image name not available'
                                     )}
@@ -150,7 +163,7 @@ function ImagesTable({
                                     />
                                 </Td>
                                 <Td>{operatingSystem}</Td>
-                                <Td>
+                                <Td modifier="nowrap">
                                     {deploymentCount > 0 ? (
                                         <>
                                             {deploymentCount}{' '}
@@ -159,10 +172,6 @@ function ImagesTable({
                                     ) : (
                                         <Flex>
                                             <div>0 deployments</div>
-                                            {/* TODO: double check on what this links to */}
-                                            <span>
-                                                ({`${watchStatusLabel[watchStatus]}`} image)
-                                            </span>
                                         </Flex>
                                     )}
                                 </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
@@ -12,11 +12,18 @@ export type WatchedImagesModalProps = {
     defaultWatchedImageName: string;
     isOpen: boolean;
     onClose: () => void;
+    onWatchedImagesChange: () => void;
 };
 
-function WatchedImagesModal({ defaultWatchedImageName, isOpen, onClose }: WatchedImagesModalProps) {
+function WatchedImagesModal({
+    defaultWatchedImageName,
+    isOpen,
+    onClose,
+    onWatchedImagesChange,
+}: WatchedImagesModalProps) {
     const { data, mutate, isSuccess, isLoading, isError, error, reset } = useRestMutation(
-        (name: string) => watchImage(name)
+        (name: string) => watchImage(name),
+        { onSuccess: onWatchedImagesChange }
     );
 
     function onCloseModal() {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameTd.tsx
@@ -4,16 +4,17 @@ import { Flex, Button, ButtonVariant, Truncate } from '@patternfly/react-core';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import { getEntityPagePath } from '../searchUtils';
 
-type ImageNameTdProps = {
+export type ImageNameTdProps = {
     name: {
         remote: string;
         registry: string;
         tag: string;
     };
     id: string;
+    children?: React.ReactNode;
 };
 
-function ImageNameTd({ name, id }: ImageNameTdProps) {
+function ImageNameTd({ name, id, children }: ImageNameTdProps) {
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsNone' }}>
             <Button
@@ -25,6 +26,7 @@ function ImageNameTd({ name, id }: ImageNameTdProps) {
                 <Truncate position="middle" content={`${name.remote}:${name.tag}`} />
             </Button>{' '}
             <span className="pf-u-color-200 pf-u-font-size-sm">in {name.registry}</span>
+            <div>{children}</div>
         </Flex>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
@@ -51,7 +51,3 @@ export function isValidEntityTab(value: unknown): value is EntityTab {
 }
 
 export type WatchStatus = 'WATCHED' | 'NOT_WATCHED';
-export const watchStatusLabel = {
-    WATCHED: 'watched',
-    NOT_WATCHED: 'not watched',
-};


### PR DESCRIPTION
## Description

Adds a (:eye: Watched image) label to the image cell of the workload cve image table, removing the equivalent text from the deployment column.

_Note that this changes the behavior in two ways from the current tech preview, making it match the behavior of VM 1.0_
1. No additional text or label will be displayed if the image is not watched and is part of zero deployments
2. Images with > 0 deployments that are watched **will** display the "watched image" label

CC @mansursyed - Do the above behavior changes make sense and accurately reflect the mocks? There are before/after screenshots below as well.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Watch some images.

Before:
![image](https://github.com/stackrox/stackrox/assets/1292638/e93da43f-b040-4b9e-920e-f71ac62105b1)

After:
![image](https://github.com/stackrox/stackrox/assets/1292638/ced456b5-b87c-4b77-946e-1c42c4a3227c)

Clicking on a watched image label will open the modal:
![image](https://github.com/stackrox/stackrox/assets/1292638/adf2c69c-30cd-4a54-ba1c-7757367494bf)


