### PR TITLE
chore(ci): Free up some space for GHA runners

### DIFF
--- a/.github/actions/job-preamble/action.yaml
+++ b/.github/actions/job-preamble/action.yaml
@@ -1,0 +1,23 @@
+name: Job Preamble
+description: Common steps for most jobs
+runs:
+  using: composite
+  steps:
+    - name: Recover docker image cache space
+      run: |
+        df --si /
+        docker system prune --force --all
+        df --si /
+      shell: bash
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Ignore dubious repository ownership
+      run: |
+        # Prevent fatal error "detected dubious ownership in repository" from recent git.
+        git config --global --add safe.directory "$(pwd)"
+      shell: bash

--- a/.github/actions/job-preamble/action.yaml
+++ b/.github/actions/job-preamble/action.yaml
@@ -10,12 +10,6 @@ runs:
         df --si /
       shell: bash
 
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
-
     - name: Ignore dubious repository ownership
       run: |
         # Prevent fatal error "detected dubious ownership in repository" from recent git.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -448,7 +448,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-         ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Checkout submodules
       run: |
@@ -577,7 +577,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-         ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,6 +80,12 @@ jobs:
     steps:
       - uses: ./.github/actions/job-preamble
 
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - uses: ./.github/actions/create-concatenated-ui-monorepo-lock
 
       - uses: ./.github/actions/cache-ui-dependencies
@@ -105,6 +111,12 @@ jobs:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
       - uses: ./.github/actions/job-preamble
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -135,6 +147,12 @@ jobs:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
       - uses: ./.github/actions/job-preamble
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -182,6 +200,12 @@ jobs:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
       - uses: ./.github/actions/job-preamble
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -262,6 +286,12 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - uses: ./.github/actions/job-preamble
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -414,6 +444,12 @@ jobs:
 
     - uses: ./.github/actions/job-preamble
 
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+         ref: ${{ github.event.pull_request.head.sha }}
+
     - name: Checkout submodules
       run: |
         git submodule update --init
@@ -469,6 +505,12 @@ jobs:
       ROX_PRODUCT_BRANDING: ${{ matrix.branding }}
     steps:
       - uses: ./.github/actions/job-preamble
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -531,6 +573,12 @@ jobs:
     steps:
     - uses: ./.github/actions/job-preamble
 
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+         ref: ${{ github.event.pull_request.head.sha }}
+
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
 
@@ -577,6 +625,12 @@ jobs:
         STACKROX_CI_INSTANCE_CENTRAL_HOST: ${{ secrets.STACKROX_CI_INSTANCE_CENTRAL_HOST }}
     steps:
       - uses: ./.github/actions/job-preamble
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout submodules
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,22 +78,7 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-      - name: Investigate runner space
-        run: |
-          df --si /
-          docker system prune --force --all
-          df --si /
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Ignore dubious repository ownership
-        run: |
-          # Prevent fatal error "detected dubious ownership in repository" from recent git.
-          git config --global --add safe.directory "$(pwd)"
+      - uses: ./.github/actions/job-preamble
 
       - uses: ./.github/actions/create-concatenated-ui-monorepo-lock
 
@@ -119,16 +104,7 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Ignore dubious repository ownership
-        run: |
-          # Prevent fatal error "detected dubious ownership in repository" from recent git.
-          git config --global --add safe.directory "$(pwd)"
+      - uses: ./.github/actions/job-preamble
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -158,16 +134,7 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Ignore dubious repository ownership
-        run: |
-          # Prevent fatal error "detected dubious ownership in repository" from recent git.
-          git config --global --add safe.directory "$(pwd)"
+      - uses: ./.github/actions/job-preamble
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -214,16 +181,7 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Ignore dubious repository ownership
-        run: |
-          # Prevent fatal error "detected dubious ownership in repository" from recent git.
-          git config --global --add safe.directory "$(pwd)"
+      - uses: ./.github/actions/job-preamble
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -303,22 +261,13 @@ jobs:
             echo "ROX_PRODUCT_BRANDING=${brand}"
           } >> "$GITHUB_ENV"
 
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: ./.github/actions/job-preamble
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      - name: Ignore dubious repository ownership
-        run: |
-          # Prevent fatal error "detected dubious ownership in repository" from recent git.
-          git config --global --add safe.directory "$(pwd)"
 
       - name: Checkout submodules
         run: |
