### PR TITLE
ROX-16600: Fix audit log layout bug in Safari

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -170,7 +170,7 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
             <Flex
                 direction={{ default: 'column' }}
                 spaceItems={{ default: 'spaceItemsNone' }}
-                className="pf-u-p-lg"
+                className="pf-u-px-lg pf-u-pt-lg"
             >
                 <Title headingLevel="h2">Policy behavior</Title>
                 <div className="pf-u-mt-sm">
@@ -205,7 +205,9 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                         </p>
                     </Flex>
                 </Alert>
-                <Form>
+            </Flex>
+            <Form>
+                <div className="pf-u-px-lg">
                     <FormGroup
                         helperText="Choose lifecycle stage to which your policy is applicable. You can select more than one stage."
                         fieldId="policy-lifecycle-stage"
@@ -255,6 +257,7 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                         label="Event sources (Runtime lifecycle only)"
                         isRequired={hasRuntime}
                         helperText={eventSourceHelperText}
+                        className="pf-u-pt-lg"
                     >
                         <Flex direction={{ default: 'row' }}>
                             <Radio
@@ -275,19 +278,17 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                             />
                         </Flex>
                     </FormGroup>
-                </Form>
-            </Flex>
-            <Divider component="div" />
-            <Flex
-                direction={{ default: 'column' }}
-                spaceItems={{ default: 'spaceItemsNone' }}
-                className="pf-u-p-lg"
-            >
-                <Title headingLevel="h2">Response method</Title>
-                <div className="pf-u-mb-md pf-u-mt-sm">
-                    Select a method to address violations of this policy.
                 </div>
-                <Form>
+                <Divider component="div" />
+                <Flex
+                    direction={{ default: 'column' }}
+                    spaceItems={{ default: 'spaceItemsNone' }}
+                    className="pf-u-px-lg pf-u-pb-lg"
+                >
+                    <Title headingLevel="h2">Response method</Title>
+                    <div className="pf-u-mb-md pf-u-mt-sm">
+                        Select a method to address violations of this policy.
+                    </div>
                     <FormGroup
                         fieldId="policy-response-method"
                         className="pf-u-mb-lg"
@@ -313,99 +314,103 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                             />
                         </Flex>
                     </FormGroup>
