### PR TITLE
ROX-19696: add functions to parse deduper state

### DIFF
--- a/sensor/common/deduper/deduper.go
+++ b/sensor/common/deduper/deduper.go
@@ -15,16 +15,10 @@ var (
 	log = logging.LoggerForModule()
 )
 
-// key is the key by which messages are deduped.
-type key struct {
-	id           string
-	resourceType reflect.Type
-}
-
 // deduper takes care of deduping sensor events.
 type deduper struct {
 	stream   messagestream.SensorMessageStream
-	lastSent map[key]uint64
+	lastSent map[Key]uint64
 
 	hasher *hash.Hasher
 }
@@ -33,7 +27,7 @@ type deduper struct {
 func NewDedupingMessageStream(stream messagestream.SensorMessageStream) messagestream.SensorMessageStream {
 	return &deduper{
 		stream:   stream,
-		lastSent: make(map[key]uint64),
+		lastSent: make(map[Key]uint64),
 		hasher:   hash.NewHasher(),
 	}
 }
@@ -49,9 +43,9 @@ func (d *deduper) Send(msg *central.MsgFromSensor) error {
 	if managedcentral.IsCentralManaged() && event.GetImageIntegration() != nil {
 		return nil
 	}
-	key := key{
-		id:           event.GetId(),
-		resourceType: reflect.TypeOf(event.GetResource()),
+	key := Key{
+		ID:           event.GetId(),
+		ResourceType: reflect.TypeOf(event.GetResource()),
 	}
 	if event.GetAction() == central.ResourceAction_REMOVE_RESOURCE {
 		priorLen := len(d.lastSent)

--- a/sensor/common/deduper/key.go
+++ b/sensor/common/deduper/key.go
@@ -1,0 +1,84 @@
+package deduper
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	eventPkg "github.com/stackrox/rox/pkg/sensor/event"
+)
+
+var (
+	deduperTypes = []any{
+		&central.SensorEvent_NetworkPolicy{},
+		&central.SensorEvent_Deployment{},
+		&central.SensorEvent_Pod{},
+		&central.SensorEvent_Namespace{},
+		&central.SensorEvent_Secret{},
+		&central.SensorEvent_Node{},
+		&central.SensorEvent_ServiceAccount{},
+		&central.SensorEvent_Role{},
+		&central.SensorEvent_Binding{},
+		&central.SensorEvent_NodeInventory{},
+		&central.SensorEvent_ProcessIndicator{},
+		&central.SensorEvent_ProviderMetadata{},
+		&central.SensorEvent_OrchestratorMetadata{},
+		&central.SensorEvent_ImageIntegration{},
+		&central.SensorEvent_ComplianceOperatorResult{},
+		&central.SensorEvent_ComplianceOperatorProfile{},
+		&central.SensorEvent_ComplianceOperatorRule{},
+		&central.SensorEvent_ComplianceOperatorScanSettingBinding{},
+		&central.SensorEvent_ComplianceOperatorScan{},
+		&central.SensorEvent_AlertResults{},
+	}
+)
+
+// Key is the Key by which messages are deduped.
+type Key struct {
+	ID           string
+	ResourceType reflect.Type
+}
+
+// CopyDeduperState makes a copy of the deduper state.
+func CopyDeduperState(state map[string]uint64) map[Key]uint64 {
+	if state == nil {
+		return make(map[Key]uint64)
+	}
+
+	result := make(map[Key]uint64, len(state))
+	for k, v := range state {
+		parsedKey, err := keyFrom(k)
+		if err != nil {
+			log.Warnf("Deduper state received from central has malformed entry: %s->%d: %s", k, v, err)
+			continue
+		}
+		result[parsedKey] = v
+	}
+	return result
+}
+
+func keyFrom(v string) (Key, error) {
+	parts := strings.Split(v, ":")
+	if len(parts) != 2 {
+		return Key{}, fmt.Errorf("invalid Key format: %s", v)
+	}
+	t, err := mapType(parts[0])
+	if err != nil {
+		return Key{}, errors.Wrap(err, "map type")
+	}
+	return Key{
+		ID:           parts[1],
+		ResourceType: t,
+	}, nil
+}
+
+func mapType(typeStr string) (reflect.Type, error) {
+	for _, t := range deduperTypes {
+		if typeStr == eventPkg.GetEventTypeWithoutPrefix(t) {
+			return reflect.TypeOf(t), nil
+		}
+	}
+	return nil, fmt.Errorf("invalid type: %s", typeStr)
+}

--- a/sensor/common/deduper/key.go
+++ b/sensor/common/deduper/key.go
@@ -35,14 +35,14 @@ var (
 	}
 )
 
-// Key is the Key by which messages are deduped.
+// Key by which messages are deduped.
 type Key struct {
 	ID           string
 	ResourceType reflect.Type
 }
 
-// CopyDeduperState makes a copy of the deduper state.
-func CopyDeduperState(state map[string]uint64) map[Key]uint64 {
+// ParseDeduperState makes a copy of the deduper state.
+func ParseDeduperState(state map[string]uint64) map[Key]uint64 {
 	if state == nil {
 		return make(map[Key]uint64)
 	}
@@ -51,7 +51,7 @@ func CopyDeduperState(state map[string]uint64) map[Key]uint64 {
 	for k, v := range state {
 		parsedKey, err := keyFrom(k)
 		if err != nil {
-			log.Warnf("Deduper state received from central has malformed entry: %s->%d: %s", k, v, err)
+			log.Warnf("Deduper state has malformed entry: %s->%d: %s", k, v, err)
 			continue
 		}
 		result[parsedKey] = v

--- a/sensor/common/deduper/key_test.go
+++ b/sensor/common/deduper/key_test.go
@@ -1,0 +1,119 @@
+package deduper
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	randomID   = "2188759360372708523"
+	randomHash = 2188759360372708523
+)
+
+var (
+	stateWithAll = map[string]uint64{
+		fmt.Sprintf("%s:%s", "NetworkPolicy", fixtureconsts.NetworkPolicy1):    randomHash,
+		fmt.Sprintf("%s:%s", "Deployment", fixtureconsts.Deployment1):          randomHash,
+		fmt.Sprintf("%s:%s", "Pod", fixtureconsts.PodUID1):                     randomHash,
+		fmt.Sprintf("%s:%s", "Namespace", fixtureconsts.Namespace1):            randomHash,
+		fmt.Sprintf("%s:%s", "Secret", fixtureconsts.ServiceAccount1):          randomHash,
+		fmt.Sprintf("%s:%s", "Node", fixtureconsts.Node1):                      randomHash,
+		fmt.Sprintf("%s:%s", "ServiceAccount", fixtureconsts.ServiceAccount1):  randomHash,
+		fmt.Sprintf("%s:%s", "Role", fixtureconsts.Role1):                      randomHash,
+		fmt.Sprintf("%s:%s", "Binding", fixtureconsts.RoleBinding1):            randomHash,
+		fmt.Sprintf("%s:%s", "NodeInventory", randomID):                        randomHash,
+		fmt.Sprintf("%s:%s", "ProcessIndicator", randomID):                     randomHash,
+		fmt.Sprintf("%s:%s", "ProviderMetadata", randomID):                     randomHash,
+		fmt.Sprintf("%s:%s", "OrchestratorMetadata", randomID):                 randomHash,
+		fmt.Sprintf("%s:%s", "ImageIntegration", randomID):                     randomHash,
+		fmt.Sprintf("%s:%s", "ComplianceOperatorResult", randomID):             randomHash,
+		fmt.Sprintf("%s:%s", "ComplianceOperatorProfile", randomID):            randomHash,
+		fmt.Sprintf("%s:%s", "ComplianceOperatorRule", randomID):               randomHash,
+		fmt.Sprintf("%s:%s", "ComplianceOperatorScanSettingBinding", randomID): randomHash,
+		fmt.Sprintf("%s:%s", "ComplianceOperatorScan", randomID):               randomHash,
+		fmt.Sprintf("%s:%s", "AlertResults", randomID):                         randomHash,
+	}
+	expectedStateWithAll = map[Key]uint64{
+		withKey(&central.SensorEvent_NetworkPolicy{}, fixtureconsts.NetworkPolicy1):    randomHash,
+		withKey(&central.SensorEvent_Deployment{}, fixtureconsts.Deployment1):          randomHash,
+		withKey(&central.SensorEvent_Pod{}, fixtureconsts.PodUID1):                     randomHash,
+		withKey(&central.SensorEvent_Namespace{}, fixtureconsts.Namespace1):            randomHash,
+		withKey(&central.SensorEvent_Secret{}, fixtureconsts.ServiceAccount1):          randomHash,
+		withKey(&central.SensorEvent_Node{}, fixtureconsts.Node1):                      randomHash,
+		withKey(&central.SensorEvent_ServiceAccount{}, fixtureconsts.ServiceAccount1):  randomHash,
+		withKey(&central.SensorEvent_Role{}, fixtureconsts.Role1):                      randomHash,
+		withKey(&central.SensorEvent_Binding{}, fixtureconsts.RoleBinding1):            randomHash,
+		withKey(&central.SensorEvent_NodeInventory{}, randomID):                        randomHash,
+		withKey(&central.SensorEvent_ProcessIndicator{}, randomID):                     randomHash,
+		withKey(&central.SensorEvent_ProviderMetadata{}, randomID):                     randomHash,
+		withKey(&central.SensorEvent_OrchestratorMetadata{}, randomID):                 randomHash,
+		withKey(&central.SensorEvent_ImageIntegration{}, randomID):                     randomHash,
+		withKey(&central.SensorEvent_ComplianceOperatorResult{}, randomID):             randomHash,
+		withKey(&central.SensorEvent_ComplianceOperatorProfile{}, randomID):            randomHash,
+		withKey(&central.SensorEvent_ComplianceOperatorRule{}, randomID):               randomHash,
+		withKey(&central.SensorEvent_ComplianceOperatorScanSettingBinding{}, randomID): randomHash,
+		withKey(&central.SensorEvent_ComplianceOperatorScan{}, randomID):               randomHash,
+		withKey(&central.SensorEvent_AlertResults{}, randomID):                         randomHash,
+	}
+)
+
+type deduperKeySuite struct {
+	suite.Suite
+}
+
+func Test_DeduperKeySuite(t *testing.T) {
+	suite.Run(t, new(deduperKeySuite))
+
+}
+
+func (s *deduperKeySuite) Test_CopyState() {
+	testCases := map[string]struct {
+		inputState    map[string]uint64
+		expectedState map[Key]uint64
+	}{
+		"All event types": {
+			inputState:    stateWithAll,
+			expectedState: expectedStateWithAll,
+		},
+		"Nil input": {
+			inputState:    nil,
+			expectedState: map[Key]uint64{},
+		},
+		"With malformed entry": {
+			inputState: map[string]uint64{
+				fmt.Sprintf("%s:%s", "Deployment", fixtureconsts.Deployment1):           randomHash,
+				fmt.Sprintf("%s_malformed_%s", "Deployment", fixtureconsts.Deployment1): randomHash,
+			},
+			expectedState: map[Key]uint64{
+				withKey(&central.SensorEvent_Deployment{}, fixtureconsts.Deployment1): randomHash,
+			},
+		},
+		"With invalid type entry": {
+			inputState: map[string]uint64{
+				fmt.Sprintf("%s:%s", "Deployment", fixtureconsts.Deployment1):  randomHash,
+				fmt.Sprintf("%s:%s", "InvalidType", fixtureconsts.Deployment1): randomHash,
+			},
+			expectedState: map[Key]uint64{
+				withKey(&central.SensorEvent_Deployment{}, fixtureconsts.Deployment1): randomHash,
+			},
+		},
+	}
+	for name, tc := range testCases {
+		s.Run(name, func() {
+			resultState := CopyDeduperState(tc.inputState)
+			s.Assert().Equal(tc.expectedState, resultState)
+		})
+	}
+}
+
+func withKey(resource any, id string) Key {
+	return Key{
+		ID:           id,
+		ResourceType: reflect.TypeOf(resource),
+	}
+}

--- a/sensor/common/deduper/key_test.go
+++ b/sensor/common/deduper/key_test.go
@@ -11,54 +11,54 @@ import (
 )
 
 const (
-	randomID   = "2188759360372708523"
-	randomHash = 2188759360372708523
+	stubID   = "2188759360372708523"
+	stubHash = 2188759360372708523
 )
 
 var (
 	stateWithAll = map[string]uint64{
-		fmt.Sprintf("%s:%s", "NetworkPolicy", fixtureconsts.NetworkPolicy1):    randomHash,
-		fmt.Sprintf("%s:%s", "Deployment", fixtureconsts.Deployment1):          randomHash,
-		fmt.Sprintf("%s:%s", "Pod", fixtureconsts.PodUID1):                     randomHash,
-		fmt.Sprintf("%s:%s", "Namespace", fixtureconsts.Namespace1):            randomHash,
-		fmt.Sprintf("%s:%s", "Secret", fixtureconsts.ServiceAccount1):          randomHash,
-		fmt.Sprintf("%s:%s", "Node", fixtureconsts.Node1):                      randomHash,
-		fmt.Sprintf("%s:%s", "ServiceAccount", fixtureconsts.ServiceAccount1):  randomHash,
-		fmt.Sprintf("%s:%s", "Role", fixtureconsts.Role1):                      randomHash,
-		fmt.Sprintf("%s:%s", "Binding", fixtureconsts.RoleBinding1):            randomHash,
-		fmt.Sprintf("%s:%s", "NodeInventory", randomID):                        randomHash,
-		fmt.Sprintf("%s:%s", "ProcessIndicator", randomID):                     randomHash,
-		fmt.Sprintf("%s:%s", "ProviderMetadata", randomID):                     randomHash,
-		fmt.Sprintf("%s:%s", "OrchestratorMetadata", randomID):                 randomHash,
-		fmt.Sprintf("%s:%s", "ImageIntegration", randomID):                     randomHash,
-		fmt.Sprintf("%s:%s", "ComplianceOperatorResult", randomID):             randomHash,
-		fmt.Sprintf("%s:%s", "ComplianceOperatorProfile", randomID):            randomHash,
-		fmt.Sprintf("%s:%s", "ComplianceOperatorRule", randomID):               randomHash,
-		fmt.Sprintf("%s:%s", "ComplianceOperatorScanSettingBinding", randomID): randomHash,
-		fmt.Sprintf("%s:%s", "ComplianceOperatorScan", randomID):               randomHash,
-		fmt.Sprintf("%s:%s", "AlertResults", randomID):                         randomHash,
+		fmt.Sprintf("%s:%s", "NetworkPolicy", fixtureconsts.NetworkPolicy1):   stubHash,
+		fmt.Sprintf("%s:%s", "Deployment", fixtureconsts.Deployment1):         stubHash,
+		fmt.Sprintf("%s:%s", "Pod", fixtureconsts.PodUID1):                    stubHash,
+		fmt.Sprintf("%s:%s", "Namespace", fixtureconsts.Namespace1):           stubHash,
+		fmt.Sprintf("%s:%s", "Secret", fixtureconsts.ServiceAccount1):         stubHash,
+		fmt.Sprintf("%s:%s", "Node", fixtureconsts.Node1):                     stubHash,
+		fmt.Sprintf("%s:%s", "ServiceAccount", fixtureconsts.ServiceAccount1): stubHash,
+		fmt.Sprintf("%s:%s", "Role", fixtureconsts.Role1):                     stubHash,
+		fmt.Sprintf("%s:%s", "Binding", fixtureconsts.RoleBinding1):           stubHash,
+		fmt.Sprintf("%s:%s", "NodeInventory", stubID):                         stubHash,
+		fmt.Sprintf("%s:%s", "ProcessIndicator", stubID):                      stubHash,
+		fmt.Sprintf("%s:%s", "ProviderMetadata", stubID):                      stubHash,
+		fmt.Sprintf("%s:%s", "OrchestratorMetadata", stubID):                  stubHash,
+		fmt.Sprintf("%s:%s", "ImageIntegration", stubID):                      stubHash,
+		fmt.Sprintf("%s:%s", "ComplianceOperatorResult", stubID):              stubHash,
+		fmt.Sprintf("%s:%s", "ComplianceOperatorProfile", stubID):             stubHash,
+		fmt.Sprintf("%s:%s", "ComplianceOperatorRule", stubID):                stubHash,
+		fmt.Sprintf("%s:%s", "ComplianceOperatorScanSettingBinding", stubID):  stubHash,
+		fmt.Sprintf("%s:%s", "ComplianceOperatorScan", stubID):                stubHash,
+		fmt.Sprintf("%s:%s", "AlertResults", stubID):                          stubHash,
 	}
 	expectedStateWithAll = map[Key]uint64{
-		withKey(&central.SensorEvent_NetworkPolicy{}, fixtureconsts.NetworkPolicy1):    randomHash,
-		withKey(&central.SensorEvent_Deployment{}, fixtureconsts.Deployment1):          randomHash,
-		withKey(&central.SensorEvent_Pod{}, fixtureconsts.PodUID1):                     randomHash,
-		withKey(&central.SensorEvent_Namespace{}, fixtureconsts.Namespace1):            randomHash,
-		withKey(&central.SensorEvent_Secret{}, fixtureconsts.ServiceAccount1):          randomHash,
-		withKey(&central.SensorEvent_Node{}, fixtureconsts.Node1):                      randomHash,
-		withKey(&central.SensorEvent_ServiceAccount{}, fixtureconsts.ServiceAccount1):  randomHash,
-		withKey(&central.SensorEvent_Role{}, fixtureconsts.Role1):                      randomHash,
-		withKey(&central.SensorEvent_Binding{}, fixtureconsts.RoleBinding1):            randomHash,
-		withKey(&central.SensorEvent_NodeInventory{}, randomID):                        randomHash,
-		withKey(&central.SensorEvent_ProcessIndicator{}, randomID):                     randomHash,
-		withKey(&central.SensorEvent_ProviderMetadata{}, randomID):                     randomHash,
-		withKey(&central.SensorEvent_OrchestratorMetadata{}, randomID):                 randomHash,
-		withKey(&central.SensorEvent_ImageIntegration{}, randomID):                     randomHash,
-		withKey(&central.SensorEvent_ComplianceOperatorResult{}, randomID):             randomHash,
-		withKey(&central.SensorEvent_ComplianceOperatorProfile{}, randomID):            randomHash,
-		withKey(&central.SensorEvent_ComplianceOperatorRule{}, randomID):               randomHash,
-		withKey(&central.SensorEvent_ComplianceOperatorScanSettingBinding{}, randomID): randomHash,
-		withKey(&central.SensorEvent_ComplianceOperatorScan{}, randomID):               randomHash,
-		withKey(&central.SensorEvent_AlertResults{}, randomID):                         randomHash,
+		withKey(&central.SensorEvent_NetworkPolicy{}, fixtureconsts.NetworkPolicy1):   stubHash,
+		withKey(&central.SensorEvent_Deployment{}, fixtureconsts.Deployment1):         stubHash,
+		withKey(&central.SensorEvent_Pod{}, fixtureconsts.PodUID1):                    stubHash,
+		withKey(&central.SensorEvent_Namespace{}, fixtureconsts.Namespace1):           stubHash,
+		withKey(&central.SensorEvent_Secret{}, fixtureconsts.ServiceAccount1):         stubHash,
+		withKey(&central.SensorEvent_Node{}, fixtureconsts.Node1):                     stubHash,
+		withKey(&central.SensorEvent_ServiceAccount{}, fixtureconsts.ServiceAccount1): stubHash,
+		withKey(&central.SensorEvent_Role{}, fixtureconsts.Role1):                     stubHash,
+		withKey(&central.SensorEvent_Binding{}, fixtureconsts.RoleBinding1):           stubHash,
+		withKey(&central.SensorEvent_NodeInventory{}, stubID):                         stubHash,
+		withKey(&central.SensorEvent_ProcessIndicator{}, stubID):                      stubHash,
+		withKey(&central.SensorEvent_ProviderMetadata{}, stubID):                      stubHash,
+		withKey(&central.SensorEvent_OrchestratorMetadata{}, stubID):                  stubHash,
+		withKey(&central.SensorEvent_ImageIntegration{}, stubID):                      stubHash,
+		withKey(&central.SensorEvent_ComplianceOperatorResult{}, stubID):              stubHash,
+		withKey(&central.SensorEvent_ComplianceOperatorProfile{}, stubID):             stubHash,
+		withKey(&central.SensorEvent_ComplianceOperatorRule{}, stubID):                stubHash,
+		withKey(&central.SensorEvent_ComplianceOperatorScanSettingBinding{}, stubID):  stubHash,
+		withKey(&central.SensorEvent_ComplianceOperatorScan{}, stubID):                stubHash,
+		withKey(&central.SensorEvent_AlertResults{}, stubID):                          stubHash,
 	}
 )
 
@@ -86,26 +86,26 @@ func (s *deduperKeySuite) Test_CopyState() {
 		},
 		"With malformed entry": {
 			inputState: map[string]uint64{
-				fmt.Sprintf("%s:%s", "Deployment", fixtureconsts.Deployment1):           randomHash,
-				fmt.Sprintf("%s_malformed_%s", "Deployment", fixtureconsts.Deployment1): randomHash,
+				fmt.Sprintf("%s:%s", "Deployment", fixtureconsts.Deployment1):           stubHash,
+				fmt.Sprintf("%s_malformed_%s", "Deployment", fixtureconsts.Deployment1): stubHash,
 			},
 			expectedState: map[Key]uint64{
-				withKey(&central.SensorEvent_Deployment{}, fixtureconsts.Deployment1): randomHash,
+				withKey(&central.SensorEvent_Deployment{}, fixtureconsts.Deployment1): stubHash,
 			},
 		},
 		"With invalid type entry": {
 			inputState: map[string]uint64{
-				fmt.Sprintf("%s:%s", "Deployment", fixtureconsts.Deployment1):  randomHash,
-				fmt.Sprintf("%s:%s", "InvalidType", fixtureconsts.Deployment1): randomHash,
+				fmt.Sprintf("%s:%s", "Deployment", fixtureconsts.Deployment1):  stubHash,
+				fmt.Sprintf("%s:%s", "InvalidType", fixtureconsts.Deployment1): stubHash,
 			},
 			expectedState: map[Key]uint64{
-				withKey(&central.SensorEvent_Deployment{}, fixtureconsts.Deployment1): randomHash,
+				withKey(&central.SensorEvent_Deployment{}, fixtureconsts.Deployment1): stubHash,
 			},
 		},
 	}
 	for name, tc := range testCases {
 		s.Run(name, func() {
-			resultState := CopyDeduperState(tc.inputState)
+			resultState := ParseDeduperState(tc.inputState)
 			s.Assert().Equal(tc.expectedState, resultState)
 		})
 	}


### PR DESCRIPTION
## Description

This PR adds functions to parse the deduper state. Follow-up PRs will be opened to call this functions and initialize the deduper state.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

* [x] Unit tests added
* [x] CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
