### PR TITLE
chore(concurrency): add return values to WithLock/WithRLock

### DIFF
--- a/central/globaldb/v2backuprestore/manager/restore_process.go
+++ b/central/globaldb/v2backuprestore/manager/restore_process.go
@@ -194,26 +194,22 @@ func (p *restoreProcess) Cancel() {
 }
 
 func (p *restoreProcess) Interrupt(ctx context.Context, attemptID string) (*v1.DBRestoreProcessStatus_ResumeInfo, error) {
-	var resumeInfo *v1.DBRestoreProcessStatus_ResumeInfo
-	var err error
-	var reattachCond concurrency.Waitable
 
-	concurrency.WithLock(&p.mutex, func() {
+	reattachCond, resumeInfo, err := concurrency.WithLock3(&p.mutex, func() (concurrency.Waitable, *v1.DBRestoreProcessStatus_ResumeInfo, error) {
 		if p.reattachC != nil {
 			// Process is already interrupted
-			resumeInfo = &v1.DBRestoreProcessStatus_ResumeInfo{
+			return nil, &v1.DBRestoreProcessStatus_ResumeInfo{
 				Pos: p.reattachPos,
-			}
-			return
+			}, nil
 		}
 
 		if p.attemptID != attemptID {
-			err = errors.Errorf("provided attempt ID %q does not match ID %s of current attempt", attemptID, p.attemptID)
-			return
+			return nil, nil,
+				errors.Errorf("provided attempt ID %q does not match ID %s of current attempt", attemptID, p.attemptID)
 		}
 
-		reattachCond = p.reattachableSig.Snapshot()
 		p.currentAttemptSig.SignalWithError(errors.New("attempt canceled"))
+		return p.reattachableSig.Snapshot(), nil, nil
 	})
 
 	if reattachCond == nil {

--- a/central/sensor/networkpolicies/controller_impl.go
+++ b/central/sensor/networkpolicies/controller_impl.go
@@ -91,12 +91,11 @@ func (c *controller) ApplyNetworkPolicies(ctx context.Context, mod *storage.Netw
 }
 
 func (c *controller) ProcessNetworkPoliciesResponse(resp *central.NetworkPoliciesResponse) error {
-	var retC chan *central.NetworkPoliciesResponse_Payload
-
 	seqID := resp.GetSeqId()
-	concurrency.WithLock(&c.returnChansMutex, func() {
-		retC = c.returnChans[seqID]
+	retC := concurrency.WithLock1(&c.returnChansMutex, func() chan *central.NetworkPoliciesResponse_Payload {
+		retC := c.returnChans[seqID]
 		delete(c.returnChans, seqID)
+		return retC
 	})
 
 	if retC == nil {

--- a/central/sensor/service/connection/manager_impl.go
+++ b/central/sensor/service/connection/manager_impl.go
@@ -349,9 +349,8 @@ func (m *manager) checkClusterWriteAccessAndRetrieveUpgradeCtrl(ctx context.Cont
 		return nil, err
 	}
 
-	var upgradeCtrl upgradecontroller.UpgradeController
-	concurrency.WithRLock(&m.connectionsByClusterIDMutex, func() {
-		upgradeCtrl = m.connectionsByClusterID[clusterID].upgradeCtrl
+	upgradeCtrl := concurrency.WithRLock1(&m.connectionsByClusterIDMutex, func() upgradecontroller.UpgradeController {
+		return m.connectionsByClusterID[clusterID].upgradeCtrl
 	})
 	if upgradeCtrl == nil {
 		return nil, errors.Errorf("no upgrade controller found for cluster ID %s; either the sensor has not checked in or the clusterID is invalid. Cannot trigger upgrade", clusterID)

--- a/central/sensor/service/connection/sensorevents.go
+++ b/central/sensor/service/connection/sensorevents.go
@@ -119,9 +119,8 @@ func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.Ms
 	metrics.IncSensorEventsDeduper(false, msg)
 
 	// Lazily create the queue for a type when not found.
-	var queue *workerQueue
-	concurrency.WithRLock(&s.workerQueuesMutex, func() {
-		queue = s.workerQueues[workerType]
+	queue := concurrency.WithRLock1(&s.workerQueuesMutex, func() *workerQueue {
+		return s.workerQueues[workerType]
 	})
 	if queue == nil {
 		concurrency.WithLock(&s.workerQueuesMutex, func() {

--- a/pkg/concurrency/lock.go
+++ b/pkg/concurrency/lock.go
@@ -25,3 +25,48 @@ func WithRLock(locker RLocker, do func()) {
 
 	do()
 }
+
+// WithRLock1 locks the RLocker of the given lockable, executes `do`, returns T, and releases the lock.
+// This function is panic-safe, i.e., even if `do()` panics, the lock will be released.
+func WithRLock1[T any](locker RLocker, do func() T) T {
+	locker.RLock()
+	defer locker.RUnlock()
+
+	return do()
+}
+
+// WithRLock2 locks the RLocker of the given lockable, executes `do`, returns T and E, and releases the lock.
+// This function is panic-safe, i.e., even if `do()` panics, the lock will be released.
+func WithRLock2[T any, E any](locker RLocker, do func() (T, E)) (T, E) {
+	locker.RLock()
+	defer locker.RUnlock()
+
+	return do()
+}
+
+// WithLock1 locks the given locker, executes `do`, returns T, and releases the lock.
+// This function is panic-safe, i.e., even if `do()` panics, the lock will be released.
+func WithLock1[T any](locker sync.Locker, do func() T) T {
+	locker.Lock()
+	defer locker.Unlock()
+
+	return do()
+}
+
+// WithLock2 locks the given locker, executes `do`, returns T and E, and releases the lock.
+// This function is panic-safe, i.e., even if `do()` panics, the lock will be released.
+func WithLock2[T any, E any](locker sync.Locker, do func() (T, E)) (T, E) {
+	locker.Lock()
+	defer locker.Unlock()
+
+	return do()
+}
+
+// WithLock3 locks the given locker, executes `do`, returns T, S , E, and releases the lock.
+// This function is panic-safe, i.e., even if `do()` panics, the lock will be released.
+func WithLock3[T any, E any, S any](locker sync.Locker, do func() (T, E, S)) (T, E, S) {
+	locker.Lock()
+	defer locker.Unlock()
+
+	return do()
+}

--- a/pkg/registries/docker/docker.go
+++ b/pkg/registries/docker/docker.go
@@ -174,9 +174,8 @@ func (r *Registry) Match(image *storage.ImageName) bool {
 		return match
 	}
 
-	var list set.StringSet
-	concurrency.WithRLock(&r.repositoryListLock, func() {
-		list = r.repositoryList
+	list := concurrency.WithRLock1(&r.repositoryListLock, func() set.StringSet {
+		return r.repositoryList
 	})
 	if list == nil {
 		return match

--- a/sensor/common/detector/deduper.go
+++ b/sensor/common/detector/deduper.go
@@ -35,10 +35,9 @@ func (d *deduper) addDeployment(deployment *storage.Deployment) {
 func (d *deduper) needsProcessing(deployment *storage.Deployment) bool {
 	hashValue := deployment.GetHash()
 
-	var noUpdate bool
-	concurrency.WithRLock(&d.hashLock, func() {
+	noUpdate := concurrency.WithRLock1(&d.hashLock, func() bool {
 		oldHashValue, exists := d.hash[deployment.GetId()]
-		noUpdate = exists && hashValue == oldHashValue
+		return exists && hashValue == oldHashValue
 	})
 	if noUpdate {
 		return false

--- a/sensor/kubernetes/listener/resources/node_store.go
+++ b/sensor/kubernetes/listener/resources/node_store.go
@@ -66,10 +66,10 @@ func (s *nodeStoreImpl) Cleanup() {
 // addOrUpdateNode upserts node into store.
 // It returns true if the IP addresses of the node changed as a result.
 func (s *nodeStoreImpl) addOrUpdateNode(node *nodeWrap) bool {
-	var oldNode *nodeWrap
-	concurrency.WithLock(&s.mutex, func() {
-		oldNode = s.nodes[node.Name]
+	oldNode := concurrency.WithLock1(&s.mutex, func() *nodeWrap {
+		oldNode := s.nodes[node.Name]
 		s.nodes[node.Name] = node
+		return oldNode
 	})
 
 	if oldNode == nil || len(oldNode.addresses) != len(node.addresses) {


### PR DESCRIPTION
## Description

Based [on a discussion within the style guide](https://github.com/stackrox/stackrox/pull/7282#discussion_r1290644635) regarding improving the usage of `WithLock/RLock` to allow multiple return values.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
