### PR TITLE
ROX-19857: long running collector should have listening endpoints load

### DIFF
--- a/scripts/release-tools/kube-burner-configs/cluster-density/berserker-configmap-endpoints-zipf.yml
+++ b/scripts/release-tools/kube-burner-configs/cluster-density/berserker-configmap-endpoints-zipf.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+￼kind: ConfigMap
+￼metadata:
+￼  name: berserker-config
+￼data:
+￼  workload.toml: |
+￼    restart_interval = 10
+￼
+￼    [workload]
+￼    type = "endpoints"
+￼    distribution = "zipf"
+￼    n_ports = 200
+￼    exponent = 1.4

--- a/scripts/release-tools/kube-burner-configs/cluster-density/berserker-configmap-endpoints-zipf.yml
+++ b/scripts/release-tools/kube-burner-configs/cluster-density/berserker-configmap-endpoints-zipf.yml
@@ -1,13 +1,14 @@
+---
 apiVersion: v1
-￼kind: ConfigMap
-￼metadata:
-￼  name: berserker-config
-￼data:
-￼  workload.toml: |
-￼    restart_interval = 10
-￼
-￼    [workload]
-￼    type = "endpoints"
-￼    distribution = "zipf"
-￼    n_ports = 200
-￼    exponent = 1.4
+kind: ConfigMap
+metadata:
+  name: {{.JobName}}-berserker-config
+data:
+  workload.toml: |
+    restart_interval = 10
+
+    [workload]
+    type = "endpoints"
+    distribution = "zipf"
+    n_ports = 200
+    exponent = 1.4

--- a/scripts/release-tools/kube-burner-configs/cluster-density/config.yml
+++ b/scripts/release-tools/kube-burner-configs/cluster-density/config.yml
@@ -11,7 +11,7 @@ global:
 jobs:
   - name: cluster-density
     namespace: cluster-density
-    jobIterations: 10
+    jobIterations: 2
     jobPause: 1000h
     qps: 20
     burst: 20
@@ -48,6 +48,42 @@ jobs:
         replicas: 10
 
       - objectTemplate: configmap.yml
+        replicas: 10
+
+      - objectTemplate: berserker-configmap-endpoints-zipf.yml
+        replicas: 10
+
+  - name: endpoint-load
+    namespace: endpoint-load
+    jobIterations: 2
+    jobPause: 1000h
+    qps: 20
+    burst: 20
+    namespacedIterations: true
+    podWait: false
+    waitWhenFinished: true
+    preLoadImages: true
+    preLoadPeriod: 30s
+    churn: false
+    churnDuration: 1000h
+    churnDelay: 200h
+    churnPercent: 20
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+
+      - objectTemplate: endpoint-load-deployment.yml
+        replicas: 5
+        inputVars:
+          podReplicas: 2
+
+      - objectTemplate: service.yml
+        replicas: 5
+
+      - objectTemplate: secret.yml
         replicas: 10
 
       - objectTemplate: berserker-configmap-endpoints-zipf.yml

--- a/scripts/release-tools/kube-burner-configs/cluster-density/config.yml
+++ b/scripts/release-tools/kube-burner-configs/cluster-density/config.yml
@@ -11,7 +11,7 @@ global:
 jobs:
   - name: cluster-density
     namespace: cluster-density
-    jobIterations: 2
+    jobIterations: 5
     jobPause: 1000h
     qps: 20
     burst: 20
@@ -48,42 +48,6 @@ jobs:
         replicas: 10
 
       - objectTemplate: configmap.yml
