### PR TITLE
ROX-19873: Delete policy properties in Vulnerability Management 1.0

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtEntityCluster.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtEntityCluster.js
@@ -28,27 +28,11 @@ const VulmMgmtEntityCluster = ({
     const workflowState = useContext(workflowStateContext);
 
     const overviewQuery = gql`
-        query getCluster($id: ID!, $policyQuery: String) {
+        query getCluster($id: ID!) {
             result: cluster(id: $id) {
                 id
                 name
                 priority
-                policyStatus(query: $policyQuery) {
-                    status
-                    failingPolicies {
-                        id
-                        name
-                        description
-                        policyStatus
-                        latestViolation
-                        severity
-                        deploymentCount: failingDeploymentCount # field changed to failingDeploymentCount to improve performance
-                        lifecycleStages
-                        enforcementActions
-                        notifiers
-                        lastUpdated
-                    }
-                }
                 #createdAt
                 status {
                     orchestratorMetadata {
@@ -57,7 +41,6 @@ const VulmMgmtEntityCluster = ({
                     }
                 }
                 istioEnabled
-                policyCount(query: $policyQuery)
                 nodeCount
                 namespaceCount
                 deploymentCount

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtEntityNamespace.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtEntityNamespace.js
@@ -28,10 +28,7 @@ const VulnMgmtNamespace = ({
     const workflowState = useContext(workflowStateContext);
 
     const overviewQuery = gql`
-        query getNamespace(
-            $id: ID!
-            $policyQuery: String
-        ) {
+        query getNamespace($id: ID!) {
             result: namespace(id: $id) {
                 metadata {
                     priority
@@ -43,23 +40,6 @@ const VulnMgmtNamespace = ({
                         value
                     }
                 }
-                policyStatus(query: $policyQuery) {
-                    status
-                    failingPolicies {
-                        id
-                        name
-                        description
-                        policyStatus
-                        latestViolation
-                        severity
-                        deploymentCount: failingDeploymentCount # field changed to failingDeploymentCount to improve performance
-                        lifecycleStages
-                        enforcementActions
-                        notifiers
-                        lastUpdated
-                    }
-                }
-                policyCount(query: $policyQuery)
                 deploymentCount
                 imageCount
                 imageComponentCount


### PR DESCRIPTION
## Description

### Problem

WorkflowAdministration is a resource requirement for `'vulnerability-management'` sub-routes:
* /main/vulnerability-management/clusters
* /main/vulnerability-management/namespaces

If user role does not have that resource:

> Unable to load data

> not authorized: "READ_ACCESS" for "WorkflowAdministration"

### Analysis

Components include unused policy properties in their query:

* VulnMgmt/Entity/Cluster does not use `policyStatus` nor `policyCount` values.
* VulnMgmt/Entity/Namespace does not use `policyStatus` nor `policyCount` values.

### Solution

Delete obsolete! It rhymes ;)

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3761413 - 3761413
        total: -1457 = 10117437 - 10118894
    * `ls -al build/static/js/*.js | wc -l`
        0 = 84 - 84 files
3. `yarn start` in ui

### Manual testing

1. Temporarily comment out WorkflowAdministration in `resourceAccessRequirements` for `vulnerability-management` route key and then specify the other resources for user role.

2. Visit /main/vulnerability-management/clusters and then click a row.

    * See error before delete
        ![VulnMgmtEntityCluster_error](https://github.com/stackrox/stackrox/assets/11862657/84324277-c158-4c35-b246-715afbdc33bf)

    * See data after delete
        ![VulnMgmtEntityCluster_data](https://github.com/stackrox/stackrox/assets/11862657/2ffee369-b297-4979-abe9-b9b8663a1b65)

3. Visit /main/vulnerability-management/namespaces and then click a row.

    * See error before delete
        ![VulnMgmtEntityNamespace_error](https://github.com/stackrox/stackrox/assets/11862657/d3c41bfc-bf6e-4cb0-a798-52329f759fa1)

    * See data after delete
        ![VulnMgmtEntityNamespace_data](https://github.com/stackrox/stackrox/assets/11862657/66a257b1-7800-4b8b-a32c-9b96ad66bfe9)

### Integration testing

* vulnmanagement/clusters.test.js
* vulnmanagement/namespaces.test.js
