### PR TITLE
ROX-19955: Prometheus resources in sensor upgrader

### DIFF
--- a/pkg/namespaces/constants.go
+++ b/pkg/namespaces/constants.go
@@ -1,12 +1,14 @@
 package namespaces
 
 const (
-	// StackRox defines the default stackrox namespace
+	// StackRox defines the default stackrox namespace.
 	StackRox = `stackrox`
-	// KubeSystem defines the default Kubernetes System namespace
+	// KubeSystem defines the default Kubernetes System namespace.
 	KubeSystem = `kube-system`
-	// KubePublic defines the default Kubernetes Public namespace
+	// KubePublic defines the default Kubernetes Public namespace.
 	KubePublic = `kube-public`
-	// Default defines the default namespace
+	// Default defines the default namespace.
 	Default = `default`
+	// OpenShiftMonitoring defines the OpenShift monitoring namespace.
+	OpenShiftMonitoring = `openshift-monitoring`
 )

--- a/sensor/upgrader/common/namespaces.go
+++ b/sensor/upgrader/common/namespaces.go
@@ -1,0 +1,16 @@
+package common
+
+import "github.com/stackrox/rox/pkg/namespaces"
+
+// AllowedNamespaces is a list of namespaces in which the upgrader may create resources.
+//
+// When adding a resource to a new namespace, add the namespace to this list with a short
+// explanation. Then adapt the namespace validation in sensor/upgrader/preflight/namespace.go.
+var AllowedNamespaces = []string{
+	// Main StackRox namespace. The upgrader lives here.
+	Namespace,
+	// Needed for OpenShift monitoring integration on OpenShift.
+	namespaces.KubeSystem,
+	// Needed for OpenShift monitoring integration on OpenShift.
+	namespaces.OpenShiftMonitoring,
+}

--- a/sensor/upgrader/preflight/namespace.go
+++ b/sensor/upgrader/preflight/namespace.go
@@ -1,10 +1,17 @@
 package preflight
 
 import (
+	"github.com/stackrox/rox/pkg/k8sutil/k8sobjects"
 	"github.com/stackrox/rox/sensor/upgrader/common"
 	"github.com/stackrox/rox/sensor/upgrader/plan"
 	"github.com/stackrox/rox/sensor/upgrader/upgradectx"
 )
+
+// Resources created in system namespaces for OpenShift monitoring.
+var resourceExceptions = map[string][]string{
+	"kube-system":          {"RoleBinding"},
+	"openshift-monitoring": {"ServiceMonitor", "PrometheusRule"},
+}
 
 type namespaceCheck struct{}
 
@@ -12,9 +19,22 @@ func (namespaceCheck) Name() string {
 	return "Allowed namespaces"
 }
 
