### PR TITLE
ROX-9510: Require access scope ID for any role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Added Features
 
 ### Removed Features
+
 - ROX-9510: As announced in release 69.0, empty value for `role.access_scope_id` is not supported anymore for `CreateRole` and `UpdateRole` in `/v1/roles/`. Role creation and update now require passing an identifier referencing a valid access scope in `role.access_scope_id`.
 
 ### Deprecated Fatures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Added Features
 
 ### Removed Features
+- ROX-9510: As announced in release 69.0, empty value for `role.access_scope_id` is not supported anymore for `CreateRole` and `UpdateRole` in `/v1/roles/`. Role creation and update now require passing an identifier referencing a valid access scope in `role.access_scope_id`.
 
 ### Deprecated Fatures
 

--- a/central/group/datastore/filter/filter.go
+++ b/central/group/datastore/filter/filter.go
@@ -11,6 +11,14 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 )
 
+// Filter is a function that, given an input group, tells whether it should be
+// filtered in (true) or out (false).
+type Filter = func(group *storage.Group) bool
+
+// Retriever is a function that, given a filter, will return the list
+// of groups that match the filter.
+type Retriever = func(ctx context.Context, filter Filter) ([]*storage.Group, error)
+
 // GetFiltered returns groups from the store filtered using filter function.
 func GetFiltered(ctx context.Context, filter func(*storage.Group) bool) ([]*storage.Group, error) {
 	return GetFilteredWithStore(ctx, filter, GroupStoreSingleton())

--- a/central/group/datastore/filter/filter_test_constructors.go
+++ b/central/group/datastore/filter/filter_test_constructors.go
@@ -1,0 +1,34 @@
+package filter
+
+import (
+	"context"
+	"testing"
+
+	postgresStore "github.com/stackrox/rox/central/group/datastore/internal/store/postgres"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres"
+)
+
+// FilterFactory is an interface to generate filtered group fetchers
+type FilterFactory interface {
+	FilteredRetriever() func(ctx context.Context, filter func(*storage.Group) bool) ([]*storage.Group, error)
+}
+
+// GetTestPostgresGroupFilterGenerator returns a generator for filtered group
+// retrieval connected to a postgres database.
+func GetTestPostgresGroupFilterGenerator(_ *testing.T, db postgres.DB) FilterFactory {
+	groupStore := postgresStore.New(db)
+	return &filterFactoryImpl{
+		store: groupStore,
+	}
+}
+
+type filterFactoryImpl struct {
+	store postgresStore.Store
+}
+
+func (f *filterFactoryImpl) FilteredRetriever() func(ctx context.Context, filter func(*storage.Group) bool) ([]*storage.Group, error) {
+	return func(ctx context.Context, filter func(*storage.Group) bool) ([]*storage.Group, error) {
+		return GetFilteredWithStore(ctx, filter, f.store)
+	}
+}

--- a/central/group/datastore/filter/filter_test_constructors.go
+++ b/central/group/datastore/filter/filter_test_constructors.go
@@ -9,14 +9,14 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 )
 
