### PR TITLE
ROX-19738: Fix policy categories filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Technical Changes
 
+- ROX-19738: Previously categories passed to the detection service's APIs `v1/detect/build, v1/detect/deploy, v1/detect/deploy/yaml`
+  have been _always_ lower-cased by the backend. However, this is not the case anymore to support custom categories, which
+  are required to be title-cased.
+
 ## [4.2.0]
 
 

--- a/central/detection/buildtime/detector_impl_test.go
+++ b/central/detection/buildtime/detector_impl_test.go
@@ -1,7 +1,6 @@
 package buildtime
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -73,11 +72,7 @@ func TestDetector(t *testing.T) {
 			filter, getUnusedCategories := detection.MakeCategoryFilter(testCase.allowedCategories)
 			alerts, err := detector.Detect(testCase.image, filter)
 			require.NoError(t, err)
-			lowercaseCategories := make([]string, len(testCase.expectedUnusedCategories))
-			for i, category := range testCase.expectedUnusedCategories {
-				lowercaseCategories[i] = strings.ToLower(category)
-			}
-			require.ElementsMatch(t, lowercaseCategories, getUnusedCategories())
+			require.ElementsMatch(t, testCase.expectedUnusedCategories, getUnusedCategories())
 			assert.Len(t, alerts, testCase.expectedAlerts)
 		})
 

--- a/central/detection/utils.go
+++ b/central/detection/utils.go
@@ -1,8 +1,6 @@
 package detection
 
 import (
-	"strings"
-
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/detection"
 	"github.com/stackrox/rox/pkg/set"
@@ -15,9 +13,8 @@ func MakeCategoryFilter(filterForCategories []string) (detection.FilterOption, f
 	allowedCategorySet := set.NewStringSet()
 	unusedCategorySet := set.NewStringSet()
 	for _, category := range filterForCategories {
-		lowercaseCategory := strings.ToLower(category)
-		allowedCategorySet.Add(lowercaseCategory)
-		unusedCategorySet.Add(lowercaseCategory)
+		allowedCategorySet.Add(category)
+		unusedCategorySet.Add(category)
 	}
 
 	filterOption := func(policy *storage.Policy) bool {
@@ -27,9 +24,8 @@ func MakeCategoryFilter(filterForCategories []string) (detection.FilterOption, f
 
 		foundAllowedCategory := false
 		for _, category := range policy.GetCategories() {
-			lowercaseCategory := strings.ToLower(category)
-			if allowedCategorySet.Contains(lowercaseCategory) {
-				unusedCategorySet.Remove(lowercaseCategory)
+			if allowedCategorySet.Contains(category) {
+				unusedCategorySet.Remove(category)
 				foundAllowedCategory = true
 			}
 		}

--- a/central/detection/utils_test.go
+++ b/central/detection/utils_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	testCategories = []string{"joseph rules"}
+	testCategories = []string{"Joseph rules"}
 	testPolicyOne  = &storage.Policy{
 		Categories: testCategories,
 	}


### PR DESCRIPTION
## Description

With the introduction of custom categories, the API enforces that custom categories are title-cased.

However, the detection APIs, where categories can be passed to filter policies, enforces all categories to be lower-cased.

This lead to issues with roxctl, where custom categories couldn't be used since the backend would always lower-case them, leading to the categories not being recognized.

This PR fixes this behavior by removing the lower-casing within the backend service.

While this may have impact on users due to a slight change in behavior, the input has been invalid to being with, and lower-casing _must_ be removed to support custom categories.

Left a changelog entry to clarify this.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see adjusted unit tests.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
