### PR TITLE
ROX-20012: Add polling for administration events

### DIFF
--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, useEffect, useState } from 'react';
 import { Alert, Bullseye, PageSection, Spinner, Text, Title } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
+import useInterval from 'hooks/useInterval';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
@@ -9,7 +10,7 @@ import {
     AdministrationEvent,
     countAdministrationEvents,
     defaultSortOption,
-    getAdministrationEventsFilter,
+    getListAdministrationEventsArg,
     listAdministrationEvents,
     sortFields,
 } from 'services/AdministrationEventsService';
@@ -23,41 +24,83 @@ function AdministrationEventsPage(): ReactElement {
     const { searchFilter, setSearchFilter } = useURLSearch();
     const { getSortParams, sortOption } = useURLSort({ defaultSortOption, sortFields });
 
-    const [isLoading, setIsLoading] = useState(false);
-    const [events, setEvents] = useState<AdministrationEvent[]>([]);
     const [count, setCount] = useState(0);
     const [errorMessage, setErrorMessage] = useState('');
+    const [events, setEvents] = useState<AdministrationEvent[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const [lastUpdatedEventIds, setLastUpdatedEventIds] = useState<Set<string>>(new Set());
+    const [lastUpdatedTime, setLastUpdatedTime] = useState('');
+    const [updatedCount, setUpdatedCount] = useState(0);
 
+    const [countAvailable, setCountAvailable] = useState(0);
+    const [pollingCount, setPollingCount] = useState(0);
+
+    /*
+     * Request count and events at initial page load or after user action:
+     * change pagination, searchFilter, sortOptions
+     * click events available button
+     */
     useEffect(() => {
-        setIsLoading(true);
+        if (updatedCount === 0) {
+            setIsLoading(true);
+        }
 
-        const filter = getAdministrationEventsFilter(searchFilter);
-        const pagination = { limit: perPage, offset: page - 1, sortOption };
-        // TODO Promise.all for consistent count and events?
+        const listArg = getListAdministrationEventsArg({ page, perPage, searchFilter, sortOption });
+        const { filter } = listArg;
 
-        listAdministrationEvents({ filter, pagination })
-            .then((eventsArg) => {
-                setEvents(eventsArg);
+        Promise.all([countAdministrationEvents(filter), listAdministrationEvents(listArg)])
+            .then(([countArg, eventsArg]) => {
+                setCount(countArg);
+                setCountAvailable(0);
                 setErrorMessage('');
+                setEvents(eventsArg);
+                setLastUpdatedEventIds(new Set(eventsArg.map(({ id }) => id)));
+                setLastUpdatedTime(new Date().toISOString());
             })
             .catch((error) => {
-                setEvents([]);
+                setCount(0);
                 setErrorMessage(getAxiosErrorMessage(error));
+                setEvents([]);
             })
             .finally(() => {
-                setIsLoading(false);
+                if (updatedCount === 0) {
+                    setIsLoading(false);
+                }
             });
+    }, [page, perPage, searchFilter, setIsLoading, sortOption, updatedCount]);
 
-        countAdministrationEvents(filter)
-            .then((countArg) => {
-                setCount(countArg);
-            })
-            .catch(() => {
-                setCount(0);
-            });
-    }, [page, perPage, searchFilter, sortOption, setIsLoading]);
+    function updateEvents() {
+        setUpdatedCount(updatedCount + 1);
+    }
 
-    // TODO polling and last updated with conditionally rendered reload button like Network Graph
+    /*
+     * Request events every minute to compute count of events available.
+     */
+    useEffect(() => {
+        if (pollingCount !== 0) {
+            const arg = getListAdministrationEventsArg({ page, perPage, searchFilter, sortOption });
+            listAdministrationEvents(arg)
+                .then((eventsArg) => {
+                    let nAvailable = 0;
+
+                    eventsArg.forEach(({ id }) => {
+                        if (!lastUpdatedEventIds.has(id)) {
+                            nAvailable += 1;
+                        }
+                    });
+
+                    setCountAvailable(nAvailable);
+                })
+                .catch(() => {});
+        }
+    }, [pollingCount]); // eslint-disable-line react-hooks/exhaustive-deps
+    // Why disable the rule for the following hook dependencies: lastUpdatedEventIds, page, perPage, searchFilter, sortOption?
+    // So polling continues on its schedule instead of immediately making a redundant request.
+
+    useInterval(() => {
+        setPollingCount(pollingCount + 1);
+    }, 60000); // 60 seconds corresponds to backend reprocessing events.
+
     /* eslint-disable no-nested-ternary */
     return (
         <>
@@ -87,12 +130,15 @@ function AdministrationEventsPage(): ReactElement {
                     <>
                         <AdministrationEventsToolbar
                             count={count}
+                            countAvailable={countAvailable}
+                            lastUpdatedTime={lastUpdatedTime}
                             page={page}
                             perPage={perPage}
                             setPage={setPage}
                             setPerPage={setPerPage}
                             searchFilter={searchFilter}
                             setSearchFilter={setSearchFilter}
+                            updateEvents={updateEvents}
                         />
                         <AdministrationEventsTable
                             events={events}

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, useCallback, useEffect, useState } from 'react';
 import { Alert, Bullseye, PageSection, Spinner, Text, Title } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
@@ -31,14 +31,16 @@ function AdministrationEventsPage(): ReactElement {
     const [isLoading, setIsLoading] = useState(false);
     const [lastUpdatedEventIds, setLastUpdatedEventIds] = useState<Set<string>>(new Set());
     const [lastUpdatedTime, setLastUpdatedTime] = useState('');
-    const [updatedCount, setUpdatedCount] = useState(0);
 
     /*
      * Request count and events at initial page load or after user action:
-     * change pagination, searchFilter, sortOptions
-     * click events available button
+     * 1. change pagination, searchFilter, sortOptions:
+     *    * because useCallback hook dependencies change,
+     *    * it returns a new updateEvents callback function,
+     *    * which is the useEffect hook dependency.
+     * 2. click events available button which has `onClick={updateEvents}` prop.
      */
-    useEffect(() => {
+    const updateEvents = useCallback(() => {
         setIsLoading(true);
 
         const listArg = getListAdministrationEventsArg({ page, perPage, searchFilter, sortOption });
@@ -61,11 +63,11 @@ function AdministrationEventsPage(): ReactElement {
             .finally(() => {
                 setIsLoading(false);
             });
-    }, [page, perPage, searchFilter, setIsLoading, sortOption, updatedCount]);
+    }, [page, perPage, searchFilter, setIsLoading, sortOption]);
 
-    function updateEvents() {
-        setUpdatedCount(updatedCount + 1);
-    }
+    useEffect(() => {
+        updateEvents();
+    }, [updateEvents]);
 
     /*
      * Request events every minute to compute count of events available.

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
@@ -39,9 +39,7 @@ function AdministrationEventsPage(): ReactElement {
      * click events available button
      */
     useEffect(() => {
-        if (updatedCount === 0) {
-            setIsLoading(true);
-        }
+        setIsLoading(true);
 
         const listArg = getListAdministrationEventsArg({ page, perPage, searchFilter, sortOption });
         const { filter } = listArg;
@@ -61,9 +59,7 @@ function AdministrationEventsPage(): ReactElement {
                 setEvents([]);
             })
             .finally(() => {
-                if (updatedCount === 0) {
-                    setIsLoading(false);
-                }
+                setIsLoading(false);
             });
     }, [page, perPage, searchFilter, setIsLoading, sortOption, updatedCount]);
 
@@ -103,7 +99,7 @@ function AdministrationEventsPage(): ReactElement {
                 </Text>
             </PageSection>
             <PageSection component="div">
-                {isLoading ? (
+                {isLoading && !lastUpdatedTime ? (
                     <Bullseye>
                         <Spinner isSVG />
                     </Bullseye>
@@ -121,6 +117,7 @@ function AdministrationEventsPage(): ReactElement {
                         <AdministrationEventsToolbar
                             count={count}
                             countAvailable={countAvailable}
+                            isDisabled={isLoading}
                             lastUpdatedTime={lastUpdatedTime}
                             page={page}
                             perPage={perPage}

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsToolbar.tsx
@@ -19,25 +19,32 @@ import { SearchFilter } from 'types/search';
 import SearchFilterDomain from './SearchFilterDomain';
 import SearchFilterLevel from './SearchFilterLevel';
 import SearchFilterResourceType from './SearchFilterResourceType';
+import UpdatedTimeOrUpdateButton from './UpdatedTimeOrUpdateButton';
 
 export type AdministrationEventsToolbarProps = {
     count: number;
+    countAvailable: number;
+    lastUpdatedTime: string;
     page: number;
     perPage: number;
     setPage: (newPage: number) => void;
     setPerPage: (newPerPage: number) => void;
     searchFilter: SearchFilter;
     setSearchFilter: (newFilter: SearchFilter) => void;
+    updateEvents: () => void;
 };
 
 function AdministrationEventsToolbar({
     count,
+    countAvailable,
+    lastUpdatedTime,
     page,
     perPage,
     setPage,
     setPerPage,
     searchFilter,
     setSearchFilter,
+    updateEvents,
 }: AdministrationEventsToolbarProps): ReactElement {
     function setDomain(domain: string | undefined) {
         setSearchFilter(replaceSearchFilterDomain(searchFilter, domain));
@@ -70,9 +77,20 @@ function AdministrationEventsToolbar({
                         <SearchFilterLevel level={level && level[0]} setLevel={setLevel} />
                     </ToolbarItem>
                 </ToolbarGroup>
-                <ToolbarGroup alignment={{ default: 'alignRight' }}>
+                <ToolbarGroup variant="button-group" alignment={{ default: 'alignRight' }}>
+                    {lastUpdatedTime && (
+                        <ToolbarItem>
+                            <UpdatedTimeOrUpdateButton
+                                countAvailable={countAvailable}
+                                isAvailableEqualToPerPage={countAvailable === perPage}
+                                lastUpdatedTime={lastUpdatedTime}
+                                updateEvents={updateEvents}
+                            />
+                        </ToolbarItem>
+                    )}
                     <ToolbarItem variant="pagination">
                         <Pagination
+                            isCompact
                             itemCount={count}
                             page={page}
                             perPage={perPage}

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsToolbar.tsx
@@ -24,6 +24,7 @@ import UpdatedTimeOrUpdateButton from './UpdatedTimeOrUpdateButton';
 export type AdministrationEventsToolbarProps = {
     count: number;
     countAvailable: number;
+    isDisabled: boolean;
     lastUpdatedTime: string;
     page: number;
     perPage: number;
@@ -37,6 +38,7 @@ export type AdministrationEventsToolbarProps = {
 function AdministrationEventsToolbar({
     count,
     countAvailable,
+    isDisabled,
     lastUpdatedTime,
     page,
     perPage,
@@ -65,16 +67,25 @@ function AdministrationEventsToolbar({
             <ToolbarContent>
                 <ToolbarGroup variant="filter-group">
                     <ToolbarItem>
-                        <SearchFilterDomain domain={domain && domain[0]} setDomain={setDomain} />
+                        <SearchFilterDomain
+                            domain={domain && domain[0]}
+                            isDisabled={isDisabled}
+                            setDomain={setDomain}
+                        />
                     </ToolbarItem>
                     <ToolbarItem>
                         <SearchFilterResourceType
+                            isDisabled={isDisabled}
                             resourceType={resourceType && resourceType[0]}
                             setResourceType={setResourceType}
                         />
                     </ToolbarItem>
                     <ToolbarItem>
-                        <SearchFilterLevel level={level && level[0]} setLevel={setLevel} />
+                        <SearchFilterLevel
+                            isDisabled={isDisabled}
+                            level={level && level[0]}
+                            setLevel={setLevel}
+                        />
                     </ToolbarItem>
                 </ToolbarGroup>
                 <ToolbarGroup variant="button-group" alignment={{ default: 'alignRight' }}>
@@ -83,6 +94,7 @@ function AdministrationEventsToolbar({
                             <UpdatedTimeOrUpdateButton
                                 countAvailable={countAvailable}
                                 isAvailableEqualToPerPage={countAvailable === perPage}
+                                isDisabled={isDisabled}
                                 lastUpdatedTime={lastUpdatedTime}
                                 updateEvents={updateEvents}
                             />
@@ -91,6 +103,7 @@ function AdministrationEventsToolbar({
                     <ToolbarItem variant="pagination">
                         <Pagination
                             isCompact
+                            isDisabled={isDisabled}
                             itemCount={count}
                             page={page}
                             perPage={perPage}

--- a/ui/apps/platform/src/Containers/Administration/Events/SearchFilterDomain.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/SearchFilterDomain.tsx
@@ -7,15 +7,12 @@ const optionAll = 'All';
 
 type SearchFilterDomainProps = {
     domain: string | undefined;
+    isDisabled: boolean;
     setDomain: (domain: string | undefined) => void;
 };
 
-function SearchFilterDomain({ domain, setDomain }: SearchFilterDomainProps) {
+function SearchFilterDomain({ domain, isDisabled, setDomain }: SearchFilterDomainProps) {
     const [isOpen, setIsOpen] = useState(false);
-
-    function onToggle(isOpenArg: boolean) {
-        setIsOpen(isOpenArg);
-    }
 
     function onSelect(_event, selection) {
         setDomain(selection === optionAll ? undefined : selection);
@@ -39,9 +36,10 @@ function SearchFilterDomain({ domain, setDomain }: SearchFilterDomainProps) {
             variant="single"
             aria-label="Domain filter menu items"
             toggleAriaLabel="Domain filter menu toggle"
-            onToggle={onToggle}
+            onToggle={setIsOpen}
             onSelect={onSelect}
             selections={domain ?? optionAll}
+            isDisabled={isDisabled}
             isOpen={isOpen}
         >
             {options}

--- a/ui/apps/platform/src/Containers/Administration/Events/SearchFilterLevel.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/SearchFilterLevel.tsx
@@ -8,16 +8,13 @@ import { getLevelText } from './AdministrationEvent';
 const optionAll = 'All';
 
 type SearchFilterLevelProps = {
+    isDisabled: boolean;
     level: AdministrationEventLevel | undefined;
     setLevel: (level: AdministrationEventLevel) => void;
 };
 
-function SearchFilterLevel({ level, setLevel }: SearchFilterLevelProps) {
+function SearchFilterLevel({ isDisabled, level, setLevel }: SearchFilterLevelProps) {
     const [isOpen, setIsOpen] = useState(false);
-
-    function onToggle(isOpenArg: boolean) {
-        setIsOpen(isOpenArg);
-    }
 
     function onSelect(_event, selection) {
         setLevel(selection === optionAll ? undefined : selection);
@@ -41,9 +38,10 @@ function SearchFilterLevel({ level, setLevel }: SearchFilterLevelProps) {
             variant="single"
             aria-label="Level filter menu items"
             toggleAriaLabel="Level filter menu toggle"
-            onToggle={onToggle}
+            onToggle={setIsOpen}
             onSelect={onSelect}
             selections={level ?? optionAll}
+            isDisabled={isDisabled}
             isOpen={isOpen}
         >
             {options}

--- a/ui/apps/platform/src/Containers/Administration/Events/SearchFilterResourceType.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/SearchFilterResourceType.tsx
@@ -6,19 +6,17 @@ import { resourceTypes } from 'services/AdministrationEventsService';
 const optionAll = 'All';
 
 type SearchFilterResourceTypeProps = {
+    isDisabled: boolean;
     resourceType: string | undefined;
     setResourceType: (resourceType: string | undefined) => void;
 };
 
 function SearchFilterResourceType({
+    isDisabled,
     resourceType,
     setResourceType,
 }: SearchFilterResourceTypeProps) {
     const [isOpen, setIsOpen] = useState(false);
-
-    function onToggle(isOpenArg: boolean) {
-        setIsOpen(isOpenArg);
-    }
 
     function onSelect(_event, selection) {
         setResourceType(selection === optionAll ? undefined : selection);
@@ -42,9 +40,10 @@ function SearchFilterResourceType({
             variant="single"
             aria-label="Resource type filter menu items"
             toggleAriaLabel="Resource type filter menu toggle"
-            onToggle={onToggle}
+            onToggle={setIsOpen}
             onSelect={onSelect}
             selections={resourceType ?? optionAll}
+            isDisabled={isDisabled}
             isOpen={isOpen}
         >
             {options}

--- a/ui/apps/platform/src/Containers/Administration/Events/UpdatedTimeOrUpdateButton.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/UpdatedTimeOrUpdateButton.tsx
@@ -1,0 +1,34 @@
+import React, { ReactElement } from 'react';
+import { Button } from '@patternfly/react-core';
+import pluralize from 'pluralize';
+
+import { getTimeHoursMinutes } from 'utils/dateUtils';
+
+type UpdatedTimeOrUpdateButtonProps = {
+    countAvailable: number;
+    isAvailableEqualToPerPage: boolean;
+    lastUpdatedTime: string; // ISO 8601
+    updateEvents: () => void;
+};
+
+const UpdatedTimeOrUpdateButton = ({
+    countAvailable,
+    isAvailableEqualToPerPage,
+    lastUpdatedTime,
+    updateEvents,
+}: UpdatedTimeOrUpdateButtonProps): ReactElement => {
+    return countAvailable === 0 ? (
+        <em className="pf-u-font-size-sm pf-u-text-nowrap">{`Last updated at ${getTimeHoursMinutes(
+            lastUpdatedTime
+        )}`}</em>
+    ) : (
+        <Button isSmall onClick={updateEvents} variant="secondary">
+            {`${countAvailable}${isAvailableEqualToPerPage ? '+' : ''} ${pluralize(
+                'event',
+                countAvailable
+            )} available`}
+        </Button>
+    );
+};
+
+export default UpdatedTimeOrUpdateButton;

--- a/ui/apps/platform/src/Containers/Administration/Events/UpdatedTimeOrUpdateButton.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/UpdatedTimeOrUpdateButton.tsx
@@ -7,6 +7,7 @@ import { getTimeHoursMinutes } from 'utils/dateUtils';
 type UpdatedTimeOrUpdateButtonProps = {
     countAvailable: number;
     isAvailableEqualToPerPage: boolean;
+    isDisabled: boolean;
     lastUpdatedTime: string; // ISO 8601
     updateEvents: () => void;
 };
@@ -14,6 +15,7 @@ type UpdatedTimeOrUpdateButtonProps = {
 const UpdatedTimeOrUpdateButton = ({
     countAvailable,
     isAvailableEqualToPerPage,
+    isDisabled,
     lastUpdatedTime,
     updateEvents,
 }: UpdatedTimeOrUpdateButtonProps): ReactElement => {
@@ -22,7 +24,7 @@ const UpdatedTimeOrUpdateButton = ({
             lastUpdatedTime
         )}`}</em>
     ) : (
-        <Button isSmall onClick={updateEvents} variant="secondary">
+        <Button isDisabled={isDisabled} isSmall onClick={updateEvents} variant="secondary">
             {`${countAvailable}${isAvailableEqualToPerPage ? '+' : ''} ${pluralize(
                 'event',
                 countAvailable

--- a/ui/apps/platform/src/services/AdministrationEventsService.ts
+++ b/ui/apps/platform/src/services/AdministrationEventsService.ts
@@ -1,6 +1,6 @@
 import qs from 'qs';
 
-import { SearchFilter } from 'types/search';
+import { ApiSortOption, SearchFilter } from 'types/search';
 import { SortOption } from 'types/table';
 
 import axios from './instance';
@@ -137,6 +137,24 @@ export function listAdministrationEvents(
     return axios
         .get<ListAdministrationEventsResponse>(`${eventsUrl}?${params}`)
         .then((response) => response.data.events);
+}
+
+type GetAdministrationEventResponseArg = {
+    page: number;
+    perPage: number;
+    searchFilter: SearchFilter;
+    sortOption: ApiSortOption;
+};
+
+export function getListAdministrationEventsArg({
+    page,
+    perPage,
+    searchFilter,
+    sortOption,
+}: GetAdministrationEventResponseArg): ListAdministrationEventsRequest {
+    const filter = getAdministrationEventsFilter(searchFilter);
+    const pagination: Pagination = { limit: perPage, offset: page - 1, sortOption };
+    return { filter, pagination };
 }
 
 // Given searchFilter from useURLSearch hook, return validated filter argument.

--- a/ui/apps/platform/src/utils/dateUtils.ts
+++ b/ui/apps/platform/src/utils/dateUtils.ts
@@ -32,6 +32,15 @@ export function getTime(timestamp: DateLike) {
     return format(timestamp, timeFormat);
 }
 
+/**
+ * Returns a formatted time with hours and minutes but without seconds.
+ * @param {DateLike} timestamp - The timestamp for the date
+ * @returns {string} - returns a formatted string for the time
+ */
+export function getTimeHoursMinutes(timestamp: DateLike) {
+    return format(timestamp, 'h:mmA');
+}
+
 export function getLatestDatedItemByKey<T>(key: string | null, list: T[] = []): T | null {
     if (!key || !list.length || !list[0][key]) {
         return null;


### PR DESCRIPTION
## Description

### Objective

Let users decide when to load new events, following the precedent of Network Graph.

Events page implicitly reloads after any user action:
* to change search filters, sorting, or (theoretically in this case) pagination
* to visit an event page and then go back

If all events in polling request are new, then render **Load 10+ new events** (or whatever is the `perPage` amount) because frontend knowledge is limited to current page.

As discussed, frontend knowledge is limited to current request params.

### Changes

1. Edit AdministrationEventsPage.tsx file.
    * Separate `useEffect` for initial request and user-initiated actions from `useEffect` for polling requests.
    * Frontend polling interval 60 seconds corresponds to backend reprocessing of events. 
    * Count available events compared to set of event id for the current page.

2. Edit AdministrationEventsToolbar.tsx file.
    * Render `UpdatedTimeOrUpdateButton` element adjacent to pagination.
    * Change from full to compact pagination according to design.

3. Add UpdatedTimeOrUpdateButton.tsx file.
    * Render either `lastUpdatedTime` paragraph or `countAvailable` button.
    * Specify 14px small size for paragraph and button same for visual compatibility with pagination.

4. Edit AdministationEventsService.ts file.
    * Add `getListAdministrationEventsArg` function to encapsulate comversion from URL hook values.

5. Edit dateUtils.ts file.
    * Add `getTimeHoursMinutes` function.

### Residue

1. Call `getTimeHoursMinutes` function:
    * https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx#L221-L227
    * https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx#L59
2. Ask at weekly joint team meeting about pro and con of date in **Last updated** on main dashboard.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before `yarn deploy` in ui, do the following:

```sh
export ROX_ADMINISTRATION_EVENTS=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js: 43 = 3893514 - 3893471
        total: 8871 = 10165134 - 10156263
    * `ls -al build/static/js/*.js | wc -l`
        1 = 83 - 82 files
3. `yarn start` in ui

### Manual testing

Pictures at 1280px width and 800px height like an older laptop.

1. Visit /main/administration-events

    * See count and list request.
    * Without `if (pollingCount !== 0) { … }` see a redundant polling request at initial page visit.
    * See `lastUpdatedTime` at the left of compact pagination.
        ![Visit](https://github.com/stackrox/stackrox/assets/11862657/b9f1232a-f7ee-428d-9520-22687c697ba2)

    * With temporary `let nAvailable = pollingCount` see update button with increasing `countAvailable` after each polling interval.
        ![countAvailable](https://github.com/stackrox/stackrox/assets/11862657/f9c35622-ea09-40d1-b6e1-a26cc5085463)

    * See **10+ events available** when all events in polling request are new (with temporary hack).
        ![isAvailableEqualToPerPage](https://github.com/stackrox/stackrox/assets/11862657/9d2405b5-0602-4442-a004-a73915551e61)

    * See `lastUpdatedTime` replace `countAvailable` button after click update button.
        ![click](https://github.com/stackrox/stackrox/assets/11862657/1773a677-56a1-4697-b372-110568caba3e)

    * Ditto after any user action to change search filters, sorting, or (theoretically in this case) pagination, also to visit an event page and then go back.
        ![filter](https://github.com/stackrox/stackrox/assets/11862657/98f3e728-24e1-4fec-ab99-0c3b0a274497)

### Integration testing

Before `yarn cypress-open` in ui/apps/platform, do the following:

```sh
export CYPRESS_ROX_ADMINISTRATION_EVENTS=true
```

* administation/events/eventsTable.test.js
