### PR TITLE
ROX-19344: Add validation and persistence to deferral config form

### DIFF
--- a/ui/apps/platform/src/Containers/DeferralConfiguration/VulnerabilitiesConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/DeferralConfiguration/VulnerabilitiesConfiguration.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 
 import {
+    Alert,
+    AlertActionCloseButton,
+    AlertGroup,
     Bullseye,
     Button,
     Divider,
     Flex,
     Form,
     FormGroup,
+    FormGroupProps,
     Grid,
     GridItem,
     PageSection,
@@ -19,41 +23,53 @@ import {
     Title,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import sortBy from 'lodash/sortBy';
 import { FormikHandlers, useFormik } from 'formik';
+import * as yup from 'yup';
 
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { VulnerabilitiesDeferralConfig } from 'services/DeferralConfigService';
+import useToasts, { Toast } from 'hooks/patternfly/useToasts';
+
+import usePermissions from 'hooks/usePermissions';
 import { useVulnerabilitiesDeferralConfig } from './useVulnerabilitiesDeferralConfig';
 
 type BaseSettingProps = {
     fieldId: string;
-    isEnabled: boolean;
+    isSettingEnabled: boolean;
+    isDisabled: boolean;
     handleChange: FormikHandlers['handleChange'];
 };
 
 function NumericSetting({
     fieldId,
     value,
-    isEnabled,
+    isSettingEnabled,
+    isDisabled,
     handleChange,
+    validated,
+    helperTextInvalid,
 }: BaseSettingProps & {
     value: number;
+    validated: FormGroupProps['validated'];
+    helperTextInvalid: FormGroupProps['helperTextInvalid'];
 }) {
     return (
         <>
             <GridItem span={8} md={4} xl={3}>
-                <FormGroup>
+                <FormGroup validated={validated} helperTextInvalid={helperTextInvalid}>
                     <Flex direction={{ default: 'row' }} flexWrap={{ default: 'nowrap' }}>
                         <TextInput
                             id={`${fieldId}.numDays`}
                             type="number"
-                            style={{ width: '70px' }}
+                            style={{ width: '100px' }}
                             value={value}
                             onChange={(_, e) => handleChange(e)}
-                            isDisabled={!isEnabled}
+                            isDisabled={!isSettingEnabled || isDisabled}
+                            validated={validated}
                         />
                         <span>days</span>
                     </Flex>
@@ -65,7 +81,8 @@ function NumericSetting({
                         id={`${fieldId}.enabled`}
                         label="Enabled"
                         labelOff="Disabled"
-                        isChecked={isEnabled}
+                        isChecked={isSettingEnabled}
+                        isDisabled={isDisabled}
                         onChange={(_, e) => handleChange(e)}
                     />
                 </FormGroup>
@@ -77,7 +94,8 @@ function NumericSetting({
 function BooleanSetting({
     fieldId,
     label,
-    isEnabled,
+    isSettingEnabled,
+    isDisabled,
     handleChange,
 }: BaseSettingProps & {
     label: string;
@@ -93,7 +111,8 @@ function BooleanSetting({
                         id={fieldId}
                         label="Enabled"
                         labelOff="Disabled"
-                        isChecked={isEnabled}
+                        isChecked={isSettingEnabled}
+                        isDisabled={isDisabled}
                         onChange={(_, e) => handleChange(e)}
                     />
                 </FormGroup>
@@ -101,6 +120,7 @@ function BooleanSetting({
         </>
     );
 }
+
 function getDefaultConfig(): VulnerabilitiesDeferralConfig {
     return {
         expiryOptions: {
@@ -118,6 +138,61 @@ function getDefaultConfig(): VulnerabilitiesDeferralConfig {
         },
     };
 }
+
+const validationSchema = yup.object({
+    expiryOptions: yup.object({
+        dayOptions: yup
+            .array()
+            .ensure()
+            .of(
+                yup.object({
+                    numDays: yup
+                        .number()
+                        .test(
+                            'isPositive',
+                            'Number of days must be greater than zero',
+                            (value) => typeof value === 'number' && value > 0
+                        )
+                        .required('Number of days must not be empty'),
+                    enabled: yup.boolean().required(),
+                })
+            )
+            .test('dayValuesAreUnique', (dayOptions, testContext) => {
+                if (!dayOptions) {
+                    return true;
+                }
+
+                const dayValueToIndexMap: Record<number, number> = {};
+                let error: yup.ValidationError | boolean = true;
+
+                // If there are duplicate, enabled `dayOptions` with the same `numDays` value return a validation
+                // error at the first index of duplication.
+                dayOptions.forEach((dayOption, currentIndex) => {
+                    if (!dayOption.enabled || error !== true) {
+                        return;
+                    }
+                    const existingIndex = dayValueToIndexMap[dayOption.numDays];
+                    if (existingIndex !== undefined) {
+                        error = testContext.createError({
+                            path: `expiryOptions.dayOptions[${existingIndex}].numDays`,
+                            message: 'Number of days must be unique',
+                        });
+                    }
+                    dayValueToIndexMap[dayOption.numDays] = currentIndex;
+                });
+
+                return error;
+            }),
+        fixableCveOptions: yup
+            .object({
+                allFixable: yup.boolean().required(),
+                anyFixable: yup.boolean().required(),
+            })
+            .required(),
+        // TODO Need 'Indefinitely' added to validation once it is available in the API
+        customDate: yup.boolean().required(),
+    }),
+});
 
 function ensureMinimumDayOptions(
     config: VulnerabilitiesDeferralConfig
@@ -138,19 +213,38 @@ function ensureMinimumDayOptions(
 }
 
 function VulnerabilitiesConfiguration() {
-    const { config, isConfigLoading, isUpdateInProgress, configLoadError } =
+    const { toasts, addToast, removeToast } = useToasts();
+
+    const { config, isConfigLoading, isUpdateInProgress, configLoadError, updateConfig } =
         useVulnerabilitiesDeferralConfig();
 
     const deferralConfig = ensureMinimumDayOptions(config ?? getDefaultConfig());
 
-    const { values, handleChange } = useFormik({
+    const { values, handleChange, errors, submitForm } = useFormik({
         enableReinitialize: true,
         // Ensure that there are at least 4 day options in case this array was set to zero via the API
         initialValues: deferralConfig,
-        onSubmit: () => {},
+        validationSchema,
+        onSubmit: (formValues) =>
+            updateConfig(formValues, {
+                onSuccess: () => {
+                    addToast('The configuration was updated successfully', 'success');
+                },
+                onError: (err: unknown) => {
+                    addToast(
+                        'There was an error updating the configuration',
+                        'danger',
+                        getAxiosErrorMessage(err)
+                    );
+                },
+            }),
     });
 
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForPage = hasReadWriteAccess('Administration');
+
     const isConfigDirty = !isEqual(deferralConfig, values);
+    const hasFormError = Object.keys(errors).length > 0;
 
     const { dayOptions, fixableCveOptions, customDate } = values.expiryOptions;
 
@@ -161,15 +255,18 @@ function VulnerabilitiesConfiguration() {
                     <SplitItem isFilled>
                         <Text>Configure deferral behavior for vulnerabilities</Text>
                     </SplitItem>
-                    <SplitItem>
-                        <Button
-                            variant="primary"
-                            isDisabled={!isConfigDirty}
-                            isLoading={isUpdateInProgress}
-                        >
-                            Save
-                        </Button>
-                    </SplitItem>
+                    {hasWriteAccessForPage && (
+                        <SplitItem>
+                            <Button
+                                variant="primary"
+                                isDisabled={!isConfigDirty || hasFormError}
+                                isLoading={isUpdateInProgress}
+                                onClick={submitForm}
+                            >
+                                Save
+                            </Button>
+                        </SplitItem>
+                    )}
                 </Split>
             </div>
             <Divider component="div" />
@@ -196,16 +293,22 @@ function VulnerabilitiesConfiguration() {
                     <Form className="pf-u-py-lg">
                         <Grid hasGutter>
                             {dayOptions.map(({ numDays, enabled }, index) => {
+                                const fieldIdPrefix = `expiryOptions.dayOptions[${index}]`;
+                                const fieldError = get(errors, `${fieldIdPrefix}.numDays`);
+                                const validated = fieldError ? 'error' : 'default';
                                 return (
                                     <NumericSetting
                                         // Note, if we ever support removing or reordering day options, we'll need to
                                         // use a non-index key here.
                                         // eslint-disable-next-line react/no-array-index-key
                                         key={index}
-                                        fieldId={`expiryOptions.dayOptions[${index}]`}
+                                        fieldId={fieldIdPrefix}
                                         value={numDays}
-                                        isEnabled={enabled}
+                                        isSettingEnabled={enabled}
+                                        isDisabled={!hasWriteAccessForPage}
                                         handleChange={handleChange}
+                                        validated={validated}
+                                        helperTextInvalid={fieldError}
                                     />
                                 );
                             })}
@@ -213,31 +316,55 @@ function VulnerabilitiesConfiguration() {
                             <BooleanSetting
                                 fieldId="TODO"
                                 label="Indefinitely (TODO)"
-                                isEnabled={false}
+                                isSettingEnabled={false}
+                                isDisabled={!hasWriteAccessForPage}
                                 handleChange={handleChange}
                             />
                             <BooleanSetting
                                 fieldId="expiryOptions.fixableCveOptions.allFixable"
                                 label="Expires when all CVEs fixable"
-                                isEnabled={fixableCveOptions.allFixable}
+                                isSettingEnabled={fixableCveOptions.allFixable}
+                                isDisabled={!hasWriteAccessForPage}
                                 handleChange={handleChange}
                             />
                             <BooleanSetting
                                 fieldId="expiryOptions.fixableCveOptions.anyFixable"
                                 label="Expires when any CVE fixable"
-                                isEnabled={fixableCveOptions.anyFixable}
+                                isSettingEnabled={fixableCveOptions.anyFixable}
+                                isDisabled={!hasWriteAccessForPage}
                                 handleChange={handleChange}
                             />
                             <BooleanSetting
                                 fieldId="expiryOptions.customDate"
                                 label="Allow custom date"
-                                isEnabled={customDate}
+                                isSettingEnabled={customDate}
+                                isDisabled={!hasWriteAccessForPage}
                                 handleChange={handleChange}
                             />
                         </Grid>
                     </Form>
                 )}
             </PageSection>
+            <AlertGroup isToast isLiveRegion>
+                {toasts.map(({ key, variant, title, children }: Toast) => (
+                    <Alert
+                        key={key}
+                        variant={variant}
+                        title={title}
+                        timeout={variant === 'success'}
+                        onTimeout={() => removeToast(key)}
+                        actionClose={
+                            <AlertActionCloseButton
+                                title={title}
+                                variantLabel={variant}
+                                onClose={() => removeToast(key)}
+                            />
+                        }
+                    >
+                        {children}
+                    </Alert>
+                ))}
+            </AlertGroup>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/DeferralConfiguration/VulnerabilitiesConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/DeferralConfiguration/VulnerabilitiesConfiguration.tsx
@@ -33,8 +33,8 @@ import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { VulnerabilitiesDeferralConfig } from 'services/DeferralConfigService';
 import useToasts, { Toast } from 'hooks/patternfly/useToasts';
-
 import usePermissions from 'hooks/usePermissions';
+
 import { useVulnerabilitiesDeferralConfig } from './useVulnerabilitiesDeferralConfig';
 
 type BaseSettingProps = {
@@ -163,12 +163,12 @@ const validationSchema = yup.object({
                 }
 
                 const dayValueToIndexMap: Record<number, number> = {};
-                let error: yup.ValidationError | boolean = true;
+                let error: yup.ValidationError | undefined;
 
                 // If there are duplicate, enabled `dayOptions` with the same `numDays` value return a validation
                 // error at the first index of duplication.
                 dayOptions.forEach((dayOption, currentIndex) => {
-                    if (!dayOption.enabled || error !== true) {
+                    if (!dayOption.enabled || error) {
                         return;
                     }
                     const existingIndex = dayValueToIndexMap[dayOption.numDays];
@@ -181,7 +181,7 @@ const validationSchema = yup.object({
                     dayValueToIndexMap[dayOption.numDays] = currentIndex;
                 });
 
-                return error;
+                return error || true; // `yup` expects either and error object on validation failure, or `true` on validation success
             }),
         fixableCveOptions: yup
             .object({


### PR DESCRIPTION
## Description

- Adds formik validation to form items
- Connects the "Save" button to update the config
- Adds READ_ACCESS permission checks to disable the form and remove the "Save" button

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

View the page with a user who has `READ_ACCESS` for `Administration`:
![image](https://github.com/stackrox/stackrox/assets/1292638/60216117-3964-4b5e-b070-93c036d9d271)

View the page with full access, change and save the configuration:
![image](https://github.com/stackrox/stackrox/assets/1292638/93b5c39d-3606-4d15-8728-75188b69ddda)

Test validation of numeric fields:
![image](https://github.com/stackrox/stackrox/assets/1292638/fc103c20-3d38-4486-8be5-418a35602d9f)
![image](https://github.com/stackrox/stackrox/assets/1292638/e6bd02d4-0b71-4508-abca-d49c65056418)
![image](https://github.com/stackrox/stackrox/assets/1292638/2159b90f-6cc1-4e05-ac5b-0949ef0a1f26)

Test that duplication validation only impacts numeric fields that are enabled:
![image](https://github.com/stackrox/stackrox/assets/1292638/11a1d008-3e65-4f92-bc5a-0d7a9bc2a12c)

