### PR TITLE
ROX-18276: Central info metric

### DIFF
--- a/central/metrics/telemetry/gauges.go
+++ b/central/metrics/telemetry/gauges.go
@@ -17,9 +17,10 @@ import (
 )
 
 var (
+	infoGaugeName            = "info"
 	securedClustersGaugeName = "secured_clusters"
 	securedNodesGaugeName    = "secured_nodes"
-	securedVCPUGaugeName     = "secured_vcpu"
+	securedVCPUGaugeName     = "secured_vcpus"
 )
 
 // FetchInstallInfo fetches the installation info.
@@ -62,6 +63,15 @@ func newGaugeMap(installation installationStore.Store) map[string]prometheus.Gau
 	}
 
 	gauges := map[string]prometheus.Gauge{
+		infoGaugeName: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   metrics.PrometheusNamespace,
+				Subsystem:   metrics.CentralSubsystem.String(),
+				Name:        infoGaugeName,
+				Help:        "Telemetry information about Central",
+				ConstLabels: labels,
+			},
+		),
 		securedClustersGaugeName: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Namespace:   metrics.PrometheusNamespace,

--- a/central/metrics/telemetry/telemetry.go
+++ b/central/metrics/telemetry/telemetry.go
@@ -53,6 +53,7 @@ func (i *telemetryImpl) Start() {
 	for _, gauge := range telemetry.gauges {
 		gauge.Set(0)
 	}
+	i.gauges[infoGaugeName].Set(1)
 }
 
 // SetClusterMetrics updates the telemetry metric with the cluster metrics.

--- a/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
@@ -109,20 +109,26 @@ spec:
       rules:
         - expr: |
             max by (build, central_id, central_version, hosting, install_method) (
-              rox_central_secured_clusters{branding=~"rhacs|RHACS"}
+              rox_central_info{branding="RHACS"}
+            )
+          record: rhacs:telemetry:rox_central_info
+
+        - expr: |
+            max by (central_id) (
+              rox_central_secured_clusters{branding="RHACS"}
             )
           record: rhacs:telemetry:rox_central_secured_clusters
 
         - expr: |