@@ -463,16 +412,7 @@ jobs:
           echo "ROX_PRODUCT_BRANDING=${brand}"
         } >> "$GITHUB_ENV"
 
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: Ignore dubious repository ownership
-      run: |
-        # Prevent fatal error "detected dubious ownership in repository" from recent git.
-        git config --global --add safe.directory "$(pwd)"
+    - uses: ./.github/actions/job-preamble
 
     - name: Checkout submodules
       run: |
@@ -528,16 +468,7 @@ jobs:
     env:
       ROX_PRODUCT_BRANDING: ${{ matrix.branding }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Ignore dubious repository ownership
-        run: |
-          # Prevent fatal error "detected dubious ownership in repository" from recent git.
-          git config --global --add safe.directory "$(pwd)"
+      - uses: ./.github/actions/job-preamble
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -598,16 +529,7 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: Ignore dubious repository ownership
-      run: |
-        # Prevent fatal error "detected dubious ownership in repository" from recent git.
-        git config --global --add safe.directory "$(pwd)"
+    - uses: ./.github/actions/job-preamble
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
@@ -654,16 +576,7 @@ jobs:
         STACKROX_CI_INSTANCE_API_KEY: ${{ secrets.STACKROX_CI_INSTANCE_API_KEY }}
         STACKROX_CI_INSTANCE_CENTRAL_HOST: ${{ secrets.STACKROX_CI_INSTANCE_CENTRAL_HOST }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Ignore dubious repository ownership
-        run: |
-          # Prevent fatal error "detected dubious ownership in repository" from recent git.
-          git config --global --add safe.directory "$(pwd)"
+      - uses: ./.github/actions/job-preamble
 
       - name: Checkout submodules
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,11 +80,9 @@ jobs:
     steps:
       - name: Investigate runner space
         run: |
-          df .
-          df /
+          df --si /
           docker system prune --force --all
-          df .
-          df /
+          df --si /
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,6 +78,14 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
+      - name: Investigate runner space
+        run: |
+          df .
+          df /
+          docker system prune --force --all
+          df .
+          df /
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,13 +78,13 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-      - uses: ./.github/actions/job-preamble
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ./.github/actions/job-preamble
 
       - uses: ./.github/actions/create-concatenated-ui-monorepo-lock
 
@@ -110,13 +110,13 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-      - uses: ./.github/actions/job-preamble
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ./.github/actions/job-preamble
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -146,13 +146,13 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-      - uses: ./.github/actions/job-preamble
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ./.github/actions/job-preamble
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -199,13 +199,13 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-      - uses: ./.github/actions/job-preamble
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ./.github/actions/job-preamble
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -285,13 +285,13 @@ jobs:
             echo "ROX_PRODUCT_BRANDING=${brand}"
           } >> "$GITHUB_ENV"
 
-      - uses: ./.github/actions/job-preamble
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ./.github/actions/job-preamble
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -442,13 +442,13 @@ jobs:
           echo "ROX_PRODUCT_BRANDING=${brand}"
         } >> "$GITHUB_ENV"
 
-    - uses: ./.github/actions/job-preamble
-
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - uses: ./.github/actions/job-preamble
 
     - name: Checkout submodules
       run: |
@@ -504,13 +504,13 @@ jobs:
     env:
       ROX_PRODUCT_BRANDING: ${{ matrix.branding }}
     steps:
-      - uses: ./.github/actions/job-preamble
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ./.github/actions/job-preamble
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -571,13 +571,13 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - uses: ./.github/actions/job-preamble
-
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - uses: ./.github/actions/job-preamble
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
@@ -624,13 +624,13 @@ jobs:
         STACKROX_CI_INSTANCE_API_KEY: ${{ secrets.STACKROX_CI_INSTANCE_API_KEY }}
         STACKROX_CI_INSTANCE_CENTRAL_HOST: ${{ secrets.STACKROX_CI_INSTANCE_CENTRAL_HOST }}
     steps:
