### PR TITLE
fix: diag bundle - log errors that are missed when context is canceled

### DIFF
--- a/central/debug/service/diagnostics.go
+++ b/central/debug/service/diagnostics.go
@@ -59,7 +59,7 @@ func pullK8sDiagnosticsFilesFromSensor(ctx context.Context, clusterName string, 
 	}
 
 	if err != nil {
-		log.Warnf("Error pulling kubernetes info from sensor: %w", err)
+		log.Warnw("Error pulling kubernetes info from sensor", err)
 		errFile := k8sintrospect.File{
 			Path:     path.Join(clusterName, "pull-error.txt"),
 			Contents: []byte(err.Error()),
@@ -86,7 +86,7 @@ func pullMetricsFromSensor(ctx context.Context, clusterName string, sensorConn c
 	}
 
 	if err != nil {
-		log.Warnf("Error pulling metrics from sensor: %w", err)
+		log.Warnw("Error pulling metrics from sensor", err)
 		errFile := k8sintrospect.File{
 			Path:     path.Join(clusterName, "pull-error.txt"),
 			Contents: []byte(err.Error()),

--- a/central/debug/service/diagnostics.go
+++ b/central/debug/service/diagnostics.go
@@ -59,6 +59,7 @@ func pullK8sDiagnosticsFilesFromSensor(ctx context.Context, clusterName string, 
 	}
 
 	if err != nil {
+		log.Warnf("Error pulling kubernetes info from sensor: %w", err)
 		errFile := k8sintrospect.File{
 			Path:     path.Join(clusterName, "pull-error.txt"),
 			Contents: []byte(err.Error()),
@@ -85,6 +86,7 @@ func pullMetricsFromSensor(ctx context.Context, clusterName string, sensorConn c
 	}
 
 	if err != nil {
+		log.Warnf("Error pulling metrics from sensor: %w", err)
 		errFile := k8sintrospect.File{
 			Path:     path.Join(clusterName, "pull-error.txt"),
 			Contents: []byte(err.Error()),

--- a/central/debug/service/diagnostics.go
+++ b/central/debug/service/diagnostics.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/k8sintrospect"
 	"github.com/stackrox/rox/pkg/k8sutil"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sliceutils"
 )
@@ -59,7 +60,7 @@ func pullK8sDiagnosticsFilesFromSensor(ctx context.Context, clusterName string, 
 	}
 
 	if err != nil {
-		log.Warnw("Error pulling kubernetes info from sensor", err)
+		log.Warnw("Error pulling kubernetes info from sensor", logging.Err(err))
 		errFile := k8sintrospect.File{
 			Path:     path.Join(clusterName, "pull-error.txt"),
 			Contents: []byte(err.Error()),
@@ -86,7 +87,7 @@ func pullMetricsFromSensor(ctx context.Context, clusterName string, sensorConn c
 	}
 
 	if err != nil {
-		log.Warnw("Error pulling metrics from sensor", err)
+		log.Warnw("Error pulling metrics from sensor", logging.Err(err))
 		errFile := k8sintrospect.File{
 			Path:     path.Join(clusterName, "pull-error.txt"),
 			Contents: []byte(err.Error()),

--- a/central/telemetry/gatherers/cluster.go
+++ b/central/telemetry/gatherers/cluster.go
@@ -100,6 +100,9 @@ type clusterFromSensorResponse struct {
 
 func (c *ClusterGatherer) clusterFromSensor(ctx context.Context, sensorConn connection.SensorConnection, outC chan<- clusterFromSensorResponse, clusterMap map[string]*storage.Cluster) {
 	clusterInfo, err := c.fetchClusterFromSensor(ctx, sensorConn, clusterMap)
+	if err != nil {
+		log.Warnf("Error pulling cluster info from sensor: %w", err)
+	}
 	select {
 	case <-ctx.Done():
 	case outC <- clusterFromSensorResponse{

--- a/central/telemetry/gatherers/cluster.go
+++ b/central/telemetry/gatherers/cluster.go
@@ -101,7 +101,7 @@ type clusterFromSensorResponse struct {
 func (c *ClusterGatherer) clusterFromSensor(ctx context.Context, sensorConn connection.SensorConnection, outC chan<- clusterFromSensorResponse, clusterMap map[string]*storage.Cluster) {
 	clusterInfo, err := c.fetchClusterFromSensor(ctx, sensorConn, clusterMap)
 	if err != nil {
-		log.Warnf("Error pulling cluster info from sensor: %w", err)
+		log.Warnw("Error pulling cluster info from sensor", err)
 	}
 	select {
 	case <-ctx.Done():

--- a/central/telemetry/gatherers/cluster.go
+++ b/central/telemetry/gatherers/cluster.go
@@ -101,7 +101,7 @@ type clusterFromSensorResponse struct {
 func (c *ClusterGatherer) clusterFromSensor(ctx context.Context, sensorConn connection.SensorConnection, outC chan<- clusterFromSensorResponse, clusterMap map[string]*storage.Cluster) {
 	clusterInfo, err := c.fetchClusterFromSensor(ctx, sensorConn, clusterMap)
 	if err != nil {
-		log.Warnw("Error pulling cluster info from sensor", err)
+		log.Warnw("Error pulling cluster info from sensor", logging.Err(err))
 	}
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
## Description

When the context is canceled, errors that returned from `PullKubernetesInfo`, `PullMetrics` or `PullClusterInfo` might get missed since they are not logged but rather sent via channel to be written to diagnostic bundle. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

1. CI is sufficient

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
