### PR TITLE
ROX-20001: Align administration events Count column head at right

### DIFF
--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.css
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.css
@@ -1,7 +1,8 @@
-#AdministrationEventsTable td:first-child {
-    width: 14px;
-}
-
-#AdministrationEventsTable td:first-child[data-label="Level icon"] {
-    vertical-align: middle;
+/*
+ * With sort button, count column head needs more than pf-u-text-align-right utility class
+ * to align at right for numeric data.
+ */
+#AdministrationEventsTable th:last-child button.pf-c-table__button {
+    margin-left: auto;
+    padding-right: 0;
 }

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
@@ -41,12 +41,7 @@ function AdministrationEventsTable({
                         <Th modifier="nowrap">Resource type</Th>
                         <Th>Level</Th>
                         <Th sort={getSortParams(lastOccurredAtField)}>Event last occurred at</Th>
-                        <Th
-                            sort={getSortParams(numOccurrencesField)}
-                            className="pf-u-text-align-right"
-                        >
-                            Count
-                        </Th>
+                        <Th sort={getSortParams(numOccurrencesField)}>Count</Th>
                     </Tr>
                 </Thead>
                 {events.map((event) => {


### PR DESCRIPTION
## Description

Yuck, in such a hurry that I copied title of subsequent pull request into commit message.

Thanks to Daniel Haus for reporting this problem that I overlooked in #7958

### Problem

**Count** column head aligned left but data aligned right (common convention for numeric values).

### Analysis

Utility class worked when column head contained only text, but `sort` param implicitly wraps text in a `button` element.

### Solution

1. Delete `className` prop.
2. Replace obsolete style rules with rule that aligns `button` element at right.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before `yarn deploy` in ui, do the following:

```sh
export ROX_ADMINISTRATION_EVENTS=true
```

### Manual testing

1. Visit /main/administration-events

    * **Count** aligned left without style rule
        ![left_without](https://github.com/stackrox/stackrox/assets/11862657/37c6fd51-e918-4547-bce9-4483cb271ff3)

    * **Count** aligned right with style rule
        ![right_with](https://github.com/stackrox/stackrox/assets/11862657/76671719-9ec8-4775-b49c-ecad3d6eab58)

### Integration testing

Before `yarn cypress-open` in ui/apps/platform, do the following:

```sh
export CYPRESS_ROX_ADMINISTRATION_EVENTS=true
```

* administation/events/eventsTable.test.js
