### PR TITLE
feat(metrics): Add dedupe metrics to detector

### DIFF
--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/externalsrcs"
 	"github.com/stackrox/rox/sensor/common/imagecacheutils"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/common/scan"
 	"github.com/stackrox/rox/sensor/common/store"
@@ -327,6 +328,8 @@ func (d *detectorImpl) runDetector() {
 				NetworkPoliciesApplied: scanOutput.networkPoliciesApplied,
 			})
 
+			metrics.IncrementDetectorDeploymentProcessed()
+
 			sort.Slice(alerts, func(i, j int) bool {
 				return alerts[i].GetPolicy().GetId() < alerts[j].GetPolicy().GetId()
 			})
@@ -467,6 +470,7 @@ func (d *detectorImpl) processDeploymentNoLock(ctx context.Context, deployment *
 		// Check if the deployment has changes that require detection, which is more expensive than hashing
 		// If not, then just return
 		if !d.deduper.needsProcessing(deployment) {
+			metrics.IncrementDetectorCacheHit()
 			return
 		}
 		d.markDeploymentForProcessing(deployment.GetId())

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -20,6 +20,20 @@ var (
 		Help:      "Number of panic calls within Sensor.",
 	}, []string{"FunctionName"})
 
+	detectorDedupeCacheHits = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "detector_dedupe_cache_hits",
+		Help:      "A counter of the total number of times we've deduped deployments in the detector",
+	})
+
+	detectorDeploymentProcessed = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "detector_deployment_processed",
+		Help:      "A counter of the total number of times we've processed deployments in the detector",
+	})
+
 	processDedupeCacheHits = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
@@ -187,6 +201,16 @@ var (
 		[]string{"central_id", "hosting", "install_method", "sensor_id"},
 	)
 )
+
+// IncrementDetectorCacheHit increments the number of deployments deduped by the detector
+func IncrementDetectorCacheHit() {
+	detectorDedupeCacheHits.Inc()
+}
+
+// IncrementDetectorDeploymentProcessed increments the number of deployments processed by the detector
+func IncrementDetectorDeploymentProcessed() {
+	detectorDeploymentProcessed.Inc()
+}
 
 // IncrementPanicCounter increments the number of panic calls seen in a function
 func IncrementPanicCounter(functionName string) {


### PR DESCRIPTION
## Description

Deduping at the detector level is one of the reason why we have to hash deployments so frequently. If we could remove the deduper in detector, we can reduce the hashing load by half. However, we first need to understand if after re-sync we are still hitting the deduper frequently. 

If `detector_deduper_cache_hit` metric is close to `0`, we could safely remove the deduper and cash-in the allocations improvement. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [ ] Run cluster against `kube-burner` workload and get metrics from prometheus. 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
