### PR TITLE
ROX-19613: Retry http calls in roxctl

### DIFF
--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -261,7 +261,7 @@ func (h *httpHandler) post(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.handleZipContentsFromVulnDump(r.Context(), tempFile); err != nil {
-		httputil.WriteGRPCStyleError(w, codes.Internal, err)
+		httputil.WriteGRPCStyleError(w, codes.InvalidArgument, err)
 		return
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,10 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
-require github.com/klauspost/compress v1.16.7
+require (
+	github.com/hashicorp/go-retryablehttp v0.7.2
+	github.com/klauspost/compress v1.16.7
+)
 
 require (
 	cloud.google.com/go v0.110.6 // indirect
@@ -251,6 +254,7 @@ require (
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.6
 	github.com/heimdalr/dag v1.3.1
@@ -64,6 +65,7 @@ require (
 	github.com/jackc/pgtype v1.14.0
 	github.com/jackc/pgx/v4 v4.18.1
 	github.com/joshdk/go-junit v1.0.0
+	github.com/klauspost/compress v1.16.7
 	github.com/lib/pq v1.10.9
 	github.com/machinebox/graphql v0.2.2
 	github.com/mailru/easyjson v0.7.7
@@ -147,11 +149,6 @@ require (
 	sigs.k8s.io/controller-tools v0.11.3
 	sigs.k8s.io/e2e-framework v0.2.0
 	sigs.k8s.io/yaml v1.3.0
-)
-
-require (
-	github.com/hashicorp/go-retryablehttp v0.7.2
-	github.com/klauspost/compress v1.16.7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -784,12 +784,16 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-hclog v1.3.1 h1:vDwF1DFNZhntP4DAjuTpOw3uEgMUpXh1pB5fW9DqHpo=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
+github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7 h1:UpiO20jno/eV1eVZcxqWnUohyKRe1g8FPV/xH1s/2qs=

--- a/pkg/httputil/error.go
+++ b/pkg/httputil/error.go
@@ -17,6 +17,12 @@ type HTTPError interface {
 	HTTPStatus
 }
 
+// TimeoutError is an interface for HTTP errors that specify whether a timeout occurred.
+type TimeoutError interface {
+	error
+	Timeout() bool
+}
+
 type httpError struct {
 	httpStatus
 }

--- a/roxctl/central/debug/download_diagnostics.go
+++ b/roxctl/central/debug/download_diagnostics.go
@@ -75,10 +75,7 @@ To specify timeout, run  'roxctl' command:
 
 func isTimeoutError(err error) bool {
 	var netErr net.Error
-	var urlErr *url.Error
 
-	// Need to unwrap the url.Error twice, since the first url.Error will not hold the correct timeout value.
-	return errors.As(err, &urlErr) && errors.As(urlErr.Err, &urlErr) && urlErr.Timeout() ||
-		errors.As(err, &netErr) && netErr.Timeout() ||
+	return errors.As(err, &netErr) && netErr.Timeout() ||
 		errors.Is(err, context.DeadlineExceeded)
 }

--- a/roxctl/central/debug/download_diagnostics.go
+++ b/roxctl/central/debug/download_diagnostics.go
@@ -3,13 +3,13 @@ package debug
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/common/util"
@@ -74,8 +74,8 @@ To specify timeout, run  'roxctl' command:
 }
 
 func isTimeoutError(err error) bool {
-	var netErr net.Error
+	var timeoutErr httputil.TimeoutError
 
-	return errors.As(err, &netErr) && netErr.Timeout() ||
+	return errors.As(err, &timeoutErr) && timeoutErr.Timeout() ||
 		errors.Is(err, context.DeadlineExceeded)
 }

--- a/roxctl/central/debug/download_diagnostics.go
+++ b/roxctl/central/debug/download_diagnostics.go
@@ -75,5 +75,10 @@ To specify timeout, run  'roxctl' command:
 
 func isTimeoutError(err error) bool {
 	var netErr net.Error
-	return (errors.As(err, &netErr) && netErr.Timeout()) || errors.Is(err, context.DeadlineExceeded)
+	var urlErr *url.Error
+
+	// Need to unwrap the url.Error twice, since the first url.Error will not hold the correct timeout value.
+	return errors.As(err, &urlErr) && errors.As(urlErr.Err, &urlErr) && urlErr.Timeout() ||
+		errors.As(err, &netErr) && netErr.Timeout() ||
+		errors.Is(err, context.DeadlineExceeded)
 }

--- a/roxctl/central/debug/download_diagnostics_test.go
+++ b/roxctl/central/debug/download_diagnostics_test.go
@@ -39,7 +39,7 @@ func TestDownloadDiagnosticsTimeoutReached(t *testing.T) {
 func TestDownloadDiagnosticsServerError(t *testing.T) {
 	expectedErrorStr := "test-server-error"
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		rw.WriteHeader(http.StatusInternalServerError)
+		rw.WriteHeader(http.StatusBadRequest)
 		_, _ = rw.Write([]byte(expectedErrorStr))
 	}))
 	defer server.Close()

--- a/roxctl/common/client.go
+++ b/roxctl/common/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -103,6 +104,11 @@ func (client *roxctlClientImpl) DoReqAndVerifyStatusCode(path string, method str
 // Do executes a http.Request
 func (client *roxctlClientImpl) Do(req *http.Request) (*http.Response, error) {
 	resp, err := client.http.Do(req)
+	// The url.Error returned by go-retryablehttp needs to be unwrapped to retrieve the correct timeout settings.
+	// See https://github.com/hashicorp/go-retryablehttp/issues/142.
+	if _, ok := err.(*url.Error); ok {
+		err = errors.Unwrap(err)
+	}
 	return resp, errors.Wrap(err, "error when doing http request")
 }
 

--- a/roxctl/common/client.go
+++ b/roxctl/common/client.go
@@ -70,6 +70,7 @@ func GetRoxctlHTTPClient(am auth.Method, timeout time.Duration, forceHTTP1 bool,
 	retryClient.RetryMax = 3
 	retryClient.HTTPClient.Transport = transport
 	retryClient.HTTPClient.Timeout = timeout
+	retryClient.RetryWaitMin = 10 * time.Second
 
 	client := retryClient.StandardClient()
 	return &roxctlClientImpl{http: client, am: am, forceHTTP1: forceHTTP1, useInsecure: useInsecure}, nil

--- a/roxctl/scanner/uploaddb/uploaddb_test.go
+++ b/roxctl/scanner/uploaddb/uploaddb_test.go
@@ -67,7 +67,7 @@ func TestScannerUploadDbCommand(t *testing.T) {
 	t.Run("server error", func(t *testing.T) {
 		expectedErrorStr := "test-server-error"
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			rw.WriteHeader(http.StatusInternalServerError)
+			rw.WriteHeader(http.StatusBadRequest)
 			_, _ = rw.Write([]byte(expectedErrorStr))
 		}))
 		defer server.Close()


### PR DESCRIPTION
## Description

We've been dealing with issues within roxctl when calling APIs via HTTP. For gRPC, retries have already been added, however for HTTP not yet.

This PR adds retries to the HTTP client shared for each command within the environment by leveraging [go-retryablehttp](https://github.com/hashicorp/go-retryablehttp).

The current retry logic is a maximum of 3 retries, using an exponential backoff with a minimum wait time of 10 second and a maximum wait time of 30 seconds in-between requests. This should help with CI flakes we've seen.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
