### PR TITLE
ROX-19888: better sorting of listening endpoints

### DIFF
--- a/central/processlisteningonport/README.md
+++ b/central/processlisteningonport/README.md
@@ -79,3 +79,9 @@ Internal API:
 
 * ProcessListeningOnPort -- counter, represents how many PLOP objects Sensor
   has sent to the Central.
+
+Public API:
+
+* Central holds all listening endpoints for a deployment in memory when the
+  public API is called. For example for 200,000 listening endpoints 2 Gi of
+  memory is consumed.

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -4,8 +4,6 @@ package datastore
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -1542,91 +1540,3 @@ func (suite *PLOPDataStoreTestSuite) TestRemovePlopsByPod() {
 	suite.Equal(expectedPlopStorage1, newPlopsFromDB2[0])
 
 }
-
-func makeRandomString(length int) string {
-        var charset = []byte("asdfqwert")
-        randomString := make([]byte, length)
-        for i := range randomString {
-                randomString[i] = charset[rand.Intn(len(charset))]
-        }
-        return string(randomString)
-}
-
-func (suite *PLOPDataStoreTestSuite) makeRandomPlops(nport int, nprocess int, npod int, deployment string) {
-        count := 0
-
-	batchSize := 100
-
-	nplops := 2*nprocess*npod*nport
-
-	if batchSize > nplops {
-		batchSize = nplops
-	}
-
-        plops := make([]*storage.ProcessListeningOnPortFromSensor, batchSize)
-        for podIdx := 0; podIdx < npod; podIdx++ {
-                podID := makeRandomString(10)
-                podUID := makeRandomString(10)
-                for processIdx := 0; processIdx < nprocess; processIdx++ {
-                        execFilePath := makeRandomString(10)
-                        for port := 0; port < nport; port++ {
-
-                                plopTCP := &storage.ProcessListeningOnPortFromSensor{
-                                        Port:     uint32(port),
-                                        Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
-					CloseTimestamp: nil,
-					Process: &storage.ProcessIndicatorUniqueKey{
-						PodId:               podID,
-						ContainerName:       "test_container1",
-						ProcessName:         "test_process1",
-						ProcessArgs:         "test_arguments1",
-						ProcessExecFilePath: execFilePath,
-					},
-					DeploymentId: deployment,
-					PodUid:       podUID,
-                                }
-                                plopUDP := &storage.ProcessListeningOnPortFromSensor{
-                                        Port:     uint32(port),
-                                        Protocol: storage.L4Protocol_L4_PROTOCOL_UDP,
-					CloseTimestamp: nil,
-					Process: &storage.ProcessIndicatorUniqueKey{
-						PodId:               podID,
-						ContainerName:       "test_container1",
-						ProcessName:         "test_process1",
-						ProcessArgs:         "test_arguments1",
-						ProcessExecFilePath: execFilePath,
-					},
-					DeploymentId: deployment,
-					PodUid:       podUID,
-                                }
-                                plops[count] = plopTCP
-                                count++
-                                plops[count] = plopUDP
-                                count++
-				if count == batchSize {
-					suite.NoError(suite.datastore.AddProcessListeningOnPort(
-						suite.hasWriteCtx, plops...))
-					count = 0
-				}
-                        }
-                }
-        }
-}
-
-func (suite *PLOPDataStoreTestSuite) TestSort1000000() {
-        nport := 100
-        nprocess := 100
-        npod := 100
-
-        suite.makeRandomPlops(nport, nprocess, npod, fixtureconsts.Deployment1)
-
-        startTime := time.Now()
-	newPlops, err := suite.datastore.GetProcessListeningOnPort(
-		suite.hasWriteCtx, fixtureconsts.Deployment1)
-	suite.NoError(err)
-        duration := time.Since(startTime)
-
-	fmt.Printf("Fetching %d plops %s took\n", len(newPlops), duration)
-
-}
-

--- a/central/processlisteningonport/store/postgres/full_store.go
+++ b/central/processlisteningonport/store/postgres/full_store.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -79,6 +80,23 @@ func (s *fullStoreImpl) retryableGetPLOP(
 	}
 
 	return results, rows.Err()
+}
+
+func plopComparison(plop1 *storage.ProcessListeningOnPort, plop2 *storage.ProcessListeningOnPort) bool {
+        if plop1.PodId != plop2.PodId {
+                return plop1.PodId < plop2.PodId
+        }
+        if plop1.Signal.ExecFilePath != plop2.Signal.ExecFilePath {
+                return plop1.Signal.ExecFilePath < plop2.Signal.ExecFilePath
+        }
+        if plop1.Endpoint.Port != plop2.Endpoint.Port {
+                return plop1.Endpoint.Port < plop2.Endpoint.Port
+        }
+        return plop1.Endpoint.Protocol < plop2.Endpoint.Protocol
+}
+
+func sortPlops(plops []*storage.ProcessListeningOnPort) {
+	sort.Slice(plops, func(i, j int) bool { return plopComparison(plops[i], plops[j]) })
 }
 
 // Manual converting of raw data from SQL query to ProcessListeningOnPort (not
@@ -168,6 +186,8 @@ func (s *fullStoreImpl) readRows(
 
 		plops = append(plops, plop)
 	}
+
+	sortPlops(plops)
 
 	log.Debugf("Read returned %+v plops", len(plops))
 	return plops, nil

