### PR TITLE
ROX-19910: Add administration events query string to page address

### DIFF
--- a/ui/apps/platform/cypress/integration/administration/events/AdministrationEvents.helpers.js
+++ b/ui/apps/platform/cypress/integration/administration/events/AdministrationEvents.helpers.js
@@ -9,11 +9,11 @@ export const eventsCountAlias = 'count/administration/events';
 const routeMatcherMapForAdministationEvents = {
     [eventsAlias]: {
         method: 'GET',
-        url: '/v1/administration/events',
+        url: '/v1/administration/events?*',
     },
     [eventsCountAlias]: {
         method: 'GET',
-        url: '/v1/count/administration/events',
+        url: '/v1/count/administration/events?*',
     },
 };
 

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEvent.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEvent.tsx
@@ -42,6 +42,20 @@ export function getLevelText(level: AdministrationEventLevel) {
     return textMap[level] ?? textMap.ADMINISTRATION_EVENT_LEVEL_UNKNOWN;
 }
 
+type AlertVariant = 'danger' | 'default' | 'info' | 'success' | 'warning';
+
+const variantMap: Record<AdministrationEventLevel, AlertVariant> = {
+    ADMINISTRATION_EVENT_LEVEL_ERROR: 'danger',
+    ADMINISTRATION_EVENT_LEVEL_INFO: 'info',
+    ADMINISTRATION_EVENT_LEVEL_SUCCESS: 'success',
+    ADMINISTRATION_EVENT_LEVEL_UNKNOWN: 'default',
+    ADMINISTRATION_EVENT_LEVEL_WARNING: 'warning',
+};
+
+export function getLevelVariant(level: AdministrationEventLevel) {
+    return variantMap[level] ?? variantMap.ADMINISTRATION_EVENT_LEVEL_UNKNOWN;
+}
+
 const typeMap: Record<AdministrationEventType, string> = {
     ADMINISTRATION_EVENT_TYPE_UNKNOWN: 'Unknown',
     ADMINISTRATION_EVENT_TYPE_GENERIC: 'Generic',

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventDescription.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventDescription.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import {
+    Alert,
     DescriptionList,
     DescriptionListDescription,
     DescriptionListGroup,
@@ -9,7 +10,8 @@ import {
 
 import { AdministrationEvent } from 'services/AdministrationEventsService';
 
-import { getTypeText } from './AdministrationEvent';
+import { getLevelText, getLevelVariant, getTypeText } from './AdministrationEvent';
+import AdministrationEventHintMessage from './AdministrationEventHintMessage';
 
 export type AdministrationEventDescriptionProps = {
     event: AdministrationEvent;
@@ -18,14 +20,19 @@ export type AdministrationEventDescriptionProps = {
 function AdministrationEventDescription({
     event,
 }: AdministrationEventDescriptionProps): ReactElement {
-    const { createdAt, id, lastOccurredAt, numOccurrences, resource, type } = event;
+    const { createdAt, id, lastOccurredAt, level, numOccurrences, resource, type } = event;
     const { id: resourceID, name: resourceName, type: resourceType } = resource;
 
-    // TODO render hint and message when page design is ready.
-    // TODO factor out if same presentation in page and table.
-    // TODO render optional resourceName when it has been added to response.
     return (
         <Flex direction={{ default: 'column' }}>
+            <Alert
+                component="p"
+                isInline
+                title={getLevelText(level)}
+                variant={getLevelVariant(level)}
+            >
+                <AdministrationEventHintMessage event={event} />
+            </Alert>
             <DescriptionList isCompact isHorizontal>
                 <DescriptionListGroup>
                     <DescriptionListTerm>Resource type</DescriptionListTerm>

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventHintMessage.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventHintMessage.tsx
@@ -1,0 +1,29 @@
+import React, { ReactElement } from 'react';
+import { CodeBlock, Flex } from '@patternfly/react-core';
+
+import { AdministrationEvent } from 'services/AdministrationEventsService';
+
+export type AdministrationEventHintMessageProps = {
+    event: AdministrationEvent;
+};
+
+function AdministrationEventHintMessage({
+    event,
+}: AdministrationEventHintMessageProps): ReactElement {
+    const { hint, message } = event;
+
+    return (
+        <Flex direction={{ default: 'column' }}>
+            {hint && (
+                <div>
+                    {hint.split('\n').map((line) => (
+                        <p key={line}>{line}</p>
+                    ))}
+                </div>
+            )}
+            <CodeBlock>{message}</CodeBlock>
+        </Flex>
+    );
+}
+
+export default AdministrationEventHintMessage;

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
@@ -21,7 +21,7 @@ import AdministrationEventsToolbar from './AdministrationEventsToolbar';
 function AdministrationEventsPage(): ReactElement {
     const { page, perPage, setPage, setPerPage } = useURLPagination(10);
     const { searchFilter } = useURLSearch();
-    const { sortOption } = useURLSort({ defaultSortOption, sortFields });
+    const { getSortParams, sortOption } = useURLSort({ defaultSortOption, sortFields });
 
     const [isLoading, setIsLoading] = useState(false);
     const [events, setEvents] = useState<AdministrationEvent[]>([]);
@@ -93,7 +93,7 @@ function AdministrationEventsPage(): ReactElement {
                             setPage={setPage}
                             setPerPage={setPerPage}
                         />
-                        <AdministrationEventsTable events={events} />
+                        <AdministrationEventsTable events={events} getSortParams={getSortParams} />
                     </>
                 )}
             </PageSection>

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
@@ -1,11 +1,17 @@
 import React, { ReactElement, useEffect, useState } from 'react';
-import { Alert, Bullseye, PageSection, Spinner, Title } from '@patternfly/react-core';
+import { Alert, Bullseye, PageSection, Spinner, Text, Title } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSearch from 'hooks/useURLSearch';
+import useURLSort from 'hooks/useURLSort';
 import {
     AdministrationEvent,
     countAdministrationEvents,
+    defaultSortOption,
+    getAdministrationEventsFilter,
     listAdministrationEvents,
+    sortFields,
 } from 'services/AdministrationEventsService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
@@ -13,18 +19,23 @@ import AdministrationEventsTable from './AdministrationEventsTable';
 import AdministrationEventsToolbar from './AdministrationEventsToolbar';
 
 function AdministrationEventsPage(): ReactElement {
-    // TODO query string for table filter and pagination
+    const { page, perPage, setPage, setPerPage } = useURLPagination(10);
+    const { searchFilter } = useURLSearch();
+    const { sortOption } = useURLSort({ defaultSortOption, sortFields });
 
     const [isLoading, setIsLoading] = useState(false);
     const [events, setEvents] = useState<AdministrationEvent[]>([]);
-    const [count, setCount] = useState('0'); // int64
+    const [count, setCount] = useState(0);
     const [errorMessage, setErrorMessage] = useState('');
 
     useEffect(() => {
         setIsLoading(true);
+
+        const filter = getAdministrationEventsFilter(searchFilter);
+        const pagination = { limit: perPage, offset: page - 1, sortOption };
         // TODO Promise.all for consistent count and events?
 
-        listAdministrationEvents()
+        listAdministrationEvents({ filter, pagination })
             .then((eventsArg) => {
                 setEvents(eventsArg);
                 setErrorMessage('');
@@ -37,14 +48,14 @@ function AdministrationEventsPage(): ReactElement {
                 setIsLoading(false);
             });
 
-        countAdministrationEvents()
+        countAdministrationEvents(filter)
             .then((countArg) => {
                 setCount(countArg);
             })
             .catch(() => {
-                setCount('0');
+                setCount(0);
             });
-    }, [setIsLoading]);
+    }, [page, perPage, searchFilter, sortOption, setIsLoading]);
 
     // TODO empty state with and without filter
     // TODO polling and last updated with conditionally rendered reload button like Network Graph
@@ -54,6 +65,10 @@ function AdministrationEventsPage(): ReactElement {
             <PageTitle title="Administration Events" />
             <PageSection component="div" variant="light">
                 <Title headingLevel="h1">Administration Events</Title>
+                <Text>
+                    Troubleshoot platform issues by reviewing event logs. Events are purged after 4
+                    days by default.
+                </Text>
             </PageSection>
             <PageSection component="div">
                 {isLoading ? (
@@ -71,7 +86,13 @@ function AdministrationEventsPage(): ReactElement {
                     </Alert>
                 ) : (
                     <>
-                        <AdministrationEventsToolbar count={count} />
+                        <AdministrationEventsToolbar
+                            count={count}
+                            page={page}
+                            perPage={perPage}
+                            setPage={setPage}
+                            setPerPage={setPerPage}
+                        />
                         <AdministrationEventsTable events={events} />
                     </>
                 )}

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { CodeBlock, Flex } from '@patternfly/react-core';
 import {
     ExpandableRowContent,
     TableComposable,
@@ -15,6 +14,7 @@ import IconText from 'Components/PatternFly/IconText/IconText';
 import { AdministrationEvent } from 'services/AdministrationEventsService';
 
 import { getLevelIcon, getLevelText } from './AdministrationEvent';
+import AdministrationEventHintMessage from './AdministrationEventHintMessage';
 
 import './AdministrationEventsTable.css';
 
@@ -36,16 +36,7 @@ function AdministrationEventsTable({ events }: AdministrationEventsTableProps): 
                     </Tr>
                 </Thead>
                 {events.map((event) => {
-                    const {
-                        domain,
-                        hint,
-                        id,
-                        lastOccurredAt,
-                        level,
-                        message,
-                        numOccurrences,
-                        resource,
-                    } = event;
+                    const { domain, id, lastOccurredAt, level, numOccurrences, resource } = event;
                     const { type: resourceType } = resource;
 
                     return (
@@ -79,16 +70,7 @@ function AdministrationEventsTable({ events }: AdministrationEventsTableProps): 
                             <Tr>
                                 <Td colSpan={5}>
                                     <ExpandableRowContent>
-                                        <Flex direction={{ default: 'column' }}>
-                                            {hint && (
-                                                <div>
-                                                    {hint.split('\n').map((line) => (
-                                                        <p key={line}>{line}</p>
-                                                    ))}
-                                                </div>
-                                            )}
-                                            <CodeBlock>{message}</CodeBlock>
-                                        </Flex>
+                                        <AdministrationEventHintMessage event={event} />
                                     </ExpandableRowContent>
                                 </Td>
                             </Tr>

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
@@ -11,7 +11,12 @@ import {
 } from '@patternfly/react-table';
 
 import IconText from 'Components/PatternFly/IconText/IconText';
-import { AdministrationEvent } from 'services/AdministrationEventsService';
+import { UseURLSortResult } from 'hooks/useURLSort';
+import {
+    AdministrationEvent,
+    lastOccurredAtField,
+    numOccurrencesField,
+} from 'services/AdministrationEventsService';
 
 import { getLevelIcon, getLevelText } from './AdministrationEvent';
 import AdministrationEventHintMessage from './AdministrationEventHintMessage';
@@ -20,9 +25,13 @@ import './AdministrationEventsTable.css';
 
 export type AdministrationEventsTableProps = {
     events: AdministrationEvent[];
+    getSortParams: UseURLSortResult['getSortParams'];
 };
 
-function AdministrationEventsTable({ events }: AdministrationEventsTableProps): ReactElement {
+function AdministrationEventsTable({
+    events,
+    getSortParams,
+}: AdministrationEventsTableProps): ReactElement {
     return (
         <>
             <TableComposable variant="compact" borders={false} id="AdministrationEventsTable">
@@ -31,8 +40,13 @@ function AdministrationEventsTable({ events }: AdministrationEventsTableProps): 
                         <Th>Domain</Th>
                         <Th modifier="nowrap">Resource type</Th>
                         <Th>Level</Th>
-                        <Th>Event last occurred at</Th>
-                        <Th className="pf-u-text-align-right">Count</Th>
+                        <Th sort={getSortParams(lastOccurredAtField)}>Event last occurred at</Th>
+                        <Th
+                            sort={getSortParams(numOccurrencesField)}
+                            className="pf-u-text-align-right"
+                        >
+                            Count
+                        </Th>
                     </Tr>
                 </Thead>
                 {events.map((event) => {

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsToolbar.tsx
@@ -1,27 +1,53 @@
 import React, { ReactElement } from 'react';
 import {
     Pagination,
+    Text,
     Toolbar,
     ToolbarContent,
     ToolbarGroup,
     ToolbarItem,
 } from '@patternfly/react-core';
+import pluralize from 'pluralize';
 
 export type AdministrationEventsToolbarProps = {
-    count: string; // int64
+    count: number;
+    page: number;
+    perPage: number;
+    setPage: (newPage: number) => void;
+    setPerPage: (newPerPage: number) => void;
 };
 
-function AdministrationEventsToolbar({ count }: AdministrationEventsToolbarProps): ReactElement {
-    // TODO table filters and pagination
-    const page = 1;
-    const perPage = 10;
+function AdministrationEventsToolbar({
+    count,
+    page,
+    perPage,
+    setPage,
+    setPerPage,
+}: AdministrationEventsToolbarProps): ReactElement {
+    const countText = `${count} ${pluralize('event', count)} found`;
 
     return (
         <Toolbar>
             <ToolbarContent>
+                <ToolbarGroup>
+                    <ToolbarItem variant="label">
+                        <Text>{countText}</Text>
+                    </ToolbarItem>
+                </ToolbarGroup>
                 <ToolbarGroup alignment={{ default: 'alignRight' }}>
                     <ToolbarItem variant="pagination">
-                        <Pagination itemCount={Number(count) ?? 0} page={page} perPage={perPage} />
+                        <Pagination
+                            itemCount={count}
+                            page={page}
+                            perPage={perPage}
+                            onSetPage={(_, newPage) => setPage(newPage)}
+                            onPerPageSelect={(_, newPerPage) => {
+                                if (count < (page - 1) * newPerPage) {
+                                    setPage(1);
+                                }
+                                setPerPage(newPerPage);
+                            }}
+                        />
                     </ToolbarItem>
                 </ToolbarGroup>
             </ToolbarContent>

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsToolbar.tsx
@@ -42,9 +42,7 @@ function AdministrationEventsToolbar({
                             perPage={perPage}
                             onSetPage={(_, newPage) => setPage(newPage)}
                             onPerPageSelect={(_, newPerPage) => {
-                                if (count < (page - 1) * newPerPage) {
-                                    setPage(1);
-                                }
+                                setPage(1);
                                 setPerPage(newPerPage);
                             }}
                         />

--- a/ui/apps/platform/src/services/AdministrationEventsService.ts
+++ b/ui/apps/platform/src/services/AdministrationEventsService.ts
@@ -178,8 +178,11 @@ function getValue(arg: SearchFilterValue): string[] | undefined {
 
 // For useURLSort hook.
 
-export const sortFields = ['Event Occurrence', 'Last Updated']; // correspond to numOccurrences and lastOccurredAt
+export const lastOccurredAtField = 'Last Updated';
+export const numOccurrencesField = 'Event Occurrence';
+
+export const sortFields = [lastOccurredAtField, numOccurrencesField]; // correspond to numOccurrences and lastOccurredAt
 export const defaultSortOption: SortOption = {
-    field: 'Last Updated',
+    field: lastOccurredAtField,
     direction: 'desc', // descending from most recent
 };

--- a/ui/apps/platform/src/services/AdministrationEventsService.ts
+++ b/ui/apps/platform/src/services/AdministrationEventsService.ts
@@ -35,31 +35,23 @@ export type AdministrationEvent = {
     createdAt: string; // ISO 8601
 };
 
-export type AdministrationEventType =
-    | 'ADMINISTRATION_EVENT_TYPE_UNKNOWN'
-    | 'ADMINISTRATION_EVENT_TYPE_GENERIC'
-    | 'ADMINISTRATION_EVENT_TYPE_LOG_MESSAGE';
-
-const types: AdministrationEventType[] = [
+const types = [
     'ADMINISTRATION_EVENT_TYPE_UNKNOWN',
     'ADMINISTRATION_EVENT_TYPE_GENERIC',
     'ADMINISTRATION_EVENT_TYPE_LOG_MESSAGE',
-]; // for isType function
+] as const; // for isType function
 
-export type AdministrationEventLevel =
-    | 'ADMINISTRATION_EVENT_LEVEL_UNKNOWN'
-    | 'ADMINISTRATION_EVENT_LEVEL_INFO'
-    | 'ADMINISTRATION_EVENT_LEVEL_SUCCESS'
-    | 'ADMINISTRATION_EVENT_LEVEL_WARNING'
-    | 'ADMINISTRATION_EVENT_LEVEL_ERROR';
+export type AdministrationEventType = (typeof types)[number];
 
-const levels: AdministrationEventLevel[] = [
+const levels = [
     'ADMINISTRATION_EVENT_LEVEL_UNKNOWN',
     'ADMINISTRATION_EVENT_LEVEL_INFO',
     'ADMINISTRATION_EVENT_LEVEL_SUCCESS',
     'ADMINISTRATION_EVENT_LEVEL_WARNING',
     'ADMINISTRATION_EVENT_LEVEL_ERROR',
-]; // for isLevel function
+] as const; // for isLevel function
+
+export type AdministrationEventLevel = (typeof levels)[number];
 
 export type AdministrationEventsFilter = {
     from?: string; // ISO 8601 lower (older) boundary
@@ -138,14 +130,14 @@ function getLevel(arg: SearchFilterValue): AdministrationEventLevel[] | undefine
     }
 
     if (Array.isArray(arg)) {
-        return arg.filter((item) => isLevel(item)) as AdministrationEventLevel[];
+        return arg.filter(isLevel);
     }
 
     return undefined;
 }
 
 function isLevel(arg: string): arg is AdministrationEventLevel {
-    return levels.includes(arg as AdministrationEventLevel);
+    return levels.some((level) => level === arg);
 }
 
 function getType(arg: SearchFilterValue): AdministrationEventType[] | undefined {
@@ -154,7 +146,7 @@ function getType(arg: SearchFilterValue): AdministrationEventType[] | undefined 
     }
 
     if (Array.isArray(arg)) {
-        return arg.filter((item) => isType(item)) as AdministrationEventType[];
+        return arg.filter(isType);
     }
 
     return undefined;

--- a/ui/apps/platform/src/services/AdministrationEventsService.ts
+++ b/ui/apps/platform/src/services/AdministrationEventsService.ts
@@ -1,3 +1,8 @@
+import qs from 'qs';
+
+import { SearchFilter } from 'types/search';
+import { SortOption } from 'types/table';
+
 import axios from './instance';
 
 import { Pagination } from './types';
@@ -35,6 +40,12 @@ export type AdministrationEventType =
     | 'ADMINISTRATION_EVENT_TYPE_GENERIC'
     | 'ADMINISTRATION_EVENT_TYPE_LOG_MESSAGE';
 
+const types: AdministrationEventType[] = [
+    'ADMINISTRATION_EVENT_TYPE_UNKNOWN',
+    'ADMINISTRATION_EVENT_TYPE_GENERIC',
+    'ADMINISTRATION_EVENT_TYPE_LOG_MESSAGE',
+]; // for isType function
+
 export type AdministrationEventLevel =
     | 'ADMINISTRATION_EVENT_LEVEL_UNKNOWN'
     | 'ADMINISTRATION_EVENT_LEVEL_INFO'
@@ -42,13 +53,21 @@ export type AdministrationEventLevel =
     | 'ADMINISTRATION_EVENT_LEVEL_WARNING'
     | 'ADMINISTRATION_EVENT_LEVEL_ERROR';
 
+const levels: AdministrationEventLevel[] = [
+    'ADMINISTRATION_EVENT_LEVEL_UNKNOWN',
+    'ADMINISTRATION_EVENT_LEVEL_INFO',
+    'ADMINISTRATION_EVENT_LEVEL_SUCCESS',
+    'ADMINISTRATION_EVENT_LEVEL_WARNING',
+    'ADMINISTRATION_EVENT_LEVEL_ERROR',
+]; // for isLevel function
+
 export type AdministrationEventsFilter = {
-    from: string; // ISO 8601 lower (older) boundary
-    until: string; // ISO 8601 upper (newer) boundary
-    domain: string;
-    resourceType: string;
-    type: AdministrationEventType;
-    level: AdministrationEventLevel;
+    from?: string; // ISO 8601 lower (older) boundary
+    until?: string; // ISO 8601 upper (newer) boundary
+    domain?: string[];
+    resourceType?: string[];
+    type?: AdministrationEventType[];
+    level?: AdministrationEventLevel[];
 };
 
 export type CountAdministrationEventsRequest = {
@@ -57,7 +76,7 @@ export type CountAdministrationEventsRequest = {
 
 // The total number of notifications after filtering and deduplication.
 export type CountAdministrationEventsResponse = {
-    count: string; // int64
+    count: number; // int32
 };
 
 export type GetAdministrationEventResponse = {
@@ -65,7 +84,7 @@ export type GetAdministrationEventResponse = {
 };
 
 export type ListAdministrationEventsRequest = {
-    pagination: Pagination;
+    pagination?: Pagination;
     filter: AdministrationEventsFilter;
 };
 
@@ -73,10 +92,10 @@ export type ListAdministrationEventsResponse = {
     events: AdministrationEvent[];
 };
 
-// TODO CountAdministrationEventsRequest
-export function countAdministrationEvents(): Promise<string> {
+export function countAdministrationEvents(filter: AdministrationEventsFilter): Promise<number> {
+    const params = qs.stringify({ filter }, { arrayFormat: 'repeat', allowDots: true });
     return axios
-        .get<CountAdministrationEventsResponse>(eventsCountUrl)
+        .get<CountAdministrationEventsResponse>(`${eventsCountUrl}?${params}`)
         .then((response) => response.data.count);
 }
 
@@ -86,9 +105,81 @@ export function getAdministrationEvent(id: string): Promise<AdministrationEvent>
         .then((response) => response.data.event);
 }
 
-// TODO ListAdministrationEventsRequest
-export function listAdministrationEvents(): Promise<AdministrationEvent[]> {
+export function listAdministrationEvents(
+    arg: ListAdministrationEventsRequest
+): Promise<AdministrationEvent[]> {
+    const params = qs.stringify(arg, { arrayFormat: 'repeat', allowDots: true });
     return axios
-        .get<ListAdministrationEventsResponse>(eventsUrl)
+        .get<ListAdministrationEventsResponse>(`${eventsUrl}?${params}`)
         .then((response) => response.data.events);
 }
+
+// Given searchFilter from useURLSearch hook, return validated filter argument.
+
+export function getAdministrationEventsFilter(
+    searchFilter: SearchFilter
+): AdministrationEventsFilter {
+    // For consistency with useURLSort hook, especially in case the table columns become sortable,
+    // useURLSearch hook also uses search strings.
+    // See proto/storage/administration_event.proto
+    return {
+        domain: getValue(searchFilter['Event Domain']),
+        level: getLevel(searchFilter['Event Level']),
+        resourceType: getValue(searchFilter['Resource Type']),
+        type: getType(searchFilter['Event Type']),
+    };
+}
+
+type SearchFilterValue = string | string[] | undefined;
+
+function getLevel(arg: SearchFilterValue): AdministrationEventLevel[] | undefined {
+    if (typeof arg === 'string' && isLevel(arg)) {
+        return [arg];
+    }
+
+    if (Array.isArray(arg)) {
+        return arg.filter((item) => isLevel(item)) as AdministrationEventLevel[];
+    }
+
+    return undefined;
+}
+
+function isLevel(arg: string): arg is AdministrationEventLevel {
+    return levels.includes(arg as AdministrationEventLevel);
+}
+
+function getType(arg: SearchFilterValue): AdministrationEventType[] | undefined {
+    if (typeof arg === 'string' && isType(arg)) {
+        return [arg];
+    }
+
+    if (Array.isArray(arg)) {
+        return arg.filter((item) => isType(item)) as AdministrationEventType[];
+    }
+
+    return undefined;
+}
+
+function isType(arg: string): arg is AdministrationEventType {
+    return types.includes(arg as AdministrationEventType);
+}
+
+function getValue(arg: SearchFilterValue): string[] | undefined {
+    if (typeof arg === 'string') {
+        return [arg];
+    }
+
+    if (Array.isArray(arg)) {
+        return arg;
+    }
+
+    return undefined;
+}
+
+// For useURLSort hook.
+
+export const sortFields = ['Event Occurrence', 'Last Updated']; // correspond to numOccurrences and lastOccurredAt
+export const defaultSortOption: SortOption = {
+    field: 'Last Updated',
+    direction: 'desc', // descending from most recent
+};


### PR DESCRIPTION
## Description

Make invisible changes to prepare for next steps in events page and visible changes to finish the event page.

If needed, sprint demos can use edited page addresses in browser history.

1. Events page
    * Add hooks for pagination, search, and sort in page address query string. Thank you, David Vail.
    * Support pagination in toolbar.
    * Add tagline following page heading.
        Troubleshoot platform issues by reviewing event logs. Events are purged after 4 days by default.
    * Add **N events found** count at left of toolbar.
2. Event page
    * Add `Alert` element to display level, hint, message properties.
    * Refactor hint and message instead of repeating code from events page.
3. AdministrationService
    * Replace `string` with `number` for count and  `string` with `string[]` for filter properties according to #7881
    * Make filter properties optional.
    * Add arguments to count and list functions.
    * Add `getAdministrationEventsFilter` to validate `searchFilter` from `useURLSearch` hook.
    * Add `sortFields` and `defaultSortOptions` for `useURLSort` hook.

### Next steps

1. Events page:
    * Add search filter elements for **Domain**, **Resource type**, **Level**.
    * Implement sorting for numeric values: **Last occurred** and **Count**. Sorting for other columns will be post MVP.
    * Display empty state with or without search filter.
2. Events page:
    * Synchronize requests for events and counts.
    * Display **Last updated** time and **N events available** button.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Before `yarn deploy` in ui, do the following:

```sh
export ROX_ADMINISTRATION_EVENTS=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js: 36 = 3761106 - 3761070
        total: 10772 = 10142821 - 10132049
    * `ls -al build/static/js/*.js | wc -l`
        1 = 86 - 85 files
3. `yarn start` in ui

### Manual testing

Pictures at 1440px width and 900px height like a laptop.

1. Visit /main/administration-events
    See newer event has count 2 and older event has count 1.
    ![AdministrationEventsPage](https://github.com/stackrox/stackrox/assets/11862657/9ec1c12f-f468-48da-a9f7-346255181573)

2. Click a link to visit /main/administration-events/id for an event
    See level, hint, message of newer event in `Alert` element.
    ![AdministrationEventPage](https://github.com/stackrox/stackrox/assets/11862657/a91ef3ec-cf4f-4ef1-b601-e185d7bae7a5)

3. Test request args by adding query string to page address:

    * `?page=2&perPage=1`
        See older event on second page with default sort descending by time
        ![page_2_perPage_1](https://github.com/stackrox/stackrox/assets/11862657/ce528145-2271-4a10-a456-19f445138a93)

    * `?page=2&perPage=1&sortOption[field]=Last%20Updated&sortOption[direction]=asc`
        See newer event on second page sorted ascending by time
        ![page_2_perPage_1_sortOption_Last_Updated_asc](https://github.com/stackrox/stackrox/assets/11862657/65257eca-adcd-48b2-a767-9bb83cd84397)

    * `?page=2&perPage=1&sortOption[field]=Event%20Occurrence&sortOption[direction]=asc`
        See newer event on second page sorted ascending by count
        ![page_2_perPage_1_sortOption_Event_Occurrence_asc](https://github.com/stackrox/stackrox/assets/11862657/bf2d15fc-6753-4ba6-930f-e797b1b998ac)

    * `?page=2&perPage=1&sortOption[field]=Event%20Occurrence&sortOption[direction]=desc`
        See older event on second page sorted descending by count
        ![page_2_perPage_1_sortOption_Event_Occurrence_desc](https://github.com/stackrox/stackrox/assets/11862657/a18946e1-0621-4753-af11-99f5e0aea550)

    * `?s[Event%20Level]=ADMINISTRATION_EVENT_LEVEL_ERROR`
        See 2 events, both of which have **Error** level. Requests have `filter.level=ADMINISTRATION_EVENT_LEVEL_ERROR`

    * `?s[Event%20Level]=ADMINISTRATION_EVENT_LEVEL_WARNING`
        See 0 events. Requests have `filter.level=ADMINISTRATION_EVENT_LEVEL_WARNING`
        **Residue**: Implement empty state with and without search filter.

    * `?s[Event%20Level]=ADMINISTRATION_EVENT_LEVEL_ERROR&s[Event%20Level]=ADMINISTRATION_EVENT_LEVEL_WARNING`
        See 2 events. Requests have `filter.level=ADMINISTRATION_EVENT_LEVEL_ERROR&filter.level=ADMINISTRATION_EVENT_LEVEL_WARNING`

    * `?s[Event%20Level][0]=ADMINISTRATION_EVENT_LEVEL_WARNING&s[Event%20Level][1]=ADMINISTRATION_EVENT_LEVEL_ERROR`
        See 2 events. Requests have `filter.level=ADMINISTRATION_EVENT_LEVEL_WARNING&filter.level=ADMINISTRATION_EVENT_LEVEL_ERROR`
        It looks like backend supports multiple values without joiner.
        By the way, MVP supports only single value via UI.

### Integration testing

Before `yarn cypress-open` in ui/apps/platform, do the following:

```sh
export CYPRESS_ROX_ADMINISTRATION_EVENTS=true
```

* administation/events/eventsTable.test.js
