### PR TITLE
fix(build): Get space for `-rcd` build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -401,6 +401,8 @@ jobs:
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
+            # Need to free up some space before push_matching_collector_scanner_images() does its pull.
+            docker system prune --all --force
             source ./scripts/ci/lib.sh
             push_matching_collector_scanner_images "${{ env.ROX_PRODUCT_BRANDING }}" "${{ matrix.arch }}"
 


### PR DESCRIPTION
## Description

The build is failing due to space constraints. [e.g.](https://github.com/stackrox/stackrox/actions/runs/6346218781/job/17262716217#step:27:228) 

This change uses `docker system prune` to claw back available space prior to the failing `push_matching_collector_scanner_images()` step which needs to pull images.

- repro: https://github.com/stackrox/stackrox/actions/runs/6355527223/job/17264416299?pr=7935#step:27:221
- fixed: https://github.com/stackrox/stackrox/actions/runs/6355979382/job/17265328071#step:27:1

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

In CI (links above).