### PR TITLE
ROX-19825: Sensor panics when invalid image passed to local enricher

### DIFF
--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -161,7 +161,7 @@ func (c *cacheValue) scanAndSet(ctx context.Context, svc v1.ImageServiceClient, 
 	if err != nil {
 		// Ignore the error and set the image to something basic,
 		// so alerting can progress.
-		log.Errorf("Scan request failed for image %s: %s", req.containerImage.GetName().GetFullName(), err)
+		log.Errorf("Scan request failed for image %q: %s", req.containerImage.GetName().GetFullName(), err)
 		c.image = types.ToImage(req.containerImage)
 		return
 	}

--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -136,7 +136,7 @@ func (s *LocalScan) EnrichLocalImageInNamespace(ctx context.Context, centralClie
 	// Enrich image with metadata from one of registries.
 	reg, pullSourceImage := s.getImageWithMetadata(ctx, errorList, namespace, srcImage)
 	if pullSourceImage == nil {
-		// A null pullSourceImage indicates that the source image and all
+		// A nil pullSourceImage indicates that the source image and all
 		// mirrors were invalid images.
 		return nil, errors.Join(errorList.ToError(), ErrEnrichNotStarted)
 	}
@@ -299,7 +299,7 @@ func (s *LocalScan) getPullSources(srcImage *storage.ContainerImage) []*storage.
 		cImages = append(cImages, img)
 	}
 
-	log.Debugf("Using %d pull sources for enriching %q: %v", len(cImages), srcImage.GetName().GetFullName(), cImages)
+	log.Debugf("Using %d pull sources for enriching %q: %+v", len(cImages), srcImage.GetName().GetFullName(), cImages)
 	return cImages
 }
 

