### PR TITLE
ROX-19344: Add tabs and vuln deferral config container

### DIFF
--- a/ui/apps/platform/src/Containers/DeferralConfiguration/DeferralConfigurationPage.tsx
+++ b/ui/apps/platform/src/Containers/DeferralConfiguration/DeferralConfigurationPage.tsx
@@ -1,14 +1,32 @@
 import React from 'react';
-import { PageSection, Title } from '@patternfly/react-core';
+import { PageSection, Tab, Tabs, Title } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
+import useURLStringUnion from 'hooks/useURLStringUnion';
+import VulnerabilitiesConfiguration from './VulnerabilitiesConfiguration';
+
+const deferralConfigurationCategories = ['Vulnerabilities'] as const;
 
 function DeferralConfigurationPage() {
+    const [category, setCategory] = useURLStringUnion('category', deferralConfigurationCategories);
+
     return (
         <>
             <PageTitle title="Deferral configuration" />
             <PageSection variant="light">
                 <Title headingLevel="h1">Deferral configuration</Title>
+            </PageSection>
+            <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                <Tabs
+                    activeKey={category}
+                    onSelect={(e, value) => setCategory(value)}
+                    usePageInsets
+                    mountOnEnter
+                >
+                    <Tab eventKey="Vulnerabilities" title="Vulnerabilities">
+                        <VulnerabilitiesConfiguration />
+                    </Tab>
+                </Tabs>
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/DeferralConfiguration/VulnerabilitiesConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/DeferralConfiguration/VulnerabilitiesConfiguration.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {
+    Button,
+    Divider,
+    PageSection,
+    Split,
+    SplitItem,
+    Text,
+    Title,
+} from '@patternfly/react-core';
+
+function VulnerabilitiesConfiguration() {
+    return (
+        <>
+            <div className="pf-u-py-md pf-u-px-md pf-u-px-lg-on-xl">
+                <Split className="pf-u-align-items-center">
+                    <SplitItem isFilled>
+                        <Text>Configure deferral behavior for vulnerabilities</Text>
+                    </SplitItem>
+                    <SplitItem>
+                        <Button variant="primary">Save</Button>
+                    </SplitItem>
+                </Split>
+            </div>
+            <Divider component="div" />
+            <PageSection variant="light">
+                <Title headingLevel="h2">Configure deferral times</Title>
+            </PageSection>
+        </>
+    );
+}
+
+export default VulnerabilitiesConfiguration;


### PR DESCRIPTION
## Description

Adds the tab structure (Vulnerabilities tab only) and basic page layout.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the deferral config page:

![image](https://github.com/stackrox/stackrox/assets/1292638/27cabbd6-8ced-4db5-ab91-013bf7f20136)
![image](https://github.com/stackrox/stackrox/assets/1292638/ae37a6c5-a4a0-470f-b0ed-f1a50ee96070)

