### PR TITLE
ROX-17646: Remove waitUntilCentralIsReady

### DIFF
--- a/sensor/common/centralclient/grpc_connection.go
+++ b/sensor/common/centralclient/grpc_connection.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"time"
 
-	"github.com/cenkalti/backoff/v3"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -74,26 +73,6 @@ func (f *centralConnectionFactoryImpl) pingCentral() error {
 	return err
 }
 
-// waitUntilCentralIsReady blocks until Central responds to a ping or until the
-// retry budget is exhausted, in which case the sensor is marked as stopped and
-// the program will exit.
-func (f *centralConnectionFactoryImpl) waitUntilCentralIsReady() error {
-	exponential := backoff.NewExponentialBackOff()
-	exponential.MaxElapsedTime = 5 * time.Minute
-	exponential.MaxInterval = 32 * time.Second
-	err := backoff.RetryNotify(func() error {
-		return f.pingCentral()
-	}, exponential, func(err error, d time.Duration) {
-		log.Infof("Check Central status failed: %s. Retrying after %s...", err, d.Round(time.Millisecond))
-	})
-
-	if err != nil {
-		return errors.Wrapf(err, "checking central status failed after %s", exponential.GetElapsedTime())
-	}
-
-	return nil
-}
-
 // getCentralTLSCerts only logs errors because this feature should not break
 // sensors start-up.
 func (f *centralConnectionFactoryImpl) getCentralTLSCerts() []*x509.Certificate {
@@ -113,10 +92,12 @@ func (f *centralConnectionFactoryImpl) SetCentralConnectionWithRetries(conn *uti
 	opts := []clientconn.ConnectionOption{clientconn.UseServiceCertToken(true)}
 
 	// waits until central is ready and has a valid license, otherwise it kills sensor by sending a signal
-	if err := f.waitUntilCentralIsReady(); err != nil {
-		f.stopSignal.SignalWithError(err)
+	if err := f.pingCentral(); err != nil {
+		log.Errorf("checking central status failed: %v", err)
+		f.stopSignal.SignalWithError(errors.Wrap(err, "checking central status failed"))
 		return
 	}
+	log.Infof("Successfully checked central status") // TODO: Remvove logging
 
 	certs := f.getCentralTLSCerts()
 	if len(certs) != 0 {

--- a/sensor/common/centralclient/grpc_connection.go
+++ b/sensor/common/centralclient/grpc_connection.go
@@ -97,7 +97,6 @@ func (f *centralConnectionFactoryImpl) SetCentralConnectionWithRetries(conn *uti
 		f.stopSignal.SignalWithError(errors.Wrap(err, "checking central status failed"))
 		return
 	}
-	log.Infof("Successfully checked central status") // TODO: Remvove logging
 
 	certs := f.getCentralTLSCerts()
 	if len(certs) != 0 {

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -363,7 +363,7 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 		log.Info("Attempting connection setup")
 		select {
 		case <-s.centralConnectionFactory.OkSignal().WaitC():
-			// Connection if up, we can try to create a new central communication
+			// Connection is up, we can try to create a new central communication
 			s.changeState(common.SensorComponentEventCentralReachable)
 		case <-s.centralConnectionFactory.StopSignal().WaitC():
 			// Connection is still broken, report and try again
@@ -371,7 +371,7 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 			return wrapOrNewError(s.centralConnectionFactory.StopSignal().Err(), "connection couldn't be re-established")
 		}
 
-		// At this point, we know that connection factory reported that connection if up.
+		// At this point, we know that connection factory reported that connection is up.
 		// Try to create a central communication component. This component will fail (Stopped() signal) if the connection
 		// suddenly broke.
 		s.centralCommunication = NewCentralCommunication(s.reconnect.Load(), s.components...)


### PR DESCRIPTION
## Description

This PR removes the inner loop of the Sensor - Central connection logic, leaving us with only one loop.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
Deployed the change to a cluster, scaled down Central to 0, observed Sensor losing connection.
Afterwards, scaled back Central to 1, observed Sensor reconnecting to Central.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
