### PR TITLE
ROX-19773: API token expiration events

### DIFF
--- a/central/apitoken/expiration/expiration_test.go
+++ b/central/apitoken/expiration/expiration_test.go
@@ -4,7 +4,6 @@ package expiration
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -138,17 +137,17 @@ func (s *apiTokenExpirationNotifierTestSuite) TestLogGeneration() {
 	expiration1 := now.Add(2*time.Hour - 10*time.Minute)
 	token1 := generateToken(&generated1, &expiration1, false)
 	log1 := generateExpiringTokenLog(token1, now, sliceDuration, sliceName)
-	s.Equal(fmt.Sprintf("API Token %s (ID %s) will expire in less than 2 hours.", token1.GetName(), token1.GetId()), log1)
+	s.Equal("API Token will expire in less than 2 hours", log1)
 
 	generated2 := now.Add(-(4*time.Hour + 10*time.Minute))
 	expiration2 := now.Add(1*time.Hour - 10*time.Minute)
 	token2 := generateToken(&generated2, &expiration2, false)
 	log2 := generateExpiringTokenLog(token2, now, sliceDuration, sliceName)
-	s.Equal(fmt.Sprintf("API Token %s (ID %s) will expire in less than 1 hour.", token2.GetName(), token2.GetId()), log2)
+	s.Equal("API Token will expire in less than 1 hour", log2)
 
 	generated3 := now.Add(-2 * time.Hour)
 	expiration3 := now.Add(3 * time.Hour)
 	token3 := generateToken(&generated3, &expiration3, false)
 	log3 := generateExpiringTokenLog(token3, now, sliceDuration, sliceName)
-	s.Equal(fmt.Sprintf("API Token %s (ID %s) will expire in less than 3 hours.", token3.GetName(), token3.GetId()), log3)
+	s.Equal("API Token will expire in less than 3 hours", log3)
 }

--- a/pkg/administration/events/domain.go
+++ b/pkg/administration/events/domain.go
@@ -3,15 +3,17 @@ package events
 import "regexp"
 
 const (
-	defaultDomain       = "General"
-	imageScanningDomain = "Image Scanning"
-	integrationDomain   = "Integrations"
+	authenticationDomain = "Authentication"
+	defaultDomain        = "General"
+	imageScanningDomain  = "Image Scanning"
+	integrationDomain    = "Integrations"
 )
 
 var (
 	moduleToDomain = map[*regexp.Regexp]string{
 		regexp.MustCompile(`^reprocessor|image/service`): imageScanningDomain,
 		regexp.MustCompile(`^pkg/notifiers(/|$)`):        integrationDomain,
+		regexp.MustCompile(`^apitoken/expiration`):       authenticationDomain,
 	}
 )
 

