### PR TITLE
chore(scanner): add scannerctl grpc option flags

### DIFF
--- a/scanner/.gitignore
+++ b/scanner/.gitignore
@@ -19,3 +19,6 @@ nohup.out
 
 # Go mod
 vendor
+
+# Local config file
+config.yaml

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -4,5 +4,41 @@ Static Image, Node, and Orchestrator Scanner.
 
 # Dev
 
+## scanner
+
 Scanner requires the Go version be aligned with the [EXPECTED_GO_VERSION](../EXPECTED_GO_VERSION).
-This is verified when building Scanner.
+This is verified when using any of Scanner's `make` targets.
+
+### Local
+
+Copy the sample config and edit it to your liking:
+```sh
+$ cp config.sample.yaml config.yaml
+```
+
+Generate the development TLS certificates:
+```sh
+$ make certs
+```
+
+Now you can build the dependencies and run scanner:
+```sh
+$ make deps
+$ go run cmd/scanner -conf config.yaml
+```
+
+## scannerctl
+
+### Local
+
+If you're connecting to your local scanner, you should already have the TLS certificates generated. If not, refer to
+running scanner in the above section.
+
+Once you have the certificates and scanner running with those certificates, you can run scannerctl:
+```sh
+$ go run cmd/scannerctl/main.go \
+    -certs certs/client \
+    -server-name localhost \
+    -port 8443 \
+    https://registry.hub.docker.com/library/hello-world:latest
+```

--- a/scanner/config.yaml.sample
+++ b/scanner/config.yaml.sample
@@ -1,0 +1,16 @@
+http_listen_addr: 127.0.0.1:9443
+grpc_listen_addr: 127.0.0.1:8443
+indexer:
+  enable: true
+  database:
+    conn_string: "host=/var/run/postgresql"
+    password_file: ""
+  get_layer_timeout: 1m
+matcher:
+  enable: true
+  database:
+    conn_string: "host=/var/run/postgresql"
+    password_file: ""
+mtls:
+  certs_dir: ""
+log_level: info


### PR DESCRIPTION
## Description

These changes allow the option for TLS verification for self-signed certs, which complements the changes from https://github.com/stackrox/stackrox/pull/7939.

## Checklist
- Investigated and inspected CI test results (N/A)
- Unit test and regression tests added (N/A?)
- Evaluated and added CHANGELOG entry if required (N/A)
- [x] Determined and documented upgrade steps
- [Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs)) (N/A)

This is a local development change so many of the items on the checklist are not applicable.

## Testing Performed

### Here I tell how I validated my change

Here's my local config file (some values redacted):
```sh
❯ cat config.yaml
indexer:
  database:
    conn_string: ...
matcher:
  database:
    conn_string: ...
mtls:
  certs_dir: certs/scanner-v4
log_level: debug
```

Run the new certs make target:
```sh
❯ make certs
```

Start `scanner`:
```sh
❯ go run cmd/scanner/main.go -conf config.yaml
```

Run `scannerctl` with default values and TLS verification:
```
❯ go run cmd/scannerctl/main.go \
    -certs certs/scannerctl \
    https://docker.io/library/hello-world:latest
2023/10/24 08:38:31 image digest: sha256:7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3
{
  "hash_id": "/v4/containerimage/sha256:7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3",
  "contents": {}
}
```

Run `scannerctl` with specified, working values and TLS verification:
```sh
❯ go run cmd/scannerctl/main.go \
    -certs certs/scannerctl \
    -server-name "localhost" \
    -address :8443 \
    https://docker.io/library/hello-world:latest
2023/10/24 08:38:44 image digest: sha256:7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3
{
  "hash_id": "/v4/containerimage/sha256:7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3",
  "contents": {}
}
```

Run `scannerctl` with incorrect values but without TLS verification:
```sh
❯ go run cmd/scannerctl/main.go \
    -certs certs/scannerctl \
    -server-name wontwork \
    -address :8443 \
    -insecure-skip-tls-verify \
    https://docker.io/library/hello-world:latest
2023/10/24 08:38:49 image digest: sha256:7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3
{
  "hash_id": "/v4/containerimage/sha256:7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3",
  "contents": {}
}
```

Run `scannerctl` with incorrect values and TLS verification:
```sh
❯ go run cmd/scannerctl/main.go \
    -certs certs/scannerctl \
    -server-name wontwork \
    -address :8443 \
    https://docker.io/library/hello-world:latest
2023/10/24 08:37:51 image digest: sha256:7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3
{"level":"debug","component":"scanner/client","method":"GetOrCreateImageIndex","error":"rpc error: code = Unavailable desc = connection error: desc = \"tran
{"level":"debug","component":"scanner/client","method":"GetOrCreateImageIndex","error":"rpc error: code = Unavailable desc = connection error: desc = \"tran
{"level":"debug","method":"GetOrCreateImageIndex","component":"scanner/client","error":"rpc error: code = Unavailable desc = connection error: desc = \"tran
{"level":"debug","component":"scanner/client","method":"GetOrCreateImageIndex","error":"rpc error: code = Unavailable desc = connection error: desc = \"tran
2023/10/24 08:38:02 scanning: get or create index: get index: rpc error: code = Unavailable desc = connection error: desc = "transport: authentication hands
exit status 1
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
