### PR TITLE
ROX-19968: Add permission checks for watched images controls

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -21,7 +21,7 @@ type ImagesTableContainerProps = {
     countsData: EntityCounts;
     cveStatusTab?: CveStatusTab; // TODO Make this required once Observed/Deferred/FP states are re-implemented
     pagination: ReturnType<typeof useURLPagination>;
-    canWriteWatchedImages: boolean;
+    hasWriteAccessForWatchedImage: boolean;
     onWatchImage: ImagesTableProps['onWatchImage'];
     onUnwatchImage: ImagesTableProps['onUnwatchImage'];
 };
@@ -31,7 +31,7 @@ function ImagesTableContainer({
     countsData,
     cveStatusTab,
     pagination,
-    canWriteWatchedImages,
+    hasWriteAccessForWatchedImage,
     onWatchImage,
     onUnwatchImage,
 }: ImagesTableContainerProps) {
@@ -84,7 +84,7 @@ function ImagesTableContainer({
                         getSortParams={getSortParams}
                         isFiltered={isFiltered}
                         filteredSeverities={searchFilter.Severity as VulnerabilitySeverityLabel[]}
-                        canWriteWatchedImages={canWriteWatchedImages}
+                        hasWriteAccessForWatchedImage={hasWriteAccessForWatchedImage}
                         onWatchImage={onWatchImage}
                         onUnwatchImage={onUnwatchImage}
                     />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -21,6 +21,7 @@ type ImagesTableContainerProps = {
     countsData: EntityCounts;
     cveStatusTab?: CveStatusTab; // TODO Make this required once Observed/Deferred/FP states are re-implemented
     pagination: ReturnType<typeof useURLPagination>;
+    canWriteWatchedImages: boolean;
     onWatchImage: ImagesTableProps['onWatchImage'];
     onUnwatchImage: ImagesTableProps['onUnwatchImage'];
 };
@@ -30,6 +31,7 @@ function ImagesTableContainer({
     countsData,
     cveStatusTab,
     pagination,
+    canWriteWatchedImages,
     onWatchImage,
     onUnwatchImage,
 }: ImagesTableContainerProps) {
@@ -82,6 +84,7 @@ function ImagesTableContainer({
                         getSortParams={getSortParams}
                         isFiltered={isFiltered}
                         filteredSeverities={searchFilter.Severity as VulnerabilitySeverityLabel[]}
+                        canWriteWatchedImages={canWriteWatchedImages}
                         onWatchImage={onWatchImage}
                         onUnwatchImage={onUnwatchImage}
                     />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -39,7 +39,7 @@ const emptyStorage: VulnMgmtLocalStorage = {
 function WorkloadCvesOverviewPage() {
     const apolloClient = useApolloClient();
     const { hasReadWriteAccess } = usePermissions();
-    const canWriteWatchedImages = hasReadWriteAccess('WatchedImage');
+    const hasWriteAccessForWatchedImage = hasReadWriteAccess('WatchedImage');
 
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
@@ -72,19 +72,15 @@ function WorkloadCvesOverviewPage() {
             <PageSection
                 className="pf-u-display-flex pf-u-flex-direction-row pf-u-align-items-center"
                 variant="light"
-                padding={{ default: 'noPadding' }}
             >
-                <Flex
-                    direction={{ default: 'column' }}
-                    className="pf-u-py-lg pf-u-pl-lg pf-u-flex-grow-1"
-                >
+                <Flex direction={{ default: 'column' }} className="pf-u-flex-grow-1">
                     <Title headingLevel="h1">Workload CVEs</Title>
                     <FlexItem>
                         Prioritize and manage scanned CVEs across images and deployments
                     </FlexItem>
                 </Flex>
-                {canWriteWatchedImages && (
-                    <FlexItem className="pf-u-pr-lg">
+                {hasWriteAccessForWatchedImage && (
+                    <FlexItem>
                         <Button
                             variant="secondary"
                             onClick={() => {
@@ -117,7 +113,7 @@ function WorkloadCvesOverviewPage() {
                                     defaultFilters={emptyStorage.preferences.defaultFilters}
                                     countsData={countsData}
                                     pagination={pagination}
-                                    canWriteWatchedImages={canWriteWatchedImages}
+                                    hasWriteAccessForWatchedImage={hasWriteAccessForWatchedImage}
                                     onWatchImage={(imageName) => {
                                         setDefaultWatchedImageName(imageName);
                                         watchedImagesModalToggle.openSelect();

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -16,7 +16,7 @@ import useURLStringUnion from 'hooks/useURLStringUnion';
 import PageTitle from 'Components/PageTitle';
 import useURLPagination from 'hooks/useURLPagination';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import { VulnMgmtLocalStorage, entityTabValues } from '../types';
+import usePermissions from 'hooks/usePermissions';
 import { parseQuerySearchFilter, getCveStatusScopedQueryString } from '../searchUtils';
 import { entityTypeCountsQuery } from '../components/EntityTypeToggleGroup';
 import CVEsTableContainer from './CVEsTableContainer';
@@ -24,6 +24,7 @@ import DeploymentsTableContainer from './DeploymentsTableContainer';
 import ImagesTableContainer, { imageListQuery } from './ImagesTableContainer';
 import WatchedImagesModal from '../WatchedImages/WatchedImagesModal';
 import UnwatchImageModal from '../WatchedImages/UnwatchImageModal';
+import { VulnMgmtLocalStorage, entityTabValues } from '../types';
 
 const emptyStorage: VulnMgmtLocalStorage = {
     preferences: {
@@ -37,6 +38,8 @@ const emptyStorage: VulnMgmtLocalStorage = {
 
 function WorkloadCvesOverviewPage() {
     const apolloClient = useApolloClient();
+    const { hasReadWriteAccess } = usePermissions();
+    const canWriteWatchedImages = hasReadWriteAccess('WatchedImage');
 
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
@@ -80,17 +83,19 @@ function WorkloadCvesOverviewPage() {
                         Prioritize and manage scanned CVEs across images and deployments
                     </FlexItem>
                 </Flex>
-                <FlexItem className="pf-u-pr-lg">
-                    <Button
-                        variant="secondary"
-                        onClick={() => {
-                            setDefaultWatchedImageName('');
-                            watchedImagesModalToggle.openSelect();
-                        }}
-                    >
-                        Manage watched images
-                    </Button>
-                </FlexItem>
+                {canWriteWatchedImages && (
+                    <FlexItem className="pf-u-pr-lg">
+                        <Button
+                            variant="secondary"
+                            onClick={() => {
+                                setDefaultWatchedImageName('');
+                                watchedImagesModalToggle.openSelect();
+                            }}
+                        >
+                            Manage watched images
+                        </Button>
+                    </FlexItem>
+                )}
             </PageSection>
             <PageSection padding={{ default: 'noPadding' }}>
                 <PageSection isCenterAligned>
@@ -112,6 +117,7 @@ function WorkloadCvesOverviewPage() {
                                     defaultFilters={emptyStorage.preferences.defaultFilters}
                                     countsData={countsData}
                                     pagination={pagination}
+                                    canWriteWatchedImages={canWriteWatchedImages}
                                     onWatchImage={(imageName) => {
                                         setDefaultWatchedImageName(imageName);
                                         watchedImagesModalToggle.openSelect();

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -79,7 +79,7 @@ export type ImagesTableProps = {
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
     filteredSeverities?: VulnerabilitySeverityLabel[];
-    canWriteWatchedImages: boolean;
+    hasWriteAccessForWatchedImage: boolean;
     onWatchImage: (imageName: string) => void;
     onUnwatchImage: (imageName: string) => void;
 };
@@ -89,11 +89,11 @@ function ImagesTable({
     getSortParams,
     isFiltered,
     filteredSeverities,
-    canWriteWatchedImages,
+    hasWriteAccessForWatchedImage,
     onWatchImage,
     onUnwatchImage,
 }: ImagesTableProps) {
-    const colSpan = canWriteWatchedImages ? 7 : 6;
+    const colSpan = hasWriteAccessForWatchedImage ? 7 : 6;
 
     return (
         <TableComposable borders={false} variant="compact">
@@ -112,7 +112,7 @@ function ImagesTable({
                     </Th>
                     <Th sort={getSortParams('Image created time')}>Age</Th>
                     <Th sort={getSortParams('Image scan time')}>Scan time</Th>
-                    {canWriteWatchedImages && <Th aria-label="Image action menu" />}
+                    {hasWriteAccessForWatchedImage && <Th aria-label="Image action menu" />}
                 </Tr>
             </Thead>
             {images.length === 0 && <EmptyTableResults colSpan={colSpan} />}
@@ -192,7 +192,7 @@ function ImagesTable({
                                 <Td>
                                     <DateDistanceTd date={scanTime} />
                                 </Td>
-                                {canWriteWatchedImages && (
+                                {hasWriteAccessForWatchedImage && (
                                     <Td isActionCell>
                                         {name?.tag && (
                                             <ActionsColumn

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -79,6 +79,7 @@ export type ImagesTableProps = {
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
     filteredSeverities?: VulnerabilitySeverityLabel[];
+    canWriteWatchedImages: boolean;
     onWatchImage: (imageName: string) => void;
     onUnwatchImage: (imageName: string) => void;
 };
@@ -88,9 +89,12 @@ function ImagesTable({
     getSortParams,
     isFiltered,
     filteredSeverities,
+    canWriteWatchedImages,
     onWatchImage,
     onUnwatchImage,
 }: ImagesTableProps) {
+    const colSpan = canWriteWatchedImages ? 7 : 6;
+
     return (
         <TableComposable borders={false} variant="compact">
             <Thead noWrap>
@@ -108,10 +112,10 @@ function ImagesTable({
                     </Th>
                     <Th sort={getSortParams('Image created time')}>Age</Th>
                     <Th sort={getSortParams('Image scan time')}>Scan time</Th>
-                    <Td />
+                    {canWriteWatchedImages && <Th aria-label="Image action menu" />}
                 </Tr>
             </Thead>
-            {images.length === 0 && <EmptyTableResults colSpan={6} />}
+            {images.length === 0 && <EmptyTableResults colSpan={colSpan} />}
             {images.map(
                 ({
                     id,
@@ -188,21 +192,23 @@ function ImagesTable({
                                 <Td>
                                     <DateDistanceTd date={scanTime} />
                                 </Td>
-                                <Td isActionCell>
-                                    {name?.tag && (
-                                        <ActionsColumn
-                                            items={[
-                                                {
-                                                    title: watchImageMenuText,
-                                                    onClick: () =>
-                                                        watchImageMenuAction(
-                                                            `${name.registry}/${name.remote}:${name.tag}`
-                                                        ),
-                                                },
-                                            ]}
-                                        />
-                                    )}
-                                </Td>
+                                {canWriteWatchedImages && (
+                                    <Td isActionCell>
+                                        {name?.tag && (
+                                            <ActionsColumn
+                                                items={[
+                                                    {
+                                                        title: watchImageMenuText,
+                                                        onClick: () =>
+                                                            watchImageMenuAction(
+                                                                `${name.registry}/${name.remote}:${name.tag}`
+                                                            ),
+                                                    },
+                                                ]}
+                                            />
+                                        )}
+                                    </Td>
+                                )}
                             </Tr>
                         </Tbody>
                     );


### PR DESCRIPTION
## Description

As titled. For simplicity and consistency with VM 1.0, watched image functionality will be restricted to users with "READ_WRITE_ACCESS" on the "WatchedImage" resource.

"Hide whitespace" for easier reviewing.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the Workload CVE list page, on the "Image" tab, with less than "READ_WRITE" permissions.
![image](https://github.com/stackrox/stackrox/assets/1292638/6bb06ad0-dfe5-470f-8498-483620fb3ee3)

Revisit the page with full permissions.
![image](https://github.com/stackrox/stackrox/assets/1292638/14b4d375-4205-4eb0-8b49-723796a91655)

