### PR TITLE
ROX-19885: Set gRPC max receive size for client connection

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -55,7 +55,7 @@ func init() {
 var (
 	log = logging.LoggerForModule()
 
-	maxMsgSizeSetting         = env.RegisterIntegerSetting("ROX_GRPC_MAX_MESSAGE_SIZE", defaultMaxMsgSize)
+	MaxMsgSizeSetting         = env.RegisterIntegerSetting("ROX_GRPC_MAX_MESSAGE_SIZE", defaultMaxMsgSize)
 	maxResponseMsgSizeSetting = env.RegisterIntegerSetting("ROX_GRPC_MAX_RESPONSE_SIZE", defaultMaxResponseMsgSize)
 	enableRequestTracing      = env.RegisterBooleanSetting("ROX_GRPC_ENABLE_REQUEST_TRACING", false)
 )
@@ -379,7 +379,7 @@ func (a *apiImpl) run(startedSig *concurrency.ErrorSignal) {
 		grpc.UnaryInterceptor(
 			grpc_middleware.ChainUnaryServer(a.unaryInterceptors()...),
 		),
-		grpc.MaxRecvMsgSize(maxMsgSizeSetting.IntegerSetting()),
+		grpc.MaxRecvMsgSize(MaxMsgSizeSetting.IntegerSetting()),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			Time: 40 * time.Second,
 		}),

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -55,6 +55,7 @@ func init() {
 var (
 	log = logging.LoggerForModule()
 
+	// MaxMsgSizeSetting is the setting used for gRPC servers and clients to set maximum receive sizes.
 	MaxMsgSizeSetting         = env.RegisterIntegerSetting("ROX_GRPC_MAX_MESSAGE_SIZE", defaultMaxMsgSize)
 	maxResponseMsgSizeSetting = env.RegisterIntegerSetting("ROX_GRPC_MAX_RESPONSE_SIZE", defaultMaxResponseMsgSize)
 	enableRequestTracing      = env.RegisterBooleanSetting("ROX_GRPC_ENABLE_REQUEST_TRACING", false)

--- a/sensor/common/centralclient/grpc_connection.go
+++ b/sensor/common/centralclient/grpc_connection.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/grpc/util"
 	"github.com/stackrox/rox/pkg/mtls"
 )
@@ -127,6 +128,10 @@ func (f *centralConnectionFactoryImpl) SetCentralConnectionWithRetries(conn *uti
 	} else {
 		log.Info("Did not add central CA cert to gRPC connection")
 	}
+
+	// Use pkg/grpc configuration for MaxMsgSize on client connections as well. This will overwrite the 4MB threshold
+	// set by gRPC lib.
+	opts = append(opts, clientconn.MaxMsgReceiveSize(grpc.MaxMsgSizeSetting.IntegerSetting()))
 
 	centralConnection, err := clientconn.AuthenticatedGRPCConnection(env.CentralEndpoint.Setting(), mtls.CentralSubject, opts...)
 	if err != nil {


### PR DESCRIPTION
## Description

Sensor shares the same variable with sensor for gRPC server max receive size (ROX_GRPC_MAX_MESSAGE_SIZE).

However, this is not considered for gRPC clients. Meaning that central messages will have a hardcoded default threshold of 4MB.

This is important for the work in #7755 since the deduper size can grow and we'd like to fine-tune the maximum receive size in sensor without patching if users are hitting the 4MB threshold. 

**Note to reviewers:** an alternative to having to expose `MaxMsgSizeSetting` from `pkg/grpc` would be to have a new variable config only for the client max size.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Running local-sensor with max receive as `10B` fails on the first received message from Central:
```
$ ROX_GRPC_MAX_MESSAGE_SIZE="10" go run ./tools/local-sensor/main.go -connect-central "localhost:8000"
... REDACTED ...
common/clusterid: 2023/09/29 11:57:04.012674 cluster_id.go:35: Info: Certificate has wildcard subject 00000000-0000-0000-0000-000000000000. Waiting to receive cluster ID from central...
common/sensor: 2023/09/29 11:57:04.645258 sensor.go:321: Error: Sensor reported an error: receiving first message from central: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (2183 vs. 10)
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