-      - uses: ./.github/actions/job-preamble
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ./.github/actions/job-preamble
 
       - name: Checkout submodules
         run: |

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -22,16 +22,7 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: Ignore dubious repository ownership
-      run: |
-        # Prevent fatal error "detected dubious ownership in repository" from recent git.
-        git config --global --add safe.directory "$(pwd)"
+    - uses: ./.github/actions/job-preamble
 
     - name: Create artifacts dir
       run: mkdir -p "$ARTIFACT_DIR"
@@ -49,19 +40,10 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
+    - uses: ./.github/actions/job-preamble
 
     - name: Create artifacts dir
       run: mkdir -p "$ARTIFACT_DIR"
-
-    - name: Ignore dubious repository ownership
-      run: |
-        # Prevent fatal error "detected dubious ownership in repository" from recent git.
-        git config --global --add safe.directory "$(pwd)"
 
     - name: Ensure no trailing whitespaces
       if: github.event_name == 'pull_request'
@@ -82,16 +64,7 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Ignore dubious repository ownership
-        run: |
-          # Prevent fatal error "detected dubious ownership in repository" from recent git.
-          git config --global --add safe.directory "$(pwd)"
+      - uses: ./.github/actions/job-preamble
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -116,16 +89,7 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: Ignore dubious repository ownership
-      run: |
-        # Prevent fatal error "detected dubious ownership in repository" from recent git.
-        git config --global --add safe.directory "$(pwd)"
+    - uses: ./.github/actions/job-preamble
 
     - name: Check Cache golangci-lint
       run: make golangci-lint-cache-status

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -24,6 +24,12 @@ jobs:
     steps:
     - uses: ./.github/actions/job-preamble
 
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+         ref: ${{ github.event.pull_request.head.sha }}
+
     - name: Create artifacts dir
       run: mkdir -p "$ARTIFACT_DIR"
 
@@ -41,6 +47,12 @@ jobs:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
     - uses: ./.github/actions/job-preamble
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Create artifacts dir
       run: mkdir -p "$ARTIFACT_DIR"
@@ -66,6 +78,12 @@ jobs:
     steps:
       - uses: ./.github/actions/job-preamble
 
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
 
@@ -90,6 +108,12 @@ jobs:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
     - uses: ./.github/actions/job-preamble
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Check Cache golangci-lint
       run: make golangci-lint-cache-status

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-         ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Create artifacts dir
       run: mkdir -p "$ARTIFACT_DIR"
@@ -52,7 +52,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-         ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Create artifacts dir
       run: mkdir -p "$ARTIFACT_DIR"
@@ -113,7 +113,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-         ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Check Cache golangci-lint
       run: make golangci-lint-cache-status

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -22,13 +22,13 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - uses: ./.github/actions/job-preamble
-
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - uses: ./.github/actions/job-preamble
 
     - name: Create artifacts dir
       run: mkdir -p "$ARTIFACT_DIR"
@@ -46,13 +46,13 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - uses: ./.github/actions/job-preamble
-
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - uses: ./.github/actions/job-preamble
 
     - name: Create artifacts dir
       run: mkdir -p "$ARTIFACT_DIR"
@@ -76,13 +76,13 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-      - uses: ./.github/actions/job-preamble
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ./.github/actions/job-preamble
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -107,13 +107,13 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - uses: ./.github/actions/job-preamble
-
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - uses: ./.github/actions/job-preamble
 
     - name: Check Cache golangci-lint
       run: make golangci-lint-cache-status

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -25,11 +25,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - uses: ./.github/actions/job-preamble
+
     - name: Check checkout
       run: |
         git log
-
-    - uses: ./.github/actions/job-preamble
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
@@ -124,11 +124,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - uses: ./.github/actions/job-preamble
+
     - name: Check checkout
       run: |
         git log
-
-    - uses: ./.github/actions/job-preamble
 
     - name: Create combined mono repo lock file
       uses: ./.github/actions/create-concatenated-ui-monorepo-lock

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,13 +20,13 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - uses: ./.github/actions/job-preamble
-
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - uses: ./.github/actions/job-preamble
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
@@ -75,13 +75,13 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - uses: ./.github/actions/job-preamble
-
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - uses: ./.github/actions/job-preamble
 
     - name: Run Postgres
       run: |
