### PR TITLE
ROX-19344: Add deferral configuration page

### DIFF
--- a/ui/apps/platform/src/Containers/DeferralConfiguration/DeferralConfigurationPage.tsx
+++ b/ui/apps/platform/src/Containers/DeferralConfiguration/DeferralConfigurationPage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { PageSection, Title } from '@patternfly/react-core';
+
+import PageTitle from 'Components/PageTitle';
+
+function DeferralConfigurationPage() {
+    return (
+        <>
+            <PageTitle title="Deferral configuration" />
+            <PageSection variant="light">
+                <Title headingLevel="h1">Deferral configuration</Title>
+            </PageSection>
+        </>
+    );
+}
+
+export default DeferralConfigurationPage;

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -15,6 +15,7 @@ import {
     compliancePath,
     configManagementPath,
     dashboardPath,
+    deferralConfigurationPath,
     deprecatedPoliciesPath,
     integrationsPath,
     isRouteEnabled, // predicate function
@@ -108,6 +109,12 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
     dashboard: {
         component: asyncComponent(() => import('Containers/Dashboard/DashboardPage')),
         path: dashboardPath,
+    },
+    'deferral-configuration': {
+        component: asyncComponent(
+            () => import('Containers/DeferralConfiguration/DeferralConfigurationPage')
+        ),
+        path: deferralConfigurationPath,
     },
     integrations: {
         component: asyncComponent(() => import('Containers/Integrations/IntegrationsPage')),

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -15,6 +15,7 @@ import {
     complianceEnhancedStatusPath,
     configManagementPath,
     dashboardPath,
+    deferralConfigurationPath,
     integrationsPath,
     isRouteEnabled, // predicate function
     listeningEndpointsBasePath,
@@ -238,6 +239,12 @@ const navDescriptions: NavDescription[] = [
                 content: 'Integrations',
                 path: integrationsPath,
                 routeKey: 'integrations',
+            },
+            {
+                type: 'child',
+                content: 'Deferral Configuration',
+                path: deferralConfigurationPath,
+                routeKey: 'deferral-configuration',
             },
             {
                 type: 'child',

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -36,6 +36,7 @@ export const complianceEnhancedStatusScansPath = `${complianceEnhancedStatusPath
 export const configManagementPath = `${mainPath}/configmanagement`;
 export const dashboardPath = `${mainPath}/dashboard`;
 export const dataRetentionPath = `${mainPath}/retention`;
+export const deferralConfigurationPath = `${mainPath}/deferral-configuration`;
 export const integrationsPath = `${mainPath}/integrations`;
 export const integrationCreatePath = `${integrationsPath}/:source/:type/create`;
 export const integrationDetailsPath = `${integrationsPath}/:source/:type/view/:id`;
@@ -130,6 +131,7 @@ export type RouteKey =
     | 'compliance-enhanced'
     | 'configmanagement'
     | 'dashboard'
+    | 'deferral-configuration'
     | 'integrations'
     | 'listening-endpoints'
     | 'network-graph'
@@ -212,6 +214,10 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     },
     dashboard: {
         resourceAccessRequirements: everyResource([]),
+    },
+    'deferral-configuration': {
+        featureFlagDependency: ['ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL'],
+        resourceAccessRequirements: everyResource(['Administration']),
     },
     integrations: {
         resourceAccessRequirements: everyResource(['Integration']),


### PR DESCRIPTION
## Description

Adds routing and an empty page for vulnerabilities deferral configuration.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the main navigation without the `ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL` flag set. "Deferral configuration" should not appear in the main navigation, and direct navigation via URL should display a not-found page.
![image](https://github.com/stackrox/stackrox/assets/1292638/d3c7b414-d1c3-494b-9627-3fcf324d1d5e)


Load the main navigation without the `Administration` resource permission. "Deferral configuration" should not appear in the main navigation, and direct navigation via URL should display a not-found page.
![image](https://github.com/stackrox/stackrox/assets/1292638/35511762-99f8-4435-84dd-ed31b78774a4)


Load the main navigation with both of the above:
![image](https://github.com/stackrox/stackrox/assets/1292638/14f1836e-b69f-45ab-a667-3022293541bc)


