### PR TITLE
fix(plop): use the correct counters

### DIFF
--- a/sensor/common/metrics/init.go
+++ b/sensor/common/metrics/init.go
@@ -18,6 +18,8 @@ func init() {
 		totalNetworkFlowsReceivedCounter,
 		totalNetworkEndpointsSentCounter,
 		totalNetworkEndpointsReceivedCounter,
+		totalProcessesSentCounter,
+		totalProcessesReceivedCounter,
 		sensorEvents,
 		k8sObjectCounts,
 		k8sObjectProcessingDuration,

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -219,12 +219,12 @@ func IncrementTotalNetworkEndpointsReceivedCounter(numberOfEndpoints int) {
 
 // IncrementTotalProcessesSentCounter increments the total number of endpoints sent
 func IncrementTotalProcessesSentCounter(numberOfProcesses int) {
-	totalNetworkEndpointsSentCounter.Add(float64(numberOfProcesses))
+	totalProcessesSentCounter.Add(float64(numberOfProcesses))
 }
 
 // IncrementTotalProcessesReceivedCounter increments the total number of endpoints received
 func IncrementTotalProcessesReceivedCounter(numberOfProcesses int) {
-	totalNetworkEndpointsReceivedCounter.Add(float64(numberOfProcesses))
+	totalProcessesReceivedCounter.Add(float64(numberOfProcesses))
 }
 
 // IncrementProcessEnrichmentDrops increments the number of times we could not enrich.


### PR DESCRIPTION
## Description

#3387 added two dedicated counters for PLOP, but they where not used correctly.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Deployed the built image, port forwarded sensor's prometheus metrics and checked the counters are properly reported.