### PR TITLE
chore(scanner): use t.TempDir for config test

### DIFF
--- a/scanner/config/config_test.go
+++ b/scanner/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,13 +44,7 @@ something: unexpected
 }
 
 func Test_MTLSConfig_validate(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "Test_MTLSConfig_validate")
-	assert.NoError(t, err)
-	t.Cleanup(func() {
-		if err = os.RemoveAll(tempDir); err != nil {
-			fmt.Printf("failed to delete test directory: %q\n", tempDir)
-		}
-	})
+	tempDir := t.TempDir()
 	t.Run("when cert dir exists and is directory then ok", func(t *testing.T) {
 		c := &MTLSConfig{CertsDir: tempDir}
 		err := c.validate()


### PR DESCRIPTION
## Description

Makes our lives easier to use `t.TempDir`, as it'll create the directory, not make us deal with error handling, and it will cleanup at the end of the test.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

This IS the test
