### PR TITLE
fix(memory): Reduce compliance memory used by process indicators

### DIFF
--- a/central/compliance/checks/common/checks.go
+++ b/central/compliance/checks/common/checks.go
@@ -498,7 +498,7 @@ func CheckSecretsInEnv(ctx framework.ComplianceContext) {
 // CheckRuntimeSupportInCluster checks if runtime is enabled and collector
 // is sending process and network data.
 func CheckRuntimeSupportInCluster(ctx framework.ComplianceContext) {
-	if ctx.Data().Cluster().GetCollectionMethod() != storage.CollectionMethod_NO_COLLECTION && len(ctx.Data().ProcessIndicators()) > 0 && len(ctx.Data().NetworkFlows()) > 0 {
+	if ctx.Data().Cluster().GetCollectionMethod() != storage.CollectionMethod_NO_COLLECTION && ctx.Data().HasProcessIndicators() && len(ctx.Data().NetworkFlows()) > 0 {
 		framework.PassNowf(ctx, "Runtime support is enabled (or collector service is running) for cluster %s. Network visualization for active network connections is possible.", ctx.Data().Cluster().GetName())
 	}
 	framework.Failf(ctx, "Runtime support is not enabled (or collector service is not running) for cluster %s. Network visualization for active network connections is not possible.", ctx.Data().Cluster().GetName())

--- a/central/compliance/checks/docker/runtime.go
+++ b/central/compliance/checks/docker/runtime.go
@@ -36,18 +36,14 @@ func ssh(ctx framework.ComplianceContext, deployment *storage.Deployment) {
 		return
 	}
 	for runningContainerID, containerName := range runningContainerIDs {
-		for _, indicator := range ctx.Data().ProcessIndicators() {
+		for _, indicator := range ctx.Data().SSHProcessIndicators() {
 			// indicator.GetSignal().GetContainerId() only returns the first 12 characters of the container ID.
 			if strings.HasPrefix(runningContainerID, indicator.GetSignal().GetContainerId()) {
-				process := indicator.GetSignal().GetExecFilePath()
-				if strings.Contains(process, "ssh") {
-					fail = true
-					processWithArgs := fmt.Sprintf("%s %s", process, indicator.GetSignal().GetArgs())
-					framework.Failf(ctx, "Container %q has ssh process running: %q", containerName, processWithArgs)
-				}
+				fail = true
+				processWithArgs := fmt.Sprintf("%s %s", indicator.GetSignal().GetExecFilePath(), indicator.GetSignal().GetArgs())
+				framework.Failf(ctx, "Container %q has ssh process running: %q", containerName, processWithArgs)
 			}
 		}
-
 		if !fail {
 			framework.Passf(ctx, "Container %q has no ssh process running", containerName)
 		}

--- a/central/compliance/checks/docker/runtime_test.go
+++ b/central/compliance/checks/docker/runtime_test.go
@@ -204,7 +204,7 @@ func runtimeTest(t *testing.T, c *testStruct, validationFunc func(*testing.T, fr
 		DockerData: &compliance.GZIPDataChunk{Gzip: jsonDataGZ.Bytes()},
 	})
 
-	data.EXPECT().ProcessIndicators().AnyTimes().Return(indicators)
+	data.EXPECT().SSHProcessIndicators().AnyTimes().Return(indicators)
 
 	run, err := framework.NewComplianceRun(check)
 	require.NoError(t, err)

--- a/central/compliance/checks/hipaa_164/check308a1iia/check_test.go
+++ b/central/compliance/checks/hipaa_164/check308a1iia/check_test.go
@@ -58,7 +58,7 @@ func (s *suiteImpl) TestFail() {
 	data.EXPECT().Cluster().AnyTimes().Return(s.cluster())
 	data.EXPECT().ImageIntegrations().AnyTimes().Return(imageIntegrations)
 	data.EXPECT().Images().AnyTimes().Return(images)
-	data.EXPECT().ProcessIndicators().AnyTimes().Return(nil)
+	data.EXPECT().HasProcessIndicators().AnyTimes().Return(false)
 	data.EXPECT().NetworkFlows().AnyTimes().Return(nil)
 
 	run, err := framework.NewComplianceRun(check)
@@ -108,11 +108,6 @@ func (s *suiteImpl) TestPass() {
 			},
 		},
 	}
-	processIndicators := []*storage.ProcessIndicator{
-		{
-			ContainerName: "foo",
-		},
-	}
 	flows := []*storage.NetworkFlow{
 		{
 			LastSeenTimestamp: types.TimestampNow(),
@@ -123,7 +118,7 @@ func (s *suiteImpl) TestPass() {
 	data.EXPECT().Cluster().AnyTimes().Return(s.cluster())
 	data.EXPECT().ImageIntegrations().AnyTimes().Return(imageIntegrations)
 	data.EXPECT().Images().AnyTimes().Return(images)
-	data.EXPECT().ProcessIndicators().AnyTimes().Return(processIndicators)
+	data.EXPECT().HasProcessIndicators().AnyTimes().Return(true)
 	data.EXPECT().NetworkFlows().AnyTimes().Return(flows)
 
 	run, err := framework.NewComplianceRun(check)

--- a/central/compliance/checks/nist800-190/check412/check.go
+++ b/central/compliance/checks/nist800-190/check412/check.go
@@ -1,8 +1,6 @@
 package check412
 
 import (
-	"strings"
-
 	"github.com/stackrox/rox/central/compliance/checks/common"
 	"github.com/stackrox/rox/central/compliance/framework"
 	"github.com/stackrox/rox/generated/storage"
@@ -43,7 +41,7 @@ func checkNIST412(ctx framework.ComplianceContext) {
 func checkSSHPortAndProcesses(ctx framework.ComplianceContext) {
 	// Map process indicators to deployments.
 	deploymentIDToIndicators := make(map[string][]*storage.ProcessIndicator)
-	for _, indicator := range ctx.Data().ProcessIndicators() {
+	for _, indicator := range ctx.Data().SSHProcessIndicators() {
 		deploymentIDToIndicators[indicator.GetDeploymentId()] = append(deploymentIDToIndicators[indicator.GetDeploymentId()], indicator)
 	}
 
@@ -68,17 +66,8 @@ func checkPrivilegedCategoryPolicies(ctx framework.ComplianceContext) {
 
 // deploymentHasSSHProcess returns true if the deployment has ssh process running.
 func deploymentHasSSHProcess(deploymentToIndicators map[string][]*storage.ProcessIndicator, deployment *storage.Deployment) bool {
-	for deploymentID, indicators := range deploymentToIndicators {
-		if deploymentID != deployment.GetId() {
-			continue
-		}
-		for _, indicator := range indicators {
-			if strings.Contains(indicator.GetSignal().GetExecFilePath(), "ssh") {
-				return true
-			}
-		}
-	}
-	return false
+	indicators := deploymentToIndicators[deployment.GetId()]
+	return len(indicators) > 0
 }
 
 // sshPolicyEnforced checks if there is a policy to detect and enforce

--- a/central/compliance/checks/nist800-190/check412/check_test.go
+++ b/central/compliance/checks/nist800-190/check412/check_test.go
@@ -261,7 +261,7 @@ func TestNIST412_Success(t *testing.T) {
 	data.EXPECT().Policies().AnyTimes().Return(policies)
 	data.EXPECT().PolicyCategories().AnyTimes().Return(categoryPolicies)
 	data.EXPECT().ImageIntegrations().AnyTimes().Return(imageIntegrations)
-	data.EXPECT().ProcessIndicators().AnyTimes().Return(indicatorsWithoutSSH)
+	data.EXPECT().SSHProcessIndicators().AnyTimes().Return(nil)
 
 	run, err := framework.NewComplianceRun(check)
 	require.NoError(t, err)
@@ -310,7 +310,7 @@ func TestNIST412_FAIL(t *testing.T) {
 	data.EXPECT().Policies().AnyTimes().Return(policies)
 	data.EXPECT().PolicyCategories().AnyTimes().Return(categoryPolicies)
 	data.EXPECT().ImageIntegrations().AnyTimes().Return(nil)
-	data.EXPECT().ProcessIndicators().AnyTimes().Return(indicatorsWithSSH)
+	data.EXPECT().SSHProcessIndicators().AnyTimes().Return(indicatorsWithSSH)
 
 	run, err := framework.NewComplianceRun(check)
 	require.NoError(t, err)

--- a/central/compliance/framework/data.go
+++ b/central/compliance/framework/data.go
@@ -33,7 +33,8 @@ type ComplianceDataRepository interface {
 	ImageIntegrations() []*storage.ImageIntegration
 	RegistryIntegrations() []ImageMatcher
 	ScannerIntegrations() []ImageMatcher
-	ProcessIndicators() []*storage.ProcessIndicator
+	SSHProcessIndicators() []*storage.ProcessIndicator
+	HasProcessIndicators() bool
 	NetworkFlows() []*storage.NetworkFlow
 	PolicyCategories() map[string]set.StringSet
 	Notifiers() []*storage.Notifier

--- a/central/compliance/framework/mocks/data.go
+++ b/central/compliance/framework/mocks/data.go
@@ -145,6 +145,20 @@ func (mr *MockComplianceDataRepositoryMockRecorder) Deployments() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deployments", reflect.TypeOf((*MockComplianceDataRepository)(nil).Deployments))
 }
 
+// HasProcessIndicators mocks base method.
+func (m *MockComplianceDataRepository) HasProcessIndicators() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasProcessIndicators")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasProcessIndicators indicates an expected call of HasProcessIndicators.
+func (mr *MockComplianceDataRepositoryMockRecorder) HasProcessIndicators() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasProcessIndicators", reflect.TypeOf((*MockComplianceDataRepository)(nil).HasProcessIndicators))
+}
+
 // HostScraped mocks base method.
 func (m *MockComplianceDataRepository) HostScraped(node *storage.Node) *compliance.ComplianceReturn {
 	m.ctrl.T.Helper()
@@ -327,20 +341,6 @@ func (mr *MockComplianceDataRepositoryMockRecorder) PolicyCategories() *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PolicyCategories", reflect.TypeOf((*MockComplianceDataRepository)(nil).PolicyCategories))
 }
 
-// ProcessIndicators mocks base method.
-func (m *MockComplianceDataRepository) ProcessIndicators() []*storage.ProcessIndicator {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessIndicators")
-	ret0, _ := ret[0].([]*storage.ProcessIndicator)
-	return ret0
-}
-
-// ProcessIndicators indicates an expected call of ProcessIndicators.
-func (mr *MockComplianceDataRepositoryMockRecorder) ProcessIndicators() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessIndicators", reflect.TypeOf((*MockComplianceDataRepository)(nil).ProcessIndicators))
-}
-
 // RegistryIntegrations mocks base method.
 func (m *MockComplianceDataRepository) RegistryIntegrations() []framework.ImageMatcher {
 	m.ctrl.T.Helper()
@@ -353,6 +353,20 @@ func (m *MockComplianceDataRepository) RegistryIntegrations() []framework.ImageM
 func (mr *MockComplianceDataRepositoryMockRecorder) RegistryIntegrations() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistryIntegrations", reflect.TypeOf((*MockComplianceDataRepository)(nil).RegistryIntegrations))
+}
+
+// SSHProcessIndicators mocks base method.
+func (m *MockComplianceDataRepository) SSHProcessIndicators() []*storage.ProcessIndicator {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SSHProcessIndicators")
+	ret0, _ := ret[0].([]*storage.ProcessIndicator)
+	return ret0
+}
+
+// SSHProcessIndicators indicates an expected call of SSHProcessIndicators.
+func (mr *MockComplianceDataRepositoryMockRecorder) SSHProcessIndicators() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SSHProcessIndicators", reflect.TypeOf((*MockComplianceDataRepository)(nil).SSHProcessIndicators))
 }
 
 // ScannerIntegrations mocks base method.


### PR DESCRIPTION
## Description

We were loading all indicators into memory in order to check that at least 1 existed and also if they were SSH processes. Instead, target the loading to only ones that could be SSH processes which should be a large subset of the processes overall.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Should be able to see the reduced memory on high process clusters

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
