### PR TITLE
fix: nil evaluation in central endpoint Helm template

### DIFF
--- a/image/templates/helm/stackrox-central/templates/_central_endpoints.tpl
+++ b/image/templates/helm/stackrox-central/templates/_central_endpoints.tpl
@@ -48,7 +48,8 @@
   {{ $containerPorts = append $containerPorts (dict "name" "monitoring" "containerPort" 9090) }}
   {{ $servicePorts = append $servicePorts (dict "name" "monitoring" "targetPort" "monitoring" "port" 9090) }}
 {{ end }}
-{{ if and $central.monitoring $central.monitoring.openshift $central.monitoring.openshift.enabled }}
+# The (...) safe-guard against nil pointer evaluations for Helm versions built with Go < 1.18.
+{{ if ((($central.monitoring).openshift).enabled) }}
   {{ $containerPorts = append $containerPorts (dict "name" "monitoring-tls" "containerPort" 9091) }}
   {{ $servicePorts = append $servicePorts (dict "name" "monitoring-tls" "targetPort" "monitoring-tls" "port" 9091) }}
 {{ end }}


### PR DESCRIPTION
## Description

Prior to Go 1.18, the `and` function evaluates all expressions instead short-circuiting. This causes a problem when intermediate values are nil. See also https://stackoverflow.com/a/59796677 for an explanation.

Fixes https://github.com/stackrox/stackrox/issues/7905.

## Testing Performed

```
export OUTPUT_FORMAT=helm
./deploy/k8s/deploy-local.sh
```

with Helm `3.9.0` with and without this patch.