-                </Form>
-                {showEnforcement && (
-                    <>
-                        <Title headingLevel="h2" className="pf-u-mt-md">
-                            Configure enforcement behavior
-                        </Title>
-                        <div className="pf-u-mb-lg pf-u-mt-sm">
-                            Based on the fields selected in your policy configuration, you may
-                            choose to apply enforcement at the following stages.
+                    {showEnforcement && (
+                        <div>
+                            <Title headingLevel="h2" className="pf-u-mt-md">
+                                Configure enforcement behavior
+                            </Title>
+                            <div className="pf-u-mb-lg pf-u-mt-sm">
+                                Based on the fields selected in your policy configuration, you may
+                                choose to apply enforcement at the following stages.
+                            </div>
+                            <Grid hasGutter>
+                                <GridItem span={4}>
+                                    <Card className="pf-u-h-100 policy-enforcement-card">
+                                        <CardHeader>
+                                            <CardTitle component="h3">Build</CardTitle>
+                                        </CardHeader>
+                                        <CardBody>
+                                            <Switch
+                                                isChecked={hasEnforcementActionForLifecycleStage(
+                                                    'BUILD',
+                                                    values.enforcementActions
+                                                )}
+                                                isDisabled={!hasBuild}
+                                                onChange={(isChecked) => {
+                                                    onChangeEnforcementActions('BUILD', isChecked);
+                                                }}
+                                                label="Enforce on Build"
+                                            />
+                                            <p className="pf-u-pt-md pf-u-pb-md">
+                                                If enabled, your CI builds will be failed when
+                                                images violate this policy. Download the CLI to get
+                                                started.
+                                            </p>
+                                            <DownloadCLIDropdown hasBuild={hasBuild} />
+                                        </CardBody>
+                                    </Card>
+                                </GridItem>
+                                <GridItem span={4}>
+                                    <Card className="policy-enforcement-card">
+                                        <CardHeader>
+                                            <CardTitle component="h3">Deploy</CardTitle>
+                                        </CardHeader>
+                                        <CardBody>
+                                            <Switch
+                                                isChecked={hasEnforcementActionForLifecycleStage(
+                                                    'DEPLOY',
+                                                    values.enforcementActions
+                                                )}
+                                                isDisabled={!hasDeploy}
+                                                onChange={(isChecked) => {
+                                                    onChangeEnforcementActions('DEPLOY', isChecked);
+                                                }}
+                                                label="Enforce on Deploy"
+                                            />
+                                            <p className="pf-u-pt-md">
+                                                If enabled, creation of deployments that violate
+                                                this policy will be blocked. In clusters with the
+                                                admission controller enabled, the Kubernetes API
+                                                server will block deployments that violate this
+                                                policy to prevent pods from being scheduled.
+                                            </p>
+                                        </CardBody>
+                                    </Card>
+                                </GridItem>
+                                <GridItem span={4}>
+                                    <Card className="policy-enforcement-card">
+                                        <CardHeader>
+                                            <CardTitle component="h3">Runtime</CardTitle>
+                                        </CardHeader>
+                                        <CardBody>
+                                            <Switch
+                                                isChecked={hasEnforcementActionForLifecycleStage(
+                                                    'RUNTIME',
+                                                    values.enforcementActions
+                                                )}
+                                                isDisabled={!hasRuntime}
+                                                onChange={(isChecked) => {
+                                                    onChangeEnforcementActions(
+                                                        'RUNTIME',
+                                                        isChecked
+                                                    );
+                                                }}
+                                                label="Enforce on Runtime"
+                                            />
+                                            <p className="pf-u-pt-md">
+                                                If enabled, executions within a pod that violate
+                                                this policy will result in the pod being deleted.
+                                                Actions taken through the API server that violate
+                                                this policy will be blocked.
+                                            </p>
+                                        </CardBody>
+                                    </Card>
+                                </GridItem>
+                            </Grid>
                         </div>
-                        <Grid hasGutter>
-                            <GridItem span={4}>
-                                <Card className="pf-u-h-100 policy-enforcement-card">
-                                    <CardHeader>
-                                        <CardTitle component="h3">Build</CardTitle>
-                                    </CardHeader>
-                                    <CardBody>
-                                        <Switch
-                                            isChecked={hasEnforcementActionForLifecycleStage(
-                                                'BUILD',
-                                                values.enforcementActions
-                                            )}
-                                            isDisabled={!hasBuild}
-                                            onChange={(isChecked) => {
-                                                onChangeEnforcementActions('BUILD', isChecked);
-                                            }}
-                                            label="Enforce on Build"
-                                        />
-                                        <p className="pf-u-pt-md pf-u-pb-md">
-                                            If enabled, your CI builds will be failed when images
-                                            violate this policy. Download the CLI to get started.
-                                        </p>
-                                        <DownloadCLIDropdown hasBuild={hasBuild} />
-                                    </CardBody>
-                                </Card>
-                            </GridItem>
-                            <GridItem span={4}>
-                                <Card className="policy-enforcement-card">
-                                    <CardHeader>
-                                        <CardTitle component="h3">Deploy</CardTitle>
-                                    </CardHeader>
-                                    <CardBody>
-                                        <Switch
-                                            isChecked={hasEnforcementActionForLifecycleStage(
-                                                'DEPLOY',
-                                                values.enforcementActions
-                                            )}
-                                            isDisabled={!hasDeploy}
-                                            onChange={(isChecked) => {
-                                                onChangeEnforcementActions('DEPLOY', isChecked);
-                                            }}
-                                            label="Enforce on Deploy"
-                                        />
-                                        <p className="pf-u-pt-md">
-                                            If enabled, creation of deployments that violate this
-                                            policy will be blocked. In clusters with the admission
-                                            controller enabled, the Kubernetes API server will block
-                                            deployments that violate this policy to prevent pods
-                                            from being scheduled.
-                                        </p>
-                                    </CardBody>
-                                </Card>
-                            </GridItem>
-                            <GridItem span={4}>
-                                <Card className="policy-enforcement-card">
-                                    <CardHeader>
-                                        <CardTitle component="h3">Runtime</CardTitle>
-                                    </CardHeader>
-                                    <CardBody>
-                                        <Switch
-                                            isChecked={hasEnforcementActionForLifecycleStage(
-                                                'RUNTIME',
-                                                values.enforcementActions
-                                            )}
-                                            isDisabled={!hasRuntime}
-                                            onChange={(isChecked) => {
-                                                onChangeEnforcementActions('RUNTIME', isChecked);
-                                            }}
-                                            label="Enforce on Runtime"
-                                        />
-                                        <p className="pf-u-pt-md">
-                                            If enabled, executions within a pod that violate this
-                                            policy will result in the pod being deleted. Actions
-                                            taken through the API server that violate this policy
-                                            will be blocked.
-                                        </p>
-                                    </CardBody>
-                                </Card>
-                            </GridItem>
-                        </Grid>
-                    </>
-                )}
-            </Flex>
+                    )}
+                </Flex>
+            </Form>
         </Flex>
     );
 }


### PR DESCRIPTION
## Description

Problem, as reported in GitHub issue #5722:
Layout problems in Safari on the Policy Behavior tab of the Policy Wizard were preventing filling out all the inputs, in particular the Event Source input.

<img width="1500" alt="Screen Shot 2023-09-12 at 3 53 59 PM" src="https://github.com/stackrox/stackrox/assets/715729/8b9d214c-2bea-4031-82d9-42d1bd260d40">

Investigation:
As an early instance of our migration to the Red Hat PatternFly library, we had used two (2) `<Form>` React components for layout purposes only (not behavior), and the interaction of the rendered markup for those two components was breaking the Safari layout.

Solution:
Wrapping all the input markup in the tab with only one `<Form>` React component, and adding some appropriate utility CSS classes to mimic the desired spacing resolves the issue in Safari, without breaking the layout in other browsers.


## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

I tested in various browsers, but in particular Safari and Chrome.

#### Fixed in Safari
<img width="1500" alt="Screen Shot 2023-09-12 at 4 21 47 PM" src="https://github.com/stackrox/stackrox/assets/715729/a49f7e4e-8b1c-40fb-b568-be9b422f39f1">

#### new markup compared in Chrome and Safari
<img width="1863" alt="Screen Shot 2023-09-12 at 4 22 52 PM" src="https://github.com/stackrox/stackrox/assets/715729/0251ea9f-8b4a-4b51-a925-7774d1b187d6">


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
