### PR TITLE
ROX-19772: Administration events for notifiers

### DIFF
--- a/central/notifiers/cscc/client/client.go
+++ b/central/notifiers/cscc/client/client.go
@@ -6,10 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/notifiers/cscc/findings"
+	"github.com/stackrox/rox/pkg/administration/events/codes"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/utils"
@@ -18,7 +19,10 @@ import (
 
 const (
 	cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
-	timeout            = 5 * time.Second
+)
+
+var (
+	timeout = env.CSCCTimeout.DurationSetting()
 )
 
 var (
@@ -76,7 +80,7 @@ func (c *Config) CreateFinding(ctx context.Context, finding *findings.Finding, i
 	}
 	defer utils.IgnoreError(resp.Body.Close)
 
-	return notifiers.CreateError("Cloud SCC", resp)
+	return notifiers.CreateError("Cloud SCC", resp, codes.CloudPlatformGeneric)
 }
 
 func (c *Config) request(finding *findings.Finding, id string) (*http.Request, error) {

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/uuid"
 	"go.uber.org/atomic"
-	"go.uber.org/zap"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -261,7 +260,7 @@ func (l *loopImpl) runReprocessingForObjects(entityType string, getIDsFunc func(
 	}
 	ids, err := getIDsFunc()
 	if err != nil {
-		log.Errorw("Failed to retrieve active IDs for entity", zap.String("entity", entityType),
+		log.Errorw("Failed to retrieve active IDs for entity", logging.String("entity", entityType),
 			logging.Err(err))
 		return
 	}
@@ -428,7 +427,7 @@ func (l *loopImpl) reprocessNode(id string) bool {
 
 	err = l.nodeEnricher.EnrichNode(node)
 	if err != nil {
-		log.Errorw("Error enriching node", zap.String("node", nodeDatastore.NodeString(node)), logging.Err(err))
+		log.Errorw("Error enriching node", logging.String("node", nodeDatastore.NodeString(node)), logging.Err(err))
 		return false
 	}
 	if err := l.risk.CalculateRiskAndUpsertNode(node); err != nil {

--- a/central/splunk/compliance.go
+++ b/central/splunk/compliance.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/jsonutil"
-	"github.com/stackrox/rox/pkg/logging"
 )
 
 var (
@@ -25,8 +24,6 @@ var (
 		storage.ComplianceState_COMPLIANCE_STATE_FAILURE: "Fail",
 		storage.ComplianceState_COMPLIANCE_STATE_ERROR:   "Error",
 	}
-
-	log = logging.LoggerForModule()
 )
 
 type splunkComplianceResult struct {

--- a/central/tlsconfig/tlsconfig.go
+++ b/central/tlsconfig/tlsconfig.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/x509utils"
-	"go.uber.org/zap"
 )
 
 const (
@@ -235,7 +234,7 @@ func getInternalCertificates(namespace string) ([]tls.Certificate, error) {
 
 	log.Warnw("Internal TLS certificates are not valid for all cluster-internal DNS names due to deployment in "+
 		"alternative namespace, issuing ephemeral certificate with adequate DNS names",
-		zap.String("namespace", namespace), zap.Strings("internalDNSNames", mtls.CentralSubject.AllHostnamesForNamespace(namespace)))
+		logging.String("namespace", namespace), logging.Strings("internalDNSNames", mtls.CentralSubject.AllHostnamesForNamespace(namespace)))
 	newInternalCert, err := issueInternalCertificate(namespace)
 	if err != nil {
 		return internalCerts, err

--- a/pkg/administration/events/codes/codes.go
+++ b/pkg/administration/events/codes/codes.go
@@ -1,0 +1,32 @@
+package codes
+
+// Holds human-readable error codes for classifying errors emitted from logs.
+// The error codes may be used for filtering within logs as well as rendering
+// specific hints for the related administration events.
+const (
+	AWSSHGeneric          = "awssh-generic"
+	AWSSHHeartBeat        = "awssh-heartbeat"
+	AWSSHInvalidTimestamp = "awssh-timestamp"
+	AWSSHBatchUpload      = "awssh-batch-upload"
+	AWSSHCacheExhausted   = "awssh-cache-exhausted"
+
+	CloudPlatformGeneric = "cloud-platform-generic"
+
+	WebhookGeneric = "webhook-generic"
+
+	EmailGeneric = "email-generic"
+
+	JIRAGeneric = "jira-generic"
+
+	PagerDutyGeneric = "pagerduty-generic"
+
+	SlackGeneric = "slack-generic"
+
+	SplunkGeneric = "splunk-generic"
+
+	SumoLogicGeneric = "sumo-logic-generic"
+
+	SyslogGeneric = "syslog-generic"
+
+	TeamsGeneric = "teams-generic"
+)

--- a/pkg/administration/events/domain.go
+++ b/pkg/administration/events/domain.go
@@ -1,5 +1,7 @@
 package events
 
+import "regexp"
+
 const (
 	defaultDomain       = "General"
 	imageScanningDomain = "Image Scanning"
@@ -7,30 +9,19 @@ const (
 )
 
 var (
-	// TODO(dhaus): Possibly switch to regexp for associating modules to domains.
-	moduleToDomain = map[string]string{
-		"reprocessor":   imageScanningDomain,
-		"image/service": imageScanningDomain,
-		// Notifiers.
-		"pkg/notifiers/awssh":     integrationDomain,
-		"pkg/notifiers/email":     integrationDomain,
-		"pkg/notifiers/generic":   integrationDomain,
-		"pkg/notifiers/jira":      integrationDomain,
-		"pkg/notifiers/pagerduty": integrationDomain,
-		"pkg/notifiers/slack":     integrationDomain,
-		"pkg/notifiers/splunk":    integrationDomain,
-		"pkg/notifiers/sumologic": integrationDomain,
-		"pkg/notifiers/syslog":    integrationDomain,
-		"pkg/notifiers/teams":     integrationDomain,
+	moduleToDomain = map[*regexp.Regexp]string{
+		regexp.MustCompile(`^reprocessor|image/service`): imageScanningDomain,
+		regexp.MustCompile(`^pkg/notifiers(/|$)`):        integrationDomain,
 	}
 )
 
 // GetDomainFromModule retrieves a domain based on a specific module which will be
 // used for administration events.
 func GetDomainFromModule(module string) string {
-	domain := moduleToDomain[module]
-	if domain == "" {
-		return defaultDomain
+	for regex, domain := range moduleToDomain {
+		if regex.MatchString(module) {
+			return domain
+		}
 	}
-	return domain
+	return defaultDomain
 }

--- a/pkg/administration/events/domain.go
+++ b/pkg/administration/events/domain.go
@@ -3,12 +3,25 @@ package events
 const (
 	defaultDomain       = "General"
 	imageScanningDomain = "Image Scanning"
+	integrationDomain   = "Integrations"
 )
 
 var (
+	// TODO(dhaus): Possibly switch to regexp for associating modules to domains.
 	moduleToDomain = map[string]string{
 		"reprocessor":   imageScanningDomain,
 		"image/service": imageScanningDomain,
+		// Notifiers.
+		"pkg/notifiers/awssh":     integrationDomain,
+		"pkg/notifiers/email":     integrationDomain,
+		"pkg/notifiers/generic":   integrationDomain,
+		"pkg/notifiers/jira":      integrationDomain,
+		"pkg/notifiers/pagerduty": integrationDomain,
+		"pkg/notifiers/slack":     integrationDomain,
+		"pkg/notifiers/splunk":    integrationDomain,
+		"pkg/notifiers/sumologic": integrationDomain,
+		"pkg/notifiers/syslog":    integrationDomain,
+		"pkg/notifiers/teams":     integrationDomain,
 	}
 )
 

--- a/pkg/administration/events/hints.go
+++ b/pkg/administration/events/hints.go
@@ -1,25 +1,127 @@
 package events
 
-import "github.com/stackrox/rox/pkg/sac/resources"
+import (
+	"github.com/stackrox/rox/pkg/administration/events/codes"
+	"github.com/stackrox/rox/pkg/sac/resources"
+)
 
 const (
-	defaultRemediation = "An unknown issue occurred. Make sure to check out the detailed log view for more details."
+	defaultRemediation = "An unknown issue occurred. Make sure to check out the detailed event message for more details."
 )
 
 var (
-	hints = map[string]map[string]string{
-		// Currently, a hint is based on the domain and the resource associated with an administration event.
-		// In the future, we may extend this, and possibly also ensure hints are loaded externally (similar to
-		// vulnerability definitions).
+	// Currently, a hint is based on the domain and the resource associated with an administration event.
+	// Additionally, an optional error code can be given based on the resource to give a more specialized hint.
+	// In the future, we may extend this, and possibly also ensure hints are loaded externally (similar to
+	// vulnerability definitions).
+	hints = map[string]map[string]map[string]string{
 		imageScanningDomain: {
 			// For now, this is an example string. We may want to revisit those together with UX / the docs team to get
 			// errors that are in-line with documentation guidelines.
-			resources.Image.String(): `An issue occurred scanning the image. Please ensure that:
+			resources.Image.String(): {
+				"": `An issue occurred scanning the image. Please ensure that:
 - Scanner can access the registry.
 - Correct credentials are configured for the particular registry / repository.
 - The scanned manifest exists within the registry / repository.`,
+			},
 		},
 		defaultDomain: {},
+		integrationDomain: {
+			"Notifier": {
+				codes.AWSSHGeneric: `An issue occurred when using the AWS Security Hub notifier.
+Please ensure that:
+- Credentials are configured correctly.
+- Central can access AWS Security Hub.
+
+For additional information, consult the event message for detailed information.`,
+				codes.AWSSHHeartBeat: `Heartbeat messages to AWS Security Hub cannot be sent.
+This indicates that the integration is not working as expected. Please ensure that:
+- Credentials are configured correctly.
+- Central can access AWS Security Hub.`,
+				codes.AWSSHInvalidTimestamp: `An incoming alert could not be sent to AWS Security Hub due to an invalid timestamp.
+You may verify the referenced alert for correctness.
+
+If the issue persists, please open a ticket with RHACS support.`,
+				codes.AWSSHBatchUpload: `Uploading alerts to the AWS Security hub failed.
+This leads to AWS Security Hub potentially missing some or all alerts emitted from Central.
+Please ensure that:
+- Credentials are configured correctly.
+- Central can access AWS Security Hub.
+
+In case a timeout happened, you may adjust the timeout for uploading alerts to AWS Security Hub by adjusting the "ROX_AWSSH_UPLOAD_TIMEOUT"
+environment variable, and increase the default timeout of 2 seconds.
+`,
+				codes.AWSSHCacheExhausted: `The cache of alerts to-be-uploaded to AWS Security Hub is increasing.
+This will lead to an increasing delay in alerts being uploaded to AWS Security Hub.
+
+You may adjust the upload interval for uploading alerts to AWS Security Hub by adjusting the "ROX_AWSSH_UPLOAD_INTERVAL"
+environment variable, and lower the default interval of 15 seconds.`,
+				codes.EmailGeneric: `An issue occurred when using the Email notifier.
+Please ensure that:
+- Configuration is valid, specifically the auth information and TLS configuration.
+- Central can access the SMTP endpoint.
+
+For additional information, consult the event message for detailed information.`,
+				codes.JIRAGeneric: `An issue occurred when creating an issue via the JIRA notifier.
+Please ensure that:
+- Configuration is valid, specifically the auth information.
+- Central can access the JIRA endpoint.
+
+For additional information, consult the event message for detailed information.`,
+				codes.PagerDutyGeneric: `An issue occurred when using the PagerDuty notifier.
+Please ensure that:
+- Configuration is valid, specifically the auth information.
+- Central can access the PagerDuty endpoint.
+
+For additional information, consult the event message for detailed information.`,
+				codes.SlackGeneric: `An issue occurred when using the Slack notifier.
+Please ensure that:
+- Configuration is valid, specifically the auth information.
+- Central can access the Slack endpoint.
+
+For additional information, consult the event message for detailed information.`,
+				codes.SyslogGeneric: `An issue occurred when using the Syslog notifier.
+Please ensure that:
+- The message format is valid.
+- Central can access the Syslog endpoint.
+
+In case a timeout error occurred, you may adjust the timeout for sending alerts to Syslog by adjusting the "ROX_SYSLOG_TIMEOUT"
+environment variable, and increase the default timeout of 5 seconds.`,
+				codes.SplunkGeneric: `An issue occurred when using the Splunk notifier.
+Please ensure that:
+- Configuration is valid, specifically the Splunk HEC's vadility.
+- Central can access the Splunk endpoint.
+
+For additional information, consult the event message for detailed information.`,
+				codes.SumoLogicGeneric: `An issue occurred when using the Sumo Logic notifier.
+Please ensure that:
+- Configuration is valid, specifically the TLS configuration.
+- Central can access the Sumo logic endpoint.
+
+For additional information, consult the event message for detailed information.`,
+				codes.TeamsGeneric: `An issue occurred when using the Teams notifier.
+Please ensure that:
+- Configuration is valid.
+- Central can access the Teams endpoint.
+
+In case a timeout error occurred, you may adjust the timeout for sending alerts to teams by adjusting the "ROX_TEAMS_TIMEOUT"
+environment variable, and increase the default timeout of 10 seconds.`,
+				codes.CloudPlatformGeneric: `An issue occurred when using the Cloud Security Platform notifier.
+Please ensure that:
+- Configuration is valid.
+- Central can access the Cloud Security platform endpoint.
+
+In case a timeout error occurred, you may adjust the timeout for sending alerts by adjusting the "ROX_CSCC_TIMEOUT"
+environment variable, and increase the default timeout of 5 seconds.`,
+				codes.WebhookGeneric: `An issue occurred when using the Generic notifier.
+Please ensure that:
+- Configuration is valid, specifically the auth information and TLS certificates.
+- Central can access the webhook endpoint.
+
+In case a timeout error occurred, you may adjust the timeout for sending alerts by adjusting the "ROX_WEBHOOK_TIMEOUT"
+environment variable, and increase the default timeout of 5 seconds.`,
+			},
+		},
 	}
 )
 
@@ -28,16 +130,16 @@ var (
 //
 // Currently, each hint is hardcoded and cannot be updated. In the future
 // it might be possible to fetch definitions for a hint externally (e.g. similar to vulnerability definitions).
-func GetHint(domain string, resource string) string {
+func GetHint(domain string, resource string, errCode string) string {
 	hintPerResource := hints[domain]
 	if hintPerResource == nil {
 		return defaultRemediation
 	}
 
-	hint := hintPerResource[resource]
-	if hint == "" {
+	hints := hintPerResource[resource]
+	if hints == nil {
 		return defaultRemediation
 	}
 
-	return hint
+	return hints[errCode]
 }

--- a/pkg/administration/events/hints.go
+++ b/pkg/administration/events/hints.go
@@ -49,13 +49,12 @@ Please ensure that:
 - Central can access AWS Security Hub.
 
 In case a timeout happened, you may adjust the timeout for uploading alerts to AWS Security Hub by adjusting the "ROX_AWSSH_UPLOAD_TIMEOUT"
-environment variable, and increase the default timeout of 2 seconds.
-`,
+environment variable.`,
 				codes.AWSSHCacheExhausted: `The cache of alerts to-be-uploaded to AWS Security Hub is increasing.
 This will lead to an increasing delay in alerts being uploaded to AWS Security Hub.
 
 You may adjust the upload interval for uploading alerts to AWS Security Hub by adjusting the "ROX_AWSSH_UPLOAD_INTERVAL"
-environment variable, and lower the default interval of 15 seconds.`,
+environment variable.`,
 				codes.EmailGeneric: `An issue occurred when using the Email notifier.
 Please ensure that:
 - Configuration is valid, specifically the auth information and TLS configuration.
@@ -105,21 +104,21 @@ Please ensure that:
 - Central can access the Teams endpoint.
 
 In case a timeout error occurred, you may adjust the timeout for sending alerts to teams by adjusting the "ROX_TEAMS_TIMEOUT"
-environment variable, and increase the default timeout of 10 seconds.`,
+environment variable.`,
 				codes.CloudPlatformGeneric: `An issue occurred when using the Cloud Security Platform notifier.
 Please ensure that:
 - Configuration is valid.
 - Central can access the Cloud Security platform endpoint.
 
 In case a timeout error occurred, you may adjust the timeout for sending alerts by adjusting the "ROX_CSCC_TIMEOUT"
-environment variable, and increase the default timeout of 5 seconds.`,
+environment variable.`,
 				codes.WebhookGeneric: `An issue occurred when using the Generic notifier.
 Please ensure that:
 - Configuration is valid, specifically the auth information and TLS certificates.
 - Central can access the webhook endpoint.
 
 In case a timeout error occurred, you may adjust the timeout for sending alerts by adjusting the "ROX_WEBHOOK_TIMEOUT"
-environment variable, and increase the default timeout of 5 seconds.`,
+environment variable.`,
 			},
 		},
 	}

--- a/pkg/administration/events/option/option.go
+++ b/pkg/administration/events/option/option.go
@@ -1,0 +1,11 @@
+package option
+
+import (
+	"github.com/stackrox/rox/pkg/administration/events/stream"
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+// EnableAdministrationEvents enables the logger to create administration events for all structured log statements.
+func EnableAdministrationEvents() logging.OptionsFunc {
+	return logging.EnableAdministrationEvents(stream.Singleton())
+}

--- a/pkg/auth/authproviders/openshift/watcher.go
+++ b/pkg/auth/authproviders/openshift/watcher.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stackrox/rox/pkg/k8scfgwatch"
 	"github.com/stackrox/rox/pkg/logging"
-	"go.uber.org/zap"
 )
 
 var (
@@ -100,7 +99,7 @@ func readCA(file string) ([]byte, bool, error) {
 		if os.IsNotExist(err) {
 			return nil, false, nil
 		}
-		log.Errorw("Reading CA file", logging.Err(err), zap.String("file", file))
+		log.Errorw("Reading CA file", logging.Err(err), logging.String("file", file))
 		return nil, false, err
 	}
 

--- a/pkg/auth/user/util.go
+++ b/pkg/auth/user/util.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stackrox/rox/pkg/auth/permissions/utils"
 	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/logging"
-	"go.uber.org/zap"
 )
 
 var log = logging.LoggerForModule()
@@ -62,17 +61,17 @@ func extractUserLogFields(user *v1.AuthStatus) []interface{} {
 		serviceIDJSON = protoToJSON(user.GetServiceId())
 	}
 	return []interface{}{
-		zap.String("userID", user.GetUserId()),
-		zap.String("serviceID", serviceIDJSON),
-		zap.Any("expires", user.GetExpires()),
-		zap.String("username", user.GetUserInfo().GetUsername()),
-		zap.String("friendlyName", user.GetUserInfo().GetFriendlyName()),
-		zap.Any("roleNames", utils.RoleNamesFromUserInfo(user.GetUserInfo().GetRoles())),
-		zap.Any("authProvider", &loggableAuthProvider{
+		logging.String("userID", user.GetUserId()),
+		logging.String("serviceID", serviceIDJSON),
+		logging.Any("expires", user.GetExpires()),
+		logging.String("username", user.GetUserInfo().GetUsername()),
+		logging.String("friendlyName", user.GetUserInfo().GetFriendlyName()),
+		logging.Any("roleNames", utils.RoleNamesFromUserInfo(user.GetUserInfo().GetRoles())),
+		logging.Any("authProvider", &loggableAuthProvider{
 			ID:   user.GetAuthProvider().GetId(),
 			Type: user.GetAuthProvider().GetType(),
 			Name: user.GetAuthProvider().GetName(),
 		}),
-		zap.Any("userAttributes", user.GetUserAttributes()),
+		logging.Any("userAttributes", user.GetUserAttributes()),
 	}
 }

--- a/pkg/auth/user/util_test.go
+++ b/pkg/auth/user/util_test.go
@@ -6,9 +6,9 @@ import (
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 )
 
 func TestExtractUserLogFields_MainFieldsTransformed(t *testing.T) {
@@ -44,18 +44,18 @@ func TestExtractUserLogFields_MainFieldsTransformed(t *testing.T) {
 	}
 	fields := extractUserLogFields(user)
 	assert.Len(t, fields, 8)
-	assert.Contains(t, fields, zap.String("userID", user.GetUserId()))
-	assert.Contains(t, fields, zap.String("serviceID", ""))
-	assert.Contains(t, fields, zap.Any("expires", user.GetExpires()))
-	assert.Contains(t, fields, zap.String("username", user.GetUserInfo().GetUsername()))
-	assert.Contains(t, fields, zap.String("friendlyName", user.GetUserInfo().GetFriendlyName()))
-	assert.Contains(t, fields, zap.Any("roleNames", []string{"Admin", "Analyst"}))
-	assert.Contains(t, fields, zap.Any("authProvider", &loggableAuthProvider{
+	assert.Contains(t, fields, logging.String("userID", user.GetUserId()))
+	assert.Contains(t, fields, logging.String("serviceID", ""))
+	assert.Contains(t, fields, logging.Any("expires", user.GetExpires()))
+	assert.Contains(t, fields, logging.String("username", user.GetUserInfo().GetUsername()))
+	assert.Contains(t, fields, logging.String("friendlyName", user.GetUserInfo().GetFriendlyName()))
+	assert.Contains(t, fields, logging.Any("roleNames", []string{"Admin", "Analyst"}))
+	assert.Contains(t, fields, logging.Any("authProvider", &loggableAuthProvider{
 		ID:   user.GetAuthProvider().GetId(),
 		Name: user.GetAuthProvider().GetName(),
 		Type: user.GetAuthProvider().GetType(),
 	}))
-	assert.Contains(t, fields, zap.Any("userAttributes", user.GetUserAttributes()))
+	assert.Contains(t, fields, logging.Any("userAttributes", user.GetUserAttributes()))
 }
 
 func TestExtractUserLogFields_ServiceIdTransformed(t *testing.T) {
@@ -71,18 +71,18 @@ func TestExtractUserLogFields_ServiceIdTransformed(t *testing.T) {
 	}
 	fields := extractUserLogFields(user)
 	assert.Len(t, fields, 8)
-	assert.Contains(t, fields, zap.String("userID", ""))
-	assert.Contains(t, fields, zap.String("serviceID", "{\"serialStr\":\"serialStr\",\"id\":\"id\",\"type\":\"CENTRAL_SERVICE\",\"initBundleId\":\"initBundleId\"}"))
-	assert.Contains(t, fields, zap.Any("expires", user.GetExpires()))
-	assert.Contains(t, fields, zap.String("username", ""))
-	assert.Contains(t, fields, zap.String("friendlyName", ""))
-	assert.Contains(t, fields, zap.Any("roleNames", []string{}))
-	assert.Contains(t, fields, zap.Any("authProvider", &loggableAuthProvider{
+	assert.Contains(t, fields, logging.String("userID", ""))
+	assert.Contains(t, fields, logging.String("serviceID", "{\"serialStr\":\"serialStr\",\"id\":\"id\",\"type\":\"CENTRAL_SERVICE\",\"initBundleId\":\"initBundleId\"}"))
+	assert.Contains(t, fields, logging.Any("expires", user.GetExpires()))
+	assert.Contains(t, fields, logging.String("username", ""))
+	assert.Contains(t, fields, logging.String("friendlyName", ""))
+	assert.Contains(t, fields, logging.Any("roleNames", []string{}))
+	assert.Contains(t, fields, logging.Any("authProvider", &loggableAuthProvider{
 		ID:   "",
 		Name: "",
 		Type: "",
 	}))
-	assert.Contains(t, fields, zap.Any("userAttributes", user.GetUserAttributes()))
+	assert.Contains(t, fields, logging.Any("userAttributes", user.GetUserAttributes()))
 
 }
 
@@ -90,16 +90,16 @@ func TestExtractUserLogFields_NilTransformed(t *testing.T) {
 	var user *v1.AuthStatus
 	fields := extractUserLogFields(user)
 	assert.Len(t, fields, 8)
-	assert.Contains(t, fields, zap.String("userID", ""))
-	assert.Contains(t, fields, zap.String("serviceID", ""))
-	assert.Contains(t, fields, zap.Any("expires", user.GetExpires()))
-	assert.Contains(t, fields, zap.String("username", ""))
-	assert.Contains(t, fields, zap.String("friendlyName", ""))
-	assert.Contains(t, fields, zap.Any("roleNames", []string{}))
-	assert.Contains(t, fields, zap.Any("authProvider", &loggableAuthProvider{
+	assert.Contains(t, fields, logging.String("userID", ""))
+	assert.Contains(t, fields, logging.String("serviceID", ""))
+	assert.Contains(t, fields, logging.Any("expires", user.GetExpires()))
+	assert.Contains(t, fields, logging.String("username", ""))
+	assert.Contains(t, fields, logging.String("friendlyName", ""))
+	assert.Contains(t, fields, logging.Any("roleNames", []string{}))
+	assert.Contains(t, fields, logging.Any("authProvider", &loggableAuthProvider{
 		ID:   "",
 		Name: "",
 		Type: "",
 	}))
-	assert.Contains(t, fields, zap.Any("userAttributes", user.GetUserAttributes()))
+	assert.Contains(t, fields, logging.Any("userAttributes", user.GetUserAttributes()))
 }

--- a/pkg/env/notifiers.go
+++ b/pkg/env/notifiers.go
@@ -1,0 +1,18 @@
+package env
+
+import "time"
+
+var (
+	// AWSSHUploadTimeout specifies the upload timeout for the AWS Security Hub notifier.
+	AWSSHUploadTimeout = registerDurationSetting("ROX_AWSSH_UPLOAD_TIMEOUT", 2*time.Second)
+	// AWSSHUploadInterval specifies the interval for uploading alerts to AWS Security Hub.
+	AWSSHUploadInterval = registerDurationSetting("ROX_AWSSH_UPLOAD_INTERVAL", 15*time.Second)
+	// SyslogUploadTimeout specifies the upload timeout for the Syslog notifier.
+	SyslogUploadTimeout = registerDurationSetting("ROX_SYSLOG_UPLOAD_TIMEOUT", 5*time.Second)
+	// TeamsTimeout specifies the timeout for posting messages to Teams via the Teams notifier.
+	TeamsTimeout = registerDurationSetting("ROX_TEAMS_TIMEOUT", 10*time.Second)
+	// CSCCTimeout specifies the timeout for sending alerts to Google Cloud Security Platform.
+	CSCCTimeout = registerDurationSetting("ROX_CSCC_TIMEOUT", 5*time.Second)
+	// WebhookTimeout specifies the timeout for sending alerts via the generic webhook notifier.
+	WebhookTimeout = registerDurationSetting("ROX_WEBHOOK_TIMEOUT", 5*time.Second)
+)

--- a/pkg/logging/fields.go
+++ b/pkg/logging/fields.go
@@ -10,6 +10,9 @@ const (
 	clusterIDField = "cluster_id"
 	imageIDField   = "image_id"
 	nodeIDField    = "node_id"
+	notifierField  = "notifier"
+	errCodeField   = "err_code"
+	alertIDField   = "alert_id"
 )
 
 var (
@@ -18,6 +21,7 @@ var (
 		imageIDField:   resources.Image.String(),
 		clusterIDField: resources.Cluster.String(),
 		nodeIDField:    resources.Node.String(),
+		notifierField:  "Notifier",
 	}
 )
 
@@ -46,6 +50,35 @@ func NodeID(id string) zap.Field {
 	return zap.String(nodeIDField, id)
 }
 
+// NotifierName provides the notifier name as a structured log field.
+func NotifierName(name string) zap.Field {
+	return zap.String(notifierField, name)
+}
+
+// ErrCode refers to a specific human-readable error code. The error code
+// will be used to identify a specific issue and may be used to render e.g. help information
+// or can be used for filtering.
+func ErrCode(code string) zap.Field {
+	return zap.String(errCodeField, code)
+}
+
+// AlertID provides the alert ID as a structured log field.
+func AlertID(id string) zap.Field {
+	return zap.String(alertIDField, id)
+}
+
+// String provides a wrapper around zap.String and adds the key-value pair as structured log field.
+// This should be _always_ preferred over direct calls to zap to minimize dependency to it.
+func String(field, value string) zap.Field {
+	return zap.String(field, value)
+}
+
+// Any provides a wrapper around zap.Any and adds the key-value pair as structured log field.
+// This should be _always_ preferred over direct calls to zap to minimize dependency to it.
+func Any(field string, value interface{}) zap.Field {
+	return zap.Any(field, value)
+}
+
 // getResourceTypeField returns whether the given zap.Field is related to a resource.
 // If it is, it will return true and the name of the resource.
 func getResourceTypeField(field zap.Field) (string, bool) {
@@ -54,5 +87,6 @@ func getResourceTypeField(field zap.Field) (string, bool) {
 }
 
 func isIDField(fieldName string) bool {
+	// TODO(dhaus): Notifier field here.
 	return fieldName != imageField
 }

--- a/pkg/logging/fields.go
+++ b/pkg/logging/fields.go
@@ -87,6 +87,5 @@ func getResourceTypeField(field zap.Field) (string, bool) {
 }
 
 func isIDField(fieldName string) bool {
-	// TODO(dhaus): Notifier field here.
-	return fieldName != imageField
+	return fieldName != imageField && fieldName != notifierField
 }

--- a/pkg/logging/fields.go
+++ b/pkg/logging/fields.go
@@ -79,6 +79,18 @@ func Any(field string, value interface{}) zap.Field {
 	return zap.Any(field, value)
 }
 
+// Strings provides a wrapper around zap.Strings and adds the key-value pair as structured log field.
+// This should be _always_ preferred over direct calls to zap to minimize dependency to it.
+func Strings(field string, values []string) zap.Field {
+	return zap.Strings(field, values)
+}
+
+// Int provides a wrapper around zap.Int and adds the key-value pair as structured log field.
+// This should be _always_ preferred over direct calls to zap to minimize dependency to it.
+func Int(field string, value int) zap.Field {
+	return zap.Int(field, value)
+}
+
 // getResourceTypeField returns whether the given zap.Field is related to a resource.
 // If it is, it will return true and the name of the resource.
 func getResourceTypeField(field zap.Field) (string, bool) {

--- a/pkg/logging/log_converter_impl.go
+++ b/pkg/logging/log_converter_impl.go
@@ -28,6 +28,7 @@ func (z *zapLogConverter) Convert(msg string, level string, module string, conte
 	// shall be a strongly-typed zap.Field.
 	var resourceType string
 	var resourceTypeKey string
+	var errCode string
 	for _, c := range context {
 		// Currently silently drop the given context of the log entry if it's not a zap.Field.
 		if field, ok := c.(zap.Field); ok {
@@ -42,6 +43,9 @@ func (z *zapLogConverter) Convert(msg string, level string, module string, conte
 					resourceType = resource
 					resourceTypeKey = field.Key
 				}
+			}
+			if field.Key == errCodeField {
+				errCode = field.String
 			}
 		}
 	}
@@ -68,7 +72,7 @@ func (z *zapLogConverter) Convert(msg string, level string, module string, conte
 	}
 
 	event.Domain = events.GetDomainFromModule(module)
-	event.Hint = events.GetHint(event.GetDomain(), resourceType)
+	event.Hint = events.GetHint(event.GetDomain(), resourceType, errCode)
 
 	return event
 }

--- a/pkg/logging/log_converter_impl.go
+++ b/pkg/logging/log_converter_impl.go
@@ -50,6 +50,15 @@ func (z *zapLogConverter) Convert(msg string, level string, module string, conte
 		}
 	}
 
+	// If no resource can be determined, we will silently skip creating an administration event for the log message.
+	// This will enable usage of structured logs without requiring _every_ statement to be converted to an administration
+	// event.
+	if resourceType == "" {
+		thisModuleLogger.Debugw("Skipping creation of administration event since no resource is specified",
+			String("message", msg), String("level", level), Any("fields", fields))
+		return nil
+	}
+
 	event := &events.AdministrationEvent{
 		Type:  storage.AdministrationEventType_ADMINISTRATION_EVENT_TYPE_LOG_MESSAGE,
 		Level: logLevelToEventLevel(level),
@@ -59,16 +68,13 @@ func (z *zapLogConverter) Convert(msg string, level string, module string, conte
 	if err != nil {
 		should(err)
 	}
-
 	event.Message = msgWithContext
 
-	if resourceType != "" {
-		event.ResourceType = resourceType
-		if isIDField(resourceTypeKey) {
-			event.ResourceID = enc.m[resourceTypeKey]
-		} else {
-			event.ResourceName = enc.m[resourceTypeKey]
-		}
+	event.ResourceType = resourceType
+	if isIDField(resourceTypeKey) {
+		event.ResourceID = enc.m[resourceTypeKey]
+	} else {
+		event.ResourceName = enc.m[resourceTypeKey]
 	}
 
 	event.Domain = events.GetDomainFromModule(module)

--- a/pkg/logging/log_converter_impl_test.go
+++ b/pkg/logging/log_converter_impl_test.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
@@ -13,26 +14,60 @@ import (
 func TestConvert(t *testing.T) {
 	zc := &zapLogConverter{consoleEncoder: zapcore.NewConsoleEncoder(config.EncoderConfig)}
 
-	expectedEvent := &events.AdministrationEvent{
-		Domain:       "Image Scanning",
-		Hint:         events.GetHint("Image Scanning", "Image", ""),
-		Level:        storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_WARNING,
-		Message:      `Warn: this is an events test {"image": "some-image", "another": true}`,
-		ResourceType: "Image",
-		ResourceName: "some-image",
-		Type:         storage.AdministrationEventType_ADMINISTRATION_EVENT_TYPE_LOG_MESSAGE,
+	cases := []struct {
+		event  *events.AdministrationEvent
+		msg    string
+		level  string
+		module string
+		fields []interface{}
+	}{
+		{
+			event: &events.AdministrationEvent{
+				Domain:       "Image Scanning",
+				Hint:         events.GetHint("Image Scanning", "Image", ""),
+				Level:        storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_WARNING,
+				Message:      `Warn: this is an events test {"image": "some-image", "another": true}`,
+				ResourceType: "Image",
+				ResourceName: "some-image",
+				Type:         storage.AdministrationEventType_ADMINISTRATION_EVENT_TYPE_LOG_MESSAGE,
+			},
+			msg:    "Warn: this is an events test",
+			level:  "warn",
+			module: "reprocessor",
+			fields: []interface{}{ImageName("some-image"), zap.Bool("another", true)},
+		},
+		{
+			event: &events.AdministrationEvent{
+				Domain:       "Integrations",
+				Hint:         events.GetHint("Integrations", "Notifier", "awssh-cache-exhausted"),
+				Level:        storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_ERROR,
+				Message:      `Error: this is an events test {"notifier": "some-notifier", "something": "somewhere", "err_code": "awssh-cache-exhausted"}`,
+				ResourceType: "Notifier",
+				ResourceName: "some-notifier",
+				Type:         storage.AdministrationEventType_ADMINISTRATION_EVENT_TYPE_LOG_MESSAGE,
+			},
+			msg:    "Error: this is an events test",
+			level:  "error",
+			module: "pkg/notifiers/awssh",
+			fields: []interface{}{
+				NotifierName("some-notifier"), String("something", "somewhere"),
+				ErrCode("awssh-cache-exhausted"),
+			},
+		},
 	}
 
-	event := zc.Convert("Warn: this is an events test", "warn", "reprocessor", ImageName("some-image"),
-		zap.Bool("another", true))
-
-	assert.Equal(t, expectedEvent.GetDomain(), event.GetDomain())
-	assert.Equal(t, expectedEvent.GetHint(), event.GetHint())
-	assert.Equal(t, expectedEvent.GetLevel(), event.GetLevel())
-	assert.Equal(t, expectedEvent.GetMessage(), event.GetMessage())
-	assert.Equal(t, expectedEvent.GetResourceID(), event.GetResourceID())
-	assert.Equal(t, expectedEvent.GetResourceName(), event.GetResourceName())
-	assert.Equal(t, expectedEvent.GetResourceType(), event.GetResourceType())
-	assert.Equal(t, expectedEvent.GetType(), event.GetType())
-	assert.NoError(t, event.Validate())
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("convert event %d", i), func(t *testing.T) {
+			event := zc.Convert(tc.msg, tc.level, tc.module, tc.fields...)
+			assert.Equal(t, tc.event.GetDomain(), event.GetDomain())
+			assert.Equal(t, tc.event.GetHint(), event.GetHint())
+			assert.Equal(t, tc.event.GetLevel(), event.GetLevel())
+			assert.Equal(t, tc.event.GetMessage(), event.GetMessage())
+			assert.Equal(t, tc.event.GetResourceID(), event.GetResourceID())
+			assert.Equal(t, tc.event.GetResourceName(), event.GetResourceName())
+			assert.Equal(t, tc.event.GetResourceType(), event.GetResourceType())
+			assert.Equal(t, tc.event.GetType(), event.GetType())
+			assert.NoError(t, event.Validate())
+		})
+	}
 }

--- a/pkg/logging/log_converter_impl_test.go
+++ b/pkg/logging/log_converter_impl_test.go
@@ -15,7 +15,7 @@ func TestConvert(t *testing.T) {
 
 	expectedEvent := &events.AdministrationEvent{
 		Domain:       "Image Scanning",
-		Hint:         events.GetHint("Image Scanning", "Image"),
+		Hint:         events.GetHint("Image Scanning", "Image", ""),
 		Level:        storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_WARNING,
 		Message:      `Warn: this is an events test {"image": "some-image", "another": true}`,
 		ResourceType: "Image",

--- a/pkg/logging/log_converter_impl_test.go
+++ b/pkg/logging/log_converter_impl_test.go
@@ -54,6 +54,14 @@ func TestConvert(t *testing.T) {
 				ErrCode("awssh-cache-exhausted"),
 			},
 		},
+		{
+			msg:    "Error: something went wrong",
+			level:  "error",
+			module: "pkg/random/something",
+			fields: []interface{}{
+				String("response", "some api response"),
+			},
+		},
 	}
 
 	for i, tc := range cases {
@@ -67,7 +75,9 @@ func TestConvert(t *testing.T) {
 			assert.Equal(t, tc.event.GetResourceName(), event.GetResourceName())
 			assert.Equal(t, tc.event.GetResourceType(), event.GetResourceType())
 			assert.Equal(t, tc.event.GetType(), event.GetType())
-			assert.NoError(t, event.Validate())
+			if tc.event != nil {
+				assert.NoError(t, event.Validate())
+			}
 		})
 	}
 }

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -208,6 +208,7 @@ func (l *LoggerImpl) createAdministrationEventFromLog(msg string, level string, 
 	}
 
 	// We will use the log converter to convert logs to an events.AdministrationEvent.
-	event := l.opts.AdministrationEventsConverter.Convert(msg, level, l.Module().Name(), keysAndValues...)
-	l.opts.AdministrationEventsStream.Produce(event)
+	if event := l.opts.AdministrationEventsConverter.Convert(msg, level, l.Module().Name(), keysAndValues...); event != nil {
+		l.opts.AdministrationEventsStream.Produce(event)
+	}
 }

--- a/pkg/notifiers/awssh/notifier.go
+++ b/pkg/notifiers/awssh/notifier.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/administration/events/codes"
-	"github.com/stackrox/rox/pkg/administration/events/stream"
+	"github.com/stackrox/rox/pkg/administration/events/option"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
@@ -32,12 +32,10 @@ const (
 )
 
 var (
-	errAlreadyRunning = errors.New("already running")
-	errNotRunning     = errors.New("not running")
-	// TODO(dhaus): Probably would be good to have some syntactic sugar for this one, encapsulating the logging + singleton call.
-	log                  = logging.CurrentModule().Logger(logging.EnableAdministrationEvents(stream.Singleton()))
+	errAlreadyRunning    = errors.New("already running")
+	errNotRunning        = errors.New("not running")
+	log                  = logging.LoggerForModule(option.EnableAdministrationEvents())
 	defaultConfiguration = configuration{
-		// TODO(dhaus): We mention below that this has to be adjusted in some cases. But, currently not possible for users...
 		upstreamTimeout: env.AWSSHUploadTimeout.DurationSetting(),
 		// From https://docs.aws.amazon.com/securityhub/latest/userguide/finding-update-batchimportfindings.html
 		// It is not clear whether they use Decimal or Binary, so we assume 1 KB = 1000 bytes.

--- a/pkg/notifiers/awssh/notifier.go
+++ b/pkg/notifiers/awssh/notifier.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/uuid"
-	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 )
 
@@ -318,7 +317,7 @@ func (n *notifier) uploadBatch(ctx context.Context) {
 	// Note that randomized iteration of map will shuffle failures.
 	if result.FailedCount != nil && *result.FailedCount > 0 {
 		log.Warnw("failed to upload some or all alerts in batch",
-			zap.Any("failures", result.FailedFindings),
+			logging.Any("failures", result.FailedFindings),
 			logging.ErrCode(codes.AWSSHBatchUpload),
 			logging.NotifierName(n.descriptor.GetName()))
 
@@ -331,7 +330,8 @@ func (n *notifier) uploadBatch(ctx context.Context) {
 
 	// Remove alerts that successfully uploaded from the cache.
 	if len(alertIds) > 0 {
-		log.Debug("successfully uploaded some or all alerts in batch", zap.Int("successes", len(alertIds)))
+		log.Debug("successfully uploaded some or all alerts in batch",
+			logging.Int("successes", len(alertIds)))
 		for id := range alertIds {
 			delete(n.cache, id)
 		}
@@ -339,7 +339,7 @@ func (n *notifier) uploadBatch(ctx context.Context) {
 
 	if len(n.cache) >= 5*n.maxBatchSize {
 		log.Warnw("alert backlog is too large; throttling might need adjusting",
-			zap.Int("cacheSize", len(n.cache)),
+			logging.Int("cacheSize", len(n.cache)),
 			logging.ErrCode(codes.AWSSHCacheExhausted),
 			logging.NotifierName(n.descriptor.GetName()))
 	}

--- a/pkg/notifiers/common.go
+++ b/pkg/notifiers/common.go
@@ -41,7 +41,7 @@ var (
 func AlertLink(endpoint string, alert *storage.Alert) string {
 	base, err := url.Parse(endpoint)
 	if err != nil {
-		log.Errorf("Invalid endpoint %s: %v", endpoint, err)
+		log.Errorw("Invalid endpoint", logging.String("endpoint", endpoint), logging.Err(err))
 		return ""
 	}
 	var alertPath string
@@ -53,7 +53,7 @@ func AlertLink(endpoint string, alert *storage.Alert) string {
 	}
 	u, err := url.Parse(alertPath)
 	if err != nil {
-		log.Errorf("Invalid alert path %s: %v", alertPath, err)
+		log.Errorw("Invalid alert path found", logging.String("alert_path", alertPath), logging.Err(err))
 		return ""
 	}
 	return base.ResolveReference(u).String()

--- a/pkg/notifiers/common.go
+++ b/pkg/notifiers/common.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/administration/events/stream"
+	"github.com/stackrox/rox/pkg/administration/events/option"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/retry"
@@ -34,7 +34,7 @@ const (
 )
 
 var (
-	log = logging.LoggerForModule(logging.EnableAdministrationEvents(stream.Singleton()))
+	log = logging.LoggerForModule(option.EnableAdministrationEvents())
 )
 
 // AlertLink is the link URL for this alert

--- a/pkg/notifiers/email/email.go
+++ b/pkg/notifiers/email/email.go
@@ -19,7 +19,7 @@ import (
 	"github.com/mitchellh/go-wordwrap"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/administration/events/codes"
-	"github.com/stackrox/rox/pkg/administration/events/stream"
+	"github.com/stackrox/rox/pkg/administration/events/option"
 	"github.com/stackrox/rox/pkg/branding"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/errorhelpers"
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	log = logging.LoggerForModule(logging.EnableAdministrationEvents(stream.Singleton()))
+	log = logging.LoggerForModule(option.EnableAdministrationEvents())
 )
 
 const (

--- a/pkg/notifiers/email/email.go
+++ b/pkg/notifiers/email/email.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/mitchellh/go-wordwrap"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/administration/events/codes"
+	"github.com/stackrox/rox/pkg/administration/events/stream"
 	"github.com/stackrox/rox/pkg/branding"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/errorhelpers"
@@ -29,7 +31,7 @@ import (
 )
 
 var (
-	log = logging.LoggerForModule()
+	log = logging.LoggerForModule(logging.EnableAdministrationEvents(stream.Singleton()))
 )
 
 const (
@@ -37,7 +39,7 @@ const (
 	emailLineLength = 78
 )
 
-// email notifier plugin
+// email notifier plugin.
 type email struct {
 	config     *storage.Email
 	smtpServer smtpServer
@@ -142,7 +144,7 @@ func validate(email *storage.Email) error {
 	return errorList.ToError()
 }
 
-// NewEmail exported to allow for usage in various components
+// NewEmail exported to allow for usage in various components.
 func NewEmail(notifier *storage.Notifier, metadataGetter notifiers.MetadataGetter, mitreStore mitreDS.AttackReadOnlyDataStore) (*email, error) {
 	emailConfig, ok := notifier.GetConfig().(*storage.Notifier_Email)
 	if !ok {
@@ -296,7 +298,7 @@ func (*email) Close(context.Context) error {
 	return nil
 }
 
-// AlertNotify takes in an alert and generates the email
+// AlertNotify takes in an alert and generates the email.
 func (e *email) AlertNotify(ctx context.Context, alert *storage.Alert) error {
 	subject := notifiers.SummaryForAlert(alert)
 	body, err := e.plainTextAlert(alert)
@@ -309,7 +311,7 @@ func (e *email) AlertNotify(ctx context.Context, alert *storage.Alert) error {
 }
 
 // ReportNotify takes in reporting data, a list of intended recipients, email subject and an email message to send out a report.
-// Set subject to empty string for v1 report configs
+// Set subject to empty string for v1 report configs.
 func (e *email) ReportNotify(ctx context.Context, zippedReportData *bytes.Buffer, recipients []string, subject, messageText string) error {
 	var from string
 	if e.config.GetFrom() != "" {
@@ -336,7 +338,7 @@ func (e *email) ReportNotify(ctx context.Context, zippedReportData *bytes.Buffer
 	return e.send(ctx, &msg)
 }
 
-// YamlNotify takes in a yaml file and generates the email message
+// NetworkPolicyYAMLNotify takes in a yaml file and generates the email message.
 func (e *email) NetworkPolicyYAMLNotify(ctx context.Context, yaml string, clusterName string) error {
 	subject := fmt.Sprintf("New network policy YAML for cluster '%s' needs to be applied", clusterName)
 
@@ -351,7 +353,7 @@ func (e *email) NetworkPolicyYAMLNotify(ctx context.Context, yaml string, cluste
 	return e.sendEmail(ctx, e.notifier.GetLabelDefault(), subject, body)
 }
 
-// Test sends a test notification
+// Test sends a test notification.
 func (e *email) Test(ctx context.Context) error {
 	subject := "StackRox Test Email"
 	body := fmt.Sprintf("%v\r\n", "This is a test email created to test integration with StackRox.")
@@ -380,49 +382,49 @@ func (e *email) sendEmail(ctx context.Context, recipient, subject, body string) 
 func (e *email) send(ctx context.Context, m *message) error {
 	conn, auth, err := e.connection(ctx)
 	if err != nil {
-		return createError("Connection failed", err)
+		return createError("Connection failed", err, e.notifier.GetName())
 	}
 
 	client, err := e.createClient(conn)
 	if err != nil {
-		return createError("SMTP client creation failed", err)
+		return createError("SMTP client creation failed", err, e.notifier.GetName())
 	}
 	defer func() {
 		if err := client.Quit(); err != nil {
-			log.Errorf("Failed to quit client cleanly: %v", err)
+			log.Error("Failed to quit client cleanly", logging.Err(err))
 		}
 	}()
 
 	if e.config.GetStartTLSAuthMethod() != storage.Email_DISABLED {
 		if err = client.StartTLS(e.tlsConfig()); err != nil {
-			return createError("SMTP STARTTLS failed", err)
+			return createError("SMTP STARTTLS failed", err, e.notifier.GetName())
 		}
 	}
 
 	if !e.notifier.GetEmail().GetAllowUnauthenticatedSmtp() {
 		if err = client.Auth(auth); err != nil {
-			return createError("SMTP authentication failed", err)
+			return createError("SMTP authentication failed", err, e.notifier.GetName())
 		}
 	}
 
 	if err = client.Mail(e.config.GetSender()); err != nil {
-		return createError("SMTP MAIL command failed", err)
+		return createError("SMTP MAIL command failed", err, e.notifier.GetName())
 	}
 	for _, toAddr := range m.To {
 		if err = client.Rcpt(toAddr); err != nil {
-			return createError("SMTP RCPT command failed", err)
+			return createError("SMTP RCPT command failed", err, e.notifier.GetName())
 		}
 	}
 
 	w, err := client.Data()
 	if err != nil {
-		return createError("SMTP DATA command failed", err)
+		return createError("SMTP DATA command failed", err, e.notifier.GetName())
 	}
 	defer utils.IgnoreError(w.Close)
 
 	_, err = w.Write(m.Bytes())
 	if err != nil {
-		return createError("SMTP message writing failed", err)
+		return createError("SMTP message writing failed", err, e.notifier.GetName())
 	}
 
 	return nil
@@ -515,12 +517,11 @@ func (e *email) ProtoNotifier() *storage.Notifier {
 	return e.notifier
 }
 
-func createError(msg string, err error) error {
+func createError(msg string, err error, notifierName string) error {
 	if e, _ := err.(*textproto.Error); e != nil {
 		msg = fmt.Sprintf("%s (code: %d)", msg, e.Code)
-	} else {
-		msg = fmt.Sprintf("%s: %v", msg, err)
 	}
-	log.Errorf("%s: %v", msg, err)
+	log.Errorw(msg, logging.Err(err), logging.ErrCode(codes.EmailGeneric),
+		logging.NotifierName(notifierName))
 	return errors.New(msg)
 }

--- a/pkg/notifiers/format.go
+++ b/pkg/notifiers/format.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/images/types"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mitre/datastore"
 	mitreUtils "github.com/stackrox/rox/pkg/mitre/utils"
 	"github.com/stackrox/rox/pkg/readable"
@@ -131,7 +132,7 @@ func FormatAlert(alert *storage.Alert, alertLink string, funcMap template.FuncMa
 
 	fullMitreVectors, err := mitreUtils.GetFullMitreAttackVectors(mitreStore, alert.GetPolicy())
 	if err != nil {
-		log.Errorf("Could not get MITRE details for alert %s: %v", alert.GetId(), err)
+		log.Errorw("Could not get MITRE details for alert", logging.AlertID(alert.GetId()), logging.Err(err))
 	}
 
 	data := policyFormatStruct{

--- a/pkg/notifiers/pagerduty/pagerduty.go
+++ b/pkg/notifiers/pagerduty/pagerduty.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/administration/events/codes"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	imagesTypes "github.com/stackrox/rox/pkg/images/types"
 	"github.com/stackrox/rox/pkg/jsonutil"
@@ -128,6 +129,9 @@ func (p *pagerDuty) postAlert(alert *storage.Alert, eventType string) error {
 
 	if err != nil {
 		log.Errorf("PagerDuty response: %+v. Error: %s", resp, err)
+		log.Errorw("Error sending alert to PagerDuty",
+			logging.Any("response", resp), logging.Err(err), logging.ErrCode(codes.PagerDutyGeneric),
+			logging.NotifierName(p.GetName()))
 
 		matches := httpStatusCodePattern.FindAllString(err.Error(), 1)
 		if len(matches) == 0 {
@@ -139,7 +143,6 @@ func (p *pagerDuty) postAlert(alert *storage.Alert, eventType string) error {
 			return err
 		}
 		if statusCode != http.StatusAccepted {
-			log.Errorf("PagerDuty error response: %v", err)
 			return errors.Errorf("Received HTTP status code %d from PagerDuty. Check central logs for full error.", statusCode)
 		}
 	}

--- a/pkg/notifiers/pagerduty/pagerduty.go
+++ b/pkg/notifiers/pagerduty/pagerduty.go
@@ -128,7 +128,6 @@ func (p *pagerDuty) postAlert(alert *storage.Alert, eventType string) error {
 	resp, err := p.pdClient.ManageEvent(&pagerDutyEvent)
 
 	if err != nil {
-		log.Errorf("PagerDuty response: %+v. Error: %s", resp, err)
 		log.Errorw("Error sending alert to PagerDuty",
 			logging.Any("response", resp), logging.Err(err), logging.ErrCode(codes.PagerDutyGeneric),
 			logging.NotifierName(p.GetName()))

--- a/pkg/notifiers/slack/slack.go
+++ b/pkg/notifiers/slack/slack.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/administration/events/codes"
-	"github.com/stackrox/rox/pkg/administration/events/stream"
+	"github.com/stackrox/rox/pkg/administration/events/option"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/logging"
 	mitreDS "github.com/stackrox/rox/pkg/mitre/datastore"
@@ -30,7 +30,7 @@ const (
 )
 
 var (
-	log = logging.LoggerForModule(logging.EnableAdministrationEvents(stream.Singleton()))
+	log = logging.LoggerForModule(option.EnableAdministrationEvents())
 )
 
 // slack notifier plugin

--- a/pkg/notifiers/slack/slack.go
+++ b/pkg/notifiers/slack/slack.go
@@ -264,7 +264,6 @@ func (s *slack) postMessage(ctx context.Context, url string, jsonPayload []byte)
 
 	resp, err := s.client.Do(req.WithContext(ctx))
 	if err != nil {
-		log.Errorf("Error posting to slack: %v", err)
 		log.Errorw("Error posting message to Slack", logging.Err(err),
 			logging.ErrCode(codes.SlackGeneric), logging.NotifierName(s.GetName()))
 		return errors.Wrap(err, "Error posting to slack")

--- a/pkg/notifiers/slack/slack.go
+++ b/pkg/notifiers/slack/slack.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/administration/events/codes"
+	"github.com/stackrox/rox/pkg/administration/events/stream"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/logging"
 	mitreDS "github.com/stackrox/rox/pkg/mitre/datastore"
@@ -28,7 +30,7 @@ const (
 )
 
 var (
-	log = logging.LoggerForModule()
+	log = logging.LoggerForModule(logging.EnableAdministrationEvents(stream.Singleton()))
 )
 
 // slack notifier plugin
@@ -263,9 +265,11 @@ func (s *slack) postMessage(ctx context.Context, url string, jsonPayload []byte)
 	resp, err := s.client.Do(req.WithContext(ctx))
 	if err != nil {
 		log.Errorf("Error posting to slack: %v", err)
+		log.Errorw("Error posting message to Slack", logging.Err(err),
+			logging.ErrCode(codes.SlackGeneric), logging.NotifierName(s.GetName()))
 		return errors.Wrap(err, "Error posting to slack")
 	}
 	defer utils.IgnoreError(resp.Body.Close)
 
-	return notifiers.CreateError("Slack", resp)
+	return notifiers.CreateError(s.GetName(), resp, codes.SlackGeneric)
 }

--- a/pkg/notifiers/splunk/splunk.go
+++ b/pkg/notifiers/splunk/splunk.go
@@ -16,9 +16,9 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/wrapper"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/administration/events/codes"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/retry"
@@ -40,8 +40,6 @@ const (
 )
 
 var (
-	log = logging.LoggerForModule()
-
 	timeout = 5 * time.Second
 
 	baseURLPattern = regexp.MustCompile(`^(https?://)?[^/]+/*$`)
@@ -184,7 +182,7 @@ func (s *splunk) sendHTTPPayload(ctx context.Context, method, path string, data 
 	}
 	defer utils.IgnoreError(resp.Body.Close)
 
-	return notifiers.CreateError("Splunk", resp)
+	return notifiers.CreateError(s.GetName(), resp, codes.SplunkGeneric)
 }
 
 func init() {

--- a/pkg/notifiers/sumologic/sumologic.go
+++ b/pkg/notifiers/sumologic/sumologic.go
@@ -12,17 +12,13 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/administration/events/codes"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stackrox/rox/pkg/urlfmt"
 	"github.com/stackrox/rox/pkg/utils"
-)
-
-var (
-	log = logging.LoggerForModule()
 )
 
 const (
@@ -80,7 +76,7 @@ func (s *sumologic) sendPayload(ctx context.Context, buf io.Reader) error {
 	}
 	defer utils.IgnoreError(resp.Body.Close)
 
-	return notifiers.CreateError("Sumo Logic", resp)
+	return notifiers.CreateError(s.GetName(), resp, codes.SumoLogicGeneric)
 }
 
 func validateConfig(sumologic *storage.SumoLogic) error {

--- a/pkg/notifiers/syslog/syslog.go
+++ b/pkg/notifiers/syslog/syslog.go
@@ -14,7 +14,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/administration/events/codes"
-	"github.com/stackrox/rox/pkg/administration/events/stream"
+	"github.com/stackrox/rox/pkg/administration/events/option"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/notifiers"
@@ -51,7 +51,7 @@ const (
 )
 
 var (
-	log = logging.LoggerForModule(logging.EnableAdministrationEvents(stream.Singleton()))
+	log = logging.LoggerForModule(option.EnableAdministrationEvents())
 
 	// We could instead do abs(severity - 4) + 2 but I feel this is high maintenance and obfuscates the meaning
 	alertToSyslogSeverityMap = map[storage.Severity]int{

--- a/pkg/notifiers/syslog/syslog.go
+++ b/pkg/notifiers/syslog/syslog.go
@@ -237,7 +237,8 @@ func makeExtensionPair(key, value string) string {
 func makeJSONExtensionPair(key string, valueObject interface{}) string {
 	value, err := json.Marshal(valueObject)
 	if err != nil {
-		log.Warnf("unable to json marshal audit log field %s due to %v", key, err)
+		log.Warnw("Unable to JSON marshal audit log field",
+			logging.String("audit_log_field", key), logging.Err(err))
 		return makeExtensionPair(key, "missing")
 	}
 	return makeExtensionPair(key, string(value))

--- a/pkg/notifiers/syslog/tcp_sender.go
+++ b/pkg/notifiers/syslog/tcp_sender.go
@@ -14,16 +14,19 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 )
 
 const (
-	// Dial timeout.  Otherwise we'll wait TCPs default 30 second timeout for things like waiting for a TLS handshake.
-	timeout = 5 * time.Second
-
 	initialBackoff             = 1 * time.Second
 	maxBackoff                 = 5 * time.Minute
 	backoffRandomizationFactor = .8
+)
+
+var (
+	// Dial timeout.  Otherwise we'll wait TCPs default 30 second timeout for things like waiting for a TLS handshake.
+	timeout = env.SyslogUploadTimeout.DurationSetting()
 )
 
 type connWrapper struct {

--- a/pkg/notifiers/syslog/tcp_sender.go
+++ b/pkg/notifiers/syslog/tcp_sender.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
+	"github.com/stackrox/rox/pkg/logging"
 )
 
 const (
@@ -198,7 +199,7 @@ func (s *tcpSender) SendSyslog(syslogBytes []byte) error {
 	_, err := conn.conn.Write(syslogFrame)
 	if err != nil {
 		conn.failed.Signal()
-		log.Errorf("failed to write syslog with error %v", err)
+		log.Errorw("Failed to write to Syslog", logging.Err(err))
 	}
 	return err
 }

--- a/pkg/notifiers/teams/teams.go
+++ b/pkg/notifiers/teams/teams.go
@@ -12,6 +12,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/administration/events/codes"
+	"github.com/stackrox/rox/pkg/administration/events/stream"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/images/types"
 	"github.com/stackrox/rox/pkg/logging"
@@ -27,10 +30,11 @@ const (
 )
 
 var (
-	log = logging.LoggerForModule()
+	log     = logging.LoggerForModule(logging.EnableAdministrationEvents(stream.Singleton()))
+	timeout = env.TeamsTimeout.DurationSetting()
 )
 
-// teams notifier plugin
+// teams notifier plugin.
 type teams struct {
 	*storage.Notifier
 
@@ -47,7 +51,7 @@ type fact struct {
 	Value string `json:"value"`
 }
 
-// notification json struct for richly-formatted notifications
+// notification json struct for richly-formatted notifications.
 type notification struct {
 	Color    string    `json:"themeColor"`
 	Title    string    `json:"title"`
@@ -254,7 +258,7 @@ func (*teams) Close(_ context.Context) error {
 	return nil
 }
 
-// AlertNotify takes in an alert and generates the Teams message
+// AlertNotify takes in an alert and generates the Teams message.
 func (t *teams) AlertNotify(ctx context.Context, alert *storage.Alert) error {
 	var sections []section
 	title := notifiers.SummaryForAlert(alert)
@@ -294,7 +298,7 @@ func (t *teams) AlertNotify(ctx context.Context, alert *storage.Alert) error {
 
 	return retry.WithRetry(
 		func() error {
-			return postMessage(ctx, webhook, jsonPayload)
+			return t.postMessage(ctx, webhook, jsonPayload)
 		},
 		retry.OnlyRetryableErrors(),
 		retry.Tries(3),
@@ -304,7 +308,7 @@ func (t *teams) AlertNotify(ctx context.Context, alert *storage.Alert) error {
 	)
 }
 
-// YamlNotify takes in a yaml file and generates the teams message
+// NetworkPolicyYAMLNotify takes in a yaml file and generates the teams message.
 func (t *teams) NetworkPolicyYAMLNotify(ctx context.Context, yaml string, clusterName string) error {
 	tagLine := fmt.Sprintf("Network policy YAML applied on cluster %q", clusterName)
 
@@ -335,7 +339,7 @@ func (t *teams) NetworkPolicyYAMLNotify(ctx context.Context, yaml string, cluste
 
 	return retry.WithRetry(
 		func() error {
-			return postMessage(ctx, webhook, jsonPayload)
+			return t.postMessage(ctx, webhook, jsonPayload)
 		},
 		retry.OnlyRetryableErrors(),
 		retry.Tries(3),
@@ -343,7 +347,7 @@ func (t *teams) NetworkPolicyYAMLNotify(ctx context.Context, yaml string, cluste
 	)
 }
 
-// NewTeams exported to allow for usage in various components
+// NewTeams exported to allow for usage in various components.
 func NewTeams(notifier *storage.Notifier, metadataGetter notifiers.MetadataGetter) (*teams, error) {
 	return &teams{
 		Notifier:       notifier,
@@ -368,7 +372,7 @@ func (t *teams) Test(ctx context.Context) error {
 
 	return retry.WithRetry(
 		func() error {
-			return postMessage(ctx, webhook, jsonPayload)
+			return t.postMessage(ctx, webhook, jsonPayload)
 		},
 		retry.OnlyRetryableErrors(),
 		retry.Tries(3),
@@ -376,23 +380,26 @@ func (t *teams) Test(ctx context.Context) error {
 	)
 }
 
-func postMessage(ctx context.Context, url string, jsonPayload []byte) error {
+func (t *teams) postMessage(ctx context.Context, url string, jsonPayload []byte) error {
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonPayload))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{
-		Timeout:   notifiers.Timeout,
+		Timeout:   timeout,
 		Transport: proxy.RoundTripper(),
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Errorf("Error posting to teams: %v", err)
+		log.Errorw("Error posting message to teams",
+			logging.Err(err),
+			logging.ErrCode(codes.TeamsGeneric),
+			logging.NotifierName(t.GetName()))
 		return errors.Wrap(err, "Error posting to teams")
 	}
 	defer utils.IgnoreError(resp.Body.Close)
-	return notifiers.CreateError("Teams", resp)
+	return notifiers.CreateError(t.GetName(), resp, codes.TeamsGeneric)
 }
 
 func backOff(previousAttempt int) {

--- a/pkg/notifiers/teams/teams.go
+++ b/pkg/notifiers/teams/teams.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/administration/events/codes"
-	"github.com/stackrox/rox/pkg/administration/events/stream"
+	"github.com/stackrox/rox/pkg/administration/events/option"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/images/types"
@@ -30,7 +30,7 @@ const (
 )
 
 var (
-	log     = logging.LoggerForModule(logging.EnableAdministrationEvents(stream.Singleton()))
+	log     = logging.LoggerForModule(option.EnableAdministrationEvents())
 	timeout = env.TeamsTimeout.DurationSetting()
 )
 

--- a/tools/roxvet/analyzers/structuredlogs/analyzer.go
+++ b/tools/roxvet/analyzers/structuredlogs/analyzer.go
@@ -33,7 +33,7 @@ var replacements = map[string]map[string]string{
 // List of the linted package paths. Since structured logs aren't being rolled out immediately to all packages,
 // we will gradually increase the list here. Ultimately, all logs should be moved to structured logs.
 var packagesToLint = []*regexp.Regexp{
-	regexp.MustCompile(`^github\.com/stackrox/rox/central/reprocessor(/|$)`),
+	regexp.MustCompile(`^github\.com/stackrox/rox/central/reprocessor(/|$)|^github\.com/stackrox/rox/central/image/service(/|$)|^github\.com/stackrox/rox/pkg/notifiers(/|$)`),
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {

--- a/tools/roxvet/analyzers/structuredlogs/analyzer.go
+++ b/tools/roxvet/analyzers/structuredlogs/analyzer.go
@@ -81,6 +81,9 @@ func isNonStructuredLogFunction(fn *types.Func) (bool, string, string) {
 		return false, "", ""
 	}
 
+	if fn.Pkg() == nil {
+		return false, "", ""
+	}
 	logReplacements, isLogFunction := replacements[fn.Pkg().Path()]
 	if !isLogFunction {
 		return false, "", ""


### PR DESCRIPTION
## Description

This PR will introduce administration events for notifiers.

For this, the domain `Integrations` and the resource `Notifier` was created. The SAC resource for notifiers `Integration` was not chosen by design, as it would've been too broad.

Besides the introduction of the resource and domain, additional `zap.Field`'s were introduced.

The PR has a few caveats:
A concept of error codes has been introduced. This field can be partially passed to the structured log context and allows for the introduction of tailored hints based on the error. Additionally it will enable us to query the logs for the particular error code.

The notifier packages were modified to fit current style principles. Previous values which were hardcoded (specifically timeout values) have been introduced as environment variables, and the hints will also reference them.

All direct usages of `zap.*` for adding structured log context have been replaced with the wrappers of `logging.*`.

There will be two follow-ups for this PR:
1. Refactoring of the notifiers packages to current style principles and such.
2. Creating a linter which forbids any package outside of the logging package to import `zap` and use any of the `zap.Field` functions.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see added unit tests.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
