### PR TITLE
chore(ci): Set BUILD_IMAGE_VERSION to 0.3.60

### DIFF
--- a/.github/workflows/build-scanner.yml
+++ b/.github/workflows/build-scanner.yml
@@ -22,7 +22,7 @@ jobs:
         goarch: ['amd64', 'arm64', 'ppc64le']
         goos: ['linux']
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.60
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -62,7 +62,7 @@ jobs:
     needs:
     - build-and-push
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.60
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,7 @@ jobs:
       ROX_PRODUCT_BRANDING: ${{ matrix.branding }}
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
   pre-build-cli:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -148,7 +148,7 @@ jobs:
     needs: define-job-matrix
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -204,7 +204,7 @@ jobs:
   pre-build-docs:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -257,7 +257,7 @@ jobs:
       GO_BINARIES_BUILD_ARTIFACT: ""
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -420,7 +420,7 @@ jobs:
     env:
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -508,7 +508,7 @@ jobs:
   build-and-push-operator:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -586,7 +586,7 @@ jobs:
   build-and-push-mock-grpc-server:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -639,7 +639,7 @@ jobs:
     needs:
       - build-and-push-main
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
       env:
         STACKROX_CI_INSTANCE_API_KEY: ${{ secrets.STACKROX_CI_INSTANCE_API_KEY }}
         STACKROX_CI_INSTANCE_CENTRAL_HOST: ${{ secrets.STACKROX_CI_INSTANCE_CENTRAL_HOST }}

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -20,7 +20,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -80,7 +80,7 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
     timeout-minutes: 240
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,7 +18,7 @@ jobs:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -75,7 +75,7 @@ jobs:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -121,7 +121,7 @@ jobs:
   ui:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -156,7 +156,7 @@ jobs:
   local-roxctl-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -27,4 +27,4 @@
 # For an example, see https://github.com/stackrox/stackrox/pull/2762 and its counterpart
 # https://github.com/openshift/release/pull/31561
 
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-stackrox-build-0.3.59
+stackrox-build-0.3.60

--- a/scale/signatures/deploy.yaml
+++ b/scale/signatures/deploy.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: update-signature
-            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.3.59
+            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.3.60
             imagePullPolicy: IfNotPresent
             command:
             - /bin/bash

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -146,7 +146,7 @@ if [[ ! -f "/i-am-rox-ci-image" ]]; then
       --platform linux/amd64 \
       --rm -it \
       --entrypoint="$0" \
-      quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59 "$@"
+      quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.60 "$@"
     exit 0
 fi
 

--- a/tests/roxctl/bats-tests/cluster/centraldb-generate.bats
+++ b/tests/roxctl/bats-tests/cluster/centraldb-generate.bats
@@ -5,7 +5,12 @@ load "../helpers.bash"
 output_dir=""
 
 setup_file() {
-  echo "Testing roxctl version: '$(roxctl-development version)'" >&3
+  local -r roxctl_version="$(roxctl-development version || true)"
+  echo "Testing roxctl version: '${roxctl_version}'" >&3
+  echo "Using Bats version: '${BATS_VERSION}'" >&3
+
+  # Using flags on `run` requires at least BATS_VERSION=1.5.0
+  bats_require_minimum_version 1.5.0
 
   command -v cat || skip "Command 'cat' required."
   command -v grep || skip "Command 'grep' required."

--- a/tests/roxctl/bats-tests/cluster/scanner-generate.bats
+++ b/tests/roxctl/bats-tests/cluster/scanner-generate.bats
@@ -7,6 +7,10 @@ output_dir=""
 setup_file() {
   local -r roxctl_version="$(roxctl-development version || true)"
   echo "Testing roxctl version: '${roxctl_version}'" >&3
+  echo "Using Bats version: '${BATS_VERSION}'" >&3
+
+  # Using flags on `run` requires at least BATS_VERSION=1.5.0
+  bats_require_minimum_version 1.5.0
 
   command -v cat || skip "Command 'cat' required."
   command -v grep || skip "Command 'grep' required."


### PR DESCRIPTION
## Description

This bumps the version of the builder image that includes bats v1.10.0.
Ref: https://github.com/stackrox/rox-ci-image/pull/189

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] Ensured that local bats tests are not failing 
- [x] After adding [3bc95e5](https://github.com/stackrox/stackrox/pull/7781/commits/3bc95e56f00dca46fbe2ee6cecabc181cf09fe84) and using the new CI image: Made sure that the Bats version reported in non-groovy is `1.10` - see https://github.com/openshift/release/pull/43304#issuecomment-1725799159
- [x] Followed [this manual](https://docs.engineering.redhat.com/pages/viewpage.action?pageId=306785028) and opened a validation PR on openshift/release https://github.com/openshift/release/pull/43304

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
