### PR TITLE
fix: Remove extra base64 encoding in k8sobject.go

### DIFF
--- a/roxctl/declarativeconfig/k8sobject/k8sobject.go
+++ b/roxctl/declarativeconfig/k8sobject/k8sobject.go
@@ -2,7 +2,6 @@ package k8sobject
 
 import (
 	"context"
-	"encoding/base64"
 	"time"
 
 	"github.com/pkg/errors"
@@ -108,11 +107,7 @@ func readSecret(ctx context.Context, client kubernetes.Interface, secretName str
 	}
 	contents := make([][]byte, 0, len(s.Data))
 	for _, data := range s.Data {
-		out, err := base64.StdEncoding.DecodeString(string(data))
-		if err != nil {
-			return nil, errors.Wrap(err, "decoding base64 input")
-		}
-		contents = append(contents, out)
+		contents = append(contents, data)
 	}
 	return contents, nil
 }

--- a/roxctl/declarativeconfig/k8sobject/k8sobject.go
+++ b/roxctl/declarativeconfig/k8sobject/k8sobject.go
@@ -63,7 +63,7 @@ func writeSecret(ctx context.Context, client kubernetes.Interface, secretName, n
 	if s.Data == nil {
 		s.Data = map[string][]byte{}
 	}
-	s.Data[key] = []byte(base64.StdEncoding.EncodeToString(yaml))
+	s.Data[key] = yaml
 	if _, err := client.CoreV1().Secrets(namespace).Update(ctx, s, metav1.UpdateOptions{}); err != nil {
 		return errors.Wrapf(err, "updating secret %s/%s", namespace, secretName)
 	}

--- a/roxctl/declarativeconfig/k8sobject/k8sobject_test.go
+++ b/roxctl/declarativeconfig/k8sobject/k8sobject_test.go
@@ -181,7 +181,7 @@ func TestReadFromK8sObject_Secret(t *testing.T) {
 					Namespace: "testing",
 				},
 				Data: map[string][]byte{
-					"some-key": []byte("dGVzdGluZw=="),
+					"some-key": []byte("testing"),
 				},
 			},
 			secret:    "test-secret",
@@ -244,7 +244,7 @@ func TestWriteToK8sObject_Secret(t *testing.T) {
 					Namespace: "testing",
 				},
 				Data: map[string][]byte{
-					"some-key": []byte("dGVzdGluZw=="),
+					"some-key": []byte("testing"),
 				},
 			},
 			secret:    "test-secret",
@@ -260,7 +260,7 @@ func TestWriteToK8sObject_Secret(t *testing.T) {
 					Namespace: "testing",
 				},
 				Data: map[string][]byte{
-					"test-key": []byte("dGVzdGluZw=="),
+					"test-key": []byte("testing"),
 				},
 			},
 			secret:    "test-secret",


### PR DESCRIPTION
## Description

K8s client encodes secrets by itself, we don't need to do base64 encoding in roxctl.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

1. Manual TBD

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