--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -418,16 +418,16 @@ func createNoAuthImageRegistry(ctx context.Context, imgName *storage.ImageName, 
 // scanning expectations.
 func validateSourceImage(srcImage *storage.ContainerImage) error {
 	if srcImage == nil {
-		return pkgErrors.Errorf("missing image")
+		return pkgErrors.New("missing image")
 	}
 
 	if srcImage.GetName() == nil {
-		return pkgErrors.Errorf("missing image name")
+		return pkgErrors.New("missing image name")
 	}
 
 	// A fully qualified image is expected at this point.
 	if srcImage.GetName().GetRegistry() == "" {
-		return pkgErrors.Errorf("missing image registry")
+		return pkgErrors.New("missing image registry")
 	}
 
 	return nil

--- a/sensor/common/scan/scan_test.go
+++ b/sensor/common/scan/scan_test.go
@@ -271,7 +271,8 @@ func (suite *scanTestSuite) TestEnrichErrorNoScanner() {
 		scannerClientSingleton: func() scannerclient.ScannerClient { return nil },
 	}
 
-	_, err := scan.EnrichLocalImageInNamespace(context.Background(), nil, &storage.ContainerImage{}, "", "", false)
+	img := &storage.ContainerImage{Name: &storage.ImageName{Registry: "fake"}}
+	_, err := scan.EnrichLocalImageInNamespace(context.Background(), nil, img, "", "", false)
 	suite.Require().ErrorIs(err, ErrNoLocalScanner)
 	suite.Require().ErrorIs(err, ErrEnrichNotStarted)
 }
@@ -288,13 +289,64 @@ func (suite *scanTestSuite) TestEnrichErrorNoImage() {
 	suite.Require().ErrorIs(err, ErrEnrichNotStarted)
 }
 
+func (suite *scanTestSuite) TestEnrichErrorBadImage() {
+	mirrorStore := mirrorStoreMocks.NewMockStore(gomock.NewController(suite.T()))
+	imageServiceClient := &echoImageServiceClient{}
+	scan := LocalScan{
+		scannerClientSingleton:            emptyScannerClientSingleton,
+		scanSemaphore:                     semaphore.NewWeighted(10),
+		getMatchingCentralRegIntegrations: emptyGetMatchingCentralIntegrations,
+		mirrorStore:                       mirrorStore,
+		getGlobalRegistryForImage:         emptyGetGlobalRegistryForImage,
+		createNoAuthImageRegistry:         failCreateNoAuthImageRegistry,
+		scanImg:                           scanImage,
+	}
+
+	imgNameStr := "   is an invalid image"
+
+	suite.Run("enrich error on nil image name", func() {
+		containerImg := &storage.ContainerImage{}
+		resultImg, err := scan.EnrichLocalImageInNamespace(context.Background(), imageServiceClient, containerImg, "", "", false)
+		suite.Require().ErrorContains(err, "missing image name")
+		suite.Require().ErrorIs(err, ErrEnrichNotStarted)
+		suite.Require().Nil(resultImg)
+
+	})
+
+	suite.Run("enrich error missing image registry", func() {
+		containerImg := &storage.ContainerImage{
+			Name: &storage.ImageName{},
+		}
+		resultImg, err := scan.EnrichLocalImageInNamespace(context.Background(), imageServiceClient, containerImg, "", "", false)
+		suite.Require().ErrorContains(err, "missing image registry")
+		suite.Require().ErrorIs(err, ErrEnrichNotStarted)
+		suite.Require().Nil(resultImg)
+
+	})
+
+	suite.Run("enrich error on bad full image name", func() {
+		containerImg := &storage.ContainerImage{
+			Name: &storage.ImageName{
+				Registry: "fake",
+				FullName: imgNameStr,
+			},
+		}
+		mirrorStore.EXPECT().PullSources(gomock.Any()).Return([]string{imgNameStr}, nil)
+		resultImg, err := scan.EnrichLocalImageInNamespace(context.Background(), imageServiceClient, containerImg, "", "", false)
+		suite.Require().ErrorContains(err, "zero valid pull sources")
+		suite.Require().ErrorIs(err, ErrEnrichNotStarted)
+		suite.Require().Nil(resultImg)
+	})
+}
+
 func (suite *scanTestSuite) TestEnrichThrottle() {
 	scan := LocalScan{
 		scannerClientSingleton: emptyScannerClientSingleton,
 		scanSemaphore:          semaphore.NewWeighted(0),
 	}
 
-	_, err := scan.EnrichLocalImageInNamespace(context.Background(), nil, &storage.ContainerImage{}, "", "", false)
+	img := &storage.ContainerImage{Name: &storage.ImageName{Registry: "fake"}}
+	_, err := scan.EnrichLocalImageInNamespace(context.Background(), nil, img, "", "", false)
 	suite.Require().ErrorIs(err, ErrTooManyParallelScans)
 	suite.Require().ErrorIs(err, ErrEnrichNotStarted)
 }
@@ -519,36 +571,6 @@ func (suite *scanTestSuite) TestNotes() {
 		resultImg, err = scan.EnrichLocalImageInNamespace(context.Background(), imageServiceClient, containerImg, "", "", false)
 		suite.Require().NoError(err)
 		suite.Require().Contains(resultImg.GetNotes(), storage.Image_MISSING_SIGNATURE)
-	})
-}
-
-func (suite *scanTestSuite) TestEnrichWithBadSrcImage() {
-	mirrorStore := mirrorStoreMocks.NewMockStore(gomock.NewController(suite.T()))
-
-	containerImg := &storage.ContainerImage{
-		Name: &storage.ImageName{
-			FullName: "   is an invalid image",
-		},
-	}
-	mirrorStore.EXPECT().PullSources(gomock.Any()).Return([]string{"   is an invalid image"}, nil)
-
-	imageServiceClient := &echoImageServiceClient{}
-
-	scan := LocalScan{
-		scannerClientSingleton:            emptyScannerClientSingleton,
-		scanSemaphore:                     semaphore.NewWeighted(10),
-		getMatchingCentralRegIntegrations: emptyGetMatchingCentralIntegrations,
-		mirrorStore:                       mirrorStore,
-		getGlobalRegistryForImage:         emptyGetGlobalRegistryForImage,
-		createNoAuthImageRegistry:         failCreateNoAuthImageRegistry,
-		scanImg:                           scanImage,
-	}
-
-	suite.Run("enrich error on bad source image", func() {
-		resultImg, err := scan.EnrichLocalImageInNamespace(context.Background(), imageServiceClient, containerImg, "", "", false)
-		suite.Require().Error(err)
-		suite.Require().ErrorIs(err, ErrEnrichNotStarted)
-		suite.Require().Nil(resultImg)
 	})
 }
 


### PR DESCRIPTION
## Description

Addresses an assumption that the image passed to the local enricher is a valid image - an invalid image was triggering a sensor panic

The enricher was being passed `srcImage.GetName().GetFullName()` = `   is an invalid image`, ultimately causing:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x2c41856]

