### PR TITLE
ROX-19860: Reduce RBAC resource requirements for routes

### DIFF
--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -296,8 +296,8 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     'vulnerability-management': {
         resourceAccessRequirements: everyResource([
             // 'Alert', // for Cluster and Deployment and Namespace
-            // 'Cluster',
-            'Deployment',
+            // 'Cluster', // on Dashboard for with most widget
+            'Deployment', // on Dashboard for Top Risky, Recently Detected, Most Common widgets
             'Image',
             // 'Namespace',
             // 'Node',

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -107,9 +107,9 @@ export function someResource(resourceItems: ResourceItem[]): ResourcePredicate {
 // If the route ever requires global resources, spread them in resourceAccessRequirements property.
 export const nonGlobalResourceNamesForNetworkGraph: ResourceName[] = [
     'Deployment',
-    'DeploymentExtension',
+    // 'DeploymentExtension',
     'NetworkGraph',
-    'NetworkPolicy',
+    // 'NetworkPolicy',
 ];
 
 type RouteRequirements = {
@@ -182,20 +182,21 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         resourceAccessRequirements: everyResource(['Deployment', 'WorkflowAdministration']),
     },
     compliance: {
+        // Same resources as compliance-enhanced although lack of commented-out resources affects entire list or entity pages.
         resourceAccessRequirements: everyResource([
-            'Alert', // for Deployment
-            'Cluster',
+            // 'Alert', // for Deployment
+            // 'Cluster',
             'Compliance',
-            'Deployment',
-            'Image', // for Deployment and Namespace
-            'K8sRole', // for Cluster
-            'K8sRoleBinding', // for Cluster
-            'K8sSubject', // for Cluster
-            'Namespace',
-            'NetworkPolicy', // for Namespace
-            'Node',
-            'Secret', // for Deployment and Namespace
-            'ServiceAccount', // for Cluster and Deployment
+            // 'Deployment',
+            // 'Image', // for Deployment and Namespace
+            // 'K8sRole', // for Cluster
+            // 'K8sRoleBinding', // for Cluster
+            // 'K8sSubject', // for Cluster
+            // 'Namespace',
+            // 'NetworkPolicy', // for Namespace
+            // 'Node',
+            // 'Secret', // for Deployment and Namespace
+            // 'ServiceAccount', // for Cluster and Deployment
         ]),
     },
     'compliance-enhanced': {
@@ -203,20 +204,21 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         resourceAccessRequirements: everyResource(['Compliance']),
     },
     configmanagement: {
-        resourceAccessRequirements: everyResource([
+        // Require at least one resource for a dashboard widget.
+        resourceAccessRequirements: someResource([
             'Alert',
-            'Cluster',
+            // 'Cluster',
             'Compliance',
-            'Deployment',
-            'Image',
-            'K8sRole',
-            'K8sRoleBinding',
+            // 'Deployment',
+            // 'Image',
+            // 'K8sRole',
+            // 'K8sRoleBinding',
             'K8sSubject',
-            'Namespace',
-            'Node',
+            // 'Namespace',
+            // 'Node',
             'Secret',
-            'ServiceAccount',
-            'WorkflowAdministration',
+            // 'ServiceAccount',
+            // 'WorkflowAdministration',
         ]),
     },
     dashboard: {
@@ -236,15 +238,16 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         resourceAccessRequirements: everyResource(nonGlobalResourceNamesForNetworkGraph),
     },
     'policy-management': {
+        // The resources that are optional to view policies might become required to clone/create/edit a policy.
         resourceAccessRequirements: everyResource([
-            'Deployment',
-            'Image',
-            'Integration',
+            // 'Deployment',
+            // 'Image',
+            // 'Integration',
             'WorkflowAdministration',
         ]),
     },
     risk: {
-        resourceAccessRequirements: everyResource(['Deployment', 'DeploymentExtension']),
+        resourceAccessRequirements: everyResource(['Deployment']),
     },
     search: {
         resourceAccessRequirements: everyResource([
@@ -291,15 +294,15 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         ]),
     },
     'vulnerability-management': {
+        // Same resources as workload-cves although lack of commented-out resources affects entire list or entity pages.
         resourceAccessRequirements: everyResource([
-            'Alert', // for Cluster and Deployment and Namespace
-            'Cluster',
+            // 'Alert', // for Cluster and Deployment and Namespace
+            // 'Cluster',
             'Deployment',
             'Image',
-            'Namespace',
-            'Node',
+            // 'Namespace',
+            // 'Node',
             'WatchedImage', // for Image
-            'WorkflowAdministration', // TODO obsolete because of policies for Cluster and Namespace?
         ]),
     },
     'workload-cves': {

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -294,7 +294,6 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         ]),
     },
     'vulnerability-management': {
-        // Same resources as workload-cves although lack of commented-out resources affects entire list or entity pages.
         resourceAccessRequirements: everyResource([
             // 'Alert', // for Cluster and Deployment and Namespace
             // 'Cluster',

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -302,7 +302,7 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
             'Image',
             // 'Namespace',
             // 'Node',
-            'WatchedImage', // for Image
+            // 'WatchedImage', // for Image
         ]),
     },
     'workload-cves': {


### PR DESCRIPTION
## Description

TL;DR reduce role-based access control resource requirements for 6 route keys:
* `compliance`
* `configmanagement`
* `'network-graph'` indirectly via `nonGlobalResourceNamesForNetworkGraph`
* `'policy-management'`
* `risk`
* `'vulnerability-management'`

For cherry pick into 4.2.1 release branch, changes are limited to prevent merge conflicts with 3 route keys added in routePaths.ts file **after** 2023-08-24 https://github.com/stackrox/stackrox/pull/7566
* `'administration-events'`
* `'clusters/init-bundles'`
* `'deferral-configuraton'`

### Problem

Because I missed the forest for the trees while adding conditional rendering within routes to reduce `resourceAccessRequirements` during sprint 4.2C, some routes became unavailable for primary use cases because of lack of resources for secondary use cases, especially for Vulnerability Management 1.0 route.

### Analysis

#### Vulnerability Management 1.0

1. WorkflowAdministration
    * VulnMgmt/Entity/Cluster does not use `policyStatus` nor `policyCount` values.
    * VulnMgmt/Entity/Namespace does not use `policyStatus` nor `policyCount` values.
2. Alert
    * Clusters, Namespaces, and Deployments use `policyStatus` and `latestViolation` values.
3. Cluster
    * ClustersWithNostClusterVulnerabilities renders database error.
    * CvesMenu renders `undefined` for all values.
    * /main/vulnerability-management/clusters route renders PageNotFound element.
4. Namespace
    * TopRiskiestEntities renders database error.
    * /main/vulnerability-management/namespaces route renders PageNotFound element.
5. Node
    * TopRiskiestEntities renders database error.
    * CvesMenu renders `undefined` for all values.
    * /main/vulnerability-management/nodes route renders PageNotFound element.

#### Compliance 1.0

With Compliance only:
* In addition to READ_WRITE_ACCESS for Compliance, **Scan environment** requires READ_ACCESS for at least one of Cluster, Namespace, Node.
* However, if environment has been scanned, absence of those resources is affects only specific widgets or pages.

#### Configuration Management

1. Unlike most other routes, it is not clear which resource (or subset of resources) are primary.
2. Dashboard is a mess even with all 4 resources directly related to its widgets.

#### Policy Management

Although, policies list and policy detail page make GET /v1/notifiers request, consider it secondary.

#### Network Graph

1. DeploymentExtension is required for 2 tabs of the side panel and IN THE FUTURE verify nowhere else:
    * Flows: GET /v1/networkbaseline/id has 403 Forbidden status
    * Baselines: ditto
2. NetworkPolicy: IN THE FUTURE investigate whether it is required only for **Network Policy** tab of side panel.

#### Listening Endpoints

With Deployment but not DeploymentExtension resource: page renders infinite polling loop.

#### Risk

With Deployment but not DeploymentExtension resource:
* Can render list page.
* Cannot render side panel, because it needs additional conditional rendering.
    * `fetchProcesses` request requires DeploymentExtension resource:
        https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Risk/RiskSidePanel.js#L27
    * `ProcessDetails` tab requires DeploymentExtension in addition to Alert resource.
        https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Risk/RiskSidePanelContent.js#L77-L98

### Solution

#### Vulnerability Management 1.0

1. Delete WorkflowAdministration resource now and then IN THE FUTURE:
    * VulnMgmt/Entity/Cluster/VulnMgmtEntityCluster.js delete unused properties from query.
    * VulnMgmt/Entity/Cluster/VulnMgmtEntityNamespace.js delete unused properties from query.
2. Comment out resources to leave the same minimum resources as Workload CVEs route.

#### Compliance 1.0

1. Comment out resources to leave same minimum resources as Compliance 2.0 route.

#### Configuration Management

1. Comment out resources to leave minimum requirement of at least one that is directly related to a dashboard widget.

#### Policy Management

1. Comment out resources except for WorkflowAdministration, even though clone/create/edit workflow will probably not work correctly without Deployment, Image, Integration.

#### Network Graph

1. Comment out DeploymentExtension and NetworkPolicy resources and IN THE FUTURE add conditional rendering.
2. Leave Deployment because required for **Details** tab of side panel.

#### Risk

1. Delete DeploymentExtension resource and IN THE FUTURE make request and tab conditional.

### Residue

IN THE FUTURE, investigate pro and con of conditional code:
1. CvesMenu on Vulnerability Management 1.0 dashboard for which the request is all or nothing for 3 resources.
2. Policies
    * For policies list and policy detail page.
    * Evaluate pro and con for clone/create/edit workflow to require the additional resources: Deployment, Image, Integration.
3. SummaryCounts on main dashboard for which the request was all or nothing for 6 resouces.
4. Investigate whether global search can conditionally render partial results.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~ Release Notes instead of CHANGELOG

## Testing Performed

### Manual testing

Adjust user role permissions from another browser window.

#### Vulnerability Management 1.0

1. Without Alert resource: see **Cannot find the whatever** error page.

    * Visit /main/vulnerability-management/clusters
    * Visit /main/vulnerability-management/namespaces
    * Visit /main/vulnerability-management/deployments

2. Without Cluster resource:

    * See `undefined` for all 3 counts in CvesMenu.
    * See database error in **Clusters and so on** widget.
        ![clusterVulnerabilityCount](https://github.com/stackrox/stackrox/assets/11862657/f0e7ca78-05c1-47f4-9498-ec29596acdf7)

3. Without Namespace resource:

    * See database error in **Top risky namespaces** widget.
        ![TopRiskiesEntities_Namespace](https://github.com/stackrox/stackrox/assets/11862657/ef46389f-40c8-4d4c-8d58-987b7f0a22b7)

4. Without Node resource:

    * See `undefined` for all 3 counts in CvesMenu.
    * See database error in **Top risky nodes** widget.
        ![nodeVulnerabilityCount](https://github.com/stackrox/stackrox/assets/11862657/8b02a7f5-cbe3-4273-a094-d7f430ad246f)

5. Without WorkflowAdministration resource:

    * Visit /main/vulnerability-management/clusters and then click a row: see error before deletion and page after.
        However, do not include this change.
        ![VulnMgmtEntityCluster](https://github.com/stackrox/stackrox/assets/11862657/2ea376f1-258c-4c91-87e8-82e8d7e6c61e)

    * Visit /main/vulnerability-management/namespaces and then click a row: see error before deletion and page after.
        However, do not include this change.
        ![VulnMgmtEntityNamespace](https://github.com/stackrox/stackrox/assets/11862657/5eb436ce-4658-47d0-99b5-f99163f5934b)

#### Compliance 1.0

With Compliance resource only:

1. With READ_WRITE_ACCESS, click **Scan environment** button.

    * See triggerScan request with `complianceTriggerRuns: []` in response.
        ![Compliance_only_without_scan](https://github.com/stackrox/stackrox/assets/11862657/3a1949a0-0d90-4910-bc43-58556efb4ea9)

2. With READ_ACCESS after a scan.

    * See data for only some widgets.
        ![Compliance_only_with_scan](https://github.com/stackrox/stackrox/assets/11862657/207e5f88-dff7-4902-b8c4-1f0ea70eaadd)

3. Add Cluster resource

    * See data for additional widget.
        ![Compliance_Cluster_1](https://github.com/stackrox/stackrox/assets/11862657/4f200a10-97f3-419b-8525-054c232832d0)

    * See data for additional widgets. My notes failed me how these look without Cluster resource :(
        ![Compliance_Cluster_2](https://github.com/stackrox/stackrox/assets/11862657/c2e7229c-6977-4bbf-9862-470331fc4627)

3. Visit /main/compliance/clusters

    * See list, but errors for side panel.
        ![Compliance_Cluster_cluster](https://github.com/stackrox/stackrox/assets/11862657/764055d7-f423-4334-9c59-02e0e747f9a3)

5. Visit /main/compliance/namespaces

    * See absence of data for list.
        ![Compliance_Cluster_namespaces](https://github.com/stackrox/stackrox/assets/11862657/7d8f2e42-00f5-4599-8095-25a3b6e43689)

#### Configuration Management

1. Visit /main/configuration-management

    * See a mess of errors, even with all 4 of the `someResource` resources.
        ![Configuration_Management_someResource](https://github.com/stackrox/stackrox/assets/11862657/785993e2-fe87-481f-a935-3db84c8201d5)

#### Policy Management

1. Visit /main/policy-management/policies

    * See GET /v1/notifiers request which has 403 Forbidden status code.
        ![WorkflowAdmnistration_Policies](https://github.com/stackrox/stackrox/assets/11862657/5074fd42-b0c6-437f-a915-99277d92b081)

2. Click a policy

    * See GET /v1/notifiers request which has 403 Forbidden status code.
        ![WorkflowAdministration_Policy](https://github.com/stackrox/stackrox/assets/11862657/51cceece-668b-430a-a7fd-d472e719c3f8)

#### Network Graph

1. Visit /main/network-graph,click a deployment, and then click **Flows** tab. Ditto for **Baselines** tab.

    * See absence of data without DeploymentExtension resource.
        ![DeploymentExtension_Network_Flows](https://github.com/stackrox/stackrox/assets/11862657/9dffb74d-3223-49d2-96a7-fcb4d93b6d86)

#### Listening Endpoints

1. Visit /main/listening-endpoints without DeploymentExtension resource.

    * See primary requests have 403 Forbidden status code.
        ![DeploymentExtension_Listening_Endpoints](https://github.com/stackrox/stackrox/assets/11862657/78697d49-97d8-4263-b162-a9bf9209865d)

#### Risk

1. Visit /main/risk without DeploymentExtension resource.

    * See list but no tabs in side panel.
        ![DeploymentExtention_Risk](https://github.com/stackrox/stackrox/assets/11862657/fec263f0-d48d-4054-8bc3-27e594eab498)
