### PR TITLE
test(ui): Add Cypress tests for Workload CVE overview page

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -70,6 +70,29 @@ export function selectEntityTab(entityType) {
 }
 
 /**
+ * Given a severity count text from an element, extract the severity
+ * @param severityCountText - The aria-label of the severity count element
+ * @returns {[string, string[]]} - The first element is the severity, the second is the unused severities
+ */
+export function extractNonZeroSeverityFromCount(severityCountText) {
+    const allSeverities = ['Critical', 'Important', 'Moderate', 'Low'];
+    const anySeverityRegExp = new RegExp(`(${allSeverities.join('|')})`, 'i');
+
+    // Extract the severity from the text
+    const rawSeverity = severityCountText.match(anySeverityRegExp)[1];
+    const targetSeverity = allSeverities.find((s) => s.toUpperCase() === rawSeverity.toUpperCase());
+
+    if (!targetSeverity) {
+        throw new Error(`Could not find valid severity in text: ${severityCountText}`);
+    }
+
+    return [
+        targetSeverity,
+        allSeverities.filter((s) => s.toUpperCase() !== targetSeverity.toUpperCase()),
+    ];
+}
+
+/**
  * Clean up any existing watched images via API
  */
 export function unwatchAllImages() {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -69,15 +69,15 @@ export function selectEntityTab(entityType) {
     cy.get(selectors.entityTypeToggleItem(entityType)).click();
 }
 
+const allSeverities = ['Critical', 'Important', 'Moderate', 'Low'];
+const anySeverityRegExp = new RegExp(`(${allSeverities.join('|')})`, 'i');
+
 /**
  * Given a severity count text from an element, extract the severity
  * @param severityCountText - The aria-label of the severity count element
  * @returns {[string, string[]]} - The first element is the severity, the second is the unused severities
  */
 export function extractNonZeroSeverityFromCount(severityCountText) {
-    const allSeverities = ['Critical', 'Important', 'Moderate', 'Low'];
-    const anySeverityRegExp = new RegExp(`(${allSeverities.join('|')})`, 'i');
-
     // Extract the severity from the text
     const rawSeverity = severityCountText.match(anySeverityRegExp)[1];
     const targetSeverity = allSeverities.find((s) => s.toUpperCase() === rawSeverity.toUpperCase());

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -9,7 +9,7 @@ export const selectors = {
     resourceValueTypeahead: (resource) =>
         `.pf-c-toolbar input[aria-label="Filter by ${resource.toUpperCase()}"]`,
     resourceValueMenuItem: (resource, value) =>
-        `.pf-c-toolbar ul[aria-label="Filter by ${resource.toUpperCase()}"] button:contains("${value}")`,
+        `.pf-c-toolbar ul[aria-label="Filter by ${resource.toUpperCase()}"] button:contains('Add "${value}"')`,
     severityDropdown: '.pf-c-toolbar button[aria-label="CVE severity filter menu toggle"]',
     severityMenuItems: '.pf-c-toolbar ul[aria-label="CVE severity filter menu items"]',
     severityMenuItem: (severity) => `${selectors.severityMenuItems} label:contains("${severity}")`,
@@ -26,7 +26,7 @@ export const selectors = {
         `${selectors.filterChipGroupForCategory(category)} + ul li:contains("${item}")`,
     filterChipGroupItemRemove: (category, item) =>
         `${selectors.filterChipGroupItem(category, item)} button[aria-label="close"]`,
-    clearFiltersButton: `${filterChipSection} .pf-c-toolbar button:contains("Clear filters")`,
+    clearFiltersButton: `${filterChipSection} button:contains("Clear filters")`,
 
     // General selectors
     filteredViewLabel: '.pf-c-label:contains("Filtered view")',

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -1,6 +1,8 @@
 const watchedImageLabelText = 'Watched image';
+const filterChipSection = '.pf-c-toolbar .pf-c-toolbar__group[aria-label="applied search filters"]';
 
 export const selectors = {
+    // Toolbar selectors
     resourceDropdown: '.pf-c-toolbar button[aria-label="resource filter menu toggle"]',
     resourceMenuItem: (resource) =>
         `.pf-c-toolbar ul[aria-label="resource filter menu items"] button:contains("${resource}")`,
@@ -15,21 +17,36 @@ export const selectors = {
     fixabilityMenuItems: '.pf-c-toolbar ul[aria-label="CVE status filter menu items"]',
     fixabilityMenuItem: (fixability) =>
         `${selectors.fixabilityMenuItems} label:contains("${fixability}")`,
-    filterChipGroup: (category) => `.pf-c-toolbar .pf-c-chip-group *:contains("${category}")`,
+    filterChipGroup: `${filterChipSection} .pf-c-chip-group`,
+    filterChipGroupForCategory: (category) =>
+        `${selectors.filterChipGroup} *:contains("${category}")`,
     filterChipGroupRemove: (category) =>
-        `${selectors.filterChipGroup(category)} button[aria-label="close"]`,
+        `${selectors.filterChipGroupForCategory(category)} button[aria-label="close"]`,
     filterChipGroupItem: (category, item) =>
-        `${selectors.filterChipGroup(category)} + ul li:contains("${item}")`,
+        `${selectors.filterChipGroupForCategory(category)} + ul li:contains("${item}")`,
     filterChipGroupItemRemove: (category, item) =>
         `${selectors.filterChipGroupItem(category, item)} button[aria-label="close"]`,
-    clearFiltersButton: '.pf-c-toolbar button:contains("Clear filters")',
+    clearFiltersButton: `${filterChipSection} .pf-c-toolbar button:contains("Clear filters")`,
+
+    // General selectors
     filteredViewLabel: '.pf-c-label:contains("Filtered view")',
     entityTypeToggleItem: (entityType) =>
         `.pf-c-toggle-group[aria-label="Entity type toggle items"] button:contains("${entityType}")`,
     summaryCard: (cardTitle) => `.pf-c-card:contains("${cardTitle}")`,
     iconText: (textContent) => `svg ~ *:contains("${textContent}")`,
+
+    // Data table selectors
+    isUpdatingTable: '*[aria-busy="true"] table',
     firstTableRow: 'table tbody:nth-of-type(1) tr:nth-of-type(1)',
     nonZeroCveSeverityCounts: '*[aria-label*="severity cves"i]:not([aria-label^="0"])',
+    nonZeroImageSeverityCounts:
+        '*[aria-label*="images with"i][aria-label$="severity"i]:not([aria-label^="0"])',
+    nonZeroCveSeverityCount: (severity) =>
+        `span[aria-label*="${severity.toLowerCase()} severity CVEs across this"]`,
+    nonZeroImageSeverityCount: (severity) =>
+        `span[aria-label*="with ${severity.toLowerCase()} severity"]`,
+    hiddenSeverityCount: (severity) =>
+        `span[aria-label="${severity} severity is hidden by the applied filter"]`,
 
     // Watched image selectors
     watchedImageLabel: `.pf-c-label:contains("${watchedImageLabelText}")`,

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
@@ -1,0 +1,100 @@
+import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
+import {
+    applyLocalSeverityFilters,
+    extractNonZeroSeverityFromCount,
+    selectEntityTab,
+    visitWorkloadCveOverview,
+} from './WorkloadCves.helpers';
+
+import { selectors } from './WorkloadCves.selectors';
+
+describe('Workload CVE overview page tests', () => {
+    withAuth();
+
+    before(function () {
+        if (!hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES')) {
+            this.skip();
+        }
+    });
+
+    it('should satisfy initial page load defaults', () => {
+        visitWorkloadCveOverview();
+
+        // TODO Test that the default tab is set to "Observed"
+
+        // Check that the CVE entity toggle is selected and Image/Deployment are disabled
+        cy.get(selectors.entityTypeToggleItem('CVE')).should('have.attr', 'aria-pressed', 'true');
+        cy.get(selectors.entityTypeToggleItem('Image')).should(
+            'not.have.attr',
+            'aria-pressed',
+            'true'
+        );
+        cy.get(selectors.entityTypeToggleItem('Deployment')).should(
+            'not.have.attr',
+            'aria-pressed',
+            'true'
+        );
+
+        // Check the no filters exist in the chips
+        cy.get(selectors.filterChipGroup).should('not.exist');
+    });
+
+    it('should correctly handle applied filters across entity tabs', () => {
+        visitWorkloadCveOverview();
+
+        // Get the first CVE row from the table with a non-zero severity count for -any- severity
+        cy.get(selectors.nonZeroImageSeverityCounts)
+            .first()
+            .then(($severityCount) => {
+                const [nonZeroSeverity, unusedSeverities] = extractNonZeroSeverityFromCount(
+                    $severityCount.attr('aria-label')
+                );
+
+                expect(unusedSeverities).to.have.lengthOf(3);
+
+                // Apply the severity filter for the first non-zero CVE severity count
+                // @ts-ignore
+                applyLocalSeverityFilters(nonZeroSeverity);
+
+                // Check that the filter chip for the severity exists
+                cy.get(selectors.filterChipGroupItem('Severity', nonZeroSeverity));
+
+                // Check that the table is no longer updating the data to reflect the new filter
+                cy.get(selectors.isUpdatingTable).should('not.exist');
+
+                // Check that all table rows have a non-zero severity count for the selected severity
+                // Check that all table rows have other severity counts hidden for all other severities
+                const hiddenSeveritySelectors = [
+                    selectors.hiddenSeverityCount(unusedSeverities[0]),
+                    selectors.hiddenSeverityCount(unusedSeverities[1]),
+                    selectors.hiddenSeverityCount(unusedSeverities[2]),
+                ];
+                const imageSeverityCountSelector = [
+                    selectors.nonZeroImageSeverityCount(nonZeroSeverity),
+                    ...hiddenSeveritySelectors,
+                ].join(',');
+
+                const cveSeverityCountSelector = [
+                    selectors.nonZeroCveSeverityCount(nonZeroSeverity),
+                    ...hiddenSeveritySelectors,
+                ].join(',');
+
+                // Check all rows for the CVE table
+                cy.get('table tbody tr:nth-of-type(1)')
+                    .each(($row) => cy.wrap($row).find(imageSeverityCountSelector))
+                    // Check all rows for the Image table
+                    .then(() => {
+                        selectEntityTab('Image');
+                        return cy.get('table tbody tr:nth-of-type(1)');
+                    })
+                    .each(($row) => cy.wrap($row).find(cveSeverityCountSelector))
+                    // Check all rows for the Deployment table
+                    .then(() => {
+                        selectEntityTab('Deployment');
+                        return cy.get('table tbody tr:nth-of-type(1)');
+                    })
+                    .each(($row) => cy.wrap($row).find(cveSeverityCountSelector));
+            });
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -41,14 +41,12 @@ function WorkloadCvesOverviewPage() {
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const [activeEntityTabKey] = useURLStringUnion('entityTab', entityTabValues);
 
-    const { data: countsData = { imageCount: 0, imageCVECount: 0, deploymentCount: 0 } } = useQuery(
-        entityTypeCountsQuery,
-        {
+    const { data: countsData = { imageCount: 0, imageCVECount: 0, deploymentCount: 0 }, loading } =
+        useQuery(entityTypeCountsQuery, {
             variables: {
                 query: getCveStatusScopedQueryString(querySearchFilter),
             },
-        }
-    );
+        });
 
     const pagination = useURLPagination(20);
 
@@ -89,7 +87,11 @@ function WorkloadCvesOverviewPage() {
             <PageSection padding={{ default: 'noPadding' }}>
                 <PageSection isCenterAligned>
                     <Card>
-                        <CardBody>
+                        <CardBody
+                            role="region"
+                            aria-live="polite"
+                            aria-busy={loading ? 'true' : 'false'}
+                        >
                             {activeEntityTabKey === 'CVE' && (
                                 <CVEsTableContainer
                                     defaultFilters={emptyStorage.preferences.defaultFilters}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
@@ -88,7 +88,7 @@ function WorkloadTableToolbar({
                     <CVESeverityDropdown searchFilter={searchFilter} onSelect={onSelect} />
                     {/* CVEStatusDropdown is disabled until fixability filters are fixed */}
                 </ToolbarGroup>
-                <ToolbarGroup className="pf-u-w-100">
+                <ToolbarGroup aria-label="applied search filters" className="pf-u-w-100">
                     <SearchFilterChips
                         onFilterChange={onFilterChange}
                         filterChipGroupDescriptors={[


### PR DESCRIPTION
## Description

e2e tests for the Workload CVE overview page

1. Tests basic page properties and defaults
2. Test behavior of severity filter across the three entity tables

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI
