### PR TITLE
ROX-19653: User is unable to unset resource requirements

### DIFF
--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -158,10 +158,33 @@
 {{ $_ = set $rox "_defaults" $defaultsCfg }}
 {{ $_ = include "srox.mergeInto" (list $rox $defaultsCfg.defaults) }}
 
-
 {{/* Expand applicable config values */}}
 {{ $expandables := $.Files.Get "internal/expandables.yaml" | fromYaml }}
 {{ include "srox.expandAll" (list $ $rox $expandables) }}
+
+{{/* Default resources adjustment */}}
+{{/*
+
+    If the user specifies resources for central/central-db/etc, they must be honored as is.
+    If we rely on the default defaulting mechanism, we might end up with resources that do
+    not correspond to what the user specified. For example, if the user only specifies
+    requests, but the default also include limits, the result will include both requests
+    and limits, which is not what the user specified. So we need to adjust those values.
+
+*/}}
+
+{{ if and $.Values.central $.Values.central.resources }}
+{{ $_ = set $._rox.central "_resources" ($.Values.central.resources | toYaml) }}
+{{ end }}
+{{ if and $.Values.central $.Values.central.db $.Values.central.db.resources }}
+{{ $_ = set $._rox.central.db "_resources" ($.Values.central.db.resources | toYaml) }}
+{{ end }}
+{{ if and $.Values.scanner $.Values.scanner.resources }}
+{{ $_ = set $._rox.scanner "_resources" ($.Values.scanner.resources | toYaml) }}
+{{ end }}
+{{ if and $.Values.scanner $.Values.scanner.dbResources }}
+{{ $_ = set $._rox.scanner "_dbResources" ($.Values.scanner.dbResources | toYaml) }}
+{{ end }}
 
 {{/* Initial image pull secret setup.
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -110,6 +110,33 @@
 {{ $expandables := $.Files.Get "internal/expandables.yaml" | fromYaml }}
 {{ include "srox.expandAll" (list $ $rox $expandables) }}
 
+{{/* Default resources adjustment */}}
+{{/*
+
+    If the user specifies resources for sensor/admission-control/etc, they must be honored as is.
+    If we rely on the default defaulting mechanism, we might end up with resources that do
+    not correspond to what the user specified. For example, if the user only specifies
+    requests, but the default also include limits, the result will include both requests
+    and limits, which is not what the user specified. So we need to adjust those values.
+
+*/}}
+
+{{ if and $.Values.sensor $.Values.sensor.resources }}
+{{ $_ = set $._rox.sensor "_resources" ($.Values.sensor.resources | toYaml) }}
+{{ end }}
+{{ if and $.Values.admissionControl $.Values.admissionControl.resources }}
+{{ $_ = set $._rox.admissionControl "_resources" ($.Values.admissionControl.resources | toYaml) }}
+{{ end }}
+{{ if and $.Values.collector $.Values.collector.resources }}
+{{ $_ = set $._rox.collector "_resources" ($.Values.collector.resources | toYaml) }}
+{{ end }}
+{{ if and $.Values.collector $.Values.collector.complianceResources }}
+{{ $_ = set $._rox.collector "_complianceResources" ($.Values.collector.complianceResources | toYaml) }}
+{{ end }}
+{{ if and $.Values.collector $.Values.collector.nodeScanningResources }}
+{{ $_ = set $._rox.collector "_nodeScanningResources" ($.Values.collector.nodeScanningResources | toYaml) }}
+{{ end }}
+
 {{/*
     General validation of effective settings.
    */}}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -136,6 +136,12 @@
 {{ if and $.Values.collector $.Values.collector.nodeScanningResources }}
 {{ $_ = set $._rox.collector "_nodeScanningResources" ($.Values.collector.nodeScanningResources | toYaml) }}
 {{ end }}
