### PR TITLE
fix(ci): release 3.74/remove problematic go cache hit

### DIFF
--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -22,5 +22,3 @@ runs:
         key: go-v2-${{ hashFiles('**/go.sum') }}-${{ github.job }}
         restore-keys: |
           go-v2-${{ hashFiles('**/go.sum') }}-${{ github.job }}
-          go-v2-${{ hashFiles('**/go.sum') }}-
-          go-v2-


### PR DESCRIPTION
Backport of https://github.com/stackrox/stackrox/pull/8036