### PR TITLE
ROX-19160: Append date to VM 2.0 Report download names

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -61,6 +61,8 @@ const sortOptions = {
     defaultSortOption: { field: 'Report Completion Time', direction: 'desc' } as const,
 };
 
+const filenameSanitizerRegex = new RegExp('(:)|(/)|(\\s)', 'gi');
+
 function ReportJobs({ reportId }: RunHistoryProps) {
     const { currentUser } = useAuthStatus();
     const { page, perPage, setPage, setPerPage } = useURLPagination(10);
@@ -247,12 +249,18 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                         const areDownloadActionsDisabled = currentUser.userId !== user.id;
 
                         function onDownload() {
+                            const { completedAt } = reportStatus;
+                            const filename = `${name}-${completedAt}`;
+                            const sanitizedFilename = filename.replaceAll(
+                                filenameSanitizerRegex,
+                                '_'
+                            );
                             return saveFile({
                                 method: 'get',
                                 url: `/api/reports/jobs/download?id=${reportJobId}`,
                                 data: null,
                                 timeout: 300000,
-                                name: `${name}.zip`,
+                                name: `${sanitizedFilename}.zip`,
                             });
                         }
 


### PR DESCRIPTION
## Description

This small change causes the datetime stamp that a report was run to be appended to the report name, when the report ZIP is downloaded.

We also do some rudimentary sanitization of the final filename to avoid file system conflicts.

Example: 
`name`: "Van 2:Electric/Slide"
`reportStatus.completedAt`: "2023-10-10T20:17:15.436832803Z"

filename used: "Van_2_Electric_Slide-2023-10-10T20_17_15.436832803Z.zip"

## Checklist
- [x] Investigated and inspected CI test results (gke-ui-e2e-tests, ocp-4-10-ui-e2e-tests had two known flakes, ocp-4-13-ui-e2e-tests didn't even deploy)

## Testing Performed

### Here I tell how I validated my change

Manual testing

I created a report name with special characters, generated the report, and then downloaded it.
![Screen Shot 2023-10-10 at 4 44 31 PM](https://github.com/stackrox/stackrox/assets/715729/aa4253bf-14b5-43b4-9926-68e2660a8590)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
