### PR TITLE
ROX-20040: Try and improve gke-operator-e2e disk performance

### DIFF
--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -32,10 +32,11 @@ class GKECluster:
     REFRESH_PATH = "scripts/ci/gke.sh"
     TEARDOWN_PATH = "scripts/ci/gke.sh"
 
-    def __init__(self, cluster_id, num_nodes=3, machine_type="e2-standard-4"):
+    def __init__(self, cluster_id, num_nodes=3, machine_type="e2-standard-4", disk_gb=40):
         self.cluster_id = cluster_id
         self.num_nodes = num_nodes
         self.machine_type = machine_type
+        self.disk_gb = disk_gb
         self.refresh_token_cmd = None
 
     def provision(self):

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -28,6 +28,7 @@ assign_env_variables() {
     local cluster_id="$1"
     local num_nodes="${2:-3}"
     local machine_type="${3:-e2-standard-4}"
+    local disk_gb="${4:-40}"
 
     ensure_CI
 
@@ -52,6 +53,9 @@ assign_env_variables() {
 
     ci_export MACHINE_TYPE "$machine_type"
     echo "Machine type is set as to $machine_type"
+
+    ci_export DISK_SIZE_GB "$disk_gb"
+    echo "Disk size is set to $disk_gb"
 
     choose_release_channel
     choose_cluster_version
@@ -145,6 +149,7 @@ create_cluster() {
     POD_SECURITY_POLICIES="${POD_SECURITY_POLICIES:-false}"
     GKE_RELEASE_CHANNEL="${GKE_RELEASE_CHANNEL:-stable}"
     MACHINE_TYPE="${MACHINE_TYPE:-e2-standard-4}"
+    DISK_SIZE_GB=${DISK_SIZE_GB:-40}
 
     echo "Creating ${NUM_NODES} node cluster with image type \"${GCP_IMAGE_TYPE}\""
 
@@ -173,7 +178,7 @@ create_cluster() {
             --machine-type "${MACHINE_TYPE}" \
             --num-nodes "${NUM_NODES}" \
             --disk-type=pd-standard \
-            --disk-size=40GB \
+            --disk-size="${DISK_SIZE_GB}GB" \
             --create-subnetwork range=/28 \
             --cluster-ipv4-cidr=/20 \
             --services-ipv4-cidr=/24 \

--- a/scripts/ci/jobs/gke_operator_e2e_tests.py
+++ b/scripts/ci/jobs/gke_operator_e2e_tests.py
@@ -11,7 +11,7 @@ from post_tests import PostClusterTest, FinalPost
 
 
 ClusterTestRunner(
-    cluster=GKECluster("operator-e2e-test"),
+    cluster=GKECluster("operator-e2e-test", disk_gb=400),
     pre_test=PreSystemTests(),
     test=OperatorE2eTest(operator_cluster_type="gke"),
     post_test=PostClusterTest(collect_central_artifacts=False),


### PR DESCRIPTION
## Description

I suspect slow scanner-db startup (up to 20x the time on OCP/AWS) that causes gke-operator-e2e tests to flake out is caused by poor disk performance. This PR tries to improve it by resizing the disks 10x, since their performance scales linearly with size. More details and calculations in the ticket.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

I wanted to conduct some experiments first but [it seems I lack permissions](https://redhat-internal.slack.com/archives/CVANK5K5W/p1697003899544809). However just giving this a go is worth doing anyway and we can observe the impact in CI.

I took a look at the `init-db` init container execution times in the `gke-operator-e2e` job for this PR, and they were:
* 1m53s 
* 2m4s
* 1m54s
* 2m3s
* 1m44s

For an unrelated PR on top of `master` it's:
* 1m58s
* 2m37s
* 2m21s
* 2ms6s
* 1m17s

So not much change in the "happy" case but I still hope this change will help avoid us the pathological 25m+ cases.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
