### PR TITLE
ROX-19984: Report emails do not have custom subject and other bugs

### DIFF
--- a/central/reports/scheduler/v2/reportgenerator/consts.go
+++ b/central/reports/scheduler/v2/reportgenerator/consts.go
@@ -51,13 +51,13 @@ const (
 		cveFieldsFragment
 	watchedImagesReportQueryOpName = "getWatchedImagesReportData"
 
-	defaultEmailSubjectTemplate = "({{.BrandedProductNameShort}}) Workload CVE Report for {{.ReportConfigName}}; Scope: {{.CollectionName}}"
+	defaultEmailSubjectTemplate = "{{.BrandedProductNameShort}} Workload CVE Report for {{.ReportConfigName}}; Scope: {{.CollectionName}}"
 
-	defaultEmailBodyTemplate = "{{.BrandedProductName}} ({{.BrandedProductNameShort}}) for Kubernetes has identified workload CVEs in the images matched by the following report configuration parameters. " +
+	defaultEmailBodyTemplate = "{{.BrandedPrefix}} for Kubernetes has identified workload CVEs in the images matched by the following report configuration parameters. " +
 		"The attached Vulnerability report lists those workload CVEs and associated details to help with remediation. " +
-		"Please review the vulnerable software packages/ components from the impacted images and update them to a version containing the fix, if one is available.\n"
+		"Please review the vulnerable software packages/components from the impacted images and update them to a version containing the fix, if one is available.\n"
 
-	defaultNoVulnsEmailBodyTemplate = "{{.BrandedProductName}} ({{.BrandedProductNameShort}}) for Kubernetes has found no workload CVEs in the images matched by the following report configuration parameters.\n"
+	defaultNoVulnsEmailBodyTemplate = "{{.BrandedPrefix}} for Kubernetes has found no workload CVEs in the images matched by the following report configuration parameters.\n"
 
 	paginatedQueryStartOffset = 0
 )

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter.go
@@ -62,8 +62,7 @@ func formatEmailSubject(subjectTemplate string, snapshot *storage.ReportSnapshot
 
 func formatEmailBody(emailTemplate string) (string, error) {
 	data := &reportEmailBodyFormat{
-		BrandedProductName:      branding.GetProductName(),
-		BrandedProductNameShort: branding.GetProductNameShort(),
+		BrandedPrefix: branding.GetCombinedProductAndShortName(),
 	}
 
 	tmpl, err := template.New("emailBody").Parse(emailTemplate)

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -124,7 +124,7 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 		}
 
 	case storage.ReportStatus_EMAIL:
-		emailSubject, err := formatEmailSubject(defaultEmailSubjectTemplate, req.ReportSnapshot)
+		defaultEmailSubject, err := formatEmailSubject(defaultEmailSubjectTemplate, req.ReportSnapshot)
 		if err != nil {
 			return errors.Wrap(err, "Error generating email subject")
 		}
@@ -160,6 +160,11 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 			emailBody := defaultEmailBody
 			if customBody != "" {
 				emailBody = customBody
+			}
+			customSubject := notifierSnap.GetEmailConfig().GetCustomSubject()
+			emailSubject := defaultEmailSubject
+			if customSubject != "" {
+				emailSubject = customSubject
 			}
 			emailBodyWithConfigDetails := addReportConfigDetails(emailBody, configDetailsHTML)
 			err := rg.retryableSendReportResults(reportNotifier, notifierSnap.GetEmailConfig().GetMailingLists(),

--- a/central/reports/scheduler/v2/reportgenerator/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/types.go
@@ -13,8 +13,7 @@ type ReportRequest struct {
 }
 
 type reportEmailBodyFormat struct {
-	BrandedProductName      string
-	BrandedProductNameShort string
+	BrandedPrefix string
 }
 
 type reportEmailSubjectFormat struct {

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	permissionsMocks "github.com/stackrox/rox/pkg/auth/permissions/mocks"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/grpc/authn"
@@ -563,7 +564,7 @@ func (s *ReportServiceTestSuite) upsertReportConfigTestCases(isUpdate bool) []up
 			desc: "Report config with invalid notifier: Custom email subject too long",
 			setMocksAndGenReportConfig: func() *apiV2.ReportConfiguration {
 				ret := fixtures.GetValidV2ReportConfigWithMultipleNotifiers()
-				ret.Notifiers[0].GetEmailConfig().CustomSubject = strings.Repeat("a", validation.CustomEmailSubjectMaxLen+1)
+				ret.Notifiers[0].GetEmailConfig().CustomSubject = strings.Repeat("a", env.ReportCustomEmailSubjectMaxLen.IntegerSetting()+1)
 				return ret
 			},
 			isValidationError: true,
@@ -572,7 +573,7 @@ func (s *ReportServiceTestSuite) upsertReportConfigTestCases(isUpdate bool) []up
 			desc: "Report config with invalid notifier: Custom email body too long",
 			setMocksAndGenReportConfig: func() *apiV2.ReportConfiguration {
 				ret := fixtures.GetValidV2ReportConfigWithMultipleNotifiers()
-				ret.Notifiers[0].GetEmailConfig().CustomBody = strings.Repeat("a", validation.CustomEmailBodyMaxLen+1)
+				ret.Notifiers[0].GetEmailConfig().CustomBody = strings.Repeat("a", env.ReportCustomEmailBodyMaxLen.IntegerSetting()+1)
 				return ret
 			},
 			isValidationError: true,

--- a/central/reports/validation/validate.go
+++ b/central/reports/validation/validate.go
@@ -13,18 +13,12 @@ import (
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	apiV2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/stringutils"
-)
-
-const (
-	// CustomEmailSubjectMaxLen is the maximum allowed length for custom email subject
-	CustomEmailSubjectMaxLen = 256
-	// CustomEmailBodyMaxLen is the maximum allowed length for custom email body
-	CustomEmailBodyMaxLen = 1500
 )
 
 // Use this context only to
@@ -129,11 +123,13 @@ func (v *Validator) validateEmailConfig(emailConfig *apiV2.EmailNotifierConfigur
 	if len(emailConfig.GetMailingLists()) == 0 {
 		return errors.Wrap(errox.InvalidArgs, "Report configuration must specify at least one email recipient to send the report to")
 	}
-	if len(emailConfig.GetCustomSubject()) > CustomEmailSubjectMaxLen {
-		return errors.Wrapf(errox.InvalidArgs, "Custom email subject must be fewer than %d characters", CustomEmailSubjectMaxLen)
+	subjectMaxLen := env.ReportCustomEmailSubjectMaxLen.IntegerSetting()
+	if len(emailConfig.GetCustomSubject()) > subjectMaxLen {
+		return errors.Wrapf(errox.InvalidArgs, "Custom email subject must be fewer than %d characters", subjectMaxLen)
 	}
-	if len(emailConfig.GetCustomBody()) > CustomEmailBodyMaxLen {
-		return errors.Wrapf(errox.InvalidArgs, "Custom email body must be fewer than than %d characters", CustomEmailBodyMaxLen)
+	bodyMaxLen := env.ReportCustomEmailBodyMaxLen.IntegerSetting()
+	if len(emailConfig.GetCustomBody()) > bodyMaxLen {
+		return errors.Wrapf(errox.InvalidArgs, "Custom email body must be fewer than than %d characters", bodyMaxLen)
 	}
 
 	errorList := errorhelpers.NewErrorList("Invalid email addresses in mailing list: ")

--- a/central/reports/validation/validate.go
+++ b/central/reports/validation/validate.go
@@ -22,9 +22,9 @@ import (
 
 const (
 	// CustomEmailSubjectMaxLen is the maximum allowed length for custom email subject
-	CustomEmailSubjectMaxLen = 250
+	CustomEmailSubjectMaxLen = 256
 	// CustomEmailBodyMaxLen is the maximum allowed length for custom email body
-	CustomEmailBodyMaxLen = 1000
+	CustomEmailBodyMaxLen = 1500
 )
 
 // Use this context only to

--- a/pkg/branding/brandedtext.go
+++ b/pkg/branding/brandedtext.go
@@ -1,5 +1,7 @@
 package branding
 
+import "fmt"
+
 const (
 	productNameRHACS    = "Red Hat Advanced Cluster Security for Kubernetes"
 	productNameStackrox = "StackRox"
@@ -19,6 +21,15 @@ func GetProductName() string {
 func GetProductNameShort() string {
 	if getProductBrandingEnv() == ProductBrandingRHACS {
 		return productNameRHACSShort
+	}
+	return productNameStackrox
+}
+
+// GetCombinedProductAndShortName returns a combined form of product name and short product name based on
+// ProductBranding env variable
+func GetCombinedProductAndShortName() string {
+	if getProductBrandingEnv() == ProductBrandingRHACS {
+		return fmt.Sprintf("%s (%s)", productNameRHACS, productNameRHACSShort)
 	}
 	return productNameStackrox
 }

--- a/pkg/env/vulnerability_management.go
+++ b/pkg/env/vulnerability_management.go
@@ -3,4 +3,10 @@ package env
 var (
 	// ReportExecutionMaxConcurrency sets the maximum number vulnerability reports that can run in parallel
 	ReportExecutionMaxConcurrency = RegisterIntegerSetting("ROX_REPORT_EXECUTION_MAX_CONCURRENCY", 5)
+
+	// ReportCustomEmailSubjectMaxLen sets the maximum allowed length for custom email subject in vulnerability report emails
+	ReportCustomEmailSubjectMaxLen = RegisterIntegerSetting("ROX_REPORT_CUSTOM_EMAIL_SUBJECT_MAX_LEN", 256)
+
+	// ReportCustomEmailBodyMaxLen sets the maximum allowed length for custom email body in vulnerability report emails
+	ReportCustomEmailBodyMaxLen = RegisterIntegerSetting("ROX_REPORT_CUSTOM_EMAIL_BODY_MAX_LEN", 1500)
 )


### PR DESCRIPTION
## Description

This PR fixes following bugs
- Custom subject not getting sent in report emails
- Increase custom subject and body max lengths to match the settings on UI
- Make the default email body consistent with the UI

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Manual testing

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
