### PR TITLE
chore(ui): Hide/show reporting v1 and v2 based on feature flag

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reportingForm.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reportingForm.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
 import {
     getDescriptionListGroup,
     getHelperElementByLabel,
@@ -19,6 +20,12 @@ import {
 
 describe('Vulnerability Management Reporting form', () => {
     withAuth();
+
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_REPORTING_ENHANCEMENTS')) {
+            this.skip();
+        }
+    });
 
     it('should navigate from table by button', () => {
         visitVulnerabilityReporting();

--- a/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reportingTable.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reportingTable.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
 
 import {
     visitVulnerabilityReportingFromLeftNav,
@@ -7,6 +8,12 @@ import {
 
 describe('Vulnerability Management Reporting table', () => {
     withAuth();
+
+    before(function () {
+        if (hasFeatureFlag('ROX_VULN_MGMT_REPORTING_ENHANCEMENTS')) {
+            this.skip();
+        }
+    });
 
     it('should go from left navigation', () => {
         visitVulnerabilityReportingFromLeftNav();

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -156,11 +156,7 @@ const navDescriptions: NavDescription[] = [
             },
             {
                 type: 'child',
-                content: (
-                    <NavigationContent variant="TechPreview">
-                        Vulnerability Reporting
-                    </NavigationContent>
-                ),
+                content: 'Vulnerability Reporting',
                 path: vulnerabilityReportsPath,
                 routeKey: 'vulnerabilities/reports',
             },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -3,9 +3,8 @@ import { Route, Switch, Redirect } from 'react-router-dom';
 
 import usePageAction from 'Containers/Vulnerabilities/VulnerablityReporting/hooks/usePageAction';
 import usePermissions from 'hooks/usePermissions';
-import { vulnManagementReportsPath, vulnerabilityReportsPath } from 'routePaths';
+import { vulnerabilityReportsPath } from 'routePaths';
 
-import TechPreviewBanner from 'Components/TechPreviewBanner';
 import VulnReportsPage from './VulnReports/VulnReportsPage';
 import CreateVulnReportPage from './ModifyVulnReport/CreateVulnReportPage';
 import EditVulnReportPage from './ModifyVulnReport/EditVulnReportPage';
@@ -28,41 +27,34 @@ function VulnReportingPage() {
         hasReadAccess('Integration'); // for notifiers
 
     return (
-        <>
-            <TechPreviewBanner
-                featureURL={vulnManagementReportsPath}
-                featureName="Vulnerability Management (1.0) Reporting"
-                routeKey="vulnerability-management/reports"
+        <Switch>
+            <Route
+                exact
+                path={vulnerabilityReportsPath}
+                render={(props) => {
+                    if (pageAction === 'create' && hasWriteAccessForReport) {
+                        return <CreateVulnReportPage {...props} />;
+                    }
+                    if (pageAction === undefined) {
+                        return <VulnReportsPage {...props} />;
+                    }
+                    return <Redirect to={vulnerabilityReportsPath} />;
+                }}
             />
-            <Switch>
-                <Route
-                    exact
-                    path={vulnerabilityReportsPath}
-                    render={(props) => {
-                        if (pageAction === 'create' && hasWriteAccessForReport) {
-                            return <CreateVulnReportPage {...props} />;
-                        }
-                        if (pageAction === undefined) {
-                            return <VulnReportsPage {...props} />;
-                        }
-                        return <Redirect to={vulnerabilityReportsPath} />;
-                    }}
-                />
-                <Route
-                    exact
-                    path={vulnerabilityReportPath}
-                    render={(props) => {
-                        if (pageAction === 'edit' && hasWriteAccessForReport) {
-                            return <EditVulnReportPage {...props} />;
-                        }
-                        if (pageAction === 'clone' && hasWriteAccessForReport) {
-                            return <CloneVulnReportPage {...props} />;
-                        }
-                        return <ViewVulnReportPage {...props} />;
-                    }}
-                />
-            </Switch>
-        </>
+            <Route
+                exact
+                path={vulnerabilityReportPath}
+                render={(props) => {
+                    if (pageAction === 'edit' && hasWriteAccessForReport) {
+                        return <EditVulnReportPage {...props} />;
+                    }
+                    if (pageAction === 'clone' && hasWriteAccessForReport) {
+                        return <CloneVulnReportPage {...props} />;
+                    }
+                    return <ViewVulnReportPage {...props} />;
+                }}
+            />
+        </Switch>
     );
 }
 

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -74,6 +74,23 @@ export const vulnerabilityReportsPath = `${vulnerabilitiesBasePath}/reports`;
 
 export const vulnManagementImagesPath = `${vulnManagementPath}/images`;
 
+// Given an array of feature flags, higher-order functions return true or false based on
+// whether all feature flags are enabled or disabled
+
+type FeatureFlagPredicate = (isFeatureFlagEnabled: IsFeatureFlagEnabled) => boolean;
+
+export function allEnabled(featureFlags: FeatureFlagEnvVar[]): FeatureFlagPredicate {
+    return (isFeatureFlagEnabled: IsFeatureFlagEnabled): boolean => {
+        return featureFlags.every((featureFlag) => isFeatureFlagEnabled(featureFlag));
+    };
+}
+
+export function allDisabled(featureFlags: FeatureFlagEnvVar[]): FeatureFlagPredicate {
+    return (isFeatureFlagEnabled: IsFeatureFlagEnabled): boolean => {
+        return featureFlags.every((featureFlag) => !isFeatureFlagEnabled(featureFlag));
+    };
+}
+
 // Compose resourceAccessRequirements from resource names and predicates.
 
 type ResourcePredicate = (hasReadAccess: HasReadAccess) => boolean;
@@ -88,7 +105,7 @@ function evaluateItem(resourceItem: ResourceItem, hasReadAccess: HasReadAccess) 
     return hasReadAccess(resourceItem);
 }
 
-// Given array or resource names, higher-order functions return predicate function.
+// Given array of resource names, higher-order functions return predicate function.
 // You can also compose every with some, if requirements ever become so complicated.
 
 export function everyResource(resourceItems: ResourceItem[]): ResourcePredicate {
@@ -113,7 +130,7 @@ export const nonGlobalResourceNamesForNetworkGraph: ResourceName[] = [
 ];
 
 type RouteRequirements = {
-    featureFlagDependency?: FeatureFlagEnvVar[]; // assume multiple feature flags imply all must be enabled
+    featureFlagRequirements?: FeatureFlagPredicate;
     resourceAccessRequirements: ResourcePredicate; // assume READ_ACCESS
 };
 
@@ -160,7 +177,7 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         resourceAccessRequirements: everyResource(['Access']),
     },
     'administration-events': {
-        featureFlagDependency: ['ROX_ADMINISTRATION_EVENTS'],
+        featureFlagRequirements: allEnabled(['ROX_ADMINISTRATION_EVENTS']),
         resourceAccessRequirements: everyResource(['Administration']),
     },
     apidocs: {
@@ -172,7 +189,7 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     },
     // Cluster init bundles must precede generic Clusters in Body and so here for consistency.
     'clusters/init-bundles': {
-        featureFlagDependency: ['ROX_MOVE_INIT_BUNDLES_UI'],
+        featureFlagRequirements: allEnabled(['ROX_MOVE_INIT_BUNDLES_UI']),
         resourceAccessRequirements: everyResource(['Administration', 'Integration']),
     },
     clusters: {
@@ -200,7 +217,7 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         ]),
     },
     'compliance-enhanced': {
-        featureFlagDependency: ['ROX_COMPLIANCE_ENHANCEMENTS'],
+        featureFlagRequirements: allEnabled(['ROX_COMPLIANCE_ENHANCEMENTS']),
         resourceAccessRequirements: everyResource(['Compliance']),
     },
     configmanagement: {
@@ -225,7 +242,7 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         resourceAccessRequirements: everyResource([]),
     },
     'deferral-configuration': {
-        featureFlagDependency: ['ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL'],
+        featureFlagRequirements: allEnabled(['ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL']),
         resourceAccessRequirements: everyResource(['Administration']),
     },
     integrations: {
@@ -279,11 +296,12 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         resourceAccessRequirements: everyResource(['Alert']),
     },
     'vulnerabilities/reports': {
-        featureFlagDependency: ['ROX_VULN_MGMT_REPORTING_ENHANCEMENTS'],
+        featureFlagRequirements: allEnabled(['ROX_VULN_MGMT_REPORTING_ENHANCEMENTS']),
         resourceAccessRequirements: everyResource(['WorkflowAdministration']),
     },
     // Reports must precede generic Vulnerability Management in Body and so here for consistency.
     'vulnerability-management/reports': {
+        featureFlagRequirements: allDisabled(['ROX_VULN_MGMT_REPORTING_ENHANCEMENTS']),
         resourceAccessRequirements: everyResource(['Integration', 'WorkflowAdministration']),
     },
     // Risk Acceptance must precede generic Vulnerability Management in Body and so here for consistency.
@@ -305,7 +323,7 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         ]),
     },
     'workload-cves': {
-        featureFlagDependency: ['ROX_VULN_MGMT_WORKLOAD_CVES'],
+        featureFlagRequirements: allEnabled(['ROX_VULN_MGMT_WORKLOAD_CVES']),
         resourceAccessRequirements: everyResource(['Deployment', 'Image', 'WatchedImage']),
     },
 };
@@ -319,19 +337,15 @@ export function isRouteEnabled(
     { hasReadAccess, isFeatureFlagEnabled }: RoutePredicates,
     routeKey: RouteKey
 ) {
-    const { featureFlagDependency, resourceAccessRequirements } = routeRequirementsMap[routeKey];
+    const { featureFlagRequirements, resourceAccessRequirements } = routeRequirementsMap[routeKey];
 
-    if (Array.isArray(featureFlagDependency)) {
-        if (
-            !featureFlagDependency.every((featureFlagEnvVar) =>
-                isFeatureFlagEnabled(featureFlagEnvVar)
-            )
-        ) {
-            return false;
-        }
-    }
+    const areFeatureFlagRequirementsMet = featureFlagRequirements
+        ? featureFlagRequirements(isFeatureFlagEnabled)
+        : true;
 
-    return resourceAccessRequirements(hasReadAccess);
+    const areResourceAccessRequirementsMet = resourceAccessRequirements(hasReadAccess);
+
+    return areFeatureFlagRequirementsMet && areResourceAccessRequirementsMet;
 }
 
 /**


### PR DESCRIPTION
## Description

This PR uses the `ROX_VULN_MGMT_REPORTING_ENHANCEMENTS` to determine whether or not to show the v1 Reporting view or the v2 Reporting view.

## Screenshots

The feature flag is on
<img width="260" alt="Screenshot 2023-09-28 at 2 50 06 PM" src="https://github.com/stackrox/stackrox/assets/4805485/a661b701-b71e-48a8-a87d-4dde2a67843b">

The feature flag is off
<img width="264" alt="Screenshot 2023-09-28 at 2 53 58 PM" src="https://github.com/stackrox/stackrox/assets/4805485/ccb4eb0c-0ef6-4e86-b93e-6b4d411b2b63">
