### PR TITLE
ROX-19139: Split config read into private and public parts

### DIFF
--- a/central/cluster/service/service_impl.go
+++ b/central/cluster/service/service_impl.go
@@ -126,12 +126,12 @@ func (s *serviceImpl) getClusterRetentionInfo(ctx context.Context, cluster *stor
 		return nil, nil
 	}
 
-	sysConfig, err := s.sysConfigDatastore.GetConfig(ctx)
+	systemPrivateConfig, err := s.sysConfigDatastore.GetPrivateConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	clusterRetentionConfig := sysConfig.GetPrivateConfig().GetDecommissionedClusterRetention()
+	clusterRetentionConfig := systemPrivateConfig.GetDecommissionedClusterRetention()
 	if clusterRetentionConfig == nil || clusterRetentionConfig.GetRetentionDurationDays() == 0 {
 		// If retention is disabled, there is no "days remaining" calculation to be done.
 		return nil, nil

--- a/central/cluster/service/service_impl_test.go
+++ b/central/cluster/service/service_impl_test.go
@@ -142,7 +142,7 @@ func (suite *ClusterServiceTestSuite) TestGetClusterWithRetentionInfo() {
 			ps := probeSourcesMocks.NewMockProbeSources(suite.mockCtrl)
 			suite.dataStore.EXPECT().GetCluster(gomock.Any(), gomock.Any()).Times(1).Return(testCase.cluster, true, nil)
 			if testCase.cluster.GetHealthStatus().GetSensorHealthStatus() == storage.ClusterHealthStatus_UNHEALTHY {
-				suite.sysConfigDatastore.EXPECT().GetConfig(gomock.Any()).Times(1).Return(testCase.config, nil)
+				suite.sysConfigDatastore.EXPECT().GetPrivateConfig(gomock.Any()).Times(1).Return(testCase.config.GetPrivateConfig(), nil)
 			}
 			clusterService := New(suite.dataStore, nil, ps, suite.sysConfigDatastore)
 
@@ -199,7 +199,7 @@ func (suite *ClusterServiceTestSuite) TestGetClustersWithRetentionInfoMap() {
 
 	ps := probeSourcesMocks.NewMockProbeSources(suite.mockCtrl)
 	suite.dataStore.EXPECT().SearchRawClusters(gomock.Any(), gomock.Any()).Times(1).Return(clusters, nil)
-	suite.sysConfigDatastore.EXPECT().GetConfig(gomock.Any()).Times(3).Return(config, nil)
+	suite.sysConfigDatastore.EXPECT().GetPrivateConfig(gomock.Any()).Times(3).Return(config.GetPrivateConfig(), nil)
 
 	clusterService := New(suite.dataStore, nil, ps, suite.sysConfigDatastore)
 	results, err := clusterService.GetClusters(context.Background(), &v1.GetClustersRequest{Query: search.EmptyQuery().String()})

--- a/central/config/datastore/datastore.go
+++ b/central/config/datastore/datastore.go
@@ -143,7 +143,13 @@ func (d *datastoreImpl) UpsertConfig(ctx context.Context, config *storage.Config
 		}
 	}
 
-	return d.store.Upsert(ctx, config)
+	upsertErr := d.store.Upsert(ctx, config)
+	if upsertErr != nil {
+		return upsertErr
+	}
+
+	_ = d.publicConfigCache.Add(publicConfigKey, config.GetPublicConfig())
+	return nil
 }
 
 func (d *datastoreImpl) getClusterRetentionConfig(ctx context.Context) (*storage.DecommissionedClusterRetentionConfig, error) {

--- a/central/config/datastore/datastore.go
+++ b/central/config/datastore/datastore.go
@@ -86,6 +86,8 @@ type datastoreImpl struct {
 // The primary data source will be the cache and the secondary the database.
 func (d *datastoreImpl) GetPublicConfig() (*storage.PublicConfig, error) {
 	var err error
+	// See the note next to the publicConfigCache variable for
+	// more information on public config caching.
 	publicConfig, found := getPublicConfigCache().Get(publicConfigKey)
 	if found && publicConfig != nil {
 		return publicConfig, nil
@@ -96,6 +98,8 @@ func (d *datastoreImpl) GetPublicConfig() (*storage.PublicConfig, error) {
 		return publicConfig, err
 	}
 
+	// See the note next to the publicConfigCache variable for
+	// more information on public config caching.
 	cachePublicConfig(publicConfig)
 
 	return publicConfig, err
@@ -175,6 +179,8 @@ func (d *datastoreImpl) UpsertConfig(ctx context.Context, config *storage.Config
 		return upsertErr
 	}
 
+	// See the note next to the publicConfigCache variable for
+	// more information on public config caching.
 	cachePublicConfig(config.GetPublicConfig())
 	return nil
 }

--- a/central/config/datastore/datastore_test.go
+++ b/central/config/datastore/datastore_test.go
@@ -122,7 +122,7 @@ func (s *configDataStoreTestSuite) TestAllowsGetPrivate() {
 	s.NoError(err, "expected no error trying to read with permissions")
 	s.NotNil(privateConfigRead)
 
-	s.storage.EXPECT().Get(gomock.Any()).Return(nil, false, nil).Times(1)
+	s.storage.EXPECT().Get(gomock.Any()).Return(sampleConfig, true, nil).Times(1)
 
 	privateConfigWrite, err := s.dataStore.GetPrivateConfig(s.hasWriteCtx)
 	s.NoError(err, "expected no error trying to read with permissions")

--- a/central/config/datastore/datastore_test.go
+++ b/central/config/datastore/datastore_test.go
@@ -88,6 +88,7 @@ var (
 )
 
 func (s *configDataStoreTestSuite) TestAllowsGetPublic() {
+	getPublicConfigCache().Purge()
 	s.storage.EXPECT().Get(gomock.Any()).Return(sampleConfig, true, nil).Times(1)
 
 	publicCfg, err := s.dataStore.GetPublicConfig()

--- a/central/config/datastore/mocks/datastore.go
+++ b/central/config/datastore/mocks/datastore.go
@@ -50,6 +50,36 @@ func (mr *MockDataStoreMockRecorder) GetConfig(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfig", reflect.TypeOf((*MockDataStore)(nil).GetConfig), arg0)
 }
 
+// GetPrivateConfig mocks base method.
+func (m *MockDataStore) GetPrivateConfig(arg0 context.Context) (*storage.PrivateConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPrivateConfig", arg0)
+	ret0, _ := ret[0].(*storage.PrivateConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPrivateConfig indicates an expected call of GetPrivateConfig.
+func (mr *MockDataStoreMockRecorder) GetPrivateConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrivateConfig", reflect.TypeOf((*MockDataStore)(nil).GetPrivateConfig), arg0)
+}
+
+// GetPublicConfig mocks base method.
+func (m *MockDataStore) GetPublicConfig(arg0 context.Context) (*storage.PublicConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPublicConfig", arg0)
+	ret0, _ := ret[0].(*storage.PublicConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPublicConfig indicates an expected call of GetPublicConfig.
+func (mr *MockDataStoreMockRecorder) GetPublicConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicConfig", reflect.TypeOf((*MockDataStore)(nil).GetPublicConfig), arg0)
+}
+
 // UpsertConfig mocks base method.
 func (m *MockDataStore) UpsertConfig(arg0 context.Context, arg1 *storage.Config) error {
 	m.ctrl.T.Helper()

--- a/central/config/datastore/mocks/datastore.go
+++ b/central/config/datastore/mocks/datastore.go
@@ -35,21 +35,6 @@ func (m *MockDataStore) EXPECT() *MockDataStoreMockRecorder {
 	return m.recorder
 }
 
-// GetCachedPublicConfig mocks base method.
-func (m *MockDataStore) GetCachedPublicConfig(arg0 context.Context) (*storage.PublicConfig, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCachedPublicConfig", arg0)
-	ret0, _ := ret[0].(*storage.PublicConfig)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCachedPublicConfig indicates an expected call of GetCachedPublicConfig.
-func (mr *MockDataStoreMockRecorder) GetCachedPublicConfig(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCachedPublicConfig", reflect.TypeOf((*MockDataStore)(nil).GetCachedPublicConfig), arg0)
-}
-
 // GetConfig mocks base method.
 func (m *MockDataStore) GetConfig(arg0 context.Context) (*storage.Config, error) {
 	m.ctrl.T.Helper()
@@ -81,18 +66,18 @@ func (mr *MockDataStoreMockRecorder) GetPrivateConfig(arg0 interface{}) *gomock.
 }
 
 // GetPublicConfig mocks base method.
-func (m *MockDataStore) GetPublicConfig(arg0 context.Context) (*storage.PublicConfig, error) {
+func (m *MockDataStore) GetPublicConfig() (*storage.PublicConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPublicConfig", arg0)
+	ret := m.ctrl.Call(m, "GetPublicConfig")
 	ret0, _ := ret[0].(*storage.PublicConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPublicConfig indicates an expected call of GetPublicConfig.
-func (mr *MockDataStoreMockRecorder) GetPublicConfig(arg0 interface{}) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) GetPublicConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicConfig", reflect.TypeOf((*MockDataStore)(nil).GetPublicConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicConfig", reflect.TypeOf((*MockDataStore)(nil).GetPublicConfig))
 }
 
 // UpsertConfig mocks base method.

--- a/central/config/datastore/mocks/datastore.go
+++ b/central/config/datastore/mocks/datastore.go
@@ -35,6 +35,21 @@ func (m *MockDataStore) EXPECT() *MockDataStoreMockRecorder {
 	return m.recorder
 }
 
+// GetCachedPublicConfig mocks base method.
+func (m *MockDataStore) GetCachedPublicConfig(arg0 context.Context) (*storage.PublicConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCachedPublicConfig", arg0)
+	ret0, _ := ret[0].(*storage.PublicConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCachedPublicConfig indicates an expected call of GetCachedPublicConfig.
+func (mr *MockDataStoreMockRecorder) GetCachedPublicConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCachedPublicConfig", reflect.TypeOf((*MockDataStore)(nil).GetCachedPublicConfig), arg0)
+}
+
 // GetConfig mocks base method.
 func (m *MockDataStore) GetConfig(arg0 context.Context) (*storage.Config, error) {
 	m.ctrl.T.Helper()

--- a/central/config/datastore/singleton.go
+++ b/central/config/datastore/singleton.go
@@ -104,6 +104,8 @@ func initialize() {
 		panic(err)
 	}
 
+	// See the note next to the publicConfigCache variable in datastore.go for
+	// more information on public config caching.
 	cachePublicConfig(config.GetPublicConfig())
 
 	privateConfig := config.GetPrivateConfig()

--- a/central/config/datastore/singleton.go
+++ b/central/config/datastore/singleton.go
@@ -104,6 +104,8 @@ func initialize() {
 		panic(err)
 	}
 
+	cachePublicConfig(config.GetPublicConfig())
+
 	privateConfig := config.GetPrivateConfig()
 	needsUpsert := false
 	if privateConfig == nil {

--- a/central/config/service/service.go
+++ b/central/config/service/service.go
@@ -79,26 +79,26 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 
 // GetPublicConfig returns the publicly available config
 func (s *serviceImpl) GetPublicConfig(ctx context.Context, _ *v1.Empty) (*storage.PublicConfig, error) {
-	config, err := s.datastore.GetConfig(ctx)
+	publicConfig, err := s.datastore.GetPublicConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if config.GetPublicConfig() == nil {
+	if publicConfig == nil {
 		return &storage.PublicConfig{}, nil
 	}
-	return config.GetPublicConfig(), nil
+	return publicConfig, nil
 }
 
 // GetPrivateConfig returns the privately available config
 func (s *serviceImpl) GetPrivateConfig(ctx context.Context, _ *v1.Empty) (*storage.PrivateConfig, error) {
-	config, err := s.datastore.GetConfig(ctx)
+	privateConfig, err := s.datastore.GetPrivateConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if config.GetPrivateConfig() == nil {
+	if privateConfig == nil {
 		return &storage.PrivateConfig{}, nil
 	}
-	return config.GetPrivateConfig(), nil
+	return privateConfig, nil
 }
 
 // GetConfig returns Central's config
@@ -134,12 +134,12 @@ func (s *serviceImpl) GetVulnerabilityDeferralConfig(ctx context.Context, _ *v1.
 	if !env.UnifiedCVEDeferral.BooleanSetting() {
 		return nil, errors.Errorf("Cannot fulfill request. Environment variable %s=false", env.UnifiedCVEDeferral.EnvVar())
 	}
-	config, err := s.datastore.GetConfig(ctx)
+	privateConfig, err := s.datastore.GetPrivateConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return &v1.GetVulnerabilityDeferralConfigResponse{
-		Config: VulnerabilityDeferralConfigStorageToV1(config.GetPrivateConfig().GetVulnerabilityDeferralConfig()),
+		Config: VulnerabilityDeferralConfigStorageToV1(privateConfig.GetVulnerabilityDeferralConfig()),
 	}, nil
 }
 

--- a/central/config/service/service.go
+++ b/central/config/service/service.go
@@ -79,7 +79,7 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 
 // GetPublicConfig returns the publicly available config
 func (s *serviceImpl) GetPublicConfig(ctx context.Context, _ *v1.Empty) (*storage.PublicConfig, error) {
-	publicConfig, err := s.datastore.GetPublicConfig(ctx)
+	publicConfig, err := s.datastore.GetCachedPublicConfig(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/central/config/service/service.go
+++ b/central/config/service/service.go
@@ -78,8 +78,8 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 }
 
 // GetPublicConfig returns the publicly available config
-func (s *serviceImpl) GetPublicConfig(ctx context.Context, _ *v1.Empty) (*storage.PublicConfig, error) {
-	publicConfig, err := s.datastore.GetCachedPublicConfig(ctx)
+func (s *serviceImpl) GetPublicConfig(_ context.Context, _ *v1.Empty) (*storage.PublicConfig, error) {
+	publicConfig, err := s.datastore.GetPublicConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/central/main.go
+++ b/central/main.go
@@ -560,12 +560,7 @@ func startGRPCServer() {
 		centralSAC.GetEnricher().GetPreAuthContextEnricher(authzTraceSink),
 	)
 
-	telemetryCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
-		sac.AllowFixedScopes(
-			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			sac.ResourceScopeKeys(resources.Administration)))
-
-	if cds, err := configDS.Singleton().GetPublicConfig(telemetryCtx); err == nil || cds == nil {
+	if cds, err := configDS.Singleton().GetPublicConfig(); err == nil || cds == nil {
 		if t := cds.GetTelemetry(); t == nil || t.GetEnabled() {
 			if cfg := centralclient.Enable(); cfg.Enabled() {
 				centralclient.RegisterCentralClient(&config, basicAuthProvider.ID())

--- a/central/main.go
+++ b/central/main.go
@@ -565,8 +565,8 @@ func startGRPCServer() {
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
 			sac.ResourceScopeKeys(resources.Administration)))
 
-	if cds, err := configDS.Singleton().GetConfig(telemetryCtx); err == nil || cds == nil {
-		if t := cds.GetPublicConfig().GetTelemetry(); t == nil || t.GetEnabled() {
+	if cds, err := configDS.Singleton().GetPublicConfig(telemetryCtx); err == nil || cds == nil {
+		if t := cds.GetTelemetry(); t == nil || t.GetEnabled() {
 			if cfg := centralclient.Enable(); cfg.Enabled() {
 				centralclient.RegisterCentralClient(&config, basicAuthProvider.ID())
 				gs := cfg.Gatherer()

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -150,17 +150,16 @@ func (g *garbageCollectorImpl) Start() {
 }
 
 func (g *garbageCollectorImpl) pruneBasedOnConfig() {
-	config, err := g.config.GetConfig(pruningCtx)
+	pvtConfig, err := g.config.GetPrivateConfig(pruningCtx)
 	if err != nil {
 		log.Error(err)
 		return
 	}
-	if config == nil {
+	if pvtConfig == nil {
 		log.Error("UNEXPECTED: Got nil config")
 		return
 	}
 	log.Info("[Pruning] Starting a garbage collection cycle")
-	pvtConfig := config.GetPrivateConfig()
 	g.collectImages(pvtConfig)
 	g.collectAlerts(pvtConfig)
 	g.removeOrphanedResources()

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -226,7 +226,7 @@ func (s *PruningTestSuite) generateImageDataStructures(ctx context.Context) (ale
 	mockBaselineDataStore := processBaselineDatastoreMocks.NewMockDataStore(ctrl)
 
 	mockConfigDatastore := configDatastoreMocks.NewMockDataStore(ctrl)
-	mockConfigDatastore.EXPECT().GetConfig(ctx).Return(testConfig, nil)
+	mockConfigDatastore.EXPECT().GetPrivateConfig(ctx).Return(testConfig.GetPrivateConfig(), nil)
 
 	mockAlertDatastore := alertDatastoreMocks.NewMockDataStore(ctrl)
 
@@ -301,7 +301,7 @@ func (s *PruningTestSuite) generateAlertDataStructures(ctx context.Context) (ale
 
 	mockImageDatastore := imageDatastoreMocks.NewMockDataStore(ctrl)
 	mockConfigDatastore := configDatastoreMocks.NewMockDataStore(ctrl)
-	mockConfigDatastore.EXPECT().GetConfig(ctx).Return(testConfig, nil)
+	mockConfigDatastore.EXPECT().GetPrivateConfig(ctx).Return(testConfig.GetPrivateConfig(), nil)
 
 	mockRiskDatastore := riskDatastoreMocks.NewMockDataStore(ctrl)
 

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -557,10 +557,10 @@ func (s *PruningTestSuite) TestImagePruning() {
 				require.NoError(t, images.UpsertImage(ctx, image))
 			}
 
-			conf, err := config.GetConfig(ctx)
+			privateConfig, err := config.GetPrivateConfig(ctx)
 			require.NoError(t, err, "failed to get config")
 			// Garbage collect all of the images
-			gc.collectImages(conf.GetPrivateConfig())
+			gc.collectImages(privateConfig)
 
 			// Grab the  actual remaining images and make sure they match the images expected to be remaining
 			remainingImages, err := images.SearchListImages(ctx, search.EmptyQuery())
@@ -1123,11 +1123,11 @@ func (s *PruningTestSuite) TestAlertPruning() {
 			}
 			log.Infof("All query returns %d objects: %v", len(all), search.ResultsToIDs(all))
 
-			conf, err := config.GetConfig(ctx)
+			privateConfig, err := config.GetPrivateConfig(ctx)
 			require.NoError(t, err, "failed to get config")
 
 			// Garbage collect all of the alerts
-			gc.collectAlerts(conf.GetPrivateConfig())
+			gc.collectAlerts(privateConfig)
 
 			// Grab the actual remaining alerts and make sure they match the alerts expected to be remaining
 			remainingAlerts, err := alerts.SearchListAlerts(ctx, getAllAlerts())


### PR DESCRIPTION
## Description

The `/v1/config/public` endpoint does not always return the data it should.
In order to ensure the public config is always returned, access to the public and private parts of the config are separated, and the access control is relaxed on the public part.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

New unit tests added.

Manual testing
```bash
# Deploy central 

# Retrieve data
% curl --insecure -XGET https://localhost:8000/v1/config/public


```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
