### PR TITLE
feat(admin-events): add benchmarks for datastore

### DIFF
--- a/central/administration/events/datastore/datastore.go
+++ b/central/administration/events/datastore/datastore.go
@@ -53,3 +53,10 @@ func UpsertTestEvents(ctx context.Context, _ testing.TB, datastore DataStore,
 	events ...*storage.AdministrationEvent) error {
 	return datastore.(*datastoreImpl).store.UpsertMany(ctx, events)
 }
+
+// RemoveTestEvents provides a way to remove storage.AdministrationEvents directly from the database.
+// This is required for test cleanups, since the datastore doesn't expose functionality to remove events for clients.
+func RemoveTestEvents(ctx context.Context, _ testing.TB, datastore DataStore,
+	ids ...string) error {
+	return datastore.(*datastoreImpl).store.DeleteMany(ctx, ids)
+}

--- a/central/administration/events/datastore/datastore_impl_benchmark_test.go
+++ b/central/administration/events/datastore/datastore_impl_benchmark_test.go
@@ -1,0 +1,163 @@
+//go:build sql_integration
+
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/administration/events"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stretchr/testify/require"
+)
+
+var testCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
+	sac.AllowFixedScopes(
+		sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+		sac.ResourceScopeKeys(resources.Administration),
+	),
+)
+
+func BenchmarkDatastore_Add_and_Flush(b *testing.B) {
+	pool := pgtest.ForT(b)
+	b.Cleanup(func() {
+		pool.Close()
+	})
+	datastore := GetTestPostgresDataStore(b, pool)
+
+	benchmarkEvents, preExistingEvents := getEvents(1000)
+	b.Run("add 1000 events to the writer and flush it", benchmarkDatastoreWithFlush(datastore, benchmarkEvents,
+		preExistingEvents))
+
+	benchmarkEvents, preExistingEvents = getEvents(5000)
+	b.Run("add 5000 events to the writer and flush it", benchmarkDatastoreWithFlush(datastore, benchmarkEvents,
+		preExistingEvents))
+
+	benchmarkEvents, preExistingEvents = getEvents(10000)
+	b.Run("add 10000 events to the writer and flush it", benchmarkDatastoreWithFlush(datastore, benchmarkEvents,
+		preExistingEvents))
+
+	benchmarkEvents, preExistingEvents = getEvents(20000)
+	b.Run("add 20000 events to the writer and flush it", benchmarkDatastoreWithFlush(datastore, benchmarkEvents,
+		preExistingEvents))
+}
+
+func BenchmarkDatastore_Add(b *testing.B) {
+	pool := pgtest.ForT(b)
+	b.Cleanup(func() {
+		pool.Close()
+	})
+	datastore := GetTestPostgresDataStore(b, pool)
+
+	benchmarkEvents, preExistingEvents := getEvents(1000)
+	b.Run("add 1000 events to the writer", benchmarkDatastoreWithoutFlush(datastore, benchmarkEvents,
+		preExistingEvents))
+
+	benchmarkEvents, preExistingEvents = getEvents(5000)
+	b.Run("add 5000 events to the writer", benchmarkDatastoreWithoutFlush(datastore, benchmarkEvents,
+		preExistingEvents))
+
+	benchmarkEvents, preExistingEvents = getEvents(10000)
+	b.Run("add 10000 events to the writer", benchmarkDatastoreWithoutFlush(datastore, benchmarkEvents,
+		preExistingEvents))
+
+	benchmarkEvents, preExistingEvents = getEvents(20000)
+	b.Run("add 20000 events to the writer", benchmarkDatastoreWithoutFlush(datastore, benchmarkEvents,
+		preExistingEvents))
+}
+
+// benchmarkDatastoreWithFlush does an explicit Flush call after adding all events, in addition to the implicit flush
+// calls done by the writer once the buffer is full.
+func benchmarkDatastoreWithFlush(datastore DataStore, benchmarkEvents []*events.AdministrationEvent,
+	preExistingEvents []*events.AdministrationEvent) func(b *testing.B) {
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			// Need to ensure the database is in its initial state:
+			// - no pre-existing events are within the database.
+			// - add the custom events that should exist beforehand.
+			// Stopping / Starting the timer in-between, as this would otherwise contribute to false benchmark timings.
+			// Also need to do this for each benchmark run, to ensure every run has the same initial conditions.
+			b.StopTimer()
+			resetDatabase(b, datastore, preExistingEvents)
+			b.StartTimer()
+
+			for _, evt := range benchmarkEvents {
+				if err := datastore.AddEvent(testCtx, evt); err != nil {
+					b.Error(err)
+				}
+			}
+			if err := datastore.Flush(testCtx); err != nil {
+				b.Error(err)
+			}
+		}
+	}
+}
+
+// benchmarkDatastoreWithoutFlush does not call an explicit flush call, instead the events will be flushed by the
+// writer implicitly.
+func benchmarkDatastoreWithoutFlush(datastore DataStore, benchmarkEvents []*events.AdministrationEvent,
+	preExistingEvents []*events.AdministrationEvent) func(b *testing.B) {
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			// Need to ensure the database is in its initial state:
+			// - no pre-existing events are within the database.
+			// - add the custom events that should exist beforehand.
+			// Stopping / Starting the timer in-between, as this would otherwise contribute to false benchmark timings.
+			// Also need to do this for each benchmark run, to ensure every run has the same initial conditions.
+			b.StopTimer()
+			resetDatabase(b, datastore, preExistingEvents)
+			b.StartTimer()
+
+			for _, evt := range benchmarkEvents {
+				if err := datastore.AddEvent(testCtx, evt); err != nil {
+					b.Error(err)
+				}
+			}
+		}
+	}
+}
+
+func resetDatabase(b *testing.B, datastore DataStore, preExistingEvents []*events.AdministrationEvent) {
+	// Flush once just to be sure.
+	require.NoError(b, datastore.Flush(testCtx))
+
+	existingEvents, err := datastore.ListEvents(testCtx, search.EmptyQuery())
+	require.NoError(b, err)
+
+	ids := make([]string, 0, len(existingEvents))
+	for _, event := range existingEvents {
+		ids = append(ids, event.GetId())
+	}
+	require.NoError(b, RemoveTestEvents(testCtx, b, datastore, ids...))
+
+	for _, event := range preExistingEvents {
+		require.NoError(b, datastore.AddEvent(testCtx, event))
+	}
+	require.NoError(b, datastore.Flush(testCtx))
+}
+
+func getEvents(numOfEvents int) ([]*events.AdministrationEvent, []*events.AdministrationEvent) {
+	fixtureEvents := fixtures.GetMultipleAdministrationEvents(numOfEvents)
+
+	preExistingEventsLength := numOfEvents / 3 / 2
+	uniqueEventsLength := numOfEvents / 3
+	preExistingEvents := make([]*events.AdministrationEvent, 0, preExistingEventsLength)
+	benchmarkEvents := make([]*events.AdministrationEvent, 0, numOfEvents)
+
+	// A third of the events will be duplicated within the input, which should lead to deduplication within the writer's
+	// buffer.
+	benchmarkEvents = append(benchmarkEvents, fixtureEvents[0:uniqueEventsLength]...)
+	benchmarkEvents = append(benchmarkEvents, fixtureEvents[0:uniqueEventsLength]...)
+	// A third of the events will be unique within the input.
+	benchmarkEvents = append(benchmarkEvents, fixtureEvents[uniqueEventsLength*2:numOfEvents]...)
+	// A couple of the unique events should be pre-populated within the database, which should lead to deduplication
+	// within the writer's buffer.
+	preExistingEvents = append(preExistingEvents, fixtureEvents[uniqueEventsLength*2:numOfEvents-preExistingEventsLength]...)
+
+	return benchmarkEvents, preExistingEvents
+}

