### PR TITLE
fix(qa): Update multi-arch image for SACTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -37,7 +37,7 @@ import spock.lang.Unroll
 
 @Tag("BAT")
 class SACTest extends BaseSpecification {
-    static final private String IMAGE = "quay.io/rhacs-eng/qa:nginx-unprivileged-1.25.2"
+    static final private String IMAGE = "quay.io/rhacs-eng/qa-multi-arch:nginx-unprivileged-1.25.2"
     static final private String DEPLOYMENTNGINX_NAMESPACE_QA1 = "sac-deploymentnginx-qa1"
     static final private String NAMESPACE_QA1 = "qa-test1"
     static final private String DEPLOYMENTNGINX_NAMESPACE_QA2 = "sac-deploymentnginx-qa2"


### PR DESCRIPTION
## Description

Updates SACTest to use multiarch image for nginx-unprivileged-1.25.2

## Testing Performed
relying on CI

