### PR TITLE
ROX-19738: Fix policy categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Technical Changes
 - Increased minimum Node.js version to 18.0.0 because 16 reached end of life. This change affects `yarn` commands in the ui folder.
 
+- ROX-19738: Previously categories passed to the detection service's APIs `v1/detect/build, v1/detect/deploy, v1/detect/deploy/yaml`
+  have been _always_ lower-cased by the backend. However, this is not the case anymore to support custom categories, which
+  are required to be title-cased.
+
 ## [4.2.0]
 
 

--- a/central/detection/buildtime/detector_impl_test.go
+++ b/central/detection/buildtime/detector_impl_test.go
@@ -1,7 +1,6 @@
 package buildtime
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -73,11 +72,7 @@ func TestDetector(t *testing.T) {
 			filter, getUnusedCategories := detection.MakeCategoryFilter(testCase.allowedCategories)
 			alerts, err := detector.Detect(testCase.image, filter)
 			require.NoError(t, err)
-			lowercaseCategories := make([]string, len(testCase.expectedUnusedCategories))
-			for i, category := range testCase.expectedUnusedCategories {
-				lowercaseCategories[i] = strings.ToLower(category)
-			}
-			require.ElementsMatch(t, lowercaseCategories, getUnusedCategories())
+			require.ElementsMatch(t, testCase.expectedUnusedCategories, getUnusedCategories())
 			assert.Len(t, alerts, testCase.expectedAlerts)
 		})
 

--- a/central/detection/utils.go
+++ b/central/detection/utils.go
@@ -1,8 +1,6 @@
 package detection
 
 import (
-	"strings"
-
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/detection"
 	"github.com/stackrox/rox/pkg/set"
@@ -15,9 +13,8 @@ func MakeCategoryFilter(filterForCategories []string) (detection.FilterOption, f
 	allowedCategorySet := set.NewStringSet()
 	unusedCategorySet := set.NewStringSet()
 	for _, category := range filterForCategories {
-		lowercaseCategory := strings.ToLower(category)
-		allowedCategorySet.Add(lowercaseCategory)
-		unusedCategorySet.Add(lowercaseCategory)
+		allowedCategorySet.Add(category)
+		unusedCategorySet.Add(category)
 	}
 
 	filterOption := func(policy *storage.Policy) bool {
@@ -27,9 +24,8 @@ func MakeCategoryFilter(filterForCategories []string) (detection.FilterOption, f
 
 		foundAllowedCategory := false
 		for _, category := range policy.GetCategories() {
-			lowercaseCategory := strings.ToLower(category)
-			if allowedCategorySet.Contains(lowercaseCategory) {
-				unusedCategorySet.Remove(lowercaseCategory)
+			if allowedCategorySet.Contains(category) {
+				unusedCategorySet.Remove(category)
 				foundAllowedCategory = true
 			}
 		}

--- a/central/detection/utils_test.go
+++ b/central/detection/utils_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	testCategories = []string{"joseph rules"}
+	testCategories = []string{"Joseph rules"}
 	testPolicyOne  = &storage.Policy{
 		Categories: testCategories,
 	}


### PR DESCRIPTION
Reverts stackrox/stackrox#7834

This was initially reverted since a CI failure related to policy categories was found within the `ui-e2e-tests` on main.

This PR ensures that the changes aren't at fault, and after confirming that the changes are good-to-be merged again.