### PR TITLE
ROX-19887: fix grpc status code in metrics

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -177,10 +177,12 @@ func (a *apiImpl) Stop() bool {
 }
 
 func (a *apiImpl) unaryInterceptors() []grpc.UnaryServerInterceptor {
+	// The metrics and error interceptors are first in line to make sure all requests are
+	// registered in Prometheus with errors converted to gRPC status codes.
 	u := []grpc.UnaryServerInterceptor{
-		contextutil.UnaryServerInterceptor(a.requestInfoHandler.UpdateContextForGRPC),
-		grpc_errors.ErrorToGrpcCodeInterceptor,
 		grpc_prometheus.UnaryServerInterceptor,
+		grpc_errors.ErrorToGrpcCodeInterceptor,
+		contextutil.UnaryServerInterceptor(a.requestInfoHandler.UpdateContextForGRPC),
 		contextutil.UnaryServerInterceptor(authn.ContextUpdater(a.config.IdentityExtractors...)),
 	}
 
@@ -216,10 +218,12 @@ func (a *apiImpl) unaryInterceptors() []grpc.UnaryServerInterceptor {
 }
 
 func (a *apiImpl) streamInterceptors() []grpc.StreamServerInterceptor {
+	// The metrics and error interceptors are first in line to make sure all requests are
+	// registered in Prometheus with errors converted to gRPC status codes.
 	s := []grpc.StreamServerInterceptor{
-		contextutil.StreamServerInterceptor(a.requestInfoHandler.UpdateContextForGRPC),
 		grpc_prometheus.StreamServerInterceptor,
 		grpc_errors.ErrorToGrpcCodeStreamInterceptor,
+		contextutil.StreamServerInterceptor(a.requestInfoHandler.UpdateContextForGRPC),
 		contextutil.StreamServerInterceptor(
 			authn.ContextUpdater(a.config.IdentityExtractors...)),
 	}
@@ -446,6 +450,5 @@ func (a *apiImpl) serveBlocking(srvAndLis serverAndListener, errC chan<- error) 
 				errC <- errors.Wrapf(err, "error serving required endpoint %s on %s: %v", srvAndLis.endpoint.Kind(), srvAndLis.listener.Addr(), err)
 			}
 		}
-
 	}
 }

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -177,8 +177,9 @@ func (a *apiImpl) Stop() bool {
 }
 
 func (a *apiImpl) unaryInterceptors() []grpc.UnaryServerInterceptor {
-	// The metrics and error interceptors are first in line to make sure all requests are
-	// registered in Prometheus with errors converted to gRPC status codes.
+	// The metrics and error interceptors are first in line, i.e., outermost, to
+	// make sure all requests are registered in Prometheus with errors converted
+	// to gRPC status codes.
 	u := []grpc.UnaryServerInterceptor{
 		grpc_prometheus.UnaryServerInterceptor,
 		grpc_errors.ErrorToGrpcCodeInterceptor,
@@ -218,8 +219,9 @@ func (a *apiImpl) unaryInterceptors() []grpc.UnaryServerInterceptor {
 }
 
 func (a *apiImpl) streamInterceptors() []grpc.StreamServerInterceptor {
-	// The metrics and error interceptors are first in line to make sure all requests are
-	// registered in Prometheus with errors converted to gRPC status codes.
+	// The metrics and error interceptors are first in line, i.e., outermost, to
+	// make sure all requests are registered in Prometheus with errors converted
+	// to gRPC status codes.
 	s := []grpc.StreamServerInterceptor{
 		grpc_prometheus.StreamServerInterceptor,
 		grpc_errors.ErrorToGrpcCodeStreamInterceptor,


### PR DESCRIPTION
## Description

We noticed that unauthorized calls to `/v1/metadata` were being recorded as `Unknown` status code in prometheus metrics, even though the corresponding error `errox.NotAuthorized` was being mapped to `403` http status code for the client. The reason this happens is the current order of the unary grpc interceptors, which record metrics *before* the error to status code conversions happens.

## Testing Performed

### Here I tell how I validated my change

before
```
grpc_server_handled_total{grpc_code="Unknown",grpc_method="GetMetadata",grpc_service="v1.MetadataService",grpc_type="unary"} 8
grpc_server_handled_total{grpc_code="Unknown",grpc_method="GetCentralCapabilities",grpc_service="v1.MetadataService",grpc_type="unary"} 2
grpc_server_handled_total{grpc_code="Unknown",grpc_method="GetConfig",grpc_service="v1.TelemetryService",grpc_type="unary"} 2
grpc_server_handled_total{grpc_code="Unknown",grpc_method="GetMyPermissions",grpc_service="v1.RoleService",grpc_type="unary"} 2
```

after
```
grpc_server_handled_total{grpc_code="PermissionDenied",grpc_method="GetMetadata",grpc_service="v1.MetadataService",grpc_type="unary"} 8
grpc_server_handled_total{grpc_code="Unauthenticated",grpc_method="GetCentralCapabilities",grpc_service="v1.MetadataService",grpc_type="unary"} 2
grpc_server_handled_total{grpc_code="Unauthenticated",grpc_method="GetConfig",grpc_service="v1.TelemetryService",grpc_type="unary"} 2
grpc_server_handled_total{grpc_code="Unauthenticated",grpc_method="GetMyPermissions",grpc_service="v1.RoleService",grpc_type="unary"} 2
```