### PR TITLE
ROX-19459: Add CVE status tabs to workload CVE list page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -29,7 +29,7 @@ import DeploymentPageResources from './DeploymentPageResources';
 import DeploymentPageVulnerabilities from './DeploymentPageVulnerabilities';
 
 const workloadCveOverviewDeploymentsPath = getOverviewCvesPath({
-    cveStatusTab: 'Observed',
+    vulnerabilityState: 'OBSERVED',
     entityTab: 'Deployment',
 });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -38,7 +38,7 @@ import {
     parseQuerySearchFilter,
     getHiddenSeverities,
     getHiddenStatuses,
-    getCveStatusScopedQueryString,
+    getVulnStateScopedQueryString,
 } from '../searchUtils';
 import { imageMetadataContextFragment } from '../Tables/table.utils';
 import DeploymentVulnerabilitiesTable, {
@@ -96,7 +96,7 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
     const hiddenSeverities = getHiddenSeverities(querySearchFilter);
     const hiddenStatuses = getHiddenStatuses(querySearchFilter);
 
-    const query = getCveStatusScopedQueryString(querySearchFilter);
+    const query = getVulnStateScopedQueryString(querySearchFilter);
 
     const summaryRequest = useQuery<
         {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -33,7 +33,7 @@ import ImageDetailBadges, {
 } from '../components/ImageDetailBadges';
 
 const workloadCveOverviewImagePath = getOverviewCvesPath({
-    cveStatusTab: 'Observed',
+    vulnerabilityState: 'OBSERVED',
     entityTab: 'Image',
 });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -37,7 +37,7 @@ import { DynamicTableLabel } from '../components/DynamicIcon';
 import {
     getHiddenSeverities,
     getHiddenStatuses,
-    getCveStatusScopedQueryString,
+    getVulnStateScopedQueryString,
     parseQuerySearchFilter,
 } from '../searchUtils';
 import BySeveritySummaryCard from '../SummaryCards/BySeveritySummaryCard';
@@ -103,7 +103,7 @@ function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
     >(imageVulnerabilitiesQuery, {
         variables: {
             id: imageId,
-            query: getCveStatusScopedQueryString(querySearchFilter),
+            query: getVulnStateScopedQueryString(querySearchFilter),
             pagination,
         },
     });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -56,7 +56,7 @@ import { Resource } from '../components/FilterResourceDropdown';
 import { VulnerabilitySeverityLabel } from '../types';
 
 const workloadCveOverviewCvePath = getOverviewCvesPath({
-    cveStatusTab: 'Observed',
+    vulnerabilityState: 'OBSERVED',
     entityTab: 'CVE',
 });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -6,25 +6,26 @@ import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import { getHasSearchApplied } from 'utils/searchUtils';
+import { VulnerabilityState } from 'types/cve.proto';
 import CVEsTable, { cveListQuery, unfilteredImageCountQuery } from '../Tables/CVEsTable';
 import TableErrorComponent from '../components/TableErrorComponent';
 import { EntityCounts } from '../components/EntityTypeToggleGroup';
-import { DefaultFilters, VulnerabilitySeverityLabel, CveStatusTab } from '../types';
-import { getCveStatusScopedQueryString, parseQuerySearchFilter } from '../searchUtils';
+import { DefaultFilters, VulnerabilitySeverityLabel } from '../types';
+import { getVulnStateScopedQueryString, parseQuerySearchFilter } from '../searchUtils';
 import { defaultCVESortFields, CVEsDefaultSort } from '../sortUtils';
 import TableEntityToolbar from '../components/TableEntityToolbar';
 
 type CVEsTableContainerProps = {
     defaultFilters: DefaultFilters;
     countsData: EntityCounts;
-    cveStatusTab?: CveStatusTab; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
+    vulnerabilityState?: VulnerabilityState; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
     pagination: ReturnType<typeof useURLPagination>;
 };
 
 function CVEsTableContainer({
     defaultFilters,
     countsData,
-    cveStatusTab,
+    vulnerabilityState,
     pagination,
 }: CVEsTableContainerProps) {
     const { searchFilter } = useURLSearch();
@@ -39,7 +40,7 @@ function CVEsTableContainer({
 
     const { error, loading, data, previousData } = useQuery(cveListQuery, {
         variables: {
-            query: getCveStatusScopedQueryString(querySearchFilter, cveStatusTab),
+            query: getVulnStateScopedQueryString(querySearchFilter, vulnerabilityState),
             pagination: {
                 offset: (page - 1) * perPage,
                 limit: perPage,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -17,7 +17,7 @@ import TableEntityToolbar from '../components/TableEntityToolbar';
 type CVEsTableContainerProps = {
     defaultFilters: DefaultFilters;
     countsData: EntityCounts;
-    cveStatusTab?: CveStatusTab; // TODO Make this required once Observed/Deferred/FP states are re-implemented
+    cveStatusTab?: CveStatusTab; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
     pagination: ReturnType<typeof useURLPagination>;
 };
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -6,25 +6,26 @@ import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import { getHasSearchApplied } from 'utils/searchUtils';
+import { VulnerabilityState } from 'types/cve.proto';
 import DeploymentsTable, { Deployment, deploymentListQuery } from '../Tables/DeploymentsTable';
 import TableErrorComponent from '../components/TableErrorComponent';
 import TableEntityToolbar from '../components/TableEntityToolbar';
 import { EntityCounts } from '../components/EntityTypeToggleGroup';
-import { getCveStatusScopedQueryString, parseQuerySearchFilter } from '../searchUtils';
+import { getVulnStateScopedQueryString, parseQuerySearchFilter } from '../searchUtils';
 import { defaultDeploymentSortFields, deploymentsDefaultSort } from '../sortUtils';
-import { DefaultFilters, VulnerabilitySeverityLabel, CveStatusTab } from '../types';
+import { DefaultFilters, VulnerabilitySeverityLabel } from '../types';
 
 type DeploymentsTableContainerProps = {
     defaultFilters: DefaultFilters;
     countsData: EntityCounts;
-    cveStatusTab?: CveStatusTab; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
+    vulnerabilityState?: VulnerabilityState; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
     pagination: ReturnType<typeof useURLPagination>;
 };
 
 function DeploymentsTableContainer({
     defaultFilters,
     countsData,
-    cveStatusTab,
+    vulnerabilityState,
     pagination,
 }: DeploymentsTableContainerProps) {
     const { searchFilter } = useURLSearch();
@@ -41,7 +42,7 @@ function DeploymentsTableContainer({
         deployments: Deployment[];
     }>(deploymentListQuery, {
         variables: {
-            query: getCveStatusScopedQueryString(querySearchFilter, cveStatusTab),
+            query: getVulnStateScopedQueryString(querySearchFilter, vulnerabilityState),
             pagination: {
                 offset: (page - 1) * perPage,
                 limit: perPage,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -17,7 +17,7 @@ import { DefaultFilters, VulnerabilitySeverityLabel, CveStatusTab } from '../typ
 type DeploymentsTableContainerProps = {
     defaultFilters: DefaultFilters;
     countsData: EntityCounts;
-    cveStatusTab?: CveStatusTab; // TODO Make this required once Observed/Deferred/FP states are re-implemented
+    cveStatusTab?: CveStatusTab; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
     pagination: ReturnType<typeof useURLPagination>;
 };
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -19,7 +19,7 @@ export { imageListQuery } from '../Tables/ImagesTable';
 type ImagesTableContainerProps = {
     defaultFilters: DefaultFilters;
     countsData: EntityCounts;
-    cveStatusTab?: CveStatusTab; // TODO Make this required once Observed/Deferred/FP states are re-implemented
+    cveStatusTab?: CveStatusTab; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
     pagination: ReturnType<typeof useURLPagination>;
     hasWriteAccessForWatchedImage: boolean;
     onWatchImage: ImagesTableProps['onWatchImage'];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -6,12 +6,13 @@ import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import { getHasSearchApplied } from 'utils/searchUtils';
+import { VulnerabilityState } from 'types/cve.proto';
 import ImagesTable, { ImagesTableProps, imageListQuery } from '../Tables/ImagesTable';
 import TableErrorComponent from '../components/TableErrorComponent';
 import { EntityCounts } from '../components/EntityTypeToggleGroup';
-import { getCveStatusScopedQueryString, parseQuerySearchFilter } from '../searchUtils';
+import { getVulnStateScopedQueryString, parseQuerySearchFilter } from '../searchUtils';
 import { defaultImageSortFields, imagesDefaultSort } from '../sortUtils';
-import { DefaultFilters, VulnerabilitySeverityLabel, CveStatusTab } from '../types';
+import { DefaultFilters, VulnerabilitySeverityLabel } from '../types';
 import TableEntityToolbar from '../components/TableEntityToolbar';
 
 export { imageListQuery } from '../Tables/ImagesTable';
@@ -19,7 +20,7 @@ export { imageListQuery } from '../Tables/ImagesTable';
 type ImagesTableContainerProps = {
     defaultFilters: DefaultFilters;
     countsData: EntityCounts;
-    cveStatusTab?: CveStatusTab; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
+    vulnerabilityState?: VulnerabilityState; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
     pagination: ReturnType<typeof useURLPagination>;
     hasWriteAccessForWatchedImage: boolean;
     onWatchImage: ImagesTableProps['onWatchImage'];
@@ -29,7 +30,7 @@ type ImagesTableContainerProps = {
 function ImagesTableContainer({
     defaultFilters,
     countsData,
-    cveStatusTab,
+    vulnerabilityState,
     pagination,
     hasWriteAccessForWatchedImage,
     onWatchImage,
@@ -48,7 +49,7 @@ function ImagesTableContainer({
 
     const { error, loading, data, previousData } = useQuery(imageListQuery, {
         variables: {
-            query: getCveStatusScopedQueryString(querySearchFilter, cveStatusTab),
+            query: getVulnStateScopedQueryString(querySearchFilter, vulnerabilityState),
             pagination: {
                 offset: (page - 1) * perPage,
                 limit: perPage,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -11,7 +11,6 @@ import {
     Tab,
     TabTitleText,
     Tabs,
-    TabsComponent,
 } from '@patternfly/react-core';
 import { useApolloClient, useQuery } from '@apollo/client';
 
@@ -22,8 +21,9 @@ import useURLPagination from 'hooks/useURLPagination';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import usePermissions from 'hooks/usePermissions';
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import { VulnMgmtLocalStorage, cveStatusTabValues, entityTabValues } from '../types';
-import { parseQuerySearchFilter, getCveStatusScopedQueryString } from '../searchUtils';
+import { vulnerabilityStates } from 'types/cve.proto';
+import { VulnMgmtLocalStorage, entityTabValues } from '../types';
+import { parseQuerySearchFilter, getVulnStateScopedQueryString } from '../searchUtils';
 import { entityTypeCountsQuery } from '../components/EntityTypeToggleGroup';
 import CVEsTableContainer from './CVEsTableContainer';
 import DeploymentsTableContainer from './DeploymentsTableContainer';
@@ -48,11 +48,11 @@ function WorkloadCvesOverviewPage() {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isUnifiedDeferralsEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL');
 
-    const [activeCVEStatusKey, setActiveCVEStatusKey] = useURLStringUnion(
-        'cveStatus',
-        cveStatusTabValues
+    const [vulnerabilityStateKey, setVulnerabilityStateKey] = useURLStringUnion(
+        'vulnerabilityState',
+        vulnerabilityStates
     );
-    const currentCveStatus = isUnifiedDeferralsEnabled ? activeCVEStatusKey : undefined;
+    const currentVulnerabilityState = isUnifiedDeferralsEnabled ? vulnerabilityStateKey : undefined;
 
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
@@ -61,7 +61,7 @@ function WorkloadCvesOverviewPage() {
     const { data: countsData = { imageCount: 0, imageCVECount: 0, deploymentCount: 0 }, loading } =
         useQuery(entityTypeCountsQuery, {
             variables: {
-                query: getCveStatusScopedQueryString(querySearchFilter, currentCveStatus),
+                query: getVulnStateScopedQueryString(querySearchFilter, currentVulnerabilityState),
             },
         });
 
@@ -78,7 +78,7 @@ function WorkloadCvesOverviewPage() {
     }
 
     function handleTabClick(e, tab) {
-        setActiveCVEStatusKey(tab);
+        setVulnerabilityStateKey(tab);
     }
 
     return (
@@ -113,18 +113,18 @@ function WorkloadCvesOverviewPage() {
             <PageSection padding={{ default: 'noPadding' }}>
                 {isUnifiedDeferralsEnabled && (
                     <Tabs
-                        activeKey={activeCVEStatusKey}
+                        activeKey={vulnerabilityStateKey}
                         onSelect={handleTabClick}
-                        component={TabsComponent.nav}
+                        component="nav"
                         className="pf-u-pl-lg pf-u-background-color-100"
                     >
                         <Tab
-                            eventKey="Observed"
+                            eventKey="OBSERVED"
                             title={<TabTitleText>Observed CVEs</TabTitleText>}
                         />
-                        <Tab eventKey="Deferred" title={<TabTitleText>Deferrals</TabTitleText>} />
+                        <Tab eventKey="DEFERRED" title={<TabTitleText>Deferrals</TabTitleText>} />
                         <Tab
-                            eventKey="False Positive"
+                            eventKey="FALSE_POSITIVE"
                             title={<TabTitleText>False positives</TabTitleText>}
                         />
                     </Tabs>
@@ -141,7 +141,7 @@ function WorkloadCvesOverviewPage() {
                                     defaultFilters={emptyStorage.preferences.defaultFilters}
                                     countsData={countsData}
                                     pagination={pagination}
-                                    cveStatusTab={currentCveStatus}
+                                    vulnerabilityState={currentVulnerabilityState}
                                 />
                             )}
                             {activeEntityTabKey === 'Image' && (
@@ -150,7 +150,7 @@ function WorkloadCvesOverviewPage() {
                                     countsData={countsData}
                                     pagination={pagination}
                                     hasWriteAccessForWatchedImage={hasWriteAccessForWatchedImage}
-                                    cveStatusTab={currentCveStatus}
+                                    vulnerabilityState={currentVulnerabilityState}
                                     onWatchImage={(imageName) => {
                                         setDefaultWatchedImageName(imageName);
                                         watchedImagesModalToggle.openSelect();
@@ -166,7 +166,7 @@ function WorkloadCvesOverviewPage() {
                                     defaultFilters={emptyStorage.preferences.defaultFilters}
                                     countsData={countsData}
                                     pagination={pagination}
-                                    cveStatusTab={currentCveStatus}
+                                    vulnerabilityState={currentVulnerabilityState}
                                 />
                             )}
                         </CardBody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
@@ -138,7 +138,7 @@ const vulnerabilitySearchStateForCveStatus: Record<CveStatusTab, VulnerabilitySt
 // Returns a search filter string that scopes results to a CVE Workflow state (e.g. 'OBSERVED')
 export function getCveStatusScopedQueryString(
     searchFilter: QuerySearchFilter,
-    cveStatusTab?: CveStatusTab /* TODO Make this required once Observed/Deferred/FP states are re-implemented */
+    cveStatusTab?: CveStatusTab // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
 ): string {
     const vulnerabilityStateFilter = cveStatusTab
         ? { 'Vulnerability State': vulnerabilitySearchStateForCveStatus[cveStatusTab] }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
@@ -4,6 +4,7 @@ import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import {
     VulnerabilitySeverity,
     VulnerabilityState,
+    isVulnerabilityState,
     vulnerabilitySeverities,
 } from 'types/cve.proto';
 import { SearchFilter } from 'types/search';
@@ -11,21 +12,23 @@ import { getQueryString } from 'utils/queryStringUtils';
 import { searchValueAsArray, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { ensureExhaustive } from 'utils/type.utils';
 
-import { CveStatusTab, FixableStatus, isValidCveStatusTab, QuerySearchFilter } from './types';
+import { FixableStatus, QuerySearchFilter } from './types';
 
 export type EntityTab = 'CVE' | 'Image' | 'Deployment';
 
 export type WorkloadCvesSearch = {
-    cveStatusTab: CveStatusTab;
+    vulnerabilityState: VulnerabilityState;
     entityTab?: EntityTab;
     s?: SearchFilter;
 };
 
 export function parseWorkloadCvesOverviewSearchString(search: string): WorkloadCvesSearch {
-    const { cveStatusTab } = qs.parse(search, { ignoreQueryPrefix: true });
+    const { vulnerabilityState } = qs.parse(search, { ignoreQueryPrefix: true });
 
     return {
-        cveStatusTab: isValidCveStatusTab(cveStatusTab) ? cveStatusTab : 'Observed',
+        vulnerabilityState: isVulnerabilityState(vulnerabilityState)
+            ? vulnerabilityState
+            : 'OBSERVED',
     };
 }
 
@@ -128,20 +131,13 @@ export function getHiddenStatuses(querySearchFilter: QuerySearchFilter): Set<Fix
     return hiddenStatuses;
 }
 
-// Map from the CVE status tab to the backend equivalent search value
-const vulnerabilitySearchStateForCveStatus: Record<CveStatusTab, VulnerabilityState> = {
-    Observed: 'OBSERVED',
-    Deferred: 'DEFERRED',
-    'False Positive': 'FALSE_POSITIVE',
-} as const;
-
-// Returns a search filter string that scopes results to a CVE Workflow state (e.g. 'OBSERVED')
-export function getCveStatusScopedQueryString(
+// Returns a search filter string that scopes results to a Vulnerability state (e.g. 'OBSERVED')
+export function getVulnStateScopedQueryString(
     searchFilter: QuerySearchFilter,
-    cveStatusTab?: CveStatusTab // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
+    vulnerabilityState?: VulnerabilityState // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
 ): string {
-    const vulnerabilityStateFilter = cveStatusTab
-        ? { 'Vulnerability State': vulnerabilitySearchStateForCveStatus[cveStatusTab] }
+    const vulnerabilityStateFilter = vulnerabilityState
+        ? { 'Vulnerability State': vulnerabilityState }
         : {};
     return getRequestQueryStringForSearchFilter({
         ...searchFilter,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
@@ -34,14 +34,6 @@ export function isDetailsTab(value: unknown): value is DetailsTab {
     return detailsTabValues.some((tab) => tab === value);
 }
 
-export const cveStatusTabValues = ['Observed', 'Deferred', 'False Positive'] as const;
-
-export type CveStatusTab = (typeof cveStatusTabValues)[number];
-
-export function isValidCveStatusTab(value: unknown): value is CveStatusTab {
-    return cveStatusTabValues.some((tab) => tab === value);
-}
-
 export const entityTabValues = ['CVE', 'Image', 'Deployment'] as const;
 
 export type EntityTab = (typeof entityTabValues)[number];

--- a/ui/apps/platform/src/types/cve.proto.ts
+++ b/ui/apps/platform/src/types/cve.proto.ts
@@ -12,7 +12,13 @@ export function isVulnerabilitySeverity(value: unknown): value is VulnerabilityS
     return vulnerabilitySeverities.some((severity) => severity === value);
 }
 
-export type VulnerabilityState = 'OBSERVED' | 'DEFERRED' | 'FALSE_POSITIVE';
+export const vulnerabilityStates = ['OBSERVED', 'DEFERRED', 'FALSE_POSITIVE'] as const;
+
+export type VulnerabilityState = (typeof vulnerabilityStates)[number];
+
+export function isVulnerabilityState(value: unknown): value is VulnerabilityState {
+    return vulnerabilityStates.some((state) => state === value);
+}
 
 export type CVSSV2 = {
     vector: string;


### PR DESCRIPTION
## Description

Adds Observed/Deferred/FP Tabs to the Workload CVE list page and scopes queries of the data to the correct status.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Create and approve a deferral and false positive via the VM 1.0 UI.
![image](https://github.com/stackrox/stackrox/assets/1292638/a75520cd-85a6-47e9-92ef-1e58b07407d9)
![image](https://github.com/stackrox/stackrox/assets/1292638/17509586-6acc-47a4-8ab7-d1da3206f844)

View the Workload CVE page with feature flag off, filtered to the approved CVEs. This view shows _all_ instances of the CVEs, regardless of exception status.
![image](https://github.com/stackrox/stackrox/assets/1292638/14928e9f-7b0c-4ec4-a061-bbc0e8d7d216)

Turn the feature flag on and view the same page. One CVE is absent (deferred across all affected images), the other CVE has a reduced affected images count.
![image](https://github.com/stackrox/stackrox/assets/1292638/c4c5c6a0-4ea0-442f-b532-552bfb77b03e)

Deferral tab:
![image](https://github.com/stackrox/stackrox/assets/1292638/ea14a615-0fff-4af6-8491-c94e89159857)

FP tab:
![image](https://github.com/stackrox/stackrox/assets/1292638/41355e3a-1f86-4711-9699-4461f1585da6)