+func isException(resource *k8sobjects.ObjectRef) bool {
+	if kinds, ok := resourceExceptions[resource.Namespace]; ok {
+		for _, k := range kinds {
+			if k == resource.GVK.Kind {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (namespaceCheck) Check(_ *upgradectx.UpgradeContext, execPlan *plan.ExecutionPlan, reporter checkReporter) error {
 	for _, act := range execPlan.Actions() {
-		if act.ObjectRef.Namespace != "" && act.ObjectRef.Namespace != common.Namespace {
+		act := act
+		doCheck := !isException(&act.ObjectRef)
+		if doCheck && act.ObjectRef.Namespace != "" && act.ObjectRef.Namespace != common.Namespace {
 			reporter.Errorf("To-be-%sd object %v is in disallowed namespace %s", act.ActionName, act.ObjectRef, common.Namespace)
 		}
 	}

--- a/sensor/upgrader/preflight/namespace_test.go
+++ b/sensor/upgrader/preflight/namespace_test.go
@@ -1,0 +1,72 @@
+package preflight
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/k8sutil/k8sobjects"
+	"github.com/stackrox/rox/pkg/namespaces"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestNamespaceExceptionMatching(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		object    *k8sobjects.ObjectRef
+		isAllowed bool
+	}{
+		"ServiceMonitor in openshift-monitoring": {
+			object: &k8sobjects.ObjectRef{
+				GVK: schema.GroupVersionKind{Kind: "ServiceMonitor"}, Namespace: namespaces.OpenShiftMonitoring,
+			},
+			isAllowed: true,
+		},
+		"PrometheusRule in openshift-monitoring": {
+			object: &k8sobjects.ObjectRef{
+				GVK: schema.GroupVersionKind{Kind: "PrometheusRule"}, Namespace: namespaces.OpenShiftMonitoring,
+			},
+			isAllowed: true,
+		},
+		"RoleBinding in kube-system": {
+			object: &k8sobjects.ObjectRef{
+				GVK: schema.GroupVersionKind{Kind: "RoleBinding"}, Namespace: namespaces.KubeSystem,
+			},
+			isAllowed: true,
+		},
+		"ServiceMonitor in kube-system": {
+			object: &k8sobjects.ObjectRef{
+				GVK: schema.GroupVersionKind{Kind: "ServiceMonitor"}, Namespace: namespaces.KubeSystem,
+			},
+			isAllowed: false,
+		},
+		"PrometheusRule in stackrox": {
+			object: &k8sobjects.ObjectRef{
+				GVK: schema.GroupVersionKind{Kind: "PrometheusRule"}, Namespace: namespaces.StackRox,
+			},
+			isAllowed: true,
+		},
+		"Deployment in stackrox": {
+			object: &k8sobjects.ObjectRef{
+				GVK: schema.GroupVersionKind{Kind: "Deployment"}, Namespace: namespaces.StackRox,
+			},
+			isAllowed: true,
+		},
+		"Deployment in kube-system": {
+			object: &k8sobjects.ObjectRef{
+				GVK: schema.GroupVersionKind{Kind: "Deployment"}, Namespace: namespaces.KubeSystem,
+			},
+			isAllowed: false,
+		},
+		"ClusterRoleBinding": {
+			object: &k8sobjects.ObjectRef{
+				GVK: schema.GroupVersionKind{Kind: "ClusterRoleBinding"}, Namespace: "",
+			},
+			isAllowed: true,
+		},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.isAllowed, namespaceAllowed(tt.object))
+		})
+	}
+}

--- a/sensor/upgrader/upgradectx/context.go
+++ b/sensor/upgrader/upgradectx/context.go
@@ -317,15 +317,17 @@ func (c *UpgradeContext) List(resourcePurpose resources.Purpose, listOpts *metav
 		if resourceMD.Purpose&resourcePurpose != resourcePurpose {
 			continue
 		}
-		resourceClient := c.DynamicClientForResource(resourceMD, common.Namespace)
-		listObj, err := resourceClient.List(c.ctx, *listOpts)
-		if err != nil {
-			return nil, errors.Wrapf(err, "listing relevant objects of type %v", resourceMD)
-		}
+		for _, ns := range common.AllowedNamespaces {
+			resourceClient := c.DynamicClientForResource(resourceMD, ns)
+			listObj, err := resourceClient.List(c.ctx, *listOpts)
+			if err != nil {
+				return nil, errors.Wrapf(err, "listing relevant objects of type %v in namespace %s", resourceMD, ns)
+			}
 
-		for _, item := range listObj.Items {
-			item := item // create a copy to prevent aliasing
-			result = append(result, &item)
+			for _, item := range listObj.Items {
+				item := item // create a copy to prevent aliasing
+				result = append(result, &item)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

The sensor upgrader is used when sensor is installed via manifest download, while at a later point central is updated to a newer version. The upgrader will then attempt to upgrade sensor to the same upgraded version. As part of the upgrade process, it currently checks that all resources are created in the stackrox namespace. With `4.2.0`, when integration with OpenShift monitoring is enabled, sensor additionally creates Prometheus resources in system namespaces.

This leads to a failure during the upgrader pre-flight check when upgrading from `4.1.x` to `4.2.0` for OpenShift secured clusters. As a fix for this issue, this PR adds the Prometheus resources to an exception list.

## Testing Performed

To reproduce the original issue:
* Install central via Helm chart version `4.1.3`.
* Install sensor via manifest download by running `./sensor.sh`.
* Upgrade central to `4.2.0` via `helm upgrade`.
* In the cluster overview page, the sensor upgrader shows an error in the pre-flight check.

To test the fix:
* Install central via Helm chart version `4.1.3`.
* Install sensor via manifest download by running `./sensor.sh`.
* Upgrade central to `4.2.0-fix` via `helm upgrade`.
* In the cluster overview page, the sensor upgrader successfully performs the upgrade.