-            max by (build, central_id, central_version, hosting, install_method) (
-              rox_central_secured_nodes{branding=~"rhacs|RHACS"}
+            max by (central_id) (
+              rox_central_secured_nodes{branding="RHACS"}
             )
           record: rhacs:telemetry:rox_central_secured_nodes
 
         - expr: |
-            max by (build, central_id, central_version, hosting, install_method) (
-              rox_central_secured_vcpu{branding=~"rhacs|RHACS"}
+            max by (central_id) (
+              rox_central_secured_vcpus{branding="RHACS"}
             )
-          record: rhacs:telemetry:rox_central_secured_vcpu
+          record: rhacs:telemetry:rox_central_secured_vcpus
 
 {{- end -}}

--- a/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/openshift-monitoring.yaml
@@ -114,7 +114,7 @@ spec:
       rules:
         - expr: |
             max by (build, central_id, hosting, install_method, sensor_id, sensor_version) (
-              rox_sensor_secured_nodes{branding=~"rhacs|RHACS"} > bool 0
+              rox_sensor_info{branding="RHACS"}
             )
           record: rhacs:telemetry:rox_sensor_info
 

--- a/sensor/common/metrics/init.go
+++ b/sensor/common/metrics/init.go
@@ -24,6 +24,7 @@ func init() {
 		k8sObjectIngestionToSendDuration,
 		resolverChannelSize,
 		outputChannelSize,
+		telemetryInfo,
 		telemetrySecuredNodes,
 		telemetrySecuredVCPU,
 	)

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -288,27 +288,19 @@ func DecOutputChannelSize() {
 
 // SetTelemetryMetrics sets the cluster metrics for the telemetry metrics.
 func SetTelemetryMetrics(cm *central.ClusterMetrics) {
-	telemetryInfo.Reset()
-	telemetryInfo.WithLabelValues(
+	labels := []string{
 		centralid.Get(),
 		getHosting(),
 		installmethod.Get(),
 		clusterid.GetNoWait(),
-	).Set(1)
+	}
+
+	telemetryInfo.Reset()
+	telemetryInfo.WithLabelValues(labels...).Set(1)
 
 	telemetrySecuredNodes.Reset()
-	telemetrySecuredNodes.WithLabelValues(
-		centralid.Get(),
-		getHosting(),
-		installmethod.Get(),
-		clusterid.GetNoWait(),
-	).Set(float64(cm.GetNodeCount()))
+	telemetrySecuredNodes.WithLabelValues(labels...).Set(float64(cm.GetNodeCount()))
 
 	telemetrySecuredVCPU.Reset()
-	telemetrySecuredVCPU.WithLabelValues(
-		centralid.Get(),
-		getHosting(),
-		installmethod.Get(),
-		clusterid.GetNoWait(),
-	).Set(float64(cm.GetCpuCapacity()))
+	telemetrySecuredVCPU.WithLabelValues(labels...).Set(float64(cm.GetCpuCapacity()))
 }

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -154,6 +154,17 @@ var (
 		"sensor_version": version.GetMainVersion(),
 	}
 
+	telemetryInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace:   metrics.PrometheusNamespace,
+			Subsystem:   metrics.SensorSubsystem.String(),
+			Name:        "info",
+			Help:        "Telemetry information about Sensor",
+			ConstLabels: telemetryLabels,
+		},
+		[]string{"central_id", "hosting", "install_method", "sensor_id"},
+	)
+
 	telemetrySecuredNodes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace:   metrics.PrometheusNamespace,
@@ -169,7 +180,7 @@ var (
 		prometheus.GaugeOpts{
 			Namespace:   metrics.PrometheusNamespace,
 			Subsystem:   metrics.SensorSubsystem.String(),
-			Name:        "secured_vcpu",
+			Name:        "secured_vcpus",
 			Help:        "The number of vCPUs secured by Sensor",
 			ConstLabels: telemetryLabels,
 		},
@@ -277,6 +288,14 @@ func DecOutputChannelSize() {
 
 // SetTelemetryMetrics sets the cluster metrics for the telemetry metrics.
 func SetTelemetryMetrics(cm *central.ClusterMetrics) {
+	telemetryInfo.Reset()
+	telemetryInfo.WithLabelValues(
+		centralid.Get(),
+		getHosting(),
+		installmethod.Get(),
+		clusterid.GetNoWait(),
+	).Set(1)
+
 	telemetrySecuredNodes.Reset()
 	telemetrySecuredNodes.WithLabelValues(
 		centralid.Get(),
@@ -284,6 +303,7 @@ func SetTelemetryMetrics(cm *central.ClusterMetrics) {
 		installmethod.Get(),
 		clusterid.GetNoWait(),
 	).Set(float64(cm.GetNodeCount()))
+
 	telemetrySecuredVCPU.Reset()
 	telemetrySecuredVCPU.WithLabelValues(
 		centralid.Get(),


### PR DESCRIPTION
## Description

Changes to conform to the latest ask by the Telemeter team to approve our telemetry metrics (see https://github.com/openshift/cluster-monitoring-operator/pull/2062).

* Normalize the Central metrics to relational structure via `rox_central_info` where `central_id` is the primary key. In queries the labels must be joined back onto the time series `rhacs:telemetry:rox_central_info * on(central_id) group_left rhacs:telemetry:rox_central_secured_vcpus`.
* Define a base `rox_sensor_info` metric for the sensor telemetry metric.

## Testing Performed

Tested with upstream image in OCP cluster with OpenShift monitoring. To simulate the downstream image, I manually set `ROX_PRODUCT_BRANDING=RHACS_BRANDING`.

<img width="1300" alt="Screenshot 2023-09-09 at 03 14 08" src="https://github.com/stackrox/stackrox/assets/55607356/655e4f2d-4675-4e66-93fd-29d55d756993">


CI `ocp-4-13-ebpf-qa-e2e-tests` failure is unrelated due to collector:
```
pkg/kocache: 2023/09/09 19:11:38.558678 source.go:58: Error: probe 2.6.0/collector-ebpf-5.14.0-284.30.1.el9_2.x86_64.o.gz does not exist in upstream https://collector-modules.stackrox.io/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656
pkg/probeupload: 2023/09/09 19:11:38.558789 server_handler.go:119: Info: kernel probe 2.6.0/collector-ebpf-5.14.0-284.30.1.el9_2.x86_64.o.gz not found
```