### PR TITLE
fix(gosec): G601

### DIFF
--- a/central/sensor/service/pipeline/nodeinventory/two_pipelines_test.go
+++ b/central/sensor/service/pipeline/nodeinventory/two_pipelines_test.go
@@ -87,7 +87,7 @@ func Test_TwoPipelines_Run(t *testing.T) {
 		updater           updater.Updater
 	}
 	tests := map[string]struct {
-		mocks                     usedMocks
+		mocks                     *usedMocks
 		riskManager               manager.Manager
 		enricher                  nodeEnricher.NodeEnricher
 		operations                []func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment) error
@@ -173,9 +173,10 @@ func Test_TwoPipelines_Run(t *testing.T) {
 		},
 	}
 	for name, tt := range tests {
+		tt := tt
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			tt.mocks = usedMocks{
+			tt.mocks = &usedMocks{
 				clusterStore:      clusterDatastoreMocks.NewMockDataStore(ctrl),
 				nodeDatastore:     nodeDatastoreMocks.NewMockDataStore(ctrl),
 				cveDatastore:      nodeCVEDataStoreMocks.NewMockDataStore(ctrl),
@@ -221,7 +222,7 @@ func Test_TwoPipelines_Run(t *testing.T) {
 			require.NoError(t, err)
 
 			if tt.setUpMocks != nil {
-				tt.setUpMocks(t, &tt.mocks)
+				tt.setUpMocks(t, tt.mocks)
 			}
 			pNode := nodes.NewPipeline(tt.mocks.clusterStore, tt.mocks.nodeDatastore, tt.enricher, tt.riskManager)
 			pNodeInv := newPipeline(tt.mocks.clusterStore, tt.mocks.nodeDatastore, tt.enricher, tt.riskManager)


### PR DESCRIPTION
## Description

Ensure the following [failure](https://github.com/stackrox/stackrox/actions/runs/6182333631/job/16781865998) does not happen:

```
central/sensor/service/pipeline/nodeinventory/two_pipelines_test.go:224:22: G601: Implicit memory aliasing in for loop. (gosec)
				tt.setUpMocks(t, &tt.mocks)
```

## Checklist
- [x] Investigated and inspected CI test results

### N/A

- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- Run `make golangci-lint` locally
- CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
