### PR TITLE
fix: Fix 4.2.0 stuck operator upgrade when 4.1.0 is skipped

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -254,6 +254,12 @@ test-upgrade: kuttl bundle-post-process ## Run OLM-based operator upgrade tests.
 	NEW_PRODUCT_VERSION=$$(make --quiet --no-print-directory -C .. tag) \
 	KUTTL=$(KUTTL) $(KUTTL) test --config kuttl-test.yaml --artifacts-dir build/kuttl-test-artifacts-upgrade $(KUTTL_TEST_RUN_LABELS_ARGS) tests/upgrade
 
+.PHONY: test-bundle-helpers
+test-bundle-helpers: ## Run Python unit tests against helper scripts.
+	set -euo pipefail ;\
+	$(ACTIVATE_PYTHON) ;\
+	pytest -v bundle_helpers
+
 .PHONY: stackrox-image-pull-secret
 stackrox-image-pull-secret: ## Create default image pull secret for StackRox images on Quay.io. Used by Helm chart.
 # Create stackrox namespace if not exists.
@@ -408,7 +414,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	$(OPERATOR_SDK) bundle validate ./bundle --select-optional suite=operatorframework
 
 .PHONY: bundle-post-process
-bundle-post-process: operator-sdk ## Post-process CSV file to include correct operator versions, etc.
+bundle-post-process: test-bundle-helpers operator-sdk ## Post-process CSV file to include correct operator versions, etc.
 # Copy the original bundle to build/ directory.
 	mkdir -p build/
 	rm -rf build/bundle

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -101,6 +101,17 @@ def patch_csv(csv_doc, version, operator_image, first_version, no_related_images
     del csv_doc['spec']['relatedImages']
 
 
+def parse_skips(spec, raw_name):
+    raw_skips = spec.get("skips", [])
+    return set([XyzVersion.parse_from(must_strip_prefix(item, f"{raw_name}.v")) for item in raw_skips])
+
+
+def must_strip_prefix(str, prefix):
+    if not str.startswith(prefix):
+        raise RuntimeError(f"{str} does not begin with {prefix}")
+    return str[len(prefix):]
+
+
 def calculate_replaced_version(version, first_version, previous_y_stream, skips):
     current_xyz = XyzVersion.parse_from(version)
     first_xyz = XyzVersion.parse_from(first_version)
@@ -124,17 +135,6 @@ def calculate_replaced_version(version, first_version, previous_y_stream, skips)
             f"Cannot identify safe patch version among skips {skips} that would be less than current {current_xyz}. Falling back to original {current_replace}.")
 
     return current_replace
-
-
-def parse_skips(spec, raw_name):
-    raw_skips = spec.get("skips", [])
-    return set([XyzVersion.parse_from(must_strip_prefix(item, f"{raw_name}.v")) for item in raw_skips])
-
-
-def must_strip_prefix(str, prefix):
-    if not str.startswith(prefix):
-        raise RuntimeError(f"{str} does not begin with {prefix}")
-    return str[len(prefix):]
 
 
 def get_previous_y_stream(version):

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -5,10 +5,9 @@ import logging
 import os
 import pathlib
 import subprocess
-from datetime import datetime, timezone
-
 import sys
 import yaml
+from datetime import datetime, timezone
 
 from rewrite import rewrite, string_replacer
 

--- a/operator/bundle_helpers/patch-csv.py
+++ b/operator/bundle_helpers/patch-csv.py
@@ -51,8 +51,7 @@ def must_replace_suffix(str, suffix, replacement):
     return splits[0] + replacement
 
 
-def patch_csv(csv_doc, version, operator_image, first_version, no_related_images, extra_supported_arches, version_skips,
-              rbac_proxy_replacement):
+def patch_csv(csv_doc, version, operator_image, first_version, no_related_images, extra_supported_arches, rbac_proxy_replacement):
     csv_doc['metadata']['annotations']['createdAt'] = datetime.now(timezone.utc).isoformat()
 
     placeholder_image = csv_doc['metadata']['annotations']['containerImage']
