### PR TITLE
ROX-19344: Add deferral config form layout

### DIFF
--- a/ui/apps/platform/src/Containers/DeferralConfiguration/VulnerabilitiesConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/DeferralConfiguration/VulnerabilitiesConfiguration.tsx
@@ -1,13 +1,60 @@
 import React from 'react';
+
 import {
     Button,
     Divider,
+    Flex,
+    Form,
+    FormGroup,
+    Grid,
+    GridItem,
     PageSection,
     Split,
     SplitItem,
+    Switch,
     Text,
+    TextInput,
     Title,
 } from '@patternfly/react-core';
+
+type BaseSettingProps = {
+    isEnabled: boolean;
+};
+
+function NumericSetting({ value, isEnabled }: BaseSettingProps & { value: number }) {
+    return (
+        <>
+            <GridItem span={8} md={4} xl={3}>
+                <FormGroup>
+                    <Flex direction={{ default: 'row' }} flexWrap={{ default: 'nowrap' }}>
+                        <TextInput type="number" style={{ width: '70px' }} value={value} />
+                        <span>days</span>
+                    </Flex>
+                </FormGroup>
+            </GridItem>
+            <GridItem span={4} md={8} xl={9}>
+                <FormGroup>
+                    <Switch label="Enabled" labelOff="Disabled" isChecked={isEnabled} />
+                </FormGroup>
+            </GridItem>
+        </>
+    );
+}
+
+function BooleanSetting({ label, isEnabled }: BaseSettingProps & { label: string }) {
+    return (
+        <>
+            <GridItem className="pf-u-py-xs" span={8} md={4} xl={3}>
+                <p>{label}</p>
+            </GridItem>
+            <GridItem className="pf-u-py-xs" span={4} md={8} xl={9}>
+                <FormGroup>
+                    <Switch label="Enabled" labelOff="Disabled" isChecked={isEnabled} />
+                </FormGroup>
+            </GridItem>
+        </>
+    );
+}
 
 function VulnerabilitiesConfiguration() {
     return (
@@ -23,8 +70,20 @@ function VulnerabilitiesConfiguration() {
                 </Split>
             </div>
             <Divider component="div" />
-            <PageSection variant="light">
+            <PageSection variant="light" component="div">
                 <Title headingLevel="h2">Configure deferral times</Title>
+                <Form className="pf-u-py-lg">
+                    <Grid hasGutter>
+                        <NumericSetting value={14} isEnabled />
+                        <NumericSetting value={30} isEnabled />
+                        <NumericSetting value={60} isEnabled />
+                        <NumericSetting value={90} isEnabled />
+                        <BooleanSetting label="Indefinitely" isEnabled />
+                        <BooleanSetting label="Expires when all CVEs fixable" isEnabled />
+                        <BooleanSetting label="Expires when any CVE fixable" isEnabled />
+                        <BooleanSetting label="Allow custom date" isEnabled />
+                    </Grid>
+                </Form>
             </PageSection>
         </>
     );


### PR DESCRIPTION
## Description

Adds the form items and layout for vuln deferral config.

This does not include
- Loading of deferral config
- Formik/validation
- Handling form controls or the Save button

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the deferral config page and test the layout at different screen sizes.

https://github.com/stackrox/stackrox/assets/1292638/3079c834-4371-4f72-9d87-58e7fb6b5cab