+{{ if and $.Values.scanner $.Values.scanner.resources }}
+{{ $_ = set $._rox.scanner "_resources" ($.Values.scanner.resources | toYaml) }}
+{{ end }}
+{{ if and $.Values.scanner $.Values.scanner.dbResources }}
+{{ $_ = set $._rox.scanner "_dbResources" ($.Values.scanner.dbResources | toYaml) }}
+{{ end }}
 
 {{/*
     General validation of effective settings.

--- a/pkg/helm/charts/tests/centralservices/resources_test.go
+++ b/pkg/helm/charts/tests/centralservices/resources_test.go
@@ -1,0 +1,352 @@
+package centralservices
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	runtimeutils "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+const (
+	defaultResourceTestValues = `
+imagePullSecrets:
+  allowNone: true
+central:
+  db:
+    enabled: true
+  persistence:
+    none: true
+`
+)
+
+type resourcesSuite struct {
+	baseSuite
+}
+
+func TestResources(t *testing.T) {
+	suite.Run(t, new(resourcesSuite))
+}
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	runtimeutils.Must(appsv1.AddToScheme(scheme))
+	runtimeutils.Must(corev1.AddToScheme(scheme))
+}
+
+func (s *resourcesSuite) TestDefaultResources() {
+
+	defaultValues := defaultResourceTestValues
+
+	type tc struct {
+		name              string
+		workloadKind      string
+		workloadName      string
+		containerName     string
+		isInitContainer   bool
+		expectedResources corev1.ResourceRequirements
+		values            []string
+	}
+
+	testCases := []tc{
+		{
+			name:          "default central resources",
+			workloadKind:  "Deployment",
+			workloadName:  "central",
+			containerName: "central",
+			values: []string{
+				defaultValues,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4000m"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1500m"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		},
+		{
+			name:          "default central-db resources",
+			workloadKind:  "Deployment",
+			workloadName:  "central-db",
+			containerName: "central-db",
+			values: []string{
+				defaultValues,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+		},
+		{
+			name:          "default scanner resources",
+			workloadKind:  "Deployment",
+			workloadName:  "scanner",
+			containerName: "scanner",
+			values: []string{
+				defaultValues,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1500Mi"),
+				},
+			},
+		},
+		{
+			name:          "default scanner-db resources",
+			workloadKind:  "Deployment",
+			workloadName:  "scanner-db",
+			containerName: "db",
+			values: []string{
+				defaultValues,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2000m"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("200Mi"),
+				},
+			},
+		},
+		{
+			name:            "default init-db resources",
+			workloadKind:    "Deployment",
+			workloadName:    "scanner-db",
+			containerName:   "init-db",
+			isInitContainer: true,
+			values: []string{
+				defaultValues,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2000m"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("200Mi"),
+				},
+			},
+		}, {
+			name:          "overridden central resources",
+			workloadKind:  "Deployment",
+			workloadName:  "central",
+			containerName: "central",
+			values: []string{
+				defaultValues,
+				`
+central:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
+`,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+		{
+			name:          "overridden central-db resources",
+			workloadKind:  "Deployment",
+			workloadName:  "central-db",
+			containerName: "central-db",
+			values: []string{
+				defaultValues,
+				`
+central:
+  db:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 100Mi
+`,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+		{
+			name:          "overridden scanner resources",
+			workloadKind:  "Deployment",
+			workloadName:  "scanner",
+			containerName: "scanner",
+			values: []string{
+				defaultValues,
+				`
+scanner:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
+`,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+		{
+			name:          "overridden scanner-db resources",
+			workloadKind:  "Deployment",
+			workloadName:  "scanner-db",
+			containerName: "db",
+			values: []string{
+				defaultValues,
+				`
+scanner:
+  dbResources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
+`,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+		{
+			name:            "overridden init-db resources",
+			workloadKind:    "Deployment",
+			workloadName:    "scanner-db",
+			containerName:   "init-db",
+			isInitContainer: true,
+			values: []string{
+				defaultValues,
+				`
+scanner:
+  dbResources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
+`,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		var tc = tc
+		s.T().Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, m := s.LoadAndRender(tc.values...)
+			require.NotEmpty(t, m)
+			p := s.ParseObjects(m)
+			objs := map[string]unstructured.Unstructured{}
+			for _, obj := range p {
+				objs[obj.GetKind()+"/"+obj.GetName()] = obj
+			}
+
+			var containers []corev1.Container
+			if tc.workloadKind == "Deployment" {
+				var deployment appsv1.Deployment
+				require.NoError(t, mustFindDeployment(objs, tc.workloadKind+"/"+tc.workloadName, &deployment))
+				if tc.isInitContainer {
+					containers = deployment.Spec.Template.Spec.InitContainers
+				} else {
+					containers = deployment.Spec.Template.Spec.Containers
+				}
+			} else {
+				t.Fatalf("unsupported workload kind %s", tc.workloadKind)
+			}
+
+			var container corev1.Container
+			require.NoError(t, mustFindContainer(containers, tc.containerName, &container))
+			require.Truef(t, assertResourceRequirementsEqual(t, tc.expectedResources, container.Resources), "expected %v, got %v", tc.expectedResources, container.Resources)
+
+		})
+	}
+
+}
+
+func assertResourceRequirementsEqual(t *testing.T, expected, actual corev1.ResourceRequirements) bool {
+	return assertResourceListEqual(t, "limits", expected.Limits, actual.Limits) && assertResourceListEqual(t, "request", expected.Requests, actual.Requests)
+}
+
+func assertResourceListEqual(t *testing.T, typ string, expected, actual corev1.ResourceList) bool {
+	// check if keys are equal
+	for key := range expected {
+		if _, ok := actual[key]; !ok {
+			t.Errorf("expected key %s.%s not found in actual", typ, key)
+			return false
+		}
+	}
+	if len(expected) != len(actual) {
+		t.Errorf("expected %d keys, got %d in %s", len(expected), len(actual), typ)
+		return false
+	}
+	// check if values are equal
+	for resourceName, expectedValue := range expected {
+		actualValue := actual[resourceName]
+		if !expectedValue.Equal(actualValue) {
+			t.Errorf("expected value %v for key %s.%s, got %v", expectedValue, typ, resourceName, actualValue)
+			return false
+		}
+	}
+	return true
+}
+
+func mustFindDeployment(objs map[string]unstructured.Unstructured, name string, target *appsv1.Deployment) error {
+	centralUnstructured, ok := objs[name]
+	if !ok {
+		return errors.Errorf("deployment %s not found", name)
+	}
+	var d appsv1.Deployment
+	if err := scheme.Convert(&centralUnstructured, &d, nil); err != nil {
+		return errors.Wrapf(err, "failed to convert %s to Deployment", name)
+	}
+	*target = d
+	return nil
+}
+
+func mustFindContainer(containers []corev1.Container, name string, target *corev1.Container) error {
+	for _, c := range containers {
+		if c.Name == name {
+			*target = c
+			return nil
+		}
+	}
+	return errors.Errorf("container %s not found", name)
+}

--- a/pkg/helm/charts/tests/securedclusterservices/resources_test.go
+++ b/pkg/helm/charts/tests/securedclusterservices/resources_test.go
@@ -1,0 +1,369 @@
+package securedclusterservices
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	runtimeutils "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+const (
+	defaultResourceTestValues = `
+ca:
+  cert: foo
+cluster:
+  name: test
+  type: OPENSHIFT4_CLUSTER
+collectorImagePullSecrets:
+  allowNone: true
+mainImagePullSecrets:
+  allowNone: true
+config:
+  createSecrets: false
+`
+)
+
+type resourcesSuite struct {
+	baseSuite
+}
+
+func TestResources(t *testing.T) {
+	suite.Run(t, new(resourcesSuite))
+}
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	runtimeutils.Must(appsv1.AddToScheme(scheme))
+	runtimeutils.Must(corev1.AddToScheme(scheme))
+}
+
+func (s *resourcesSuite) TestDefaultResources() {
+
+	defaultValues := defaultResourceTestValues
+
+	type tc struct {
+		name              string
+		workloadKind      string
+		workloadName      string
+		containerName     string
+		isInitContainer   bool
+		expectedResources corev1.ResourceRequirements
+		values            []string
+	}
+
+	testCases := []tc{
+		{
+			name:          "default sensor resources",
+			workloadKind:  "Deployment",
+			workloadName:  "sensor",
+			containerName: "sensor",
+			values: []string{
+				defaultValues,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		},
+		{
+			name:          "default admission-control resources",
+			workloadKind:  "Deployment",
+			workloadName:  "admission-control",
+			containerName: "admission-control",
+			values: []string{
+				defaultValues,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("500Mi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("50m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+		{
+			name:          "default collector resources",
+			workloadKind:  "DaemonSet",
+			workloadName:  "collector",
+			containerName: "collector",
+			values: []string{
+				defaultValues,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("750m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("50m"),
+					corev1.ResourceMemory: resource.MustParse("320Mi"),
+				},
+			},
+		},
+		{
+			name:          "default node-inventory resources",
+			workloadKind:  "DaemonSet",
+			workloadName:  "collector",
+			containerName: "node-inventory",
+			values: []string{
+				defaultValues,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("500Mi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("10Mi"),
+				},
+			},
+		},
+		{
+			name:          "default compliance resources",
+			workloadKind:  "DaemonSet",
+			workloadName:  "collector",
+			containerName: "compliance",
+			values: []string{
+				defaultValues,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("10Mi"),
+				},
+			},
+		}, {
+			name:          "overridden sensor resources",
+			workloadKind:  "Deployment",
+			workloadName:  "sensor",
+			containerName: "sensor",
+			values: []string{
+				defaultValues,
+				`
+sensor:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi`,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+		{
+			name:          "overridden admission-control resources",
+			workloadKind:  "Deployment",
+			workloadName:  "admission-control",
+			containerName: "admission-control",
+			values: []string{
+				defaultValues,
+				`
+admissionControl:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi`,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+		{
+			name:          "overridden collector resources",
+			workloadKind:  "DaemonSet",
+			workloadName:  "collector",
+			containerName: "collector",
+			values: []string{
+				defaultValues,
+				`
+collector:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi`,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+		{
+			name:          "overridden node-inventory resources",
+			workloadKind:  "DaemonSet",
+			workloadName:  "collector",
+			containerName: "node-inventory",
+			values: []string{
+				defaultValues,
+				`
+collector:
+  nodeScanningResources:
+    limits:
+      cpu: 100m
+      memory: 100Mi`,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+		{
+			name:          "default compliance resources",
+			workloadKind:  "DaemonSet",
+			workloadName:  "collector",
+			containerName: "compliance",
+			values: []string{
+				defaultValues,
+				`
+collector:
+  complianceResources:
+    limits:
+      cpu: 100m
+      memory: 100Mi`,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		var tc = tc
+		s.T().Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, m := s.LoadAndRender(tc.values...)
+			require.NotEmpty(t, m)
+			p := s.ParseObjects(m)
+			objs := map[string]unstructured.Unstructured{}
+			for _, obj := range p {
+				objs[obj.GetKind()+"/"+obj.GetName()] = obj
+			}
+
+			var containers []corev1.Container
+			if tc.workloadKind == "Deployment" {
+				var deployment appsv1.Deployment
+				require.NoError(t, mustFindDeployment(objs, tc.workloadKind+"/"+tc.workloadName, &deployment))
+				if tc.isInitContainer {
+					containers = deployment.Spec.Template.Spec.InitContainers
+				} else {
+					containers = deployment.Spec.Template.Spec.Containers
+				}
+			} else if tc.workloadKind == "DaemonSet" {
+				var daemonSet appsv1.DaemonSet
+				require.NoError(t, mustFindDaemonSet(objs, tc.workloadKind+"/"+tc.workloadName, &daemonSet))
+				if tc.isInitContainer {
+					containers = daemonSet.Spec.Template.Spec.InitContainers
+				} else {
+					containers = daemonSet.Spec.Template.Spec.Containers
+				}
+			} else {
+				t.Fatalf("unsupported workload kind %s", tc.workloadKind)
+			}
+
+			var container corev1.Container
+			require.NoError(t, mustFindContainer(containers, tc.containerName, &container))
+			require.Truef(t, assertResourceRequirementsEqual(t, tc.expectedResources, container.Resources), "expected %v, got %v", tc.expectedResources, container.Resources)
+
+		})
+	}
+
+}
+
+func assertResourceRequirementsEqual(t *testing.T, expected, actual corev1.ResourceRequirements) bool {
+	return assertResourceListEqual(t, "limits", expected.Limits, actual.Limits) && assertResourceListEqual(t, "request", expected.Requests, actual.Requests)
+}
+
+func assertResourceListEqual(t *testing.T, typ string, expected, actual corev1.ResourceList) bool {
+	// check if keys are equal
+	for key := range expected {
+		if _, ok := actual[key]; !ok {
+			t.Errorf("expected key %s.%s not found in actual", typ, key)
+			return false
+		}
+	}
+	if len(expected) != len(actual) {
+		t.Errorf("expected %d keys, got %d in %s", len(expected), len(actual), typ)
+		return false
+	}
+	// check if values are equal
+	for resourceName, expectedValue := range expected {
+		actualValue := actual[resourceName]
+		if !expectedValue.Equal(actualValue) {
+			t.Errorf("expected value %v for key %s.%s, got %v", expectedValue, typ, resourceName, actualValue)
+			return false
+		}
+	}
+	return true
+}
+
+func mustFindDeployment(objs map[string]unstructured.Unstructured, name string, target *appsv1.Deployment) error {
+	centralUnstructured, ok := objs[name]
+	if !ok {
+		return errors.Errorf("deployment %s not found", name)
+	}
+	var d appsv1.Deployment
+	if err := scheme.Convert(&centralUnstructured, &d, nil); err != nil {
+		return errors.Wrapf(err, "failed to convert %s to Deployment", name)
+	}
+	*target = d
+	return nil
+}
+
+func mustFindDaemonSet(objs map[string]unstructured.Unstructured, name string, target *appsv1.DaemonSet) error {
+	centralUnstructured, ok := objs[name]
+	if !ok {
+		return errors.Errorf("daemonset %s not found", name)
+	}
+	var d appsv1.DaemonSet
+	if err := scheme.Convert(&centralUnstructured, &d, nil); err != nil {
+		return errors.Wrapf(err, "failed to convert %s to DaemonSet", name)
+	}
+	*target = d
+	return nil
+}
+
+func mustFindContainer(containers []corev1.Container, name string, target *corev1.Container) error {
+	for _, c := range containers {
+		if c.Name == name {
+			*target = c
+			return nil
+		}
+	}
+	return errors.Errorf("container %s not found", name)
+}

--- a/pkg/helm/charts/tests/securedclusterservices/resources_test.go
+++ b/pkg/helm/charts/tests/securedclusterservices/resources_test.go
@@ -27,6 +27,10 @@ mainImagePullSecrets:
   allowNone: true
 config:
   createSecrets: false
+scanner:
+  disable: false
+imagePullSecrets:
+  allowNone: true
 `
 )
 
@@ -156,7 +160,66 @@ func (s *resourcesSuite) TestDefaultResources() {
 					corev1.ResourceMemory: resource.MustParse("10Mi"),
 				},
 			},
-		}, {
+		},
+		{
+			name:          "default scanner resources",
+			workloadKind:  "Deployment",
+			workloadName:  "scanner",
+			containerName: "scanner",
+			values: []string{
+				defaultValues,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1500Mi"),
+				},
+			},
+		},
+		{
+			name:          "default scanner-db resources",
+			workloadKind:  "Deployment",
+			workloadName:  "scanner-db",
+			containerName: "db",
+			values: []string{
+				defaultValues,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2000m"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("200Mi"),
+				},
+			},
+		},
+		{
+			name:            "default scanner init-db resources",
+			workloadKind:    "Deployment",
+			workloadName:    "scanner-db",
+			containerName:   "init-db",
+			isInitContainer: true,
+			values: []string{
+				defaultValues,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2000m"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("200Mi"),
+				},
+			},
+		},
+		{
 			name:          "overridden sensor resources",
 			workloadKind:  "Deployment",
 			workloadName:  "sensor",
@@ -241,7 +304,7 @@ collector:
 			},
 		},
 		{
-			name:          "default compliance resources",
+			name:          "overridden compliance resources",
 			workloadKind:  "DaemonSet",
 			workloadName:  "collector",
 			containerName: "compliance",
@@ -250,6 +313,71 @@ collector:
 				`
 collector:
   complianceResources:
+    limits:
+      cpu: 100m
+      memory: 100Mi`,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+
+		{
+			name:          "overridden scanner resources",
+			workloadKind:  "Deployment",
+			workloadName:  "scanner",
+			containerName: "scanner",
+			values: []string{
+				defaultValues,
+				`
+scanner:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi`,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+		{
+			name:          "overridden scanner-db resources",
+			workloadKind:  "Deployment",
+			workloadName:  "scanner-db",
+			containerName: "db",
+			values: []string{
+				defaultValues,
+				`
+scanner:
+  dbResources:
+    limits:
+      cpu: 100m
+      memory: 100Mi`,
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+		{
+			name:            "overridden scanner-db init container resources",
+			workloadKind:    "Deployment",
+			workloadName:    "scanner-db",
+			containerName:   "init-db",
+			isInitContainer: true,
+			values: []string{
+				defaultValues,
+				`
+scanner:
+  dbResources:
     limits:
       cpu: 100m
       memory: 100Mi`,


### PR DESCRIPTION
## Description

When the user sets `resources` for any of the components, there might be situations where the rendered manifests are not as expected. 

For example, the user sets
```
kind: Central
spec:
  central:
    resources:
      request: 
        cpu: 100m
        memory: 100Mi
```

This will get merged with the defaults. If the defaults are 
```
kind: Central
spec:
  central:
    resources:
      request: 
        cpu: 200m
        memory: 200Mi
      limits: 
        cpu: 300m
        memory: 300Mi
```

Then the result will be 

```
kind: Pod
spec:
  containers:
  - name: central
    resources:
      request: 
        cpu: 100m
        memory: 100Mi
      limits: 
        cpu: 300m
        memory: 300Mi
```

But the expected manifests should have 

```
kind: Pod
spec:
  containers:
  - name: central
    resources:
      request: 
        cpu: 100m
        memory: 100Mi
```

Note how the user is unable to "unset" the resource limits. The resources will always get merged with the defaults. Though, the desired behavior would be to use the user-provided resources "as-is", without merging them with the defaults, if the user has specified resources requirements. 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

I manually added overrides for each component of stackrox and could confirm that the deployment/daemonSet containers had the appropriate/expected value. 

- central
- central-db
- scanner
- scanner-db
- sensor
- compliance
- node-inventory
- collector
- admission-control

I also deployed a "local scanner" - colocated with `SecuredCluster` by adding the following to the `SecuredCluster` example spec outlined below and observed that the resources requirements are as expected

```
  scanner:
    analyzer:
      resources:
        requests:
          cpu: 200m
          memory: 200Mi
    db:
      resources:
        requests:
          cpu: 200m
          memory: 200Mi
    scannerComponent: AutoSense
```

### Here I tell how I validated my change

This is the `securedCluster` that I've used to check that the resources are appropriately applied: 

```
apiVersion: platform.stackrox.io/v1alpha1
kind: SecuredCluster
metadata:
  name: stackrox-secured-cluster-services
  namespace: stackrox
spec:
  admissionControl:
    resources:
      requests:
        cpu: 100m
        memory: 200Mi
    timeoutSeconds: 20
  centralEndpoint: acs-data-ck02k7mqfgn70db812c0.acs.rhcloud.com:443
  clusterName: my-cluster
  monitoring:
    openshift:
      enabled: false
  perNode:
    collector:
      resources:
        requests:
          cpu: 200m
          memory: 200Mi
    compliance:
      resources:
        requests:
          cpu: 200m
          memory: 200Mi
    nodeInventory:
      resources:
        requests:
          cpu: 200m
          memory: 200Mi
  sensor:
    resources:
      requests:
        cpu: 200m
        memory: 200Mi
```

This is the `Central` used

```
apiVersion: platform.stackrox.io/v1alpha1
kind: Central
metadata:
  name: test2
  namespace: stackrox
spec: 
  central:
    resources:
      requests:
        cpu: 200m
        memory: 200Mi
    db:
      resources:
        requests:
          cpu: 200m
          memory: 200Mi
  scanner:
    scannerComponent: Enabled
    analyzer:
      resources:
        requests:
          cpu: 200m
          memory: 200Mi
    db:
      resources:
        requests:
          cpu: 200m
          memory: 200Mi
  monitoring:
    openshift:
      enabled: false
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
