### PR TITLE
ROX-19997: Bump timeout to 25 minutes when we wait for scanner.

### DIFF
--- a/operator/tests/central/basic-central/10-assert.yaml
+++ b/operator/tests/central/basic-central/10-assert.yaml
@@ -22,7 +22,7 @@ collectors:
 - command: kubectl describe pod -n $NAMESPACE -l app=central-db
 - command: kubectl describe pod -n $NAMESPACE -l app=scanner
 - command: kubectl describe pod -n $NAMESPACE -l app=scanner-db
-timeout: 900
+timeout: 1500
 ---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: Central

--- a/operator/tests/central/basic-central/61-assert.yaml
+++ b/operator/tests/central/basic-central/61-assert.yaml
@@ -17,6 +17,7 @@ collectors:
 - type: pod
   selector: app=scanner-db
   tail: -1
+timeout: 1500
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/operator/tests/central/basic-central/62-assert.yaml
+++ b/operator/tests/central/basic-central/62-assert.yaml
@@ -10,6 +10,7 @@ collectors:
 - type: pod
   selector: app=scanner-db
   tail: -1
+timeout: 1500
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/operator/tests/common/central-cr-assert.yaml
+++ b/operator/tests/common/central-cr-assert.yaml
@@ -17,7 +17,7 @@ collectors:
 - command: kubectl describe pod -n $NAMESPACE -l app=central-db
 - command: kubectl describe pod -n $NAMESPACE -l app=scanner
 - command: kubectl describe pod -n $NAMESPACE -l app=scanner-db
-timeout: 900
+timeout: 1500
 ---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: Central

--- a/operator/tests/common/secured-cluster-cr-assert.yaml
+++ b/operator/tests/common/secured-cluster-cr-assert.yaml
@@ -9,6 +9,7 @@ collectors:
   tail: -1
 - command: kubectl describe pod -n $NAMESPACE -l app=sensor
 - command: kubectl describe pod -n $NAMESPACE -l app=admission-control
+timeout: 1500
 ---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: SecuredCluster


### PR DESCRIPTION
## Description

Workaround for recently slow scanner startup while it is being investigated by the scanner team. I just added another 10 minutes to the deadline we already have for lack of a better number.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
