### PR TITLE
fix(ui): Remove table row action for images without a tag

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -107,6 +107,10 @@ export function watchImageFlowFromModal(imageFullName, imageNameAndTag) {
     // Add it to the watch list
     cy.get(selectors.addImageToWatchListButton).click();
 
+    // Watch for the success alert
+    cy.get(selectors.modalAlertWithText('The image was successfully added to the watch list'));
+    cy.get(selectors.modalAlertWithText(imageFullName));
+
     // Verify that the image is added to the watched images table
     cy.get(selectors.currentWatchedImageRow(imageFullName));
 
@@ -124,6 +128,9 @@ export function watchImageFlowFromModal(imageFullName, imageNameAndTag) {
 export function unwatchImageFromModal(imageFullName, imageNameAndTag) {
     // Delete the image from the watch list
     cy.get(selectors.removeImageFromTableButton(imageFullName)).click();
+
+    // Watch for the success alert
+    cy.get(selectors.modalAlertWithText('The image was successfully removed from the watch list'));
 
     // Verify that the image is no longer in the table
     cy.get(selectors.currentWatchedImageRow(imageFullName)).should('not.exist');

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -68,3 +68,69 @@ export function typeAndEnterResourceFilterValue(entityType, value) {
 export function selectEntityTab(entityType) {
     cy.get(selectors.entityTypeToggleItem(entityType)).click();
 }
+
+/**
+ * Clean up any existing watched images via API
+ */
+export function unwatchAllImages() {
+    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
+
+    cy.request({ url: '/v1/watchedimages', auth }).as('listWatchedImages');
+
+    cy.get('@listWatchedImages').then((res) => {
+        res.body.watchedImages.forEach(({ name }) => {
+            cy.request({ url: `/v1/watchedimages?name=${name}`, auth, method: 'DELETE' });
+        });
+    });
+}
+
+/**
+ * Find an image from the table that is not watched, and yields the registry, name:tag, and full name
+ * of the image
+ */
+export function selectUnwatchedImageTextFromTable() {
+    return cy.get(selectors.firstUnwatchedImageRow).then(($row) => {
+        const $imageLink = $row.find('td[data-label="Image"] div > a');
+        const $imageRegistryText = $row.find('td[data-label="Image"] div > span');
+        const nameAndTag = $imageLink.text().replace(/\s+/g, ''); // clean up whitespace
+        const registry = $imageRegistryText.text().replace(/in\s+/, ''); // remove "in" prefix before registry
+        const fullName = `${registry}/${nameAndTag}`;
+        return [registry, nameAndTag, fullName];
+    });
+}
+
+/**
+ * Watch an image from the modal, and verify that it is added to the watched images table.
+ * Assumes that the modal is already open.
+ */
+export function watchImageFlowFromModal(imageFullName, imageNameAndTag) {
+    // Add it to the watch list
+    cy.get(selectors.addImageToWatchListButton).click();
+
+    // Verify that the image is added to the watched images table
+    cy.get(selectors.currentWatchedImageRow(imageFullName));
+
+    // close the modal
+    cy.get(selectors.closeWatchedImageDialogButton).click();
+
+    // check that the table row containing the image name has a watched image label
+    cy.get(`${selectors.watchedImageCellWithName(imageNameAndTag)} ${selectors.watchedImageLabel}`);
+}
+
+/**
+ * Unwatch an image from the modal, and verify that it is removed from the watched images table.
+ * Assumes that the modal is already open.
+ */
+export function unwatchImageFromModal(imageFullName, imageNameAndTag) {
+    // Delete the image from the watch list
+    cy.get(selectors.removeImageFromTableButton(imageFullName)).click();
+
+    // Verify that the image is no longer in the table
+    cy.get(selectors.currentWatchedImageRow(imageFullName)).should('not.exist');
+
+    // close the modal
+    cy.get(selectors.closeWatchedImageDialogButton).click();
+
+    // Verify that the image no longer has a watched image label in the workload cve table
+    cy.get(selectors.watchedImageCellWithName(imageNameAndTag)).should('not.exist');
+}

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -1,3 +1,5 @@
+const watchedImageLabelText = 'Watched image';
+
 export const selectors = {
     resourceDropdown: '.pf-c-toolbar button[aria-label="resource filter menu toggle"]',
     resourceMenuItem: (resource) =>
@@ -28,8 +30,20 @@ export const selectors = {
     iconText: (textContent) => `svg ~ *:contains("${textContent}")`,
     firstTableRow: 'table tbody:nth-of-type(1) tr:nth-of-type(1)',
     nonZeroCveSeverityCounts: '*[aria-label*="severity cves"i]:not([aria-label^="0"])',
-    firstUnwatchedImageRow:
-        'tbody tr:not(:has(td[data-label="Image"]:contains("Watched image"))):eq(0)',
+
+    // Watched image selectors
+    watchedImageLabel: `.pf-c-label:contains("${watchedImageLabelText}")`,
+    firstUnwatchedImageRow: `tbody tr:has(td[data-label="Image"]:not(:contains("${watchedImageLabelText}"))):eq(0)`,
+    watchedImageCellWithName: (name) =>
+        `tbody tr td[data-label="Image"]:contains("${name}"):contains("${watchedImageLabelText}")`,
     manageWatchedImagesButton: 'button:contains("Manage watched images")',
+    closeWatchedImageDialogButton: '*[role="dialog"] button:contains("Close")',
     addWatchedImageNameInput: '*[role="dialog"] input[id="imageName"]',
+    addImageToWatchListButton: 'button:contains("Add image to watch list")',
+    currentWatchedImagesTable: '*[role="dialog"] table',
+    modalAlertWithText: (text) => `*[role="dialog"] .pf-c-alert:contains("${text}")`,
+    currentWatchedImageRow: (name) =>
+        `${selectors.currentWatchedImagesTable} tr:has(td:contains("${name}"))`,
+    removeImageFromTableButton: (name) =>
+        `${selectors.currentWatchedImagesTable} tr:has(td:contains("${name}")) button:contains("Remove watch")`,
 };

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
@@ -24,47 +24,60 @@ describe('Workload CVE watched images flow', () => {
         unwatchAllImages();
     });
 
-    it('should allow adding a watched image via the images table row action', () => {
-        visitWorkloadCveOverview();
-        selectEntityTab('Image');
+    it(
+        'should allow adding a watched image via the images table row action',
+        {
+            defaultCommandTimeout: 10000,
+        },
+        () => {
+            visitWorkloadCveOverview();
+            selectEntityTab('Image');
 
-        selectUnwatchedImageTextFromTable().then(([, nameAndTag, fullName]) => {
-            cy.get(`${selectors.firstUnwatchedImageRow} *[aria-label="Actions"]`).click();
-            cy.get('button:contains("Watch image")').click();
+            selectUnwatchedImageTextFromTable().then(([, nameAndTag, fullName]) => {
+                cy.get(`${selectors.firstUnwatchedImageRow} *[aria-label="Actions"]`).click();
+                cy.get('button:contains("Watch image")').click();
 
-            // Verify that the selected image is pre-populated in the modal
-            cy.get(`${selectors.addWatchedImageNameInput}[value="${fullName}"]`);
+                // Verify that the selected image is pre-populated in the modal
+                cy.get(`${selectors.addWatchedImageNameInput}[value="${fullName}"]`);
 
-            watchImageFlowFromModal(fullName, nameAndTag);
-        });
-    });
-
-    it('should allow management of watched images via the overview page header button', () => {
-        visitWorkloadCveOverview();
-        selectEntityTab('Image');
-
-        selectUnwatchedImageTextFromTable().then(([, nameAndTag, fullName]) => {
-            // Open the modal and watch the image
-            cy.get(selectors.manageWatchedImagesButton).click();
-            cy.get(selectors.addWatchedImageNameInput).type(fullName);
-            watchImageFlowFromModal(fullName, nameAndTag);
-
-            // Watch a second image to verify functionality with multiple images
-            selectUnwatchedImageTextFromTable().then(([, secondNameAndTag, secondFullName]) => {
-                // Open the modal and watch a second image
-                cy.get(selectors.manageWatchedImagesButton).click();
-                cy.get(selectors.addWatchedImageNameInput).type(secondFullName);
-                watchImageFlowFromModal(secondFullName, secondNameAndTag);
-
-                // Unwatch both images
-                cy.get(selectors.manageWatchedImagesButton).click();
-                unwatchImageFromModal(fullName, nameAndTag);
-
-                cy.get(selectors.manageWatchedImagesButton).click();
-                unwatchImageFromModal(secondFullName, secondNameAndTag);
+                watchImageFlowFromModal(fullName, nameAndTag);
             });
-        });
-    });
+        }
+    );
+
+    it(
+        'should allow management of watched images via the overview page header button',
+
+        {
+            defaultCommandTimeout: 10000,
+        },
+        () => {
+            visitWorkloadCveOverview();
+            selectEntityTab('Image');
+
+            selectUnwatchedImageTextFromTable().then(([, nameAndTag, fullName]) => {
+                // Open the modal and watch the image
+                cy.get(selectors.manageWatchedImagesButton).click();
+                cy.get(selectors.addWatchedImageNameInput).type(fullName);
+                watchImageFlowFromModal(fullName, nameAndTag);
+
+                // Watch a second image to verify functionality with multiple images
+                selectUnwatchedImageTextFromTable().then(([, secondNameAndTag, secondFullName]) => {
+                    // Open the modal and watch a second image
+                    cy.get(selectors.manageWatchedImagesButton).click();
+                    cy.get(selectors.addWatchedImageNameInput).type(secondFullName);
+                    watchImageFlowFromModal(secondFullName, secondNameAndTag);
+
+                    // Unwatch both images
+                    cy.get(selectors.manageWatchedImagesButton).click();
+                    unwatchImageFromModal(fullName, nameAndTag);
+
+                    cy.get(selectors.manageWatchedImagesButton).click();
+                    unwatchImageFromModal(secondFullName, secondNameAndTag);
+                });
+            });
+        }
+    );
 
     it('should not allow adding a blank or invalid image name to the watch list', () => {
         visitWorkloadCveOverview();

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
@@ -1,6 +1,13 @@
 import withAuth from '../../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../../helpers/features';
-import { visitWorkloadCveOverview, selectEntityTab } from './WorkloadCves.helpers';
+import {
+    visitWorkloadCveOverview,
+    selectEntityTab,
+    unwatchAllImages,
+    selectUnwatchedImageTextFromTable,
+    watchImageFlowFromModal,
+    unwatchImageFromModal,
+} from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 
 describe('Workload CVE watched images flow', () => {
@@ -10,53 +17,81 @@ describe('Workload CVE watched images flow', () => {
         if (!hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES')) {
             this.skip();
         }
+    });
 
-        // TODO - Clear any existing watched images before running tests
+    beforeEach(() => {
+        // clean up any existing watched images
+        unwatchAllImages();
     });
 
     it('should allow adding a watched image via the images table row action', () => {
         visitWorkloadCveOverview();
-
         selectEntityTab('Image');
 
-        cy.get(
-            [
-                `${selectors.firstUnwatchedImageRow} td[data-label="Image"] div > a`,
-                `${selectors.firstUnwatchedImageRow} td[data-label="Image"] div > span`,
-            ].join(',')
-        ).then(([$imageLink, $imageRegistryText]) => {
-            const nameAndTag = $imageLink.innerText.replace(/\s+/g, ''); // clean up whitespace
-            const registry = $imageRegistryText.innerText.replace(/in\s+/, ''); // remove "in" prefix before registry
-            const fullName = `${registry}/${nameAndTag}`;
+        selectUnwatchedImageTextFromTable().then(([, nameAndTag, fullName]) => {
             cy.get(`${selectors.firstUnwatchedImageRow} *[aria-label="Actions"]`).click();
             cy.get('button:contains("Watch image")').click();
 
             // Verify that the selected image is pre-populated in the modal
             cy.get(`${selectors.addWatchedImageNameInput}[value="${fullName}"]`);
 
-            // TODO - Test for ability to add the selected image to the watch list
-
-            // TODO - Test that the image appears with a "Watched image" label in the table
+            watchImageFlowFromModal(fullName, nameAndTag);
         });
     });
 
     it('should allow management of watched images via the overview page header button', () => {
         visitWorkloadCveOverview();
+        selectEntityTab('Image');
 
+        selectUnwatchedImageTextFromTable().then(([, nameAndTag, fullName]) => {
+            // Open the modal and watch the image
+            cy.get(selectors.manageWatchedImagesButton).click();
+            cy.get(selectors.addWatchedImageNameInput).type(fullName);
+            watchImageFlowFromModal(fullName, nameAndTag);
+
+            // Watch a second image to verify functionality with multiple images
+            selectUnwatchedImageTextFromTable().then(([, secondNameAndTag, secondFullName]) => {
+                // Open the modal and watch a second image
+                cy.get(selectors.manageWatchedImagesButton).click();
+                cy.get(selectors.addWatchedImageNameInput).type(secondFullName);
+                watchImageFlowFromModal(secondFullName, secondNameAndTag);
+
+                // Unwatch both images
+                cy.get(selectors.manageWatchedImagesButton).click();
+                unwatchImageFromModal(fullName, nameAndTag);
+
+                cy.get(selectors.manageWatchedImagesButton).click();
+                unwatchImageFromModal(secondFullName, secondNameAndTag);
+            });
+        });
+    });
+
+    it('should not allow adding a blank or invalid image name to the watch list', () => {
+        visitWorkloadCveOverview();
         selectEntityTab('Image');
 
         cy.get(selectors.manageWatchedImagesButton).click();
 
-        // TODO - Test that the image name input is empty
+        // "touch" the input
+        cy.get(`${selectors.addWatchedImageNameInput}`).click();
+        cy.get(`${selectors.addWatchedImageNameInput}`).blur();
 
-        // TODO - Test for ability to add an image to the watch list by typing the name
+        // Verify that the add image button is disabled due to the empty input
+        cy.get(selectors.addImageToWatchListButton).should('be.disabled');
 
-        // TODO - Test that the image appears in the table with a "Watched image" label
+        // Enter an invalid image name into the input
+        cy.get(`${selectors.addWatchedImageNameInput}`).type('bogus.xyz/invalid-ns:0.0.0.0');
 
-        // TODO - Test for ability to remove images from the watch list
+        // Click the add image button
+        cy.get(selectors.addImageToWatchListButton).click();
 
-        // TODO - Test that the image appears in the table without a "Watched image" label
+        // Verify that an error appears
+        cy.get(
+            selectors.modalAlertWithText('There was an error adding the image to the watch list')
+        );
 
-        // TODO - Test that the image is no longer visible in the modal
+        // Verify that the table is not present
+        cy.get(selectors.currentWatchedImagesTable).should('not.exist');
+        cy.get('*:contains("No watched images found")');
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -182,19 +182,19 @@ function ImagesTable({
                                     <DateDistanceTd date={scanTime} />
                                 </Td>
                                 <Td isActionCell>
-                                    <ActionsColumn
-                                        items={[
-                                            {
-                                                title: 'Watch image',
-                                                onClick: () =>
-                                                    onWatchImage(
-                                                        name
-                                                            ? `${name.registry}/${name.remote}:${name.tag}`
-                                                            : ''
-                                                    ),
-                                            },
-                                        ]}
-                                    />
+                                    {name?.tag && (
+                                        <ActionsColumn
+                                            items={[
+                                                {
+                                                    title: 'Watch image',
+                                                    onClick: () =>
+                                                        onWatchImage(
+                                                            `${name.registry}/${name.remote}:${name.tag}`
+                                                        ),
+                                                },
+                                            ]}
+                                        />
+                                    )}
                                 </Td>
                             </Tr>
                         </Tbody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -144,7 +144,7 @@ function ImagesTable({
                                                     className="pf-u-mt-xs"
                                                     icon={<EyeIcon />}
                                                 >
-                                                    Watched Image
+                                                    Watched image
                                                 </Label>
                                             )}
                                         </ImageNameTd>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesForm.tsx
@@ -3,7 +3,9 @@ import { Button, Form, FormGroup, TextInput } from '@patternfly/react-core';
 import { FormikHelpers, useFormik } from 'formik';
 import * as yup from 'yup';
 
+import { UseRestQueryReturn } from 'hooks/useRestQuery';
 import { UseRestMutationReturn } from 'hooks/useRestMutation';
+import { WatchedImage } from 'types/image.proto';
 
 const validationSchema = yup.object({
     imageName: yup.string().required('A valid image name is required'),
@@ -13,10 +15,15 @@ type FormData = yup.InferType<typeof validationSchema>;
 
 export type WatchedImagesFormProps = {
     defaultWatchedImageName: string;
+    watchedImagesRequest: UseRestQueryReturn<WatchedImage[]>;
     watchImage: UseRestMutationReturn<string, string>['mutate'];
 };
 
-function WatchedImagesForm({ defaultWatchedImageName, watchImage }: WatchedImagesFormProps) {
+function WatchedImagesForm({
+    defaultWatchedImageName,
+    watchedImagesRequest,
+    watchImage,
+}: WatchedImagesFormProps) {
     const {
         values,
         errors,
@@ -36,6 +43,7 @@ function WatchedImagesForm({ defaultWatchedImageName, watchImage }: WatchedImage
 
     function addToWatchedImages(formValues: FormData, { setSubmitting }: FormikHelpers<FormData>) {
         watchImage(formValues.imageName, {
+            onSuccess: () => watchedImagesRequest.refetch(),
             onSettled: () => setSubmitting(false),
         });
     }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
@@ -1,12 +1,24 @@
-import React from 'react';
-import { Alert, Button, Flex, Modal } from '@patternfly/react-core';
+import React, { CSSProperties, useCallback } from 'react';
+import {
+    Alert,
+    Bullseye,
+    Button,
+    Divider,
+    Flex,
+    Modal,
+    pluralize,
+    Spinner,
+    Title,
+} from '@patternfly/react-core';
 import noop from 'lodash/noop';
 
-import { watchImage } from 'services/imageService';
+import { getWatchedImages, unwatchImage, watchImage } from 'services/imageService';
 import useRestMutation from 'hooks/useRestMutation';
+import useRestQuery from 'hooks/useRestQuery';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import WatchedImagesForm from './WatchedImagesForm';
+import WatchedImagesTable from './WatchedImagesTable';
 
 export type WatchedImagesModalProps = {
     defaultWatchedImageName: string;
@@ -21,15 +33,27 @@ function WatchedImagesModal({
     onClose,
     onWatchedImagesChange,
 }: WatchedImagesModalProps) {
-    const { data, mutate, isSuccess, isLoading, isError, error, reset } = useRestMutation(
-        (name: string) => watchImage(name),
-        { onSuccess: onWatchedImagesChange }
-    );
+    const watchedImagesFn = useCallback(getWatchedImages, []);
+    const currentWatchedImagesRequest = useRestQuery(watchedImagesFn);
+
+    const watchImageMutation = useRestMutation((name: string) => watchImage(name), {
+        onSuccess: onWatchedImagesChange,
+    });
+
+    const unwatchImageMutation = useRestMutation((name: string) => unwatchImage(name), {
+        onSuccess: () => {
+            onWatchedImagesChange();
+            currentWatchedImagesRequest.refetch();
+        },
+    });
 
     function onCloseModal() {
         onClose();
-        reset();
+        watchImageMutation.reset();
+        unwatchImageMutation.reset();
     }
+
+    const watchedImages = currentWatchedImagesRequest.data ?? [];
 
     return (
         <Modal
@@ -37,37 +61,93 @@ function WatchedImagesModal({
             isOpen={isOpen}
             onClose={onCloseModal}
             variant="medium"
-            showClose={!isLoading}
-            onEscapePress={isLoading ? noop : onCloseModal}
+            showClose={false}
+            onEscapePress={watchImageMutation.isLoading ? noop : onCloseModal}
             actions={[
-                <Button key="Close" onClick={onCloseModal} isDisabled={isLoading}>
+                <Button
+                    key="Close"
+                    onClick={onCloseModal}
+                    isDisabled={watchImageMutation.isLoading}
+                >
                     Close
                 </Button>,
             ]}
         >
             <Flex direction={{ default: 'column' }}>
-                {isSuccess && (
+                {watchImageMutation.isSuccess && (
                     <Alert
                         variant="success"
                         isInline
                         title="The image was successfully added to the watch list"
                     >
-                        {data ?? ''}
+                        {watchImageMutation.data ?? ''}
                     </Alert>
                 )}
-                {isError && (
+                {watchImageMutation.isError && (
                     <Alert
                         variant="danger"
                         isInline
                         title="There was an error adding the image to the watch list"
                     >
-                        {getAxiosErrorMessage(error)}
+                        {getAxiosErrorMessage(watchImageMutation.error)}
                     </Alert>
                 )}
                 <WatchedImagesForm
                     defaultWatchedImageName={defaultWatchedImageName}
-                    watchImage={mutate}
+                    watchImage={watchImageMutation.mutate}
+                    watchedImagesRequest={currentWatchedImagesRequest}
                 />
+                <Divider component="div" />
+                {unwatchImageMutation.isSuccess && (
+                    <Alert
+                        variant="success"
+                        isInline
+                        title="The image was successfully removed from the watch list"
+                    />
+                )}
+                {unwatchImageMutation.isError && (
+                    <Alert
+                        variant="danger"
+                        isInline
+                        title="There was an error removing the image from the watch list"
+                    >
+                        {getAxiosErrorMessage(unwatchImageMutation.error)}
+                    </Alert>
+                )}
+                {currentWatchedImagesRequest.error && (
+                    <Alert
+                        variant="danger"
+                        isInline
+                        title="There was an error loading the current list of watched images"
+                    >
+                        {getAxiosErrorMessage(currentWatchedImagesRequest.error)}
+                    </Alert>
+                )}
+                {currentWatchedImagesRequest.loading && !currentWatchedImagesRequest.data && (
+                    <Bullseye>
+                        <Spinner isSVG aria-label="Loading current watched images" />
+                    </Bullseye>
+                )}
+                {currentWatchedImagesRequest.data && (
+                    <>
+                        <Title id="current-watched-images-list" headingLevel="h2">
+                            {pluralize(watchedImages.length, 'watched image')}
+                        </Title>
+                        <WatchedImagesTable
+                            aria-labelledby="current-watched-images-list"
+                            className="pf-u-max-height"
+                            style={
+                                {
+                                    overflowY: 'auto',
+                                    '--pf-u-max-height--MaxHeight': '280px',
+                                } as CSSProperties
+                            }
+                            watchedImages={watchedImages}
+                            unwatchImage={unwatchImageMutation.mutate}
+                            isUnwatchInProgress={unwatchImageMutation.isLoading}
+                        />
+                    </>
+                )}
             </Flex>
         </Modal>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
@@ -8,6 +8,7 @@ import {
     Modal,
     pluralize,
     Spinner,
+    Text,
     Title,
 } from '@patternfly/react-core';
 import noop from 'lodash/noop';
@@ -57,7 +58,17 @@ function WatchedImagesModal({
 
     return (
         <Modal
-            title="Manage watched images"
+            header={
+                <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXs' }}>
+                    <Title headingLevel="h2" size="2xl">
+                        Manage watched images
+                    </Title>
+                    <Text>
+                        Enter an image name to mark it as watched, so that it will continue to be
+                        scanned even if no deployments use it.
+                    </Text>
+                </Flex>
+            }
             isOpen={isOpen}
             onClose={onCloseModal}
             variant="medium"
@@ -92,12 +103,6 @@ function WatchedImagesModal({
                         {getAxiosErrorMessage(watchImageMutation.error)}
                     </Alert>
                 )}
-                <WatchedImagesForm
-                    defaultWatchedImageName={defaultWatchedImageName}
-                    watchImage={watchImageMutation.mutate}
-                    watchedImagesRequest={currentWatchedImagesRequest}
-                />
-                <Divider component="div" />
                 {unwatchImageMutation.isSuccess && (
                     <Alert
                         variant="success"
@@ -123,6 +128,12 @@ function WatchedImagesModal({
                         {getAxiosErrorMessage(currentWatchedImagesRequest.error)}
                     </Alert>
                 )}
+                <WatchedImagesForm
+                    defaultWatchedImageName={defaultWatchedImageName}
+                    watchImage={watchImageMutation.mutate}
+                    watchedImagesRequest={currentWatchedImagesRequest}
+                />
+                <Divider component="div" />
                 {currentWatchedImagesRequest.loading && !currentWatchedImagesRequest.data && (
                     <Bullseye>
                         <Spinner isSVG aria-label="Loading current watched images" />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesTable.tsx
@@ -1,0 +1,80 @@
+import React, { CSSProperties } from 'react';
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Bullseye, Button } from '@patternfly/react-core';
+import { MinusCircleIcon } from '@patternfly/react-icons';
+
+import { WatchedImage } from 'types/image.proto';
+import { UseRestMutationReturn } from 'hooks/useRestMutation';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+import { Empty } from 'services/types';
+
+export type WatchedImagesTableProps = {
+    className?: string;
+    style?: CSSProperties;
+    watchedImages: WatchedImage[];
+    unwatchImage: UseRestMutationReturn<string, Empty>['mutate'];
+    isUnwatchInProgress: boolean;
+    'aria-labelledby'?: string;
+};
+
+function WatchedImagesTable({
+    className,
+    style,
+    watchedImages,
+    unwatchImage,
+    isUnwatchInProgress,
+    ...props
+}: WatchedImagesTableProps) {
+    return (
+        <div className={className} style={style}>
+            {watchedImages.length === 0 && (
+                <Bullseye>
+                    <EmptyStateTemplate title="No watched images found" headingLevel="h2" />
+                </Bullseye>
+            )}
+            {watchedImages.length > 0 && (
+                <TableComposable
+                    aria-labelledby={props['aria-labelledby']}
+                    variant="compact"
+                    style={
+                        {
+                            '--pf-c-table--m-compact--cell--first-last-child--PaddingLeft': '0',
+                        } as CSSProperties
+                    }
+                >
+                    <Thead noWrap>
+                        <Tr>
+                            <Th>Image</Th>
+                            <Th aria-label="Remove watched image" />
+                        </Tr>
+                    </Thead>
+                    <Tbody>
+                        {watchedImages.map(({ name }) => (
+                            <Tr key={name}>
+                                <Td dataLabel="Image">{name}</Td>
+                                <Td
+                                    dataLabel="Remove watched image"
+                                    className="pf-u-text-align-right"
+                                >
+                                    <Button
+                                        variant="link"
+                                        isInline
+                                        icon={
+                                            <MinusCircleIcon color="var(--pf-global--Color--200)" />
+                                        }
+                                        onClick={() => unwatchImage(name)}
+                                        disabled={isUnwatchInProgress}
+                                    >
+                                        Remove watch
+                                    </Button>
+                                </Td>
+                            </Tr>
+                        ))}
+                    </Tbody>
+                </TableComposable>
+            )}
+        </div>
+    );
+}
+
+export default WatchedImagesTable;


### PR DESCRIPTION
## Description

Hides the action cell and "Watch image" option for images that do not have a tag (e.g. digest based images). Currently attempting to watch one of these images always results in an error, so the option has been removed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the images tab and see images without tags and without table actions:
![image](https://github.com/stackrox/stackrox/assets/1292638/3e333707-57d7-4f76-b5cc-f48a5a585755)

