### PR TITLE
fix(ci): Generate slack message, then send it

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -40,9 +40,10 @@ ci_exit_trap() {
 
     finalize_job_record "${exit_code}" "false"
 
-    (send_slack_notice_for_failures_on_merge "${exit_code}") || { echo "ERROR: Could not slack a test failure message"; }
-
+    # `post_process_test_results` will generate the Slack attachment first, then
+    # `send_slack_notice_for_failures_on_merge` will check that attachment and send it
     post_process_test_results
+    (send_slack_notice_for_failures_on_merge "${exit_code}") || { echo "ERROR: Could not slack a test failure message"; }
 
     while [[ -e /tmp/hold ]]; do
         info "Holding this job for debug"


### PR DESCRIPTION
## Description

This fixes a bug with the CI where, on PR failure, would first send a Slack message informing the developer of the commit of the failure, _then_ generate the attachment from `junit2jira`. These changes simply swap that order