### PR TITLE
ROX-19990: Add administration events search filters and empty state

### DIFF
--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsEmptyState.tsx
@@ -1,0 +1,33 @@
+import React, { ReactElement } from 'react';
+import { Bullseye, EmptyState, EmptyStateBody, EmptyStateIcon } from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons';
+import { Tbody, Td, Tr } from '@patternfly/react-table';
+
+export type AdministrationEventsEmptyStateProps = {
+    colSpan: number;
+    hasFilter: boolean;
+};
+
+function AdministrationEventsEmptyState({
+    colSpan,
+    hasFilter,
+}: AdministrationEventsEmptyStateProps): ReactElement {
+    return (
+        <Tbody>
+            <Tr>
+                <Td colSpan={colSpan}>
+                    <Bullseye>
+                        <EmptyState>
+                            {hasFilter && <EmptyStateIcon icon={FilterIcon} />}
+                            <EmptyStateBody>
+                                {hasFilter ? 'No events found' : 'No events'}
+                            </EmptyStateBody>
+                        </EmptyState>
+                    </Bullseye>
+                </Td>
+            </Tr>
+        </Tbody>
+    );
+}
+
+export default AdministrationEventsEmptyState;

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
@@ -20,7 +20,7 @@ import AdministrationEventsToolbar from './AdministrationEventsToolbar';
 
 function AdministrationEventsPage(): ReactElement {
     const { page, perPage, setPage, setPerPage } = useURLPagination(10);
-    const { searchFilter } = useURLSearch();
+    const { searchFilter, setSearchFilter } = useURLSearch();
     const { getSortParams, sortOption } = useURLSort({ defaultSortOption, sortFields });
 
     const [isLoading, setIsLoading] = useState(false);
@@ -57,7 +57,6 @@ function AdministrationEventsPage(): ReactElement {
             });
     }, [page, perPage, searchFilter, sortOption, setIsLoading]);
 
-    // TODO empty state with and without filter
     // TODO polling and last updated with conditionally rendered reload button like Network Graph
     /* eslint-disable no-nested-ternary */
     return (
@@ -92,8 +91,14 @@ function AdministrationEventsPage(): ReactElement {
                             perPage={perPage}
                             setPage={setPage}
                             setPerPage={setPerPage}
+                            searchFilter={searchFilter}
+                            setSearchFilter={setSearchFilter}
                         />
-                        <AdministrationEventsTable events={events} getSortParams={getSortParams} />
+                        <AdministrationEventsTable
+                            events={events}
+                            getSortParams={getSortParams}
+                            searchFilter={searchFilter}
+                        />
                     </>
                 )}
             </PageSection>

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
@@ -14,37 +14,49 @@ import IconText from 'Components/PatternFly/IconText/IconText';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import {
     AdministrationEvent,
+    hasAdministrationEventsFilter,
     lastOccurredAtField,
     numOccurrencesField,
 } from 'services/AdministrationEventsService';
+import { SearchFilter } from 'types/search';
 
 import { getLevelIcon, getLevelText } from './AdministrationEvent';
 import AdministrationEventHintMessage from './AdministrationEventHintMessage';
 
 import './AdministrationEventsTable.css';
