### PR TITLE
ROX-19483: Add default email subject, body and config details to emailed reports

### DIFF
--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -277,15 +277,16 @@ func (s *scheduler) sendReportResults(req *ReportRequest) error {
 		return err
 	}
 	// Format results into CSV
-	zippedCSVData, empty, err := common.Format(reportData, nil, "")
+	zippedCSVResult, err := common.Format(reportData, nil, "")
 	if err != nil {
 		return errors.Wrap(err, "error formatting the report data")
 	}
+	zippedCSVData := zippedCSVResult.ZippedCsv
+
 	// If it is an empty report, do not send an attachment in the final notification email and the email body
 	// will indicate that no vulns were found
-
 	templateStr := vulnReportEmailTemplate
-	if empty {
+	if zippedCSVResult.NumDeployedImageCVEs == 0 && zippedCSVResult.NumWatchedImageCVEs == 0 {
 		// If it is an empty report, the email body will indicate that no vulns were found
 		zippedCSVData = nil
 		templateStr = noVulnsFoundEmailTemplate

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -298,7 +298,11 @@ func (s *scheduler) sendReportResults(req *ReportRequest) error {
 
 	if err = retry.WithRetry(func() error {
 		return reportNotifier.ReportNotify(req.Ctx, zippedCSVData,
+<<<<<<< HEAD
 			rc.GetEmailConfig().GetMailingLists(), messageText, "")
+=======
+			rc.GetEmailConfig().GetMailingLists(), "", messageText)
+>>>>>>> 5096449de5 (Add support for adding custom email subject, body and config details)
 	},
 		retry.OnlyRetryableErrors(),
 		retry.Tries(3),

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -299,11 +299,7 @@ func (s *scheduler) sendReportResults(req *ReportRequest) error {
 
 	if err = retry.WithRetry(func() error {
 		return reportNotifier.ReportNotify(req.Ctx, zippedCSVData,
-<<<<<<< HEAD
-			rc.GetEmailConfig().GetMailingLists(), messageText, "")
-=======
 			rc.GetEmailConfig().GetMailingLists(), "", messageText)
->>>>>>> 5096449de5 (Add support for adding custom email subject, body and config details)
 	},
 		retry.OnlyRetryableErrors(),
 		retry.Tries(3),

--- a/central/reports/scheduler/v2/reportgenerator/consts.go
+++ b/central/reports/scheduler/v2/reportgenerator/consts.go
@@ -51,13 +51,13 @@ const (
 		cveFieldsFragment
 	watchedImagesReportQueryOpName = "getWatchedImagesReportData"
 
-	vulnReportEmailTemplate = `
-	{{.BrandedProductName}} has found vulnerabilities associated with the {{.ImageTypes}} images owned by your organization. Please review the attached vulnerability report {{.WhichVulns}} for {{.DateStr}}.
+	defaultEmailSubjectTemplate = "({{.BrandedProductNameShort}}) Workload CVE Report for {{.ReportConfigName}}; Scope: {{.CollectionName}}"
 
-	To address these findings, please review the impacted software packages in the images you are responsible for and update them to a version containing the fix, if one is available.`
+	defaultEmailBodyTemplate_vulnsFound = "{{.BrandedProductName}} ({{.BrandedProductNameShort}}) for Kubernetes has identified workload CVEs in the images matched by the following report configuration parameters. " +
+		"The attached Vulnerability report lists those workload CVEs and associated details to help with remediation. " +
+		"Please review the vulnerable software packages/ components from the impacted images and update them to a version containing the fix, if one is available.\n"
 
-	noVulnsFoundEmailTemplate = `
-	{{.BrandedProductName}} has found zero vulnerabilities associated with the {{.ImageTypes}} images owned by your organization.`
+	defaultEmailBodyTemplate_noVulnsFound = "{{.BrandedProductName}} ({{.BrandedProductNameShort}}) for Kubernetes has found no workload CVEs in the images matched by the following report configuration parameters.\n"
 
 	paginatedQueryStartOffset = 0
 )

--- a/central/reports/scheduler/v2/reportgenerator/consts.go
+++ b/central/reports/scheduler/v2/reportgenerator/consts.go
@@ -53,11 +53,11 @@ const (
 
 	defaultEmailSubjectTemplate = "({{.BrandedProductNameShort}}) Workload CVE Report for {{.ReportConfigName}}; Scope: {{.CollectionName}}"
 
-	defaultEmailBodyTemplate_vulnsFound = "{{.BrandedProductName}} ({{.BrandedProductNameShort}}) for Kubernetes has identified workload CVEs in the images matched by the following report configuration parameters. " +
+	defaultEmailBodyTemplate = "{{.BrandedProductName}} ({{.BrandedProductNameShort}}) for Kubernetes has identified workload CVEs in the images matched by the following report configuration parameters. " +
 		"The attached Vulnerability report lists those workload CVEs and associated details to help with remediation. " +
 		"Please review the vulnerable software packages/ components from the impacted images and update them to a version containing the fix, if one is available.\n"
 
-	defaultEmailBodyTemplate_noVulnsFound = "{{.BrandedProductName}} ({{.BrandedProductNameShort}}) for Kubernetes has found no workload CVEs in the images matched by the following report configuration parameters.\n"
+	defaultNoVulnsEmailBodyTemplate = "{{.BrandedProductName}} ({{.BrandedProductNameShort}}) for Kubernetes has found no workload CVEs in the images matched by the following report configuration parameters.\n"
 
 	paginatedQueryStartOffset = 0
 )

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter.go
@@ -76,7 +76,7 @@ func formatEmailBody(emailTemplate string) (string, error) {
 func addReportConfigDetails(emailBody, configDetailsHTML string) string {
 	var writer strings.Builder
 	writer.WriteString(emailBody)
-	writer.WriteString("\n\n")
+	writer.WriteString("<br><br>")
 	writer.WriteString(configDetailsHTML)
 
 	return writer.String()

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter.go
@@ -73,11 +73,11 @@ func formatEmailBody(emailTemplate string) (string, error) {
 	return templates.ExecuteToString(tmpl, data)
 }
 
-func addReportConfigDetails(emailBody, configDetailsHtml string) string {
+func addReportConfigDetails(emailBody, configDetailsHTML string) string {
 	var writer strings.Builder
 	writer.WriteString(emailBody)
 	writer.WriteString("\n\n")
-	writer.WriteString(configDetailsHtml)
+	writer.WriteString(configDetailsHTML)
 
 	return writer.String()
 }

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter.go
@@ -1,0 +1,189 @@
+package reportgenerator
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/branding"
+	"github.com/stackrox/rox/pkg/templates"
+	"github.com/stackrox/rox/pkg/timestamp"
+)
+
+const (
+	MaxConfigNameLenInSubject     = 40
+	MaxCollectionNameLenInSubject = 40
+)
+
+var (
+	cveSeverityToText = map[storage.VulnerabilitySeverity]string{
+		storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY:   "Unknown",
+		storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY:       "Low",
+		storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY:  "Moderate",
+		storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY: "Important",
+		storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY:  "Critical",
+	}
+
+	fixabilityToText = map[storage.VulnerabilityReportFilters_Fixability]string{
+		storage.VulnerabilityReportFilters_FIXABLE:     "Fixable",
+		storage.VulnerabilityReportFilters_NOT_FIXABLE: "Not Fixable",
+	}
+
+	imageTypeToText = map[storage.VulnerabilityReportFilters_ImageType]string{
+		storage.VulnerabilityReportFilters_DEPLOYED: "Deployed Images",
+		storage.VulnerabilityReportFilters_WATCHED:  "Watched Images",
+	}
+)
+
+func formatEmailSubject(subjectTemplate string, snapshot *storage.ReportSnapshot) (string, error) {
+	configName := snapshot.GetName()
+	if len(configName) > MaxConfigNameLenInSubject {
+		configName = fmt.Sprintf("%s...", configName[0:MaxConfigNameLenInSubject])
+	}
+	collectionName := snapshot.GetCollection().GetName()
+	if len(collectionName) > MaxCollectionNameLenInSubject {
+		collectionName = fmt.Sprintf("%s...", collectionName[0:MaxCollectionNameLenInSubject])
+	}
+
+	data := &reportEmailSubjectFormat{
+		BrandedProductNameShort: branding.GetProductNameShort(),
+		ReportConfigName:        configName,
+		CollectionName:          collectionName,
+	}
+	tmpl, err := template.New("emailSubject").Parse(subjectTemplate)
+	if err != nil {
+		return "", err
+	}
+	return templates.ExecuteToString(tmpl, data)
+}
+
+func formatEmailBody(emailTemplate string) (string, error) {
+	data := &reportEmailBodyFormat{
+		BrandedProductName:      branding.GetProductName(),
+		BrandedProductNameShort: branding.GetProductNameShort(),
+	}
+
+	tmpl, err := template.New("emailBody").Parse(emailTemplate)
+	if err != nil {
+		return "", err
+	}
+	return templates.ExecuteToString(tmpl, data)
+}
+
+func addReportConfigDetails(emailBody, configDetailsHtml string) string {
+	var writer strings.Builder
+	writer.WriteString(emailBody)
+	writer.WriteString("\n\n")
+	writer.WriteString(configDetailsHtml)
+
+	return writer.String()
+}
+
+func formatReportConfigurationDetails(snapshot *storage.ReportSnapshot) (string, error) {
+	var writer strings.Builder
+
+	writer.WriteString("<html>")
+	writer.WriteString("<body>")
+
+	err := validateSnapshot(snapshot)
+	if err != nil {
+		return "", err
+	}
+	reportFilters := snapshot.GetVulnReportFilters()
+
+	writer.WriteString("<table style=\"width: 100%; border-collapse: collapse; border: none; text-align: left;\">")
+
+	// Add severities and fixabilities
+	fillTableHeadings(&writer, "CVE Severity", "CVE Status")
+	writer.WriteString("<tr>")
+	fillTableCellWithValues(&writer, reportFilters.GetSeverities())
+	fixabilities := expandFixability(reportFilters.GetFixability())
+	fillTableCellWithValues(&writer, fixabilities)
+	writer.WriteString("</tr>")
+
+	// Add collection, image types and CVEs discovered since filters
+	fillTableHeadings(&writer, "Report Scope", "Image Type", "CVEs discovered since")
+	writer.WriteString("<tr>")
+	fillTableCellWithValues(&writer, snapshot.GetCollection())
+	fillTableCellWithValues(&writer, reportFilters.GetImageTypes())
+	fillTableCellWithValues(&writer, reportFilters.GetCvesSince())
+	writer.WriteString("</tr>")
+
+	writer.WriteString("</table>")
+	writer.WriteString("</body>")
+	writer.WriteString("</html>")
+
+	return writer.String(), nil
+}
+
+func expandFixability(fixability storage.VulnerabilityReportFilters_Fixability) []storage.VulnerabilityReportFilters_Fixability {
+	if fixability == storage.VulnerabilityReportFilters_BOTH {
+		return []storage.VulnerabilityReportFilters_Fixability{
+			storage.VulnerabilityReportFilters_FIXABLE,
+			storage.VulnerabilityReportFilters_NOT_FIXABLE,
+		}
+	}
+	return []storage.VulnerabilityReportFilters_Fixability{fixability}
+}
+
+func fillTableHeadings(writer *strings.Builder, headings ...string) {
+	writer.WriteString("<tr>")
+	for _, h := range headings {
+		writer.WriteString(fmt.Sprintf("<th style=\"background-color: #f0f0f0; padding: 10px;\">%s</th>", h))
+	}
+	writer.WriteString("</tr>")
+}
+
+func fillTableCellWithValues(writer *strings.Builder, values ...interface{}) {
+	writer.WriteString("<td style=\"padding: 10px; word-wrap: break-word; white-space: normal;\">")
+	if len(values) > 0 {
+		writer.WriteString("<table style=\"width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;\">")
+		for _, valI := range values {
+			writer.WriteString("<tr><td style=\"padding: 10px;\">")
+			writer.WriteString(convertValueToFriendlyText(valI))
+			writer.WriteString("</td></tr>")
+		}
+		writer.WriteString("</table>")
+	}
+	writer.WriteString("</td>")
+}
+
+func convertValueToFriendlyText(valI interface{}) string {
+	switch val := valI.(type) {
+	case *storage.CollectionSnapshot:
+		return val.GetName()
+	case storage.VulnerabilitySeverity:
+		return cveSeverityToText[val]
+	case storage.VulnerabilityReportFilters_Fixability:
+		return fixabilityToText[val]
+	case storage.VulnerabilityReportFilters_ImageType:
+		return imageTypeToText[val]
+	case *storage.VulnerabilityReportFilters_AllVuln:
+		return "All Time"
+	case *storage.VulnerabilityReportFilters_SinceLastSentScheduledReport:
+		return "Last successful scheduled report"
+	case *storage.VulnerabilityReportFilters_SinceStartDate:
+		return timestamp.FromProtobuf(val.SinceStartDate).GoTime().Format("January 02, 2006")
+	default:
+		return ""
+	}
+}
+
+func validateSnapshot(snapshot *storage.ReportSnapshot) error {
+	reportFilters := snapshot.GetVulnReportFilters()
+	if reportFilters == nil {
+		return errors.New("Report snapshot is missing vulnerability report filters")
+	}
+	if snapshot.GetCollection() == nil {
+		return errors.New("Report snapshot is missing collection snapshot")
+	}
+	if len(reportFilters.GetImageTypes()) == 0 {
+		return errors.New("Report snapshot is missing image type filters")
+	}
+	if reportFilters.GetCvesSince() == nil {
+		return errors.New("Report snapshot is missing 'CVEs since' filter")
+	}
+	return nil
+}

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter.go
@@ -85,9 +85,6 @@ func addReportConfigDetails(emailBody, configDetailsHtml string) string {
 func formatReportConfigDetails(snapshot *storage.ReportSnapshot) (string, error) {
 	var writer strings.Builder
 
-	writer.WriteString("<html>")
-	writer.WriteString("<body>")
-
 	err := validateSnapshot(snapshot)
 	if err != nil {
 		return "", err
@@ -121,8 +118,6 @@ func formatReportConfigDetails(snapshot *storage.ReportSnapshot) (string, error)
 	writer.WriteString("</tr>")
 
 	writer.WriteString("</table>")
-	writer.WriteString("</body>")
-	writer.WriteString("</html>")
 
 	return writer.String(), nil
 }

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
@@ -36,7 +36,7 @@ func (s *EmailFormatterTestSuite) SetupSuite() {
 func (s *EmailFormatterTestSuite) TestFormatReportConfigDetails() {
 	for _, tc := range s.configDetailsTestCases() {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			configHtml, err := formatReportConfigDetails(tc.snapshot)
+			configHtml, err := formatReportConfigDetails(tc.snapshot, 50, 30)
 			s.Require().NoError(err)
 			expectedHtml := strings.ReplaceAll(tc.expectedHtml, "\n", "")
 			expectedHtml = strings.ReplaceAll(expectedHtml, "\t", "")
@@ -50,55 +50,50 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 		{
 			desc:     "All severities, image types, fixabilities; Cves since last scheduled report",
 			snapshot: testReportSnapshot(),
-			expectedHtml: `<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-						<tr>
-							<th style="background-color: #f0f0f0; padding: 10px;">CVE Severity</th>
-							<th style="background-color: #f0f0f0; padding: 10px;">CVE Status</th>
-						</tr>
-						<tr>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr><td style="padding: 10px;">Critical</td></tr>
-									<tr><td style="padding: 10px;">Important</td></tr>
-									<tr><td style="padding: 10px;">Moderate</td></tr>
-									<tr><td style="padding: 10px;">Low</td></tr>
-								</table>
-							</td>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr><td style="padding: 10px;">Fixable</td></tr>
-									<tr><td style="padding: 10px;">Not Fixable</td></tr>
-								</table>
-							</td>
-						</tr>
-						<tr>
-							<th style="background-color: #f0f0f0; padding: 10px;">Report Scope</th>
-							<th style="background-color: #f0f0f0; padding: 10px;">Image Type</th>
-							<th style="background-color: #f0f0f0; padding: 10px;">CVEs discovered since</th>
-						</tr>
-						<tr>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr>
-										<td style="padding: 10px;">
-											collection-1
-										</td>
-									</tr>
-								</table>
-							</td>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr><td style="padding: 10px;">Deployed Images</td></tr>
-									<tr><td style="padding: 10px;">Watched Images</td></tr>
-								</table>
-							</td>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr><td style="padding: 10px;">Last successful scheduled report</td></tr>
-								</table>
-							</td>
-						</tr>
-					</table>`,
+			expectedHtml: `<div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Config name: 
+							</span>
+							<span>config-1</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Number of CVEs found: 
+							</span>
+							<span>50 in Deployed images, 30 in Watched images</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								CVE severity: 
+							</span>
+							<span>Critical, Important, Moderate, Low</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								CVE status: 
+							</span>
+							<span>Fixable, Not fixable</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Report scope: 
+							</span>
+							<span>collection-1</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Image type: 
+							</span>
+							<span>Deployed images, Watched images</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								CVEs discovered since: 
+							</span>
+							<span>Last successful scheduled report</span>
+						</div>
+					</div>`,
 		},
 		{
 			desc: "All severities, image types, fixabilities; Cves since All time",
@@ -109,58 +104,53 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 				}
 				return snap
 			}(),
-			expectedHtml: `<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-						<tr>
-							<th style="background-color: #f0f0f0; padding: 10px;">CVE Severity</th>
-							<th style="background-color: #f0f0f0; padding: 10px;">CVE Status</th>
-						</tr>
-						<tr>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr><td style="padding: 10px;">Critical</td></tr>
-									<tr><td style="padding: 10px;">Important</td></tr>
-									<tr><td style="padding: 10px;">Moderate</td></tr>
-									<tr><td style="padding: 10px;">Low</td></tr>
-								</table>
-							</td>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr><td style="padding: 10px;">Fixable</td></tr>
-									<tr><td style="padding: 10px;">Not Fixable</td></tr>
-								</table>
-							</td>
-						</tr>
-						<tr>
-							<th style="background-color: #f0f0f0; padding: 10px;">Report Scope</th>
-							<th style="background-color: #f0f0f0; padding: 10px;">Image Type</th>
-							<th style="background-color: #f0f0f0; padding: 10px;">CVEs discovered since</th>
-						</tr>
-						<tr>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr>
-										<td style="padding: 10px;">
-											collection-1
-										</td>
-									</tr>
-								</table>
-							</td>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr><td style="padding: 10px;">Deployed Images</td></tr>
-									<tr><td style="padding: 10px;">Watched Images</td></tr>
-								</table>
-							</td>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr><td style="padding: 10px;">All Time</td></tr>
-								</table>
-							</td>
-						</tr>
-					</table>`,
+			expectedHtml: `<div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Config name: 
+							</span>
+							<span>config-1</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Number of CVEs found: 
+							</span>
+							<span>50 in Deployed images, 30 in Watched images</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								CVE severity: 
+							</span>
+							<span>Critical, Important, Moderate, Low</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								CVE status: 
+							</span>
+							<span>Fixable, Not fixable</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Report scope: 
+							</span>
+							<span>collection-1</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Image type: 
+							</span>
+							<span>Deployed images, Watched images</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								CVEs discovered since: 
+							</span>
+							<span>All time</span>
+						</div>
+					</div>`,
 		},
 		{
-			desc: "Critical severity, fixable CVEs, Watched Images; Cves since custom date",
+			desc: "Critical severity, fixable CVEs, Deployed Images; Cves since custom date",
 			snapshot: func() *storage.ReportSnapshot {
 				snap := testReportSnapshot()
 				snap.GetVulnReportFilters().Severities = []storage.VulnerabilitySeverity{
@@ -177,50 +167,50 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 				}
 				return snap
 			}(),
-			expectedHtml: `<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-						<tr>
-							<th style="background-color: #f0f0f0; padding: 10px;">CVE Severity</th>
-							<th style="background-color: #f0f0f0; padding: 10px;">CVE Status</th>
-						</tr>
-						<tr>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr><td style="padding: 10px;">Critical</td></tr>
-								</table>
-							</td>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr><td style="padding: 10px;">Fixable</td></tr>
-								</table>
-							</td>
-						</tr>
-						<tr>
-							<th style="background-color: #f0f0f0; padding: 10px;">Report Scope</th>
-							<th style="background-color: #f0f0f0; padding: 10px;">Image Type</th>
-							<th style="background-color: #f0f0f0; padding: 10px;">CVEs discovered since</th>
-						</tr>
-						<tr>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr>
-										<td style="padding: 10px;">
-											collection-1
-										</td>
-									</tr>
-								</table>
-							</td>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr><td style="padding: 10px;">Deployed Images</td></tr>
-								</table>
-							</td>
-							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
-								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
-									<tr><td style="padding: 10px;">January 20, 2023</td></tr>
-								</table>
-							</td>
-						</tr>
-					</table>`,
+			expectedHtml: `<div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Config name: 
+							</span>
+							<span>config-1</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Number of CVEs found: 
+							</span>
+							<span>50 in Deployed images, 30 in Watched images</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								CVE severity: 
+							</span>
+							<span>Critical</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								CVE status: 
+							</span>
+							<span>Fixable</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Report scope: 
+							</span>
+							<span>collection-1</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Image type: 
+							</span>
+							<span>Deployed images</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								CVEs discovered since: 
+							</span>
+							<span>January 20, 2023</span>
+						</div>
+					</div>`,
 		},
 	}
 	return cases

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
@@ -53,44 +53,37 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 			expectedHtml: `<div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								Config name: 
-							</span>
+								Config name: </span>
 							<span>config-1</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								Number of CVEs found: 
-							</span>
+								Number of CVEs found: </span>
 							<span>50 in Deployed images, 30 in Watched images</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								CVE severity: 
-							</span>
+								CVE severity: </span>
 							<span>Critical, Important, Moderate, Low</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								CVE status: 
-							</span>
+								CVE status: </span>
 							<span>Fixable, Not fixable</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								Report scope: 
-							</span>
+								Report scope: </span>
 							<span>collection-1</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								Image type: 
-							</span>
+								Image type: </span>
 							<span>Deployed images, Watched images</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								CVEs discovered since: 
-							</span>
+								CVEs discovered since: </span>
 							<span>Last successful scheduled report</span>
 						</div>
 					</div>`,

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
@@ -50,9 +50,7 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 		{
 			desc:     "All severities, image types, fixabilities; Cves since last scheduled report",
 			snapshot: testReportSnapshot(),
-			expectedHtml: `<html>
-				<body>
-					<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+			expectedHtml: `<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
 						<tr>
 							<th style="background-color: #f0f0f0; padding: 10px;">CVE Severity</th>
 							<th style="background-color: #f0f0f0; padding: 10px;">CVE Status</th>
@@ -101,9 +99,7 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 								</table>
 							</td>
 						</tr>
-					</table>
-				</body>
-				</html>`,
+					</table>`,
 		},
 		{
 			desc: "All severities, image types, fixabilities; Cves since All time",
@@ -114,9 +110,7 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 				}
 				return snap
 			}(),
-			expectedHtml: `<html>
-				<body>
-					<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+			expectedHtml: `<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
 						<tr>
 							<th style="background-color: #f0f0f0; padding: 10px;">CVE Severity</th>
 							<th style="background-color: #f0f0f0; padding: 10px;">CVE Status</th>
@@ -165,9 +159,7 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 								</table>
 							</td>
 						</tr>
-					</table>
-				</body>
-				</html>`,
+					</table>`,
 		},
 		{
 			desc: "Critical severity, fixable CVEs, Watched Images; Cves since custom date",
@@ -187,9 +179,7 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 				}
 				return snap
 			}(),
-			expectedHtml: `<html>
-				<body>
-					<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+			expectedHtml: `<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
 						<tr>
 							<th style="background-color: #f0f0f0; padding: 10px;">CVE Severity</th>
 							<th style="background-color: #f0f0f0; padding: 10px;">CVE Status</th>
@@ -233,9 +223,7 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 								</table>
 							</td>
 						</tr>
-					</table>
-				</body>
-				</html>`,
+					</table>`,
 		},
 	}
 	return cases

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
@@ -64,7 +64,6 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 									<tr><td style="padding: 10px;">Low</td></tr>
 								</table>
 							</td>
-				
 							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
 								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
 									<tr><td style="padding: 10px;">Fixable</td></tr>
@@ -124,7 +123,6 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 									<tr><td style="padding: 10px;">Low</td></tr>
 								</table>
 							</td>
-				
 							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
 								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
 									<tr><td style="padding: 10px;">Fixable</td></tr>
@@ -190,7 +188,6 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 									<tr><td style="padding: 10px;">Critical</td></tr>
 								</table>
 							</td>
-				
 							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
 								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
 									<tr><td style="padding: 10px;">Fixable</td></tr>

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/timeutil"
 	"github.com/stretchr/testify/suite"
 )
@@ -48,13 +49,19 @@ func (s *EmailFormatterTestSuite) TestFormatReportConfigDetails() {
 func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCase {
 	cases := []configDetailsTestCase{
 		{
-			desc:     "All severities, image types, fixabilities; Cves since last scheduled report",
-			snapshot: testReportSnapshot(),
+			desc: "All severities, image types, fixabilities; Cves since last scheduled report",
+			snapshot: func() *storage.ReportSnapshot {
+				snap := fixtures.GetReportSnapshot()
+				snap.GetVulnReportFilters().CvesSince = &storage.VulnerabilityReportFilters_SinceLastSentScheduledReport{
+					SinceLastSentScheduledReport: true,
+				}
+				return snap
+			}(),
 			expectedHtml: `<div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
 								Config name: </span>
-							<span>config-1</span>
+							<span>App Team 1 Report</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
@@ -89,55 +96,42 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 					</div>`,
 		},
 		{
-			desc: "All severities, image types, fixabilities; Cves since All time",
-			snapshot: func() *storage.ReportSnapshot {
-				snap := testReportSnapshot()
-				snap.GetVulnReportFilters().CvesSince = &storage.VulnerabilityReportFilters_AllVuln{
-					AllVuln: true,
-				}
-				return snap
-			}(),
+			desc:     "All severities, image types, fixabilities; Cves since All time",
+			snapshot: fixtures.GetReportSnapshot(),
 			expectedHtml: `<div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								Config name: 
-							</span>
-							<span>config-1</span>
+								Config name: </span>
+							<span>App Team 1 Report</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								Number of CVEs found: 
-							</span>
+								Number of CVEs found: </span>
 							<span>50 in Deployed images, 30 in Watched images</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								CVE severity: 
-							</span>
+								CVE severity: </span>
 							<span>Critical, Important, Moderate, Low</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								CVE status: 
-							</span>
+								CVE status: </span>
 							<span>Fixable, Not fixable</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								Report scope: 
-							</span>
+								Report scope: </span>
 							<span>collection-1</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								Image type: 
-							</span>
+								Image type: </span>
 							<span>Deployed images, Watched images</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								CVEs discovered since: 
-							</span>
+								CVEs discovered since: </span>
 							<span>All time</span>
 						</div>
 					</div>`,
@@ -145,7 +139,7 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 		{
 			desc: "Critical severity, fixable CVEs, Deployed Images; Cves since custom date",
 			snapshot: func() *storage.ReportSnapshot {
-				snap := testReportSnapshot()
+				snap := fixtures.GetReportSnapshot()
 				snap.GetVulnReportFilters().Severities = []storage.VulnerabilitySeverity{
 					storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
 				}
@@ -163,77 +157,41 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 			expectedHtml: `<div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								Config name: 
-							</span>
-							<span>config-1</span>
+								Config name: </span>
+							<span>App Team 1 Report</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								Number of CVEs found: 
-							</span>
+								Number of CVEs found: </span>
 							<span>50 in Deployed images, 30 in Watched images</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								CVE severity: 
-							</span>
+								CVE severity: </span>
 							<span>Critical</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								CVE status: 
-							</span>
+								CVE status: </span>
 							<span>Fixable</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								Report scope: 
-							</span>
+								Report scope: </span>
 							<span>collection-1</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								Image type: 
-							</span>
+								Image type: </span>
 							<span>Deployed images</span>
 						</div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
-								CVEs discovered since: 
-							</span>
+								CVEs discovered since: </span>
 							<span>January 20, 2023</span>
 						</div>
 					</div>`,
 		},
 	}
 	return cases
-}
-
-func testReportSnapshot() *storage.ReportSnapshot {
-	return &storage.ReportSnapshot{
-		ReportConfigurationId: "config-1",
-		Name:                  "config-1",
-		Collection: &storage.CollectionSnapshot{
-			Id:   "collection-1",
-			Name: "collection-1",
-		},
-		Filter: &storage.ReportSnapshot_VulnReportFilters{
-			VulnReportFilters: &storage.VulnerabilityReportFilters{
-				Fixability: storage.VulnerabilityReportFilters_BOTH,
-				Severities: []storage.VulnerabilitySeverity{
-					storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY,
-					storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
-					storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
-					storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
-				},
-				ImageTypes: []storage.VulnerabilityReportFilters_ImageType{
-					storage.VulnerabilityReportFilters_DEPLOYED,
-					storage.VulnerabilityReportFilters_WATCHED,
-				},
-				CvesSince: &storage.VulnerabilityReportFilters_SinceLastSentScheduledReport{
-					SinceLastSentScheduledReport: true,
-				},
-			},
-		},
-	}
 }

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
@@ -15,7 +15,7 @@ import (
 type configDetailsTestCase struct {
 	desc         string
 	snapshot     *storage.ReportSnapshot
-	expectedHtml string
+	expectedHTML string
 }
 
 func TestEmailFormatter(t *testing.T) {
@@ -37,11 +37,11 @@ func (s *EmailFormatterTestSuite) SetupSuite() {
 func (s *EmailFormatterTestSuite) TestFormatReportConfigDetails() {
 	for _, tc := range s.configDetailsTestCases() {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			configHtml, err := formatReportConfigDetails(tc.snapshot, 50, 30)
+			configHTML, err := formatReportConfigDetails(tc.snapshot, 50, 30)
 			s.Require().NoError(err)
-			expectedHtml := strings.ReplaceAll(tc.expectedHtml, "\n", "")
-			expectedHtml = strings.ReplaceAll(expectedHtml, "\t", "")
-			s.Require().Equal(expectedHtml, configHtml)
+			expectedHTML := strings.ReplaceAll(tc.expectedHTML, "\n", "")
+			expectedHTML = strings.ReplaceAll(expectedHTML, "\t", "")
+			s.Require().Equal(expectedHTML, configHTML)
 		})
 	}
 }
@@ -57,7 +57,7 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 				}
 				return snap
 			}(),
-			expectedHtml: `<div>
+			expectedHTML: `<div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
 								Config name: </span>
@@ -98,7 +98,7 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 		{
 			desc:     "All severities, image types, fixabilities; Cves since All time",
 			snapshot: fixtures.GetReportSnapshot(),
-			expectedHtml: `<div>
+			expectedHTML: `<div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
 								Config name: </span>
@@ -154,7 +154,7 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 				}
 				return snap
 			}(),
-			expectedHtml: `<div>
+			expectedHTML: `<div>
 						<div style="padding: 0 0 10px 0">
 							<span style="font-weight: bold; margin-right: 10px">
 								Config name: </span>

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
@@ -1,0 +1,271 @@
+package reportgenerator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/timeutil"
+	"github.com/stretchr/testify/suite"
+)
+
+type configDetailsTestCase struct {
+	desc         string
+	snapshot     *storage.ReportSnapshot
+	expectedHtml string
+}
+
+func TestEmailFormatter(t *testing.T) {
+	suite.Run(t, new(EmailFormatterTestSuite))
+}
+
+type EmailFormatterTestSuite struct {
+	suite.Suite
+}
+
+func (s *EmailFormatterTestSuite) SetupSuite() {
+	s.T().Setenv(env.VulnReportingEnhancements.EnvVar(), "true")
+	if !env.VulnReportingEnhancements.BooleanSetting() {
+		s.T().Skip("Skip tests when ROX_VULN_MGMT_REPORTING_ENHANCEMENTS disabled")
+		s.T().SkipNow()
+	}
+}
+
+func (s *EmailFormatterTestSuite) TestFormatReportConfigDetails() {
+	for _, tc := range s.configDetailsTestCases() {
+		s.T().Run(tc.desc, func(t *testing.T) {
+			configHtml, err := formatReportConfigDetails(tc.snapshot)
+			s.Require().NoError(err)
+			expectedHtml := strings.ReplaceAll(tc.expectedHtml, "\n", "")
+			expectedHtml = strings.ReplaceAll(expectedHtml, "\t", "")
+			s.Require().Equal(expectedHtml, configHtml)
+		})
+	}
+}
+
+func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCase {
+	cases := []configDetailsTestCase{
+		{
+			desc:     "All severities, image types, fixabilities; Cves since last scheduled report",
+			snapshot: testReportSnapshot(),
+			expectedHtml: `<html>
+				<body>
+					<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+						<tr>
+							<th style="background-color: #f0f0f0; padding: 10px;">CVE Severity</th>
+							<th style="background-color: #f0f0f0; padding: 10px;">CVE Status</th>
+						</tr>
+						<tr>
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr><td style="padding: 10px;">Critical</td></tr>
+									<tr><td style="padding: 10px;">Important</td></tr>
+									<tr><td style="padding: 10px;">Moderate</td></tr>
+									<tr><td style="padding: 10px;">Low</td></tr>
+								</table>
+							</td>
+				
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr><td style="padding: 10px;">Fixable</td></tr>
+									<tr><td style="padding: 10px;">Not Fixable</td></tr>
+								</table>
+							</td>
+						</tr>
+						<tr>
+							<th style="background-color: #f0f0f0; padding: 10px;">Report Scope</th>
+							<th style="background-color: #f0f0f0; padding: 10px;">Image Type</th>
+							<th style="background-color: #f0f0f0; padding: 10px;">CVEs discovered since</th>
+						</tr>
+						<tr>
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr>
+										<td style="padding: 10px;">
+											collection-1
+										</td>
+									</tr>
+								</table>
+							</td>
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr><td style="padding: 10px;">Deployed Images</td></tr>
+									<tr><td style="padding: 10px;">Watched Images</td></tr>
+								</table>
+							</td>
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr><td style="padding: 10px;">Last successful scheduled report</td></tr>
+								</table>
+							</td>
+						</tr>
+					</table>
+				</body>
+				</html>`,
+		},
+		{
+			desc: "All severities, image types, fixabilities; Cves since All time",
+			snapshot: func() *storage.ReportSnapshot {
+				snap := testReportSnapshot()
+				snap.GetVulnReportFilters().CvesSince = &storage.VulnerabilityReportFilters_AllVuln{
+					AllVuln: true,
+				}
+				return snap
+			}(),
+			expectedHtml: `<html>
+				<body>
+					<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+						<tr>
+							<th style="background-color: #f0f0f0; padding: 10px;">CVE Severity</th>
+							<th style="background-color: #f0f0f0; padding: 10px;">CVE Status</th>
+						</tr>
+						<tr>
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr><td style="padding: 10px;">Critical</td></tr>
+									<tr><td style="padding: 10px;">Important</td></tr>
+									<tr><td style="padding: 10px;">Moderate</td></tr>
+									<tr><td style="padding: 10px;">Low</td></tr>
+								</table>
+							</td>
+				
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr><td style="padding: 10px;">Fixable</td></tr>
+									<tr><td style="padding: 10px;">Not Fixable</td></tr>
+								</table>
+							</td>
+						</tr>
+						<tr>
+							<th style="background-color: #f0f0f0; padding: 10px;">Report Scope</th>
+							<th style="background-color: #f0f0f0; padding: 10px;">Image Type</th>
+							<th style="background-color: #f0f0f0; padding: 10px;">CVEs discovered since</th>
+						</tr>
+						<tr>
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr>
+										<td style="padding: 10px;">
+											collection-1
+										</td>
+									</tr>
+								</table>
+							</td>
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr><td style="padding: 10px;">Deployed Images</td></tr>
+									<tr><td style="padding: 10px;">Watched Images</td></tr>
+								</table>
+							</td>
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr><td style="padding: 10px;">All Time</td></tr>
+								</table>
+							</td>
+						</tr>
+					</table>
+				</body>
+				</html>`,
+		},
+		{
+			desc: "Critical severity, fixable CVEs, Watched Images; Cves since custom date",
+			snapshot: func() *storage.ReportSnapshot {
+				snap := testReportSnapshot()
+				snap.GetVulnReportFilters().Severities = []storage.VulnerabilitySeverity{
+					storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+				}
+				snap.GetVulnReportFilters().Fixability = storage.VulnerabilityReportFilters_FIXABLE
+				snap.GetVulnReportFilters().ImageTypes = []storage.VulnerabilityReportFilters_ImageType{
+					storage.VulnerabilityReportFilters_DEPLOYED,
+				}
+				dateTs, err := types.TimestampProto(timeutil.MustParse("2006-01-02 15:04:05", "2023-01-20 22:42:02"))
+				s.Require().NoError(err)
+				snap.GetVulnReportFilters().CvesSince = &storage.VulnerabilityReportFilters_SinceStartDate{
+					SinceStartDate: dateTs,
+				}
+				return snap
+			}(),
+			expectedHtml: `<html>
+				<body>
+					<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+						<tr>
+							<th style="background-color: #f0f0f0; padding: 10px;">CVE Severity</th>
+							<th style="background-color: #f0f0f0; padding: 10px;">CVE Status</th>
+						</tr>
+						<tr>
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr><td style="padding: 10px;">Critical</td></tr>
+								</table>
+							</td>
+				
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr><td style="padding: 10px;">Fixable</td></tr>
+								</table>
+							</td>
+						</tr>
+						<tr>
+							<th style="background-color: #f0f0f0; padding: 10px;">Report Scope</th>
+							<th style="background-color: #f0f0f0; padding: 10px;">Image Type</th>
+							<th style="background-color: #f0f0f0; padding: 10px;">CVEs discovered since</th>
+						</tr>
+						<tr>
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr>
+										<td style="padding: 10px;">
+											collection-1
+										</td>
+									</tr>
+								</table>
+							</td>
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr><td style="padding: 10px;">Deployed Images</td></tr>
+								</table>
+							</td>
+							<td style="padding: 10px; word-wrap: break-word; white-space: normal;">
+								<table style="width: 100%; border-collapse: collapse; table-layout: fixed; border: none; text-align: left;">
+									<tr><td style="padding: 10px;">January 20, 2023</td></tr>
+								</table>
+							</td>
+						</tr>
+					</table>
+				</body>
+				</html>`,
+		},
+	}
+	return cases
+}
+
+func testReportSnapshot() *storage.ReportSnapshot {
+	return &storage.ReportSnapshot{
+		ReportConfigurationId: "config-1",
+		Name:                  "config-1",
+		Collection: &storage.CollectionSnapshot{
+			Id:   "collection-1",
+			Name: "collection-1",
+		},
+		Filter: &storage.ReportSnapshot_VulnReportFilters{
+			VulnReportFilters: &storage.VulnerabilityReportFilters{
+				Fixability: storage.VulnerabilityReportFilters_BOTH,
+				Severities: []storage.VulnerabilitySeverity{
+					storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY,
+					storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+					storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+					storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+				},
+				ImageTypes: []storage.VulnerabilityReportFilters_ImageType{
+					storage.VulnerabilityReportFilters_DEPLOYED,
+					storage.VulnerabilityReportFilters_WATCHED,
+				},
+				CvesSince: &storage.VulnerabilityReportFilters_SinceLastSentScheduledReport{
+					SinceLastSentScheduledReport: true,
+				},
+			},
+		},
+	}
+}

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -130,11 +130,11 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 		}
 		// If it is an empty report, do not send an attachment in the final notification email and the email body
 		// will indicate that no vulns were found
-		templateStr := defaultEmailBodyTemplate_vulnsFound
+		templateStr := defaultEmailBodyTemplate
 		if zippedSCVResult.NumDeployedImageCVEs == 0 && zippedSCVResult.NumWatchedImageCVEs == 0 {
 			// If it is an empty report, the email body will indicate that no vulns were found
 			zippedCSVData = nil
-			templateStr = defaultEmailBodyTemplate_noVulnsFound
+			templateStr = defaultNoVulnsEmailBodyTemplate
 		}
 
 		defaultEmailBody, err := formatEmailBody(templateStr)
@@ -142,7 +142,7 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 			return errors.Wrap(err, "Error generating email body")
 		}
 
