### PR TITLE
ROX-19719: increase quay.io client timeout

### DIFF
--- a/pkg/scanners/quay/quay.go
+++ b/pkg/scanners/quay/quay.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	requestTimeout = 20 * time.Second
+	requestTimeout = 60 * time.Second
 
 	typeString = "quay"
 )


### PR DESCRIPTION
## Description

We've seen regular timeouts in the scanner qa-tests.

I measured the typical response time of quay.io using our qa-test image scan endpoint

```
GET https://quay.io/api/v1/repository/rhacs-eng/qa/manifest/sha256:451efa58416d38e138afd1e0c5afcfffccf98f4c4ae9e0a7823adb9800a8beda/security?features=true&vulnerabilities=true
```

I queried the above endpoint 1000 times using 16 parallel requests and recorded the response time.

<img width="650" alt="Screenshot 2023-09-18 at 23 34 32" src="https://github.com/stackrox/stackrox/assets/55607356/7c66b924-700f-449f-a1f9-aa1b2c5d9acd">

Based on these results, it looks like our 20 second timeout is cutting it a bit close. Therefore I propose increasing the client timeout to 60 seconds.

Note that we have retries in the qa-tests, but other clients don't necessarily retry.