### PR TITLE
fix(dep): update zap dep to avoid verbose logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -459,7 +459,7 @@ replace (
 	github.com/sigstore/cosign/v2 => github.com/stackrox/cosign/v2 v2.0.0-20230524131509-aa1a890d9fb7
 
 	github.com/tecbot/gorocksdb => github.com/DataDog/gorocksdb v0.0.0-20200107201226-9722c3a2e063
-	go.uber.org/zap => github.com/stackrox/zap v1.15.1-0.20200720133746-810fd602fd0f
+	go.uber.org/zap => github.com/stackrox/zap v1.15.1-0.20230918235618-2bd149903d0e
 	// Our fork has a change exposing a method to do generic POST requests
 	// against the OAuth server in order to realize the refresh token flow.
 	// The problem is that:

--- a/go.sum
+++ b/go.sum
@@ -1516,8 +1516,8 @@ github.com/stackrox/yaml/v2 v2.4.1 h1:09ux+QFfvp+Lk73pwGlMTAHeZoS2pqs6CCngYaJ6EQ
 github.com/stackrox/yaml/v2 v2.4.1/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 github.com/stackrox/yaml/v3 v3.0.0 h1:GF9Xtco/eGpj6Ytivh7RcUJQR2jKxzEBfw2Qlrzci7g=
 github.com/stackrox/yaml/v3 v3.0.0/go.mod h1:360StwOazy3cplMWHzBAA9y6InmKu/v7WB0/eMiPXB8=
-github.com/stackrox/zap v1.15.1-0.20200720133746-810fd602fd0f h1:Ofa3PAa609eSHcHP2kCJDUWUnuEWfiqXhsuppk/QtOE=
-github.com/stackrox/zap v1.15.1-0.20200720133746-810fd602fd0f/go.mod h1:MA8QOfq0BHJwdXa996Y4dYkAqRKB8/1K1QMMZVaNZjQ=
+github.com/stackrox/zap v1.15.1-0.20230918235618-2bd149903d0e h1:tufzLLs6t5cNlZbCaU5ftO8qNc4UkcSRfF1Oj1dlIzg=
+github.com/stackrox/zap v1.15.1-0.20230918235618-2bd149903d0e/go.mod h1:MA8QOfq0BHJwdXa996Y4dYkAqRKB8/1K1QMMZVaNZjQ=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=


### PR DESCRIPTION
## Description

This updates the zap dep, as has already been done on master.

The updated version doesn't print stack traces when structured logs are used, which leads to _very_ verbose logs such as:
```log
reprocessor: 2023/09/25 16:10:42.793474 reprocessor.go:312: Error: Error enriching image {"image": "quay.io/stackrox-io/scanner-db:2.31.x-7-gf65eb03ab0", "error": "image enrichment error: error getting metadata for image: quay.io/stackrox-io/scanner-db:2.31.x-7-gf65eb03ab0 errors: [getting metadata from registry: \"Autogenerated https://quay.io/ for cluster remote\": failed to get the manifest digest: Head \"https://quay.io/v2/stackrox-io/scanner-db/manifests/sha256:abf679f955906b7ee8e2c0c44c1f55744cf874ea4d68c1264e30292dc24b5ce2\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers), getting metadata from registry: \"Public Quay.io\": failed to get the manifest digest: Head \"https://quay.io/v2/stackrox-io/scanner-db/manifests/sha256:abf679f955906b7ee8e2c0c44c1f55744cf874ea4d68c1264e30292dc24b5ce2\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)]", "errorCauses": [{"error": "error getting metadata for image: quay.io/stackrox-io/scanner-db:2.31.x-7-gf65eb03ab0 errors: [getting metadata from registry: \"Autogenerated https://quay.io/ for cluster remote\": failed to get the manifest digest: Head \"https://quay.io/v2/stackrox-io/scanner-db/manifests/sha256:abf679f955906b7ee8e2c0c44c1f55744cf874ea4d68c1264e30292dc24b5ce2\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers), getting metadata from registry: \"Public Quay.io\": failed to get the manifest digest: Head \"https://quay.io/v2/stackrox-io/scanner-db/manifests/sha256:abf679f955906b7ee8e2c0c44c1f55744cf874ea4d68c1264e30292dc24b5ce2\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)]", "errorCauses": [{"error": "getting metadata from registry: \"Autogenerated https://quay.io/ for cluster remote\": failed to get the manifest digest: Head \"https://quay.io/v2/stackrox-io/scanner-db/manifests/sha256:abf679f955906b7ee8e2c0c44c1f55744cf874ea4d68c1264e30292dc24b5ce2\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)", "errorVerbose": "Head \"https://quay.io/v2/stackrox-io/scanner-db/manifests/sha256:abf679f955906b7ee8e2c0c44c1f55744cf874ea4d68c1264e30292dc24b5ce2\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)\nfailed to get the manifest digest\ngithub.com/stackrox/rox/pkg/registries/docker.(*Registry).Metadata\n\tgithub.com/stackrox/rox/pkg/registries/docker/docker.go:234\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).enrichImageWithRegistry\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:442\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).enrichWithMetadata\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:361\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).EnrichImage\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:232\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).enrichImage\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:513\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).reprocessImage\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:307\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).reprocessImagesAndResyncDeployments.func1\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:366\nruntime.goexit\n\truntime/asm_arm64.s:1172\ngetting metadata from registry: \"Autogenerated https://quay.io/ for cluster remote\"\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).enrichImageWithRegistry\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:444\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).enrichWithMetadata\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:361\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).EnrichImage\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:232\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).enrichImage\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:513\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).reprocessImage\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:307\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).reprocessImagesAndResyncDeployments.func1\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:366\nruntime.goexit\n\truntime/asm_arm64.s:1172"}, {"error": "getting metadata from registry: \"Public Quay.io\": failed to get the manifest digest: Head \"https://quay.io/v2/stackrox-io/scanner-db/manifests/sha256:abf679f955906b7ee8e2c0c44c1f55744cf874ea4d68c1264e30292dc24b5ce2\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)", "errorVerbose": "Head \"https://quay.io/v2/stackrox-io/scanner-db/manifests/sha256:abf679f955906b7ee8e2c0c44c1f55744cf874ea4d68c1264e30292dc24b5ce2\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)\nfailed to get the manifest digest\ngithub.com/stackrox/rox/pkg/registries/docker.(*Registry).Metadata\n\tgithub.com/stackrox/rox/pkg/registries/docker/docker.go:234\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).enrichImageWithRegistry\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:442\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).enrichWithMetadata\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:361\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).EnrichImage\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:232\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).enrichImage\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:513\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).reprocessImage\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:307\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).reprocessImagesAndResyncDeployments.func1\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:366\nruntime.goexit\n\truntime/asm_arm64.s:1172\ngetting metadata from registry: \"Public Quay.io\"\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).enrichImageWithRegistry\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:444\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).enrichWithMetadata\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:361\ngithub.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).EnrichImage\n\tgithub.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:232\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).enrichImage\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:513\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).reprocessImage\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:307\ngithub.com/stackrox/rox/central/reprocessor.(*loopImpl).reprocessImagesAndResyncDeployments.func1\n\tgithub.com/stackrox/rox/central/reprocessor/reprocessor.go:366\nruntime.goexit\n\truntime/asm_arm64.s:1172"}]}]}-
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