--- a/pkg/administration/events/hints.go
+++ b/pkg/administration/events/hints.go
@@ -2,7 +2,7 @@ package events
 
 import (
 	"github.com/stackrox/rox/pkg/administration/events/codes"
-	"github.com/stackrox/rox/pkg/sac/resources"
+	adminResources "github.com/stackrox/rox/pkg/administration/events/resources"
 )
 
 const (
@@ -15,19 +15,30 @@ var (
 	// In the future, we may extend this, and possibly also ensure hints are loaded externally (similar to
 	// vulnerability definitions).
 	hints = map[string]map[string]map[string]string{
+		authenticationDomain: {
+			adminResources.APIToken: {
+				"": `An API token is about to expire. See the details on the expiration time within the event message.
+It is not possible to re-create the token, instead you have to do the following:
+- Delete the expiring API token.
+- Create a new API token (you may choose the same name).
+
+Afterwards, you may use the newly created API token.
+`,
+			},
+		},
+		defaultDomain: {},
 		imageScanningDomain: {
 			// For now, this is an example string. We may want to revisit those together with UX / the docs team to get
 			// errors that are in-line with documentation guidelines.
-			resources.Image.String(): {
+			adminResources.Image: {
 				"": `An issue occurred scanning the image. Please ensure that:
 - Scanner can access the registry.
 - Correct credentials are configured for the particular registry / repository.
 - The scanned manifest exists within the registry / repository.`,
 			},
 		},
-		defaultDomain: {},
 		integrationDomain: {
-			"Notifier": {
+			adminResources.Notifier: {
 				codes.AWSSHGeneric: `An issue occurred when using the AWS Security Hub notifier.
 Please ensure that:
 - Credentials are configured correctly.

--- a/pkg/administration/events/resources/resources.go
+++ b/pkg/administration/events/resources/resources.go
@@ -1,0 +1,16 @@
+package resources
+
+import "github.com/stackrox/rox/pkg/sac/resources"
+
+// Resources used in administration events.
+const (
+	APIToken = "API Token"
+	Notifier = "Notifier"
+)
+
+// Resources used in administration events.
+var (
+	Image   = resources.Image.String()
+	Cluster = resources.Cluster.String()
+	Node    = resources.Node.String()
+)

--- a/pkg/logging/fields.go
+++ b/pkg/logging/fields.go
@@ -1,27 +1,31 @@
 package logging
 
 import (
-	"github.com/stackrox/rox/pkg/sac/resources"
+	administrationResources "github.com/stackrox/rox/pkg/administration/events/resources"
 	"go.uber.org/zap"
 )
 
 const (
-	imageField     = "image"
-	clusterIDField = "cluster_id"
-	imageIDField   = "image_id"
-	nodeIDField    = "node_id"
-	notifierField  = "notifier"
-	errCodeField   = "err_code"
-	alertIDField   = "alert_id"
+	imageField        = "image"
+	clusterIDField    = "cluster_id"
+	imageIDField      = "image_id"
+	nodeIDField       = "node_id"
+	notifierField     = "notifier"
+	errCodeField      = "err_code"
+	alertIDField      = "alert_id"
+	apiTokenIDField   = "api_token_id"
+	apiTokenNameField = "api_token_name"
 )
 
 var (
 	resourceTypeFields = map[string]string{
-		imageField:     resources.Image.String(),
-		imageIDField:   resources.Image.String(),
-		clusterIDField: resources.Cluster.String(),
-		nodeIDField:    resources.Node.String(),
-		notifierField:  "Notifier",
+		imageField:        administrationResources.Image,
+		imageIDField:      administrationResources.Image,
+		clusterIDField:    administrationResources.Cluster,
+		nodeIDField:       administrationResources.Node,
+		notifierField:     administrationResources.Notifier,
+		apiTokenIDField:   administrationResources.APIToken,
+		apiTokenNameField: administrationResources.APIToken,
 	}
 )
 
@@ -67,6 +71,18 @@ func AlertID(id string) zap.Field {
 	return zap.String(alertIDField, id)
 }
 
+// APITokenID provides the API token ID as a structured log field.
+func APITokenID(id string) zap.Field {
+	return zap.String(apiTokenIDField, id)
+}
+
+// APITokenName provides the API token name as a structured log field.
+func APITokenName(name string) zap.Field {
+	return zap.String(apiTokenNameField, name)
+}
+
+// Wrapper functions for zap.Field functions.
+
 // String provides a wrapper around zap.String and adds the key-value pair as structured log field.
 // This should be _always_ preferred over direct calls to zap to minimize dependency to it.
 func String(field, value string) zap.Field {
@@ -91,6 +107,10 @@ func Int(field string, value int) zap.Field {
 	return zap.Int(field, value)
 }
 
+// End Wrapper functions for zap.field functions.
+
+// Helper functions.
+
 // getResourceTypeField returns whether the given zap.Field is related to a resource.
 // If it is, it will return true and the name of the resource.
 func getResourceTypeField(field zap.Field) (string, bool) {
@@ -99,5 +119,7 @@ func getResourceTypeField(field zap.Field) (string, bool) {
 }
 
 func isIDField(fieldName string) bool {
-	return fieldName != imageField && fieldName != notifierField
+	return fieldName != imageField &&
+		fieldName != notifierField &&
+		fieldName != apiTokenNameField
 }

--- a/pkg/logging/log_converter_impl_test.go
+++ b/pkg/logging/log_converter_impl_test.go
@@ -55,6 +55,24 @@ func TestConvert(t *testing.T) {
 			},
 		},
 		{
+			event: &events.AdministrationEvent{
+				Domain:       "Authentication",
+				Hint:         events.GetHint("Authentication", "API Token", ""),
+				Level:        storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_ERROR,
+				Message:      `Error: this is an events test {"api_token_id": "some-token-id", "api_token_name": "some-token-name"}`,
+				ResourceType: "API Token",
+				ResourceName: "some-token-name",
+				ResourceID:   "some-token-id",
+				Type:         storage.AdministrationEventType_ADMINISTRATION_EVENT_TYPE_LOG_MESSAGE,
+			},
+			msg:    "Error: this is an events test",
+			level:  "error",
+			module: "apitoken/expiration",
+			fields: []interface{}{
+				APITokenID("some-token-id"), APITokenName("some-token-name"),
+			},
+		},
+		{
 			msg:    "Error: something went wrong",
 			level:  "error",
 			module: "pkg/random/something",


### PR DESCRIPTION
## Description

This PR enables the creation of administration events for the log messages for API token expirations.

This enables more visiblity for the expiration.

A new resource `API Token` was created with the new domain `Authentication`.

Additionally provided a fix to allow passing both `resource ID` and `resource name` fields via zap.Field. Previously this rendered in an error.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see the added unit tests.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
