### PR TITLE
fix(bug): Return unknown when not authorized for watch status

### DIFF
--- a/central/graphql/resolvers/images.go
+++ b/central/graphql/resolvers/images.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/central/metrics"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/sac/resources"
@@ -271,6 +272,9 @@ func (resolver *imageResolver) Scan(ctx context.Context) (*imageScanResolver, er
 func (resolver *imageResolver) WatchStatus(ctx context.Context) (string, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Images, "WatchStatus")
 	if err := readAuth(resources.WatchedImage)(ctx); err != nil {
+		if errors.Is(err, errox.NotAuthorized) {
+			return "unknown", nil
+		}
 		return "", err
 	}
 	watched, err := resolver.root.WatchedImageDataStore.Exists(ctx, resolver.data.GetName().GetFullName())

--- a/central/graphql/resolvers/images.go
+++ b/central/graphql/resolvers/images.go
@@ -23,6 +23,7 @@ import (
 var (
 	imageWatchStatuses []string
 
+	unknownImageWatchStatus    = registerImageWatchStatus("UNKNOWN")
 	notWatchedImageWatchStatus = registerImageWatchStatus("NOT_WATCHED")
 	watchedImageStatus         = registerImageWatchStatus("WATCHED")
 )
@@ -273,7 +274,7 @@ func (resolver *imageResolver) WatchStatus(ctx context.Context) (string, error) 
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Images, "WatchStatus")
 	if err := readAuth(resources.WatchedImage)(ctx); err != nil {
 		if errors.Is(err, errox.NotAuthorized) {
-			return "unknown", nil
+			return unknownImageWatchStatus, nil
 		}
 		return "", err
 	}

--- a/ui/apps/platform/src/Components/CVEStackedPill/CVEStackedPill.js
+++ b/ui/apps/platform/src/Components/CVEStackedPill/CVEStackedPill.js
@@ -52,7 +52,7 @@ const CVEStackedPill = ({
     return (
         <div className="flex items-center w-full">
             {useScan && !hasScan && <span>{entityName} not scanned</span>}
-            {!hasCounts && <span>No CVEs</span>}
+            {(!useScan || hasScan) && !hasCounts && <span>No CVEs</span>}
             {hasCounts && (
                 <>
                     <div className={`mr-2 ${width}`}>

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.constants.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.constants.ts
@@ -1,6 +1,7 @@
 export const imageWatchStatuses = {
     NOT_WATCHED: 'NOT_WATCHED',
     WATCHED: 'WATCHED',
+    UNKNOWN: 'UNKNOWN',
 };
 
 export const entityPriorityField = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -30,6 +30,7 @@ import ImageComponentVulnerabilitiesTable, {
 import EmptyTableResults from '../components/EmptyTableResults';
 import DateDistanceTd from '../components/DatePhraseTd';
 import CvssTd from '../components/CvssTd';
+import { WatchStatus } from '../types';
 
 export type ImageForCve = {
     id: string;
@@ -47,7 +48,7 @@ export type ImageForCve = {
         } | null;
     } | null;
     operatingSystem: string;
-    watchStatus: 'WATCHED' | 'NOT_WATCHED';
+    watchStatus: WatchStatus;
     scanTime: string | null;
     imageComponents: (ImageComponentVulnerability & {
         imageVulnerabilities: (ImageComponentVulnerability['imageVulnerabilities'][number] & {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
@@ -50,4 +50,4 @@ export function isValidEntityTab(value: unknown): value is EntityTab {
     return entityTabValues.some((tab) => tab === value);
 }
 
-export type WatchStatus = 'WATCHED' | 'NOT_WATCHED';
+export type WatchStatus = 'WATCHED' | 'NOT_WATCHED' | 'UNKNOWN';

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -324,7 +324,7 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     },
     'workload-cves': {
         featureFlagRequirements: allEnabled(['ROX_VULN_MGMT_WORKLOAD_CVES']),
-        resourceAccessRequirements: everyResource(['Deployment', 'Image', 'WatchedImage']),
+        resourceAccessRequirements: everyResource(['Deployment', 'Image']),
     },
 };
 


### PR DESCRIPTION
## Description

We should not block access to images if a user is not authorized to look at a watched image. Instead just return unknown.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Will run with a role without watched image and ensure that the ui and everything looks good

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
