### PR TITLE
fix(CI): operator build out of space

### DIFF
--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -19,4 +19,3 @@ runs:
         key: go-v3-${{ github.job }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           go-v3-${{ github.job }}-${{ hashFiles('**/go.sum') }}
-          go-v3-${{ github.job }}-


### PR DESCRIPTION
## Description

The operator build for release-4.2 was running out of space. This change removes the job only cache restore key which might be the culprit.

Re: https://redhat-internal.slack.com/archives/C05MSQS5FCJ/p1694559313461909?thread_ts=1694536962.249039&cid=C05MSQS5FCJ

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Reproduced the issue: https://github.com/stackrox/stackrox/actions/runs/6165725672
Verified fixed: https://github.com/stackrox/stackrox/actions/runs/6165852925
