### PR TITLE
ROX-19678: Add metric delegate scan namespace access check

### DIFF
--- a/central/delegatedregistryconfig/delegator/delegator.go
+++ b/central/delegatedregistryconfig/delegator/delegator.go
@@ -3,10 +3,12 @@ package delegator
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/delegatedregistryconfig/datastore"
 	deleConnection "github.com/stackrox/rox/central/delegatedregistryconfig/util/connection"
+	centralMetrics "github.com/stackrox/rox/central/metrics"
 	namespaceDataStore "github.com/stackrox/rox/central/namespace/datastore"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -123,6 +125,9 @@ func (d *delegatorImpl) inferNamespace(ctx context.Context, imgName *storage.Ima
 	namespace := utils.ExtractOpenShiftProject(imgName)
 
 	q := search.NewQueryBuilder().AddExactMatches(search.Namespace, namespace).AddExactMatches(search.ClusterID, clusterID).ProtoQuery()
+
+	defer centralMetrics.SetFunctionSegmentDuration(time.Now(), "ScanDelegatorSearchNamespaces")
+
 	// SearchNamespaces will only return a result if user has access.
 	namespaces, err := d.namespaceDS.SearchNamespaces(ctx, q)
 	if err != nil {


### PR DESCRIPTION
## Description

Adds the segment `ScanDelegatorSearchNamespaces` to the existing `function_segment_duration_bucket` metric for capturing how long the namespace access checks take for delegated scans.

This was requested in a [previous PR review](https://github.com/stackrox/stackrox/pull/7650#discussion_r1324288105).

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

On an OCP infra cluster:

- Installed ACS Central Services and Secured Cluster
- Scanned `nginx` and 3 other images using: `roxctl ... --cluster=remote`
- Set up port-forward to central deployment metrics port: `k port-forward deploy/central 9090`
- Observed new metric was created via output from `localhost:9090`

```
# HELP rox_central_function_segment_duration Histogram of how long a particular segment within a function takes
# TYPE rox_central_function_segment_duration histogram
...
rox_central_function_segment_duration_bucket{Segment="ScanDelegatorSearchNamespaces",le="4"} 4
rox_central_function_segment_duration_bucket{Segment="ScanDelegatorSearchNamespaces",le="8"} 4
rox_central_function_segment_duration_bucket{Segment="ScanDelegatorSearchNamespaces",le="16"} 4
rox_central_function_segment_duration_bucket{Segment="ScanDelegatorSearchNamespaces",le="32"} 4
rox_central_function_segment_duration_bucket{Segment="ScanDelegatorSearchNamespaces",le="64"} 4
rox_central_function_segment_duration_bucket{Segment="ScanDelegatorSearchNamespaces",le="128"} 4
rox_central_function_segment_duration_bucket{Segment="ScanDelegatorSearchNamespaces",le="256"} 4
rox_central_function_segment_duration_bucket{Segment="ScanDelegatorSearchNamespaces",le="512"} 4
rox_central_function_segment_duration_bucket{Segment="ScanDelegatorSearchNamespaces",le="+Inf"} 4
rox_central_function_segment_duration_sum{Segment="ScanDelegatorSearchNamespaces"} 5.578859
rox_central_function_segment_duration_count{Segment="ScanDelegatorSearchNamespaces"} 4
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
