### PR TITLE
ROX-20112: Prevent double-reporting `kuttl` errors.

### DIFF
--- a/operator/tests/run.sh
+++ b/operator/tests/run.sh
@@ -40,6 +40,10 @@ _EO_KUTTL_HELP_
                "${kuttl_help}" \
                "make" "-C" "operator" "test-upgrade" || FAILED=1
     store_test_results "operator/build/kuttl-test-artifacts-upgrade" "kuttl-test-artifacts-upgrade"
+    if junit_contains_failure "$(stored_test_results "kuttl-test-artifacts-upgrade")"; then
+        # Prevent double-reporting
+        remove_junit_record test-upgrade
+    fi
     [[ $FAILED = 0 ]] || die "operator upgrade tests failed"
 
     info "Executing operator e2e tests"
@@ -48,6 +52,10 @@ _EO_KUTTL_HELP_
                "${kuttl_help}" \
                "make" "-C" "operator" "test-e2e-deployed" || FAILED=1
     store_test_results "operator/build/kuttl-test-artifacts" "kuttl-test-artifacts"
+    if junit_contains_failure "$(stored_test_results "kuttl-test-artifacts")"; then
+        # Prevent double-reporting
+        remove_junit_record test-e2e
+    fi
     [[ $FAILED = 0 ]] || die "operator e2e tests failed"
 
     info "Executing Operator Bundle Scorecard tests"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1091,7 +1091,8 @@ store_test_results() {
 
     info "Copying test results from $from to $to"
 
-    local dest="$(stored_test_results "$to")"
+    local dest
+    dest="$(stored_test_results "$to")"
 
     cp -a "$from" "$dest" || true # (best effort)
 }
@@ -1361,7 +1362,7 @@ junit_contains_failure() {
     if [[ ! -d $dir ]]; then
         return 1
     fi
-    for f in $(find "$dir" -type f -iname '*.xml'); do
+    for f in $(find "$dir" -type f -iname '*.xml'); do # shellcheck disable=SC2044
         if grep -q '<failure ' "$f"; then
             return 0
         fi

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1362,7 +1362,10 @@ junit_contains_failure() {
     if [[ ! -d $dir ]]; then
         return 1
     fi
-    for f in $(find "$dir" -type f -iname '*.xml'); do # shellcheck disable=SC2044
+    # There should be few files in such dir, and they should have well-behaved names,
+    # and "return" does not mix with piping to "while read", so we use a "for" over find.
+    # shellcheck disable=SC2044
+    for f in $(find "$dir" -type f -iname '*.xml'); do
         if grep -q '<failure ' "$f"; then
             return 0
         fi


### PR DESCRIPTION
## Description

The main operator test e2e run script contains several phases, each wrapped in a command which creates a JUnit report file in case of a failure. However a couple of those steps which use `kuttl` underneath themselves create separate, more fine-grained JUnit report files on *most* failures.

As a result, the junit2jira bot often creates duplicate bug reports - one with precise kuttl step failure information (titled [`central / basic-central FAILED`](https://issues.redhat.com/browse/ROX-20040?focusedId=23244250&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-23244250) or [`securedcluster / basic-sc FAILED`](https://issues.redhat.com/browse/ROX-20065), and another one just mentioning the overal phase failure titled [`test-e2e / Run operator E2E tests. FAILED`](https://issues.redhat.com/browse/ROX-20066). Similar in case the upgrade part failed.

This PR adds code which tries to detect whether the kuttl-produced report file(s) mention any failures, and if so, simply deletes the wrapper-produced report file. This should prevent the bot from creating duplicate bugs.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
