### PR TITLE
ROX-19138: `/v1/resources` and `/v1/featureflags` authentication doc

### DIFF
--- a/central/featureflags/service/service_impl.go
+++ b/central/featureflags/service/service_impl.go
@@ -18,11 +18,9 @@ var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
 		allow.Anonymous(): {
 			// This endpoint is used by the UI to populate framework
-			// information. The population of this part of framework
-			// information is done at UI start, where there is usually
-			// no authenticated user, nor associated information to provide.
-			// It should stay anonymous / public as long as the UI needs it
-			// at startup time.
+			// information which is done at UI start when there is no
+			// authenticated user yet. It should stay anonymous / public
+			// as long as the UI needs it at startup time.
 			"/v1.FeatureFlagService/GetFeatureFlags",
 		},
 	})

--- a/central/featureflags/service/service_impl.go
+++ b/central/featureflags/service/service_impl.go
@@ -17,6 +17,12 @@ import (
 var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
 		allow.Anonymous(): {
+			// This endpoint is used by the UI to populate framework
+			// information. The population of this part of framework
+			// information is done at UI start, where there is usually
+			// no authenticated user, nor associated information to provide.
+			// It should stay anonymous / public as long as the UI needs it
+			// at startup time.
 			"/v1.FeatureFlagService/GetFeatureFlags",
 		},
 	})

--- a/central/role/service/service_impl.go
+++ b/central/role/service/service_impl.go
@@ -58,9 +58,9 @@ var (
 			"/v1.RoleService/GetNamespacesForClusterAndPermissions",
 		},
 		allow.Anonymous(): {
-			// This endpoint is used by the UI in order to populate the resource
-			// list when displaying or editing permission sets.
-			// TODO(ROX-19814): move this service to either user.Authenticated()
+			// This endpoint is used by the UI to populate the resource list
+			// when displaying or editing permission sets.
+			// TODO(ROX-19814): move this handler to either user.Authenticated()
 			// or user.With(permissions.View(resource.Access)) group.
 			"/v1.RoleService/GetResources",
 		},

--- a/central/role/service/service_impl.go
+++ b/central/role/service/service_impl.go
@@ -58,6 +58,10 @@ var (
 			"/v1.RoleService/GetNamespacesForClusterAndPermissions",
 		},
 		allow.Anonymous(): {
+			// This endpoint is used by the UI in order to populate the resource
+			// list when displaying or editing permission sets.
+			// TODO(ROX-19814): move this service to either user.Authenticated()
+			// or user.With(permissions.View(resource.Access)) group.
 			"/v1.RoleService/GetResources",
 		},
 	})


### PR DESCRIPTION
## Description

Document why the two mentioned endpoints are not authenticated, and the steps to make them authenticated.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
- [ ] Evaluated and added CHANGELOG entry if required => Done in #7565 
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Only adding documentation comments. There should be no imapct.
CI is therefore sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
