### PR TITLE
ROX-18291: Add environment variable to configure GRPC message size (#…

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	maxMsgSize                = 12 * 1024 * 1024
+	defaultMaxMsgSize         = 12 * 1024 * 1024
 	defaultMaxResponseMsgSize = 256 * 1024 * 1024 // 256MB
 )
 
@@ -56,6 +56,7 @@ var (
 	log = logging.LoggerForModule()
 
 	maxResponseMsgSizeSetting = env.RegisterSetting("ROX_GRPC_MAX_RESPONSE_SIZE")
+	maxMsgSizeSetting         = env.RegisterIntegerSetting("ROX_GRPC_MAX_MESSAGE_SIZE", defaultMaxMsgSize)
 	enableRequestTracing      = env.RegisterBooleanSetting("ROX_GRPC_ENABLE_REQUEST_TRACING", false)
 )
 
@@ -336,7 +337,7 @@ func (a *apiImpl) run(startedSig *concurrency.Signal) {
 		grpc.UnaryInterceptor(
 			grpc_middleware.ChainUnaryServer(a.unaryInterceptors()...),
 		),
-		grpc.MaxRecvMsgSize(maxMsgSize),
+		grpc.MaxRecvMsgSize(maxMsgSizeSetting.IntegerSetting()),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			Time: 40 * time.Second,
 		}),


### PR DESCRIPTION
…7492)

## Description

Backport patch to 3.74 release branch. See diff for comparison: https://github.com/stackrox/stackrox/commit/b9eeb0580669f644e9f22f17f94730efb09b6f58#diff-af62cb3a3a7c777bd1b8feed18657c3ecae951d2dbdea55527f08c8c67967c71