--- a/central/processlisteningonport/store/postgres/full_store.go
+++ b/central/processlisteningonport/store/postgres/full_store.go
@@ -83,16 +83,16 @@ func (s *fullStoreImpl) retryableGetPLOP(
 }
 
 func plopComparison(plop1 *storage.ProcessListeningOnPort, plop2 *storage.ProcessListeningOnPort) bool {
-        if plop1.PodId != plop2.PodId {
-                return plop1.PodId < plop2.PodId
-        }
-        if plop1.Signal.ExecFilePath != plop2.Signal.ExecFilePath {
-                return plop1.Signal.ExecFilePath < plop2.Signal.ExecFilePath
-        }
-        if plop1.Endpoint.Port != plop2.Endpoint.Port {
-                return plop1.Endpoint.Port < plop2.Endpoint.Port
-        }
-        return plop1.Endpoint.Protocol < plop2.Endpoint.Protocol
+	if plop1.PodId != plop2.PodId {
+		return plop1.PodId < plop2.PodId
+	}
+	if plop1.Signal.ExecFilePath != plop2.Signal.ExecFilePath {
+		return plop1.Signal.ExecFilePath < plop2.Signal.ExecFilePath
+	}
+	if plop1.Endpoint.Port != plop2.Endpoint.Port {
+		return plop1.Endpoint.Port < plop2.Endpoint.Port
+	}
+	return plop1.Endpoint.Protocol < plop2.Endpoint.Protocol
 }
 
 func sortPlops(plops []*storage.ProcessListeningOnPort) {

--- a/central/processlisteningonport/store/postgres/full_store.go
+++ b/central/processlisteningonport/store/postgres/full_store.go
@@ -86,9 +86,27 @@ func plopComparison(plop1 *storage.ProcessListeningOnPort, plop2 *storage.Proces
 	if plop1.PodId != plop2.PodId {
 		return plop1.PodId < plop2.PodId
 	}
+
+	if plop1.Signal == nil {
+		return true
+	}
+
+	if plop2.Signal == nil {
+		return false
+	}
+
 	if plop1.Signal.ExecFilePath != plop2.Signal.ExecFilePath {
 		return plop1.Signal.ExecFilePath < plop2.Signal.ExecFilePath
 	}
+
+	if plop1.Endpoint == nil {
+		return true
+	}
+
+	if plop2.Endpoint == nil {
+		return false
+	}
+
 	if plop1.Endpoint.Port != plop2.Endpoint.Port {
 		return plop1.Endpoint.Port < plop2.Endpoint.Port
 	}

--- a/central/processlisteningonport/store/postgres/sort_test.go
+++ b/central/processlisteningonport/store/postgres/sort_test.go
@@ -1,0 +1,140 @@
+package postgres
+
+import (
+	"math/rand"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/suite"
+)
+
+type SortSuite struct {
+	suite.Suite
+}
+
+func TestSortSuite(t *testing.T) {
+	suite.Run(t, new(SortSuite))
+}
+
+func makeRandomString(length int) string {
+	var charset = []byte("asdfqwert")
+	randomString := make([]byte, length)
+	for i := range randomString {
+		randomString[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(randomString)
+}
+
+func makeRandomPlops(nport int, nprocess int, npod int) []*storage.ProcessListeningOnPort {
+	deploymentId := makeRandomString(10)
+	count := 0
+
+	plops := make([]*storage.ProcessListeningOnPort, 2*nport*nprocess*npod)
+	for podIdx := 0; podIdx < npod; podIdx++ {
+		podId := makeRandomString(10)
+		podUid := makeRandomString(10)
+		for processIdx := 0; processIdx < nprocess; processIdx++ {
+			execFilePath := makeRandomString(10)
+			for port := 0; port < nport; port++ {
+
+				plopTcp := &storage.ProcessListeningOnPort{
+					Endpoint: &storage.ProcessListeningOnPort_Endpoint{
+						Port:     uint32(port),
+						Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+					},
+					DeploymentId:  deploymentId,
+					PodId:         podId,
+					PodUid:        podUid,
+					Signal: &storage.ProcessSignal{
+						ExecFilePath: execFilePath,
+					},
+				}
+				plopUdp := &storage.ProcessListeningOnPort{
+					Endpoint: &storage.ProcessListeningOnPort_Endpoint{
+						Port:     uint32(port),
+						Protocol: storage.L4Protocol_L4_PROTOCOL_UDP,
+					},
+					DeploymentId:  deploymentId,
+					PodId:         podId,
+					PodUid:        podUid,
+					Signal: &storage.ProcessSignal{
+						ExecFilePath: execFilePath,
+					},
+				}
+				plops[count] = plopTcp
+				count++
+				plops[count] = plopUdp
+				count++
+			}
+		}
+	}
+
+	return plops
+}
+
+
+func (s *SortSuite) TestSort1000() {
+	nport := 10
+	nprocess := 10
+	npod := 10
+	plops := makeRandomPlops(nport, nprocess, npod)
+
+	startTime := time.Now()
+	sortPlops(plops)
+	duration := time.Since(startTime)
+
+
+	fmt.Printf("Sorting %d took %s\n", len(plops), duration)
+
+}
+
+func (s *SortSuite) TestSort8000() {
+	nport := 20
+	nprocess := 20
+	npod := 20
+	plops := makeRandomPlops(nport, nprocess, npod)
+
+	startTime := time.Now()
+	sortPlops(plops)
+	duration := time.Since(startTime)
+
+
+	fmt.Printf("Sorting %d took %s\n", len(plops), duration)
+
+}
+
+func (s *SortSuite) TestSort125000() {
+	nport := 50
+	nprocess := 50
+	npod := 50
+	plops := makeRandomPlops(nport, nprocess, npod)
+
+	startTime := time.Now()
+	sortPlops(plops)
+	duration := time.Since(startTime)
+
+
+	fmt.Printf("Sorting %d took %s\n", len(plops), duration)
+
+}
+
+func (s *SortSuite) TestSort1000000() {
+	nport := 100
+	nprocess := 100
+	npod := 100
+	plops := makeRandomPlops(nport, nprocess, npod)
+
+	startTime := time.Now()
+	sortPlops(plops)
+	duration := time.Since(startTime)
+
+	// var m runtime.MemStats
+	// runtime.ReadMemStats(&m)
+	// fmt.Printf("Memory usage: %d bytes\n", m.Alloc)
+
+
+	fmt.Printf("Sorting %d took %s\n", len(plops), duration)
+
+}

--- a/central/processlisteningonport/store/postgres/sort_test.go
+++ b/central/processlisteningonport/store/postgres/sort_test.go
@@ -1,8 +1,8 @@
 package postgres
 
 import (
-	"math/rand"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -29,44 +29,44 @@ func makeRandomString(length int) string {
 }
 
 func makeRandomPlops(nport int, nprocess int, npod int) []*storage.ProcessListeningOnPort {
-	deploymentId := makeRandomString(10)
+	deploymentID := makeRandomString(10)
 	count := 0
 
 	plops := make([]*storage.ProcessListeningOnPort, 2*nport*nprocess*npod)
 	for podIdx := 0; podIdx < npod; podIdx++ {
-		podId := makeRandomString(10)
-		podUid := makeRandomString(10)
+		podID := makeRandomString(10)
+		podUID := makeRandomString(10)
 		for processIdx := 0; processIdx < nprocess; processIdx++ {
 			execFilePath := makeRandomString(10)
 			for port := 0; port < nport; port++ {
 
-				plopTcp := &storage.ProcessListeningOnPort{
+				plopTCP := &storage.ProcessListeningOnPort{
 					Endpoint: &storage.ProcessListeningOnPort_Endpoint{
 						Port:     uint32(port),
 						Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
 					},
-					DeploymentId:  deploymentId,
-					PodId:         podId,
-					PodUid:        podUid,
+					DeploymentId: deploymentID,
+					PodId:        podID,
+					PodUid:       podUID,
 					Signal: &storage.ProcessSignal{
 						ExecFilePath: execFilePath,
 					},
 				}
-				plopUdp := &storage.ProcessListeningOnPort{
+				plopUDP := &storage.ProcessListeningOnPort{
 					Endpoint: &storage.ProcessListeningOnPort_Endpoint{
 						Port:     uint32(port),
 						Protocol: storage.L4Protocol_L4_PROTOCOL_UDP,
 					},
-					DeploymentId:  deploymentId,
-					PodId:         podId,
-					PodUid:        podUid,
+					DeploymentId: deploymentID,
+					PodId:        podID,
+					PodUid:       podUID,
 					Signal: &storage.ProcessSignal{
 						ExecFilePath: execFilePath,
 					},
 				}
-				plops[count] = plopTcp
+				plops[count] = plopTCP
 				count++
-				plops[count] = plopUdp
+				plops[count] = plopUDP
 				count++
 			}
 		}
@@ -74,7 +74,6 @@ func makeRandomPlops(nport int, nprocess int, npod int) []*storage.ProcessListen
 
 	return plops
 }
-
 
 func (suite *SortSuite) TestSort1000() {
 	nport := 10
@@ -85,7 +84,6 @@ func (suite *SortSuite) TestSort1000() {
 	startTime := time.Now()
 	sortPlops(plops)
 	duration := time.Since(startTime)
-
 
 	fmt.Printf("Sorting %d took %s\n", len(plops), duration)
 
@@ -101,7 +99,6 @@ func (suite *SortSuite) TestSort8000() {
 	sortPlops(plops)
 	duration := time.Since(startTime)
 
-
 	fmt.Printf("Sorting %d took %s\n", len(plops), duration)
 
 }
@@ -115,7 +112,6 @@ func (suite *SortSuite) TestSort125000() {
 	startTime := time.Now()
 	sortPlops(plops)
 	duration := time.Since(startTime)
-
 
 	fmt.Printf("Sorting %d took %s\n", len(plops), duration)
 
@@ -131,23 +127,9 @@ func (suite *SortSuite) TestSort1000000() {
 	sortPlops(plops)
 	duration := time.Since(startTime)
 
-
 	fmt.Printf("Sorting %d took %s\n", len(plops), duration)
 
 }
-
-// func plopComparison(plop1 *storage.ProcessListeningOnPort, plop2 *storage.ProcessListeningOnPort) bool {
-// 	if plop1.PodId != plop2.PodId {
-// 		return plop1.PodId < plop2.PodId
-// 	}
-// 	if plop1.Signal.ExecFilePath != plop2.Signal.ExecFilePath {
-// 		return plop1.Signal.ExecFilePath < plop2.Signal.ExecFilePath
-// 	}
-// 	if plop1.Endpoint.Port != plop2.Endpoint.Port {
-// 		return plop1.Endpoint.Port < plop2.Endpoint.Port
-// 	}
-// 	return plop1.Endpoint.Protocol < plop2.Endpoint.Protocol
-// }
 
 func (suite *SortSuite) TestSortVarious() {
 
@@ -159,9 +141,9 @@ func (suite *SortSuite) TestSortVarious() {
 			Port:     80,
 			Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
 		},
-		DeploymentId:  fixtureconsts.Deployment1,
-		PodId:         fixtureconsts.PodName1,
-		PodUid:        fixtureconsts.PodUID1,
+		DeploymentId: fixtureconsts.Deployment1,
+		PodId:        fixtureconsts.PodName1,
+		PodUid:       fixtureconsts.PodUID1,
 		Signal: &storage.ProcessSignal{
 			ExecFilePath: execFilePath1,
 		},
@@ -172,9 +154,9 @@ func (suite *SortSuite) TestSortVarious() {
 			Port:     1234,
 			Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
 		},
-		DeploymentId:  fixtureconsts.Deployment1,
-		PodId:         fixtureconsts.PodName1,
-		PodUid:        fixtureconsts.PodUID1,
+		DeploymentId: fixtureconsts.Deployment1,
+		PodId:        fixtureconsts.PodName1,
+		PodUid:       fixtureconsts.PodUID1,
 		Signal: &storage.ProcessSignal{
 			ExecFilePath: execFilePath1,
 		},
@@ -185,9 +167,9 @@ func (suite *SortSuite) TestSortVarious() {
 			Port:     1234,
 			Protocol: storage.L4Protocol_L4_PROTOCOL_UDP,
 		},
-		DeploymentId:  fixtureconsts.Deployment1,
-		PodId:         fixtureconsts.PodName1,
-		PodUid:        fixtureconsts.PodUID1,
+		DeploymentId: fixtureconsts.Deployment1,
+		PodId:        fixtureconsts.PodName1,
+		PodUid:       fixtureconsts.PodUID1,
 		Signal: &storage.ProcessSignal{
 			ExecFilePath: execFilePath1,
 		},
@@ -198,9 +180,9 @@ func (suite *SortSuite) TestSortVarious() {
 			Port:     1234,
 			Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
 		},
-		DeploymentId:  fixtureconsts.Deployment1,
-		PodId:         fixtureconsts.PodName1,
-		PodUid:        fixtureconsts.PodUID1,
+		DeploymentId: fixtureconsts.Deployment1,
+		PodId:        fixtureconsts.PodName1,
+		PodUid:       fixtureconsts.PodUID1,
 		Signal: &storage.ProcessSignal{
 			ExecFilePath: execFilePath2,
 		},
@@ -211,9 +193,9 @@ func (suite *SortSuite) TestSortVarious() {
 			Port:     1234,
 			Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
 		},
-		DeploymentId:  fixtureconsts.Deployment1,
-		PodId:         fixtureconsts.PodName2,
-		PodUid:        fixtureconsts.PodUID2,
+		DeploymentId: fixtureconsts.Deployment1,
+		PodId:        fixtureconsts.PodName2,
+		PodUid:       fixtureconsts.PodUID2,
 		Signal: &storage.ProcessSignal{
 			ExecFilePath: execFilePath1,
 		},

--- a/central/processlisteningonport/store/postgres/sort_test.go
+++ b/central/processlisteningonport/store/postgres/sort_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -75,7 +76,7 @@ func makeRandomPlops(nport int, nprocess int, npod int) []*storage.ProcessListen
 }
 
 
-func (s *SortSuite) TestSort1000() {
+func (suite *SortSuite) TestSort1000() {
 	nport := 10
 	nprocess := 10
 	npod := 10
@@ -90,7 +91,7 @@ func (s *SortSuite) TestSort1000() {
 
 }
 
-func (s *SortSuite) TestSort8000() {
+func (suite *SortSuite) TestSort8000() {
 	nport := 20
 	nprocess := 20
 	npod := 20
@@ -105,7 +106,7 @@ func (s *SortSuite) TestSort8000() {
 
 }
 
-func (s *SortSuite) TestSort125000() {
+func (suite *SortSuite) TestSort125000() {
 	nport := 50
 	nprocess := 50
 	npod := 50
@@ -120,7 +121,7 @@ func (s *SortSuite) TestSort125000() {
 
 }
 
-func (s *SortSuite) TestSort1000000() {
+func (suite *SortSuite) TestSort1000000() {
 	nport := 100
 	nprocess := 100
 	npod := 100
@@ -130,11 +131,99 @@ func (s *SortSuite) TestSort1000000() {
 	sortPlops(plops)
 	duration := time.Since(startTime)
 
-	// var m runtime.MemStats
-	// runtime.ReadMemStats(&m)
-	// fmt.Printf("Memory usage: %d bytes\n", m.Alloc)
-
 
 	fmt.Printf("Sorting %d took %s\n", len(plops), duration)
 
+}
+
+// func plopComparison(plop1 *storage.ProcessListeningOnPort, plop2 *storage.ProcessListeningOnPort) bool {
+// 	if plop1.PodId != plop2.PodId {
+// 		return plop1.PodId < plop2.PodId
+// 	}
+// 	if plop1.Signal.ExecFilePath != plop2.Signal.ExecFilePath {
+// 		return plop1.Signal.ExecFilePath < plop2.Signal.ExecFilePath
+// 	}
+// 	if plop1.Endpoint.Port != plop2.Endpoint.Port {
+// 		return plop1.Endpoint.Port < plop2.Endpoint.Port
+// 	}
+// 	return plop1.Endpoint.Protocol < plop2.Endpoint.Protocol
+// }
+
+func (suite *SortSuite) TestSortVarious() {
+
+	execFilePath1 := "app"
+	execFilePath2 := "zap"
+
+	plop1 := storage.ProcessListeningOnPort{
+		Endpoint: &storage.ProcessListeningOnPort_Endpoint{
+			Port:     80,
+			Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+		},
+		DeploymentId:  fixtureconsts.Deployment1,
+		PodId:         fixtureconsts.PodName1,
+		PodUid:        fixtureconsts.PodUID1,
+		Signal: &storage.ProcessSignal{
+			ExecFilePath: execFilePath1,
+		},
+	}
+
+	plop2 := storage.ProcessListeningOnPort{
+		Endpoint: &storage.ProcessListeningOnPort_Endpoint{
+			Port:     1234,
+			Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+		},
+		DeploymentId:  fixtureconsts.Deployment1,
+		PodId:         fixtureconsts.PodName1,
+		PodUid:        fixtureconsts.PodUID1,
+		Signal: &storage.ProcessSignal{
+			ExecFilePath: execFilePath1,
+		},
+	}
+
+	plop3 := storage.ProcessListeningOnPort{
+		Endpoint: &storage.ProcessListeningOnPort_Endpoint{
+			Port:     1234,
+			Protocol: storage.L4Protocol_L4_PROTOCOL_UDP,
+		},
+		DeploymentId:  fixtureconsts.Deployment1,
+		PodId:         fixtureconsts.PodName1,
+		PodUid:        fixtureconsts.PodUID1,
+		Signal: &storage.ProcessSignal{
+			ExecFilePath: execFilePath1,
+		},
+	}
+
+	plop4 := storage.ProcessListeningOnPort{
+		Endpoint: &storage.ProcessListeningOnPort_Endpoint{
+			Port:     1234,
+			Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+		},
+		DeploymentId:  fixtureconsts.Deployment1,
+		PodId:         fixtureconsts.PodName1,
+		PodUid:        fixtureconsts.PodUID1,
+		Signal: &storage.ProcessSignal{
+			ExecFilePath: execFilePath2,
+		},
+	}
+
+	plop5 := storage.ProcessListeningOnPort{
+		Endpoint: &storage.ProcessListeningOnPort_Endpoint{
+			Port:     1234,
+			Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+		},
+		DeploymentId:  fixtureconsts.Deployment1,
+		PodId:         fixtureconsts.PodName2,
+		PodUid:        fixtureconsts.PodUID2,
+		Signal: &storage.ProcessSignal{
+			ExecFilePath: execFilePath1,
+		},
+	}
+
+	plops := []*storage.ProcessListeningOnPort{&plop3, &plop5, &plop1, &plop2, &plop4}
+
+	sortPlops(plops)
+
+	expectedSortedPlops := []*storage.ProcessListeningOnPort{&plop1, &plop2, &plop3, &plop4, &plop5}
+
+	suite.Equal(expectedSortedPlops, plops)
 }

--- a/central/processlisteningonport/store/postgres/sort_test.go
+++ b/central/processlisteningonport/store/postgres/sort_test.go
@@ -1,10 +1,7 @@
 package postgres
 
 import (
-	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
@@ -17,118 +14,6 @@ type SortSuite struct {
 
 func TestSortSuite(t *testing.T) {
 	suite.Run(t, new(SortSuite))
-}
-
-func makeRandomString(length int) string {
-	var charset = []byte("asdfqwert")
-	randomString := make([]byte, length)
-	for i := range randomString {
-		randomString[i] = charset[rand.Intn(len(charset))]
-	}
-	return string(randomString)
-}
-
-func makeRandomPlops(nport int, nprocess int, npod int) []*storage.ProcessListeningOnPort {
-	deploymentID := makeRandomString(10)
-	count := 0
-
-	plops := make([]*storage.ProcessListeningOnPort, 2*nport*nprocess*npod)
-	for podIdx := 0; podIdx < npod; podIdx++ {
-		podID := makeRandomString(10)
-		podUID := makeRandomString(10)
-		for processIdx := 0; processIdx < nprocess; processIdx++ {
-			execFilePath := makeRandomString(10)
-			for port := 0; port < nport; port++ {
-
-				plopTCP := &storage.ProcessListeningOnPort{
-					Endpoint: &storage.ProcessListeningOnPort_Endpoint{
-						Port:     uint32(port),
-						Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
-					},
-					DeploymentId: deploymentID,
-					PodId:        podID,
-					PodUid:       podUID,
-					Signal: &storage.ProcessSignal{
-						ExecFilePath: execFilePath,
-					},
-				}
-				plopUDP := &storage.ProcessListeningOnPort{
-					Endpoint: &storage.ProcessListeningOnPort_Endpoint{
-						Port:     uint32(port),
-						Protocol: storage.L4Protocol_L4_PROTOCOL_UDP,
-					},
-					DeploymentId: deploymentID,
-					PodId:        podID,
-					PodUid:       podUID,
-					Signal: &storage.ProcessSignal{
-						ExecFilePath: execFilePath,
-					},
-				}
-				plops[count] = plopTCP
-				count++
-				plops[count] = plopUDP
-				count++
-			}
-		}
-	}
-
-	return plops
-}
-
-func (suite *SortSuite) TestSort1000() {
-	nport := 10
-	nprocess := 10
-	npod := 10
-	plops := makeRandomPlops(nport, nprocess, npod)
-
-	startTime := time.Now()
-	sortPlops(plops)
-	duration := time.Since(startTime)
-
-	fmt.Printf("Sorting %d took %s\n", len(plops), duration)
-
-}
-
-func (suite *SortSuite) TestSort8000() {
-	nport := 20
-	nprocess := 20
-	npod := 20
-	plops := makeRandomPlops(nport, nprocess, npod)
-
-	startTime := time.Now()
-	sortPlops(plops)
-	duration := time.Since(startTime)
-
-	fmt.Printf("Sorting %d took %s\n", len(plops), duration)
-
-}
-
-func (suite *SortSuite) TestSort125000() {
-	nport := 50
-	nprocess := 50
-	npod := 50
-	plops := makeRandomPlops(nport, nprocess, npod)
-
-	startTime := time.Now()
-	sortPlops(plops)
-	duration := time.Since(startTime)
-
-	fmt.Printf("Sorting %d took %s\n", len(plops), duration)
-
-}
-
-func (suite *SortSuite) TestSort1000000() {
-	nport := 100
-	nprocess := 100
-	npod := 100
-	plops := makeRandomPlops(nport, nprocess, npod)
-
-	startTime := time.Now()
-	sortPlops(plops)
-	duration := time.Since(startTime)
-
-	fmt.Printf("Sorting %d took %s\n", len(plops), duration)
-
 }
 
 func (suite *SortSuite) TestSortVarious() {

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -111,7 +111,8 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         def list = processesListeningOnPorts.listeningEndpointsList
         assert list.size() == 2
 
-        def endpoint1 = list.find { it.endpoint.port == 80 }
+        def endpoint1 = list[0]
+        //def endpoint1 = list.find { it.endpoint.port == 80 }
 
         assert endpoint1
         assert endpoint1.deploymentId
@@ -122,7 +123,8 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         assert endpoint1.signal.execFilePath == "/usr/bin/socat"
         assert endpoint1.signal.args == "-d -d -v TCP-LISTEN:80,fork STDOUT"
 
-        def endpoint2 = list.find { it.endpoint.port == 8080 }
+        def endpoint2 = list[1]
+        //def endpoint2 = list.find { it.endpoint.port == 8080 }
 
         assert endpoint2
         assert endpoint2.deploymentId

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -112,7 +112,6 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         assert list.size() == 2
 
         def endpoint1 = list[0]
-        //def endpoint1 = list.find { it.endpoint.port == 80 }
 
         assert endpoint1
         assert endpoint1.deploymentId
@@ -124,7 +123,6 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         assert endpoint1.signal.args == "-d -d -v TCP-LISTEN:80,fork STDOUT"
 
         def endpoint2 = list[1]
-        //def endpoint2 = list.find { it.endpoint.port == 8080 }
 
         assert endpoint2
         assert endpoint2.deploymentId


### PR DESCRIPTION
## Description

Sorts API responses by podID, executable file path, port, and protocol.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Checked the ordering in the UI
- [x] Bench marking
- [x] Load testing
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Checking the UI

![Screenshot from 2023-10-02 18-30-22](https://github.com/stackrox/stackrox/assets/24723000/58b0bac9-d3e4-4289-98f2-6c85a1d902ef)

The UI has the desired ordering.

### Benchmarking

The time used by the sorting function was measured on another branch, https://github.com/stackrox/stackrox/pull/8299

```
git checkout jv-ROX-19888-better-sorting-of-listening-endpoints-testing
cd central/processlisteningonport/store/postgres
go test
Sorting 2000 took 218.638µs
Sorting 2000000 took 554.243997ms
Sorting 250000 took 55.002619ms
Sorting 16000 took 2.102102ms
```

Not sure how much extra memory was used.

### Benchmarking with db

```
git checkout jv-ROX-19888-better-sorting-of-listening-endpoints-testing
cd central/processlisteningonport/datastore

go test -tags=sql_integration -v
```

Without sorting 
```
=== RUN   TestPLOPDataStore/TestSort1000000
Fetching 2000000 plops 2.419662924s took
```

With sorting
```
=== RUN   TestPLOPDataStore/TestSort1000000
Fetching 2000000 plops 3.804959441s took
```
In production the number of fetched plops will be orders of magnitude less than this.

### Load testing

The testing version of this branch was checked out. It had some improvements for the load generation.

```
git checkout jv-ROX-19888-better-sorting-of-listening-endpoints-testing
```

The following script was used generate load for testing
```
#!/usr/bin/env bash
set -eou pipefail

cluster_name=$1
tag=${2:-}

export CLUSTER_NAME="$cluster_name"
export MAIN_IMAGE_TAG=$tag

if [[ -z "$tag" ]]; then
	tag="$(make tag)"
fi
echo "tag= $tag"

build=true

if [[ $build == "true" ]]; then
    printf 'yes\n'  | /home/jvirtane/go/src/github.com/stackrox/workflow/scripts/runtime/teardown.sh &
    make image
    make central-db-image
    make docker-build-roxctl-image
    docker tag quay.io/stackrox-io/main:$tag quay.io/jvirtane/main:$tag
    docker push quay.io/jvirtane/main:$tag
    docker tag quay.io/stackrox-io/central-db:$tag quay.io/jvirtane/central-db:$tag
    docker push quay.io/jvirtane/central-db:$tag
    docker tag quay.io/stackrox-io/roxctl:$tag quay.io/jvirtane/roxctl:$tag
    docker push quay.io/jvirtane/roxctl:$tag
else
    printf 'yes\n' | /home/jvirtane/go/src/github.com/stackrox/workflow/scripts/runtime/teardown.sh
fi

infractl get $CLUSTER_NAME --json | jq '.Connect' -r | bash

export USE_MIDSTREAM_IMAGES=false

export MAIN_IMAGE_REPO=quay.io/jvirtane/main
export CENTRAL_DB_IMAGE_REPO=quay.io/jvirtane/central-db
export ROXCTL_IMAGE_REPO=quay.io/jvirtane/roxctl

export API_ENDPOINT=localhost:8000

export STORAGE=pvc # Backing storage
export STORAGE_CLASS=faster # Runs on an SSD type
export STORAGE_SIZE=100 # 100G
export MONITORING_SUPPORT=true # Runs monitoring
export LOAD_BALANCER=lb

./deploy/k8s/central.sh # Launches central

kubectl -n stackrox port-forward deploy/central 8000:8443 > /dev/null 2>&1 &

sleep 20

export ROX_ADMIN_USERNAME=admin

password="$(cat deploy/k8s/central-deploy/password)"

export ROX_ADMIN_PASSWORD="$password"

./deploy/k8s/sensor.sh

kubectl -n stackrox set env deploy/sensor MUTEX_WATCHDOG_TIMEOUT_SEC=0
kubectl -n stackrox set env deploy/sensor ROX_FAKE_KUBERNETES_WORKLOAD=long-running

kubectl -n stackrox set env deploy/central MUTEX_WATCHDOG_TIMEOUT_SECS=0

./scale/launch_workload.sh sort-plop

```

You may need to make manual changes to push to your repository instead.

The workload for the test was the following
```
$ cat scale/workloads/sort-plop.yaml
deploymentWorkload:
- deploymentType: Deployment
  lifecycleDuration: 72h
  numDeployments: 1
  numLifecycles: 0
  podWorkload:
    containerWorkload:
      numImages: 0
    lifecycleDuration: 72h
    numContainers: 30
    numPods: 50
    processWorkload:
      alertRate: 0.001
      processInterval: 1s
  updateInterval: 10m0s
networkWorkload:
  batchSize: 5000
  flowInterval: 30s
nodeWorkload:
  numNodes: 1
rbacWorkload:
  numBindings: 100
  numRoles: 100
  numServiceAccounts: 100
```
The number of deployments was set to 1 so that when the API was called all of the listening endpoints would be sorted and central would be under maximum stress. The number of pods and containers was increased compensate for the low number of deployments. lifecycleDuration was set to a long time, so that the pods and their associated listening endpoints would not be deleted.

The image repository for sensor was set manually after running the script.

```
central_active=# select count(*) from listening_endpoints ;
-[ RECORD 1 ]-
count | 199883

central_active=# select count(*) from process_indicators ;
-[ RECORD 1 ]
count | 9993
```

```
central_active=# select distinct deploymentid from listening_endpoints ;
-[ RECORD 1 ]+-------------------------------------
deploymentid | 80afe7c2-0c93-46b6-a7d6-886ea521116e
```

This confirms that there is only one deployment.

Once this number of records were in the database, sensor was killed so that the number of records would not change during the tests.

```
ks delete deployment sensor
```

The following script was run generate the test file

```
$ cat MakeK6.sh 
#!/usr/bin/env bash
set -eoux pipefail

outfile=$1

port=8000

logmein localhost:$port &> token_file.txt

token="$(cat token_file.txt | sed 's|.*token=||' | sed 's|&type.*||')"

password="$(cat ./deploy/k8s/central-deploy/password)"

curl -sSkf -u "admin:$password" -o /dev/null -w '%{redirect_url}' "https://localhost:$port/sso/providers/basic/4df1b98c-24ed-4073-a9ad-356aec6bb62d/challenge?micro_ts=0"

deployments="$(curl --location --request GET "https://localhost:$port/v1/deployments" -k -H "Authorization: Bearer $token")"


deployment="$(echo "$deployments" | jq -r .deployments[0].id)"

ndeployment="$(echo $deployments | jq '.deployments | length')"

cp k6-script-prefix.js $outfile

for ((i = 0; i < ndeployment; i = i + 1)); do
    deployment="$(echo "$deployments" | jq -r .deployments[$i].id)"

    echo "deployment= $deployment"
    echo "  postman[Request]({" >> $outfile
    echo "    name: \"https://localhost:$port/v1/listening_endpoints/deployment/$deployment\"," >> $outfile
    echo "    id: \"$deployment\"," >> $outfile
    echo "    method: \"GET\"," >> $outfile
    echo "    address:" >> $outfile
    echo "      \"https://localhost:$port/v1/listening_endpoints/deployment/$deployment\"," >> $outfile
    echo "    auth(config, Var) {" >> $outfile
    echo "      config.headers.Authorization =" >> $outfile
    echo "        \"Bearer $token\";" >> $outfile
    echo "    }," >> $outfile
    echo "  });" >> $outfile
    echo "" >> $outfile
done


echo "}" >> $outfile
```

```
$ cat k6-script-prefix.js
import "/home/jvirtane/.nvm/versions/node/v20.7.0/lib/node_modules/postman-to-k6/lib/shim/core.js";

export let options = { maxRedirects: 4, insecureSkipTLSVerify: true };

const Request = Symbol.for("request");
postman[Symbol.for("initial")]({
  options,
});

export default function () {
```

The command to generate the test file was 

```
/MakeK6.sh k6-sort-plop-delete-2.js
```


The following script was run to perform load testing and monitor CPU and memory usage during the test.

```
$ cat K6AndTopPod.sh 
#!/usr/bin/env bash
set -eou pipefail

suffix=$1

./TopPod.sh &> top_pod_${suffix}.txt & 
sleep 5
k6 run /home/jvirtane/go/src/github.com/stackrox/stackrox/k6-sort-plop-delete-2.js --vus 5 --iterations 10 --out csv=k6-sort-plop-delete.csv &> k6_load_testing_${suffix}.txt
```

With TopPod.sh having the following
```
#!/usr/bin/env bash
set -eou pipefail

while true; do
	kubectl -n stackrox top pod
	sleep 1
done
```

#### Results with sorting

```
./K6AndTopPod.sh with_sort
```

```
          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: /home/jvirtane/go/src/github.com/stackrox/stackrox/k6-sort-plop-delete-2.js
     output: csv (k6-sort-plop-delete.csv)

  scenarios: (100.00%) 1 scenario, 5 max VUs, 10m30s max duration (incl. graceful stop):
           * default: 10 iterations shared among 5 VUs (maxDuration: 10m0s, gracefulStop: 30s)


     data_received..................: 696 MB 13 MB/s
     data_sent......................: 1.1 MB 20 kB/s
     http_req_blocked...............: avg=103.11ms min=264ns   med=98.75ms  max=208.83ms p(90)=208.75ms p(95)=208.79ms
     http_req_connecting............: avg=71.02µs  min=0s      med=66.51µs  max=152.72µs p(90)=147.35µs p(95)=150.03µs
     http_req_duration..............: avg=25.77s   min=9.82s   med=25.71s   max=34.32s   p(90)=33.93s   p(95)=34.13s
       { expected_response:true }...: avg=25.77s   min=9.82s   med=25.71s   max=34.32s   p(90)=33.93s   p(95)=34.13s
     http_req_failed................: 0.00%  ✓ 0       ✗ 10
     http_req_receiving.............: avg=16.63s   min=5.89s   med=16.61s   max=22.87s   p(90)=22.85s   p(95)=22.86s
     http_req_sending...............: avg=254.35µs min=44.01µs med=244.67µs max=490.96µs p(90)=490.46µs p(95)=490.71µs
     http_req_tls_handshaking.......: avg=102.48ms min=0s      med=98.11ms  max=207.56ms p(90)=207.49ms p(95)=207.52ms
     http_req_waiting...............: avg=9.13s    min=3.93s   med=9.23s    max=11.67s   p(90)=11.41s   p(95)=11.54s
     http_reqs......................: 10     0.18141/s
     iteration_duration.............: avg=25.87s   min=9.82s   med=25.81s   max=34.53s   p(90)=34.14s   p(95)=34.34s
     iterations.....................: 10     0.18141/s
     vus............................: 2      min=2     max=5
     vus_max........................: 5      min=5     max=5


running (00m55.1s), 0/5 VUs, 10 complete and 0 interrupted iterations
default ✓ [ 100% ] 5 VUs  00m55.1s/10m0s  10/10 shared iters
```

#### Results without sorting

```
git checkout jv-ROX-19888-better-sorting-of-listening-endpoints-testing-without-sort

make image
```

Push the image if needed. Change the image for central manually.
Run the load test with monitoring.

```
./K6AndTopPod.sh without_sort
```

```
          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: /home/jvirtane/go/src/github.com/stackrox/stackrox/k6-sort-plop-delete-2.js
     output: csv (k6-sort-plop-delete.csv)

  scenarios: (100.00%) 1 scenario, 5 max VUs, 10m30s max duration (incl. graceful stop):
           * default: 10 iterations shared among 5 VUs (maxDuration: 10m0s, gracefulStop: 30s)


     data_received..................: 696 MB 13 MB/s
     data_sent......................: 1.1 MB 20 kB/s
     http_req_blocked...............: avg=100.76ms min=242ns   med=97.22ms max=204.25ms p(90)=204.2ms  p(95)=204.22ms
     http_req_connecting............: avg=45.05µs  min=0s      med=41.52µs max=94.68µs  p(90)=93.74µs  p(95)=94.21µs
     http_req_duration..............: avg=26.16s   min=23.8s   med=26.36s  max=27.5s    p(90)=27.47s   p(95)=27.49s
       { expected_response:true }...: avg=26.16s   min=23.8s   med=26.36s  max=27.5s    p(90)=27.47s   p(95)=27.49s
     http_req_failed................: 0.00%  ✓ 0        ✗ 10
     http_req_receiving.............: avg=16.81s   min=16.24s  med=16.66s  max=17.88s   p(90)=17.46s   p(95)=17.67s
     http_req_sending...............: avg=88.09µs  min=45.84µs med=85.49µs max=168.12µs p(90)=123.9µs  p(95)=146.01µs
     http_req_tls_handshaking.......: avg=100.24ms min=0s      med=96.67ms max=203.16ms p(90)=203.14ms p(95)=203.15ms
     http_req_waiting...............: avg=9.34s    min=7.07s   med=9.39s   max=11.19s   p(90)=11.05s   p(95)=11.12s
     http_reqs......................: 10     0.187838/s
     iteration_duration.............: avg=26.27s   min=23.8s   med=26.47s  max=27.71s   p(90)=27.67s   p(95)=27.69s
     iterations.....................: 10     0.187838/s
     vus............................: 3      min=3      max=5
     vus_max........................: 5      min=5      max=5


running (00m53.2s), 0/5 VUs, 10 complete and 0 interrupted iterations
default ✓ [ 100% ] 5 VUs  00m53.2s/10m0s  10/10 shared iters
```

#### Comparison of load testing with and without sorting

![Screenshot from 2023-10-25 16-47-43](https://github.com/stackrox/stackrox/assets/24723000/15b0f793-f502-4c54-8578-edb8bcae0b3a)

Here the initial baseline memory usage before the API call, is subtracted from each point. The maximum memory usage is approximately the same. However the peak in the memory usage lasts much longer when there is sorting, than without. The duration of high memory usage is longer when there is sorting.

![Screenshot from 2023-10-25 16-58-52](https://github.com/stackrox/stackrox/assets/24723000/df28ebe2-bac5-40b7-80de-ba7dc6734c52)

Again the peak CPU memory usage is very similar for the two cases, but the duration of high memory usage is greater for sorting. The CPU usage is high until only about ~70 second mark. This suggests that the high memory usage after 70 seconds is not because the listening endpoints are still being operated on, but because they are being held in memory until the API response is done being sent, which takes a long time as there are ~200,000 listening endpoints.

Looking at the K6 output. There doesn't seem to be much difference. The most important thing is that in both cases all of the requests succeeded. 

The next most important things are the p(90) and p(95) for http_req_waiting.

```
--------------------------------------
|             | Sorting | No Sorting |
--------------------------------------
|p(90) (s)    | 11.41   | 11.05      |
--------------------------------------
|p(95) (s)    | 11.54   | 11.12      |
--------------------------------------
```

These are very long times for an API response, but keep in mind that ~200,000 records are processed in this case. There is no significant difference here between sorting and not sorting.

#### Load testing one single API call

The above load testing performed 10 queries to the API. The load testing was done with just one API call to measure the memory used when doing just one API call.

![Screenshot from 2023-10-26 14-31-05](https://github.com/stackrox/stackrox/assets/24723000/fc24d52a-388a-47fc-983d-a18362a3a9a5)

With one API call the memory used increased by 1 Gi as opposed to 2 Gi when doing the load testing with 10 API calls.

In this case there where 194,939 listening_endpoints and 25,225 listening_endpoints.

```
central_active=# select count(*) from listening_endpoints ;
-[ RECORD 1 ]-
count | 194939

central_active=# select count(*) from process_indicators ;
-[ RECORD 1 ]
count | 25225
``` 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
