### PR TITLE
fix(localscan): `nil` registry can cause Sensor to panic

### DIFF
--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -363,6 +363,9 @@ func (s *LocalScan) fetchSignatures(ctx context.Context, errorList *errorhelpers
 // scanImage will scan the given image and return its components.
 func scanImage(ctx context.Context, image *storage.Image,
 	registry registryTypes.ImageRegistry, scannerClient scannerclient.ScannerClient) (*scannerclient.ImageAnalysis, error) {
+	if registry == nil {
+		return nil, fmt.Errorf("cannot scan image with nil registry")
+	}
 	// Get the image analysis from the local Scanner.
 	scanResp, err := scannerClient.GetImageAnalysis(ctx, image, registry.Config())
 	if err != nil {

--- a/sensor/common/scan/scan_test.go
+++ b/sensor/common/scan/scan_test.go
@@ -179,6 +179,12 @@ func (suite *scanTestSuite) TestEnrichImageFailures() {
 	}
 }
 
+func (suite *scanTestSuite) TestScanImage() {
+	client := emptyScannerClientSingleton()
+	_, err := scanImage(context.Background(), &storage.Image{}, nil, client)
+	suite.ErrorContains(err, "cannot scan image with nil registry")
+}
+
 func (suite *scanTestSuite) TestMetadataBeingSet() {
 	fakeRegStore := &fakeRegistryStore{}
 	mirrorStore := mirrorStoreMocks.NewMockStore(gomock.NewController(suite.T()))


### PR DESCRIPTION
## Description

The test in this PR panics without the patch. This is the same `nil` panic some users are experiencing with local image scan. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] Unit test reproducing the panic
- [ ] Reproducing the panic with local image scanning code

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
