### PR TITLE
ROX-20056: Make BuiltinPoliciesTest multi-arch compliant

### DIFF
--- a/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
@@ -11,6 +11,7 @@ import services.PolicyService
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Unroll
+import util.Env
 
 class BuiltinPoliciesTest extends BaseSpecification {
     static final private String TRIGGER_MOST = "trigger-most"
@@ -20,10 +21,18 @@ class BuiltinPoliciesTest extends BaseSpecification {
     static final private String TRIGGER_UNSCANNED = "trigger-unscanned"
     static final private String TEST_PASSWORD = "test-password"
 
+    // Arch specific test images
+    static final private String TRIGGER_MOST_IMAGE = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
+        "us.gcr.io/stackrox-ci/qa/trigger-policy-violations/most:0.19":
+        "quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-most")
+    static final private String TRIGGER_ALPINE_IMAGE = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
+        "us.gcr.io/stackrox-ci/qa/trigger-policy-violations/alpine:0.6":
+        "quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-alpine")
+
     static final private List<Deployment> DEPLOYMENTS = [
             new Deployment()
                     .setName(TRIGGER_MOST)
-                    .setImage("us.gcr.io/stackrox-ci/qa/trigger-policy-violations/most:0.19")
+                    .setImage(TRIGGER_MOST_IMAGE)
                     // For: "Emergency Deployment Annotation"
                     .addAnnotation("admission.stackrox.io/break-glass", "yay")
                     // For: "Secret Mounted as Environment Variable"
@@ -38,7 +47,7 @@ class BuiltinPoliciesTest extends BaseSpecification {
             // For: "Alpine Linux Package Manager (apk) in Image"
             new Deployment()
                     .setName(TRIGGER_ALPINE)
-                    .setImage("us.gcr.io/stackrox-ci/qa/trigger-policy-violations/alpine:0.6"),
+                    .setImage(TRIGGER_ALPINE_IMAGE),
     ]
     static final private List<Deployment> NO_WAIT_DEPLOYMENTS = [
             new Deployment()

--- a/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
@@ -122,7 +122,7 @@ class BuiltinPoliciesTest extends BaseSpecification {
 
         then:
         "Verify Violation for #policyName is triggered"
-        assert waitForViolation(deploymentName, policyName, isRaceBuild() ? 450 : 30)
+        assert waitForViolation(deploymentName, policyName, isRaceBuild() ? 450 : 120)
 
         where:
         "Data inputs are:"


### PR DESCRIPTION
This PR intends to add multi-arch support for the `BuiltinPoliciesTest` QA test.
Test images used in respective test are changed to use alternate multi-arch images which support 3 platforms viz. `x86_64`, `ppc64le` and `s390x`.

Changes are verified manually using `./gradlew test --tests=BuiltinPoliciesTest`