### PR TITLE
ROX-19767: Auto-decline similar scoped vuln requests

### DIFF
--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -96,11 +96,13 @@ func (m *managerImpl) Create(ctx context.Context, req *storage.VulnerabilityRequ
 	if idx := utils.FirstIndexMatchingScope(req, existingReqs); idx != -1 {
 		newReqCVEs := set.NewStringSet(req.GetCves().GetCves()...)
 		existingReqCVEs := set.NewStringSet(existingReqs[idx].GetCves().GetCves()...)
-		commonCVEs := newReqCVEs.Intersect(existingReqCVEs)
-
+		commonCVEs := newReqCVEs.Intersect(existingReqCVEs).AsSlice()
+		errPrefix := fmt.Sprintf("CVEs %s are", commonCVEs)
+		if len(commonCVEs) == 1 {
+			errPrefix = fmt.Sprintf("CVE %s is", commonCVEs[0])
+		}
 		return errors.Wrap(errox.AlreadyExists,
-			fmt.Sprintf("CVEs %s are already covered by request %s for the specified scope",
-				commonCVEs.AsSlice(), existingReqs[idx].GetId()))
+			fmt.Sprintf("%s already covered by request %s for the scope", errPrefix, existingReqs[idx].GetId()))
 	}
 
 	req.Id = uuid.NewV4().String()
