### PR TITLE
ROX-18197: reenable test sensor reconnects

### DIFF
--- a/sensor/tests/connection/connection_test.go
+++ b/sensor/tests/connection/connection_test.go
@@ -66,9 +66,6 @@ func Test_SensorHello2(t *testing.T) {
 }
 
 func Test_SensorReconnects(t *testing.T) {
-	// TODO(ROX-18197) Address flakiness
-	t.Skipf("This test is too flaky. Has to be fixed before re-enabled")
-
 	t.Setenv("ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT", "true")
 	t.Setenv("ROX_RESYNC_DISABLED", "true")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", "1s")

--- a/sensor/tests/connection/connection_test.go
+++ b/sensor/tests/connection/connection_test.go
@@ -17,6 +17,9 @@ var (
 )
 
 func Test_SensorHello(t *testing.T) {
+	// TODO(ROX-18197): Re-enable this test before merging and fix the cleanup
+	t.Skipf("Skipping temorarily to see if that makes Test_SensorReconnect pass")
+
 	t.Setenv("ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT", "true")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", "1s")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL", "2s")

--- a/sensor/tests/connection/connection_test.go
+++ b/sensor/tests/connection/connection_test.go
@@ -17,9 +17,6 @@ var (
 )
 
 func Test_SensorHello(t *testing.T) {
-	// TODO(ROX-18197): Re-enable this test before merging and fix the cleanup
-	t.Skipf("Skipping temorarily to see if that makes Test_SensorReconnect pass")
-
 	t.Setenv("ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT", "true")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", "1s")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL", "2s")


### PR DESCRIPTION
## Description

Testing if Test_SensorReconnects is still flaky

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Testing if Test_SensorReconnects is still flaky