@@ -75,9 +74,6 @@ def patch_csv(csv_doc, version, operator_image, first_version, no_related_images
 
     # An olm.skipRange doesn't hurt if it references non-existing versions.
     csv_doc["metadata"]["annotations"]["olm.skipRange"] = f'>= {previous_y_stream} < {version}'
-
-    if version_skips:
-        csv_doc["spec"]["skips"] = version_skips
 
     # multi-arch
     if "labels" not in csv_doc["metadata"]:
@@ -119,11 +115,6 @@ def parse_args():
     parser.add_argument("--add-supported-arch", action='append', required=False,
                         help='Enable specified operator architecture via CSV labels (may be passed multiple times)',
                         default=[])
-    parser.add_argument("--add-version-skips", action='append', required=False,
-                        help='Add spec.skips values to CSV to configure which previously released versions should be '
-                             'skipped due to being unsafe (may be passed multiple times). '
-                             'Example usage: --add-version-skips rhacs-operator.v3.73.0',
-                        default=[])
     return parser.parse_args()
 
 
@@ -137,7 +128,6 @@ def main():
               first_version=args.first_version,
               no_related_images=args.no_related_images,
               extra_supported_arches=args.add_supported_arch,
-              version_skips=args.add_version_skips,
               rbac_proxy_replacement=args.replace_rbac_proxy)
     print(yaml.safe_dump(doc))
 

--- a/operator/bundle_helpers/requirements.txt
+++ b/operator/bundle_helpers/requirements.txt
@@ -1,2 +1,2 @@
 PyYAML==6.0
-pytest==7.4.1
+pytest==7.0.1

--- a/operator/bundle_helpers/requirements.txt
+++ b/operator/bundle_helpers/requirements.txt
@@ -1,1 +1,2 @@
 PyYAML==6.0
+pytest==7.4.1

--- a/operator/bundle_helpers/test_patch-csv.py
+++ b/operator/bundle_helpers/test_patch-csv.py
@@ -1,0 +1,46 @@
+import importlib
+import pytest
+
+patch_csv = importlib.import_module("patch-csv")
+
+XyzVersion = patch_csv.XyzVersion
+
+
+@pytest.mark.parametrize("current,first,previous,skips,expected", [
+    ("1.0.0", "4.0.0", "0.0.0", [], None),
+    ("4.0.0", "4.0.0", "3.74.0", [], None),
+    ("4.1.3", "4.0.0", "4.1.0", [], "4.1.2"),
+    ("4.1.1", "4.0.0", "4.1.0", [], "4.1.0"),
+    ("4.1.1", "4.0.0", "4.1.0", ["4.1.0"], "4.1.0"),
+    ("4.2.0", "4.0.0", "4.1.0", ["4.1.0"], "4.1.1"),
+    ("4.3.0", "4.0.0", "4.2.0", ["4.1.0", "4.2.1", "4.4.0"], "4.2.0"),
+    ("4.3.0", "4.0.0", "4.2.0", ["4.1.0", "4.2.0", "4.2.1", "4.2.2", "4.4.0"], "4.2.3"),
+])
+def test_calculate_replaced_version(current, first, previous, skips, expected):
+    skips = {XyzVersion.parse_from(s) for s in skips}
+
+    result = patch_csv.calculate_replaced_version(current, first, previous, skips)
+
+    expected = XyzVersion.parse_from(expected) if expected is not None else None
+    assert result == expected
+
+
+@pytest.mark.parametrize("spec,raw_name,expected", [
+    (
+            {
+                "skips": ["rhacs-operator.v4.1.0", "rhacs-operator.v3.72.0", "rhacs-operator.v3.62.2"]
+            },
+            "rhacs-operator",
+            {XyzVersion(4, 1, 0), XyzVersion(3, 62, 2), XyzVersion(3, 72, 0)}
+    ),
+    ({"skips": []}, "blah", set()),
+    ({}, "blah", set()),
+])
+def test_parse_skips(spec, raw_name, expected):
+    result = patch_csv.parse_skips(spec, raw_name)
+    assert result == expected
+
+
+def test_parse_skips_exception():
+    with pytest.raises(RuntimeError, match="odd_one.* does not begin with different_one"):
+        patch_csv.parse_skips({"skips": ["odd_one.v1.2.3"]}, "different_one")