-        replicas: 10
-
-      - objectTemplate: berserker-configmap-endpoints-zipf.yml
-        replicas: 10
-
-  - name: endpoint-load
-    namespace: endpoint-load
-    jobIterations: 2
-    jobPause: 1000h
-    qps: 20
-    burst: 20
-    namespacedIterations: true
-    podWait: false
-    waitWhenFinished: true
-    preLoadImages: true
-    preLoadPeriod: 30s
-    churn: false
-    churnDuration: 1000h
-    churnDelay: 200h
-    churnPercent: 20
-    namespaceLabels:
-      security.openshift.io/scc.podSecurityLabelSync: false
-      pod-security.kubernetes.io/enforce: privileged
-      pod-security.kubernetes.io/audit: privileged
-      pod-security.kubernetes.io/warn: privileged
-    objects:
-
-      - objectTemplate: endpoint-load-deployment.yml
-        replicas: 5
-        inputVars:
-          podReplicas: 2
-
-      - objectTemplate: service.yml
-        replicas: 5
-
-      - objectTemplate: secret.yml
         replicas: 10
 
       - objectTemplate: berserker-configmap-endpoints-zipf.yml

--- a/scripts/release-tools/kube-burner-configs/cluster-density/config.yml
+++ b/scripts/release-tools/kube-burner-configs/cluster-density/config.yml
@@ -36,6 +36,11 @@ jobs:
         inputVars:
           podReplicas: 2
 
+      - objectTemplate: endpoint-load-deployment.yml
+        replicas: 5
+        inputVars:
+          podReplicas: 2
+
       - objectTemplate: service.yml
         replicas: 5
 
@@ -43,4 +48,7 @@ jobs:
         replicas: 10
 
       - objectTemplate: configmap.yml
+        replicas: 10
+
+      - objectTemplate: berserker-configmap-endpoints-zipf.yml
         replicas: 10

--- a/scripts/release-tools/kube-burner-configs/cluster-density/endpoint-load-deployment.yml
+++ b/scripts/release-tools/kube-burner-configs/cluster-density/endpoint-load-deployment.yml
@@ -51,11 +51,6 @@ spec:
           items:
           - key: workload.toml
             path: workload.toml
-            #    downwardAPI:
-            #      items:
-            #        - path: "labels"
-            #          fieldRef:
-            #            fieldPath: metadata.labels
       # Add not-ready/unreachable tolerations for 15 minutes so that node
       # failure doesn't trigger pod deletion.
       tolerations:

--- a/scripts/release-tools/kube-burner-configs/cluster-density/endpoint-load-deployment.yml
+++ b/scripts/release-tools/kube-burner-configs/cluster-density/endpoint-load-deployment.yml
@@ -16,7 +16,7 @@ spec:
       imagePullSecrets:
       - name: {{.JobName}}-{{.Replica}}
       containers:
-      - image: quay.io/rhacs-eng/qa:berserker-1.0-26-g56b1cf4e5d
+      - image: quay.io/rhacs-eng/qa:berserker-1.0-38-ge3b2927865
         resources:
           requests:
             memory: "150Mi"

--- a/scripts/release-tools/kube-burner-configs/cluster-density/endpoint-load-deployment.yml
+++ b/scripts/release-tools/kube-burner-configs/cluster-density/endpoint-load-deployment.yml
@@ -16,7 +16,7 @@ spec:
       imagePullSecrets:
       - name: {{.JobName}}-{{.Replica}}
       containers:
-      - image: quay.io/rhacs-eng/qa:berserker-1.0-38-ge3b2927865
+      - image: quay.io/rhacs-eng/qa:berserker-1.0-40-ge3bd96aa5a
         resources:
           requests:
             memory: "150Mi"

--- a/scripts/release-tools/kube-burner-configs/cluster-density/endpoint-load-deployment.yml
+++ b/scripts/release-tools/kube-burner-configs/cluster-density/endpoint-load-deployment.yml
@@ -14,12 +14,9 @@ spec:
         app: endpoint-load-{{.Replica}}
     spec:
       imagePullSecrets:
-        - name: {{.JobName}}-{{.Replica}}
+      - name: {{.JobName}}-{{.Replica}}
       containers:
-      - args:
-        - sleep
-        - infinity
-        image: quay.io/rhacs-eng/qa:berserker-1.0-26-g56b1cf4e5d
+      - image: quay.io/rhacs-eng/qa:berserker-1.0-26-g56b1cf4e5d
         resources:
           requests:
             memory: "150Mi"
@@ -28,9 +25,9 @@ spec:
             memory: "150Mi"
             cpu: "250m"
         volumeMounts:
-￼          - name: config
-￼            mountPath: "/etc/berserker"
-￼            readOnly: true
+        - name: config
+          mountPath: "/etc/berserker"
+          readOnly: true
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -49,16 +46,16 @@ spec:
           value: "250"
       volumes:
       - name: config
-￼        configMap:
-￼          name: berserker-config
-￼          items:
-￼          - key: workload.toml
-￼            path: workload.toml
-        downwardAPI:
+        configMap:
+          name: {{.JobName}}-berserker-config
           items:
-            - path: "labels"
-              fieldRef:
-                fieldPath: metadata.labels
+          - key: workload.toml
+            path: workload.toml
+            #    downwardAPI:
+            #      items:
+            #        - path: "labels"
+            #          fieldRef:
+            #            fieldPath: metadata.labels
       # Add not-ready/unreachable tolerations for 15 minutes so that node
       # failure doesn't trigger pod deletion.
       tolerations:

--- a/scripts/release-tools/kube-burner-configs/cluster-density/endpoint-load-deployment.yml
+++ b/scripts/release-tools/kube-burner-configs/cluster-density/endpoint-load-deployment.yml
@@ -1,0 +1,72 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: endpoint-load-{{.Replica}}
+spec:
+  replicas: {{.podReplicas}}
+  selector:
+    matchLabels:
+      app: endpoint-load-{{.Replica}}
+  template:
+    metadata:
+      labels:
+        app: endpoint-load-{{.Replica}}
+    spec:
+      imagePullSecrets:
+        - name: {{.JobName}}-{{.Replica}}
+      containers:
+      - args:
+        - sleep
+        - infinity
+        image: quay.io/rhacs-eng/qa:berserker-1.0-26-g56b1cf4e5d
+        resources:
+          requests:
+            memory: "150Mi"
+            cpu: "250m"
+          limits:
+            memory: "150Mi"
+            cpu: "250m"
+        volumeMounts:
+￼          - name: config
+￼            mountPath: "/etc/berserker"
+￼            readOnly: true
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        - containerPort: 8443
+          protocol: TCP
+        name: cluster-density
+        env:
+        - name: ENVVAR1
+          value: "250"
+        - name: ENVVAR2
+          value: "250"
+        - name: ENVVAR3
+          value: "250"
+        - name: ENVVAR4
+          value: "250"
+      volumes:
+      - name: config
+￼        configMap:
+￼          name: berserker-config
+￼          items:
+￼          - key: workload.toml
+￼            path: workload.toml
+        downwardAPI:
+          items:
+            - path: "labels"
+              fieldRef:
+                fieldPath: metadata.labels
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900


### PR DESCRIPTION
## Description

Kube-burner now creates listening endpoints load via berserker. A new deployment is created in which berserker reads a workload file that specifies the endpoints load. The workload used for the endpoints is specified in a confimap.

## Checklist
- [x] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

This just changes some config files for kube-burner, so no testing or user facing documentation is required. 

## Testing Performed

Go to https://github.com/stackrox/test-gh-actions/actions/workflows/create-clusters.yml

Click on "Run workflow".
Change branch to jv-ROX-19857-long-running-collector-should-have-listening-endpoints-load

Select "Create a long-running cluster on RC1" and "Create a GKE demo cluster"
Click run workflow.

The names of created clusters are "real-load-4-1-1" and "fake-load-4-1-1".
Download the artifacts for the clusters and use their kubeconfigs.

Connect to the central-db in the cluster running the fake workload. Check the number of listening endpoints.

central_active=# select count(*) from listening_endpoints ;
-[ RECORD 1 ]
count | 20987

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
