### PR TITLE
fix(detection): update build time policies for detection

### DIFF
--- a/central/detection/buildtime/detector.go
+++ b/central/detection/buildtime/detector.go
@@ -7,6 +7,8 @@ import (
 
 // Detector provides an interface for running build time policy violations.
 type Detector interface {
+	PolicySet() detection.PolicySet
+
 	Detect(image *storage.Image, policyFilters ...detection.FilterOption) ([]*storage.Alert, error)
 }
 

--- a/central/detection/buildtime/detector_impl.go
+++ b/central/detection/buildtime/detector_impl.go
@@ -14,6 +14,11 @@ type detectorImpl struct {
 	policySet detection.PolicySet
 }
 
+// PolicySet retrieves the policy set.
+func (d *detectorImpl) PolicySet() detection.PolicySet {
+	return d.policySet
+}
+
 // Detect runs detection on an image, returning any generated alerts.  If policy categories are specified, we will only
 // run policies with the specified categories
 func (d *detectorImpl) Detect(image *storage.Image, policyFilters ...detection.FilterOption) ([]*storage.Alert, error) {

--- a/central/detection/deploytime/detector_impl.go
+++ b/central/detection/deploytime/detector_impl.go
@@ -5,11 +5,6 @@ import (
 	"github.com/stackrox/rox/pkg/booleanpolicy"
 	"github.com/stackrox/rox/pkg/detection"
 	"github.com/stackrox/rox/pkg/detection/deploytime"
-	"github.com/stackrox/rox/pkg/logging"
-)
-
-var (
-	log = logging.LoggerForModule()
 )
 
 type detectorImpl struct {
@@ -17,12 +12,12 @@ type detectorImpl struct {
 	singleDetector deploytime.Detector
 }
 
-// UpsertPolicy adds or updates a policy in the set.
+// PolicySet retrieves the policy set.
 func (d *detectorImpl) PolicySet() detection.PolicySet {
 	return d.policySet
 }
 
-// Detect runs detection on an deployment, returning any generated alerts.
+// Detect runs detection on a deployment, returning any generated alerts.
 func (d *detectorImpl) Detect(ctx deploytime.DetectionContext, enhancedDeployment booleanpolicy.EnhancedDeployment, policyFilters ...detection.FilterOption) ([]*storage.Alert, error) {
 	alerts, err := d.singleDetector.Detect(ctx, enhancedDeployment, policyFilters...)
 	if err != nil {

--- a/central/detection/lifecycle/manager.go
+++ b/central/detection/lifecycle/manager.go
@@ -7,6 +7,7 @@ import (
 	deploymentDatastore "github.com/stackrox/rox/central/deployment/datastore"
 	"github.com/stackrox/rox/central/deployment/queue"
 	"github.com/stackrox/rox/central/detection/alertmanager"
+	"github.com/stackrox/rox/central/detection/buildtime"
 	"github.com/stackrox/rox/central/detection/deploytime"
 	"github.com/stackrox/rox/central/detection/runtime"
 	baselineDataStore "github.com/stackrox/rox/central/processbaseline/datastore"
@@ -44,12 +45,13 @@ type Manager interface {
 }
 
 // newManager returns a new manager with the injected dependencies.
-func newManager(deploytimeDetector deploytime.Detector, runtimeDetector runtime.Detector,
+func newManager(buildTimeDetector buildtime.Detector, deployTimeDetector deploytime.Detector, runtimeDetector runtime.Detector,
 	deploymentDatastore deploymentDatastore.DataStore, processesDataStore processDatastore.DataStore, baselines baselineDataStore.DataStore,
 	alertManager alertmanager.AlertManager, reprocessor reprocessor.Loop, deletedDeploymentsCache expiringcache.Cache, filter filter.Filter,
 	processAggregator aggregator.ProcessAggregator) *managerImpl {
 	m := &managerImpl{
-		deploytimeDetector:      deploytimeDetector,
+		buildTimeDetector:       buildTimeDetector,
+		deployTimeDetector:      deployTimeDetector,
 		runtimeDetector:         runtimeDetector,
 		alertManager:            alertManager,
 		deploymentDataStore:     deploymentDatastore,

--- a/central/detection/lifecycle/singleton.go
+++ b/central/detection/lifecycle/singleton.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/central/deployment/cache"
 	deploymentDatastore "github.com/stackrox/rox/central/deployment/datastore"
 	"github.com/stackrox/rox/central/detection/alertmanager"
+	"github.com/stackrox/rox/central/detection/buildtime"
 	"github.com/stackrox/rox/central/detection/deploytime"
 	"github.com/stackrox/rox/central/detection/runtime"
 	policyDataStore "github.com/stackrox/rox/central/policy/datastore"
@@ -24,6 +25,7 @@ var (
 
 func initialize() {
 	manager = newManager(
+		buildtime.SingletonDetector(),
 		deploytime.SingletonDetector(),
 		runtime.SingletonDetector(),
 		deploymentDatastore.Singleton(),

--- a/central/detection/runtime/detector_impl.go
+++ b/central/detection/runtime/detector_impl.go
@@ -18,7 +18,7 @@ type detectorImpl struct {
 	deployments datastore.DataStore
 }
 
-// UpsertPolicy adds or updates a policy in the set.
+// PolicySet retrieves the policy set.
 func (d *detectorImpl) PolicySet() detection.PolicySet {
 	return d.policySet
 }


### PR DESCRIPTION
## Description

This issue was found during testing / verifying the fix for [ROX-19738](https://issues.redhat.com/browse/ROX-19738): when creating a build-time policy and using the detection service to check for policy violations (e.g. via `roxctl image check`), the behavior currently is as-follows:
- The build time detector's policy set will be filled with the existing policies during [within the initialize function](https://github.com/stackrox/stackrox/blob/master/central/detection/buildtime/singleton.go#L38).
- Afterwards, no modifications are made to the policy set, meaning neither newly added, updated, or removed policies will be taken into account.
- The result of the `DetectBuildTime` request then may contain stale data, either from policies that _may_ have been already removed / updated, or miss data from policies that _have_ been created.

The only fix for the above would be to restart Central each time a new build-time policy is added / updated / removed, ensuring that the build time detector uses the latest available policies.

The PR fixes this by ensuring the lifecycle manager will update the buildtime's policy set when upserting / removing policies. This will ensure that the result of the `DetectBuildTime` request is actually up-to-date and not potentially stale.

Note: in addition to the actual fix, minor style / naming fixes are within the PR as well.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

The previous behavior was the following:

1. Create a custom policy category for testing, e.g. `Testing Something`.

2. Create a policy with the category `Testing Something` and lifecycle stage `BUILD`. You can create a dummy criteria in it (used `Image Tag != 1.23`).

3. Run a roxctl image check command:
```bash
export ROX_ENDPOINT="<central-endpoint>:443"
export ROX_PASSWORD="<central-admin-password>"

roxctl image check --image docker.io/nginx:1.23 --categories "Testing Something"
```

4. You should observe a failure that the category doesn't match _any_ policy.
```log
ERROR:	Checking image failed: could not check build-time alerts: rpc error: code = Internal desc = allowed categories ["Testing Somethingf"] did not match any policy categories. Retrying after 3 seconds...
```

5. Upgrade Central to the version of this PR.

6. Re-create the policy category, and the policy.

7. Run the roxctl image cehck command:
```bash
export ROX_ENDPOINT="<central-endpoint>:443"
export ROX_PASSWORD="<central-admin-password>"

roxctl image check --image docker.io/nginx:1.23 --categories "Testing Something"
```

8. The command should execute successfully, and you should see a violation depending on your used image + policy criteria.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
