### PR TITLE
ROX-19344: Add service for vuln deferral config

### DIFF
--- a/ui/apps/platform/src/Containers/DeferralConfiguration/useVulnerabilitiesDeferralConfig.ts
+++ b/ui/apps/platform/src/Containers/DeferralConfiguration/useVulnerabilitiesDeferralConfig.ts
@@ -1,0 +1,36 @@
+import { useCallback } from 'react';
+
+import useRestMutation, { UseRestMutationReturn } from 'hooks/useRestMutation';
+import useRestQuery from 'hooks/useRestQuery';
+import {
+    VulnerabilitiesDeferralConfig,
+    fetchVulnerabilitiesDeferralConfig,
+    updateVulnerabilitiesDeferralConfig,
+} from 'services/DeferralConfigService';
+
+export type UseVulnerabilitiesDeferralConfigReturn = {
+    config: VulnerabilitiesDeferralConfig | undefined;
+    isConfigLoading: boolean;
+    configLoadError: unknown;
+    isUpdateInProgress: boolean;
+    updateConfig: UseRestMutationReturn<
+        Partial<VulnerabilitiesDeferralConfig>,
+        Partial<VulnerabilitiesDeferralConfig>
+    >['mutate'];
+};
+
+export function useVulnerabilitiesDeferralConfig(): UseVulnerabilitiesDeferralConfigReturn {
+    const fetchConfigFn = useCallback(fetchVulnerabilitiesDeferralConfig, []);
+    const getConfigRequest = useRestQuery(fetchConfigFn);
+    const updateConfigMutation = useRestMutation(updateVulnerabilitiesDeferralConfig, {
+        onSuccess: getConfigRequest.refetch,
+    });
+
+    return {
+        config: getConfigRequest.data ?? undefined,
+        isConfigLoading: getConfigRequest.loading,
+        configLoadError: getConfigRequest.error,
+        isUpdateInProgress: updateConfigMutation.isLoading,
+        updateConfig: updateConfigMutation.mutate,
+    };
+}

--- a/ui/apps/platform/src/Containers/DeferralConfiguration/useVulnerabilitiesDeferralConfig.ts
+++ b/ui/apps/platform/src/Containers/DeferralConfiguration/useVulnerabilitiesDeferralConfig.ts
@@ -1,5 +1,3 @@
-import { useCallback } from 'react';
-
 import useRestMutation, { UseRestMutationReturn } from 'hooks/useRestMutation';
 import useRestQuery from 'hooks/useRestQuery';
 import {
@@ -20,8 +18,7 @@ export type UseVulnerabilitiesDeferralConfigReturn = {
 };
 
 export function useVulnerabilitiesDeferralConfig(): UseVulnerabilitiesDeferralConfigReturn {
-    const fetchConfigFn = useCallback(fetchVulnerabilitiesDeferralConfig, []);
-    const getConfigRequest = useRestQuery(fetchConfigFn);
+    const getConfigRequest = useRestQuery(fetchVulnerabilitiesDeferralConfig);
     const updateConfigMutation = useRestMutation(updateVulnerabilitiesDeferralConfig, {
         onSuccess: getConfigRequest.refetch,
     });

--- a/ui/apps/platform/src/services/DeferralConfigService.ts
+++ b/ui/apps/platform/src/services/DeferralConfigService.ts
@@ -1,0 +1,31 @@
+import axios from './instance';
+
+const vulnBaseUrl = '/v1/config/private/deferral/vulnerabilities';
+
+export type VulnerabilitiesDeferralConfig = {
+    expiryOptions: {
+        dayOptions: {
+            numDays: number;
+            enabled: boolean;
+        }[];
+        fixableCveOptions: {
+            allFixable: boolean;
+            anyFixable: boolean;
+        };
+        customDate: boolean;
+    };
+};
+
+export function fetchVulnerabilitiesDeferralConfig(): Promise<VulnerabilitiesDeferralConfig | null> {
+    return axios
+        .get<{ config: VulnerabilitiesDeferralConfig | null }>(vulnBaseUrl)
+        .then(({ data }) => data.config);
+}
+
+export function updateVulnerabilitiesDeferralConfig(
+    config: Partial<VulnerabilitiesDeferralConfig>
+): Promise<Partial<VulnerabilitiesDeferralConfig>> {
+    return axios
+        .put<{ config: Partial<VulnerabilitiesDeferralConfig> }>(`${vulnBaseUrl}`, { config })
+        .then(({ data }) => data.config);
+}


### PR DESCRIPTION
## Description

Adds service calls for vulnerability deferral config and a hook to read/write config data.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing of the APIs via REST client only.

Functional testing is done in follow up PRs.
