### PR TITLE
ROX-20042: Add 'first' qualifier to watched image row selectors

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -141,7 +141,11 @@ export function watchImageFlowFromModal(imageFullName, imageNameAndTag) {
     cy.get(selectors.closeWatchedImageDialogButton).click();
 
     // check that the table row containing the image name has a watched image label
-    cy.get(`${selectors.watchedImageCellWithName(imageNameAndTag)} ${selectors.watchedImageLabel}`);
+    cy.get(
+        `${selectors.watchedImageCellWithName(imageNameAndTag)}:first ${
+            selectors.watchedImageLabel
+        }`
+    );
 }
 
 /**

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
@@ -126,7 +126,7 @@ describe('Workload CVE watched images flow', () => {
                 watchImageFlowFromModal(fullName, nameAndTag);
 
                 // Open the unwatch modal via the table row action
-                cy.get(selectors.tableRowActionsForImage(nameAndTag)).click();
+                cy.get(selectors.tableRowActionsForImage(nameAndTag)).first().click();
                 cy.get('button:contains("Unwatch image")').click();
 
                 cy.get('*[role="dialog"] button:contains("Unwatch")').click();
@@ -138,7 +138,7 @@ describe('Workload CVE watched images flow', () => {
                 );
 
                 // Close the modal and verify the update in the table
-                cy.get('*[role="dialog"]  button:contains("Close")').click();
+                cy.get('*[role="dialog"] button:contains("Close")').click();
                 cy.get(selectors.watchedImageCellWithName(nameAndTag)).should('not.exist');
             });
         }


### PR DESCRIPTION
## Description

In some flavors of the OCP UI e2e tests, multiple rows with the same image name are returned in the default response when an image is watched. This ensures when selecting those images, that we grab the first one to avoid a Cypress error of attempting to click multiple elements.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local Cypress run

Awaiting CI
