### PR TITLE
chore: Add excludeCluster parameter to diagnostics API

### DIFF
--- a/central/debug/service/diagnostics.go
+++ b/central/debug/service/diagnostics.go
@@ -245,10 +245,10 @@ func getClusterCandidate(conn connection.SensorConnection, clusterNameMap map[st
 }
 
 func checkClusterExcluded(opts debugDumpOptions, clusterName string) bool {
-	if opts.clusters != nil && sliceutils.Find(opts.clusters, clusterName) == -1 {
+	if opts.clusters != nil && slices.Index(opts.clusters, clusterName) == -1 {
 		return true
 	}
-	if opts.excludeClusters != nil && sliceutils.Find(opts.excludeClusters, clusterName) != -1 {
+	if opts.excludeClusters != nil && slices.Index(opts.excludeClusters, clusterName) != -1 {
 		return true
 	}
 	return false

--- a/central/debug/service/diagnostics.go
+++ b/central/debug/service/diagnostics.go
@@ -54,7 +54,7 @@ func (s *serviceImpl) getK8sDiagnostics(ctx context.Context, zipWriter *zipWrite
 	if len(clusterNameMap) > 0 {
 		// This is simply creating a static k8sintrospect.File, hence the context can be safely ignored.
 		gatherPool.Go(func(_ context.Context) ([]k8sintrospect.File, error) {
-			return addMissingClustersInfo(clusterNameMap, opts.clusters)
+			return addMissingClustersInfo(clusterNameMap, opts)
 		})
 	}
 

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -612,6 +612,7 @@ type debugDumpOptions struct {
 	withNotifiers     bool
 	withCentral       bool
 	clusters          []string
+	excludeClusters   []string
 	since             time.Time
 }
 
@@ -842,8 +843,16 @@ func getOptionalQueryParams(opts *debugDumpOptions, u *url.URL) error {
 	values := u.Query()
 
 	clusters := values["cluster"]
+	excludeClusters := values["excludeCluster"]
+	if len(clusters) > 0 && len(excludeClusters) > 0 {
+		return errox.InvalidArgs.New("cluster and excludeCluster parameters are mutually exclusive")
+	}
+
 	if len(clusters) > 0 {
 		opts.clusters = clusters
+	}
+	if len(excludeClusters) > 0 {
+		opts.excludeClusters = excludeClusters
 	}
 
 	timeSince := values.Get("since")

--- a/roxctl/central/debug/download_diagnostics.go
+++ b/roxctl/central/debug/download_diagnostics.go
@@ -24,6 +24,7 @@ const (
 func downloadDiagnosticsCommand(cliEnvironment environment.Environment) *cobra.Command {
 	var outputDir string
 	var clusters []string
+	var excludedClusters []string
 	var since string
 
 	c := &cobra.Command{
@@ -37,6 +38,9 @@ func downloadDiagnosticsCommand(cliEnvironment environment.Environment) *cobra.C
 			values := url.Values{}
 			for _, cluster := range clusters {
 				values.Add("cluster", cluster)
+			}
+			for _, cluster := range excludedClusters {
+				values.Add("excludeCluster", cluster)
 			}
 			if since != "" {
 				values.Add("since", since)
@@ -68,7 +72,9 @@ To specify timeout, run  'roxctl' command:
 	flags.AddTimeoutWithDefault(c, diagnosticBundleDownloadTimeout)
 	c.PersistentFlags().StringVar(&outputDir, "output-dir", "", "output directory in which to store bundle")
 	c.PersistentFlags().StringSliceVar(&clusters, "clusters", nil, "comma separated list of sensor clusters from which logs should be collected")
+	c.PersistentFlags().StringSliceVar(&excludedClusters, "excluded-clusters", nil, "comma separated list of sensor clusters from which logs should NOT collected")
 	c.PersistentFlags().StringVar(&since, "since", "", "timestamp starting when logs should be collected from sensor clusters")
+	c.MarkFlagsMutuallyExclusive("clusters", "excluded-clusters")
 
 	return c
 }

--- a/roxctl/central/debug/download_diagnostics.go
+++ b/roxctl/central/debug/download_diagnostics.go
@@ -70,10 +70,10 @@ To specify timeout, run  'roxctl' command:
 		}),
 	}
 	flags.AddTimeoutWithDefault(c, diagnosticBundleDownloadTimeout)
-	c.PersistentFlags().StringVar(&outputDir, "output-dir", "", "output directory in which to store bundle")
-	c.PersistentFlags().StringSliceVar(&clusters, "clusters", nil, "comma separated list of sensor clusters from which logs should be collected")
-	c.PersistentFlags().StringSliceVar(&excludedClusters, "excluded-clusters", nil, "comma separated list of sensor clusters from which logs should NOT collected")
-	c.PersistentFlags().StringVar(&since, "since", "", "timestamp starting when logs should be collected from sensor clusters")
+	c.PersistentFlags().StringVar(&outputDir, "output-dir", "", "Output directory in which to store bundle")
+	c.PersistentFlags().StringSliceVar(&clusters, "clusters", nil, "Comma separated list of sensor clusters from which logs should be collected")
+	c.PersistentFlags().StringSliceVar(&excludedClusters, "excluded-clusters", nil, "Comma separated list of sensor clusters from which logs should NOT collected")
+	c.PersistentFlags().StringVar(&since, "since", "", "Timestamp starting when logs should be collected from sensor clusters")
 	c.MarkFlagsMutuallyExclusive("clusters", "excluded-clusters")
 
 	return c

--- a/roxctl/common/flags/timeout.go
+++ b/roxctl/common/flags/timeout.go
@@ -13,7 +13,7 @@ const (
 
 // AddTimeoutWithDefault adds a timeout flag to the given command with the given default.
 func AddTimeoutWithDefault(c *cobra.Command, defaultDuration time.Duration) {
-	c.PersistentFlags().DurationP(timeoutFlagName, "t", defaultDuration, "timeout for API requests; represents the maximum duration of a request")
+	c.PersistentFlags().DurationP(timeoutFlagName, "t", defaultDuration, "Timeout for API requests; represents the maximum duration of a request")
 }
 
 // AddTimeout adds a timeout flag to the given command with the global default value.


### PR DESCRIPTION
## Description

 We already have `cluster` parameter which works nicely when you need only a few clusters data. However, when customer has >10 clusters listing all of them becomes obnoxious.
You can only use either `cluster` or `excludeCluster` parameter(so either download diag bundle for **all specified** clusters or for **all clusters except specified**).

`roxctl` command flag will be added in the following PR.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TBD

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
