### PR TITLE
ROX-19696: Process deduper state

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -59,4 +59,7 @@ var (
 
 	// UnifiedCVEDeferral enables APIs and UI pages for unified deferral workflow.
 	UnifiedCVEDeferral = registerFeature("Enable new unified Vulnerability deferral workflow", "ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL", false)
+
+	// SensorReconciliationOnReconnect enables sensors to support reconciliation when reconnecting
+	SensorReconciliationOnReconnect = registerFeature("Enable Sensors to support reconciliation on reconnect", "ROX_SENSOR_RECONCILIATION", false)
 )

--- a/sensor/common/deduper/deduper.go
+++ b/sensor/common/deduper/deduper.go
@@ -1,11 +1,16 @@
 package deduper
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/alert"
 	"github.com/stackrox/rox/pkg/logging"
+	eventPkg "github.com/stackrox/rox/pkg/sensor/event"
 	"github.com/stackrox/rox/pkg/sensor/hash"
 	"github.com/stackrox/rox/sensor/common/managedcentral"
 	"github.com/stackrox/rox/sensor/common/messagestream"
@@ -13,12 +18,58 @@ import (
 
 var (
 	log = logging.LoggerForModule()
+
+	deduperTypes = []any{
+		storage.NetworkPolicy{},
+		storage.Deployment{},
+		storage.Pod{},
+		storage.NamespaceMetadata{},
+		storage.Secret{},
+		storage.Node{},
+		storage.NodeInventory{},
+		storage.ServiceAccount{},
+		storage.K8SRole{},
+		storage.K8SRoleBinding{},
+		storage.ProcessIndicator{},
+		storage.ProviderMetadata{},
+		storage.OrchestratorMetadata{},
+		storage.ImageIntegration{},
+		storage.ComplianceOperatorCheckResult{},
+		storage.ComplianceOperatorProfile{},
+		storage.ComplianceOperatorRule{},
+		storage.ComplianceOperatorScanSettingBinding{},
+		storage.ComplianceOperatorScan{},
+	}
 )
 
 // key is the key by which messages are deduped.
 type key struct {
 	id           string
 	resourceType reflect.Type
+}
+
+func keyFrom(v string) (key, error) {
+	parts := strings.Split(v, ":")
+	if len(parts) != 2 {
+		return key{}, fmt.Errorf("invalid key format: %s", v)
+	}
+	t, err := mapType(parts[0])
+	if err != nil {
+		return key{}, errors.Wrap(err, "map type")
+	}
+	return key{
+		id:           parts[1],
+		resourceType: t,
+	}, nil
+}
+
+func mapType(typeStr string) (reflect.Type, error) {
+	for _, t := range deduperTypes {
+		if typeStr == eventPkg.GetEventTypeWithoutPrefix(t) {
+			return reflect.TypeOf(t), nil
+		}
+	}
+	return nil, fmt.Errorf("invalid type: %s", typeStr)
 }
 
 // deduper takes care of deduping sensor events.
@@ -30,13 +81,31 @@ type deduper struct {
 }
 
 // NewDedupingMessageStream wraps a SensorMessageStream and dedupes events. Other message types are forwarded as-is.
-func NewDedupingMessageStream(stream messagestream.SensorMessageStream, deduperState *central.DeduperState) messagestream.SensorMessageStream {
+func NewDedupingMessageStream(stream messagestream.SensorMessageStream, deduperState map[string]uint64) messagestream.SensorMessageStream {
+	lastSeen := copyDeduperState(deduperState)
 
 	return &deduper{
 		stream:   stream,
-		lastSent: make(map[key]uint64),
+		lastSent: lastSeen,
 		hasher:   hash.NewHasher(),
 	}
+}
+
+func copyDeduperState(state map[string]uint64) map[key]uint64 {
+	if state == nil {
+		return make(map[key]uint64)
+	}
+
+	result := make(map[key]uint64, len(state))
+	for k, v := range state {
+		parsedKey, err := keyFrom(k)
+		if err != nil {
+			log.Warnf("Deduper state received from central has malformed entry: %s->%d: %s", k, v, err)
+			continue
+		}
+		result[parsedKey] = v
+	}
+	return result
 }
 
 func (d *deduper) Send(msg *central.MsgFromSensor) error {
@@ -50,6 +119,7 @@ func (d *deduper) Send(msg *central.MsgFromSensor) error {
 	if managedcentral.IsCentralManaged() && event.GetImageIntegration() != nil {
 		return nil
 	}
+
 	key := key{
 		id:           event.GetId(),
 		resourceType: reflect.TypeOf(event.GetResource()),

--- a/sensor/common/deduper/deduper.go
+++ b/sensor/common/deduper/deduper.go
@@ -43,8 +43,8 @@ var (
 
 // Key is the key by which messages are deduped.
 type Key struct {
-	id           string
-	resourceType reflect.Type
+	Id           string
+	ResourceType reflect.Type
 }
 
 func keyFrom(v string) (Key, error) {
@@ -57,8 +57,8 @@ func keyFrom(v string) (Key, error) {
 		return Key{}, errors.Wrap(err, "map type")
 	}
 	return Key{
-		id:           parts[1],
-		resourceType: t,
+		Id:           parts[1],
+		ResourceType: t,
 	}, nil
 }
 
@@ -81,6 +81,9 @@ type deduper struct {
 
 // NewDedupingMessageStream wraps a SensorMessageStream and dedupes events. Other message types are forwarded as-is.
 func NewDedupingMessageStream(stream messagestream.SensorMessageStream, deduperState map[Key]uint64) messagestream.SensorMessageStream {
+	if deduperState == nil {
+		deduperState = make(map[Key]uint64)
+	}
 	return &deduper{
 		stream:   stream,
 		lastSent: deduperState,
@@ -119,8 +122,8 @@ func (d *deduper) Send(msg *central.MsgFromSensor) error {
 	}
 
 	key := Key{
-		id:           event.GetId(),
-		resourceType: reflect.TypeOf(event.GetResource()),
+		Id:           event.GetId(),
+		ResourceType: reflect.TypeOf(event.GetResource()),
 	}
 	if event.GetAction() == central.ResourceAction_REMOVE_RESOURCE {
 		priorLen := len(d.lastSent)

--- a/sensor/common/deduper/deduper.go
+++ b/sensor/common/deduper/deduper.go
@@ -30,7 +30,8 @@ type deduper struct {
 }
 
 // NewDedupingMessageStream wraps a SensorMessageStream and dedupes events. Other message types are forwarded as-is.
-func NewDedupingMessageStream(stream messagestream.SensorMessageStream) messagestream.SensorMessageStream {
+func NewDedupingMessageStream(stream messagestream.SensorMessageStream, deduperState *central.DeduperState) messagestream.SensorMessageStream {
+
 	return &deduper{
 		stream:   stream,
 		lastSent: make(map[key]uint64),

--- a/sensor/common/deduper/deduper.go
+++ b/sensor/common/deduper/deduper.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/alert"
 	"github.com/stackrox/rox/pkg/logging"
 	eventPkg "github.com/stackrox/rox/pkg/sensor/event"
@@ -20,25 +19,25 @@ var (
 	log = logging.LoggerForModule()
 
 	deduperTypes = []any{
-		storage.NetworkPolicy{},
-		storage.Deployment{},
-		storage.Pod{},
-		storage.NamespaceMetadata{},
-		storage.Secret{},
-		storage.Node{},
-		storage.NodeInventory{},
-		storage.ServiceAccount{},
-		storage.K8SRole{},
-		storage.K8SRoleBinding{},
-		storage.ProcessIndicator{},
-		storage.ProviderMetadata{},
-		storage.OrchestratorMetadata{},
-		storage.ImageIntegration{},
-		storage.ComplianceOperatorCheckResult{},
-		storage.ComplianceOperatorProfile{},
-		storage.ComplianceOperatorRule{},
-		storage.ComplianceOperatorScanSettingBinding{},
-		storage.ComplianceOperatorScan{},
+		&central.SensorEvent_NetworkPolicy{},
+		&central.SensorEvent_Deployment{},
+		&central.SensorEvent_Pod{},
+		&central.SensorEvent_Namespace{},
+		&central.SensorEvent_Secret{},
+		&central.SensorEvent_Node{},
+		&central.SensorEvent_NodeInventory{},
+		&central.SensorEvent_ServiceAccount{},
+		&central.SensorEvent_Role{},
+		&central.SensorEvent_Binding{},
+		&central.SensorEvent_ProcessIndicator{},
+		&central.SensorEvent_ProviderMetadata{},
+		&central.SensorEvent_OrchestratorMetadata{},
+		&central.SensorEvent_ImageIntegration{},
+		&central.SensorEvent_ComplianceOperatorResult{},
+		&central.SensorEvent_ComplianceOperatorProfile{},
+		&central.SensorEvent_ComplianceOperatorRule{},
+		&central.SensorEvent_ComplianceOperatorScanSettingBinding{},
+		&central.SensorEvent_ComplianceOperatorScan{},
 	}
 )
 

--- a/sensor/common/sensor/central_communication.go
+++ b/sensor/common/sensor/central_communication.go
@@ -17,7 +17,7 @@ type CentralCommunication interface {
 }
 
 // NewCentralCommunication returns a new CentralCommunication.
-func NewCentralCommunication(reconnect bool, components ...common.SensorComponent) CentralCommunication {
+func NewCentralCommunication(clientReconcile bool, reconnect bool, components ...common.SensorComponent) CentralCommunication {
 	finished := sync.WaitGroup{}
 	return &centralCommunicationImpl{
 		allFinished: &finished,
@@ -25,7 +25,8 @@ func NewCentralCommunication(reconnect bool, components ...common.SensorComponen
 		sender:      NewCentralSender(&finished, components...),
 		components:  components,
 
-		stopper:     concurrency.NewStopper(),
-		isReconnect: reconnect,
+		stopper:              concurrency.NewStopper(),
+		isReconnect:          reconnect,
+		clientReconciliation: clientReconcile,
 	}
 }

--- a/sensor/common/sensor/central_communication.go
+++ b/sensor/common/sensor/central_communication.go
@@ -1,6 +1,8 @@
 package sensor
 
 import (
+	"time"
+
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
@@ -28,5 +30,6 @@ func NewCentralCommunication(clientReconcile bool, reconnect bool, components ..
 		stopper:              concurrency.NewStopper(),
 		isReconnect:          reconnect,
 		clientReconciliation: clientReconcile,
+		syncTimeout:          10 * time.Second,
 	}
 }

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -42,7 +42,8 @@ type centralCommunicationImpl struct {
 	// allFinished waits until both receiver and sender fully stopped before cleaning up the stream.
 	allFinished *sync.WaitGroup
 
-	isReconnect bool
+	isReconnect          bool
+	clientReconciliation bool
 }
 
 func (s *centralCommunicationImpl) Start(conn grpc.ClientConnInterface, centralReachable *concurrency.Flag, configHandler config.Handler, detector detector.Detector) {

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -278,9 +278,8 @@ func (s *centralCommunicationImpl) initialDeduperSync(stream central.SensorServi
 
 	if deduperState := msg.GetDeduperState(); deduperState == nil {
 		return errors.Wrapf(err, "expected deduper state to be sent but received: %T", msg.Msg)
-	} else {
-		s.initialDeduperState = deduperState.GetResourceHashes()
 	}
+	s.initialDeduperState = msg.GetDeduperState().GetResourceHashes()
 	return nil
 }
 

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/certdistribution"
 	"github.com/stackrox/rox/sensor/common/clusterid"
 	"github.com/stackrox/rox/sensor/common/config"
+	"github.com/stackrox/rox/sensor/common/deduper"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/managedcentral"
 	"github.com/stackrox/rox/sensor/common/sensor/helmconfig"
@@ -45,7 +46,7 @@ type centralCommunicationImpl struct {
 
 	isReconnect          bool
 	clientReconciliation bool
-	initialDeduperState  map[string]uint64
+	initialDeduperState  map[deduper.Key]uint64
 	syncTimeout          time.Duration
 }
 
@@ -279,7 +280,7 @@ func (s *centralCommunicationImpl) initialDeduperSync(stream central.SensorServi
 	if deduperState := msg.GetDeduperState(); deduperState == nil {
 		return errors.Wrapf(err, "expected deduper state to be sent but received: %T", msg.Msg)
 	}
-	s.initialDeduperState = msg.GetDeduperState().GetResourceHashes()
+	s.initialDeduperState = deduper.CopyDeduperState(msg.GetDeduperState().GetResourceHashes())
 	return nil
 }
 

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	"github.com/stackrox/rox/pkg/sensor/hash"
 	"github.com/stackrox/rox/sensor/common"
 	configMocks "github.com/stackrox/rox/sensor/common/config/mocks"
 	mocksDetector "github.com/stackrox/rox/sensor/common/detector/mocks"
@@ -160,6 +161,14 @@ func expectSyncMessages(messages []*central.MsgToSensor, service *MockSensorServ
 }
 
 func (c *centralCommunicationSuite) Test_ClientReconciliation() {
+	dep1 := givenDeployment(fixtureconsts.Deployment1, "dep1", map[string]string{"app": "central"})
+	dep2 := givenDeployment(fixtureconsts.Deployment2, "dep2", map[string]string{"app": "sensor"})
+	updatedDep1 := givenDeployment(fixtureconsts.Deployment1, "dep1", map[string]string{"app": "central_updated"})
+	hasher := hash.NewHasher()
+	hash1, _ := hasher.HashEvent(dep1.GetEvent())
+	updatedHash1, _ := hasher.HashEvent(updatedDep1.GetEvent())
+	setSensorHash(dep1, hash1)
+	setSensorHash(updatedDep1, updatedHash1)
 	testCases := map[string]struct {
 		deduperState           map[string]uint64
 		componentMessages      []*central.MsgFromSensor
@@ -168,29 +177,22 @@ func (c *centralCommunicationSuite) Test_ClientReconciliation() {
 	}{
 		"Deduper hash hit": {
 			deduperState: map[string]uint64{
-				deploymentKey(fixtureconsts.Deployment1): 1111,
+				deploymentKey(fixtureconsts.Deployment1): hash1,
 			},
-			componentMessages: []*central.MsgFromSensor{
-				givenDeployment(fixtureconsts.Deployment1, "dep1", "1111"),
-			},
+			componentMessages: []*central.MsgFromSensor{dep1},
 			neverMatchesState: anyDeploymentSent,
 		},
 		"All deployments sent": {
-			deduperState: map[string]uint64{},
-			componentMessages: []*central.MsgFromSensor{
-				givenDeployment(fixtureconsts.Deployment1, "dep1", "1111"),
-				givenDeployment(fixtureconsts.Deployment2, "dep2", "2222"),
-			},
+			deduperState:           map[string]uint64{},
+			componentMessages:      []*central.MsgFromSensor{dep1, dep2},
 			eventuallyMatchesState: deploymentsSentCount(2),
 		},
 		"Updated deployment": {
 			deduperState: map[string]uint64{
-				deploymentKey(fixtureconsts.Deployment1): 1111,
+				deploymentKey(fixtureconsts.Deployment1): hash1,
 			},
-			componentMessages: []*central.MsgFromSensor{
-				givenDeployment(fixtureconsts.Deployment1, "dep1", "1212"), // hash was updated
-			},
-			eventuallyMatchesState: deploymentIDSent(fixtureconsts.Deployment1),
+			componentMessages:      []*central.MsgFromSensor{updatedDep1},
+			eventuallyMatchesState: deploymentIDSent(fixtureconsts.Deployment1, updatedHash1),
 		},
 	}
 
@@ -229,11 +231,11 @@ func (c *centralCommunicationSuite) Test_ClientReconciliation() {
 	}
 }
 
-func deploymentIDSent(id string) func([]*central.MsgFromSensor) bool {
+func deploymentIDSent(id string, hash uint64) func([]*central.MsgFromSensor) bool {
 	return func(messages []*central.MsgFromSensor) bool {
 		for _, m := range messages {
 			if dep := m.GetEvent().GetDeployment(); dep != nil {
-				if dep.GetId() == id {
+				if dep.GetId() == id && m.GetEvent().GetSensorHash() == hash {
 					return true
 				}
 			}
@@ -275,25 +277,37 @@ func NewFakeSensorComponent(responsesC chan *message.ExpiringMessage) common.Sen
 	}
 }
 
-func givenDeployment(uuid, name, hash string) *central.MsgFromSensor {
+func givenDeployment(uuid, name string, labels map[string]string) *central.MsgFromSensor {
 	return &central.MsgFromSensor{
 		HashKey:           "",
-		DedupeKey:         "", // TODO: check if these are the properties I need to use in deduper
+		DedupeKey:         "",
 		ProcessingAttempt: 0,
 		Msg: &central.MsgFromSensor_Event{
+			// The hash in the gRPC deduper is constructed by the central.SensorEvent struct
+			// Any changes in this struct will prevent the deduper from filtering the message
 			Event: &central.SensorEvent{
-				Id:              "",
-				Action:          0,
-				Timing:          nil,
-				SensorHashOneof: nil, // TODO: or maybe this hash?
+				Id:     uuid,
+				Action: 0,
+				Timing: nil,
+				// SensorHash stores the SensorEvent hash. It is set later
+				SensorHashOneof: nil,
 				Resource: &central.SensorEvent_Deployment{
 					Deployment: &storage.Deployment{
-						Id:   uuid,
-						Name: name,
+						Id:     uuid,
+						Name:   name,
+						Labels: labels,
 					},
 				},
 			},
 		},
+	}
+}
+
+func setSensorHash(sensorMsg *central.MsgFromSensor, sensorHash uint64) {
+	if event := sensorMsg.GetEvent(); event != nil {
+		event.SensorHashOneof = &central.SensorEvent_SensorHash{
+			SensorHash: sensorHash,
+		}
 	}
 }
 

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -266,7 +266,7 @@ func anyDeploymentSent(messages []*central.MsgFromSensor) bool {
 	return false
 }
 func deploymentKey(id string) string {
-	return fmt.Sprintf("deployment:%s", id)
+	return fmt.Sprintf("Deployment:%s", id)
 }
 
 func NewFakeSensorComponent(responsesC chan *message.ExpiringMessage) common.SensorComponent {

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -2,6 +2,7 @@ package sensor
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common"
 	configMocks "github.com/stackrox/rox/sensor/common/config/mocks"
 	mocksDetector "github.com/stackrox/rox/sensor/common/detector/mocks"
@@ -157,9 +159,68 @@ func expectSyncMessages(messages []*central.MsgToSensor, service *MockSensorServ
 	gomock.InOrder(orderedCalls...)
 }
 
+func (c *centralCommunicationSuite) Test_CentralCommunication_Start_ClientReconciliation() {
+	deploymentUUID := uuid.NewV4()
+	deploymentKey := fmt.Sprintf("deployment:%s", deploymentUUID)
+
+	centralHashes := map[string]uint64{
+		deploymentKey: 1234,
+	}
+
+	syncMessages := append(centralSyncMessages, debuggerMessage.DeduperState(centralHashes))
+
+	expectSyncMessages(syncMessages, c.mockService)
+
+	deploymentsReceived := 0
+	ch := make(chan struct{})
+	c.mockService.client.EXPECT().Send(gomock.Any()).Times(2).DoAndReturn(func(msg *central.MsgFromSensor) error {
+		if msg.GetEvent().GetDeployment() != nil {
+			deploymentsReceived++
+		}
+		if deploymentsReceived == 2 {
+			close(ch)
+		}
+		return nil
+	})
+
+	c.responsesC <- message.New(givenDeployment(uuid.NewV4().String(), "deployment-a", "4321"))
+	c.responsesC <- message.New(givenDeployment(deploymentUUID.String(), "deployment-b", "1234"))
+
+	// Wait for sync message or timeout after 5s
+	timeout := time.After(5 * time.Second)
+	select {
+	case <-timeout:
+		c.FailNow("Didn't receive deployments after 5 seconds")
+	case <-ch:
+		break
+	}
+}
+
 func NewFakeSensorComponent(responsesC chan *message.ExpiringMessage) common.SensorComponent {
 	return &fakeSensorComponent{
 		responsesC: responsesC,
+	}
+}
+
+func givenDeployment(uuid, name, hash string) *central.MsgFromSensor {
+	return &central.MsgFromSensor{
+		HashKey:           "",
+		DedupeKey:         "", // TODO: check if these are the properties I need to use in deduper
+		ProcessingAttempt: 0,
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:              "",
+				Action:          0,
+				Timing:          nil,
+				SensorHashOneof: nil, // TODO: or maybe this hash?
+				Resource: &central.SensorEvent_Deployment{
+					Deployment: &storage.Deployment{
+						Id:   uuid,
+						Name: name,
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -41,7 +41,6 @@ type centralCommunicationSuite struct {
 var _ suite.SetupTestSuite = (*centralCommunicationSuite)(nil)
 
 func (c *centralCommunicationSuite) SetupTest() {
-	fmt.Println("setup test")
 	mockCtrl := gomock.NewController(c.T())
 
 	c.controller = mockCtrl

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -249,13 +249,10 @@ func deploymentsSentCount(n int) func([]*central.MsgFromSensor) bool {
 		var count int
 		for _, m := range messages {
 			if m.GetEvent().GetDeployment() != nil {
-				count += 1
+				count++
 			}
 		}
-		if count == n {
-			return true
-		}
-		return false
+		return count == n
 	}
 }
 

--- a/sensor/common/sensor/central_sender.go
+++ b/sensor/common/sensor/central_sender.go
@@ -9,7 +9,7 @@ import (
 
 // CentralSender handles sending from sensor to central.
 type CentralSender interface {
-	Start(stream central.SensorService_CommunicateClient, onStops ...func(error))
+	Start(stream central.SensorService_CommunicateClient, initialDeduperState map[string]uint64, onStops ...func(error))
 	Stop(err error)
 	Stopped() concurrency.ReadOnlyErrorSignal
 }

--- a/sensor/common/sensor/central_sender.go
+++ b/sensor/common/sensor/central_sender.go
@@ -5,11 +5,12 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/deduper"
 )
 
 // CentralSender handles sending from sensor to central.
 type CentralSender interface {
-	Start(stream central.SensorService_CommunicateClient, initialDeduperState map[string]uint64, onStops ...func(error))
+	Start(stream central.SensorService_CommunicateClient, initialDeduperState map[deduper.Key]uint64, onStops ...func(error))
 	Stop(err error)
 	Stopped() concurrency.ReadOnlyErrorSignal
 }

--- a/sensor/common/sensor/central_sender_impl.go
+++ b/sensor/common/sensor/central_sender_impl.go
@@ -13,13 +13,13 @@ import (
 )
 
 type centralSenderImpl struct {
-	initialState map[string]uint64
+	initialState map[deduper.Key]uint64
 	senders      []common.SensorComponent
 	stopper      concurrency.Stopper
 	finished     *sync.WaitGroup
 }
 
-func (s *centralSenderImpl) Start(stream central.SensorService_CommunicateClient, initialDeduperState map[string]uint64, onStops ...func(error)) {
+func (s *centralSenderImpl) Start(stream central.SensorService_CommunicateClient, initialDeduperState map[deduper.Key]uint64, onStops ...func(error)) {
 	s.initialState = initialDeduperState
 	go s.send(stream, onStops...)
 }

--- a/sensor/common/sensor/central_sender_impl.go
+++ b/sensor/common/sensor/central_sender_impl.go
@@ -57,7 +57,7 @@ func (s *centralSenderImpl) send(stream central.SensorService_CommunicateClient,
 
 	wrappedStream := metrics.NewCountingEventStream(stream, "unique")
 	wrappedStream = metrics.NewTimingEventStream(wrappedStream, "unique")
-	wrappedStream = deduper.NewDedupingMessageStream(wrappedStream)
+	wrappedStream = deduper.NewDedupingMessageStream(wrappedStream, nil)
 	wrappedStream = metrics.NewCountingEventStream(wrappedStream, "total")
 	wrappedStream = metrics.NewTimingEventStream(wrappedStream, "total")
 

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -374,7 +374,9 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 		// At this point, we know that connection factory reported that connection is up.
 		// Try to create a central communication component. This component will fail (Stopped() signal) if the connection
 		// suddenly broke.
-		s.centralCommunication = NewCentralCommunication(false, s.reconnect.Load(), s.components...)
+		clientReconciliation := features.SensorReconciliationOnReconnect.Enabled() // && TODO: check if central has the capability
+
+		s.centralCommunication = NewCentralCommunication(clientReconciliation, s.reconnect.Load(), s.components...)
 		s.centralCommunication.Start(s.centralConnection, centralReachable, s.configHandler, s.detector)
 		// Reset the exponential back-off if the connection successes
 		exponential.Reset()

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -313,7 +313,7 @@ func (s *Sensor) Stop() {
 }
 
 func (s *Sensor) communicationWithCentral(centralReachable *concurrency.Flag) {
-	s.centralCommunication = NewCentralCommunication(false, s.components...)
+	s.centralCommunication = NewCentralCommunication(false, false, s.components...)
 
 	s.centralCommunication.Start(s.centralConnection, centralReachable, s.configHandler, s.detector)
 
@@ -374,7 +374,7 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 		// At this point, we know that connection factory reported that connection is up.
 		// Try to create a central communication component. This component will fail (Stopped() signal) if the connection
 		// suddenly broke.
-		s.centralCommunication = NewCentralCommunication(s.reconnect.Load(), s.components...)
+		s.centralCommunication = NewCentralCommunication(false, s.reconnect.Load(), s.components...)
 		s.centralCommunication.Start(s.centralConnection, centralReachable, s.configHandler, s.detector)
 		// Reset the exponential back-off if the connection successes
 		exponential.Reset()

--- a/sensor/debugger/message/fake.go
+++ b/sensor/debugger/message/fake.go
@@ -17,6 +17,17 @@ func SensorHello(clsuterID string) *central.MsgToSensor {
 	}
 }
 
+// DeduperState returns as fake DeduperState message
+func DeduperState(state map[string]uint64) *central.MsgToSensor {
+	return &central.MsgToSensor{
+		Msg: &central.MsgToSensor_DeduperState{
+			DeduperState: &central.DeduperState{
+				ResourceHashes: state,
+			},
+		},
+	}
+}
+
 // ClusterConfig returns a fake ClusterConfig message
 func ClusterConfig() *central.MsgToSensor {
 	return &central.MsgToSensor{


### PR DESCRIPTION
## Description

When reconciling on sensor side, sensor's gRPC deduper should be populated from central resource hashes.

* Follow-up: After #7755 is merged, we need to check if central has the capabilities before going down the path of setting the deduper state.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

* [x] Unit tests added.
* [x] CI

Manual tests cannot be done before #7755

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
