### PR TITLE
fix(scan): set scanner-slim URL back to original value

### DIFF
--- a/sensor/common/scannerclient/grpc_client.go
+++ b/sensor/common/scannerclient/grpc_client.go
@@ -126,7 +126,7 @@ func dial(endpoint string, certID mtls.Subject) (*grpc.ClientConn, error) {
 
 // dialV2 connect to scanner V1 gRPC and return a new ScannerClient.
 func dialV2() (ScannerClient, error) {
-	endpoint, err := getScannerEndpoint(env.ScannerV4GRPCEndpoint)
+	endpoint, err := getScannerEndpoint(env.ScannerSlimGRPCEndpoint)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Fixes a broken URL used by sensor to talk to scanner-slim

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- [X] Evaluated and added CHANGELOG entry if required
- [X] Determined and documented upgrade steps
- [X] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Testing for current PRs for delegated scanning are breaking, expecting V2 scanner to be used.

```
common/delegatedregistry: 2023/09/12 20:43:21.373178 delegated_registry_handler.go:108: Info: Received scan request: "request_id:\"959df5bc-2017-4896-aac4-56b1073c53ba\" image_name:\"image-registry.openshift-image-registry.svc:5000/dave/dave-is:latest\" namespace:\"dave\" "
common/scannerclient: 2023/09/12 20:43:21.373351 grpc_client.go:133: Info: dialing scanner-v2 client: scanner-v4.stackrox.svc:8443
common/scannerclient: 2023/09/12 20:43:21.373752 grpc_client.go:119: Info: dialing scanner at scanner-v4.stackrox.svc:8443
grpc_internal: 2023/09/12 20:43:21.373792 clientconn.go:318: Debug: [core][Channel #25] Channel created
grpc_internal: 2023/09/12 20:43:21.373832 logging.go:43: Debug: [core][Channel #25] original dial target is: "scanner-v4.stackrox.svc:8443"
grpc_internal: 2023/09/12 20:43:21.373854 logging.go:43: Debug: [core][Channel #25] parsed dial target is: {URL:{Scheme:scanner-v4.stackrox.svc Opaque:8443 User: Host: Path: RawPath: OmitHost:false ForceQuery:false RawQuery: Fragment: RawFragment:}}
grpc_internal: 2023/09/12 20:43:21.373865 logging.go:43: Debug: [core][Channel #25] fallback to scheme "passthrough"
grpc_internal: 2023/09/12 20:43:21.373880 logging.go:43: Debug: [core][Channel #25] parsed dial target is: {URL:{Scheme:passthrough Opaque: User: Host: Path:/scanner-v4.stackrox.svc:8443 RawPath: OmitHost:false ForceQuery:false RawQuery: Fragment: RawFragment:}}
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
