### PR TITLE
fix(retry): make backoff exponential

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -1,6 +1,9 @@
 package retry
 
-import "time"
+import (
+	"math"
+	"time"
+)
 
 // WithRetry allows you to call an error returning function with a suite of retry options and modifiers.
 func WithRetry(f func() error, retriableOptions ...OptionsModifier) error {
@@ -65,9 +68,8 @@ func (t *retryOptions) do() (err error) {
 					t.between(i)
 				}
 				if t.withExponentialBackoff {
-					// Back off by 100 milliseconds after the first attempt,
-					// 400 milliseconds after the second, 900 milliseconds after the third, etc.
-					time.Sleep(time.Duration(100*(i+1)*(i+1)) * time.Millisecond)
+					backoff := math.Pow(2, float64(i)) * float64(100)
+					time.Sleep(time.Duration(backoff))
 				}
 			} else {
 				// If we can't retry then return.


### PR DESCRIPTION
## Description

While there should be a exponential backoff, we currently have a quadratic backoff. This isn't necessarily the worst thing, since usages of the retry package only have a low number of retries (usually not more than 5) so this isn't too bad.

Nevertheless, this change does introduce the exponential backoff.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
