### PR TITLE
ROX-19561: Add limiter for maximum allowed init sync sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-19156: Ad-hoc image scanning is now enabled for images in the OCP integrated registry.
   - RHACS attempts to infer the OCP project name from the image path and utilize the project secrets for registry authentication.
 
-- ROX-19561: A new environment variable, `ROX_CENTRAL_MAX_INIT_SYNC_SENSORS`, has been introduced in Central, with a default value of `0`.
+- ROX-19561: A new environment variable, `ROX_CENTRAL_MAX_INIT_SYNC_SENSORS`, has been introduced in Central, with a default value of `0` (unlimited).
   When a value greater than `0` is assigned to it, it serves as a limit on the number of sensors performing initial synchronization.
   This synchronization occurs once sensors establish a connection with Central. It is recommended to set this limit when a significant
   number of secured clusters are connected to a single Central instance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-19156: Ad-hoc image scanning is now enabled for images in the OCP integrated registry.
   - RHACS attempts to infer the OCP project name from the image path and utilize the project secrets for registry authentication.
 
+- ROX-19561: A new environment variable, `ROX_CENTRAL_MAX_INIT_SYNC_SENSORS`, has been introduced in Central, with a default value of `0`.
+  When a value greater than `0` is assigned to it, it serves as a limit on the number of sensors performing initial synchronization.
+  This synchronization occurs once sensors establish a connection with Central. It is recommended to set this limit when a significant
+  number of secured clusters are connected to a single Central instance.
+
 ### Removed Features
 
 - ROX-9510: As announced in release 69.0, empty value for `role.access_scope_id` is not supported anymore for `CreateRole` and `UpdateRole` in `/v1/roles/`. Role creation and update now require passing an identifier referencing a valid access scope in `role.access_scope_id`.

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -82,6 +82,7 @@ func newConnection(ctx context.Context,
 	imageIntegrationMgr common.ImageIntegrationManager,
 	hashMgr hashManager.Manager,
 	complianceOperatorMgr common.ComplianceOperatorManager,
+	initSyncMgr *initSyncManager,
 ) *sensorConnection {
 
 	conn := &sensorConnection{
@@ -110,7 +111,7 @@ func newConnection(ctx context.Context,
 	deduper := hashMgr.GetDeduper(ctx, cluster.GetId())
 	deduper.StartSync()
 
-	conn.sensorEventHandler = newSensorEventHandler(cluster, sensorHello.GetSensorVersion(), eventPipeline, conn, &conn.stopSig, deduper)
+	conn.sensorEventHandler = newSensorEventHandler(cluster, sensorHello.GetSensorVersion(), eventPipeline, conn, &conn.stopSig, deduper, initSyncMgr)
 	conn.scrapeCtrl = scrape.NewController(conn, &conn.stopSig)
 	conn.networkPoliciesCtrl = networkpolicies.NewController(conn, &conn.stopSig)
 	conn.networkEntitiesCtrl = networkentities.NewController(cluster.GetId(), networkEntityMgr, graph.Singleton(), conn, &conn.stopSig)

--- a/central/sensor/service/connection/initsync_manager.go
+++ b/central/sensor/service/connection/initsync_manager.go
@@ -30,12 +30,12 @@ func NewInitSyncManager() *initSyncManager {
 }
 
 func (m *initSyncManager) Add(clusterID string) bool {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
 	if m.maxSensors == 0 {
 		return true
 	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 
 	if m.sensors.Contains(clusterID) {
 		return true
@@ -50,12 +50,12 @@ func (m *initSyncManager) Add(clusterID string) bool {
 }
 
 func (m *initSyncManager) Remove(clusterID string) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
 	if m.maxSensors == 0 {
 		return
 	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 
 	m.sensors.Remove(clusterID)
 }

--- a/central/sensor/service/connection/initsync_manager.go
+++ b/central/sensor/service/connection/initsync_manager.go
@@ -37,10 +37,6 @@ func (m *initSyncManager) Add(clusterID string) bool {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	if m.sensors.Contains(clusterID) {
-		return true
-	}
-
 	if len(m.sensors) >= m.maxSensors {
 		return false
 	}

--- a/central/sensor/service/connection/initsync_manager.go
+++ b/central/sensor/service/connection/initsync_manager.go
@@ -15,6 +15,8 @@ type initSyncManager struct {
 	sensors    set.StringSet
 }
 
+// NewInitSyncManager creates an initSyncManager with max sensors
+// retrieved from env variable, ensuring it is non-negative.
 func NewInitSyncManager() *initSyncManager {
 	maxSensors := env.CentralMaxInitSyncSensors.IntegerSetting()
 	if maxSensors < 0 {

--- a/central/sensor/service/connection/initsync_manager_test.go
+++ b/central/sensor/service/connection/initsync_manager_test.go
@@ -1,0 +1,42 @@
+package connection
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewInitSyncManagerNegativeMaxPanics(t *testing.T) {
+	t.Setenv(env.CentralMaxInitSyncSensors.EnvVar(), "-1")
+	assert.Panics(t, func() { NewInitSyncManager() })
+}
+
+func TestInitSyncManagerZeroNoLimit(t *testing.T) {
+	t.Setenv(env.CentralMaxInitSyncSensors.EnvVar(), "0")
+	m := NewInitSyncManager()
+
+	assert.Equal(t, 0, m.maxSensors)
+	assert.True(t, m.Add("test-1"), "Can add if limit is set to 0")
+	m.Remove("test-2")
+}
+
+func TestInitSyncManager(t *testing.T) {
+	t.Setenv(env.CentralMaxInitSyncSensors.EnvVar(), "3")
+	m := NewInitSyncManager()
+
+	for i := 0; i < 3; i++ {
+		assert.True(t, m.Add(fmt.Sprintf("test-%d", i)))
+	}
+	assert.False(t, m.Add("test-a"), "Unable to add after limit is reached")
+	assert.True(t, m.Add("test-2"), "Can add already existing")
+
+	m.Remove("test-a")
+	assert.False(t, m.Add("test-a"), "Unable to add after removing non-existing")
+
+	m.Remove("test-1")
+	assert.True(t, m.Add("test-a"), "Can add after one is removed")
+
+	assert.False(t, m.Add("test-b"), "Unable to add after limit is reached")
+}

--- a/central/sensor/service/connection/initsync_manager_test.go
+++ b/central/sensor/service/connection/initsync_manager_test.go
@@ -19,10 +19,10 @@ func TestInitSyncManagerZeroNoLimit(t *testing.T) {
 	assert.Equal(t, 0, m.maxSensors)
 
 	assert.True(t, m.Add("test-1"), "Can add if limit is set to 0")
-	assert.Equal(t, 0, len(m.sensors))
+	assert.Len(t, m.sensors, 0)
 
 	m.Remove("test-2")
-	assert.Equal(t, 0, len(m.sensors))
+	assert.Len(t, m.sensors, 0)
 }
 
 func TestInitSyncManagerDefault(t *testing.T) {
@@ -30,7 +30,7 @@ func TestInitSyncManagerDefault(t *testing.T) {
 	assert.Equal(t, 0, m.maxSensors)
 
 	assert.True(t, m.Add("test-1"), "Can add if limit is set to 0")
-	assert.Equal(t, 0, len(m.sensors))
+	assert.Len(t, m.sensors, 0)
 }
 
 func TestInitSyncManager(t *testing.T) {
@@ -41,15 +41,15 @@ func TestInitSyncManager(t *testing.T) {
 		assert.True(t, m.Add(fmt.Sprintf("test-%d", i)))
 	}
 	assert.False(t, m.Add("test-a"), "Unable to add after limit is reached")
-	assert.Equal(t, 3, len(m.sensors))
+	assert.Len(t, m.sensors, 3)
 
 	m.Remove("test-a")
 	assert.False(t, m.Add("test-a"), "Unable to add after removing non-existing")
 
 	m.Remove("test-1")
-	assert.Equal(t, 2, len(m.sensors))
+	assert.Len(t, m.sensors, 2)
 	assert.True(t, m.Add("test-a"), "Can add after one is removed")
-	assert.Equal(t, 3, len(m.sensors))
+	assert.Len(t, m.sensors, 3)
 
 	assert.False(t, m.Add("test-b"), "Unable to add after limit is reached")
 }

--- a/central/sensor/service/connection/initsync_manager_test.go
+++ b/central/sensor/service/connection/initsync_manager_test.go
@@ -16,10 +16,21 @@ func TestNewInitSyncManagerNegativeMaxPanics(t *testing.T) {
 func TestInitSyncManagerZeroNoLimit(t *testing.T) {
 	t.Setenv(env.CentralMaxInitSyncSensors.EnvVar(), "0")
 	m := NewInitSyncManager()
-
 	assert.Equal(t, 0, m.maxSensors)
+
 	assert.True(t, m.Add("test-1"), "Can add if limit is set to 0")
+	assert.Equal(t, 0, len(m.sensors))
+
 	m.Remove("test-2")
+	assert.Equal(t, 0, len(m.sensors))
+}
+
+func TestInitSyncManagerDefault(t *testing.T) {
+	m := NewInitSyncManager()
+	assert.Equal(t, 0, m.maxSensors)
+
+	assert.True(t, m.Add("test-1"), "Can add if limit is set to 0")
+	assert.Equal(t, 0, len(m.sensors))
 }
 
 func TestInitSyncManager(t *testing.T) {
@@ -30,13 +41,15 @@ func TestInitSyncManager(t *testing.T) {
 		assert.True(t, m.Add(fmt.Sprintf("test-%d", i)))
 	}
 	assert.False(t, m.Add("test-a"), "Unable to add after limit is reached")
-	assert.True(t, m.Add("test-2"), "Can add already existing")
+	assert.Equal(t, 3, len(m.sensors))
 
 	m.Remove("test-a")
 	assert.False(t, m.Add("test-a"), "Unable to add after removing non-existing")
 
 	m.Remove("test-1")
+	assert.Equal(t, 2, len(m.sensors))
 	assert.True(t, m.Add("test-a"), "Can add after one is removed")
+	assert.Equal(t, 3, len(m.sensors))
 
 	assert.False(t, m.Add("test-b"), "Unable to add after limit is reached")
 }

--- a/central/sensor/service/connection/sensorevents.go
+++ b/central/sensor/service/connection/sensorevents.go
@@ -32,15 +32,16 @@ type sensorEventHandler struct {
 	workerQueues      map[string]*workerQueue
 	workerQueuesMutex sync.RWMutex
 
-	deduper  hashManager.Deduper
-	pipeline pipeline.ClusterPipeline
-	injector common.MessageInjector
-	stopSig  *concurrency.ErrorSignal
+	deduper     hashManager.Deduper
+	initSyncMgr *initSyncManager
+	pipeline    pipeline.ClusterPipeline
+	injector    common.MessageInjector
+	stopSig     *concurrency.ErrorSignal
 
 	reconciliationMap *reconciliation.StoreMap
 }
 
-func newSensorEventHandler(cluster *storage.Cluster, sensorVersion string, pipeline pipeline.ClusterPipeline, injector common.MessageInjector, stopSig *concurrency.ErrorSignal, deduper hashManager.Deduper) *sensorEventHandler {
+func newSensorEventHandler(cluster *storage.Cluster, sensorVersion string, pipeline pipeline.ClusterPipeline, injector common.MessageInjector, stopSig *concurrency.ErrorSignal, deduper hashManager.Deduper, initSyncMgr *initSyncManager) *sensorEventHandler {
 	return &sensorEventHandler{
 		cluster:       cluster,
 		sensorVersion: sensorVersion,
@@ -48,10 +49,11 @@ func newSensorEventHandler(cluster *storage.Cluster, sensorVersion string, pipel
 		workerQueues:      make(map[string]*workerQueue),
 		reconciliationMap: reconciliation.NewStoreMap(),
 
-		deduper:  deduper,
-		pipeline: pipeline,
-		injector: injector,
-		stopSig:  stopSig,
+		deduper:     deduper,
+		initSyncMgr: initSyncMgr,
+		pipeline:    pipeline,
+		injector:    injector,
+		stopSig:     stopSig,
 	}
 }
 
@@ -76,6 +78,7 @@ func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.Ms
 	var workerType string
 	switch event.Resource.(type) {
 	case *central.SensorEvent_Synced:
+		s.initSyncMgr.Remove(s.cluster.GetId())
 		// Call the reconcile functions
 		if err := s.pipeline.Reconcile(ctx, s.reconciliationMap); err != nil {
 			log.Errorf("error reconciling state: %v", err)

--- a/central/sensor/service/connection/sensorevents.go
+++ b/central/sensor/service/connection/sensorevents.go
@@ -77,6 +77,8 @@ func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.Ms
 
 	var workerType string
 	switch event.Resource.(type) {
+	// The occurrence of a "Synced" event from the sensor marks the conclusion
+	// of the initial synchronization process.
 	case *central.SensorEvent_Synced:
 		// Call the reconcile functions
 		if err := s.pipeline.Reconcile(ctx, s.reconciliationMap); err != nil {

--- a/central/sensor/service/connection/sensorevents.go
+++ b/central/sensor/service/connection/sensorevents.go
@@ -78,11 +78,11 @@ func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.Ms
 	var workerType string
 	switch event.Resource.(type) {
 	case *central.SensorEvent_Synced:
-		s.initSyncMgr.Remove(s.cluster.GetId())
 		// Call the reconcile functions
 		if err := s.pipeline.Reconcile(ctx, s.reconciliationMap); err != nil {
 			log.Errorf("error reconciling state: %v", err)
 		}
+		s.initSyncMgr.Remove(s.cluster.GetId())
 		s.deduper.ProcessSync()
 		s.reconciliationMap.Close()
 		return

--- a/pkg/env/rate_limit.go
+++ b/pkg/env/rate_limit.go
@@ -1,0 +1,7 @@
+package env
+
+var (
+	// CentralMaxInitSyncSensors defines maximum number of sensors that are doing initial sync in parallel.
+	// Default to 0 (no limit).
+	CentralMaxInitSyncSensors = RegisterIntegerSetting("ROX_CENTRAL_MAX_INIT_SYNC_SENSORS", 0)
+)

--- a/pkg/errox/errors.go
+++ b/pkg/errox/errors.go
@@ -42,5 +42,9 @@ var (
 	// ServerError is a generic server error.
 	ServerError = makeSentinel("server error")
 
+	// ResourceExhausted indicates that service is unable to respond because
+	// a quota is reached. i.e., max number of connections, etc.
+	ResourceExhausted = makeSentinel("resource exhausted")
+
 	// When adding a new error please update the translators in this package (gRPC, etc.).
 )

--- a/pkg/errox/grpc/mapping.go
+++ b/pkg/errox/grpc/mapping.go
@@ -29,6 +29,8 @@ func RoxErrorToGRPCCode(err error) codes.Code {
 		return codes.PermissionDenied
 	case errors.Is(err, errox.NoAuthzConfigured):
 		return codes.Unimplemented
+	case errors.Is(err, errox.ResourceExhausted):
+		return codes.ResourceExhausted
 	case errors.Is(err, context.Canceled):
 		return codes.Canceled
 	case errors.Is(err, context.DeadlineExceeded):


### PR DESCRIPTION
## Description

This PR introduces an option to limit the number of sensors in init sync mode. This will reduce resource consumption for the Central component in situations when many sensors are doing initial sync (i.e., central update, or other situations where central is restarted)

Behavior is that if limit is reached we will not allow other sensors to connect. A returned error will use code 429 Resource Exhausted.

**Considerations**

1. The current solution uses set. My concern is if we can get into sitatuon where we will have lingering clusters in the set. That can lead to a state where sensors are not able to connect. Should we consider using `expiringcache.Cache` with an expiring time of 2h or so?
2. nitpick: The solution for no limit (0 limit) currently uses special `if` cases. Maybe we can consider setting the value to `MaxInt` and remove if cases. That would simplify the code a bit.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- ~[ ] Determined and documented upgrade steps~
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

1. Unit tests
3. **planned** Testing with `scale/dev` scripts where we can define that X number of sensors are connected. I'm planning to test without and with the limit. And compare resource utilization and time required to initial sync.
