### PR TITLE
ROX-19868: Fix broken file search in ca-setup.sh

### DIFF
--- a/image/templates/common/ca-setup.sh
+++ b/image/templates/common/ca-setup.sh
@@ -57,7 +57,7 @@ function create_directory {
 	local dir="$1"
 	echo "The following certificates will be used as additional CAs:"
 	from_file_args=()
-	for f in "$dir/*.crt" "$dir/*.pem"; do
+	for f in "$dir"/*.crt "$dir"/*.pem; do
     	if [ -f "$f" ] ; then
     		from_file_args+=("--from-file=$(basename "$f")=$f")
 			echo "  - $f"


### PR DESCRIPTION
## Description
Fix broken file search in `ca-setup.sh`.
Currently the script could not find any file in the directory, even with the correct extensions `.crt` and `.pem`. 


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
1. Download a Sensor bundle from Central (ACSCS instance)
2. Extract it
3. ./sensor/ca-setup-sensor.sh -d sensor/additional-cas
```
RHACS ./sensor/ca-setup-sensor.sh -d sensor/additional-cas
The following certificates will be used as additional CAs:
  - sensor/additional-cas/00-rds-ca-bundle.crt
W1004 11:14:04.253818   48979 helpers.go:663] --dry-run is deprecated and can be replaced with --dry-run=client.
secret/additional-ca-sensor created
secret/additional-ca-sensor labeled
``` 


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