+import AdministrationEventsEmptyState from './AdministrationEventsEmptyState';
+
+const colSpan = 6;
 
 export type AdministrationEventsTableProps = {
     events: AdministrationEvent[];
     getSortParams: UseURLSortResult['getSortParams'];
+    searchFilter: SearchFilter;
 };
 
 function AdministrationEventsTable({
     events,
     getSortParams,
+    searchFilter,
 }: AdministrationEventsTableProps): ReactElement {
     return (
-        <>
-            <TableComposable variant="compact" borders={false} id="AdministrationEventsTable">
-                <Thead>
-                    <Tr>
-                        <Th>Domain</Th>
-                        <Th modifier="nowrap">Resource type</Th>
-                        <Th>Level</Th>
-                        <Th sort={getSortParams(lastOccurredAtField)}>Event last occurred at</Th>
-                        <Th sort={getSortParams(numOccurrencesField)}>Count</Th>
-                    </Tr>
-                </Thead>
-                {events.map((event) => {
+        <TableComposable variant="compact" borders={false} id="AdministrationEventsTable">
+            <Thead>
+                <Tr>
+                    <Th>Domain</Th>
+                    <Th modifier="nowrap">Resource type</Th>
+                    <Th>Level</Th>
+                    <Th sort={getSortParams(lastOccurredAtField)}>Event last occurred at</Th>
+                    <Th sort={getSortParams(numOccurrencesField)}>Count</Th>
+                </Tr>
+            </Thead>
+            {events.length === 0 ? (
+                <AdministrationEventsEmptyState
+                    colSpan={colSpan}
+                    hasFilter={hasAdministrationEventsFilter(searchFilter)}
+                />
+            ) : (
+                events.map((event) => {
                     const { domain, id, lastOccurredAt, level, numOccurrences, resource } = event;
                     const { type: resourceType } = resource;
 
@@ -77,7 +89,7 @@ function AdministrationEventsTable({
                                 </Td>
                             </Tr>
                             <Tr>
-                                <Td colSpan={5}>
+                                <Td colSpan={colSpan}>
                                     <ExpandableRowContent>
                                         <AdministrationEventHintMessage event={event} />
                                     </ExpandableRowContent>
@@ -85,9 +97,9 @@ function AdministrationEventsTable({
                             </Tr>
                         </Tbody>
                     );
-                })}
-            </TableComposable>
-        </>
+                })
+            )}
+        </TableComposable>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsToolbar.tsx
@@ -1,13 +1,24 @@
 import React, { ReactElement } from 'react';
 import {
     Pagination,
-    Text,
     Toolbar,
     ToolbarContent,
     ToolbarGroup,
     ToolbarItem,
 } from '@patternfly/react-core';
-import pluralize from 'pluralize';
+
+import {
+    AdministrationEventLevel,
+    getAdministrationEventsFilter,
+    replaceSearchFilterDomain,
+    replaceSearchFilterLevel,
+    replaceSearchFilterResourceType,
+} from 'services/AdministrationEventsService';
+import { SearchFilter } from 'types/search';
+
+import SearchFilterDomain from './SearchFilterDomain';
+import SearchFilterLevel from './SearchFilterLevel';
+import SearchFilterResourceType from './SearchFilterResourceType';
 
 export type AdministrationEventsToolbarProps = {
     count: number;
@@ -15,6 +26,8 @@ export type AdministrationEventsToolbarProps = {
     perPage: number;
     setPage: (newPage: number) => void;
     setPerPage: (newPerPage: number) => void;
+    searchFilter: SearchFilter;
+    setSearchFilter: (newFilter: SearchFilter) => void;
 };
 
 function AdministrationEventsToolbar({
@@ -23,15 +36,38 @@ function AdministrationEventsToolbar({
     perPage,
     setPage,
     setPerPage,
+    searchFilter,
+    setSearchFilter,
 }: AdministrationEventsToolbarProps): ReactElement {
-    const countText = `${count} ${pluralize('event', count)} found`;
+    function setDomain(domain: string | undefined) {
+        setSearchFilter(replaceSearchFilterDomain(searchFilter, domain));
+    }
+
+    function setLevel(level: AdministrationEventLevel | undefined) {
+        setSearchFilter(replaceSearchFilterLevel(searchFilter, level));
+    }
+
+    function setResourceType(resourceType: string | undefined) {
+        setSearchFilter(replaceSearchFilterResourceType(searchFilter, resourceType));
+    }
+
+    const { domain, level, resourceType } = getAdministrationEventsFilter(searchFilter);
 
     return (
         <Toolbar>
             <ToolbarContent>
-                <ToolbarGroup>
-                    <ToolbarItem variant="label">
-                        <Text>{countText}</Text>
+                <ToolbarGroup variant="filter-group">
+                    <ToolbarItem>
+                        <SearchFilterDomain domain={domain && domain[0]} setDomain={setDomain} />
+                    </ToolbarItem>
+                    <ToolbarItem>
+                        <SearchFilterResourceType
+                            resourceType={resourceType && resourceType[0]}
+                            setResourceType={setResourceType}
+                        />
+                    </ToolbarItem>
+                    <ToolbarItem>
+                        <SearchFilterLevel level={level && level[0]} setLevel={setLevel} />
                     </ToolbarItem>
                 </ToolbarGroup>
                 <ToolbarGroup alignment={{ default: 'alignRight' }}>

--- a/ui/apps/platform/src/Containers/Administration/Events/SearchFilterDomain.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/SearchFilterDomain.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { Divider, Select, SelectOption } from '@patternfly/react-core';
+
+import { domains } from 'services/AdministrationEventsService';
+
+const optionAll = 'All';
+
+type SearchFilterDomainProps = {
+    domain: string | undefined;
+    setDomain: (domain: string | undefined) => void;
+};
+
+function SearchFilterDomain({ domain, setDomain }: SearchFilterDomainProps) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    function onToggle(isOpenArg: boolean) {
+        setIsOpen(isOpenArg);
+    }
+
+    function onSelect(_event, selection) {
+        setDomain(selection === optionAll ? undefined : selection);
+        setIsOpen(false);
+    }
+
+    const options = domains.map((domainArg) => (
+        <SelectOption key={domainArg} value={domainArg}>
+            {domainArg}
+        </SelectOption>
+    ));
+    options.push(
+        <Divider key="Divider" />,
+        <SelectOption key="All" value={optionAll} isPlaceholder>
+            All domains
+        </SelectOption>
+    );
+
+    return (
+        <Select
+            variant="single"
+            aria-label="Domain filter menu items"
+            toggleAriaLabel="Domain filter menu toggle"
+            onToggle={onToggle}
+            onSelect={onSelect}
+            selections={domain ?? optionAll}
+            isOpen={isOpen}
+        >
+            {options}
+        </Select>
+    );
+}
+
+export default SearchFilterDomain;

--- a/ui/apps/platform/src/Containers/Administration/Events/SearchFilterLevel.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/SearchFilterLevel.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { Divider, Select, SelectOption } from '@patternfly/react-core';
+
+import { AdministrationEventLevel, levels } from 'services/AdministrationEventsService';
+
+import { getLevelText } from './AdministrationEvent';
+
+const optionAll = 'All';
+
+type SearchFilterLevelProps = {
+    level: AdministrationEventLevel | undefined;
+    setLevel: (level: AdministrationEventLevel) => void;
+};
+
+function SearchFilterLevel({ level, setLevel }: SearchFilterLevelProps) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    function onToggle(isOpenArg: boolean) {
+        setIsOpen(isOpenArg);
+    }
+
+    function onSelect(_event, selection) {
+        setLevel(selection === optionAll ? undefined : selection);
+        setIsOpen(false);
+    }
+
+    const options = levels.map((levelArg) => (
+        <SelectOption key={levelArg} value={levelArg}>
+            {getLevelText(levelArg)}
+        </SelectOption>
+    ));
+    options.push(
+        <Divider key="Divider" />,
+        <SelectOption key="All" value={optionAll} isPlaceholder>
+            All levels
+        </SelectOption>
+    );
+
+    return (
+        <Select
+            variant="single"
+            aria-label="Level filter menu items"
+            toggleAriaLabel="Level filter menu toggle"
+            onToggle={onToggle}
+            onSelect={onSelect}
+            selections={level ?? optionAll}
+            isOpen={isOpen}
+        >
+            {options}
+        </Select>
+    );
+}
+
+export default SearchFilterLevel;

--- a/ui/apps/platform/src/Containers/Administration/Events/SearchFilterResourceType.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/SearchFilterResourceType.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { Divider, Select, SelectOption } from '@patternfly/react-core';
+
+import { resourceTypes } from 'services/AdministrationEventsService';
+
+const optionAll = 'All';
+
+type SearchFilterResourceTypeProps = {
+    resourceType: string | undefined;
+    setResourceType: (resourceType: string | undefined) => void;
+};
+
+function SearchFilterResourceType({
+    resourceType,
+    setResourceType,
+}: SearchFilterResourceTypeProps) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    function onToggle(isOpenArg: boolean) {
+        setIsOpen(isOpenArg);
+    }
+
+    function onSelect(_event, selection) {
+        setResourceType(selection === optionAll ? undefined : selection);
+        setIsOpen(false);
+    }
+
+    const options = resourceTypes.map((resourceTypeArg) => (
+        <SelectOption key={resourceTypeArg} value={resourceTypeArg}>
+            {resourceTypeArg}
+        </SelectOption>
+    ));
+    options.push(
+        <Divider key="Divider" />,
+        <SelectOption key="All" value={optionAll} isPlaceholder>
+            All resource types
+        </SelectOption>
+    );
+
+    return (
+        <Select
+            variant="single"
+            aria-label="Resource type filter menu items"
+            toggleAriaLabel="Resource type filter menu toggle"
+            onToggle={onToggle}
+            onSelect={onSelect}
+            selections={resourceType ?? optionAll}
+            isOpen={isOpen}
+        >
+            {options}
+        </Select>
+    );
+}
+
+export default SearchFilterResourceType;


### PR DESCRIPTION
## Description

### Objective

Filter events to troubleshoot a particular platform issue.

### Changes

Thanks again to David Vail for clear examples of search filters in Workload CVEs.

1. Edit AdministrationEventsPage.tsx file:
    * Add props from `useURLSearch` hook to `AdministrationEventsToolbar` element.
    * Add `searchFilter` prop to `AdministrationEventsTable` element.

2. Edit AdministrationEventsTable.tsx file:
    * Delete unneeded fragment.
    * Add conditional rendering for empty state.

3. Add AdministrationEventsEmptyState.tsx file:
    * Adapt from existing examples.

4. Edit AdministrationEventsToolbar.tsx file:
    * Add callback functions which call generic `setSearchFilter` function from `useURLSearch` hook with value from specific `replaceSearchFilterWhatever` functions.
    * Call pure `getAdministrationEventsFilter` function that returns service-specific filter object given generic `searchFilter` from page address query string.
    * Replace count with search filter elements following design guideline (although administration events does not have generic search filter).
        https://www.patternfly.org/components/toolbar/design-guidelines#search-filter

5. Add 3 search filter elements with names independent of which PatternFly element, because it might change from `Select` to something else in the future.
    * SearchFilterDomain, which might add creatable **post-MVP** so additions to backend do not require frontend changes.
    * SearchFilterLevel, which might become multi-select **post-MVP**.
    * SearchFilterResourceType, which might add creatable **post-MVP** so additions to backend do not require frontend changes.

6. Edit AdministrationEventsService.ts file
    * Reverse order of `types` and `levels` arrays (with comment that order is for search filter elements). Although I usually write frontend types in similar order as backend source of truth for clarity of comparison, it seems opposite to intuitive looking from the outside in.
    * Add `domains` array and comment about backend file that is source of truth.
    * Add `resourceTypes` array and comment about backend files that are sources of truth.
    * Replace inline strings with variables for search fields.
    * Remove optional `?` for `pagination` because hook always provides a value.
    * Add `from` and `until` to `getAdministrationEventsFilter` function so testing of date filter is possible via page address query string.
    * Add `hasAdministrationEventsFilter` function to distinguish empty state with or without filter.
    * Add `replaceSearchFilterWhatever` functions to encapsulate relationship between generic `searchFilter` properties and service-specific `filter` properties.

### Residue

1. Collaborate with Daniel and Stephan to test `from` and `until` time filters. Initial search results were not what I expected.
2. Estimate effort to include search filters for time, whether for MVP or post-MVP.
3. Estimate effort to include information about filtering in page title similar to global search. Related to backward cause-and-effect testing described at the end of the steps.

### Next step

1. Events page:
    * Synchronize requests for events and counts.
    * Display **Last updated** time and **N events available** button.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before `yarn deploy` in ui, do the following:

```sh
export ROX_ADMINISTRATION_EVENTS=true
```

Hard to know why the decrease in bundle size and number of files.

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js: -36 = 3893591 - 3893627
        total: -2622 = 10155037 - 10157659
    * `ls -al build/static/js/*.js | wc -l`
        -1 = 82 - 83 files
3. `yarn start` in ui

### Manual testing

Pictures at 1440px width like a laptop but 1080px height of a panel.

1. Visit /main/administration-events

    * See query string in count request: `?`
    * See placeholders in search filters: **All domains**, **All resource types**, **All levels**
        ![1](https://github.com/stackrox/stackrox/assets/11862657/acdcff2f-da03-4c94-b016-ef799c57fbb9)

2. Select **Image Scanning** in domain filter.

    * See query string in count request: `?filter.domain=Image%20Scanning`
    * See query string in page address: `?s[Event%20Domain]=Image%20Scanning`
    * See all results.
        ![2](https://github.com/stackrox/stackrox/assets/11862657/f3821f21-a893-44df-a6be-2f908179e3fe)

3. Select **Integrations** in domain filter.

    * See query string in count request: `?filter.domain=Integrations`
    * See query string in page address: `?s[Event%20Domain]=Integrations`
    * See empty state with filter.
        ![3](https://github.com/stackrox/stackrox/assets/11862657/779eec79-e75d-4b72-a471-9c22d9d5c532)

4. Select **All domains** in domain filter, and then select **Image** in resource type filter.

    * See query string in count request: `?filter.resourceType=Image`
    * See query string in page address: `?s[Resource%20Type]=Image`
    * See all results.
        ![4](https://github.com/stackrox/stackrox/assets/11862657/53222e0f-eb66-40a7-a0d2-8b46ea1bab88)

5. Select **Notifier** in resource type filter.

    * See query string in count request: `?filter.resourceType=Notifier`
    * See query string in page address: `?s[Resource%20Type]=Notifier`
    * See empty state with filter.
        ![5](https://github.com/stackrox/stackrox/assets/11862657/fbd5f6be-5fdf-40b6-ae36-e4708a928d22)

6. Select **All resource types** in resource type filter, and then select **Error** in level filter.

    * See query string in count request: `?filter.level=ADMINISTRATION_EVENT_LEVEL_ERROR`
    * See query string in page address: `?s[Event%20Level]=ADMINISTRATION_EVENT_LEVEL_ERROR`
    * See all results.
        ![6](https://github.com/stackrox/stackrox/assets/11862657/0750c40e-8fec-4c5b-9e24-ca380a3ab432)

7. Select **Warning** in level filter.

    * See query string in count request: `?filter.level=ADMINISTRATION_EVENT_LEVEL_WARNING`
    * See query string in page address: `?s[Event%20Level]=ADMINISTRATION_EVENT_LEVEL_WARNING`
    * See empty state with filter.
        ![7](https://github.com/stackrox/stackrox/assets/11862657/6deca408-200a-4e94-ba8f-887bd7d851cf)

8. Select **Image Scanning** in domain filter.

    * See query string in count request: `?filter.domain=Image%20Scanning&filter.level=ADMINISTRATION_EVENT_LEVEL_WARNING`
    * See query string in page address: `?s[Event%20Level]=ADMINISTRATION_EVENT_LEVEL_WARNING&s[Event%20Domain]=Image%20Scanning`
    * See empty state with filter.
        ![8](https://github.com/stackrox/stackrox/assets/11862657/5da44fa3-a0f8-4aa6-8fe5-101dcc1b2456)

9. Select **Image** in resource type filter, select **Error** in level filter, and then click to sort ascending by time.

    * See query string in events request: `?filter.domain=Image%20Scanning&filter.level=ADMINISTRATION_EVENT_LEVEL_ERROR&filter.resourceType=Image&pagination.limit=10&pagination.offset=0&pagination.sortOption.field=Last%20Updated&pagination.sortOption.reversed=false`
    * See query string in count request: `?filter.domain=Image%20Scanning&filter.level=ADMINISTRATION_EVENT_LEVEL_ERROR&filter.resourceType=Image`
    * See query string in page address: `?s[Event%20Level]=ADMINISTRATION_EVENT_LEVEL_ERROR&s[Event%20Domain]=Image%20Scanning&s[Resource%20Type]=Image&sortOption[field]=Last%20Updated&sortOption[direction]=asc`
    * See all results sorted correctly.
        ![9](https://github.com/stackrox/stackrox/assets/11862657/ce8a9d5b-371d-4ac1-ad67-f1318992f742)

10. Click to sort ascending by count.

    * See query string in events request: `?filter.domain=Image%20Scanning&filter.level=ADMINISTRATION_EVENT_LEVEL_ERROR&filter.resourceType=Image&pagination.limit=10&pagination.offset=0&pagination.sortOption.field=Event%20Occurrence&pagination.sortOption.reversed=false`
    * See query string in count request: `?filter.domain=Image%20Scanning&filter.level=ADMINISTRATION_EVENT_LEVEL_ERROR&filter.resourceType=Image`
    * See query string in page address: `?s[Event%20Level]=ADMINISTRATION_EVENT_LEVEL_ERROR&s[Event%20Domain]=Image%20Scanning&s[Resource%20Type]=Image&sortOption[field]=Event%20Occurrence&sortOption[direction]=asc`
    * See all results sorted correctly.
        ![10](https://github.com/stackrox/stackrox/assets/11862657/ef0817ed-dd06-446a-a5e8-9b37b72e2a01)

11. Temporarily edit code to simulate no events.

    * See empty state without filter.
        ![11](https://github.com/stackrox/stackrox/assets/11862657/bf9f831f-5b3e-4feb-b7c5-b3d95f7a3aab)

In addition to cause-and-effect relationship between filter selection and query strings, I tested via browser history cause-and-effect relationship between page address query string:
* query string in request
* filter selection 

### Integration testing

Before `yarn cypress-open` in ui/apps/platform, do the following:

```sh
export CYPRESS_ROX_ADMINISTRATION_EVENTS=true
```

* administation/events/eventsTable.test.js
