### PR TITLE
fix(perf): Move risk reprocessing to debounce over a 10 minute period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   are required to be title-cased.
 - ROX-14701: Starting from 4.3.0 release, `roxctl` binaries for `ppc64le` and `s390x` architectures are available for download from `https://mirror.openshift.com/pub/rhacs/assets/<version>/Linux/roxctl-<ppc64le|s390x>` (e.g. <https://mirror.openshift.com/pub/rhacs/assets/4.3.0/Linux/roxctl-s390x>).
 - The experimental API `/v1/product/usage` has been renamed to `/v1/administration/usage`.
+- Risk reprocessing has been shifted from being potentially computed every 15 seconds to 10 minutes. This will improve system performance by debouncing expensive risk calculations.
 
 ## [4.2.0]
 

--- a/pkg/env/reprocessing_interval.go
+++ b/pkg/env/reprocessing_interval.go
@@ -4,7 +4,7 @@ import "time"
 
 var (
 	// RiskReprocessInterval will set the duration for which to debounce risk reprocessing
-	RiskReprocessInterval = registerDurationSetting("ROX_RISK_REPROCESSING_INTERVAL", 15*time.Second)
+	RiskReprocessInterval = registerDurationSetting("ROX_RISK_REPROCESSING_INTERVAL", 10*time.Minute)
 	// ReprocessInterval will set the duration for which to reprocess all deployments and get new scans
 	ReprocessInterval = registerDurationSetting("ROX_REPROCESSING_INTERVAL", 4*time.Hour)
 	// ActiveVulnRefreshInterval will set the duration for which to refresh active components and vulnerabilities.

--- a/scripts/ci/jobs/aks_qa_e2e_tests.py
+++ b/scripts/ci/jobs/aks_qa_e2e_tests.py
@@ -11,5 +11,6 @@ from clusters import AutomationFlavorsCluster
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/aro_qa_e2e_tests.py
+++ b/scripts/ci/jobs/aro_qa_e2e_tests.py
@@ -12,5 +12,6 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["SENSOR_HELM_DEPLOY"] = "true"
 
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/eks_qa_e2e_tests.py
+++ b/scripts/ci/jobs/eks_qa_e2e_tests.py
@@ -12,5 +12,6 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 
 # don't use postgres
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/gke_qa_e2e_tests.py
+++ b/scripts/ci/jobs/gke_qa_e2e_tests.py
@@ -13,5 +13,6 @@ os.environ["GCP_IMAGE_TYPE"] = "cos_containerd"
 
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_ACTIVE_VULN_MGMT"] = "true"
+os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 
 make_qa_e2e_test_runner(cluster=GKECluster("qa-e2e-test")).run()

--- a/scripts/ci/jobs/gke_race_condition_qa_e2e_tests.py
+++ b/scripts/ci/jobs/gke_race_condition_qa_e2e_tests.py
@@ -16,5 +16,6 @@ os.environ["MAIN_IMAGE_TAG"] = os.environ["STACKROX_BUILD_TAG"] + "-rcd"
 os.environ["CENTRAL_DB_IMAGE_TAG"] = os.environ["STACKROX_BUILD_TAG"]
 os.environ["USE_LOCAL_ROXCTL"] = "true"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 
 make_qa_e2e_test_runner(cluster=GKECluster("race-condition-qa-e2e-test")).run()

--- a/scripts/ci/jobs/ibmcloudz_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ibmcloudz_qa_e2e_tests.py
@@ -14,5 +14,6 @@ os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["USE_MIDSTREAM_IMAGES"] = "true"
 os.environ["REMOTE_CLUSTER_ARCH"] = "s390x"
 os.environ["COLLECTION_METHOD"] = "core_bpf"
+os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 
 make_qa_e2e_test_runner_custom(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/ocp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_qa_e2e_tests.py
@@ -11,6 +11,7 @@ from clusters import OpenShiftScaleWorkersCluster
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 
 # Scale up the cluster to support postgres
 cluster = OpenShiftScaleWorkersCluster(increment=1)

--- a/scripts/ci/jobs/ocp_sensor_integration_tests.py
+++ b/scripts/ci/jobs/ocp_sensor_integration_tests.py
@@ -12,6 +12,7 @@ from ci_tests import SensorIntegrationOCP
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_ACTIVE_VULN_MGMT"] = "true"
+os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 
 ClusterTestRunner(
     pre_test=PreSystemTests(run_poll_for_system_test_images=False),

--- a/scripts/ci/jobs/osd_aws_qa_e2e_tests.py
+++ b/scripts/ci/jobs/osd_aws_qa_e2e_tests.py
@@ -12,5 +12,6 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["SENSOR_HELM_DEPLOY"] = "true"
 
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/osd_gcp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/osd_gcp_qa_e2e_tests.py
@@ -12,5 +12,6 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["SENSOR_HELM_DEPLOY"] = "true"
 
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/powervs_qa_e2e_tests.py
+++ b/scripts/ci/jobs/powervs_qa_e2e_tests.py
@@ -14,6 +14,7 @@ os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["USE_MIDSTREAM_IMAGES"] = "true"
 os.environ["REMOTE_CLUSTER_ARCH"] = "ppc64le"
 os.environ["COLLECTION_METHOD"] = "ebpf"
+os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 
 # Trigger tests
 make_qa_e2e_test_runner_custom(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/rosa_qa_e2e_tests.py
+++ b/scripts/ci/jobs/rosa_qa_e2e_tests.py
@@ -12,5 +12,6 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["SENSOR_HELM_DEPLOY"] = "true"
 
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -223,19 +223,20 @@ deploy_central_via_operator() {
         customize_envVars+=$'\n      - name: MUTEX_WATCHDOG_TIMEOUT_SECS'
         customize_envVars+=$'\n        value: "15"'
     fi
-
-    # Add all ROX_ variables
-    export ROX_DEVELOPMENT_BUILD=true
-    export ROX_POSTGRES_DATASTORE=${ROX_POSTGRES_DATASTORE:-false}
-    export ROX_PROCESSES_LISTENING_ON_PORT=${ROX_PROCESSES_LISTENING_ON_PORT:-true}
-    export ROX_TELEMETRY_STORAGE_KEY_V1=${ROX_TELEMETRY_STORAGE_KEY_V1:-DISABLED}
-    for envvar in $(env | grep '^ROX_'); do
-        key=$(echo "$envvar" | awk -F '=' '{print $1}')
-        value=$(echo "$envvar" | awk -F '=' '{print $2}')
-
-        customize_envVars+=$'\n      - name: "'"${key}"'"'
-        customize_envVars+=$'\n        value: "'"${value}"'"'
-    done
+    customize_envVars+=$'\n      - name: ROX_BASELINE_GENERATION_DURATION'
+    customize_envVars+=$'\n        value: '"${ROX_BASELINE_GENERATION_DURATION}"
+    customize_envVars+=$'\n      - name: ROX_DEVELOPMENT_BUILD'
+    customize_envVars+=$'\n        value: "true"'
+    customize_envVars+=$'\n      - name: ROX_NETWORK_BASELINE_OBSERVATION_PERIOD'
+    customize_envVars+=$'\n        value: '"${ROX_NETWORK_BASELINE_OBSERVATION_PERIOD}"
+    customize_envVars+=$'\n      - name: ROX_POSTGRES_DATASTORE'
+    customize_envVars+=$'\n        value: "'"${ROX_POSTGRES_DATASTORE:-false}"'"'
+    customize_envVars+=$'\n      - name: ROX_PROCESSES_LISTENING_ON_PORT'
+    customize_envVars+=$'\n        value: "'"${ROX_PROCESSES_LISTENING_ON_PORT:-true}"'"'
+    customize_envVars+=$'\n      - name: ROX_TELEMETRY_STORAGE_KEY_V1'
+    customize_envVars+=$'\n        value: "'"${ROX_TELEMETRY_STORAGE_KEY_V1:-DISABLED}"'"'
+    customize_envVars+=$'\n      - name: ROX_RISK_REPROCESSING_INTERVAL'
+    customize_envVars+=$'\n        value: "15s"'
 
     CENTRAL_YAML_PATH="tests/e2e/yaml/central-cr.envsubst.yaml"
     # Different yaml for midstream images
@@ -250,10 +251,7 @@ deploy_central_via_operator() {
       central_exposure_route_enabled="$central_exposure_route_enabled" \
       customize_envVars="$customize_envVars" \
     envsubst \
-      < "${CENTRAL_YAML_PATH}" > cr.yaml
-
-    cat cr.yaml
-    kubectl apply -n stackrox -f cr.yaml
+      < "${CENTRAL_YAML_PATH}" | kubectl apply -n stackrox -f -
 
     wait_for_object_to_appear stackrox deploy/central 300
 }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -223,18 +223,19 @@ deploy_central_via_operator() {
         customize_envVars+=$'\n      - name: MUTEX_WATCHDOG_TIMEOUT_SECS'
         customize_envVars+=$'\n        value: "15"'
     fi
-    customize_envVars+=$'\n      - name: ROX_BASELINE_GENERATION_DURATION'
-    customize_envVars+=$'\n        value: '"${ROX_BASELINE_GENERATION_DURATION}"
-    customize_envVars+=$'\n      - name: ROX_DEVELOPMENT_BUILD'
-    customize_envVars+=$'\n        value: "true"'
-    customize_envVars+=$'\n      - name: ROX_NETWORK_BASELINE_OBSERVATION_PERIOD'
-    customize_envVars+=$'\n        value: '"${ROX_NETWORK_BASELINE_OBSERVATION_PERIOD}"
-    customize_envVars+=$'\n      - name: ROX_POSTGRES_DATASTORE'
-    customize_envVars+=$'\n        value: "'"${ROX_POSTGRES_DATASTORE:-false}"'"'
-    customize_envVars+=$'\n      - name: ROX_PROCESSES_LISTENING_ON_PORT'
-    customize_envVars+=$'\n        value: "'"${ROX_PROCESSES_LISTENING_ON_PORT:-true}"'"'
-    customize_envVars+=$'\n      - name: ROX_TELEMETRY_STORAGE_KEY_V1'
-    customize_envVars+=$'\n        value: "'"${ROX_TELEMETRY_STORAGE_KEY_V1:-DISABLED}"'"'
+
+    # Add all ROX_ variables
+    export ROX_DEVELOPMENT_BUILD=true
+    export ROX_POSTGRES_DATASTORE=${ROX_POSTGRES_DATASTORE:-false}
+    export ROX_PROCESSES_LISTENING_ON_PORT=${ROX_PROCESSES_LISTENING_ON_PORT:-true}
+    export ROX_TELEMETRY_STORAGE_KEY_V1=${ROX_TELEMETRY_STORAGE_KEY_V1:-DISABLED}
+    for envvar in $(env | grep '^ROX_'); do
+        key=$(echo "$envvar" | awk -F '=' '{print $1}')
+        value=$(echo "$envvar" | awk -F '=' '{print $2}')
+
+        customize_envVars+=$'\n      - name: "'"${key}"'"'
+        customize_envVars+=$'\n        value: "'"${value}"'"'
+    done
 
     CENTRAL_YAML_PATH="tests/e2e/yaml/central-cr.envsubst.yaml"
     # Different yaml for midstream images

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -250,7 +250,10 @@ deploy_central_via_operator() {
       central_exposure_route_enabled="$central_exposure_route_enabled" \
       customize_envVars="$customize_envVars" \
     envsubst \
-      < "${CENTRAL_YAML_PATH}" | kubectl apply -n stackrox -f -
+      < "${CENTRAL_YAML_PATH}" > cr.yaml
+
+    cat cr.yaml
+    kubectl apply -n stackrox -f cr.yaml
 
     wait_for_object_to_appear stackrox deploy/central 300
 }


### PR DESCRIPTION
## Description

There are several circumstances where risk reprocessing can be triggered rapidly:
- Flapping deployment changes
- Random process executions
- Lots of alert changes

This can lead to flapping risk calculations which are fairly expensive. A 10 minute debounce period minimizes the impact of these potential issues. This leads to a fairly reasonable cap for risk. Back of envelope math:

50,000 deployments with a 600 second debounce is a max of 83 risk reprocessings per second

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI (may need to tweak the env var for CI to finish quickly)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
