### PR TITLE
feat(kind): Load kind image after image builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -586,6 +586,7 @@ all-builds: cli main-build clean-image $(MERGED_API_SWAGGER_SPEC) $(MERGED_API_S
 main-image: all-builds
 	make docker-build-main-image
 
+kind_available := $(shell command -v "kind")
 .PHONY: docker-build-main-image
 docker-build-main-image: copy-binaries-to-image-dir central-db-image
 	$(DOCKERBUILD) \
@@ -603,7 +604,9 @@ docker-build-main-image: copy-binaries-to-image-dir central-db-image
 		image/rhel
 	@echo "Built main image for RHEL with tag: $(TAG), image flavor: $(ROX_IMAGE_FLAVOR)"
 	@echo "You may wish to:       export MAIN_IMAGE_TAG=$(TAG)"
-ifeq ("$(CLUSTER_TYPE)","kind")
+ifeq ($(strip $(kind_available)),)
+else
+	@echo "kind installed, loading images"
 	@echo "Loading image $(DEFAULT_IMAGE_REGISTRY)/main:$(TAG) into kind"
 	kind load docker-image $(DEFAULT_IMAGE_REGISTRY)/main:$(TAG)
 	@echo "Loading image stackrox/main:$(TAG) into kind"

--- a/Makefile
+++ b/Makefile
@@ -603,6 +603,12 @@ docker-build-main-image: copy-binaries-to-image-dir central-db-image
 		image/rhel
 	@echo "Built main image for RHEL with tag: $(TAG), image flavor: $(ROX_IMAGE_FLAVOR)"
 	@echo "You may wish to:       export MAIN_IMAGE_TAG=$(TAG)"
+ifeq ("$(CLUSTER_TYPE)","kind")
+	@echo "Loading image $(DEFAULT_IMAGE_REGISTRY)/main:$(TAG) into kind"
+	kind load docker-image $(DEFAULT_IMAGE_REGISTRY)/main:$(TAG)
+	@echo "Loading image stackrox/main:$(TAG) into kind"
+	kind load docker-image stackrox/main:$(TAG)
+endif
 
 .PHONY: docker-build-roxctl-image
 docker-build-roxctl-image:


### PR DESCRIPTION
## Description

Add kind load image calls to image builds

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

 - Run `CLUSTER_TYPE=kind make image`
 - Validate that image is present in kind