goroutine 14758 [running]:
github.com/stackrox/rox/sensor/common/scan.scanImage({0x41bea48, 0xc01b9226c0}, 0x41ce8a?, {0x0?, 0x0?}, 0x28?)
	github.com/stackrox/rox/sensor/common/scan/scan.go:366 +0x36
github.com/stackrox/rox/sensor/common/scan.(*LocalScan).fetchImageAnalysis(0xc004573b20, {0x41bea48, 0xc01b9226c0}, 0xc01e74bce0, {0x0, 0x0}, 0xc02dbf7b30)
	github.com/stackrox/rox/sensor/common/scan/scan.go:325 +0xd1
github.com/stackrox/rox/sensor/common/scan.(*LocalScan).EnrichLocalImageInNamespace(0xc004573b20, {0x41bea48, 0xc01b9226c0}, {0x7f2593184638, 0xc005145320}, 0xc01fe3c0c0, {0xc0265c4fa0, 0x1a}, {0x0, 0x0}, ...)
	github.com/stackrox/rox/sensor/common/scan/scan.go:139 +0x44d
github.com/stackrox/rox/sensor/common/detector.scanImageLocal({0x41c32b0?, 0xc023cf5f50?}, {0x41d90e0?, 0xc005145320}, 0xc0244014a0, 0x0?)
	github.com/stackrox/rox/sensor/common/detector/enricher.go:96 +0x106
github.com/stackrox/rox/sensor/common/detector.(*cacheValue).scanWithRetries(0xc02442cc40, {0x41c32b0, 0xc023cf5f50}, {0x41d90e0, 0xc005145320}, 0xc0244014a0, 0x3c88940)
	github.com/stackrox/rox/sensor/common/detector/enricher.go:118 +0x129
github.com/stackrox/rox/sensor/common/detector.(*cacheValue).scanAndSet(0xc02442cc40, {0x41c32b0, 0xc023cf5f50}, {0x41d90e0, 0xc005145320}, 0xc0244014a0)
	github.com/stackrox/rox/sensor/common/detector/enricher.go:157 +0x28f
github.com/stackrox/rox/sensor/common/detector.(*enricher).runScan(0xc0003f21e0, 0xc0244014a0)
	github.com/stackrox/rox/sensor/common/detector/enricher.go:236 +0x4cf
github.com/stackrox/rox/sensor/common/detector.(*enricher).runImageScanAsync.func1()
	github.com/stackrox/rox/sensor/common/detector/enricher.go:254 +0x2a
created by github.com/stackrox/rox/sensor/common/detector.(*enricher).runImageScanAsync
	github.com/stackrox/rox/sensor/common/detector/enricher.go:252 +0x92
```


## Checklist
- [x] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- [X] Evaluated and added CHANGELOG entry if required
- [X] Determined and documented upgrade steps
- [X] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Unit test added that duplicates observed panic.

Also on running infra cluster created a deployment with an invalid name and observed the panic with delegated scanning enabled, and observed with this fix there is no long a panic.

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: empty
  namespace: default
  labels:
    app: empty
spec:
  replicas: 1
  selector:
    matchLabels:
      app: empty
  template:
    metadata:
      labels:
        app: empty
    spec:
      containers:
      - name: main
        image: "  "
```

After fix logs show detection of scenario:
```
❯ ktailsensor | grep -i "invalid"
pkg/protoconv/resources: 2023/09/21 19:41:24.417132 resources.go:432: Error: error parsing image name '  ': invalid reference format
common/detector: 2023/09/21 19:41:24.433769 enricher.go:152: Debug: Sending scan to local scanner for image "   is an invalid image"
common/detector: 2023/09/21 19:41:24.433861 enricher.go:164: Error: Scan request failed for image "   is an invalid image": missing image registry
```

### Additional fix explanation
The logic in [resources.go](https://github.com/stackrox/stackrox/blob/2eb7c93ef981411a5cf30b0fdca537cab1fd2b2e/pkg/protoconv/resources/resources.go#L427-L441) will send a `storage.ContainerImage` through the enrichment pipeline that has an `storage.ImageName` with the `Registry`, `Remote`, and `Tag` fields = "", and a `FullName` field = "<something> is an invalid image"

The newly added `validateSourceImage()` will validate (amongst other things) if `Registry` == `""`, and therefore any invalid image from a deployment will be caught and scanning not attempted.  If `Registry` is populated it can be safely assumed in the current call path that `srcImage` represents a valid image/reference.

Additionally, the logic which determines mirrors will now correctly produce an error if all mirrors and source image are invalid.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