--- a/operator/bundle_helpers/test_patch-csv.py
+++ b/operator/bundle_helpers/test_patch-csv.py
@@ -8,9 +8,7 @@ XyzVersion = patch_csv.XyzVersion
 
 @pytest.mark.parametrize("spec,raw_name,expected", [
     (
-            {
-                "skips": ["rhacs-operator.v4.1.0", "rhacs-operator.v3.72.0", "rhacs-operator.v3.62.2"]
-            },
+            {"skips": ["rhacs-operator.v4.1.0", "rhacs-operator.v3.72.0", "rhacs-operator.v3.62.2"]},
             "rhacs-operator",
             {XyzVersion(4, 1, 0), XyzVersion(3, 62, 2), XyzVersion(3, 72, 0)}
     ),

--- a/operator/bundle_helpers/test_patch-csv.py
+++ b/operator/bundle_helpers/test_patch-csv.py
@@ -6,6 +6,27 @@ patch_csv = importlib.import_module("patch-csv")
 XyzVersion = patch_csv.XyzVersion
 
 
+@pytest.mark.parametrize("spec,raw_name,expected", [
+    (
+            {
+                "skips": ["rhacs-operator.v4.1.0", "rhacs-operator.v3.72.0", "rhacs-operator.v3.62.2"]
+            },
+            "rhacs-operator",
+            {XyzVersion(4, 1, 0), XyzVersion(3, 62, 2), XyzVersion(3, 72, 0)}
+    ),
+    ({"skips": []}, "blah", set()),
+    ({}, "blah", set()),
+])
+def test_parse_skips(spec, raw_name, expected):
+    result = patch_csv.parse_skips(spec, raw_name)
+    assert result == expected
+
+
+def test_parse_skips_exception():
+    with pytest.raises(RuntimeError, match="odd_one.* does not begin with different_one"):
+        patch_csv.parse_skips({"skips": ["odd_one.v1.2.3"]}, "different_one")
+
+
 @pytest.mark.parametrize("current,first,previous,skips,expected", [
     # Downstream trunk builds get no replace since their version is too small.
     ("1.0.0", "4.0.0", "0.0.0", [], None),
@@ -38,24 +59,3 @@ def test_calculate_replaced_version(current, first, previous, skips, expected):
 
     expected = XyzVersion.parse_from(expected) if expected is not None else None
     assert result == expected
-
-
-@pytest.mark.parametrize("spec,raw_name,expected", [
-    (
-            {
-                "skips": ["rhacs-operator.v4.1.0", "rhacs-operator.v3.72.0", "rhacs-operator.v3.62.2"]
-            },
-            "rhacs-operator",
-            {XyzVersion(4, 1, 0), XyzVersion(3, 62, 2), XyzVersion(3, 72, 0)}
-    ),
-    ({"skips": []}, "blah", set()),
-    ({}, "blah", set()),
-])
-def test_parse_skips(spec, raw_name, expected):
-    result = patch_csv.parse_skips(spec, raw_name)
-    assert result == expected
-
-
-def test_parse_skips_exception():
-    with pytest.raises(RuntimeError, match="odd_one.* does not begin with different_one"):
-        patch_csv.parse_skips({"skips": ["odd_one.v1.2.3"]}, "different_one")

--- a/operator/bundle_helpers/test_patch-csv.py
+++ b/operator/bundle_helpers/test_patch-csv.py
@@ -7,13 +7,28 @@ XyzVersion = patch_csv.XyzVersion
 
 
 @pytest.mark.parametrize("current,first,previous,skips,expected", [
+    # Downstream trunk builds get no replace since their version is too small.
     ("1.0.0", "4.0.0", "0.0.0", [], None),
+    # First 4.0.0 release gets no replace despite previous Y-Stream.
     ("4.0.0", "4.0.0", "3.74.0", [], None),
-    ("4.1.3", "4.0.0", "4.1.0", [], "4.1.2"),
-    ("4.1.1", "4.0.0", "4.1.0", [], "4.1.0"),
-    ("4.1.1", "4.0.0", "4.1.0", ["4.1.0"], "4.1.0"),
+
+    # Patch follows normal release in absence of replaces.
+    ("4.0.1", "4.0.0", "3.74.0", [], "4.0.0"),
+    # Normal Y-Stream release replaces previous Y-Stream.
+    ("4.2.0", "4.0.0", "4.1.0", [], "4.1.0"),
+    # Normal patch, no skips, replaces previous patch.
+    ("4.1.3", "4.0.0", "4.0.0", [], "4.1.2"),
+    # Normal first patch, no skips, replaces its Y-Stream.
+    ("4.1.1", "4.0.0", "4.0.0", [], "4.1.0"),
+
+    # When the skipped patch is immediately preceding, it is still taken for replacement.
+    ("4.1.1", "4.0.0", "4.0.0", ["4.1.0"], "4.1.0"),
+    ("4.1.3", "4.0.0", "4.0.0", ["4.1.2"], "4.1.2"),
+    # When the previous Y-Stream is skipped, we'd target the next patch.
     ("4.2.0", "4.0.0", "4.1.0", ["4.1.0"], "4.1.1"),
+    # When skips don't hit, they play no role.
     ("4.3.0", "4.0.0", "4.2.0", ["4.1.0", "4.2.1", "4.4.0"], "4.2.0"),
+    # It should keep iterating patches until it finds the one that's not skipped.
     ("4.3.0", "4.0.0", "4.2.0", ["4.1.0", "4.2.0", "4.2.1", "4.2.2", "4.4.0"], "4.2.3"),
 ])
 def test_calculate_replaced_version(current, first, previous, skips, expected):


### PR DESCRIPTION
## Description

Context https://redhat-internal.slack.com/archives/C05MSQS5FCJ/p1694025354934279

Before this change, we have 4.2.0 release that has the following combination of attributes in CSV:

* `olm.skipRange: '>= 4.1.0 < 4.2.0'`
* `replaces: rhacs-operator.v4.1.0`
* `skips:  - rhacs-operator.v4.1.0` (de-newlined)

The problem is that all 4.1.1+ patches are truncated from the upgrade graph due to `replaces: rhacs-operator.v4.1.0`, and 4.1.0 can't be installed because it is skipped.

This change will make us have `replaces: rhacs-operator.v4.1.1`, i.e. the next patch in such situation. It's not optimal because currently the latest patch is 4.1.3 and we'd ideally do `replaces: rhacs-operator.v4.1.3`.
However, I don't know of a reliable way to find out patch versions already released that does not involve pulling repositories. Pulling image repositories should be possible from the `pre_build_script` downstream that invokes `patch-csv.py` but it smells trouble and so I preferred to stay away from it.

The alternative is to allow release engineers configure replaced versions by updating `pre_build_script`. One more manual step in the hopes we automate it some day. Maybe it's worth it? Let me know.

For reviewers: it is best to review per commit. I tried to write meaningful messages and descriptions.

Note that we took a quick fix approach for 4.2.0 release and landed <https://gitlab.cee.redhat.com/stackrox/rhacs-midstream/-/merge_requests/1859>. This https://github.com/stackrox/stackrox/pull/7731 is to make manual fixes unnecessary in the future.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added - some of them.

Won't do these as the change isn't that concerning for users once they _can_ upgrade:
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

Made diff with master.

```bash
$ git checkout misha/fix-4-2-0-operator-upgrade
$ make -C operator bundle bundle-post-process
$ cp operator/build/bundle/manifests/rhacs-operator.clusterserviceversion.yaml /tmp/
$ git checkout master
$ make -C operator bundle bundle-post-process
$ diff operator/build/bundle/manifests/rhacs-operator.clusterserviceversion.yaml /tmp/rhacs-operator.clusterserviceversion.yaml
```

The output is following. Left is `master`, right is this change. The important place to look at is `replaces:`.
```diff
16,17c16,17
<     containerImage: quay.io/stackrox-io/stackrox-operator:4.2.0-125-ga4ce4584ce
<     createdAt: '2023-09-12T08:09:52.913435+00:00'
---
>     containerImage: quay.io/stackrox-io/stackrox-operator:4.2.0-110-g336c366c67
>     createdAt: '2023-09-12T08:07:38.211995+00:00'
20c20
<     olm.skipRange: '>= 4.1.0 < 4.2.0-125-ga4ce4584ce'
---
>     olm.skipRange: '>= 4.1.0 < 4.2.0-110-g336c366c67'
30c30
<   name: rhacs-operator.v4.2.0-125-ga4ce4584ce
---
>   name: rhacs-operator.v4.2.0-110-g336c366c67
1053c1053
<                 image: quay.io/stackrox-io/stackrox-operator:4.2.0-125-ga4ce4584ce
---
>                 image: quay.io/stackrox-io/stackrox-operator:4.2.0-110-g336c366c67
1175c1175
<   replaces: rhacs-operator.v4.1.0
---
>   replaces: rhacs-operator.v4.1.1
1178c1178
<   version: 4.2.0-125-ga4ce4584ce
---
>   version: 4.2.0-110-g336c366c67
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