@@ -119,13 +119,13 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - uses: ./.github/actions/job-preamble
-
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - uses: ./.github/actions/job-preamble
 
     - name: Create combined mono repo lock file
       uses: ./.github/actions/create-concatenated-ui-monorepo-lock
@@ -154,13 +154,13 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - uses: ./.github/actions/job-preamble
-
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - uses: ./.github/actions/job-preamble
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -24,7 +24,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Check checkout
+      run: |
+        git log
 
     - uses: ./.github/actions/job-preamble
 
@@ -79,7 +82,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
 
     - uses: ./.github/actions/job-preamble
 
@@ -121,9 +123,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Check checkout
+      run: |
+        git log
 
     - uses: ./.github/actions/job-preamble
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -27,10 +27,6 @@ jobs:
 
     - uses: ./.github/actions/job-preamble
 
-    - name: Check checkout
-      run: |
-        git log
-
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
 
@@ -125,10 +121,6 @@ jobs:
       uses: actions/checkout@v4
 
     - uses: ./.github/actions/job-preamble
-
-    - name: Check checkout
-      run: |
-        git log
 
     - name: Create combined mono repo lock file
       uses: ./.github/actions/create-concatenated-ui-monorepo-lock

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-         ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
@@ -81,7 +81,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-         ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Run Postgres
       run: |
@@ -125,7 +125,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-         ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Create combined mono repo lock file
       uses: ./.github/actions/create-concatenated-ui-monorepo-lock
@@ -160,7 +160,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-         ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -22,6 +22,12 @@ jobs:
     steps:
     - uses: ./.github/actions/job-preamble
 
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+         ref: ${{ github.event.pull_request.head.sha }}
+
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
 
@@ -71,6 +77,12 @@ jobs:
     steps:
     - uses: ./.github/actions/job-preamble
 
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+         ref: ${{ github.event.pull_request.head.sha }}
+
     - name: Run Postgres
       run: |
         su postgres -c 'initdb -D /tmp/data'
@@ -109,6 +121,12 @@ jobs:
     steps:
     - uses: ./.github/actions/job-preamble
 
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+         ref: ${{ github.event.pull_request.head.sha }}
+
     - name: Create combined mono repo lock file
       uses: ./.github/actions/create-concatenated-ui-monorepo-lock
 
@@ -137,6 +155,12 @@ jobs:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
     - uses: ./.github/actions/job-preamble
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,15 +20,7 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Ignore dubious repository ownership
-      run: |
-        # Prevent fatal error "detected dubious ownership in repository" from recent git.
-        git config --global --add safe.directory "$(pwd)"
+    - uses: ./.github/actions/job-preamble
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
@@ -77,15 +69,7 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Ignore dubious repository ownership
-      run: |
-        # Prevent fatal error "detected dubious ownership in repository" from recent git.
-        git config --global --add safe.directory "$(pwd)"
+    - uses: ./.github/actions/job-preamble
 
     - name: Run Postgres
       run: |
@@ -123,13 +107,7 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Ignore dubious repository ownership
-      run: |
-        # Prevent fatal error "detected dubious ownership in repository" from recent git.
-        git config --global --add safe.directory "$(pwd)"
+    - uses: ./.github/actions/job-preamble
 
     - name: Create combined mono repo lock file
       uses: ./.github/actions/create-concatenated-ui-monorepo-lock
@@ -158,16 +136,7 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.59
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: Ignore dubious repository ownership
-      run: |
-        # Prevent fatal error "detected dubious ownership in repository" from recent git.
-        git config --global --add safe.directory "$(pwd)"
+    - uses: ./.github/actions/job-preamble
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies


### PR DESCRIPTION
## Description

GHA jobs often fail due to insufficient disk space. The containerized jobs start with 16G available:
https://github.com/stackrox/stackrox/actions/runs/6422072015/job/17437813543?pr=7985#step:3:9
There is a cache of docker images that are not relevant to stackrox style, unit-test, build needs:
https://github.com/stackrox/stackrox/actions/runs/6422072015/job/17437813543?pr=7985#step:3:11
Which if freed gets 22G available:
https://github.com/stackrox/stackrox/actions/runs/6422072015/job/17437813543?pr=7985#step:3:129

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient