### PR TITLE
ROX-19262: Move CI to RH

### DIFF
--- a/scripts/ci/gcp.sh
+++ b/scripts/ci/gcp.sh
@@ -20,13 +20,13 @@ setup_gcp() {
 
     require_executable "gcloud"
 
-    if [[ "$(gcloud config get-value core/project 2>/dev/null)" == "stackrox-ci" ]]; then
-        echo "Current project is already set to stackrox-ci. Assuming configuration already applied."
+    if [[ "$(gcloud config get-value core/project 2>/dev/null)" == "acs-san-stackroxci" ]]; then
+        echo "Current project is already set to acs-san-stackroxci. Assuming configuration already applied."
         return
     fi
     gcloud auth activate-service-account --key-file <(echo "$service_account")
     gcloud auth list
-    gcloud config set project stackrox-ci
+    gcloud config set project acs-san-stackroxci
     gcloud config set compute/region us-central1
     gcloud config unset compute/zone
     gcloud config set core/disable_prompts True

--- a/scripts/ci/gcp.sh
+++ b/scripts/ci/gcp.sh
@@ -8,9 +8,11 @@ setup_gcp() {
     info "Setting up GCP auth and config"
 
     local service_account
-    if [[ -n "${GCLOUD_SERVICE_ACCOUNT_OPENSHIFT_CI_ROX:-}" ]]; then
-        service_account="${GCLOUD_SERVICE_ACCOUNT_OPENSHIFT_CI_ROX}"
+    if [[ -n "${GCP_SERVICE_ACCOUNT_STACKROX_CI:-}" ]]; then
+        service_account="${GCP_SERVICE_ACCOUNT_STACKROX_CI}"
     elif [[ -n "${GCLOUD_SERVICE_ACCOUNT_CI_ROX:-}" ]]; then
+        # ROX-19985 stackrox/jenkins-plugin relies on this env name. This can be
+        # removed once that issue is closed.
         service_account="${GCLOUD_SERVICE_ACCOUNT_CI_ROX}"
     else
         die "Support is missing for this environment"

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -312,7 +312,7 @@ refresh_gke_token() {
         echo >/tmp/kubeconfig-new
         chmod 0600 /tmp/kubeconfig-new
         # shellcheck disable=SC2153
-        KUBECONFIG=/tmp/kubeconfig-new gcloud container clusters get-credentials --project stackrox-ci --zone "$ZONE" "$CLUSTER_NAME"
+        KUBECONFIG=/tmp/kubeconfig-new gcloud container clusters get-credentials --project acs-san-stackroxci --zone "$ZONE" "$CLUSTER_NAME"
         KUBECONFIG=/tmp/kubeconfig-new kubectl get ns >/dev/null
         mv /tmp/kubeconfig-new "$real_kubeconfig"
     done

--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -8,7 +8,7 @@ source "$ROOT/scripts/ci/gcp.sh"
 
 set -euo pipefail
 
-_TABLE_NAME="stackrox-ci.ci_metrics.stackrox_jobs"
+_TABLE_NAME="acs-san-stackroxci.ci_metrics.stackrox_jobs"
 
 create_job_record() {
     _create_job_record "$@" || {

--- a/scripts/ci/store-artifacts.bats
+++ b/scripts/ci/store-artifacts.bats
@@ -74,7 +74,7 @@ make_env() {
         PULL_PULL_SHA="12345"
     fi
     if is_OPENSHIFT_CI; then
-        GS_URL="gs://roxci-artifacts/${REPO_NAME}/${PULL_PULL_SHA:-${PULL_BASE_SHA}}/${BUILD_ID}-${JOB_NAME}"
+        GS_URL="gs://stackrox-ci-artifacts/${REPO_NAME}/${PULL_PULL_SHA:-${PULL_BASE_SHA}}/${BUILD_ID}-${JOB_NAME}"
     fi
     PATH="$BATS_RUN_TMPDIR:$PATH"
     TEST_OUTPUT=1

--- a/scripts/ci/store-artifacts.sh
+++ b/scripts/ci/store-artifacts.sh
@@ -81,7 +81,7 @@ get_unique_gs_destination() {
 }
 
 set_gs_path_vars() {
-    GS_URL="gs://roxci-artifacts"
+    GS_URL="gs://stackrox-ci-artifacts"
 
     if is_OPENSHIFT_CI; then
         local repo

--- a/scripts/ci/store-artifacts.sh
+++ b/scripts/ci/store-artifacts.sh
@@ -133,7 +133,7 @@ make_artifacts_help() {
     
     local gs_workflow_url="$GS_URL/$WORKFLOW_SUBDIR"
     local gs_job_url="$gs_workflow_url/$JOB_SUBDIR"
-    local browser_url="https://console.cloud.google.com/storage/browser/roxci-artifacts"
+    local browser_url="https://console.cloud.google.com/storage/browser/stackrox-ci-artifacts"
     local browser_job_url="$browser_url/$WORKFLOW_SUBDIR/$JOB_SUBDIR"
 
     local help_file

--- a/scripts/ci/tools/get-info-about-osci-jobs/get-info-for-shas.sh
+++ b/scripts/ci/tools/get-info-about-osci-jobs/get-info-for-shas.sh
@@ -62,7 +62,7 @@ for sha in "${shas[@]}"; do
     temp_file="$(mktemp)"
 
     error_code=0
-    gsutil -m cp -r "gs://roxci-artifacts/stackrox/$sha" "$temp_dir" || error_code=$?
+    gsutil -m cp -r "gs://stackrox-ci-artifacts/stackrox/$sha" "$temp_dir" || error_code=$?
     if (( error_code == 0 )); then
         "$DIR/get-info-about-osci-jobs.sh" "$temp_dir" >> "$output"
         tail -n +2 "$output" >> "$temp_file"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -754,7 +754,7 @@ restore_56_1_backup() {
     require_environment "API_ENDPOINT"
     require_environment "ROX_PASSWORD"
 
-    gsutil cp gs://acs-stackrox-ci/upgrade-test-dbs/stackrox_56_1_fixed_upgrade.zip .
+    gsutil cp gs://stackrox-ci-upgrade-test-fixtures/upgrade-test-dbs/stackrox_56_1_fixed_upgrade.zip .
     roxctl -e "$API_ENDPOINT" -p "$ROX_PASSWORD" \
         central db restore --timeout 2m stackrox_56_1_fixed_upgrade.zip
 }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -754,7 +754,7 @@ restore_56_1_backup() {
     require_environment "API_ENDPOINT"
     require_environment "ROX_PASSWORD"
 
-    gsutil cp gs://stackrox-ci-upgrade-test-dbs/stackrox_56_1_fixed_upgrade.zip .
+    gsutil cp gs://acs-stackrox-ci/upgrade-test-dbs/stackrox_56_1_fixed_upgrade.zip .
     roxctl -e "$API_ENDPOINT" -p "$ROX_PASSWORD" \
         central db restore --timeout 2m stackrox_56_1_fixed_upgrade.zip
 }

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -81,7 +81,7 @@ get_prometheus_metrics_parser() {
 
 compare_with_stored_metrics() {
     local debug_dump_dir="$1"
-    local gs_path="gs://acs-stackrox-ci/${COMPARISON_METRICS}"
+    local gs_path="gs://stackrox-ci-scale-test-results/${COMPARISON_METRICS}"
     local baseline_source
     local baseline_dir="/tmp/scale-test-baseline-metrics"
     local baseline_metrics

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -81,7 +81,7 @@ get_prometheus_metrics_parser() {
 
 compare_with_stored_metrics() {
     local debug_dump_dir="$1"
-    local gs_path="gs://stackrox-ci-metrics/${COMPARISON_METRICS}"
+    local gs_path="gs://acs-stackrox-ci/${COMPARISON_METRICS}"
     local baseline_source
     local baseline_dir="/tmp/scale-test-baseline-metrics"
     local baseline_metrics


### PR DESCRIPTION
## Description

This PR changes the GCP login for CI to a RH project. And moves metrics, GKE clusters, artifacts and misc storage buckets to use those in that project created by IaC: https://github.com/stackrox/automation-iac/pull/25.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- All QA
- Plus upgrade and scale tests due to their use of GCS