### PR TITLE
ROX-19004: Enabling central pulling CVSS data

### DIFF
--- a/central/scannerV4Definitions/cvss/cvssupdater.go
+++ b/central/scannerV4Definitions/cvss/cvssupdater.go
@@ -1,4 +1,4 @@
-package scannerV4Definitions
+package cvss
 
 import (
 	"context"
@@ -12,11 +12,6 @@ import (
 	"github.com/stackrox/rox/central/scannerdefinitions/file"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
-)
-
-const (
-	lastModifiedHeader    = "Last-Modified"
-	ifModifiedSinceHeader = "If-Modified-Since"
 )
 
 var (
@@ -97,12 +92,12 @@ func (u *cvssUpdater) update(ctx context.Context) {
 }
 
 func (u *cvssUpdater) doUpdate(ctx context.Context) error {
-	_, _, err := runEnricher(ctx, u.enricher)
+	rc, _, err := runEnricher(ctx, u.enricher)
 	if err != nil {
 		// TODO log error
 		return err
 	}
-	return nil
+	return u.file.WriteContent(rc)
 }
 
 func runEnricher(ctx context.Context, u driver.EnrichmentUpdater) (io.ReadCloser, driver.Fingerprint, error) {

--- a/central/scannerV4Definitions/cvss/cvssupdater_test.go
+++ b/central/scannerV4Definitions/cvss/cvssupdater_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defURL = "https://definitions.stackrox.io/e799c68a-671f-44db-9682-f24248cd0ffe/diff.zip"
+	defURL = "https://storage.googleapis.com/scanner-v4-test/nvddata/"
 )
 
 func assertOnFileExistence(t *testing.T, path string, shouldExist bool) {

--- a/central/scannerV4Definitions/cvss/cvssupdater_test.go
+++ b/central/scannerV4Definitions/cvss/cvssupdater_test.go
@@ -1,8 +1,15 @@
 package cvss
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
+	"github.com/stackrox/rox/central/scannerdefinitions/file"
 	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stretchr/testify/require"
 
@@ -17,4 +24,44 @@ func assertOnFileExistence(t *testing.T, path string, shouldExist bool) {
 	exists, err := fileutils.Exists(path)
 	require.NoError(t, err)
 	assert.Equal(t, shouldExist, exists)
+}
+
+func TestUpdate(t *testing.T) {
+	ctx := context.Background()
+	filePath := filepath.Join(t.TempDir(), "cvss.zip")
+	u, err := NewUpdaterWithEnricher(file.New(filePath), &http.Client{Timeout: 30 * time.Second}, defURL, 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Failed to create new updater with enricher: %v", err)
+	}
+	// Should fetch first time.
+	require.NoError(t, u.doUpdate(ctx))
+	assertOnFileExistence(t, filePath, true)
+}
+
+func TestUpdateMemory(t *testing.T) {
+	ctx := context.Background()
+	filePath := filepath.Join(t.TempDir(), "cvss.zip")
+	u, err := NewUpdaterWithEnricher(file.New(filePath), &http.Client{Timeout: 30 * time.Second}, defURL, 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Failed to create new updater with enricher: %v", err)
+	}
+
+	// Measure memory before
+	var memStart, memEnd runtime.MemStats
+	runtime.ReadMemStats(&memStart)
+
+	// Call the function
+	require.NoError(t, u.doUpdate(ctx))
+
+	// Measure memory after
+	runtime.ReadMemStats(&memEnd)
+
+	// Calculate and print the difference
+	allocDiff := memEnd.Alloc - memStart.Alloc
+	totalAllocDiff := memEnd.TotalAlloc - memStart.TotalAlloc
+
+	fmt.Printf("Memory Alloc (difference): %v bytes\n", allocDiff)
+	fmt.Printf("Memory TotalAlloc (difference): %v bytes\n", totalAllocDiff)
+
+	assertOnFileExistence(t, filePath, true)
 }

--- a/central/scannerV4Definitions/cvss/cvssupdater_test.go
+++ b/central/scannerV4Definitions/cvss/cvssupdater_test.go
@@ -1,0 +1,20 @@
+package cvss
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/fileutils"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	defURL = "https://definitions.stackrox.io/e799c68a-671f-44db-9682-f24248cd0ffe/diff.zip"
+)
+
+func assertOnFileExistence(t *testing.T, path string, shouldExist bool) {
+	exists, err := fileutils.Exists(path)
+	require.NoError(t, err)
+	assert.Equal(t, shouldExist, exists)
+}

--- a/central/scannerV4Definitions/cvssupdater.go
+++ b/central/scannerV4Definitions/cvssupdater.go
@@ -1,0 +1,147 @@
+package scannerV4Definitions
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/quay/claircore/enricher/cvss"
+	"github.com/quay/claircore/libvuln/driver"
+	"github.com/stackrox/rox/central/scannerdefinitions/file"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+const (
+	lastModifiedHeader    = "Last-Modified"
+	ifModifiedSinceHeader = "If-Modified-Since"
+)
+
+var (
+	pkgClient = &http.Client{}
+
+	fp driver.Fingerprint
+)
+
+// updater periodically updates a file by downloading the contents from the downloadURL.
+type updater struct {
+	file *file.File
+
+	client      *http.Client
+	downloadURL string
+	interval    time.Duration
+	once        sync.Once
+	stopSig     concurrency.Signal
+}
+
+// newUpdater creates a new updater.
+func newUpdater(file *file.File, client *http.Client, downloadURL string, interval time.Duration) *updater {
+	return &updater{
+		file:        file,
+		client:      client,
+		downloadURL: downloadURL,
+		interval:    interval,
+		stopSig:     concurrency.NewSignal(),
+	}
+}
+
+// Stop stops the updater.
+func (u *updater) Stop() {
+	u.stopSig.Signal()
+}
+
+// Start starts the updater.
+// The updater is only started once.
+func (u *updater) Start() {
+	u.once.Do(func() {
+		ctx := context.Background() // Creating a background context
+
+		// Run the first update in a blocking-manner.
+		u.update(ctx)
+		go u.runForever()
+	})
+}
+
+func (u *updater) runForever() {
+	t := time.NewTicker(u.interval)
+	defer t.Stop()
+
+	ctx := context.Background() // Creating a background context
+
+	for {
+		select {
+		case <-t.C:
+			u.update(ctx) // Passing the context to update function
+		case <-u.stopSig.Done():
+			return
+		}
+	}
+}
+
+func (u *updater) update(ctx context.Context) {
+	if err := u.doUpdate(ctx); err != nil {
+		// TODO log error
+	}
+}
+
+func (u *updater) doUpdate(ctx context.Context) error {
+	e := &cvss.Enricher{}
+	// Create a custom config unmarshaler
+	configFunc := func(cfg interface{}) error {
+		c, ok := cfg.(*cvss.Config) // Type assertion for safety
+		if !ok {
+			return errors.New("invalid config type")
+		}
+		c.FeedRoot = &u.downloadURL
+		return nil
+	}
+
+	err := e.Configure(ctx, configFunc, pkgClient)
+	if err != nil {
+		// TODO log error
+		return err
+	}
+
+	_, _, err = runEnricher(ctx, e)
+	if err != nil {
+		// TODO log error
+		return err
+	}
+	return nil
+}
+
+func runEnricher(ctx context.Context, u driver.EnrichmentUpdater) (io.ReadCloser, driver.Fingerprint, error) {
+	var rc io.ReadCloser
+	var nfp driver.Fingerprint
+	var err error
+
+	// Debounce any network hiccups.
+	for i := 0; i < 5; i++ {
+		rc, nfp, err = u.FetchEnrichment(ctx, fp)
+		if err == nil {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			// Return the error instead of calling t.Fatal
+			return nil, nfp, ctx.Err()
+		case <-time.After((2 << i) * time.Second):
+		}
+	}
+
+	if err != nil {
+		return nil, nfp, err
+	}
+
+	defer func() {
+		if err := rc.Close(); err != nil {
+			// TODO log error
+			return
+		}
+	}()
+
+	return rc, nfp, nil
+}

--- a/central/scannerV4Definitions/cvssupdater.go
+++ b/central/scannerV4Definitions/cvssupdater.go
@@ -24,7 +24,7 @@ var (
 	fp        driver.Fingerprint
 )
 
-type updater struct {
+type cvssUpdater struct {
 	file        *file.File
 	client      *http.Client
 	downloadURL string
@@ -34,7 +34,7 @@ type updater struct {
 	enricher    *cvss.Enricher
 }
 
-func NewUpdaterWithEnricher(file *file.File, client *http.Client, downloadURL string, interval time.Duration) (*updater, error) {
+func NewUpdaterWithEnricher(file *file.File, client *http.Client, downloadURL string, interval time.Duration) (*cvssUpdater, error) {
 	e := &cvss.Enricher{}
 	ctx := context.Background() // Or pass a context in if available.
 
@@ -52,7 +52,7 @@ func NewUpdaterWithEnricher(file *file.File, client *http.Client, downloadURL st
 		return nil, err
 	}
 
-	return &updater{
+	return &cvssUpdater{
 		file:        file,
 		client:      client,
 		downloadURL: downloadURL,
@@ -62,11 +62,11 @@ func NewUpdaterWithEnricher(file *file.File, client *http.Client, downloadURL st
 	}, nil
 }
 
-func (u *updater) Stop() {
+func (u *cvssUpdater) Stop() {
 	u.stopSig.Signal()
 }
 
-func (u *updater) Start() {
+func (u *cvssUpdater) Start() {
 	u.once.Do(func() {
 		ctx := context.Background()
 		u.update(ctx)
@@ -74,7 +74,7 @@ func (u *updater) Start() {
 	})
 }
 
-func (u *updater) runForever() {
+func (u *cvssUpdater) runForever() {
 	t := time.NewTicker(u.interval)
 	defer t.Stop()
 
@@ -90,13 +90,13 @@ func (u *updater) runForever() {
 	}
 }
 
-func (u *updater) update(ctx context.Context) {
+func (u *cvssUpdater) update(ctx context.Context) {
 	if err := u.doUpdate(ctx); err != nil {
 		// TODO log error
 	}
 }
 
-func (u *updater) doUpdate(ctx context.Context) error {
+func (u *cvssUpdater) doUpdate(ctx context.Context) error {
 	_, _, err := runEnricher(ctx, u.enricher)
 	if err != nil {
 		// TODO log error

--- a/central/scannerdefinitions/file/file.go
+++ b/central/scannerdefinitions/file/file.go
@@ -31,10 +31,26 @@ func (file *File) Path() string {
 	return file.path
 }
 
-// Write writes the contents of r into the path represented by the given file.
-// The file's modified time is set to the given modifiedTime.
-// Write is thread-safe.
 func (file *File) Write(r io.Reader, modifiedTime time.Time) error {
+	err := file.writeInternal(r)
+	if err != nil {
+		return err
+	}
+
+	// Set the file's modified time after the write is completed
+	err = os.Chtimes(file.path, time.Now(), modifiedTime)
+	if err != nil {
+		return errors.Wrap(err, "changing modified time of scanner defs")
+	}
+
+	return nil
+}
+
+func (file *File) WriteContent(r io.Reader) error {
+	return file.writeInternal(r)
+}
+
+func (file *File) writeInternal(r io.Reader) error {
 	dir := filepath.Dir(file.path)
 
 	err := os.MkdirAll(dir, 0755)
@@ -42,14 +58,10 @@ func (file *File) Write(r io.Reader, modifiedTime time.Time) error {
 		return errors.Wrap(err, "creating subdirectory for scanner defs")
 	}
 
-	// Write the contents of r into a temporary destination to prevent us from having to hold a lock
-	// while reading from r. The reader may be dependent on the network, and we do not want to
-	// lock while depending on something as unpredictable as the network.
 	scannerDefsFile, err := os.CreateTemp(dir, tempFilePattern)
 	if err != nil {
 		return errors.Wrap(err, "creating scanner defs file")
 	}
-	// Close the file in case of error.
 	defer utils.IgnoreError(scannerDefsFile.Close)
 
 	_, err = io.Copy(scannerDefsFile, r)
@@ -57,22 +69,11 @@ func (file *File) Write(r io.Reader, modifiedTime time.Time) error {
 		return errors.Wrapf(err, "writing scanner defs zip to temporary file %q", scannerDefsFile.Name())
 	}
 
-	// No longer need the file descriptor, so release it.
-	// Closing here, as it is possible Close updates the mtime
-	// (for example: the data is not flushed until Close is called).
 	err = scannerDefsFile.Close()
 	if err != nil {
 		return errors.Wrap(err, "closing temp scanner defs file")
 	}
 
-	err = os.Chtimes(scannerDefsFile.Name(), time.Now(), modifiedTime)
-	if err != nil {
-		return errors.Wrap(err, "changing modified time of scanner defs")
-	}
-
-	// Note: os.Rename does not alter the file's modified time,
-	// so there is no need to call os.Chtimes here.
-	// Rename is guaranteed to be atomic inside the same directory.
 	err = os.Rename(scannerDefsFile.Name(), file.path)
 	if err != nil {
 		return errors.Wrap(err, "renaming temporary scanner defs file to final location")

--- a/go.mod
+++ b/go.mod
@@ -341,7 +341,7 @@ require (
 	github.com/segmentio/backo-go v1.0.1 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
-	github.com/sigstore/rekor v1.2.1 // indirect
+	github.com/sigstore/rekor v1.1.0 // indirect
 	github.com/sigstore/timestamp-authority v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
@@ -356,6 +356,7 @@ require (
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
+	github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613 // indirect
 	github.com/theupdateframework/go-tuf v0.5.2 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,7 +60,6 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1 h1:EKPd1INOIyr5hWOWhvpmQpY6tKjeG0hT1s3AMC/9fic=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1/go.mod h1:VzwV+t+dZ9j/H867F1M2ziD+yLHtB46oM35FxxMJ4d0=
-github.com/AdamKorcz/go-fuzz-headers-1 v0.0.0-20230329111138-12e09aba5ebd h1:1tbEqR4NyQLgiod7vLXSswHteGetAVZrMGCqrJxLKRs=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
@@ -1429,8 +1428,8 @@ github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFR
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/sigstore/rekor v1.2.1 h1:cEI4qn9IBvM7EkPQYl3YzCwCw97Mx8O2nHrv02XiI8U=
-github.com/sigstore/rekor v1.2.1/go.mod h1:zcFO54qIg2G1/i0sE/nvmELUOng/n0MPjTszRYByVPo=
+github.com/sigstore/rekor v1.1.0 h1:9fjPvW0WERE7VPtSSVSTbDLLOsrNx3RtiIeZ4/1tmDI=
+github.com/sigstore/rekor v1.1.0/go.mod h1:jEOGDGPMURBt9WR50N0rO7X8GZzLE3UQT+ln6BKJ/m0=
 github.com/sigstore/sigstore v1.6.4 h1:jH4AzR7qlEH/EWzm+opSpxCfuUcjHL+LJPuQE7h40WE=
 github.com/sigstore/sigstore v1.6.4/go.mod h1:pjR64lBxnjoSrAr+Ydye/FV73IfrgtoYlAI11a8xMfA=
 github.com/sigstore/timestamp-authority v1.0.0 h1:UisIGA9anE6xyWctJaiEmsk1M+txQ6kAPQDCyu+ieQw=
@@ -1550,6 +1549,8 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDdvS342BElfbETmL1Aiz3i2t0zfRj16Hs=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
+github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613 h1:iGnD/q9160NWqKZZ5vY4p0dMiYMRknzctfSkqA4nBDw=
+github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613/go.mod h1:g6AnIpDSYMcphz193otpSIzN+11Rs+AAIIC6rm1enug=
 github.com/tetafro/godot v1.3.0/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
 github.com/theupdateframework/go-tuf v0.5.2 h1:habfDzTmpbzBLIFGWa2ZpVhYvFBoK0C1onC3a4zuPRA=
 github.com/theupdateframework/go-tuf v0.5.2/go.mod h1:SyMV5kg5n4uEclsyxXJZI2UxPFJNDc4Y+r7wv+MlvTA=
@@ -1693,7 +1694,7 @@ go.opentelemetry.io/otel/trace v1.14.0/go.mod h1:8avnQLK+CG77yNLUae4ea2JDQ6iT+go
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.starlark.net v0.0.0-20221010140840-6bf6f0955179 h1:Mc5MkF55Iasgq23vSYpL6/l7EJXtlNjzw+8hbMQ/ShY=
 go.starlark.net v0.0.0-20221010140840-6bf6f0955179/go.mod h1:kIVgS18CjmEC3PqMd5kaJSGEifyV/CeB9x506ZJ1Vbk=
-go.step.sm/crypto v0.30.0 h1:EzqPTvW1g6kxEnfIf/exDW+MhHGeEhtoNMhQX7P/UwI=
+go.step.sm/crypto v0.29.3 h1:lFCsFQQGic1VZIa0B/87iMCDy67+LW8eEl119GTyeWI=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=


### PR DESCRIPTION
## Description

For the scanner v4 matcher, the scanner updater (matcher updater) needs to periodically request for CVSS enrichment data by reaching out to central’s CVSS data request handler. (This part will be done in another pr)

`cvsshandler.go` handles requests from the scanner/matcher on central cluster and checks if there’s existing NVD CVSS dump otherwise it will download the data from google storage or last download is more than 24 hours.

Central’s CVSS updater (`cvssupdater.go`) gets the NVD CVSS data from google storage and save it into the file system of central. The current idea is to use Claircore `cvss.Enricher.fetchEnrichment()` which output an io.Closer and it's actually a temp file. 

Currently the CVSS data gets updated once a day in google storage (this could be changed) so the scanner doesn’t have to request for new CVSS data too frequently. 

We also need to touch base with Cong Du regarding the storage method of the data dump in Central's file system. @RTann  mentioned in a previous discussion that Cong has transitioned to saving the data dump by using a blob store, so it's crucial to gain clarity on this update.

