### PR TITLE
chore: Remove vulnerability request creation race

### DIFF
--- a/central/vulnerabilityrequest/datastore/datastore.go
+++ b/central/vulnerabilityrequest/datastore/datastore.go
@@ -53,7 +53,7 @@ func New(s store.Store, searcher searcher.Searcher,
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(t *testing.T, pool postgres.DB, pendingReqCache cache.VulnReqCache, activeReqCache cache.VulnReqCache) (DataStore, error) {
+func GetTestPostgresDataStore(t testing.TB, pool postgres.DB, pendingReqCache cache.VulnReqCache, activeReqCache cache.VulnReqCache) (DataStore, error) {
 	testutils.MustBeInTest(t)
 
 	storage := pgStore.New(pool)

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -89,18 +89,18 @@ func (m *managerImpl) Create(ctx context.Context, req *storage.VulnerabilityRequ
 	// There might be another request where the scope object evaluates to the same, but that is allowed. Just not the same CVE.
 
 	// Find all requests for this CVE that are active and approved
-	reqs, err := m.vulnReqs.SearchRawRequests(ctx, utils.GetEnforcedRequestsV1Query(req.GetCves().GetCves()...))
+	existingReqs, err := m.vulnReqs.SearchRawRequests(ctx, utils.GetEnforcedRequestsV1Query(req.GetCves().GetCves()...))
 	if err != nil {
 		return errors.Wrap(err, "could not search for other vulnerability requests")
 	}
-	if idx := utils.FirstIndexMatchingScope(req, reqs); idx != -1 {
+	if idx := utils.FirstIndexMatchingScope(req, existingReqs); idx != -1 {
 		newReqCVEs := set.NewStringSet(req.GetCves().GetCves()...)
-		existingReqCVEs := set.NewStringSet(req.GetCves().GetCves()...)
+		existingReqCVEs := set.NewStringSet(existingReqs[idx].GetCves().GetCves()...)
 		commonCVEs := newReqCVEs.Intersect(existingReqCVEs)
 
 		return errors.Wrap(errox.AlreadyExists,
 			fmt.Sprintf("CVEs %s are already covered by request %s for the specified scope",
-				commonCVEs.AsSlice(), reqs[idx].GetId()))
+				commonCVEs.AsSlice(), existingReqs[idx].GetId()))
 	}
 
 	req.Id = uuid.NewV4().String()

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -26,7 +26,9 @@ import (
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	deploymentOptionsMap "github.com/stackrox/rox/pkg/search/options/deployments"
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/uuid"
+	"golang.org/x/sync/semaphore"
 )
 
 var (
@@ -51,6 +53,7 @@ type managerImpl struct {
 	reprocessor       reprocessor.Loop
 	activeReqCache    cache.VulnReqCache
 	pendingReqCache   cache.VulnReqCache
+	upsertSem         *semaphore.Weighted
 
 	reObserveTimedDeferralsTickerDuration     time.Duration
 	reObserveWhenFixedDeferralsTickerDuration time.Duration
@@ -75,14 +78,27 @@ func (m *managerImpl) Create(ctx context.Context, req *storage.VulnerabilityRequ
 		return errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 
+	// Process one request at a time since there could be a race between validation and database update.
+	m.upsertSem.Acquire(ctx, 1)
+	defer m.upsertSem.Release(1)
+
+	// Validate that the CVEs in `req` are not snoozed for the scope specified in the request.
+	// Only one request can exist for the exact same CVE and scope _object_ combo regardless of target state (FP or defer).
+	// There might be another request where the scope object evaluates to the same, but that is allowed. Just not the same CVE.
+
 	// Find all requests for this CVE that are active and approved
-	reqs, err := m.vulnReqs.SearchRawRequests(ctx, utils.GetQueryForApprovedReqsWithSimilarScope(req.GetCves().GetCves()...))
+	reqs, err := m.vulnReqs.SearchRawRequests(ctx, utils.GetEnforcedRequestsV1Query(req.GetCves().GetCves()...))
 	if err != nil {
 		return errors.Wrap(err, "could not search for other vulnerability requests")
 	}
-	// And validate that this CVE + VulnReqScope combo hasn't been unwatched already
-	if err := validator.ValidateSuppressVulnRequestIsUnique(req, reqs); err != nil {
-		return errors.Wrap(errox.AlreadyExists, err.Error())
+	if idx := utils.FirstIndexMatchingScope(req, reqs); idx != -1 {
+		newReqCVEs := set.NewStringSet(req.GetCves().GetCves()...)
+		existingReqCVEs := set.NewStringSet(req.GetCves().GetCves()...)
+		commonCVEs := newReqCVEs.Intersect(existingReqCVEs)
+
+		return errors.Wrap(errox.AlreadyExists,
+			fmt.Sprintf("CVEs %s are already covered by request %s for the specified scope",
+				commonCVEs.AsSlice(), reqs[idx].GetId()))
 	}
 
 	req.Id = uuid.NewV4().String()
@@ -99,14 +115,22 @@ func (m *managerImpl) Approve(ctx context.Context, id string, reqParams *common.
 	if reqParams == nil || reqParams.Comment == "" {
 		return nil, errors.Wrap(errox.InvalidArgs, "comment must be provided")
 	}
-	req, err := m.vulnReqs.UpdateRequestStatus(ctx, id, reqParams.Comment, storage.RequestStatus_APPROVED)
+	req, err := m.updateRequestStatus(ctx, id, reqParams.Comment, storage.RequestStatus_APPROVED)
 	if err != nil {
 		return nil, errors.Wrapf(err, "approving vulnerability request %s", id)
 	}
 	if err := m.SnoozeVulnerabilityOnRequest(ctx, req); err != nil {
-		return nil, errors.Wrapf(err, "approving vulnerability request %s", id)
+		return nil, errors.Wrapf(err, "enforcing approved vulnerability request %s", id)
 	}
 	return req, nil
+}
+
+func (m *managerImpl) updateRequestStatus(ctx context.Context, id string, comment string, status storage.RequestStatus) (*storage.VulnerabilityRequest, error) {
+	// Process one request at a time since updating request status could race with creating new request.
+	m.upsertSem.Acquire(ctx, 1)
+	defer m.upsertSem.Release(1)
+
+	return m.vulnReqs.UpdateRequestStatus(ctx, id, comment, status)
 }
 
 func (m *managerImpl) Delete(ctx context.Context, id string) error {

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -79,7 +79,9 @@ func (m *managerImpl) Create(ctx context.Context, req *storage.VulnerabilityRequ
 	}
 
 	// Process one request at a time since there could be a race between validation and database update.
-	m.upsertSem.Acquire(ctx, 1)
+	if err := m.upsertSem.Acquire(ctx, 1); err != nil {
+		return errors.Wrap(err, "creating vulnerability request")
+	}
 	defer m.upsertSem.Release(1)
 
 	// Validate that the CVEs in `req` are not snoozed for the scope specified in the request.
@@ -127,7 +129,9 @@ func (m *managerImpl) Approve(ctx context.Context, id string, reqParams *common.
 
 func (m *managerImpl) updateRequestStatus(ctx context.Context, id string, comment string, status storage.RequestStatus) (*storage.VulnerabilityRequest, error) {
 	// Process one request at a time since updating request status could race with creating new request.
-	m.upsertSem.Acquire(ctx, 1)
+	if err := m.upsertSem.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
 	defer m.upsertSem.Release(1)
 
 	return m.vulnReqs.UpdateRequestStatus(ctx, id, comment, status)

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_benchmark_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_benchmark_test.go
@@ -1,0 +1,45 @@
+package requestmgr
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	vulnReqCache "github.com/stackrox/rox/central/vulnerabilityrequest/cache"
+	vulnReqDS "github.com/stackrox/rox/central/vulnerabilityrequest/datastore"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkCreate(b *testing.B) {
+	testDB := *pgtest.ForT(b)
+	defer testDB.Teardown(b)
+
+	pendingCache, activeCache := vulnReqCache.New(), vulnReqCache.New()
+	vulnReqDataStore, err := vulnReqDS.GetTestPostgresDataStore(b, testDB, pendingCache, activeCache)
+	require.NoError(b, err)
+
+	ctx := sac.WithAllAccess(context.Background())
+	numExistingReqs := 10000
+	for i := 0; i < numExistingReqs; i++ {
+		req := fixtures.GetImageScopeDeferralRequest("registry", "remote", fmt.Sprintf("%d", i), "cve-2023-xyz")
+		err := vulnReqDataStore.AddRequest(ctx, req)
+		assert.NoError(b, err)
+	}
+
+	manager := New(nil, vulnReqDataStore, pendingCache, nil, nil, nil, nil, nil)
+
+	b.Run("create", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			tag := fmt.Sprintf("%d", rand.Intn(numExistingReqs))
+			req := fixtures.GetImageScopeDeferralRequest("registry", "remote", tag, "cve-2023-xyz")
+			req.Id = ""
+
+			assert.NoError(b, manager.Create(ctx, req))
+		}
+	})
+}

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_cache_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_cache_test.go
@@ -23,13 +23,7 @@ func TestVulnReqCacheUpdatesForApproval(t *testing.T) {
 
 	vulnReqDS := dsMock.NewMockDataStore(mockCtrl)
 	imageDS := imageMock.NewMockDataStore(mockCtrl)
-
-	manager := &managerImpl{
-		images:          imageDS,
-		vulnReqs:        vulnReqDS,
-		pendingReqCache: pendingReqCache,
-		activeReqCache:  activeReqCache,
-	}
+	manager := New(nil, vulnReqDS, pendingReqCache, activeReqCache, imageDS, nil, nil, nil)
 
 	// Test unexpired request.
 	expected := fixtures.GetImageScopeDeferralRequest("r", "r", "g", "cve")
@@ -64,13 +58,7 @@ func TestVulnReqCacheUpdatesForDenial(t *testing.T) {
 
 	vulnReqDS := dsMock.NewMockDataStore(mockCtrl)
 	imageDS := imageMock.NewMockDataStore(mockCtrl)
-
-	manager := &managerImpl{
-		images:          imageDS,
-		vulnReqs:        vulnReqDS,
-		pendingReqCache: pendingReqCache,
-		activeReqCache:  activeReqCache,
-	}
+	manager := New(nil, vulnReqDS, pendingReqCache, activeReqCache, imageDS, nil, nil, nil)
 
 	expected := fixtures.GetImageScopeDeferralRequest("r", "r", "g", "cve")
 	vulnReqDS.EXPECT().UpdateRequestStatus(allAccessCtx, expected.GetId(), "denied", storage.RequestStatus_DENIED).
@@ -93,13 +81,7 @@ func TestVulnReqCacheUpdatesForDelete(t *testing.T) {
 
 	vulnReqDS := dsMock.NewMockDataStore(mockCtrl)
 	imageDS := imageMock.NewMockDataStore(mockCtrl)
-
-	manager := &managerImpl{
-		images:          imageDS,
-		vulnReqs:        vulnReqDS,
-		pendingReqCache: pendingReqCache,
-		activeReqCache:  activeReqCache,
-	}
+	manager := New(nil, vulnReqDS, pendingReqCache, activeReqCache, imageDS, nil, nil, nil)
 
 	expected := fixtures.GetImageScopeDeferralRequest("r", "r", "g", "cve")
 	vulnReqDS.EXPECT().RemoveRequest(allAccessCtx, expected.GetId()).Return(nil)
@@ -118,13 +100,7 @@ func TestVulnReqCacheUpdatesForUndo(t *testing.T) {
 
 	vulnReqDS := dsMock.NewMockDataStore(mockCtrl)
 	imageDS := imageMock.NewMockDataStore(mockCtrl)
-
-	manager := &managerImpl{
-		images:          imageDS,
-		vulnReqs:        vulnReqDS,
-		pendingReqCache: pendingReqCache,
-		activeReqCache:  activeReqCache,
-	}
+	manager := New(nil, vulnReqDS, pendingReqCache, activeReqCache, imageDS, nil, nil, nil)
 
 	expected := fixtures.GetImageScopeDeferralRequest("r", "r", "g", "cve")
 	vulnReqDS.EXPECT().MarkRequestInactive(allAccessCtx, expected.GetId(), gomock.Any()).Return(expected, nil)
@@ -147,13 +123,7 @@ func TestVulnReqCacheUpdatesForUpdateExpiry(t *testing.T) {
 
 	vulnReqDS := dsMock.NewMockDataStore(mockCtrl)
 	imageDS := imageMock.NewMockDataStore(mockCtrl)
-
-	manager := &managerImpl{
-		images:          imageDS,
-		vulnReqs:        vulnReqDS,
-		pendingReqCache: pendingReqCache,
-		activeReqCache:  activeReqCache,
-	}
+	manager := New(nil, vulnReqDS, pendingReqCache, activeReqCache, imageDS, nil, nil, nil)
 
 	// Test unexpired request.
 	expected := fixtures.GetImageScopeDeferralRequest("r", "r", "g", "cve")

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
@@ -19,10 +19,7 @@ func TestCreateReqErrorsIfRequestAlreadyExists(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	datastore := dsMock.NewMockDataStore(mockCtrl)
-	manager := &managerImpl{
-		vulnReqs:        datastore,
-		pendingReqCache: vulnReqCache.New(),
-	}
+	manager := New(nil, datastore, vulnReqCache.New(), nil, nil, nil, nil, nil)
 
 	cve := "CVE-2021-1031"
 	globalDefReq := fixtures.GetGlobalDeferralRequest(cve)
@@ -103,7 +100,7 @@ func TestCreateReqErrorsIfRequestAlreadyExists(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			datastore.EXPECT().SearchRawRequests(allAllowedCtx, utils.GetQueryForApprovedReqsWithSimilarScope(cve)).Return(c.existingReqs, nil)
+			datastore.EXPECT().SearchRawRequests(allAllowedCtx, utils.GetEnforcedRequestsV1Query(cve)).Return(c.existingReqs, nil)
 			if c.allow {
 				datastore.EXPECT().AddRequest(allAllowedCtx, gomock.Any()).Return(nil)
 			}

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -101,7 +102,8 @@ func (s *VulnRequestManagerTestSuite) SetupTest() {
 		activeReqCache:                        s.activeReqCache,
 		reObserveTimedDeferralsTickerDuration: expiryLoopDurationForTest,
 		reObserveWhenFixedDeferralsTickerDuration: expiryLoopDurationForTest,
-		stopper: concurrency.NewStopper(),
+		stopper:   concurrency.NewStopper(),
+		upsertSem: semaphore.NewWeighted(1),
 	}
 }
 

--- a/central/vulnerabilityrequest/manager/requestmgr/singleton.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/singleton.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
+	"golang.org/x/sync/semaphore"
 )
 
 var (
@@ -64,5 +65,7 @@ func New(
 		reObserveTimedDeferralsTickerDuration:     env.VulnDeferralTimedReObserveInterval.DurationSetting(),
 		reObserveWhenFixedDeferralsTickerDuration: env.VulnDeferralFixableReObserveInterval.DurationSetting(),
 		stopper: concurrency.NewStopper(),
+
+		upsertSem: semaphore.NewWeighted(1),
 	}
 }

--- a/central/vulnerabilityrequest/utils/util.go
+++ b/central/vulnerabilityrequest/utils/util.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
@@ -120,12 +121,13 @@ func CreateRequestCommentProto(ctx context.Context, message string) *storage.Req
 	}
 }
 
-// GetQueryForApprovedReqsWithSimilarScope returns a *v1.Query which will search for all requests for a CVE with similar scope that has been approved
-func GetQueryForApprovedReqsWithSimilarScope(cve ...string) *v1.Query {
-	return search.ConjunctionQuery(
-		search.NewQueryBuilder().AddExactMatches(search.CVE, cve...).AddBools(search.ExpiredRequest, false).ProtoQuery(),
-		search.NewQueryBuilder().AddExactMatches(search.RequestStatus, storage.RequestStatus_APPROVED.String(), storage.RequestStatus_APPROVED_PENDING_UPDATE.String()).ProtoQuery(),
-	)
+// GetEnforcedRequestsV1Query returns a *v1.Query which will search for all enforced requests for specified CVEs.
+func GetEnforcedRequestsV1Query(cve ...string) *v1.Query {
+	return search.NewQueryBuilder().
+		AddExactMatches(search.CVE, cve...).
+		AddBools(search.ExpiredRequest, false).
+		AddExactMatches(search.RequestStatus, storage.RequestStatus_APPROVED.String(), storage.RequestStatus_APPROVED_PENDING_UPDATE.String()).
+		ProtoQuery()
 }
 
 // GetAffectedImagesQuery returns a *v1.Query object that can be used to fetch images affected by
@@ -197,4 +199,16 @@ func GetActiveApprovedReqQuery() *v1.Query {
 // IsPending returns true if the original request or the update to original request is in pending state.
 func IsPending(req *storage.VulnerabilityRequest) bool {
 	return req.GetStatus() == storage.RequestStatus_PENDING || req.GetStatus() == storage.RequestStatus_APPROVED_PENDING_UPDATE
+}
+
+// FirstIndexMatchingScope returns the index of first vulnerability request in `matchWith` with scope matching that of `toMatch`.
+// If no match is found, -1 is returned.
+func FirstIndexMatchingScope(toMatch *storage.VulnerabilityRequest, matchWith []*storage.VulnerabilityRequest) int {
+	for idx, r := range matchWith {
+		// If both the CVE and scope match the one in the request...
+		if reflect.DeepEqual(r.GetScope(), toMatch.GetScope()) {
+			return idx
+		}
+	}
+	return -1
 }

--- a/central/vulnerabilityrequest/utils/util.go
+++ b/central/vulnerabilityrequest/utils/util.go
@@ -205,7 +205,7 @@ func IsPending(req *storage.VulnerabilityRequest) bool {
 // If no match is found, -1 is returned.
 func FirstIndexMatchingScope(toMatch *storage.VulnerabilityRequest, matchWith []*storage.VulnerabilityRequest) int {
 	for idx, r := range matchWith {
-		// If both the CVE and scope match the one in the request...
+		// Check if the scopes match.
 		if reflect.DeepEqual(r.GetScope(), toMatch.GetScope()) {
 			return idx
 		}

--- a/central/vulnerabilityrequest/validator/validate.go
+++ b/central/vulnerabilityrequest/validator/validate.go
@@ -2,7 +2,6 @@ package validator
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
@@ -10,19 +9,6 @@ import (
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 )
-
-// ValidateSuppressVulnRequestIsUnique ensures that there doesn't already exist a request for the same CVE and scope object
-func ValidateSuppressVulnRequestIsUnique(req *storage.VulnerabilityRequest, existingReqs []*storage.VulnerabilityRequest) error {
-	for _, r := range existingReqs {
-		// If both the CVE and scope match the one in the request...
-		if reflect.DeepEqual(r.GetScope(), req.GetScope()) {
-			// ... do not allow. Only one request can exist for the exact same CVE and scope _object_ combo regardless of target state (FP or defer).
-			// There might be another request where the scope object evaluates to the same, but that is allowed. Just not the exact same values.
-			return errors.Errorf("request %s already covers this CVE and scope", r.GetId())
-		}
-	}
-	return nil
-}
 
 // ValidateNewSuppressVulnRequest ensures that the new request to suppress vulnerability is correct.
 func ValidateNewSuppressVulnRequest(req *storage.VulnerabilityRequest) error {

--- a/pkg/testutils/verify_in_test_only.go
+++ b/pkg/testutils/verify_in_test_only.go
@@ -16,7 +16,7 @@ var (
 // It is essentially impossible to create a valid one outside a test since the
 // struct has no exported fields. We use this for methods that are "testing only", to make
 // sure that they do not get exercised outside tests.
-func MustBeInTest(t *testing.T) {
+func MustBeInTest(t testing.TB) {
 	if v := flag.Lookup("test.v"); v != nil && v.Value.String() == "true" {
 		return
 	}


### PR DESCRIPTION
## Description

**Background:**
We prohibit users from creating vulnerability requests for CVEs in a scope if a existing requests already covers the CVE in that scope. 

**Issue:**
The issue was there existed race between the validation against existing requests and adding new request to database. Thus, the validation could be wrong by the time the request is actually database. 

**Solution:**
This PR ensure that the vulnerability request creation is not racy by allowing only one request to be evaluated at a time.

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
Unit + benchmark

```
BenchmarkCreate
BenchmarkCreate/create
BenchmarkCreate/create-8         	     250	   4319530 ns/op
PASS
```