### PR TITLE
chore(cleanup): Adjust position of ui team codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,8 @@ pkg/sac/**/*    @stackrox/merlin
 */declarativeconfig/**/* @stackrox/merlin
 tests/performance @stackrox/merlin
 
+/ui/**/* @stackrox/ui
+
 pkg/images/defaults/**/* @stackrox/maple
 
 # Data Shepherds team's responsibilities include migrator and interactions with Postgres
@@ -47,5 +49,3 @@ operator/**/* @stackrox/draco
 /sensor/kubernetes/listener/resources/secrets.go      @stackrox/scanner
 /sensor/kubernetes/listener/resources/secrets_test.go @stackrox/scanner
 /SCANNER_VERSION                                      @stackrox/scanner
-
-ui/**/* @stackrox/ui


### PR DESCRIPTION
## Description

Trying two things:
- a higher position in the config file
- adding a leading path delimiter

in order to avoid UI team members from getting tagged by operator file changes, which happened earlier today

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

N/A

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
