### PR TITLE
fix(ci): only restore go cache by hash on go.sum(s)

### DIFF
--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -19,4 +19,3 @@ runs:
         key: go-v3-${{ github.job }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           go-v3-${{ github.job }}-${{ hashFiles('**/go.sum') }}
-          go-v3-${{ github.job }}-


### PR DESCRIPTION
## Description

Per title.

## Checklist
- [x] Investigated and inspected CI test results

## Backports?

- [x] 4.2 already done
- [x]  4.1 already done
- [x]  4.0 required - https://github.com/stackrox/stackrox/pull/8038
- [x]  3.74 required - https://github.com/stackrox/stackrox/pull/8037

## Testing Performed

CI