### PR TITLE
ROX-19636: Fix bulk suppress/reobserve CVEs in VM 1.0

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
@@ -20,6 +20,7 @@ import { splitCvesByType } from 'utils/vulnerabilityUtils';
 import CustomDialogue from '../../Components/CustomDialogue';
 
 import CveToPolicyShortForm, { emptyPolicy } from './CveToPolicyShortForm';
+import { parseCveNamesFromIds } from './ListCVEs.utils';
 
 const findCVEField = (policySections) => {
     let policySectionIdx = null;
@@ -40,10 +41,7 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds, cveType }) => {
     const dialogueRef = useRef(null);
 
     // the combined CVEs are used for the GraphQL query var
-    const cvesStr =
-        cveType === entityTypes.CVE
-            ? bulkActionCveIds.join(',')
-            : bulkActionCveIds.map((cve) => cve.split('#')[0]).join(','); // only use the cve name, not the OS after the hash
+    const cvesStr = parseCveNamesFromIds(bulkActionCveIds).join(','); // only use the cve name, not the OS after the hash
 
     // prepare policy object
     const [policyIdentifer, setPolicyIdentifier] = useState('');
@@ -81,27 +79,14 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds, cveType }) => {
             `;
             break;
         }
-        case entityTypes.IMAGE_CVE: {
+        case entityTypes.IMAGE_CVE:
+        default: {
             CVE_QUERY = gql`
                 query getImageCves($query: String) {
                     results: imageVulnerabilities(query: $query) {
                         id
                         cve
                         summary
-                    }
-                }
-            `;
-            break;
-        }
-        case entityTypes.CVE:
-        default: {
-            CVE_QUERY = gql`
-                query getCves($query: String) {
-                    results: vulnerabilities(query: $query) {
-                        id
-                        cve
-                        summary
-                        vulnerabilityTypes
                     }
                 }
             `;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.js
@@ -1,3 +1,5 @@
+import uniq from 'lodash/uniq';
+
 import entityTypes from 'constants/entityTypes';
 
 export function getFilteredCVEColumns(columns, workflowState, isFeatureFlagEnabled) {
@@ -67,6 +69,15 @@ export function getFilteredCVEColumns(columns, workflowState, isFeatureFlagEnabl
     });
 }
 
+export function parseCveNamesFromIds(cveIds) {
+    const cveNames = cveIds.map((cveId) => {
+        return cveId.split('#')[0];
+    });
+
+    return uniq(cveNames);
+}
+
 export default {
     getFilteredCVEColumns,
+    parseCveNamesFromIds,
 };

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.test.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.test.js
@@ -4,7 +4,7 @@ import WorkflowEntity from 'utils/WorkflowEntity';
 import { WorkflowState } from 'utils/WorkflowState';
 
 import { getCveTableColumns } from './VulnMgmtListCves';
-import { getFilteredCVEColumns } from './ListCVEs.utils';
+import { getFilteredCVEColumns, parseCveNamesFromIds } from './ListCVEs.utils';
 
 function mockIsFeatureFlagEnabled(flag) {
     if (flag === 'ROX_ACTIVE_VULN_MGMT') {
@@ -84,6 +84,39 @@ describe('ListCVEs.utils', () => {
             );
 
             expect(filteredColumns).toEqual(tableColumns);
+        });
+    });
+
+    describe('parseCveNamesFromIds', () => {
+        it('should return an empty array when passed an empty array', () => {
+            const selectedCveIds = [];
+
+            const parseCveNames = parseCveNamesFromIds(selectedCveIds);
+
+            expect(parseCveNames).toEqual([]);
+        });
+
+        it('should return just the first CVE name parts of a list of CVE IDs', () => {
+            const selectedCveIds = ['CVE-2005-2541#debian:12', 'CVE-2014-7187#debian:8'];
+
+            const parseCveNames = parseCveNamesFromIds(selectedCveIds);
+
+            expect(parseCveNames).toEqual(['CVE-2005-2541', 'CVE-2014-7187']);
+        });
+
+        it('should return a deduped list of first CVE name parts, when multiple CVE IDs start the same', () => {
+            const selectedCveIds = [
+                'CVE-2005-2541#debian:11',
+                'CVE-2005-2541#debian:10',
+                'CVE-2005-2541#debian:12',
+                'CVE-2014-7187#debian:8',
+                'CVE-2004-0971#debian:9',
+                'CVE-2004-0971#unknown',
+            ];
+
+            const parseCveNames = parseCveNamesFromIds(selectedCveIds);
+
+            expect(parseCveNames).toEqual(['CVE-2005-2541', 'CVE-2014-7187', 'CVE-2004-0971']);
         });
     });
 });

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -4,7 +4,6 @@ import { gql } from '@apollo/client';
 import * as Icon from 'react-feather';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import uniq from 'lodash/uniq';
 
 import {
     defaultHeaderClassName,
@@ -45,7 +44,7 @@ import CveBulkActionDialogue from './CveBulkActionDialogue';
 
 import { entityCountNounOrdinaryCase } from '../../entitiesForVulnerabilityManagement';
 import WorkflowListPage from '../WorkflowListPage';
-import { getFilteredCVEColumns } from './ListCVEs.utils';
+import { getFilteredCVEColumns, parseCveNamesFromIds } from './ListCVEs.utils';
 
 export const defaultCveSort = [
     {
@@ -53,14 +52,6 @@ export const defaultCveSort = [
         desc: true,
     },
 ];
-
-function parseCveNamesFromIds(cveIds) {
-    const cveNames = cveIds.map((cveId) => {
-        return cveId.split('#')[0] || '';
-    })
-
-    return uniq(cveNames);
-}
 
 export function getCveTableColumns(workflowState, isFeatureFlagEnabled) {
     // to determine whether to show the counts as links in the table when not in pure CVE state


### PR DESCRIPTION
## Description

Problem to be solved (explanation from bug ticket investigation):
An incorrect request is sent from the frontend to the backend. The /v1/suppress and /v1/unsuppress APIs expect CVE name not the ACS ID of the CVE. The bulk operation seems to use database ID instead of CVE name.

Solution in this PR:
The container where the handler for globally suppressing or re-observing CVEs only has access to the list of selected rows, which are the full IDs of the CVEs. (The actual CVE data for the rows is retrieved in a child component; this is a legacy of the infinite nesting nature of pages in VM 1.0.)

Therefore, the simplest solution to get back to the CVE names is to take the array of selected CVE IDs, split them on the separator ("#"), and take the first part, which is the CVE name.

Note that this reveals the somewhat incongruous edge case that if you have selected more than one CVE by its unique ID that start with the same name, then all the CVEs that start with that ID will be suppress or re-observed.  "_Sunt lacrimae rerum / et mentem mortalia tangunt_"

## Checklist
- [x] Investigated and inspected CI test results (failure in ocp-4-13-ui-e2e-tests is a random flake)
- [x] Unit test and regression tests added

## Testing Performed

### Here I tell how I validated my change

Manual testing

#### Select some CVEs
<img width="1676" alt="Screen Shot 2023-09-12 at 12 13 32 PM" src="https://github.com/stackrox/stackrox/assets/715729/ced00a7d-4bd1-49c5-840d-7383d76dcc0f">

#### Choose to "Defer and Approve" those CVEs for some duration
<img width="1676" alt="Screen Shot 2023-09-12 at 12 13 40 PM" src="https://github.com/stackrox/stackrox/assets/715729/a466171a-c362-4723-8e2c-7824303b38e4">

#### See the success message
<img width="1676" alt="Screen Shot 2023-09-12 at 12 13 44 PM" src="https://github.com/stackrox/stackrox/assets/715729/2b37f498-c9bf-4a18-87f9-1444f42282a3">


#### Select some CVEs
<img width="1676" alt="Screen Shot 2023-09-12 at 12 15 12 PM" src="https://github.com/stackrox/stackrox/assets/715729/0e011e53-f21f-4cd2-9b83-32e7868440a4">

#### Choose to "Reobserve" those CVEs for some duration
<img width="1676" alt="Screen Shot 2023-09-12 at 12 15 16 PM" src="https://github.com/stackrox/stackrox/assets/715729/ab32a4a7-d60b-4c23-88f1-6c018ced936f">

#### See the success message
<img width="1676" alt="Screen Shot 2023-09-12 at 12 15 21 PM" src="https://github.com/stackrox/stackrox/assets/715729/7bf74d6e-ac49-404b-871d-8220ffaa3656">


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