@@ -117,24 +119,39 @@ func (m *managerImpl) Approve(ctx context.Context, id string, reqParams *common.
 	if reqParams == nil || reqParams.Comment == "" {
 		return nil, errors.Wrap(errox.InvalidArgs, "comment must be provided")
 	}
+
+	// Process one request at a time since there could be a race with vulnerability request creation.
+	//
+	// Once the request is approved, it is enforced. Thus, the vulnerability request creation may validate against a
+	// system state prior to this approval and may upsert after this approval.
 	req, err := m.updateRequestStatus(ctx, id, reqParams.Comment, storage.RequestStatus_APPROVED)
 	if err != nil {
 		return nil, errors.Wrapf(err, "approving vulnerability request %s", id)
 	}
+
+	// Find and invalidate the pending requests covering the same CVEs and scope.
+	existingReqs, err := m.vulnReqs.SearchRawRequests(ctx, utils.GetPendingRequestsV1Query(req.GetCves().GetCves()...))
+	if err != nil {
+		return nil, errors.Wrap(err, "could not search for other vulnerability requests")
+	}
+
+	invalidateReqComment := func(reqIDToDeny string) *common.VulnRequestParams {
+		return &common.VulnRequestParams{
+			Comment: fmt.Sprintf("Vulnerability request %s was auto-declined when request %s covering one or more requested CVEs was approved", reqIDToDeny, id),
+		}
+	}
+	for _, coveredReq := range utils.RequestsWithCoveredScope(req, existingReqs) {
+		// Use the identity of approving user to decline similar requests.
+		_, err := m.Deny(ctx, coveredReq.GetId(), invalidateReqComment(coveredReq.GetId()))
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if err := m.SnoozeVulnerabilityOnRequest(ctx, req); err != nil {
 		return nil, errors.Wrapf(err, "enforcing approved vulnerability request %s", id)
 	}
 	return req, nil
-}
-
-func (m *managerImpl) updateRequestStatus(ctx context.Context, id string, comment string, status storage.RequestStatus) (*storage.VulnerabilityRequest, error) {
-	// Process one request at a time since updating request status could race with creating new request.
-	if err := m.upsertSem.Acquire(ctx, 1); err != nil {
-		return nil, err
-	}
-	defer m.upsertSem.Release(1)
-
-	return m.vulnReqs.UpdateRequestStatus(ctx, id, comment, status)
 }
 
 func (m *managerImpl) Delete(ctx context.Context, id string) error {
@@ -267,6 +284,16 @@ func (m *managerImpl) UnSnoozeVulnerabilityOnRequest(_ context.Context, request 
 
 	go m.reprocessAffectedEntities(request.GetId(), imageIDs...)
 	return nil
+}
+
+func (m *managerImpl) updateRequestStatus(ctx context.Context, id string, comment string, status storage.RequestStatus) (*storage.VulnerabilityRequest, error) {
+	// Process one request at a time since updating request status could race with creating new request.
+	if err := m.upsertSem.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
+	defer m.upsertSem.Release(1)
+
+	return m.vulnReqs.UpdateRequestStatus(ctx, id, comment, status)
 }
 
 func (m *managerImpl) reprocessAffectedEntities(requestID string, affectedImages ...string) {

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_cache_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_cache_test.go
@@ -29,6 +29,7 @@ func TestVulnReqCacheUpdatesForApproval(t *testing.T) {
 	expected := fixtures.GetImageScopeDeferralRequest("r", "r", "g", "cve")
 	vulnReqDS.EXPECT().UpdateRequestStatus(allAccessCtx, expected.GetId(), "approved", storage.RequestStatus_APPROVED).
 		Return(expected, nil)
+	vulnReqDS.EXPECT().SearchRawRequests(gomock.Any(), gomock.Any()).Return(nil, nil)
 	expected.Status = storage.RequestStatus_APPROVED
 	pendingReqCache.EXPECT().Remove(expected.GetId())
 	activeReqCache.EXPECT().Add(expected)
@@ -38,10 +39,11 @@ func TestVulnReqCacheUpdatesForApproval(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expected.GetId(), req.GetId())
 
-	// Test expired request does not lead to cache (snooze workflow).
+	// Test expired request does not cause cache updates (snooze workflow).
 	expected.Expired = true
 	vulnReqDS.EXPECT().UpdateRequestStatus(allAccessCtx, expected.GetId(), "approved", storage.RequestStatus_APPROVED).
 		Return(expected, nil)
+	vulnReqDS.EXPECT().SearchRawRequests(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	req, err = manager.Approve(allAccessCtx, expected.GetId(), &common.VulnRequestParams{Comment: "approved"})
 	assert.Error(t, err)

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package requestmgr
 
 import (
@@ -141,6 +143,7 @@ func TestApproval(t *testing.T) {
 
 	testDB := pgtest.ForT(t)
 	defer testDB.Teardown(t)
+
 	pendingReqCache, activeReqCache := vulnReqCache.New(), vulnReqCache.New()
 	datastore, err := vulReqDS.GetTestPostgresDataStore(t, testDB, pendingReqCache, activeReqCache)
 	require.NoError(t, err)

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
@@ -5,13 +5,24 @@ import (
 	"fmt"
 	"testing"
 
+	componentCVEEdgeDSMocks "github.com/stackrox/rox/central/componentcveedge/datastore/mocks"
+	imageDSMocks "github.com/stackrox/rox/central/image/datastore/mocks"
+	reprocessorMocks "github.com/stackrox/rox/central/reprocessor/mocks"
+	sensorConnMgrMocks "github.com/stackrox/rox/central/sensor/service/connection/mocks"
 	vulnReqCache "github.com/stackrox/rox/central/vulnerabilityrequest/cache"
+	"github.com/stackrox/rox/central/vulnerabilityrequest/common"
+	vulReqDS "github.com/stackrox/rox/central/vulnerabilityrequest/datastore"
 	dsMock "github.com/stackrox/rox/central/vulnerabilityrequest/datastore/mocks"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/utils"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/grpc/authn"
+	mockIdentity "github.com/stackrox/rox/pkg/grpc/authn/mocks"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -121,6 +132,85 @@ func TestCreateReqErrorsIfRequestAlreadyExists(t *testing.T) {
 			} else {
 				assert.Error(t, err)
 			}
+		})
+	}
+}
+
+func TestApproval(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+
+	testDB := pgtest.ForT(t)
+	defer testDB.Teardown(t)
+	pendingReqCache, activeReqCache := vulnReqCache.New(), vulnReqCache.New()
+	datastore, err := vulReqDS.GetTestPostgresDataStore(t, testDB, pendingReqCache, activeReqCache)
+	require.NoError(t, err)
+	imageDataStore := imageDSMocks.NewMockDataStore(mockCtrl)
+	require.NoError(t, err)
+	sensorConnMgrMocks := sensorConnMgrMocks.NewMockManager(mockCtrl)
+	reprocessor := reprocessorMocks.NewMockLoop(mockCtrl)
+	componentCVEEdgeDataStore := componentCVEEdgeDSMocks.NewMockDataStore(mockCtrl)
+	require.NoError(t, err)
+	manager := New(nil, datastore, pendingReqCache, activeReqCache, imageDataStore, componentCVEEdgeDataStore, sensorConnMgrMocks, reprocessor)
+
+	globalCVE1DefReq := fixtures.GetGlobalDeferralRequest("cve-1")
+	globalCVE1FPReq := fixtures.GetGlobalFPRequest("cve-1")
+	imageScopedCVE1Req := fixtures.GetImageScopeDeferralRequest("reg1", "img1", "1.0", "cve-1")
+	allTagCVE1Req := fixtures.GetImageScopeDeferralRequest("reg1", "img1", ".*", "cve-1")
+	otherImageReq := fixtures.GetImageScopeDeferralRequest("reg2", "img1", "1.0", "cve-2")
+
+	existingReqs := []*storage.VulnerabilityRequest{
+		globalCVE1DefReq,
+		globalCVE1FPReq,
+		imageScopedCVE1Req,
+		allTagCVE1Req,
+		otherImageReq,
+	}
+
+	approver := &storage.SlimUser{
+		Id:   "approver",
+		Name: "approver",
+	}
+	mockID := mockIdentity.NewMockIdentity(mockCtrl)
+	approverCtx := authn.ContextWithIdentity(sac.WithAllAccess(context.Background()), mockID, t)
+	deniedReqQ := search.NewQueryBuilder().AddExactMatches(search.RequestStatus, storage.RequestStatus_DENIED.String()).ProtoQuery()
+	for _, tc := range []struct {
+		desc             string
+		approvedReq      *storage.VulnerabilityRequest
+		expectedDeclined []string
+	}{
+		{
+			desc:             "decline cve-1 requests in covered scopes; global, all tags, specific tag",
+			approvedReq:      globalCVE1DefReq,
+			expectedDeclined: []string{globalCVE1FPReq.GetId(), allTagCVE1Req.GetId(), imageScopedCVE1Req.GetId()},
+		},
+		{
+			desc:             "decline cve-1 requests in covered scopes; all tags, specific tag",
+			approvedReq:      allTagCVE1Req,
+			expectedDeclined: []string{imageScopedCVE1Req.GetId()},
+		},
+		{
+			desc:        "none declined",
+			approvedReq: otherImageReq,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			for _, req := range existingReqs {
+				assert.NoError(t, datastore.AddRequest(allAccessCtx, req))
+			}
+
+			mockID.EXPECT().UID().Return(approver.Id).AnyTimes()
+			mockID.EXPECT().FullName().Return(approver.Name).AnyTimes()
+			mockID.EXPECT().FriendlyName().Return(approver.Name).AnyTimes()
+
+			fmt.Println(tc.approvedReq.GetId())
+			imageDataStore.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, nil)
+			_, err := manager.Approve(approverCtx, tc.approvedReq.GetId(), &common.VulnRequestParams{
+				Comment: "test approval",
+			})
+			assert.NoError(t, err)
+			results, err := datastore.Search(allAccessCtx, deniedReqQ)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tc.expectedDeclined, search.ResultsToIDs(results))
 		})
 	}
 }

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
@@ -202,7 +202,6 @@ func TestApproval(t *testing.T) {
 			mockID.EXPECT().FullName().Return(approver.Name).AnyTimes()
 			mockID.EXPECT().FriendlyName().Return(approver.Name).AnyTimes()
 
-			fmt.Println(tc.approvedReq.GetId())
 			imageDataStore.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, nil)
 			_, err := manager.Approve(approverCtx, tc.approvedReq.GetId(), &common.VulnRequestParams{
 				Comment: "test approval",
@@ -211,6 +210,10 @@ func TestApproval(t *testing.T) {
 			results, err := datastore.Search(allAccessCtx, deniedReqQ)
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, tc.expectedDeclined, search.ResultsToIDs(results))
+
+			for _, req := range existingReqs {
+				assert.NoError(t, datastore.RemoveRequestsInternal(allAccessCtx, []string{req.GetId()}))
+			}
 		})
 	}
 }

