### PR TITLE
ROX-20119: Properly stop gRPC in tests

### DIFF
--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -315,16 +315,12 @@ func (s *Sensor) Stop() {
 		}
 	}
 
-	if s.server != nil {
-		if !s.server.Stop() {
-			log.Warnf("Sensor gRPC server stop was called more than once")
-		}
+	if s.server != nil && !s.server.Stop() {
+		log.Warnf("Sensor gRPC server stop was called more than once")
 	}
 
-	if s.webhookServer != nil {
-		if !s.webhookServer.Stop() {
-			log.Warnf("Sensor webhook server stop was called more than once")
-		}
+	if s.webhookServer != nil && !s.webhookServer.Stop() {
+		log.Warnf("Sensor webhook server stop was called more than once")
 	}
 
 	log.Info("Sensor shutdown complete")

--- a/sensor/tests/connection/connection_test.go
+++ b/sensor/tests/connection/connection_test.go
@@ -25,6 +25,32 @@ func Test_SensorHello(t *testing.T) {
 		InitialSystemPolicies: nil,
 		CertFilePath:          "../../../tools/local-sensor/certs/",
 	})
+	t.Cleanup(c.Stop)
+
+	require.NoError(t, err)
+
+	c.RunTest(t, helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {
+		hello1 := testContext.WaitForHello(t, 3*time.Minute)
+		require.NotNil(t, hello1)
+		assert.Equal(t, central.SensorHello_STARTUP, hello1.GetSensorState())
+		testContext.RestartFakeCentralConnection()
+		hello2 := testContext.WaitForHello(t, 3*time.Minute)
+		require.NotNil(t, hello2)
+		assert.Equal(t, central.SensorHello_RECONNECT, hello2.GetSensorState())
+	}))
+
+}
+
+func Test_SensorHello2(t *testing.T) {
+	t.Setenv("ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT", "true")
+	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", "1s")
+	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL", "2s")
+
+	c, err := helper.NewContextWithConfig(t, helper.CentralConfig{
+		InitialSystemPolicies: nil,
+		CertFilePath:          "../../../tools/local-sensor/certs/",
+	})
+	t.Cleanup(c.Stop)
 
 	t.Cleanup(c.Stop)
 
@@ -54,6 +80,8 @@ func Test_SensorReconnects(t *testing.T) {
 		InitialSystemPolicies: nil,
 		CertFilePath:          "../../../tools/local-sensor/certs/",
 	})
+
+	t.Cleanup(c.Stop)
 
 	require.NoError(t, err)
 

--- a/sensor/tests/connection/connection_test.go
+++ b/sensor/tests/connection/connection_test.go
@@ -52,8 +52,6 @@ func Test_SensorHello2(t *testing.T) {
 	})
 	t.Cleanup(c.Stop)
 
-	t.Cleanup(c.Stop)
-
 	require.NoError(t, err)
 
 	c.RunTest(t, helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {

--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -728,7 +728,7 @@ func (c *TestContext) startSensorInstance(t *testing.T, env *envconf.Config) {
 
 	c.sensorStopped = s.Stopped()
 	c.stopFn = func() {
-		go s.Stop()
+		s.Stop()
 		c.fakeCentral.KillSwitch.Done()
 	}
 


### PR DESCRIPTION
Depends on #8120 

## Description

This PR is a long overdue follow-up from #6602. Which introduced the possibility of stopping gRPC connections. 

Sensor integration tests were not able to be written in the same file. This PR introduces a change to sensor `Stop()` function that allows a single test to have many sensor runtimes due to properly stopping the listeners. 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Created a second `SensorHello` test just to prove that this works. 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
