### PR TITLE
fix(GHA): long running clusters must have shorter names (#132)

### DIFF
--- a/.github/workflows/create-clusters.yml
+++ b/.github/workflows/create-clusters.yml
@@ -54,5 +54,5 @@ jobs:
       workflow-ref: v1
       kube-burner-config-ref: ${{ github.event.inputs.version }}
       kube-burner-config-repo: stackrox
-      cluster-with-fake-load-name: gke-long-running-fake-load-${{ github.event.inputs.version }}
-      cluster-with-real-load-name: gke-long-running-real-load-${{ github.event.inputs.version }}
+      cluster-with-fake-load-name: long-fake-load-${{ github.event.inputs.version }}
+      cluster-with-real-load-name: long-real-load-${{ github.event.inputs.version }}

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -320,5 +320,5 @@ jobs:
       workflow-ref: v1
       kube-burner-config-ref: ${{needs.variables.outputs.milestone}}
       kube-burner-config-repo: stackrox
-      cluster-with-fake-load-name: gke-long-running-fake-load-${{needs.variables.outputs.milestone}}
-      cluster-with-real-load-name: gke-long-running-real-load-${{needs.variables.outputs.milestone}}
+      cluster-with-fake-load-name: long-fake-load-${{ needs.variables.outputs.milestone }}
+      cluster-with-real-load-name: long-real-load-${{ needs.variables.outputs.milestone }}


### PR DESCRIPTION
Auto-generated PR to update the upstream GHA automation with [643a2c906d31aa0bff39c4bbd886f5cea3868d8d](https://github.com/stackrox/test-gh-actions/commit/643a2c906d31aa0bff39c4bbd886f5cea3868d8d).