-// Factory is an interface to generate filtered group fetchers.
-type Factory interface {
-	FilteredRetriever() func(ctx context.Context, filter func(*storage.Group) bool) ([]*storage.Group, error)
+// RetrieverFactory is an interface to generate filtered group fetchers.
+type RetrieverFactory interface {
+	NewFilteredRetriever() Retriever
 }
 
 // GetTestPostgresGroupFilterGenerator returns a generator for filtered group
 // retrieval connected to a postgres database.
-func GetTestPostgresGroupFilterGenerator(_ *testing.T, db postgres.DB) Factory {
+func GetTestPostgresGroupFilterGenerator(_ *testing.T, db postgres.DB) RetrieverFactory {
 	groupStore := postgresStore.New(db)
 	return &factoryImpl{
 		store: groupStore,
@@ -27,8 +27,8 @@ type factoryImpl struct {
 	store postgresStore.Store
 }
 
-func (f *factoryImpl) FilteredRetriever() func(ctx context.Context, filter func(*storage.Group) bool) ([]*storage.Group, error) {
-	return func(ctx context.Context, filter func(*storage.Group) bool) ([]*storage.Group, error) {
+func (f *factoryImpl) NewFilteredRetriever() Retriever {
+	return func(ctx context.Context, filter Filter) ([]*storage.Group, error) {
 		return GetFilteredWithStore(ctx, filter, f.store)
 	}
 }

--- a/central/group/datastore/filter/filter_test_constructors.go
+++ b/central/group/datastore/filter/filter_test_constructors.go
@@ -9,25 +9,25 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 )
 
-// FilterFactory is an interface to generate filtered group fetchers
-type FilterFactory interface {
+// Factory is an interface to generate filtered group fetchers.
+type Factory interface {
 	FilteredRetriever() func(ctx context.Context, filter func(*storage.Group) bool) ([]*storage.Group, error)
 }
 
 // GetTestPostgresGroupFilterGenerator returns a generator for filtered group
 // retrieval connected to a postgres database.
-func GetTestPostgresGroupFilterGenerator(_ *testing.T, db postgres.DB) FilterFactory {
+func GetTestPostgresGroupFilterGenerator(_ *testing.T, db postgres.DB) Factory {
 	groupStore := postgresStore.New(db)
-	return &filterFactoryImpl{
+	return &factoryImpl{
 		store: groupStore,
 	}
 }
 
-type filterFactoryImpl struct {
+type factoryImpl struct {
 	store postgresStore.Store
 }
 
-func (f *filterFactoryImpl) FilteredRetriever() func(ctx context.Context, filter func(*storage.Group) bool) ([]*storage.Group, error) {
+func (f *factoryImpl) FilteredRetriever() func(ctx context.Context, filter func(*storage.Group) bool) ([]*storage.Group, error) {
 	return func(ctx context.Context, filter func(*storage.Group) bool) ([]*storage.Group, error) {
 		return GetFilteredWithStore(ctx, filter, f.store)
 	}

--- a/central/role/datastore/datastore_test_constructors.go
+++ b/central/role/datastore/datastore_test_constructors.go
@@ -11,10 +11,12 @@ import (
 )
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) (DataStore, error) {
 	permissionStore := permissionSetPostgresStore.New(pool)
 	roleStore := rolePostgresStore.New(pool)
 	scopeStore := accessScopePostgresStore.New(pool)
 
-	return New(roleStore, permissionStore, scopeStore, groupFilter.GetFiltered), nil
+	getFilteredFactory := groupFilter.GetTestPostgresGroupFilterGenerator(t, pool)
+
+	return New(roleStore, permissionStore, scopeStore, getFilteredFactory.FilteredRetriever()), nil
 }

--- a/central/role/datastore/datastore_test_constructors.go
+++ b/central/role/datastore/datastore_test_constructors.go
@@ -18,5 +18,5 @@ func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) (DataStore, error)
 
 	getFilteredFactory := groupFilter.GetTestPostgresGroupFilterGenerator(t, pool)
 
-	return New(roleStore, permissionStore, scopeStore, getFilteredFactory.FilteredRetriever()), nil
+	return New(roleStore, permissionStore, scopeStore, getFilteredFactory.NewFilteredRetriever()), nil
 }

--- a/central/role/service/service_impl.go
+++ b/central/role/service/service_impl.go
@@ -127,12 +127,6 @@ func (s *serviceImpl) CreateRole(ctx context.Context, roleRequest *v1.CreateRole
 	}
 	role.Name = roleRequest.GetName()
 
-	// Empty access scope ID is deprecated. Fill the default during the adoption
-	// period.
-	// TODO(ROX-9510): remove this block.
-	if role.GetAccessScopeId() == "" {
-		role.AccessScopeId = rolePkg.AccessScopeIncludeAll.GetId()
-	}
 	err := s.roleDataStore.AddRole(ctx, role)
 	if err != nil {
 		return nil, err
@@ -141,12 +135,6 @@ func (s *serviceImpl) CreateRole(ctx context.Context, roleRequest *v1.CreateRole
 }
 
 func (s *serviceImpl) UpdateRole(ctx context.Context, role *storage.Role) (*v1.Empty, error) {
-	// Empty access scope ID is deprecated. Fill the default during the adoption
-	// period.
-	// TODO(ROX-9510): remove this block.
-	if role.GetAccessScopeId() == "" {
-		role.AccessScopeId = rolePkg.AccessScopeIncludeAll.GetId()
-	}
 	err := s.roleDataStore.UpdateRole(ctx, role)
 	if err != nil {
 		return nil, err

--- a/central/role/service/service_impl_test.go
+++ b/central/role/service/service_impl_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -507,6 +508,10 @@ type serviceImplTestSuite struct {
 	storedClusterIDs   []string
 	storedNamespaceIDs []string
 	clusterNameToIDMap map[string]string
+
+	storedPermissionSetIDs []string
+	storedAccessScopeIDs   []string
+	storedRoleNames        []string
 }
 
 func (s *serviceImplTestSuite) SetupSuite() {
@@ -534,6 +539,10 @@ func (s *serviceImplTestSuite) TearDownSuite() {
 }
 
 func (s *serviceImplTestSuite) SetupTest() {
+	s.storedAccessScopeIDs = make([]string, 0)
+	s.storedPermissionSetIDs = make([]string, 0)
+	s.storedRoleNames = make([]string, 0)
+
 	s.storedClusterIDs = make([]string, 0)
 	s.storedNamespaceIDs = make([]string, 0)
 	s.clusterNameToIDMap = make(map[string]string, 0)
@@ -573,6 +582,15 @@ func (s *serviceImplTestSuite) TearDownTest() {
 	s.storedClusterIDs = s.storedClusterIDs[:0]
 	for _, namespaceID := range s.storedNamespaceIDs {
 		s.Require().NoError(s.service.namespaceDataStore.RemoveNamespace(writeCtx, namespaceID))
+	}
+	for _, roleName := range s.storedRoleNames {
+		s.deleteRole(roleName)
+	}
+	for _, permissionSetID := range s.storedPermissionSetIDs {
+		s.deletePermissionSet(permissionSetID)
+	}
+	for _, accessScopeID := range s.storedAccessScopeIDs {
+		s.deleteAccessScope(accessScopeID)
 	}
 }
 
@@ -1026,6 +1044,177 @@ func (s *serviceImplTestSuite) TestGetNamespacesForClusterAndPermissions() {
 			s.ElementsMatch(namespaceResponse.GetNamespaces(), c.expectedNamespaces)
 		})
 	}
+}
+
+func getValidRole(name string) *storage.Role {
+	permissionSetID := accesscontrol.DefaultPermissionSetIDs[accesscontrol.Admin]
+	scopeID := accesscontrol.DefaultAccessScopeIDs[accesscontrol.UnrestrictedAccessScope]
+	return &storage.Role{
+		Name:            name,
+		Description:     fmt.Sprintf("Test role for %s", name),
+		PermissionSetId: permissionSetID,
+		AccessScopeId:   scopeID,
+		Traits:          nil,
+	}
+}
+
+func (s *serviceImplTestSuite) TestCreateRoleValidAccessScopeID() {
+	ctx := sac.WithAllAccess(context.Background())
+	roleName := "TestCreateRoleValidAccessScopeID"
+
+	ps := s.createPermissionSet(roleName)
+	scope := s.createAccessScope(roleName)
+
+	role := getValidRole(roleName)
+	role.PermissionSetId = ps.GetId()
+	role.AccessScopeId = scope.GetId()
+	createRoleRequest := &v1.CreateRoleRequest{
+		Name: roleName,
+		Role: role,
+	}
+	_, err := s.service.CreateRole(ctx, createRoleRequest)
+	s.NoError(err)
+	s.storedRoleNames = append(s.storedRoleNames, role.GetName())
+}
+
+func (s *serviceImplTestSuite) TestCreateRoleEmptyAccessScopeID() {
+	ctx := sac.WithAllAccess(context.Background())
+	roleName := "TestCreateRoleEmptyAccessScopeID"
+
+	ps := s.createPermissionSet(roleName)
+
+	role := getValidRole(roleName)
+	role.PermissionSetId = ps.GetId()
+	role.AccessScopeId = ""
+	createRoleRequest := &v1.CreateRoleRequest{
+		Name: roleName,
+		Role: role,
+	}
+	_, err := s.service.CreateRole(ctx, createRoleRequest)
+	s.ErrorContains(err, "role access_scope_id field must be set")
+}
+
+func (s *serviceImplTestSuite) TestUpdateExistingRoleValidAccessScopeID() {
+	ctx := sac.WithAllAccess(context.Background())
+	role := s.createRole("TestUpdateExistingRoleValidAccessScopeID")
+	newScope := s.createAccessScope("new scope")
+	role.AccessScopeId = newScope.GetId()
+	_, err := s.service.UpdateRole(ctx, role)
+	s.NoError(err)
+}
+
+func (s *serviceImplTestSuite) TestUpdateExistingRoleEmptyAccessScopeID() {
+	ctx := sac.WithAllAccess(context.Background())
+	roleName := "TestUpdateExistingRoleEmptyAccessScopeID"
+	role := s.createRole(roleName)
+	role.AccessScopeId = ""
+	_, err := s.service.UpdateRole(ctx, role)
+	s.ErrorContains(err, "role access_scope_id field must be set")
+}
+
+func (s *serviceImplTestSuite) TestUpdateMissingRoleValidAccessScopeID() {
+	ctx := sac.WithAllAccess(context.Background())
+	roleName := "TestUpdateMissingRoleValidAccessScopeID"
+	ps := s.createPermissionSet(roleName)
+	scope := s.createAccessScope(roleName)
+	role := getValidRole(roleName)
+	role.PermissionSetId = ps.GetId()
+	role.AccessScopeId = scope.GetId()
+	_, err := s.service.UpdateRole(ctx, role)
+	s.ErrorIs(err, errox.NotFound)
+}
+
+func (s *serviceImplTestSuite) TestUpdateMissingRoleEmptyAccessScopeID() {
+	ctx := sac.WithAllAccess(context.Background())
+	roleName := "TestUpdateMissingRoleEmptyAccessScopeID"
+	ps := s.createPermissionSet(roleName)
+	role := getValidRole(roleName)
+	role.PermissionSetId = ps.GetId()
+	role.AccessScopeId = ""
+	_, err := s.service.UpdateRole(ctx, role)
+	s.ErrorContains(err, "role access_scope_id field must be set")
+}
+
+func (s *serviceImplTestSuite) createAccessScope(name string) *storage.SimpleAccessScope {
+	ctx := sac.WithAllAccess(context.Background())
+	scope := &storage.SimpleAccessScope{
+		Name:        name,
+		Description: fmt.Sprintf("Test access scope for %s", name),
+		Rules: &storage.SimpleAccessScope_Rules{
+			IncludedClusters: []string{"test"},
+		},
+		Traits: nil,
+	}
+	postedScope, postErr := s.service.PostSimpleAccessScope(ctx, scope)
+	s.Require().NoError(postErr)
+	s.storedAccessScopeIDs = append(s.storedAccessScopeIDs, postedScope.GetId())
+	return postedScope
+}
+
+func (s *serviceImplTestSuite) deleteAccessScope(id string) {
+	ctx := sac.WithAllAccess(context.Background())
+	request := &v1.ResourceByID{
+		Id: id,
+	}
+	_, deleteErr := s.service.DeleteSimpleAccessScope(ctx, request)
+	s.Require().NoError(deleteErr)
+}
+
+func (s *serviceImplTestSuite) createPermissionSet(name string) *storage.PermissionSet {
+	ctx := sac.WithAllAccess(context.Background())
+	permissionSet := &storage.PermissionSet{
+		Name:             name,
+		Description:      fmt.Sprintf("Test permission set for %s", name),
+		ResourceToAccess: nil,
+		Traits:           nil,
+	}
+	ps, postErr := s.service.PostPermissionSet(ctx, permissionSet)
+	s.Require().NoError(postErr)
+	s.storedPermissionSetIDs = append(s.storedPermissionSetIDs, ps.GetId())
+	return ps
+}
+
+func (s *serviceImplTestSuite) deletePermissionSet(id string) {
+	ctx := sac.WithAllAccess(context.Background())
+	request := &v1.ResourceByID{
+		Id: id,
+	}
+	_, deleteErr := s.service.DeletePermissionSet(ctx, request)
+	s.Require().NoError(deleteErr)
+}
+
+func (s *serviceImplTestSuite) createRole(roleName string) *storage.Role {
+	ctx := sac.WithAllAccess(context.Background())
+
+	ps := s.createPermissionSet(roleName)
+	scope := s.createAccessScope(roleName)
+
+	createRoleRequest := &v1.CreateRoleRequest{
+		Name: roleName,
+		Role: getValidRole(roleName),
+	}
+	createRoleRequest.Role.PermissionSetId = ps.GetId()
+	createRoleRequest.Role.AccessScopeId = scope.GetId()
+
+	_, createErr := s.service.CreateRole(ctx, createRoleRequest)
+	s.Require().NoError(createErr)
+	s.storedRoleNames = append(s.storedRoleNames, roleName)
+
+	readRoleRequest := &v1.ResourceByID{
+		Id: roleName,
+	}
+	role, readErr := s.service.GetRole(ctx, readRoleRequest)
+	s.Require().NoError(readErr)
+	return role
+}
+
+func (s *serviceImplTestSuite) deleteRole(name string) {
+	ctx := sac.WithAllAccess(context.Background())
+	request := &v1.ResourceByID{
+		Id: name,
+	}
+	_, deleteErr := s.service.DeleteRole(ctx, request)
+	s.Require().NoError(deleteErr)
 }
 
 func TestGetMyPermissions(t *testing.T) {

--- a/central/role/validate_test.go
+++ b/central/role/validate_test.go
@@ -19,7 +19,7 @@ func TestValidateRole(t *testing.T) {
 				"Policy": storage.Access_READ_ACCESS,
 			},
 		},
-		"role must reference an existing permission set": constructRole("role with no permission set", "", ""),
+		"role must reference an existing permission set": constructRole("role with no permission set", "", GenerateAccessScopeID()),
 		"empty access scope reference is not allowed":    constructRole("role with no access scope", GeneratePermissionSetID(), ""),
 	}
 
@@ -129,6 +129,7 @@ func TestEnsureValidPermissionSetIDPostgres(t *testing.T) {
 func TestValidateSimpleAccessScope(t *testing.T) {
 	mockGoodID := uuid.NewDummy().String()
 	mockBadID := "42"
+	emptyID := ""
 	mockName := "Heart of Gold"
 	mockDescription := "HHGTTG"
 	mockGoodRules := &storage.SimpleAccessScope_Rules{
@@ -183,6 +184,11 @@ func TestValidateSimpleAccessScope(t *testing.T) {
 		{
 			name:                   "id is missing",
 			scope:                  &storage.SimpleAccessScope{Name: mockName, Rules: &storage.SimpleAccessScope_Rules{}},
+			expectedNumberOfErrors: 1,
+		},
+		{
+			name:                   "empty id",
+			scope:                  &storage.SimpleAccessScope{Id: emptyID, Name: mockName, Rules: &storage.SimpleAccessScope_Rules{}},
 			expectedNumberOfErrors: 1,
 		}, {
 			name:                   "name is missing",


### PR DESCRIPTION
## Description

For a long time now, roles are created with the `Unrestricted` access scope when the parameter is missing.
The goal of the change is to now systematically require a valid access scope ID when creating a new role

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Added integrated unit tests for the role creation and update with either correct or empty access scope IDs

Manual testing:
```bash
# Deploy central
# Create role from the UI
% curl --insecure -XGET -u admin:$(cat deploy/k8s/central-deploy/password) https://localhost:8000/v1/roles/AnalystClone|jq .

{
  "name": "AnalystClone",
  "description": "",
  "permissionSetId": "ffffffff-ffff-fff4-f5ff-fffffffffffe",
  "accessScopeId": "ffffffff-ffff-fff4-f5ff-ffffffffffff",
  "globalAccess": "NO_ACCESS",
  "resourceToAccess": {},
  "traits": null
}

# Try to update the created role with an empty scope ID from the REST API
% curl --insecure -XPUT -u admin:$(cat deploy/k8s/central-deploy/password) https://localhost:8000/v1/roles/AnalystClone --data '{"name":"AnalystClone", "description":"", "permissionSetId": "ffffffff-ffff-fff4-f5ff-fffffffffffe", "traits": {"origin": "IMPERATIVE"}}'|jq .

{
  "error":"1 error occurred:\n\t* role access_scope_id field must be set\n\n: invalid arguments",
  "code":3,
  "message":"1 error occurred:\n\t* role access_scope_id field must be set\n\n: invalid arguments",
  "details":[]
}

% curl --insecure -XPUT -u admin:$(cat deploy/k8s/central-deploy/password) https://localhost:8000/v1/roles/AnalystClone --data '{"name":"AnalystClone", "description":"", "permissionSetId": "ffffffff-ffff-fff4-f5ff-fffffffffffe", "accessScopeId": "", "traits": {"origin": "IMPERATIVE"}}'|jq .

{
  "error":"1 error occurred:\n\t* role access_scope_id field must be set\n\n: invalid arguments",
  "code":3,
  "message":"1 error occurred:\n\t* role access_scope_id field must be set\n\n: invalid arguments",
  "details":[]
}

# Try to create a role with empty scope ID from the REST API
% curl --insecure -XPOST -u admin:$(cat deploy/k8s/central-deploy/password) https://localhost:8000/v1/roles/SensorCreatorClone --data '{"name":"SensorCreatorClone", "description":"", "permissionSetId": "ffffffff-ffff-fff4-f5ff-fffffffffffa", "accessScopeId": "", "traits": {"origin": "IMPERATIVE"}}'

{
  "error":"1 error occurred:\n\t* role access_scope_id field must be set\n\n: invalid arguments",
  "code":3,
  "message":"1 error occurred:\n\t* role access_scope_id field must be set\n\n: invalid arguments",
  "details":[]
}

% curl --insecure -XPOST -u admin:$(cat deploy/k8s/central-deploy/password) https://localhost:8000/v1/roles/NetworkGraphViewerClone --data '{"name":"NetworkGraphViewerClone", "description":"", "permissionSetId": "ffffffff-ffff-fff4-f5ff-fffffffffff5", "traits": {"origin": "IMPERATIVE"}}' 

{
  "error":"1 error occurred:\n\t* role access_scope_id field must be set\n\n: invalid arguments",
  "code":3,
  "message":"1 error occurred:\n\t* role access_scope_id field must be set\n\n: invalid arguments",
  "details":[]
}
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
