### PR TITLE
ROX-19573: Change UI for new audit log options

### DIFF
--- a/ui/apps/platform/cypress/fixtures/alerts/alerts.json
+++ b/ui/apps/platform/cypress/fixtures/alerts/alerts.json
@@ -27,7 +27,42 @@
                 "resourceType": "DEPLOYMENT"
             },
             "stale": false,
-            "markedStale": null
+            "markedStale": null,
+            "enforcementAction": "UNSET_ENFORCEMENT",
+            "enforcementCount": 0
+        },
+        {
+            "id": "8aaa344c-6266-4037-bc21-cd9323a54a4c",
+            "time": "2018-09-27T21:30:00.729700614Z",
+            "lifecycleStage": "RUNTIME",
+            "policy": {
+                "id": "75db9968-8c45-4e18-8180-024f59973d15",
+                "name": "00 test scc",
+                "severity": "HIGH_SEVERITY",
+                "description": "Access to security context constraint",
+                "categories": ["Network Configuration Change", "Reconnaissance"],
+                "lifecycleStage": "RUNTIME"
+            },
+            "deployment": null,
+            "commonEntityInfo": {
+                "clusterName": "aaa_remote",
+                "namespace": "",
+                "clusterId": "99aa88df-b6df-444d-b077-4812cb501ccf",
+                "namespaceId": "",
+                "resourceType": "SECURITY_CONTEXT_CONSTRAITS"
+            },
+            "resource": {
+                "name": "test-scc",
+                "clusterName": "aaa_remote",
+                "namespace": "",
+                "clusterId": "99aa88df-b6df-444d-b077-4812cb501ccf",
+                "namespaceId": "",
+                "resourceType": "SECURITY_CONTEXT_CONSTRAITS"
+            },
+            "stale": false,
+            "markedStale": null,
+            "enforcementAction": "UNSET_ENFORCEMENT",
+            "enforcementCount": 0
         },
         {
             "id": "83f1d8d0-1e2b-410a-b1c3-c77ae2bb5ad9",

--- a/ui/apps/platform/cypress/integration/violations/violations.test.js
+++ b/ui/apps/platform/cypress/integration/violations/violations.test.js
@@ -29,7 +29,7 @@ describe('Violations', () => {
     it('should have violations in table', () => {
         visitViolationsWithFixture('alerts/alerts.json');
 
-        const count = 2;
+        const count = 3;
         cy.get(`h2:contains("${count} result")`); // Partial match is independent of singular or plural count
         cy.get('tbody tr').should('have.length', count);
     });
@@ -48,9 +48,21 @@ describe('Violations', () => {
         cy.get('th[scope="col"]:contains("Lifecycle")');
         cy.get('th[scope="col"]:contains("Time")');
 
+        // check Deployment type
         cy.get('tbody tr:nth-child(1) td[data-label="Entity"]').should('contain', 'ip-masq-agent'); // table cell also has cluster/namespace
-        cy.get('tbody tr:nth-child(1) td[data-label="Type"]').should('have.text', 'deployment');
+        cy.get('tbody tr:nth-child(1) td[data-label="Type"]').should('have.text', 'Deployment');
         cy.get('tbody tr:nth-child(1) td[data-label="Lifecycle"]').should('have.text', 'Runtime');
+
+        // check audit log type
+        cy.get('tbody tr:nth-child(2) td[data-label="Entity"]').should('contain', 'test-scc'); // table cell also has cluster
+        cy.get('tbody tr:nth-child(2) td[data-label="Entity"] div.pf-u-font-size-xs').should(
+            'have.text',
+            'in "aaa_remote"'
+        ); // table cell also has cluster
+        cy.get('tbody tr:nth-child(2) td[data-label="Type"]').should(
+            'have.text',
+            'Security Context Constraits'
+        );
     });
 
     it('should go to the detail page on row click', () => {
@@ -58,7 +70,7 @@ describe('Violations', () => {
         visitViolationFromTableWithFixture('alerts/alertFirstInAlerts.json');
 
         cy.get(selectors.details.title).should('have.text', 'Misuse of iptables');
-        cy.get(selectors.details.subtitle).should('have.text', 'in "ip-masq-agent" deployment');
+        cy.get(selectors.details.subtitle).should('have.text', 'in "ip-masq-agent" Deployment');
     });
 
     it('should have 4 tabs in the sidepanel', () => {
@@ -93,15 +105,15 @@ describe('Violations', () => {
         cy.get(`tbody tr:nth-child(1) ${selectors.actions.btn}`).click(); // click kabob to close actions menu
 
         // Lifecycle: Deploy
-        cy.get(`tbody tr:nth-child(2) ${selectors.actions.btn}`).click(); // click kabob to open actions menu
-        cy.get('tbody tr:nth-child(2)')
+        cy.get(`tbody tr:nth-child(3) ${selectors.actions.btn}`).click(); // click kabob to open actions menu
+        cy.get('tbody tr:nth-child(3)')
             .get(selectors.actions.resolveBtn)
             .should('not.exist')
             .get(selectors.actions.resolveAndAddToBaselineBtn)
             .should('not.exist')
             .get(selectors.actions.excludeDeploymentBtn)
             .should('exist');
-        cy.get(`tbody tr:nth-child(2) ${selectors.actions.btn}`).click(); // click kabob to close actions menu
+        cy.get(`tbody tr:nth-child(3) ${selectors.actions.btn}`).click(); // click kabob to close actions menu
     });
 
     // TODO test of bulk actions

--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
+import startCase from 'lodash/startCase';
 import {
     TabTitleText,
     Tabs,
@@ -68,15 +69,17 @@ function ViolationDetailsPage(): ReactElement {
 
     const { policy, deployment, resource, commonEntityInfo, enforcement } = alert;
     const title = policy.name || 'Unknown violation';
-    const { name: entityName } = resource || deployment || {};
+    const entityName = resource?.clusterName || deployment?.name || '';
     const resourceType = resource?.resourceType || commonEntityInfo?.resourceType || 'deployment';
+
+    const displayedResourceType = startCase(resourceType.toLowerCase());
 
     return (
         <>
             <ViolationsBreadcrumbs current={title} />
             <PageSection variant="light">
                 <Title headingLevel="h1">{title}</Title>
-                <Title headingLevel="h2">{`in "${entityName as string}" ${resourceType}`}</Title>
+                <Title headingLevel="h2">{`in "${entityName}" ${displayedResourceType}`}</Title>
             </PageSection>
             <PageSection variant="default" padding={{ default: 'noPadding' }}>
                 <Tabs

--- a/ui/apps/platform/src/Containers/Violations/types/violationTypes.ts
+++ b/ui/apps/platform/src/Containers/Violations/types/violationTypes.ts
@@ -99,6 +99,7 @@ export type Alert = {
     };
     resource?: {
         name: string;
+        clusterName: string;
         resourceType: string;
     };
     enforcement?: {

--- a/ui/apps/platform/src/Containers/Violations/violationTableColumnDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Violations/violationTableColumnDescriptors.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import pluralize from 'pluralize';
 import dateFns from 'date-fns';
+import startCase from 'lodash/startCase';
 import { Button, ButtonVariant, Flex, FlexItem, Tooltip } from '@patternfly/react-core';
 
 import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverityIconText';
@@ -31,12 +32,13 @@ function EntityTableCell({ original }: EntityTableCellProps): ReactElement {
     const { commonEntityInfo, resource, deployment } = original;
     const { name } = resource || deployment;
     const { namespace, clusterName } = commonEntityInfo;
+
+    const entityPath = namespace ? `${clusterName}/${namespace}` : clusterName;
+
     return (
         <Flex direction={{ default: 'column' }}>
             <FlexItem className="pf-u-mb-0">{name}</FlexItem>
-            <FlexItem className="pf-u-color-200 pf-u-font-size-xs">
-                {`in "${clusterName}/${namespace}"`}
-            </FlexItem>
+            <FlexItem className="pf-u-color-200 pf-u-font-size-xs">{`in "${entityPath}"`}</FlexItem>
         </Flex>
     );
 }
@@ -102,7 +104,7 @@ const tableColumnDescriptor = [
     {
         Header: 'Type',
         accessor: 'commonEntityInfo.resourceType',
-        Cell: ({ value }): string => value.toLowerCase() as string,
+        Cell: ({ value }): string => startCase(value.toLowerCase()),
     },
     {
         Header: 'Enforced',

--- a/ui/apps/platform/src/utils/textUtils.ts
+++ b/ui/apps/platform/src/utils/textUtils.ts
@@ -1,4 +1,4 @@
-export function truncate(str, maxLength = 200) {
+export function truncate(str: string, maxLength = 200) {
     if (str.length <= maxLength) {
         return str;
     }


### PR DESCRIPTION
## Description

Two primary changes for this PR:
1. Display the new audit log types with the constants converted from snake case (e.g., "network_policy") to start case ("Network Policy")
2. For audit log violations that only have a cluster, but no namespace, display only the cluster name (e.g., instead of "remote/", it should be "remote"

In addition, there are two small related changes in this PR
- I converted `ui/apps/platform/src/utils/textUtils.js` to TypeScript `ui/apps/platform/src/utils/textUtils.ts` before I realized I could leverage a lodash import to do the change here. I let the conversion stand.
- I fixed a small bug where audit log violations showed the policy name instead of the cluster name on the ViolationDetailsPage.


## Checklist
- [x] Investigated and inspected CI test results (both ui-e2e-tests failures are flakes)

## Testing Performed

### Here I tell how I validated my change

Testing manually against an OpenShift cluster with appropriate policies set up, and violations triggered.

Violations table view
<img width="1204" alt="Screen Shot 2023-09-07 at 6 52 40 PM" src="https://github.com/stackrox/stackrox/assets/715729/b52ffdfa-5f0f-48bc-9923-4389301eb624">


Violation detail view
<img width="1232" alt="Screen Shot 2023-09-07 at 7 02 55 PM" src="https://github.com/stackrox/stackrox/assets/715729/75d104c8-cedc-4f99-b053-0ebd9267f04f">



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