-		configDetailsHtml, err := formatReportConfigDetails(req.ReportSnapshot, zippedSCVResult.NumDeployedImageCVEs,
+		configDetailsHTML, err := formatReportConfigDetails(req.ReportSnapshot, zippedSCVResult.NumDeployedImageCVEs,
 			zippedSCVResult.NumWatchedImageCVEs)
 		if err != nil {
 			return errors.Wrap(err, "Error adding report config details")
@@ -161,7 +161,7 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 			if customBody != "" {
 				emailBody = customBody
 			}
-			emailBodyWithConfigDetails := addReportConfigDetails(emailBody, configDetailsHtml)
+			emailBodyWithConfigDetails := addReportConfigDetails(emailBody, configDetailsHTML)
 			err := rg.retryableSendReportResults(reportNotifier, notifierSnap.GetEmailConfig().GetMailingLists(),
 				zippedCSVData, emailSubject, emailBodyWithConfigDetails)
 			if err != nil {

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/gogo/protobuf/types"
@@ -25,7 +24,6 @@ import (
 	watchedImageDS "github.com/stackrox/rox/central/watchedimage/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/branding"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
 	"github.com/stackrox/rox/pkg/logging"
@@ -35,7 +33,6 @@ import (
 	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
-	"github.com/stackrox/rox/pkg/templates"
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -126,19 +123,30 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 		}
 
 	case storage.ReportStatus_EMAIL:
+		emailSubject, err := formatEmailSubject(defaultEmailSubjectTemplate, req.ReportSnapshot)
+		if err != nil {
+			return errors.Wrap(err, "Error generating email subject")
+		}
 		// If it is an empty report, do not send an attachment in the final notification email and the email body
 		// will indicate that no vulns were found
-		templateStr := vulnReportEmailTemplate
+		templateStr := defaultEmailBodyTemplate_vulnsFound
 		if empty {
 			// If it is an empty report, the email body will indicate that no vulns were found
 			zippedCSVData = nil
-			templateStr = noVulnsFoundEmailTemplate
+			templateStr = defaultEmailBodyTemplate_noVulnsFound
 		}
-		errorList := errorhelpers.NewErrorList("Error sending email notifications: ")
-		defaultMessageText, err := formatMessage(req.DataStartTime, templateStr, req.ReportSnapshot.GetVulnReportFilters().GetImageTypes())
+
+		defaultEmailBody, err := formatEmailBody(templateStr)
 		if err != nil {
-			return errors.Wrap(err, "error formatting the report email text")
+			return errors.Wrap(err, "Error generating email body")
 		}
+
+		configDetailsHtml, err := formatReportConfigurationDetails(req.ReportSnapshot)
+		if err != nil {
+			return errors.Wrap(err, "Error adding report config details")
+		}
+
+		errorList := errorhelpers.NewErrorList("Error sending email notifications: ")
 		for _, notifierSnap := range req.ReportSnapshot.GetNotifiers() {
 			nf := rg.notificationProcessor.GetNotifier(reportGenCtx, notifierSnap.GetEmailConfig().GetNotifierId())
 			reportNotifier, ok := nf.(notifiers.ReportNotifier)
@@ -147,12 +155,13 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 				continue
 			}
 			customBody := notifierSnap.GetEmailConfig().GetCustomBody()
-			messageText := defaultMessageText
+			emailBody := defaultEmailBody
 			if customBody != "" {
-				messageText = customBody
+				emailBody = customBody
 			}
-			err = rg.retryableSendReportResults(reportNotifier, notifierSnap.GetEmailConfig().GetMailingLists(),
-				zippedCSVData, messageText, notifierSnap.GetEmailConfig().GetCustomSubject())
+			emailBodyWithConfigDetails := addReportConfigDetails(emailBody, configDetailsHtml)
+			err := rg.retryableSendReportResults(reportNotifier, notifierSnap.GetEmailConfig().GetMailingLists(),
+				zippedCSVData, emailSubject, emailBodyWithConfigDetails)
 			if err != nil {
 				errorList.AddError(errors.Errorf("Error sending email for notifier '%s': %s",
 					notifierSnap.GetEmailConfig().GetNotifierId(), err))
@@ -325,9 +334,9 @@ func execQuery[T any](rg *reportGeneratorImpl, gqlQuery, opName, scopeQuery, cve
 /* Utility Functions */
 
 func (rg *reportGeneratorImpl) retryableSendReportResults(reportNotifier notifiers.ReportNotifier, mailingList []string,
-	zippedCSVData *bytes.Buffer, messageText string, subject string) error {
+	zippedCSVData *bytes.Buffer, emailSubject, emailBody string) error {
 	return retry.WithRetry(func() error {
-		return reportNotifier.ReportNotify(reportGenCtx, zippedCSVData, mailingList, messageText, subject)
+		return reportNotifier.ReportNotify(reportGenCtx, zippedCSVData, mailingList, emailSubject, emailBody)
 	},
 		retry.OnlyRetryableErrors(),
 		retry.Tries(3),
@@ -411,36 +420,6 @@ func filterOnImageType(imageTypes []storage.VulnerabilityReportFilters_ImageType
 		}
 	}
 	return false
-}
-
-func formatMessage(dataStartTime *types.Timestamp, emailTemplate string,
-	imageTypes []storage.VulnerabilityReportFilters_ImageType) (string, error) {
-	var imageTypesStr string
-	includeDeployed := filterOnImageType(imageTypes, storage.VulnerabilityReportFilters_DEPLOYED)
-	includeWatched := filterOnImageType(imageTypes, storage.VulnerabilityReportFilters_WATCHED)
-	if includeDeployed && includeWatched {
-		imageTypesStr = "deployed and watched"
-	} else if includeDeployed {
-		imageTypesStr = "deployed"
-	} else {
-		imageTypesStr = "watched"
-	}
-
-	data := &reportEmailFormat{
-		BrandedProductName: branding.GetProductName(),
-		WhichVulns:         "for all vulnerabilities",
-		DateStr:            time.Now().Format("January 02, 2006"),
-		ImageTypes:         imageTypesStr,
-	}
-	if dataStartTime != nil {
-		data.WhichVulns = fmt.Sprintf("for new vulnerabilities since %s",
-			timestamp.FromProtobuf(dataStartTime).GoTime().Format("January 02, 2006"))
-	}
-	tmpl, err := template.New("emailBody").Parse(emailTemplate)
-	if err != nil {
-		return "", err
-	}
-	return templates.ExecuteToString(tmpl, data)
 }
 
 func orderByClusterAndNamespace(deployments []*common.Deployment) []*common.Deployment {

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -141,7 +141,7 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 			return errors.Wrap(err, "Error generating email body")
 		}
 
-		configDetailsHtml, err := formatReportConfigurationDetails(req.ReportSnapshot)
+		configDetailsHtml, err := formatReportConfigDetails(req.ReportSnapshot)
 		if err != nil {
 			return errors.Wrap(err, "Error adding report config details")
 		}

--- a/central/reports/scheduler/v2/reportgenerator/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/types.go
@@ -12,9 +12,13 @@ type ReportRequest struct {
 	DataStartTime  *types.Timestamp
 }
 
-type reportEmailFormat struct {
-	BrandedProductName string
-	WhichVulns         string
-	DateStr            string
-	ImageTypes         string
+type reportEmailBodyFormat struct {
+	BrandedProductName      string
+	BrandedProductNameShort string
+}
+
+type reportEmailSubjectFormat struct {
+	BrandedProductNameShort string
+	ReportConfigName        string
+	CollectionName          string
 }

--- a/pkg/fixtures/report_snapshot.go
+++ b/pkg/fixtures/report_snapshot.go
@@ -24,6 +24,24 @@ func GetReportSnapshot() *storage.ReportSnapshot {
 				},
 			},
 		},
+		Filter: &storage.ReportSnapshot_VulnReportFilters{
+			VulnReportFilters: &storage.VulnerabilityReportFilters{
+				Fixability: storage.VulnerabilityReportFilters_BOTH,
+				Severities: []storage.VulnerabilitySeverity{
+					storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY,
+					storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+					storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+					storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+				},
+				ImageTypes: []storage.VulnerabilityReportFilters_ImageType{
+					storage.VulnerabilityReportFilters_DEPLOYED,
+					storage.VulnerabilityReportFilters_WATCHED,
+				},
+				CvesSince: &storage.VulnerabilityReportFilters_AllVuln{
+					AllVuln: true,
+				},
+			},
+		},
 		ReportStatus: &storage.ReportStatus{
 			RunState:                 storage.ReportStatus_PREPARING,
 			QueuedAt:                 timestamp.TimestampNow(),

--- a/pkg/notifiers/email/email.go
+++ b/pkg/notifiers/email/email.go
@@ -308,8 +308,9 @@ func (e *email) AlertNotify(ctx context.Context, alert *storage.Alert) error {
 	return e.sendEmail(ctx, recipient, subject, body)
 }
 
-// ReportNotify takes in reporting data, a list of intended recipients, and an email message and subject to send out a report. Set subject to empty string for v1
-func (e *email) ReportNotify(ctx context.Context, zippedReportData *bytes.Buffer, recipients []string, messageText string, subject string) error {
+// ReportNotify takes in reporting data, a list of intended recipients, email subject and an email message to send out a report.
+// Set subject to empty string for v1 report configs
+func (e *email) ReportNotify(ctx context.Context, zippedReportData *bytes.Buffer, recipients []string, subject, messageText string) error {
 	var from string
 	if e.config.GetFrom() != "" {
 		from = fmt.Sprintf("%s <%s>", e.config.GetFrom(), e.config.GetSender())
@@ -319,7 +320,6 @@ func (e *email) ReportNotify(ctx context.Context, zippedReportData *bytes.Buffer
 	if subject == "" {
 		subject = fmt.Sprintf("%s Image Vulnerability Report for %s", branding.GetProductNameShort(), time.Now().Format("02-January-2006"))
 	}
-
 	msg := message{
 		To:        recipients,
 		From:      from,

--- a/pkg/notifiers/report_notifier.go
+++ b/pkg/notifiers/report_notifier.go
@@ -11,5 +11,5 @@ import (
 type ReportNotifier interface {
 	Notifier
 	// ReportNotify triggers the plugins to send a notification about a report
-	ReportNotify(ctx context.Context, zippedReportData *bytes.Buffer, recipients []string, messageText string, subject string) error
+	ReportNotify(ctx context.Context, zippedReportData *bytes.Buffer, recipients []string, subject, messageText string) error
 }


### PR DESCRIPTION
## Description

Same as title

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- Unit tests

#### Manual tests
##### Default subject with config name and collection name

##### WhenCVEs since : All Time

##### When CVEs since : Last successful scheduled report

##### Long collection name: Subject should truncate the name.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
