### PR TITLE
fix(ci): revert policy category PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,6 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Technical Changes
 - Increased minimum Node.js version to 18.0.0 because 16 reached end of life. This change affects `yarn` commands in the ui folder.
 
-- ROX-19738: Previously categories passed to the detection service's APIs `v1/detect/build, v1/detect/deploy, v1/detect/deploy/yaml`
-  have been _always_ lower-cased by the backend. However, this is not the case anymore to support custom categories, which
-  are required to be title-cased.
-
 ## [4.2.0]
 
 

--- a/central/detection/buildtime/detector_impl_test.go
+++ b/central/detection/buildtime/detector_impl_test.go
@@ -1,6 +1,7 @@
 package buildtime
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -72,7 +73,11 @@ func TestDetector(t *testing.T) {
 			filter, getUnusedCategories := detection.MakeCategoryFilter(testCase.allowedCategories)
 			alerts, err := detector.Detect(testCase.image, filter)
 			require.NoError(t, err)
-			require.ElementsMatch(t, testCase.expectedUnusedCategories, getUnusedCategories())
+			lowercaseCategories := make([]string, len(testCase.expectedUnusedCategories))
+			for i, category := range testCase.expectedUnusedCategories {
+				lowercaseCategories[i] = strings.ToLower(category)
+			}
+			require.ElementsMatch(t, lowercaseCategories, getUnusedCategories())
 			assert.Len(t, alerts, testCase.expectedAlerts)
 		})
 

--- a/central/detection/utils.go
+++ b/central/detection/utils.go
@@ -1,6 +1,8 @@
 package detection
 
 import (
+	"strings"
+
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/detection"
 	"github.com/stackrox/rox/pkg/set"
@@ -13,8 +15,9 @@ func MakeCategoryFilter(filterForCategories []string) (detection.FilterOption, f
 	allowedCategorySet := set.NewStringSet()
 	unusedCategorySet := set.NewStringSet()
 	for _, category := range filterForCategories {
-		allowedCategorySet.Add(category)
-		unusedCategorySet.Add(category)
+		lowercaseCategory := strings.ToLower(category)
+		allowedCategorySet.Add(lowercaseCategory)
+		unusedCategorySet.Add(lowercaseCategory)
 	}
 
 	filterOption := func(policy *storage.Policy) bool {
@@ -24,8 +27,9 @@ func MakeCategoryFilter(filterForCategories []string) (detection.FilterOption, f
 
 		foundAllowedCategory := false
 		for _, category := range policy.GetCategories() {
-			if allowedCategorySet.Contains(category) {
-				unusedCategorySet.Remove(category)
+			lowercaseCategory := strings.ToLower(category)
+			if allowedCategorySet.Contains(lowercaseCategory) {
+				unusedCategorySet.Remove(lowercaseCategory)
 				foundAllowedCategory = true
 			}
 		}

--- a/central/detection/utils_test.go
+++ b/central/detection/utils_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	testCategories = []string{"Joseph rules"}
+	testCategories = []string{"joseph rules"}
 	testPolicyOne  = &storage.Policy{
 		Categories: testCategories,
 	}


### PR DESCRIPTION
Reverts stackrox/stackrox#7824

UI E2E tests are failing, which need to be fixed.
Originally, UI e2e tests are not running on normal PRs without UI changes, hence this slipped through.