### PR TITLE
ROX-19824: Fix severity count selector in UI e2e test

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -40,7 +40,7 @@ export const selectors = {
     firstTableRow: 'table tbody:nth-of-type(1) tr:nth-of-type(1)',
     nonZeroCveSeverityCounts: '*[aria-label*="severity cves"i]:not([aria-label^="0"])',
     nonZeroImageSeverityCounts:
-        '*[aria-label*="images with"i][aria-label$="severity"i]:not([aria-label^="0"])',
+        'td[data-label="Images by severity"] *[aria-label$="severity"i]:not([aria-label^="0"])',
     nonZeroCveSeverityCount: (severity) =>
         `span[aria-label*="${severity.toLowerCase()} severity CVEs across this"]`,
     nonZeroImageSeverityCount: (severity) =>


### PR DESCRIPTION
## Description

Should fix a flake (permanent flake?) due to all CVEs reported on the Workload CVE list page only affecting a single image.

The selector to grab this element looked for `"images with"` in the aria-label, which is correctly rendered as `"image with"` when there is only one.

See video screenshot from a failed test run:
![image](https://github.com/stackrox/stackrox/assets/1292638/f8a85f71-4475-44dc-82df-6f3e3649a10d)


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local test run.

Awaiting CI.