### PR TITLE
ROX-19312: Rename ROX_NAMESPACE to POD_NAMESPACE in remaining places.

### DIFF
--- a/operator/tests/central/basic-central/80-assert-non-openshift.yaml
+++ b/operator/tests/central/basic-central/80-assert-non-openshift.yaml
@@ -30,7 +30,7 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-            - name: ROX_NAMESPACE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/operator/tests/central/basic-central/81-assert-non-openshift.yaml
+++ b/operator/tests/central/basic-central/81-assert-non-openshift.yaml
@@ -30,7 +30,7 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-            - name: ROX_NAMESPACE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1


### PR DESCRIPTION
## Description

Rename the env var in places which were apparently missed in https://github.com/stackrox/stackrox/pull/7614 but was not caught because the GKE operator e2e test job was not automatically triggered at that point yet.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

CI should be sufficient now that the job is triggered automatically.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
