### PR TITLE
fix(ui): Swap COMPONENT->IMAGE_COMPONENT in affected components modal

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
@@ -19,6 +19,7 @@ import {
     Tr,
 } from '@patternfly/react-table';
 
+import entityTypes from 'constants/entityTypes';
 import workflowStateContext from 'Containers/workflowStateContext';
 import { EmbeddedImageScanComponent } from '../imageVulnerabilities.graphql';
 
@@ -90,7 +91,7 @@ function AffectedComponentsModal({
                     </Thead>
                     {filteredComponents.map((component, rowIndex) => {
                         const componentURL = workflowState
-                            .pushList('COMPONENT')
+                            .pushList(entityTypes.IMAGE_COMPONENT)
                             .pushListItem(component.id)
                             .toUrl();
                         return (


### PR DESCRIPTION
## Description

Discovered this issue when attempting to reproduce https://github.com/stackrox/stackrox/issues/7464. That issue was filed against 4.1.1 while this fix was tested against a different error in 4.3.0-dev. It is possible that this is the same problem manifesting in a different way due to changes since 4.1.1

## Analysis

The `listType` passed from the AffectedComponentsModal is eventually passed to [`getFragmentInfo`](https://github.com/stackrox/stackrox/blob/4bf9049dea4ef56dd9da2e8464ea0c48068cffd5/ui/apps/platform/src/utils/queryService.js#L290) in utils/queryService.js, which calls [`getFragmentName`](https://github.com/stackrox/stackrox/blob/4bf9049dea4ef56dd9da2e8464ea0c48068cffd5/ui/apps/platform/src/utils/queryService.js#L194) in the same file. None of the expected values in this function match the hard coded `'COMPONENT'` value, so an empty string is returned. This results in an invalid GraphQL query since the returned string value is spread into fields between two braces [here](https://github.com/stackrox/stackrox/blob/4bf9049dea4ef56dd9da2e8464ea0c48068cffd5/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtEntityImage.js#L100).

I'm guessing this was a missed string when CVEs and components were split into "Image" and "Node" specific types.
Since the only use of the `AffectedComponentsModal` is in an image context, `IMAGE_COMPONENT` seems like a safe choice for a replacement.



## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

To repro:

Visit VM 1.0, "Images" page, click an image, scroll down to CVEs, click the "# components" link in a row. Clicking the name of a component in the modal then opens a new page with a "not found" error.
![image](https://github.com/stackrox/stackrox/assets/1292638/1dfe7d57-8c7e-4e37-a526-44be800f5c36)
![image](https://github.com/stackrox/stackrox/assets/1292638/2ea2007e-eec9-4442-b81e-72dac8b93e02)


Additionally, visit VM 1.0, "Image CVEs" page, click a CVE, click the arrow at the top of the sidebar to go to the CVE full page, then click the images tab, scroll to CVEs, click a component, and click the component name in the modal. This opens a new page with a GraphQL error:
![image](https://github.com/stackrox/stackrox/assets/1292638/25561b31-4b3f-4a4f-aa40-412ab6241895)
![image](https://github.com/stackrox/stackrox/assets/1292638/c9f7d354-04e2-4c01-98bf-e0306459af06)


After the fix, both the previous two steps result in this page:
![image](https://github.com/stackrox/stackrox/assets/1292638/5ba06691-43ed-4b6b-8196-1089e02faac1)