--- a/central/administration/events/datastore/internal/store/mocks/store.go
+++ b/central/administration/events/datastore/internal/store/mocks/store.go
@@ -36,6 +36,20 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
+// DeleteMany mocks base method.
+func (m *MockStore) DeleteMany(ctx context.Context, identifiers []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteMany", ctx, identifiers)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteMany indicates an expected call of DeleteMany.
+func (mr *MockStoreMockRecorder) DeleteMany(ctx, identifiers interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, identifiers)
+}
+
 // Get mocks base method.
 func (m *MockStore) Get(ctx context.Context, id string) (*storage.AdministrationEvent, bool, error) {
 	m.ctrl.T.Helper()

--- a/central/administration/events/datastore/internal/store/store.go
+++ b/central/administration/events/datastore/internal/store/store.go
@@ -14,4 +14,5 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storage.AdministrationEvent, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.AdministrationEvent, error)
 	UpsertMany(ctx context.Context, objs []*storage.AdministrationEvent) error
+	DeleteMany(ctx context.Context, identifiers []string) error
 }


### PR DESCRIPTION
## Description

This PR adds a benchmark to the datastore for administration events, specifically to benchmark the buffered writer's `Upsert` and `Flush` methods.

A follow-up PR will be created to address the issue of slow mutex, this can be seen as a prefactor to allow for performance comparision.

The result of the benchmark ran locally:
```
goos: darwin
goarch: amd64
pkg: github.com/stackrox/rox/central/administration/events/datastore
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDatastore_Add_and_Flush
BenchmarkDatastore_Add_and_Flush/add_1000_events_to_the_writer_and_flush_it
BenchmarkDatastore_Add_and_Flush/add_1000_events_to_the_writer_and_flush_it-12         	      10	 836921826 ns/op
BenchmarkDatastore_Add_and_Flush/add_5000_events_to_the_writer_and_flush_it
BenchmarkDatastore_Add_and_Flush/add_5000_events_to_the_writer_and_flush_it-12         	      10	6038313783 ns/op
BenchmarkDatastore_Add_and_Flush/add_10000_events_to_the_writer_and_flush_it
BenchmarkDatastore_Add_and_Flush/add_10000_events_to_the_writer_and_flush_it-12        	      10	12902175842 ns/op
BenchmarkDatastore_Add_and_Flush/add_20000_events_to_the_writer_and_flush_it
BenchmarkDatastore_Add_and_Flush/add_20000_events_to_the_writer_and_flush_it-12        	      10	27043088743 ns/op
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI, only benchmark tests have been added.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
