### PR TITLE
chore(ui): Update eslint-plugin-testing-library to 6.0.1

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -142,7 +142,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.27.0",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "eslint-plugin-testing-library": "^5.11.1",
+        "eslint-plugin-testing-library": "^6.0.1",
         "http-proxy-middleware": "^2.0.1",
         "jest-junit": "^12.0.0",
         "levenary": "^1.1.1",

--- a/ui/apps/platform/src/Containers/Dashboard/ScopeBar.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/ScopeBar.test.tsx
@@ -36,6 +36,8 @@ beforeEach(() => {
 });
 
 const setup = () => {
+    // Ignore false positive, see: https://github.com/testing-library/eslint-plugin-testing-library/issues/800
+    // eslint-disable-next-line testing-library/await-async-events
     const user = userEvent.setup();
     const utils = renderWithRouter(
         <MockedProvider mocks={mocks} addTypename={false}>

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImages.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImages.test.tsx
@@ -48,6 +48,8 @@ beforeEach(() => {
 });
 
 const setup = () => {
+    // Ignore false positive, see: https://github.com/testing-library/eslint-plugin-testing-library/issues/800
+    // eslint-disable-next-line testing-library/await-async-events
     const user = userEvent.setup();
     const utils = renderWithRouter(
         <MockedProvider mocks={mocks} addTypename={false}>

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -65,6 +65,8 @@ beforeEach(() => {
 });
 
 const setup = () => {
+    // Ignore false positive, see: https://github.com/testing-library/eslint-plugin-testing-library/issues/800
+    // eslint-disable-next-line testing-library/await-async-events
     const user = userEvent.setup();
     const utils = renderWithRouter(
         <MockedProvider mocks={mocks} addTypename={false}>

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRisk.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRisk.test.tsx
@@ -74,6 +74,8 @@ beforeEach(() => {
 });
 
 function setup() {
+    // Ignore false positive, see: https://github.com/testing-library/eslint-plugin-testing-library/issues/800
+    // eslint-disable-next-line testing-library/await-async-events
     const user = userEvent.setup();
     const utils = renderWithRouter(
         <MockedProvider mocks={mocks} addTypename={false}>

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategory.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategory.test.tsx
@@ -43,6 +43,8 @@ beforeEach(() => {
 });
 
 const setup = () => {
+    // Ignore false positive, see: https://github.com/testing-library/eslint-plugin-testing-library/issues/800
+    // eslint-disable-next-line testing-library/await-async-events
     const user = userEvent.setup();
     const utils = renderWithRouter(<ViolationsByPolicyCategory />);
 

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicySeverity.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicySeverity.test.tsx
@@ -64,6 +64,8 @@ beforeEach(() => {
 });
 
 function setup() {
+    // Ignore false positive, see: https://github.com/testing-library/eslint-plugin-testing-library/issues/800
+    // eslint-disable-next-line testing-library/await-async-events
     const user = userEvent.setup();
     const utils = renderWithRouter(
         <MockedProvider mocks={mocks} addTypename={false}>
@@ -119,7 +121,7 @@ describe('Violations by policy severity widget', () => {
         expect(history.location.search).toContain('[Severity]=CRITICAL_SEVERITY');
 
         // Test links from the 'most recent violations' section
-        await user.click(await screen.findByText(/ubuntu package manager/gi));
+        await user.click(await screen.findByText(/ubuntu package manager/i));
         expect(history.location.pathname).toBe(`${violationsBasePath}/${mockAlerts[0].id}`);
     });
 });

--- a/ui/package.json
+++ b/ui/package.json
@@ -45,7 +45,8 @@
     },
     "resolutions": {
         "@typescript-eslint/parser": "^4.32.0",
-        "autoprefixer": "10.4.5"
+        "autoprefixer": "10.4.5",
+        "eslint-plugin-testing-library": "^6.0.1"
     },
     "devDependencies": {
         "chalk-cli": "^5.0.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9019,10 +9019,10 @@ eslint-plugin-react@^7.27.1:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.7"
 
-eslint-plugin-testing-library@^5.0.1, eslint-plugin-testing-library@^5.11.1:
-  version "5.11.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.11.1.tgz#5b46cdae96d4a78918711c0b4792f90088e62d20"
-  integrity sha512-5eX9e1Kc2PqVRed3taaLnAAqPZGEX75C+M/rXzUAI3wIg/ZxzUm1OVAwfe/O+vE+6YXOLetSe9g5GKD2ecXipw==
+eslint-plugin-testing-library@^5.0.1, eslint-plugin-testing-library@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.0.1.tgz#c92325341f01fb2f76a3ab1c70d3c0c968c70b11"
+  integrity sha512-CEYtjpcF3hAaQtYsTZqciR7s5z+T0LCMTwJeW+pz6kBnGtc866wAKmhaiK2Gsjc2jWNP7Gt6zhNr2DE1ZW4e+g==
   dependencies:
     "@typescript-eslint/utils" "^5.58.0"
 


### PR DESCRIPTION
## Description

Because `eslint-config-react-app@^7.0.1` has `eslint-plugin-testing-library "^5.0.1"` add `"eslint-plugin-testing-library": "^6.0.1"` to `resolutions` in ui/package.json file.

Apparently with mono-repo, `resolutions` does not work in ui/apps/platform/package.json file, even after deleted from `devDependencies` in ui-components in #7808

### Errors

Only 2 breaking changes:

1. testing-library/await-async-events: Promise returned from async event method `user` must be handled
    * src/Containers/Dashboard/ScopeBar.test.tsx
    * src/Containers/Dashboard/Widgets/AgingImages.test.tsx
    * src/Containers/Dashboard/Widgets/ComplianceLevelsByStandard.test.tsx
    * src/Containers/Dashboard/Widgets/ImagesAtMostRisk.test.tsx
    * src/Containers/Dashboard/Widgets/ViolationsByPolicyCategory.test.tsx
    * src/Containers/Dashboard/Widgets/ViolationsByPolicySeverity.test.tsx
2. testing-library/no-global-regexp-flag-in-query: Avoid using the global RegExp flag (/g) in queries
    * src/Containers/Dashboard/Widgets/ViolationsByPolicySeverity.test.tsx

### Analysis

1. Moving `const user = userEvent.setup();` into tests causes the lint rule to pass but `screen` methods to fail, even though that is an alternative in the docs.
    https://testing-library.com/docs/user-event/intro/#writing-tests-with-userevent

### Solution

1. Because `setup` function follows the docs, add eslint-disable comment because error for `setup` method as false positive.
2. Delete unneeded global RegExp flag.

### Residue

1. testing-library/await-async-events
    * Watch for an updated that fixes the issue: https://github.com/testing-library/eslint-plugin-testing-library/issues/800
    * Test the inline alternative that seems to have a timing problem after upgrades to jest and testing-library packages.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui and also in ui/apps/platform