--- a/central/vulnerabilityrequest/utils/util.go
+++ b/central/vulnerabilityrequest/utils/util.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
@@ -130,6 +129,15 @@ func GetEnforcedRequestsV1Query(cve ...string) *v1.Query {
 		ProtoQuery()
 }
 
+// GetPendingRequestsV1Query returns a *v1.Query which will search for all pending requests for specified CVEs.
+func GetPendingRequestsV1Query(cve ...string) *v1.Query {
+	return search.NewQueryBuilder().
+		AddExactMatches(search.CVE, cve...).
+		AddBools(search.ExpiredRequest, false).
+		AddExactMatches(search.RequestStatus, storage.RequestStatus_PENDING.String()).
+		ProtoQuery()
+}
+
 // GetAffectedImagesQuery returns a *v1.Query object that can be used to fetch images affected by
 // the vuln request as well as satisfying the incoming query.
 func GetAffectedImagesQuery(request *storage.VulnerabilityRequest, query *v1.Query) (*v1.Query, error) {
@@ -203,12 +211,58 @@ func IsPending(req *storage.VulnerabilityRequest) bool {
 
 // FirstIndexMatchingScope returns the index of first vulnerability request in `matchWith` with scope matching that of `toMatch`.
 // If no match is found, -1 is returned.
+// Note that this function does not check requested CVEs.
 func FirstIndexMatchingScope(toMatch *storage.VulnerabilityRequest, matchWith []*storage.VulnerabilityRequest) int {
 	for idx, r := range matchWith {
 		// Check if the scopes match.
-		if reflect.DeepEqual(r.GetScope(), toMatch.GetScope()) {
+		if scopeCovered(r.GetScope(), toMatch.GetScope()) {
 			return idx
 		}
 	}
 	return -1
+}
+
+// RequestsWithCoveredScope returns all the requests whose scope is covered by the scope of `toMatch`.
+// Note that this function does not check requested CVEs.
+func RequestsWithCoveredScope(toMatch *storage.VulnerabilityRequest, matchWith []*storage.VulnerabilityRequest) []*storage.VulnerabilityRequest {
+	if toMatch.GetScope() == nil {
+		return nil
+	}
+	// If `toMatch` has global scope, then it covers all other scopes. Return early.
+	if toMatch.GetScope().GetGlobalScope() != nil {
+		return matchWith
+	}
+
+	var ret []*storage.VulnerabilityRequest
+	for _, r := range matchWith {
+		if scopeCovered(toMatch.GetScope(), r.GetScope()) {
+			ret = append(ret, r)
+		}
+	}
+	return ret
+}
+
+func scopeCovered(toMatch *storage.VulnerabilityRequest_Scope, matchWith *storage.VulnerabilityRequest_Scope) bool {
+	if toMatch == nil || matchWith == nil {
+		return false
+	}
+
+	if toMatch.GetGlobalScope() != nil {
+		return true
+	}
+
+	// If `toMatch` is not a global scope but `matchWith` is, `toMatch` definitely does not cover `matchWith`.
+	if matchWith.GetGlobalScope() != nil {
+		return false
+	}
+
+	if matchWith.GetImageScope() == nil {
+		return false
+	}
+
+	toMatchImgScope := toMatch.GetImageScope()
+	matchWithImgScope := matchWith.GetImageScope()
+	return matchWithImgScope.GetRegistry() == toMatchImgScope.GetRegistry() &&
+		matchWithImgScope.GetRemote() == toMatchImgScope.GetRemote() &&
+		(matchWithImgScope.GetTag() == toMatchImgScope.GetTag() || toMatchImgScope.GetTag() == common.MatchAll)
 }

--- a/central/vulnerabilityrequest/utils/util_test.go
+++ b/central/vulnerabilityrequest/utils/util_test.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScopeCoverage(t *testing.T) {
+	globalCVE1DefReq := fixtures.GetGlobalDeferralRequest("cve-1")
+	globalCVE1FPReq := fixtures.GetGlobalFPRequest("cve-1")
+	imageScopedCVE1Req := fixtures.GetImageScopeDeferralRequest("reg1", "img1", "1.0", "cve-1")
+	allTagCVE1Req := fixtures.GetImageScopeDeferralRequest("reg1", "img1", ".*", "cve-1")
+	otherImageReq := fixtures.GetImageScopeDeferralRequest("reg2", "img1", "1.0", "cve-1")
+
+	existingReqs := []*storage.VulnerabilityRequest{
+		globalCVE1DefReq,
+		globalCVE1FPReq,
+		imageScopedCVE1Req,
+		allTagCVE1Req,
+		otherImageReq,
+	}
+	for _, tc := range []struct {
+		desc               string
+		toMatch            *storage.VulnerabilityRequest
+		expectedMatches    []*storage.VulnerabilityRequest
+		expectedFirstIndex int
+	}{
+		{
+			desc:               "match cve-1 requests in covered scopes; global, all tags, specific tag",
+			toMatch:            globalCVE1DefReq,
+			expectedMatches:    existingReqs,
+			expectedFirstIndex: 0,
+		},
+		{
+			desc:               "match cve-1 requests in covered scopes; all tags, specific tag",
+			toMatch:            allTagCVE1Req,
+			expectedMatches:    []*storage.VulnerabilityRequest{allTagCVE1Req, imageScopedCVE1Req},
+			expectedFirstIndex: 2,
+		},
+		{
+			desc:               "match cve-1 requests in covered scopes; specific tag",
+			toMatch:            imageScopedCVE1Req,
+			expectedMatches:    []*storage.VulnerabilityRequest{imageScopedCVE1Req},
+			expectedFirstIndex: 2,
+		},
+		{
+			desc:               "none matched",
+			toMatch:            fixtures.GetImageScopeDeferralRequest("reg3", "img1", "1.0", "cve-1"),
+			expectedFirstIndex: -1,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			covered := RequestsWithCoveredScope(tc.toMatch, existingReqs)
+			assert.ElementsMatch(t, tc.expectedMatches, covered)
+
+			idx := FirstIndexMatchingScope(tc.toMatch, existingReqs)
+			assert.Equal(t, tc.expectedFirstIndex, idx)
+		})
+	}
+}

--- a/central/vulnerabilityrequest/utils/util_test.go
+++ b/central/vulnerabilityrequest/utils/util_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestScopeCoverage(t *testing.T) {
+func TestRequestsWithCoveredScope(t *testing.T) {
 	globalCVE1DefReq := fixtures.GetGlobalDeferralRequest("cve-1")
 	globalCVE1FPReq := fixtures.GetGlobalFPRequest("cve-1")
 	imageScopedCVE1Req := fixtures.GetImageScopeDeferralRequest("reg1", "img1", "1.0", "cve-1")
@@ -23,40 +23,100 @@ func TestScopeCoverage(t *testing.T) {
 		otherImageReq,
 	}
 	for _, tc := range []struct {
-		desc               string
-		toMatch            *storage.VulnerabilityRequest
-		expectedMatches    []*storage.VulnerabilityRequest
-		expectedFirstIndex int
+		desc            string
+		toMatch         *storage.VulnerabilityRequest
+		expectedMatches []*storage.VulnerabilityRequest
 	}{
 		{
-			desc:               "match cve-1 requests in covered scopes; global, all tags, specific tag",
-			toMatch:            globalCVE1DefReq,
-			expectedMatches:    existingReqs,
-			expectedFirstIndex: 0,
+			desc:            "match cve-1 requests in covered scopes; global, all tags, specific tag",
+			toMatch:         globalCVE1DefReq,
+			expectedMatches: existingReqs,
 		},
 		{
-			desc:               "match cve-1 requests in covered scopes; all tags, specific tag",
-			toMatch:            allTagCVE1Req,
-			expectedMatches:    []*storage.VulnerabilityRequest{allTagCVE1Req, imageScopedCVE1Req},
-			expectedFirstIndex: 2,
+			desc:            "match cve-1 requests in covered scopes; all tags, specific tag",
+			toMatch:         allTagCVE1Req,
+			expectedMatches: []*storage.VulnerabilityRequest{allTagCVE1Req, imageScopedCVE1Req},
 		},
 		{
-			desc:               "match cve-1 requests in covered scopes; specific tag",
-			toMatch:            imageScopedCVE1Req,
-			expectedMatches:    []*storage.VulnerabilityRequest{imageScopedCVE1Req},
-			expectedFirstIndex: 2,
+			desc:            "match cve-1 requests in covered scopes; specific tag",
+			toMatch:         imageScopedCVE1Req,
+			expectedMatches: []*storage.VulnerabilityRequest{imageScopedCVE1Req},
 		},
 		{
-			desc:               "none matched",
-			toMatch:            fixtures.GetImageScopeDeferralRequest("reg3", "img1", "1.0", "cve-1"),
-			expectedFirstIndex: -1,
+			desc:    "none matched",
+			toMatch: fixtures.GetImageScopeDeferralRequest("reg3", "img1", "1.0", "cve-1"),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			covered := RequestsWithCoveredScope(tc.toMatch, existingReqs)
 			assert.ElementsMatch(t, tc.expectedMatches, covered)
+		})
+	}
+}
 
-			idx := FirstIndexMatchingScope(tc.toMatch, existingReqs)
+func TestFirstIndexMatchingScope(t *testing.T) {
+	globalCVE1DefReq := fixtures.GetGlobalDeferralRequest("cve-1")
+	globalCVE1FPReq := fixtures.GetGlobalFPRequest("cve-1")
+	imageScopedCVE1Req := fixtures.GetImageScopeDeferralRequest("reg1", "img1", "1.0", "cve-1")
+	allTagCVE1Req := fixtures.GetImageScopeDeferralRequest("reg1", "img1", ".*", "cve-1")
+	otherImageReq := fixtures.GetImageScopeDeferralRequest("reg2", "img1", "1.0", "cve-1")
+
+	for _, tc := range []struct {
+		desc               string
+		toMatch            *storage.VulnerabilityRequest
+		matchWith          []*storage.VulnerabilityRequest
+		expectedFirstIndex int
+	}{
+		{
+			desc:    "match cve-1 requests in covered scopes; global, all tags, specific tag",
+			toMatch: globalCVE1DefReq,
+			matchWith: []*storage.VulnerabilityRequest{
+				otherImageReq,
+				allTagCVE1Req,
+				imageScopedCVE1Req,
+				globalCVE1DefReq,
+				globalCVE1FPReq,
+			},
+			expectedFirstIndex: 3,
+		},
+		{
+			desc:    "match cve-1 requests in covered scopes; all tags, specific tag",
+			toMatch: allTagCVE1Req,
+			matchWith: []*storage.VulnerabilityRequest{
+				otherImageReq,
+				allTagCVE1Req,
+				imageScopedCVE1Req,
+				globalCVE1DefReq,
+				globalCVE1FPReq,
+			},
+			expectedFirstIndex: 1,
+		},
+		{
+			desc:    "match cve-1 requests in covered scopes; specific tag",
+			toMatch: imageScopedCVE1Req,
+			matchWith: []*storage.VulnerabilityRequest{
+				otherImageReq,
+				allTagCVE1Req,
+				imageScopedCVE1Req,
+				globalCVE1DefReq,
+				globalCVE1FPReq,
+			},
+			expectedFirstIndex: 1,
+		},
+		{
+			desc:               "none matched",
+			toMatch:            fixtures.GetImageScopeDeferralRequest("reg3", "img1", "1.0", "cve-1"),
+			matchWith:          []*storage.VulnerabilityRequest{allTagCVE1Req, imageScopedCVE1Req},
+			expectedFirstIndex: -1,
+		},
+		{
+			desc:               "none matched again",
+			toMatch:            fixtures.GetImageScopeDeferralRequest("reg3", "img1", "1.0", "cve-1"),
+			expectedFirstIndex: -1,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			idx := FirstIndexMatchingScope(tc.toMatch, tc.matchWith)
 			assert.Equal(t, tc.expectedFirstIndex, idx)
 		})
 	}


### PR DESCRIPTION
## Description

When a vulnerability request is approved, other vulnerability requests whose one or more CVEs are covered by the approved requests should be auto-declined.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests

https://github.com/stackrox/stackrox/assets/9895898/9c61587f-7575-489a-a74f-42a684d9cdbd


https://github.com/stackrox/stackrox/assets/9895898/40304753-0317-42e3-8b40-7a4fb36bcbe1

