### PR TITLE
ROX-20057: Implement reconciliation in ServiceAccount Store

### DIFF
--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -597,24 +597,6 @@ func (c *sensorConnection) Run(ctx context.Context, server central.SensorService
 		}
 	}
 
-	// TODO: Temporary block from https://github.com/stackrox/stackrox/pull/7755
-	// Sensor is capable of doing the reconciliation by itself if receives the hashes from central.
-	// Central should only attempt to do that if sensor is reconnecting, otherwise Central should
-	// do the reconciliation itself, since events might have been missed.
-	log.Info("Sensor reconnecting: Reconciliation will be done in Sensor")
-	// Send hashes to sensor
-	c.sensorEventHandler.disableReconciliation()
-	successfulHashes := c.hashDeduper.GetSuccessfulHashes()
-	log.Infof("Sending hashes to Sensor: %v", successfulHashes)
-	err2 := server.Send(&central.MsgToSensor{Msg: &central.MsgToSensor_DeduperState{
-		DeduperState: &central.DeduperState{
-			ResourceHashes: successfulHashes,
-		},
-	}})
-	if err2 != nil {
-		log.Errorf("Sending deduper state to Sensor: %s", err)
-	}
-
 	go c.runSend(server)
 
 	// Trigger initial network graph external sources sync. Network graph external sources capability is added to sensor only if the the feature is enabled.

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -67,6 +67,8 @@ type sensorConnection struct {
 
 	sensorHello  *central.SensorHello
 	capabilities set.Set[centralsensor.SensorCapability]
+
+	hashDeduper hashManager.Deduper
 }
 
 func newConnection(ctx context.Context,
@@ -111,6 +113,7 @@ func newConnection(ctx context.Context,
 	deduper := hashMgr.GetDeduper(ctx, cluster.GetId())
 	deduper.StartSync()
 
+	conn.hashDeduper = deduper
 	conn.sensorEventHandler = newSensorEventHandler(cluster, sensorHello.GetSensorVersion(), eventPipeline, conn, &conn.stopSig, deduper, initSyncMgr)
 	conn.scrapeCtrl = scrape.NewController(conn, &conn.stopSig)
 	conn.networkPoliciesCtrl = networkpolicies.NewController(conn, &conn.stopSig)
@@ -592,6 +595,28 @@ func (c *sensorConnection) Run(ctx context.Context, server central.SensorService
 
 			log.Infof("Sent %d image integrations to cluster %q", len(msg.GetImageIntegrations().GetUpdatedIntegrations()), c.clusterID)
 		}
+	}
+
+	// TODO: Temporary block from https://github.com/stackrox/stackrox/pull/7755
+	// Sensor is capable of doing the reconciliation by itself if receives the hashes from central.
+	// Central should only attempt to do that if sensor is reconnecting, otherwise Central should
+	// do the reconciliation itself, since events might have been missed.
+	if c.sensorHello.GetSensorState() == central.SensorHello_RECONNECT {
+		log.Info("Sensor reconnecting: Reconciliation will be done in Sensor")
+		// Send hashes to sensor
+		c.sensorEventHandler.disableReconciliation()
+		successfulHashes := c.hashDeduper.GetSuccessfulHashes()
+		log.Infof("Sending hashes to Sensor: %v", successfulHashes)
+		err := server.Send(&central.MsgToSensor{Msg: &central.MsgToSensor_DeduperState{
+			DeduperState: &central.DeduperState{
+				ResourceHashes: successfulHashes,
+			},
+		}})
+		if err != nil {
+			log.Errorf("Sending deduper state to Sensor: %s", err)
+		}
+	} else {
+		log.Info("Sensor restarted: Reconciliation will be done in Central")
 	}
 
 	go c.runSend(server)

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -601,22 +601,18 @@ func (c *sensorConnection) Run(ctx context.Context, server central.SensorService
 	// Sensor is capable of doing the reconciliation by itself if receives the hashes from central.
 	// Central should only attempt to do that if sensor is reconnecting, otherwise Central should
 	// do the reconciliation itself, since events might have been missed.
-	if c.sensorHello.GetSensorState() == central.SensorHello_RECONNECT {
-		log.Info("Sensor reconnecting: Reconciliation will be done in Sensor")
-		// Send hashes to sensor
-		c.sensorEventHandler.disableReconciliation()
-		successfulHashes := c.hashDeduper.GetSuccessfulHashes()
-		log.Infof("Sending hashes to Sensor: %v", successfulHashes)
-		err := server.Send(&central.MsgToSensor{Msg: &central.MsgToSensor_DeduperState{
-			DeduperState: &central.DeduperState{
-				ResourceHashes: successfulHashes,
-			},
-		}})
-		if err != nil {
-			log.Errorf("Sending deduper state to Sensor: %s", err)
-		}
-	} else {
-		log.Info("Sensor restarted: Reconciliation will be done in Central")
+	log.Info("Sensor reconnecting: Reconciliation will be done in Sensor")
+	// Send hashes to sensor
+	c.sensorEventHandler.disableReconciliation()
+	successfulHashes := c.hashDeduper.GetSuccessfulHashes()
+	log.Infof("Sending hashes to Sensor: %v", successfulHashes)
+	err2 := server.Send(&central.MsgToSensor{Msg: &central.MsgToSensor_DeduperState{
+		DeduperState: &central.DeduperState{
+			ResourceHashes: successfulHashes,
+		},
+	}})
+	if err2 != nil {
+		log.Errorf("Sending deduper state to Sensor: %s", err)
 	}
 
 	go c.runSend(server)

--- a/central/sensor/service/connection/sensorevents.go
+++ b/central/sensor/service/connection/sensorevents.go
@@ -68,10 +68,6 @@ func stripTypePrefix(s string) string {
 	return s
 }
 
-func (s *sensorEventHandler) disableReconciliation() {
-	s.reconciliationMap.Close()
-}
-
 func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.MsgFromSensor) {
 	event := msg.GetEvent()
 	if event == nil {
@@ -85,12 +81,6 @@ func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.Ms
 	// of the initial synchronization process.
 	case *central.SensorEvent_Synced:
 		// Call the reconcile functions
-		// TODO: Temporary copy from https://github.com/stackrox/stackrox/pull/7755
-		log.Info("Receiving reconciliation event")
-		if s.reconciliationMap.IsClosed() {
-			log.Info("Ignoring SYNC since reconciliationMap is already closed")
-			return
-		}
 		if err := s.pipeline.Reconcile(ctx, s.reconciliationMap); err != nil {
 			log.Errorf("error reconciling state: %v", err)
 		}

--- a/central/sensor/service/pipeline/mocks/pipeline.go
+++ b/central/sensor/service/pipeline/mocks/pipeline.go
@@ -121,7 +121,7 @@ func (mr *MockClusterPipelineMockRecorder) OnFinish(clusterID any) *gomock.Call 
 // Reconcile mocks base method.
 func (m *MockClusterPipeline) Reconcile(ctx context.Context, reconciliationStore *reconciliation.StoreMap) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Reconcile", ctx, reconciliationStore)
+	ret := m.ctrl.Call(m, "ReconcileDelete", ctx, reconciliationStore)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -129,7 +129,7 @@ func (m *MockClusterPipeline) Reconcile(ctx context.Context, reconciliationStore
 // Reconcile indicates an expected call of Reconcile.
 func (mr *MockClusterPipelineMockRecorder) Reconcile(ctx, reconciliationStore any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockClusterPipeline)(nil).Reconcile), ctx, reconciliationStore)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileDelete", reflect.TypeOf((*MockClusterPipeline)(nil).Reconcile), ctx, reconciliationStore)
 }
 
 // Run mocks base method.
@@ -250,7 +250,7 @@ func (mr *MockFragmentMockRecorder) OnFinish(clusterID any) *gomock.Call {
 // Reconcile mocks base method.
 func (m *MockFragment) Reconcile(ctx context.Context, clusterID string, reconciliationStore *reconciliation.StoreMap) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Reconcile", ctx, clusterID, reconciliationStore)
+	ret := m.ctrl.Call(m, "ReconcileDelete", ctx, clusterID, reconciliationStore)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -258,7 +258,7 @@ func (m *MockFragment) Reconcile(ctx context.Context, clusterID string, reconcil
 // Reconcile indicates an expected call of Reconcile.
 func (mr *MockFragmentMockRecorder) Reconcile(ctx, clusterID, reconciliationStore any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockFragment)(nil).Reconcile), ctx, clusterID, reconciliationStore)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileDelete", reflect.TypeOf((*MockFragment)(nil).Reconcile), ctx, clusterID, reconciliationStore)
 }
 
 // Run mocks base method.

--- a/central/sensor/service/pipeline/mocks/pipeline.go
+++ b/central/sensor/service/pipeline/mocks/pipeline.go
@@ -121,7 +121,7 @@ func (mr *MockClusterPipelineMockRecorder) OnFinish(clusterID any) *gomock.Call 
 // Reconcile mocks base method.
 func (m *MockClusterPipeline) Reconcile(ctx context.Context, reconciliationStore *reconciliation.StoreMap) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReconcileDelete", ctx, reconciliationStore)
+	ret := m.ctrl.Call(m, "Reconcile", ctx, reconciliationStore)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -129,7 +129,7 @@ func (m *MockClusterPipeline) Reconcile(ctx context.Context, reconciliationStore
 // Reconcile indicates an expected call of Reconcile.
 func (mr *MockClusterPipelineMockRecorder) Reconcile(ctx, reconciliationStore any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileDelete", reflect.TypeOf((*MockClusterPipeline)(nil).Reconcile), ctx, reconciliationStore)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockClusterPipeline)(nil).Reconcile), ctx, reconciliationStore)
 }
 
 // Run mocks base method.
@@ -250,7 +250,7 @@ func (mr *MockFragmentMockRecorder) OnFinish(clusterID any) *gomock.Call {
 // Reconcile mocks base method.
 func (m *MockFragment) Reconcile(ctx context.Context, clusterID string, reconciliationStore *reconciliation.StoreMap) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReconcileDelete", ctx, clusterID, reconciliationStore)
+	ret := m.ctrl.Call(m, "Reconcile", ctx, clusterID, reconciliationStore)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -258,7 +258,7 @@ func (m *MockFragment) Reconcile(ctx context.Context, clusterID string, reconcil
 // Reconcile indicates an expected call of Reconcile.
 func (mr *MockFragmentMockRecorder) Reconcile(ctx, clusterID, reconciliationStore any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileDelete", reflect.TypeOf((*MockFragment)(nil).Reconcile), ctx, clusterID, reconciliationStore)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockFragment)(nil).Reconcile), ctx, clusterID, reconciliationStore)
 }
 
 // Run mocks base method.

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -1,0 +1,20 @@
+package reconcile
+
+// SensorReconciliationEvent defines what kind of message needs to be sent back to central to sync the states
+type SensorReconciliationEvent string
+
+const (
+	// SensorReconciliationEventNoop means that no change in Central is needed
+	SensorReconciliationEventNoop SensorReconciliationEvent = "noop"
+	// SensorReconciliationEventDelete means that entry in Central shall be deleted
+	SensorReconciliationEventDelete = "delete"
+	// SensorReconciliationEventUpdate means that no entry in Central shall be updated
+	SensorReconciliationEventUpdate = "update"
+)
+
+// Reconcilable is a Sensor object that supports reconciliation.
+// The Reconcile method is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state.
+type Reconcilable interface {
+	Reconcile(resType, resID string, resHash uint64) (map[string]SensorReconciliationEvent, error)
+}

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -1,20 +1,8 @@
 package reconcile
 
-// SensorReconciliationEvent defines what kind of message needs to be sent back to central to sync the states
-type SensorReconciliationEvent string
-
-const (
-	// SensorReconciliationEventNoop means that no change in Central is needed
-	SensorReconciliationEventNoop SensorReconciliationEvent = "noop"
-	// SensorReconciliationEventDelete means that entry in Central shall be deleted
-	SensorReconciliationEventDelete = "delete"
-	// SensorReconciliationEventUpdate means that no entry in Central shall be updated
-	SensorReconciliationEventUpdate = "update"
-)
-
 // Reconcilable is a Sensor object that supports reconciliation.
 // The Reconcile method is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state.
 type Reconcilable interface {
-	Reconcile(resType, resID string, resHash uint64) (map[string]SensorReconciliationEvent, error)
+	ReconcileDelete(resType, resID string, resHash uint64) ([]string, error)
 }

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -1,10 +1,8 @@
 package reconcile
 
-import "github.com/stackrox/rox/generated/internalapi/central"
-
 // Reconcilable is a Sensor object that supports reconciliation.
 // The Reconcile method is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state.
 type Reconcilable interface {
-	ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error)
+	ReconcileDelete(resType, resID string, resHash uint64) (string, error)
 }

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -1,8 +1,10 @@
 package reconcile
 
+import "github.com/stackrox/rox/generated/internalapi/central"
+
 // Reconcilable is a Sensor object that supports reconciliation.
 // The Reconcile method is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state.
 type Reconcilable interface {
-	ReconcileDelete(resType, resID string, resHash uint64) ([]string, error)
+	ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error)
 }

--- a/pkg/registrymirror/mocks/store.go
+++ b/pkg/registrymirror/mocks/store.go
@@ -13,6 +13,7 @@ import (
 
 	v1 "github.com/openshift/api/config/v1"
 	v1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	reconcile "github.com/stackrox/rox/pkg/reconcile"
 	gomock "go.uber.org/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
 )
@@ -107,6 +108,21 @@ func (m *MockStore) PullSources(srcImage string) ([]string, error) {
 func (mr *MockStoreMockRecorder) PullSources(srcImage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullSources", reflect.TypeOf((*MockStore)(nil).PullSources), srcImage)
+}
+
+// Reconcile mocks base method.
+func (m *MockStore) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Reconcile", resType, resID, resHash)
+	ret0, _ := ret[0].(map[string]reconcile.SensorReconciliationEvent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Reconcile indicates an expected call of Reconcile.
+func (mr *MockStoreMockRecorder) Reconcile(resType, resID, resHash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockStore)(nil).Reconcile), resType, resID, resHash)
 }
 
 // UpsertImageContentSourcePolicy mocks base method.

--- a/pkg/registrymirror/mocks/store.go
+++ b/pkg/registrymirror/mocks/store.go
@@ -13,6 +13,7 @@ import (
 
 	v1 "github.com/openshift/api/config/v1"
 	v1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	central "github.com/stackrox/rox/generated/internalapi/central"
 	gomock "go.uber.org/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
 )
@@ -110,10 +111,10 @@ func (mr *MockStoreMockRecorder) PullSources(srcImage any) *gomock.Call {
 }
 
 // ReconcileDelete mocks base method.
-func (m *MockStore) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
+func (m *MockStore) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReconcileDelete", resType, resID, resHash)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].(*central.MsgFromSensor)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/registrymirror/mocks/store.go
+++ b/pkg/registrymirror/mocks/store.go
@@ -119,7 +119,7 @@ func (m *MockStore) ReconcileDelete(resType, resID string, resHash uint64) (stri
 }
 
 // ReconcileDelete indicates an expected call of ReconcileDelete.
-func (mr *MockStoreMockRecorder) ReconcileDelete(resType, resID, resHash interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) ReconcileDelete(resType, resID, resHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileDelete", reflect.TypeOf((*MockStore)(nil).ReconcileDelete), resType, resID, resHash)
 }

--- a/pkg/registrymirror/mocks/store.go
+++ b/pkg/registrymirror/mocks/store.go
@@ -13,7 +13,6 @@ import (
 
 	v1 "github.com/openshift/api/config/v1"
 	v1alpha1 "github.com/openshift/api/operator/v1alpha1"
-	central "github.com/stackrox/rox/generated/internalapi/central"
 	gomock "go.uber.org/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
 )
@@ -111,10 +110,10 @@ func (mr *MockStoreMockRecorder) PullSources(srcImage any) *gomock.Call {
 }
 
 // ReconcileDelete mocks base method.
-func (m *MockStore) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
+func (m *MockStore) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReconcileDelete", resType, resID, resHash)
-	ret0, _ := ret[0].(*central.MsgFromSensor)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/registrymirror/mocks/store.go
+++ b/pkg/registrymirror/mocks/store.go
@@ -118,8 +118,8 @@ func (m *MockStore) ReconcileDelete(resType, resID string, resHash uint64) ([]st
 	return ret0, ret1
 }
 
-// Reconcile indicates an expected call of Reconcile.
-func (mr *MockStoreMockRecorder) Reconcile(resType, resID, resHash interface{}) *gomock.Call {
+// ReconcileDelete indicates an expected call of ReconcileDelete.
+func (mr *MockStoreMockRecorder) ReconcileDelete(resType, resID, resHash interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileDelete", reflect.TypeOf((*MockStore)(nil).ReconcileDelete), resType, resID, resHash)
 }

--- a/pkg/registrymirror/mocks/store.go
+++ b/pkg/registrymirror/mocks/store.go
@@ -13,7 +13,6 @@ import (
 
 	v1 "github.com/openshift/api/config/v1"
 	v1alpha1 "github.com/openshift/api/operator/v1alpha1"
-	reconcile "github.com/stackrox/rox/pkg/reconcile"
 	gomock "go.uber.org/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
 )
@@ -110,11 +109,11 @@ func (mr *MockStoreMockRecorder) PullSources(srcImage any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullSources", reflect.TypeOf((*MockStore)(nil).PullSources), srcImage)
 }
 
-// Reconcile mocks base method.
-func (m *MockStore) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+// ReconcileDelete mocks base method.
+func (m *MockStore) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Reconcile", resType, resID, resHash)
-	ret0, _ := ret[0].(map[string]reconcile.SensorReconciliationEvent)
+	ret := m.ctrl.Call(m, "ReconcileDelete", resType, resID, resHash)
+	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -122,7 +121,7 @@ func (m *MockStore) Reconcile(resType, resID string, resHash uint64) (map[string
 // Reconcile indicates an expected call of Reconcile.
 func (mr *MockStoreMockRecorder) Reconcile(resType, resID, resHash interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockStore)(nil).Reconcile), resType, resID, resHash)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileDelete", reflect.TypeOf((*MockStore)(nil).ReconcileDelete), resType, resID, resHash)
 }
 
 // UpsertImageContentSourcePolicy mocks base method.

--- a/pkg/registrymirror/store.go
+++ b/pkg/registrymirror/store.go
@@ -14,6 +14,7 @@ import (
 	operatorV1Alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/runtime-utils/pkg/registries"
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/maputil"
@@ -42,7 +43,7 @@ var (
 //go:generate mockgen-wrapper
 type Store interface {
 	Cleanup()
-	ReconcileDelete(resType, resID string, resHash uint64) ([]string, error)
+	ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error)
 
 	UpsertImageContentSourcePolicy(icsp *operatorV1Alpha1.ImageContentSourcePolicy) error
 	DeleteImageContentSourcePolicy(uid types.UID) error
@@ -112,7 +113,7 @@ func NewFileStore(opts ...fileStoreOption) *FileStore {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (s *FileStore) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
+func (s *FileStore) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/pkg/registrymirror/store.go
+++ b/pkg/registrymirror/store.go
@@ -14,7 +14,6 @@ import (
 	operatorV1Alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/runtime-utils/pkg/registries"
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/maputil"
@@ -43,7 +42,7 @@ var (
 //go:generate mockgen-wrapper
 type Store interface {
 	Cleanup()
-	ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error)
+	ReconcileDelete(resType, resID string, resHash uint64) (string, error)
 
 	UpsertImageContentSourcePolicy(icsp *operatorV1Alpha1.ImageContentSourcePolicy) error
 	DeleteImageContentSourcePolicy(uid types.UID) error
@@ -113,7 +112,7 @@ func NewFileStore(opts ...fileStoreOption) *FileStore {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (s *FileStore) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
+func (s *FileStore) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/pkg/registrymirror/store.go
+++ b/pkg/registrymirror/store.go
@@ -115,7 +115,7 @@ func NewFileStore(opts ...fileStoreOption) *FileStore {
 func (s *FileStore) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
-	panic("implement me")
+	return "", errors.New("Not implemented")
 }
 
 // Cleanup resets the store which includes in-memory and disk resources.

--- a/pkg/registrymirror/store.go
+++ b/pkg/registrymirror/store.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/maputil"
+	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"k8s.io/apimachinery/pkg/types"
@@ -42,6 +43,7 @@ var (
 //go:generate mockgen-wrapper
 type Store interface {
 	Cleanup()
+	Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error)
 
 	UpsertImageContentSourcePolicy(icsp *operatorV1Alpha1.ImageContentSourcePolicy) error
 	DeleteImageContentSourcePolicy(uid types.UID) error
@@ -106,6 +108,14 @@ func NewFileStore(opts ...fileStoreOption) *FileStore {
 		SystemRegistriesConfPath: s.configPath,
 	}
 	return s
+}
+
+// Reconcile is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state.
+func (s *FileStore) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+	_, _, _ = resType, resID, resHash
+	// TODO implement me
+	panic("implement me")
 }
 
 // Cleanup resets the store which includes in-memory and disk resources.

--- a/pkg/registrymirror/store.go
+++ b/pkg/registrymirror/store.go
@@ -114,7 +114,7 @@ func NewFileStore(opts ...fileStoreOption) *FileStore {
 // shall be deleted from Central.
 func (s *FileStore) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
-	// TODO implement me
+	// TODO(ROX-20076): Implement me
 	return "", errors.New("Not implemented")
 }
 

--- a/pkg/registrymirror/store.go
+++ b/pkg/registrymirror/store.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/maputil"
-	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,7 +42,7 @@ var (
 //go:generate mockgen-wrapper
 type Store interface {
 	Cleanup()
-	Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error)
+	ReconcileDelete(resType, resID string, resHash uint64) ([]string, error)
 
 	UpsertImageContentSourcePolicy(icsp *operatorV1Alpha1.ImageContentSourcePolicy) error
 	DeleteImageContentSourcePolicy(uid types.UID) error
@@ -110,9 +109,10 @@ func NewFileStore(opts ...fileStoreOption) *FileStore {
 	return s
 }
 
-// Reconcile is called after Sensor reconnects with Central and receives its state hashes.
-// Reconciliacion ensures that Sensor and Central have the same state.
-func (s *FileStore) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+// ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
+// shall be deleted from Central.
+func (s *FileStore) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -61,7 +61,7 @@ type Store struct {
 func (e *Store) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
-	panic("implement me")
+	return "", errors.New("Not implemented")
 }
 
 // NewStore creates and returns a new store instance.

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -60,7 +60,7 @@ type Store struct {
 // shall be deleted from Central.
 func (e *Store) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
-	// TODO implement me
+	// TODO(ROX-20075): Implement me
 	return "", errors.New("Not implemented")
 }
 

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -58,7 +58,7 @@ type Store struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (e *Store) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
+func (e *Store) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/networkgraph"
+	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -53,6 +54,14 @@ type Store struct {
 	publicIPsListeners map[PublicIPsListener]struct{}
 
 	mutex sync.RWMutex
+}
+
+// Reconcile is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state.
+func (e *Store) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+	_, _, _ = resType, resID, resHash
+	// TODO implement me
+	panic("implement me")
 }
 
 // NewStore creates and returns a new store instance.

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -5,7 +5,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/networkgraph"
-	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -56,9 +55,10 @@ type Store struct {
 	mutex sync.RWMutex
 }
 
-// Reconcile is called after Sensor reconnects with Central and receives its state hashes.
-// Reconciliacion ensures that Sensor and Central have the same state.
-func (e *Store) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+// ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
+// shall be deleted from Central.
+func (e *Store) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/common/deduper/deduper.go
+++ b/sensor/common/deduper/deduper.go
@@ -15,16 +15,61 @@ var (
 	log = logging.LoggerForModule()
 )
 
-// key is the key by which messages are deduped.
-type key struct {
-	id           string
-	resourceType reflect.Type
+// Key is the key by which messages are deduped.
+type Key struct {
+	ID           string
+	ResourceType reflect.Type
 }
+
+// FIXME(ROX-19696): This is a temporary fixture. Remove in favor of PR #8006
+
+var (
+	// TypeNetworkPolicy represents a NetworkPolicy Type
+	TypeNetworkPolicy = reflect.TypeOf(&central.SensorEvent_NetworkPolicy{})
+	// TypeDeployment represents a Deployment Type
+	TypeDeployment = reflect.TypeOf(&central.SensorEvent_Deployment{})
+	// TypePod represents a Pod Type
+	TypePod = reflect.TypeOf(&central.SensorEvent_Pod{})
+	// TypeNamespace represents a Namespace Type
+	TypeNamespace = reflect.TypeOf(&central.SensorEvent_Namespace{})
+	// TypeSecret represents a Secret Type
+	TypeSecret = reflect.TypeOf(&central.SensorEvent_Secret{})
+	// TypeNode represents a Node Type
+	TypeNode = reflect.TypeOf(&central.SensorEvent_Node{})
+	// TypeNodeInventory represents a NodeInventory Type
+	TypeNodeInventory = reflect.TypeOf(&central.SensorEvent_NodeInventory{})
+	// TypeServiceAccount represents a ServiceAccount Type
+	TypeServiceAccount = reflect.TypeOf(&central.SensorEvent_ServiceAccount{})
+	// TypeRole represents a Role Type
+	TypeRole = reflect.TypeOf(&central.SensorEvent_Role{})
+	// TypeBinding represents a Binding Type
+	TypeBinding = reflect.TypeOf(&central.SensorEvent_Binding{})
+	// TypeProcessIndicator represents a ProcessIndicator Type
+	TypeProcessIndicator = reflect.TypeOf(&central.SensorEvent_ProcessIndicator{})
+	// TypeProviderMetadata represents a ProviderMetadata Type
+	TypeProviderMetadata = reflect.TypeOf(&central.SensorEvent_ProviderMetadata{})
+	// TypeOrchestratorMetadata represents a OrchestratorMetadata Type
+	TypeOrchestratorMetadata = reflect.TypeOf(&central.SensorEvent_OrchestratorMetadata{})
+	// TypeImageIntegration represents a ImageIntegration Type
+	TypeImageIntegration = reflect.TypeOf(&central.SensorEvent_ImageIntegration{})
+	// TypeComplianceOperatorResult represents a ComplianceOperatorResult Type
+	TypeComplianceOperatorResult = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorResult{})
+	// TypeComplianceOperatorProfile represents a ComplianceOperatorProfile Type
+	TypeComplianceOperatorProfile = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorProfile{})
+	// TypeComplianceOperatorRule represents a ComplianceOperatorRule Type
+	TypeComplianceOperatorRule = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorRule{})
+	// TypeComplianceOperatorScanSettingBinding represents a ComplianceOperatorScanSettingBinding Type
+	TypeComplianceOperatorScanSettingBinding = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorScanSettingBinding{})
+	// TypeComplianceOperatorScan represents a ComplianceOperatorScan Type
+	TypeComplianceOperatorScan = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorScan{})
+)
+
+// FIXME(ROX-19696)
 
 // deduper takes care of deduping sensor events.
 type deduper struct {
 	stream   messagestream.SensorMessageStream
-	lastSent map[key]uint64
+	lastSent map[Key]uint64
 
 	hasher *hash.Hasher
 }
@@ -33,7 +78,7 @@ type deduper struct {
 func NewDedupingMessageStream(stream messagestream.SensorMessageStream) messagestream.SensorMessageStream {
 	return &deduper{
 		stream:   stream,
-		lastSent: make(map[key]uint64),
+		lastSent: make(map[Key]uint64),
 		hasher:   hash.NewHasher(),
 	}
 }
@@ -49,9 +94,9 @@ func (d *deduper) Send(msg *central.MsgFromSensor) error {
 	if managedcentral.IsCentralManaged() && event.GetImageIntegration() != nil {
 		return nil
 	}
-	key := key{
-		id:           event.GetId(),
-		resourceType: reflect.TypeOf(event.GetResource()),
+	key := Key{
+		ID:           event.GetId(),
+		ResourceType: reflect.TypeOf(event.GetResource()),
 	}
 	if event.GetAction() == central.ResourceAction_REMOVE_RESOURCE {
 		priorLen := len(d.lastSent)

--- a/sensor/common/deduper/deduper.go
+++ b/sensor/common/deduper/deduper.go
@@ -21,8 +21,6 @@ type Key struct {
 	ResourceType reflect.Type
 }
 
-// FIXME(ROX-19696): This is a temporary fixture. Remove in favor of PR #8006
-
 var (
 	// TypeNetworkPolicy represents a NetworkPolicy Type
 	TypeNetworkPolicy = reflect.TypeOf(&central.SensorEvent_NetworkPolicy{})
@@ -63,8 +61,6 @@ var (
 	// TypeComplianceOperatorScan represents a ComplianceOperatorScan Type
 	TypeComplianceOperatorScan = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorScan{})
 )
-
-// FIXME(ROX-19696)
 
 // deduper takes care of deduping sensor events.
 type deduper struct {

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -63,7 +63,7 @@ type Store struct {
 func (rs *Store) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
-	panic("implement me")
+	return "", errors.New("Not implemented")
 }
 
 // CheckTLS defines a function which checks if the given address is using TLS.

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -62,7 +62,7 @@ type Store struct {
 // shall be deleted from Central.
 func (rs *Store) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
-	// TODO implement me
+	// TODO(ROX-20074): Implement me
 	return "", errors.New("Not implemented")
 }
 

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -60,7 +60,7 @@ type Store struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (rs *Store) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
+func (rs *Store) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/docker/config"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/registries"
 	dockerFactory "github.com/stackrox/rox/pkg/registries/docker"
 	rhelFactory "github.com/stackrox/rox/pkg/registries/rhel"
@@ -55,6 +56,14 @@ type Store struct {
 
 	// centralRegistryIntegration holds registry integrations sync'd from Central.
 	centralRegistryIntegrations registries.Set
+}
+
+// Reconcile is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state.
+func (rs *Store) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+	_, _, _ = resType, resID, resHash
+	// TODO implement me
+	panic("implement me")
 }
 
 // CheckTLS defines a function which checks if the given address is using TLS.

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/docker/config"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/registries"
 	dockerFactory "github.com/stackrox/rox/pkg/registries/docker"
 	rhelFactory "github.com/stackrox/rox/pkg/registries/rhel"
@@ -58,9 +57,10 @@ type Store struct {
 	centralRegistryIntegrations registries.Set
 }
 
-// Reconcile is called after Sensor reconnects with Central and receives its state hashes.
-// Reconciliacion ensures that Sensor and Central have the same state.
-func (rs *Store) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+// ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
+// shall be deleted from Central.
+func (rs *Store) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -60,7 +60,7 @@ type Store struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (rs *Store) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
+func (rs *Store) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/common/sensor/central_communication.go
+++ b/sensor/common/sensor/central_communication.go
@@ -17,13 +17,14 @@ type CentralCommunication interface {
 }
 
 // NewCentralCommunication returns a new CentralCommunication.
-func NewCentralCommunication(reconnect bool, components ...common.SensorComponent) CentralCommunication {
+func NewCentralCommunication(reconnect bool, hashReconciliator reconciliationHandler, components ...common.SensorComponent) CentralCommunication {
 	finished := sync.WaitGroup{}
 	return &centralCommunicationImpl{
-		allFinished: &finished,
-		receiver:    NewCentralReceiver(&finished, components...),
-		sender:      NewCentralSender(&finished, components...),
-		components:  components,
+		allFinished:       &finished,
+		receiver:          NewCentralReceiver(&finished, components...),
+		sender:            NewCentralSender(&finished, components...),
+		components:        components,
+		hashReconciliator: hashReconciliator,
 
 		stopper:     concurrency.NewStopper(),
 		isReconnect: reconnect,

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -246,21 +246,6 @@ func (s *centralCommunicationImpl) initialSync(stream central.SensorService_Comm
 	return s.initialPolicySync(stream, detector)
 }
 
-// TODO: Call this function
-func (s *centralCommunicationImpl) handleReconciliationHashes(stream central.SensorService_CommunicateClient, handler reconciliationHandler) error {
-	msg, err := stream.Recv()
-	if err != nil {
-		return errors.Wrap(err, "receiving reconciliation hashes from central")
-	}
-	if msg.GetDeduperState() == nil {
-		log.Errorf("initial message received from Sensor was not a deduper state: %T", msg.Msg)
-		return nil // Ignore this message
-	}
-	events := handler.ProcessHashes(msg.GetDeduperState().GetResourceHashes())
-	log.Infof("Hash processing result: %v", events)
-	return nil
-}
-
 func (s *centralCommunicationImpl) initialConfigSync(stream central.SensorService_CommunicateClient, handler config.Handler) error {
 	msg, err := stream.Recv()
 	if err != nil {

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -243,19 +243,18 @@ func (s *centralCommunicationImpl) initialSync(stream central.SensorService_Comm
 		return err
 	}
 
-	if err := s.initialPolicySync(stream, detector); err != nil {
-		return err
-	}
-	return s.handleReconciliationHashes(stream, s.hashReconciliator)
+	return s.initialPolicySync(stream, detector)
 }
 
+// TODO: Call this function
 func (s *centralCommunicationImpl) handleReconciliationHashes(stream central.SensorService_CommunicateClient, handler reconciliationHandler) error {
 	msg, err := stream.Recv()
 	if err != nil {
-		return errors.Wrap(err, "receiving reconciliation hashes")
+		return errors.Wrap(err, "receiving reconciliation hashes from central")
 	}
 	if msg.GetDeduperState() == nil {
-		return errors.Errorf("initial message received from Sensor was not a deduper state: %T", msg.Msg)
+		log.Errorf("initial message received from Sensor was not a deduper state: %T", msg.Msg)
+		return nil // Ignore this message
 	}
 	events := handler.ProcessHashes(msg.GetDeduperState().GetResourceHashes())
 	log.Infof("Hash processing result: %v", events)

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -61,7 +61,7 @@ func (c *centralCommunicationSuite) SetupTest() {
 
 	// Create a fake SensorComponent
 	c.responsesC = make(chan *message.ExpiringMessage)
-	c.comm = NewCentralCommunication(false, fakeStoreReconciler{}, NewFakeSensorComponent(c.responsesC))
+	c.comm = NewCentralCommunication(false, NewMockStoreReconciler(), NewFakeSensorComponent(c.responsesC))
 
 	c.mockService = &MockSensorServiceClient{
 		connected: concurrency.NewSignal(),
@@ -77,11 +77,15 @@ func Test_CentralCommunicationSuite(t *testing.T) {
 	suite.Run(t, new(centralCommunicationSuite))
 }
 
-type fakeStoreReconciler struct {
+type mockStoreReconciler struct {
 }
 
-func (f fakeStoreReconciler) ProcessHashes(map[deduper.Key]uint64) []central.MsgFromSensor {
+func (m mockStoreReconciler) ProcessHashes(map[deduper.Key]uint64) []central.MsgFromSensor {
 	return []central.MsgFromSensor{}
+}
+
+func NewMockStoreReconciler() reconciliationHandler {
+	return mockStoreReconciler{}
 }
 
 type MockSensorServiceClient struct {

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/message"
 	mocksClient "github.com/stackrox/rox/sensor/common/sensor/mocks"
 	debuggerMessage "github.com/stackrox/rox/sensor/debugger/message"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
@@ -60,7 +61,9 @@ func (c *centralCommunicationSuite) SetupTest() {
 
 	// Create a fake SensorComponent
 	c.responsesC = make(chan *message.ExpiringMessage)
-	c.comm = NewCentralCommunication(false, NewFakeSensorComponent(c.responsesC))
+	storeProvider := resources.InitializeStore()
+	hashReconciliator := resources.NewResourceStoreReconciler(storeProvider)
+	c.comm = NewCentralCommunication(false, hashReconciliator, NewFakeSensorComponent(c.responsesC))
 
 	c.mockService = &MockSensorServiceClient{
 		connected: concurrency.NewSignal(),

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/centralclient"
 	"github.com/stackrox/rox/sensor/common/chaos"
 	"github.com/stackrox/rox/sensor/common/config"
+	"github.com/stackrox/rox/sensor/common/deduper"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/image"
 	"github.com/stackrox/rox/sensor/common/scannerdefinitions"
@@ -79,7 +80,7 @@ type Sensor struct {
 }
 
 type reconciliationHandler interface {
-	ProcessHashes(map[string]uint64) []central.MsgFromSensor
+	ProcessHashes(map[deduper.Key]uint64) []central.MsgFromSensor
 }
 
 // NewSensor initializes a Sensor, including reading configurations from the environment.

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cenkalti/backoff/v3"
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
@@ -78,7 +79,7 @@ type Sensor struct {
 }
 
 type reconciliationHandler interface {
-	ProcessHashes(map[string]uint64) []string
+	ProcessHashes(map[string]uint64) []central.MsgFromSensor
 }
 
 // NewSensor initializes a Sensor, including reading configurations from the environment.

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/mtls/verifier"
 	"github.com/stackrox/rox/pkg/probeupload"
-	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common"
@@ -79,7 +78,7 @@ type Sensor struct {
 }
 
 type reconciliationHandler interface {
-	ProcessHashes(map[string]uint64) map[string]reconcile.SensorReconciliationEvent
+	ProcessHashes(map[string]uint64) []string
 }
 
 // NewSensor initializes a Sensor, including reading configurations from the environment.

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -1,10 +1,8 @@
 package resources
 
 import (
-	"github.com/mitchellh/hashstructure/v2"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/imagecacheutils"
@@ -22,26 +20,19 @@ type DeploymentStore struct {
 	deployments map[string]*deploymentWrap
 }
 
-// Reconcile is called after Sensor reconnects with Central and receives its state hashes.
-// Reconciliacion ensures that Sensor and Central have the same state.
-func (ds *DeploymentStore) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+// ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
+// shall be deleted from Central.
+func (ds *DeploymentStore) ReconcileDelete(resType, resID string, _ uint64) ([]string, error) {
 	if resType != "Deployment" {
-		return map[string]reconcile.SensorReconciliationEvent{}, nil
+		return []string{}, nil
 	}
 	depl := ds.Get(resID)
 	if depl == nil {
 		// found on Central, not found on Sensor - need to send a Delete message
-		return map[string]reconcile.SensorReconciliationEvent{resID: reconcile.SensorReconciliationEventDelete}, nil
+		return []string{resID}, nil
 	}
-	hashValue, err := hashstructure.Hash(depl, hashstructure.FormatV2, &hashstructure.HashOptions{})
-	if err != nil || hashValue != resHash {
-		// Any problems with hash calculation should trigger an update.
-		// Found deployment in Sensor, but hash is different - need to send an Update message
-		return map[string]reconcile.SensorReconciliationEvent{resID: reconcile.SensorReconciliationEventUpdate},
-			errors.Wrap(err, "calculating deployment hash")
-	}
-	// Deployment found and still up to date
-	return map[string]reconcile.SensorReconciliationEvent{resID: reconcile.SensorReconciliationEventNoop}, nil
+	return []string{}, nil
 }
 
 // newDeploymentStore creates and returns a new deployment store.

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -24,7 +24,7 @@ type DeploymentStore struct {
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
 func (ds *DeploymentStore) ReconcileDelete(resType, resID string, _ uint64) (string, error) {
-	if resType != "Deployment" {
+	if resType != TypeDeployment.String() {
 		return "", nil
 	}
 	depl := ds.Get(resID)

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -27,8 +27,10 @@ func (ds *DeploymentStore) ReconcileDelete(resType, resID string, _ uint64) (str
 	if resType != TypeDeployment.String() {
 		return "", nil
 	}
-	depl := ds.Get(resID)
-	if depl == nil {
+	ds.lock.RLock()
+	defer ds.lock.RUnlock()
+	_, exists := ds.deployments[resID]
+	if !exists {
 		// found on Central, not found on Sensor - need to send a Delete message
 		return resID, nil
 	}

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/deduper"
 	"github.com/stackrox/rox/sensor/common/imagecacheutils"
 	"github.com/stackrox/rox/sensor/common/selector"
 	"github.com/stackrox/rox/sensor/common/store"
@@ -24,7 +25,7 @@ type DeploymentStore struct {
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
 func (ds *DeploymentStore) ReconcileDelete(resType, resID string, _ uint64) (string, error) {
-	if resType != TypeDeployment.String() {
+	if resType != deduper.TypeDeployment.String() {
 		return "", nil
 	}
 	ds.lock.RLock()

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
@@ -24,26 +23,16 @@ type DeploymentStore struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (ds *DeploymentStore) ReconcileDelete(resType, resID string, _ uint64) (*central.MsgFromSensor, error) {
+func (ds *DeploymentStore) ReconcileDelete(resType, resID string, _ uint64) (string, error) {
 	if resType != "Deployment" {
-		return nil, nil
+		return "", nil
 	}
 	depl := ds.Get(resID)
 	if depl == nil {
 		// found on Central, not found on Sensor - need to send a Delete message
-		msg := central.MsgFromSensor_Event{
-			Event: &central.SensorEvent{
-				Id:     resID,
-				Action: central.ResourceAction_REMOVE_RESOURCE,
-				Resource: &central.SensorEvent_Deployment{
-					Deployment: &storage.Deployment{Id: resID},
-				},
-			},
-		}
-		return &central.MsgFromSensor{Msg: &msg}, nil
+		return resID, nil
 	}
-
-	return nil, nil
+	return "", nil
 }
 
 // newDeploymentStore creates and returns a new deployment store.

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
@@ -23,16 +24,26 @@ type DeploymentStore struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (ds *DeploymentStore) ReconcileDelete(resType, resID string, _ uint64) ([]string, error) {
+func (ds *DeploymentStore) ReconcileDelete(resType, resID string, _ uint64) (*central.MsgFromSensor, error) {
 	if resType != "Deployment" {
-		return []string{}, nil
+		return nil, nil
 	}
 	depl := ds.Get(resID)
 	if depl == nil {
 		// found on Central, not found on Sensor - need to send a Delete message
-		return []string{resID}, nil
+		msg := central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     resID,
+				Action: central.ResourceAction_REMOVE_RESOURCE,
+				Resource: &central.SensorEvent_Deployment{
+					Deployment: &storage.Deployment{Id: resID},
+				},
+			},
+		}
+		return &central.MsgFromSensor{Msg: &msg}, nil
 	}
-	return []string{}, nil
+
+	return nil, nil
 }
 
 // newDeploymentStore creates and returns a new deployment store.

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -9,31 +9,52 @@ import (
 )
 
 // FIXME(ROX-19696): This is a temporary test interface. Remove in favor of PR #8006
+
+// Key is a representation of Deduper entries
 type Key struct {
 	ID   string
 	Type reflect.Type
 }
 
 var (
-	TypeNetworkPolicy                        = reflect.TypeOf(&central.SensorEvent_NetworkPolicy{})
-	TypeDeployment                           = reflect.TypeOf(&central.SensorEvent_Deployment{})
-	TypePod                                  = reflect.TypeOf(&central.SensorEvent_Pod{})
-	TypeNamespace                            = reflect.TypeOf(&central.SensorEvent_Namespace{})
-	TypeSecret                               = reflect.TypeOf(&central.SensorEvent_Secret{})
-	TypeNode                                 = reflect.TypeOf(&central.SensorEvent_Node{})
-	TypeNodeInventory                        = reflect.TypeOf(&central.SensorEvent_NodeInventory{})
-	TypeServiceAccount                       = reflect.TypeOf(&central.SensorEvent_ServiceAccount{})
-	TypeRole                                 = reflect.TypeOf(&central.SensorEvent_Role{})
-	TypeBinding                              = reflect.TypeOf(&central.SensorEvent_Binding{})
-	TypeProcessIndicator                     = reflect.TypeOf(&central.SensorEvent_ProcessIndicator{})
-	TypeProviderMetadata                     = reflect.TypeOf(&central.SensorEvent_ProviderMetadata{})
-	TypeOrchestratorMetadata                 = reflect.TypeOf(&central.SensorEvent_OrchestratorMetadata{})
-	TypeImageIntegration                     = reflect.TypeOf(&central.SensorEvent_ImageIntegration{})
-	TypeComplianceOperatorResult             = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorResult{})
-	TypeComplianceOperatorProfile            = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorProfile{})
-	TypeComplianceOperatorRule               = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorRule{})
+	// TypeNetworkPolicy represents a NetworkPolicy Type
+	TypeNetworkPolicy = reflect.TypeOf(&central.SensorEvent_NetworkPolicy{})
+	// TypeDeployment represents a Deployment Type
+	TypeDeployment = reflect.TypeOf(&central.SensorEvent_Deployment{})
+	// TypePod represents a Pod Type
+	TypePod = reflect.TypeOf(&central.SensorEvent_Pod{})
+	// TypeNamespace represents a Namespace Type
+	TypeNamespace = reflect.TypeOf(&central.SensorEvent_Namespace{})
+	// TypeSecret represents a Secret Type
+	TypeSecret = reflect.TypeOf(&central.SensorEvent_Secret{})
+	// TypeNode represents a Node Type
+	TypeNode = reflect.TypeOf(&central.SensorEvent_Node{})
+	// TypeNodeInventory represents a NodeInventory Type
+	TypeNodeInventory = reflect.TypeOf(&central.SensorEvent_NodeInventory{})
+	// TypeServiceAccount represents a ServiceAccount Type
+	TypeServiceAccount = reflect.TypeOf(&central.SensorEvent_ServiceAccount{})
+	// TypeRole represents a Role Type
+	TypeRole = reflect.TypeOf(&central.SensorEvent_Role{})
+	// TypeBinding represents a Binding Type
+	TypeBinding = reflect.TypeOf(&central.SensorEvent_Binding{})
+	// TypeProcessIndicator represents a ProcessIndicator Type
+	TypeProcessIndicator = reflect.TypeOf(&central.SensorEvent_ProcessIndicator{})
+	// TypeProviderMetadata represents a ProviderMetadata Type
+	TypeProviderMetadata = reflect.TypeOf(&central.SensorEvent_ProviderMetadata{})
+	// TypeOrchestratorMetadata represents a OrchestratorMetadata Type
+	TypeOrchestratorMetadata = reflect.TypeOf(&central.SensorEvent_OrchestratorMetadata{})
+	// TypeImageIntegration represents a ImageIntegration Type
+	TypeImageIntegration = reflect.TypeOf(&central.SensorEvent_ImageIntegration{})
+	// TypeComplianceOperatorResult represents a ComplianceOperatorResult Type
+	TypeComplianceOperatorResult = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorResult{})
+	// TypeComplianceOperatorProfile represents a ComplianceOperatorProfile Type
+	TypeComplianceOperatorProfile = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorProfile{})
+	// TypeComplianceOperatorRule represents a ComplianceOperatorRule Type
+	TypeComplianceOperatorRule = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorRule{})
+	// TypeComplianceOperatorScanSettingBinding represents a ComplianceOperatorScanSettingBinding Type
 	TypeComplianceOperatorScanSettingBinding = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorScanSettingBinding{})
-	TypeComplianceOperatorScan               = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorScan{})
+	// TypeComplianceOperatorScan represents a ComplianceOperatorScan Type
+	TypeComplianceOperatorScan = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorScan{})
 )
 
 // FIXME(ROX-19696)

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -1,11 +1,42 @@
 package resources
 
 import (
+	"reflect"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/stringutils"
 )
+
+// FIXME(ROX-19696): This is a temporary test interface. Remove in favor of PR #8006
+type Key struct {
+	ID   string
+	Type reflect.Type
+}
+
+var (
+	TypeNetworkPolicy                        = reflect.TypeOf(&central.SensorEvent_NetworkPolicy{})
+	TypeDeployment                           = reflect.TypeOf(&central.SensorEvent_Deployment{})
+	TypePod                                  = reflect.TypeOf(&central.SensorEvent_Pod{})
+	TypeNamespace                            = reflect.TypeOf(&central.SensorEvent_Namespace{})
+	TypeSecret                               = reflect.TypeOf(&central.SensorEvent_Secret{})
+	TypeNode                                 = reflect.TypeOf(&central.SensorEvent_Node{})
+	TypeNodeInventory                        = reflect.TypeOf(&central.SensorEvent_NodeInventory{})
+	TypeServiceAccount                       = reflect.TypeOf(&central.SensorEvent_ServiceAccount{})
+	TypeRole                                 = reflect.TypeOf(&central.SensorEvent_Role{})
+	TypeBinding                              = reflect.TypeOf(&central.SensorEvent_Binding{})
+	TypeProcessIndicator                     = reflect.TypeOf(&central.SensorEvent_ProcessIndicator{})
+	TypeProviderMetadata                     = reflect.TypeOf(&central.SensorEvent_ProviderMetadata{})
+	TypeOrchestratorMetadata                 = reflect.TypeOf(&central.SensorEvent_OrchestratorMetadata{})
+	TypeImageIntegration                     = reflect.TypeOf(&central.SensorEvent_ImageIntegration{})
+	TypeComplianceOperatorResult             = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorResult{})
+	TypeComplianceOperatorProfile            = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorProfile{})
+	TypeComplianceOperatorRule               = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorRule{})
+	TypeComplianceOperatorScanSettingBinding = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorScanSettingBinding{})
+	TypeComplianceOperatorScan               = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorScan{})
+)
+
+// FIXME(ROX-19696)
 
 // ResourceStoreReconciler handles sensor-side reconciliation using in-memory store
 type ResourceStoreReconciler struct {
@@ -19,15 +50,10 @@ func NewResourceStoreReconciler(storeProvider *InMemoryStoreProvider) *ResourceS
 
 // ProcessHashes orchestrates the sensor-side reconciliation after a reconnect. It returns a slice of resource IDs that
 // should be deleted in Central to keep the state of Sensor and Central in sync.
-func (hr *ResourceStoreReconciler) ProcessHashes(h map[string]uint64) []central.MsgFromSensor {
+func (hr *ResourceStoreReconciler) ProcessHashes(h map[Key]uint64) []central.MsgFromSensor {
 	events := make([]central.MsgFromSensor, 0)
-	for typeWithID, hashValue := range h {
-		resType, resID := stringutils.Split2(typeWithID, ":")
-		if resID == "" {
-			log.Errorf("malformed hash key: %s", typeWithID)
-			continue
-		}
-		toDeleteID, err := hr.storeProvider.ReconcileDelete(resType, resID, hashValue)
+	for hash, hashValue := range h {
+		toDeleteID, err := hr.storeProvider.ReconcileDelete(hash.Type.String(), hash.ID, hashValue)
 		if err != nil {
 			log.Errorf("reconciliation error: %s", err)
 			continue
@@ -36,7 +62,7 @@ func (hr *ResourceStoreReconciler) ProcessHashes(h map[string]uint64) []central.
 			log.Debug("empty reconciliation result - not found on Sensor")
 			continue
 		}
-		delMsg, err := resourceToMessage(resType, toDeleteID)
+		delMsg, err := resourceToMessage(hash.Type.String(), toDeleteID)
 		if err != nil {
 			log.Errorf("converting resource to MsgFromSensor: %s", err)
 			continue
@@ -48,7 +74,7 @@ func (hr *ResourceStoreReconciler) ProcessHashes(h map[string]uint64) []central.
 
 func resourceToMessage(resType string, resID string) (*central.MsgFromSensor, error) {
 	switch resType {
-	case "Deployment":
+	case TypeDeployment.String():
 		msg := central.MsgFromSensor_Event{
 			Event: &central.SensorEvent{
 				Id:     resID,
@@ -59,7 +85,7 @@ func resourceToMessage(resType string, resID string) (*central.MsgFromSensor, er
 			},
 		}
 		return &central.MsgFromSensor{Msg: &msg}, nil
-	case "Pod":
+	case TypePod.String():
 		msg := central.MsgFromSensor_Event{
 			Event: &central.SensorEvent{
 				Id:     resID,

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -25,15 +25,26 @@ func (hr *InMemoryStoreReconciler) ProcessHashes(h map[string]uint64) []central.
 			log.Errorf("malformed hash key: %s", typeWithID)
 			continue
 		}
-		resEvent, err := hr.storeProvider.ReconcileDelete(resType, resID, hashValue)
+		toDeleteID, err := hr.storeProvider.ReconcileDelete(resType, resID, hashValue)
 		if err != nil {
 			log.Errorf("reconciliation error: %s", err)
 		}
-		if resEvent == nil {
+		if toDeleteID == "" {
 			log.Error("empty reconciliation result")
 			continue
 		}
-		events = append(events, *resEvent)
+		delMsg, err := resourceToMessage(resType, toDeleteID)
+		if err != nil {
+			log.Errorf("converting resource to MsgFromSensor: %s", err)
+			continue
+		}
+		events = append(events, *delMsg)
 	}
 	return events
+}
+
+func resourceToMessage(resType string, resID string) (*central.MsgFromSensor, error) {
+	_, _ = resType, resID
+	panic("Not implemented")
+
 }

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/stringutils"
 )
 
@@ -16,23 +17,23 @@ func NewInMemoryStoreReconciler(storeProvider *InMemoryStoreProvider) *InMemoryS
 
 // ProcessHashes orchestrates the sensor-side reconciliation after a reconnect. It returns a slice of resource IDs that
 // should be deleted in Central to keep the state of Sensor and Central in sync.
-func (hr *InMemoryStoreReconciler) ProcessHashes(h map[string]uint64) []string {
-	events := make([]string, 0)
+func (hr *InMemoryStoreReconciler) ProcessHashes(h map[string]uint64) []central.MsgFromSensor {
+	events := make([]central.MsgFromSensor, 0)
 	for typeWithID, hashValue := range h {
 		resType, resID := stringutils.Split2(typeWithID, ":")
 		if resID == "" {
 			log.Errorf("malformed hash key: %s", typeWithID)
 			continue
 		}
-		resEvents, err := hr.storeProvider.ReconcileDelete(resType, resID, hashValue)
+		resEvent, err := hr.storeProvider.ReconcileDelete(resType, resID, hashValue)
 		if err != nil {
 			log.Errorf("reconciliation error: %s", err)
 		}
-		if resEvents == nil {
+		if resEvent == nil {
 			log.Error("empty reconciliation result")
 			continue
 		}
-		events = append(events, resEvents...)
+		events = append(events, *resEvent)
 	}
 	return events
 }

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -30,6 +30,7 @@ func (hr *ResourceStoreReconciler) ProcessHashes(h map[string]uint64) []central.
 		toDeleteID, err := hr.storeProvider.ReconcileDelete(resType, resID, hashValue)
 		if err != nil {
 			log.Errorf("reconciliation error: %s", err)
+			continue
 		}
 		if toDeleteID == "" {
 			log.Debug("empty reconciliation result - not found on Sensor")

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -1,0 +1,41 @@
+package resources
+
+import (
+	"github.com/stackrox/rox/pkg/reconcile"
+	"github.com/stackrox/rox/pkg/stringutils"
+)
+
+// InMemoryStoreReconciler handles sensor-side reconciliation using in-memory store
+type InMemoryStoreReconciler struct {
+	storeProvider *InMemoryStoreProvider
+}
+
+// NewInMemoryStoreReconciler builds InMemoryStoreReconciler for sensor-side reconciliation
+func NewInMemoryStoreReconciler(storeProvider *InMemoryStoreProvider) *InMemoryStoreReconciler {
+	return &InMemoryStoreReconciler{storeProvider: storeProvider}
+}
+
+// ProcessHashes orchestrates the sensor-side reconciliation after a reconnect. It returns a map of events that
+// should be sent back to Central to ensure that the states in Sensor and Central are in sync.
+func (hr *InMemoryStoreReconciler) ProcessHashes(h map[string]uint64) map[string]reconcile.SensorReconciliationEvent {
+	events := make(map[string]reconcile.SensorReconciliationEvent)
+	for typeWithID, hashValue := range h {
+		resType, resID := stringutils.Split2(typeWithID, ":")
+		if resID == "" {
+			log.Errorf("malformed hash key: %s", typeWithID)
+			continue
+		}
+		resEvents, err := hr.storeProvider.Reconcile(resType, resID, hashValue)
+		if err != nil {
+			log.Errorf("reconciliation error: %s", err)
+		}
+		if resEvents == nil {
+			log.Error("empty reconciliation result")
+			continue
+		}
+		for ek, ev := range resEvents {
+			events[ek] = ev
+		}
+	}
+	return events
+}

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -1,63 +1,11 @@
 package resources
 
 import (
-	"reflect"
-
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/sensor/common/deduper"
 )
-
-// FIXME(ROX-19696): This is a temporary test interface. Remove in favor of PR #8006
-
-// Key is a representation of Deduper entries
-type Key struct {
-	ID   string
-	Type reflect.Type
-}
-
-var (
-	// TypeNetworkPolicy represents a NetworkPolicy Type
-	TypeNetworkPolicy = reflect.TypeOf(&central.SensorEvent_NetworkPolicy{})
-	// TypeDeployment represents a Deployment Type
-	TypeDeployment = reflect.TypeOf(&central.SensorEvent_Deployment{})
-	// TypePod represents a Pod Type
-	TypePod = reflect.TypeOf(&central.SensorEvent_Pod{})
-	// TypeNamespace represents a Namespace Type
-	TypeNamespace = reflect.TypeOf(&central.SensorEvent_Namespace{})
-	// TypeSecret represents a Secret Type
-	TypeSecret = reflect.TypeOf(&central.SensorEvent_Secret{})
-	// TypeNode represents a Node Type
-	TypeNode = reflect.TypeOf(&central.SensorEvent_Node{})
-	// TypeNodeInventory represents a NodeInventory Type
-	TypeNodeInventory = reflect.TypeOf(&central.SensorEvent_NodeInventory{})
-	// TypeServiceAccount represents a ServiceAccount Type
-	TypeServiceAccount = reflect.TypeOf(&central.SensorEvent_ServiceAccount{})
-	// TypeRole represents a Role Type
-	TypeRole = reflect.TypeOf(&central.SensorEvent_Role{})
-	// TypeBinding represents a Binding Type
-	TypeBinding = reflect.TypeOf(&central.SensorEvent_Binding{})
-	// TypeProcessIndicator represents a ProcessIndicator Type
-	TypeProcessIndicator = reflect.TypeOf(&central.SensorEvent_ProcessIndicator{})
-	// TypeProviderMetadata represents a ProviderMetadata Type
-	TypeProviderMetadata = reflect.TypeOf(&central.SensorEvent_ProviderMetadata{})
-	// TypeOrchestratorMetadata represents a OrchestratorMetadata Type
-	TypeOrchestratorMetadata = reflect.TypeOf(&central.SensorEvent_OrchestratorMetadata{})
-	// TypeImageIntegration represents a ImageIntegration Type
-	TypeImageIntegration = reflect.TypeOf(&central.SensorEvent_ImageIntegration{})
-	// TypeComplianceOperatorResult represents a ComplianceOperatorResult Type
-	TypeComplianceOperatorResult = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorResult{})
-	// TypeComplianceOperatorProfile represents a ComplianceOperatorProfile Type
-	TypeComplianceOperatorProfile = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorProfile{})
-	// TypeComplianceOperatorRule represents a ComplianceOperatorRule Type
-	TypeComplianceOperatorRule = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorRule{})
-	// TypeComplianceOperatorScanSettingBinding represents a ComplianceOperatorScanSettingBinding Type
-	TypeComplianceOperatorScanSettingBinding = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorScanSettingBinding{})
-	// TypeComplianceOperatorScan represents a ComplianceOperatorScan Type
-	TypeComplianceOperatorScan = reflect.TypeOf(&central.SensorEvent_ComplianceOperatorScan{})
-)
-
-// FIXME(ROX-19696)
 
 // ResourceStoreReconciler handles sensor-side reconciliation using in-memory store
 type ResourceStoreReconciler struct {
@@ -71,10 +19,10 @@ func NewResourceStoreReconciler(storeProvider *InMemoryStoreProvider) *ResourceS
 
 // ProcessHashes orchestrates the sensor-side reconciliation after a reconnect. It returns a slice of resource IDs that
 // should be deleted in Central to keep the state of Sensor and Central in sync.
-func (hr *ResourceStoreReconciler) ProcessHashes(h map[Key]uint64) []central.MsgFromSensor {
+func (hr *ResourceStoreReconciler) ProcessHashes(h map[deduper.Key]uint64) []central.MsgFromSensor {
 	events := make([]central.MsgFromSensor, 0)
 	for hash, hashValue := range h {
-		toDeleteID, err := hr.storeProvider.ReconcileDelete(hash.Type.String(), hash.ID, hashValue)
+		toDeleteID, err := hr.storeProvider.ReconcileDelete(hash.ResourceType.String(), hash.ID, hashValue)
 		if err != nil {
 			log.Errorf("reconciliation error: %s", err)
 			continue
@@ -83,7 +31,7 @@ func (hr *ResourceStoreReconciler) ProcessHashes(h map[Key]uint64) []central.Msg
 			log.Debug("empty reconciliation result - not found on Sensor")
 			continue
 		}
-		delMsg, err := resourceToMessage(hash.Type.String(), toDeleteID)
+		delMsg, err := resourceToMessage(hash.ResourceType.String(), toDeleteID)
 		if err != nil {
 			log.Errorf("converting resource to MsgFromSensor: %s", err)
 			continue
@@ -95,7 +43,7 @@ func (hr *ResourceStoreReconciler) ProcessHashes(h map[Key]uint64) []central.Msg
 
 func resourceToMessage(resType string, resID string) (*central.MsgFromSensor, error) {
 	switch resType {
-	case TypeDeployment.String():
+	case deduper.TypeDeployment.String():
 		msg := central.MsgFromSensor_Event{
 			Event: &central.SensorEvent{
 				Id:     resID,
@@ -106,7 +54,7 @@ func resourceToMessage(resType string, resID string) (*central.MsgFromSensor, er
 			},
 		}
 		return &central.MsgFromSensor{Msg: &msg}, nil
-	case TypePod.String():
+	case deduper.TypePod.String():
 		msg := central.MsgFromSensor_Event{
 			Event: &central.SensorEvent{
 				Id:     resID,

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -17,7 +17,7 @@ func NewResourceStoreReconciler(storeProvider *InMemoryStoreProvider) *ResourceS
 	return &ResourceStoreReconciler{storeProvider: storeProvider}
 }
 
-// ProcessHashes orchestrates the sensor-side reconciliation after a reconnect. It returns a slice of resource IDs that
+// ProcessHashes orchestrates the sensor-side reconciliation after a reconnect. It returns a slice of Sensor messages that
 // should be deleted in Central to keep the state of Sensor and Central in sync.
 func (hr *ResourceStoreReconciler) ProcessHashes(h map[deduper.Key]uint64) []central.MsgFromSensor {
 	events := make([]central.MsgFromSensor, 0)

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -65,6 +65,17 @@ func resourceToMessage(resType string, resID string) (*central.MsgFromSensor, er
 			},
 		}
 		return &central.MsgFromSensor{Msg: &msg}, nil
+	case deduper.TypeServiceAccount.String():
+		msg := central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     resID,
+				Action: central.ResourceAction_REMOVE_RESOURCE,
+				Resource: &central.SensorEvent_ServiceAccount{
+					ServiceAccount: &storage.ServiceAccount{Id: resID},
+				},
+			},
+		}
+		return &central.MsgFromSensor{Msg: &msg}, nil
 	default:
 		return nil, errors.Errorf("Not implemented for resource type %v", resType)
 	}

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -6,7 +6,7 @@ import (
 )
 
 // InMemoryStoreReconciler handles sensor-side reconciliation using in-memory store
-type InMemoryStoreReconciler struct {
+type ResourceStoreReconciler struct {
 	storeProvider *InMemoryStoreProvider
 }
 

--- a/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
@@ -56,3 +56,72 @@ func (s *HashReconciliationSuite) TestResourceToMessage() {
 		})
 	}
 }
+
+func (s *HashReconciliationSuite) TestEmptyDeploymentProvider() {
+	store := InitializeStore()
+	rc := NewResourceStoreReconciler(store)
+
+	// given the stores are empty, if you provide a single deduper entry, generate 1 delete event
+	dstate := map[string]uint64{
+		"Deployment:1234": 01234,
+	}
+
+	msgs := rc.ProcessHashes(dstate)
+
+	s.Equal(1, len(msgs))
+	s.Equal(msgs[0].GetEvent().Action, central.ResourceAction_REMOVE_RESOURCE)
+	s.Equal(msgs[0].GetEvent().GetDeployment().GetId(), "1234")
+}
+
+func (s *HashReconciliationSuite) TestDeploymentProviderSingleDelete() {
+	store := InitializeStore()
+	store.deploymentStore.addOrUpdateDeployment(createWrapWithID("123"))
+	store.deploymentStore.addOrUpdateDeployment(createWrapWithID("456"))
+	store.deploymentStore.addOrUpdateDeployment(createWrapWithID("678"))
+	rc := NewResourceStoreReconciler(store)
+
+	// given the stores are empty, if you provide a single deduper entry, generate 1 delete event
+	dstate := map[string]uint64{
+		"Deployment:1234": 87654,
+		"Deployment:456":  76543,
+	}
+
+	msgs := rc.ProcessHashes(dstate)
+
+	s.Equal(1, len(msgs))
+	s.Equal(msgs[0].GetEvent().Action, central.ResourceAction_REMOVE_RESOURCE)
+	s.Equal(msgs[0].GetEvent().GetDeployment().GetId(), "1234")
+}
+
+func (s *HashReconciliationSuite) TestDeploymentProviderMultiDelete() {
+	store := InitializeStore()
+	store.deploymentStore.addOrUpdateDeployment(createWrapWithID("123"))
+	store.deploymentStore.addOrUpdateDeployment(createWrapWithID("456"))
+	store.deploymentStore.addOrUpdateDeployment(createWrapWithID("678"))
+	rc := NewResourceStoreReconciler(store)
+
+	// given the stores are empty, if you provide a single deduper entry, generate 1 delete event
+	dstate := map[string]uint64{
+		"Deployment:1234": 87654,
+		"Deployment:456":  76543,
+		"Deployment:0987": 98755,
+	}
+
+	msgs := rc.ProcessHashes(dstate)
+
+	s.Equal(2, len(msgs))
+
+	ids := make([]string, 0)
+	for _, m := range msgs {
+		s.Require().Equal(central.ResourceAction_REMOVE_RESOURCE, m.GetEvent().GetAction())
+		ids = append(ids, m.GetEvent().GetDeployment().GetId())
+	}
+
+	s.ElementsMatch([]string{"0987", "1234"}, ids)
+}
+
+func createWrapWithID(id string) *deploymentWrap {
+	d := createDeploymentWrap()
+	d.Id = id
+	return d
+}

--- a/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
@@ -149,9 +149,9 @@ func (s *HashReconciliationSuite) TestProcessHashes() {
 			ids := make([]string, 0)
 			for _, m := range msgs {
 				s.Require().Equal(central.ResourceAction_REMOVE_RESOURCE, m.GetEvent().GetAction())
-				getIdFn, err := resourceTypeToFn(reflect.TypeOf(m.GetEvent().GetResource()).String())
+				getIDFn, err := resourceTypeToFn(reflect.TypeOf(m.GetEvent().GetResource()).String())
 				s.Require().NoError(err)
-				ids = append(ids, getIdFn(m.GetEvent()))
+				ids = append(ids, getIDFn(m.GetEvent()))
 			}
 			s.ElementsMatch(c.deletedIDs, ids)
 		})

--- a/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
@@ -82,54 +82,58 @@ func initStore() *InMemoryStoreProvider {
 	return s
 }
 
+func makeKey(id string, t reflect.Type) Key {
+	return Key{id, t}
+}
+
 func (s *HashReconciliationSuite) TestProcessHashes() {
 	cases := map[string]struct {
-		dstate     map[string]uint64
+		dstate     map[Key]uint64
 		deletedIDs []string
 	}{
 		"No Deployment": {
-			dstate: map[string]uint64{
-				"Deployment:1": 76543,
-				"Deployment:2": 76543,
+			dstate: map[Key]uint64{
+				makeKey("1", TypeDeployment): 76543,
+				makeKey("2", TypeDeployment): 76543,
 			},
 			deletedIDs: []string{},
 		},
 		"Single Deployment": {
-			dstate: map[string]uint64{
-				"Deployment:99": 87654,
-				"Deployment:1":  76543,
+			dstate: map[Key]uint64{
+				makeKey("99", TypeDeployment): 87654,
+				makeKey("1", TypeDeployment):  76543,
 			},
 			deletedIDs: []string{"99"},
 		},
 		"Multiple Deployments": {
-			dstate: map[string]uint64{
-				"Deployment:99": 87654,
-				"Deployment:98": 88888,
-				"Deployment:97": 77777,
-				"Deployment:1":  76543,
+			dstate: map[Key]uint64{
+				makeKey("99", TypeDeployment): 87654,
+				makeKey("98", TypeDeployment): 88888,
+				makeKey("97", TypeDeployment): 77777,
+				makeKey("1", TypeDeployment):  76543,
 			},
 			deletedIDs: []string{"99", "98", "97"},
 		},
 		"No Pod": {
-			dstate: map[string]uint64{
-				"Pod:3": 76543,
-				"Pod:4": 76543,
+			dstate: map[Key]uint64{
+				makeKey("3", TypePod): 76543,
+				makeKey("4", TypePod): 76543,
 			},
 			deletedIDs: []string{},
 		},
 		"Single Pod": {
-			dstate: map[string]uint64{
-				"Pod:99": 87654,
-				"Pod:3":  76543,
+			dstate: map[Key]uint64{
+				makeKey("99", TypePod): 87654,
+				makeKey("3", TypePod):  76543,
 			},
 			deletedIDs: []string{"99"},
 		},
 		"Multiple Pods": {
-			dstate: map[string]uint64{
-				"Pod:99":  87654,
-				"Pod:100": 87654,
-				"Pod:101": 87654,
-				"Pod:3":   76543,
+			dstate: map[Key]uint64{
+				makeKey("99", TypePod):  87654,
+				makeKey("100", TypePod): 87654,
+				makeKey("101", TypePod): 87654,
+				makeKey("3", TypePod):   76543,
 			},
 			deletedIDs: []string{"99", "100", "101"},
 		},
@@ -140,7 +144,7 @@ func (s *HashReconciliationSuite) TestProcessHashes() {
 			rc := NewResourceStoreReconciler(initStore())
 			msgs := rc.ProcessHashes(c.dstate)
 
-			s.Len(c.deletedIDs, len(msgs))
+			s.Len(msgs, len(c.deletedIDs))
 
 			ids := make([]string, 0)
 			for _, m := range msgs {

--- a/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/sensor/common/deduper"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -82,58 +83,58 @@ func initStore() *InMemoryStoreProvider {
 	return s
 }
 
-func makeKey(id string, t reflect.Type) Key {
-	return Key{id, t}
+func makeKey(id string, t reflect.Type) deduper.Key {
+	return deduper.Key{ID: id, ResourceType: t}
 }
 
 func (s *HashReconciliationSuite) TestProcessHashes() {
 	cases := map[string]struct {
-		dstate     map[Key]uint64
+		dstate     map[deduper.Key]uint64
 		deletedIDs []string
 	}{
 		"No Deployment": {
-			dstate: map[Key]uint64{
-				makeKey("1", TypeDeployment): 76543,
-				makeKey("2", TypeDeployment): 76543,
+			dstate: map[deduper.Key]uint64{
+				makeKey("1", deduper.TypeDeployment): 76543,
+				makeKey("2", deduper.TypeDeployment): 76543,
 			},
 			deletedIDs: []string{},
 		},
 		"Single Deployment": {
-			dstate: map[Key]uint64{
-				makeKey("99", TypeDeployment): 87654,
-				makeKey("1", TypeDeployment):  76543,
+			dstate: map[deduper.Key]uint64{
+				makeKey("99", deduper.TypeDeployment): 87654,
+				makeKey("1", deduper.TypeDeployment):  76543,
 			},
 			deletedIDs: []string{"99"},
 		},
 		"Multiple Deployments": {
-			dstate: map[Key]uint64{
-				makeKey("99", TypeDeployment): 87654,
-				makeKey("98", TypeDeployment): 88888,
-				makeKey("97", TypeDeployment): 77777,
-				makeKey("1", TypeDeployment):  76543,
+			dstate: map[deduper.Key]uint64{
+				makeKey("99", deduper.TypeDeployment): 87654,
+				makeKey("98", deduper.TypeDeployment): 88888,
+				makeKey("97", deduper.TypeDeployment): 77777,
+				makeKey("1", deduper.TypeDeployment):  76543,
 			},
 			deletedIDs: []string{"99", "98", "97"},
 		},
 		"No Pod": {
-			dstate: map[Key]uint64{
-				makeKey("3", TypePod): 76543,
-				makeKey("4", TypePod): 76543,
+			dstate: map[deduper.Key]uint64{
+				makeKey("3", deduper.TypePod): 76543,
+				makeKey("4", deduper.TypePod): 76543,
 			},
 			deletedIDs: []string{},
 		},
 		"Single Pod": {
-			dstate: map[Key]uint64{
-				makeKey("99", TypePod): 87654,
-				makeKey("3", TypePod):  76543,
+			dstate: map[deduper.Key]uint64{
+				makeKey("99", deduper.TypePod): 87654,
+				makeKey("3", deduper.TypePod):  76543,
 			},
 			deletedIDs: []string{"99"},
 		},
 		"Multiple Pods": {
-			dstate: map[Key]uint64{
-				makeKey("99", TypePod):  87654,
-				makeKey("100", TypePod): 87654,
-				makeKey("101", TypePod): 87654,
-				makeKey("3", TypePod):   76543,
+			dstate: map[deduper.Key]uint64{
+				makeKey("99", deduper.TypePod):  87654,
+				makeKey("100", deduper.TypePod): 87654,
+				makeKey("101", deduper.TypePod): 87654,
+				makeKey("3", deduper.TypePod):   76543,
 			},
 			deletedIDs: []string{"99", "100", "101"},
 		},

--- a/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
@@ -159,6 +159,29 @@ func (s *HashReconciliationSuite) TestProcessHashes() {
 			},
 			deletedIDs: []string{"99", "100", "101"},
 		},
+		"No ServiceAccount": {
+			dstate: map[deduper.Key]uint64{
+				makeKey("5", deduper.TypeServiceAccount): 76543,
+				makeKey("6", deduper.TypeServiceAccount): 65432,
+			},
+			deletedIDs: []string{},
+		},
+		"Single ServiceAccount": {
+			dstate: map[deduper.Key]uint64{
+				makeKey("99", deduper.TypeServiceAccount): 87654,
+				makeKey("5", deduper.TypeServiceAccount):  76543,
+			},
+			deletedIDs: []string{"99"},
+		},
+		"Multiple ServiceAccounts": {
+			dstate: map[deduper.Key]uint64{
+				makeKey("99", deduper.TypeServiceAccount):  87654,
+				makeKey("100", deduper.TypeServiceAccount): 87654,
+				makeKey("101", deduper.TypeServiceAccount): 87654,
+				makeKey("5", deduper.TypeServiceAccount):   76543,
+			},
+			deletedIDs: []string{"99", "100", "101"},
+		},
 	}
 
 	for n, c := range cases {

--- a/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
@@ -29,12 +29,12 @@ func (s *HashReconciliationSuite) TestResourceToMessage() {
 		expectedError error
 	}{
 		"Pod": {
-			resType:       "Pod",
+			resType:       deduper.TypePod.String(),
 			expectedMsg:   &central.MsgFromSensor_Event{Event: &central.SensorEvent{Id: testResID, Action: central.ResourceAction_REMOVE_RESOURCE, Resource: &central.SensorEvent_Pod{Pod: &storage.Pod{Id: testResID}}}},
 			expectedError: nil,
 		},
 		"Deployment": {
-			resType:       "Deployment",
+			resType:       deduper.TypeDeployment.String(),
 			expectedMsg:   &central.MsgFromSensor_Event{Event: &central.SensorEvent{Id: testResID, Action: central.ResourceAction_REMOVE_RESOURCE, Resource: &central.SensorEvent_Deployment{Deployment: &storage.Deployment{Id: testResID}}}},
 			expectedError: nil,
 		},
@@ -60,11 +60,11 @@ func (s *HashReconciliationSuite) TestResourceToMessage() {
 
 func resourceTypeToFn(resType string) (func(*central.SensorEvent) string, error) {
 	switch resType {
-	case "*central.SensorEvent_Deployment":
+	case deduper.TypeDeployment.String():
 		return func(event *central.SensorEvent) string {
 			return event.GetDeployment().GetId()
 		}, nil
-	case "*central.SensorEvent_Pod":
+	case deduper.TypePod.String():
 		return func(event *central.SensorEvent) string {
 			return event.GetPod().GetId()
 		}, nil

--- a/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
@@ -38,6 +38,11 @@ func (s *HashReconciliationSuite) TestResourceToMessage() {
 			expectedMsg:   &central.MsgFromSensor_Event{Event: &central.SensorEvent{Id: testResID, Action: central.ResourceAction_REMOVE_RESOURCE, Resource: &central.SensorEvent_Deployment{Deployment: &storage.Deployment{Id: testResID}}}},
 			expectedError: nil,
 		},
+		"ServiceAccount": {
+			resType:       deduper.TypeServiceAccount.String(),
+			expectedMsg:   &central.MsgFromSensor_Event{Event: &central.SensorEvent{Id: testResID, Action: central.ResourceAction_REMOVE_RESOURCE, Resource: &central.SensorEvent_ServiceAccount{ServiceAccount: &storage.ServiceAccount{Id: testResID}}}},
+			expectedError: nil,
+		},
 		"Unknown should throw error": {
 			resType:       "Unknown",
 			expectedMsg:   nil,
@@ -68,6 +73,10 @@ func resourceTypeToFn(resType string) (func(*central.SensorEvent) string, error)
 		return func(event *central.SensorEvent) string {
 			return event.GetPod().GetId()
 		}, nil
+	case deduper.TypeServiceAccount.String():
+		return func(event *central.SensorEvent) string {
+			return event.GetServiceAccount().GetId()
+		}, nil
 	default:
 		return nil, errors.Errorf("not implemented for resource type %v", resType)
 	}
@@ -80,6 +89,18 @@ func initStore() *InMemoryStoreProvider {
 	s.deploymentStore.addOrUpdateDeployment(createWrapWithID("2"))
 	s.podStore.addOrUpdatePod(&storage.Pod{Id: "3"})
 	s.podStore.addOrUpdatePod(&storage.Pod{Id: "4"})
+	s.serviceAccountStore.Add(&storage.ServiceAccount{
+		Id:               "5",
+		Name:             "Acc1",
+		Namespace:        "Test",
+		ImagePullSecrets: []string{},
+	})
+	s.serviceAccountStore.Add(&storage.ServiceAccount{
+		Id:               "6",
+		Name:             "Acc2",
+		Namespace:        "Test",
+		ImagePullSecrets: []string{},
+	})
 	return s
 }
 

--- a/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
@@ -40,7 +40,7 @@ func (s *HashReconciliationSuite) TestResourceToMessage() {
 		"Unknown should throw error": {
 			resType:       "Unknown",
 			expectedMsg:   nil,
-			expectedError: errors.Errorf("Not implemented for resource type Unknown"),
+			expectedError: errors.New("Not implemented for resource type Unknown"),
 		},
 	}
 

--- a/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
@@ -1,0 +1,58 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestHashReconciliation(t *testing.T) {
+	suite.Run(t, new(HashReconciliationSuite))
+}
+
+type HashReconciliationSuite struct {
+	suite.Suite
+}
+
+var testResID = uuid.NewDummy().String()
+
+func (s *HashReconciliationSuite) TestResourceToMessage() {
+	cases := map[string]struct {
+		resType       string
+		expectedMsg   *central.MsgFromSensor_Event
+		expectedError error
+	}{
+		"Pod": {
+			resType:       "Pod",
+			expectedMsg:   &central.MsgFromSensor_Event{Event: &central.SensorEvent{Id: testResID, Action: central.ResourceAction_REMOVE_RESOURCE, Resource: &central.SensorEvent_Pod{Pod: &storage.Pod{Id: testResID}}}},
+			expectedError: nil,
+		},
+		"Deployment": {
+			resType:       "Deployment",
+			expectedMsg:   &central.MsgFromSensor_Event{Event: &central.SensorEvent{Id: testResID, Action: central.ResourceAction_REMOVE_RESOURCE, Resource: &central.SensorEvent_Deployment{Deployment: &storage.Deployment{Id: testResID}}}},
+			expectedError: nil,
+		},
+		"Unknown should throw error": {
+			resType:       "Unknown",
+			expectedMsg:   nil,
+			expectedError: errors.Errorf("Not implemented for resource type Unknown"),
+		},
+	}
+
+	for name, c := range cases {
+		s.T().Run(name, func(t *testing.T) {
+			actual, err := resourceToMessage(c.resType, testResID)
+			if c.expectedError != nil {
+				require.Error(t, err)
+				return
+			}
+			s.Equal(c.expectedMsg, actual.Msg)
+			s.NoError(err)
+		})
+	}
+}

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -88,7 +88,7 @@ type networkPolicyStoreImpl struct {
 // shall be deleted from Central.
 func (n *networkPolicyStoreImpl) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
-	// TODO implement me
+	// TODO(ROX-20073): Implement me
 	return "", errors.New("Not implemented")
 }
 

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stackrox/rox/sensor/common/detector/metrics"
 	"github.com/stackrox/rox/sensor/common/store"
 
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -86,7 +85,7 @@ type networkPolicyStoreImpl struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (n *networkPolicyStoreImpl) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
+func (n *networkPolicyStoreImpl) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"github.com/stackrox/rox/pkg/labels"
-	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/detector/metrics"
 	"github.com/stackrox/rox/sensor/common/store"
@@ -83,7 +82,10 @@ type networkPolicyStoreImpl struct {
 	data map[string]map[string]*storage.NetworkPolicy
 }
 
-func (n *networkPolicyStoreImpl) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+// ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
+// shall be deleted from Central.
+func (n *networkPolicyStoreImpl) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"github.com/stackrox/rox/pkg/labels"
+	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/detector/metrics"
 	"github.com/stackrox/rox/sensor/common/store"
@@ -80,6 +81,12 @@ type networkPolicyStoreImpl struct {
 	lock sync.RWMutex
 	// data: namespace -> result (map: policyID -> policy object ref)
 	data map[string]map[string]*storage.NetworkPolicy
+}
+
+func (n *networkPolicyStoreImpl) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+	_, _, _ = resType, resID, resHash
+	// TODO implement me
+	panic("implement me")
 }
 
 func newNetworkPoliciesStore() *networkPolicyStoreImpl {

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/labels"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/detector/metrics"
@@ -88,7 +89,7 @@ type networkPolicyStoreImpl struct {
 func (n *networkPolicyStoreImpl) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
-	panic("implement me")
+	return "", errors.New("Not implemented")
 }
 
 func newNetworkPoliciesStore() *networkPolicyStoreImpl {

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/detector/metrics"
 	"github.com/stackrox/rox/sensor/common/store"
 
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -85,7 +86,7 @@ type networkPolicyStoreImpl struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (n *networkPolicyStoreImpl) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
+func (n *networkPolicyStoreImpl) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/node_store.go
+++ b/sensor/kubernetes/listener/resources/node_store.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"sort"
 
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/net"
@@ -54,7 +53,7 @@ type nodeStoreImpl struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (s *nodeStoreImpl) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
+func (s *nodeStoreImpl) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/node_store.go
+++ b/sensor/kubernetes/listener/resources/node_store.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/net"
-	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/store"
 	v1 "k8s.io/api/core/v1"
@@ -51,7 +50,10 @@ type nodeStoreImpl struct {
 	nodes map[string]*nodeWrap
 }
 
-func (s *nodeStoreImpl) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+// ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
+// shall be deleted from Central.
+func (s *nodeStoreImpl) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/node_store.go
+++ b/sensor/kubernetes/listener/resources/node_store.go
@@ -56,7 +56,7 @@ type nodeStoreImpl struct {
 // shall be deleted from Central.
 func (s *nodeStoreImpl) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
-	// TODO implement me
+	// TODO(ROX-20072): Implement me
 	return "", errors.New("Not implemented")
 }
 

--- a/sensor/kubernetes/listener/resources/node_store.go
+++ b/sensor/kubernetes/listener/resources/node_store.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"sort"
 
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/net"
@@ -53,7 +54,7 @@ type nodeStoreImpl struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (s *nodeStoreImpl) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
+func (s *nodeStoreImpl) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/node_store.go
+++ b/sensor/kubernetes/listener/resources/node_store.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"sort"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/net"
@@ -56,7 +57,7 @@ type nodeStoreImpl struct {
 func (s *nodeStoreImpl) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
-	panic("implement me")
+	return "", errors.New("Not implemented")
 }
 
 func newNodeStore() *nodeStoreImpl {

--- a/sensor/kubernetes/listener/resources/node_store.go
+++ b/sensor/kubernetes/listener/resources/node_store.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/net"
+	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/store"
 	v1 "k8s.io/api/core/v1"
@@ -48,6 +49,12 @@ var _ store.NodeStore = (*nodeStoreImpl)(nil)
 type nodeStoreImpl struct {
 	mutex sync.RWMutex
 	nodes map[string]*nodeWrap
+}
+
+func (s *nodeStoreImpl) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+	_, _, _ = resType, resID, resHash
+	// TODO implement me
+	panic("implement me")
 }
 
 func newNodeStore() *nodeStoreImpl {

--- a/sensor/kubernetes/listener/resources/pod_store.go
+++ b/sensor/kubernetes/listener/resources/pod_store.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
@@ -16,9 +15,9 @@ type PodStore struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (ps *PodStore) ReconcileDelete(resType, resID string, _ uint64) (*central.MsgFromSensor, error) {
+func (ps *PodStore) ReconcileDelete(resType, resID string, _ uint64) (string, error) {
 	if resType != "Pod" {
-		return nil, nil
+		return "", nil
 	}
 	var pod *storage.Pod
 	for _, p := range ps.GetAll() {
@@ -29,19 +28,10 @@ func (ps *PodStore) ReconcileDelete(resType, resID string, _ uint64) (*central.M
 	}
 	// Resource exists on central but not on Sensor, send delete event
 	if pod == nil {
-		msg := central.MsgFromSensor_Event{
-			Event: &central.SensorEvent{
-				Id:     resID,
-				Action: central.ResourceAction_REMOVE_RESOURCE,
-				Resource: &central.SensorEvent_Pod{
-					Pod: &storage.Pod{Id: resID},
-				},
-			},
-		}
-		return &central.MsgFromSensor{Msg: &msg}, nil
+		return resID, nil
 
 	}
-	return nil, nil
+	return "", nil
 }
 
 // Cleanup deletes all entries from store

--- a/sensor/kubernetes/listener/resources/pod_store.go
+++ b/sensor/kubernetes/listener/resources/pod_store.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/deduper"
 )
 
 // PodStore stores pods (by namespace, deploymentID, and id).
@@ -16,7 +17,7 @@ type PodStore struct {
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
 func (ps *PodStore) ReconcileDelete(resType, resID string, _ uint64) (string, error) {
-	if resType != TypePod.String() {
+	if resType != deduper.TypePod.String() {
 		return "", nil
 	}
 	ps.lock.RLock()

--- a/sensor/kubernetes/listener/resources/pod_store.go
+++ b/sensor/kubernetes/listener/resources/pod_store.go
@@ -16,7 +16,7 @@ type PodStore struct {
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
 func (ps *PodStore) ReconcileDelete(resType, resID string, _ uint64) (string, error) {
-	if resType != "Pod" {
+	if resType != TypePod.String() {
 		return "", nil
 	}
 	var pod *storage.Pod

--- a/sensor/kubernetes/listener/resources/rbac/store.go
+++ b/sensor/kubernetes/listener/resources/rbac/store.go
@@ -2,7 +2,6 @@ package rbac
 
 import (
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/sensor/common/rbac"
 	v1 "k8s.io/api/rbac/v1"
 )
@@ -29,7 +28,7 @@ type Store interface {
 	FindBindingForNamespacedRole(namespace, roleName string) []namespacedBindingID
 
 	Cleanup()
-	Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error)
+	ReconcileDelete(resType, resID string, resHash uint64) ([]string, error)
 }
 
 // NewStore creates a new instance of Store

--- a/sensor/kubernetes/listener/resources/rbac/store.go
+++ b/sensor/kubernetes/listener/resources/rbac/store.go
@@ -2,6 +2,7 @@ package rbac
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/sensor/common/rbac"
 	v1 "k8s.io/api/rbac/v1"
 )
@@ -28,6 +29,7 @@ type Store interface {
 	FindBindingForNamespacedRole(namespace, roleName string) []namespacedBindingID
 
 	Cleanup()
+	Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error)
 }
 
 // NewStore creates a new instance of Store

--- a/sensor/kubernetes/listener/resources/rbac/store.go
+++ b/sensor/kubernetes/listener/resources/rbac/store.go
@@ -1,6 +1,7 @@
 package rbac
 
 import (
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/sensor/common/rbac"
 	v1 "k8s.io/api/rbac/v1"
@@ -28,7 +29,7 @@ type Store interface {
 	FindBindingForNamespacedRole(namespace, roleName string) []namespacedBindingID
 
 	Cleanup()
-	ReconcileDelete(resType, resID string, resHash uint64) ([]string, error)
+	ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error)
 }
 
 // NewStore creates a new instance of Store

--- a/sensor/kubernetes/listener/resources/rbac/store.go
+++ b/sensor/kubernetes/listener/resources/rbac/store.go
@@ -1,7 +1,6 @@
 package rbac
 
 import (
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/sensor/common/rbac"
 	v1 "k8s.io/api/rbac/v1"
@@ -29,7 +28,7 @@ type Store interface {
 	FindBindingForNamespacedRole(namespace, roleName string) []namespacedBindingID
 
 	Cleanup()
-	ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error)
+	ReconcileDelete(resType, resID string, resHash uint64) (string, error)
 }
 
 // NewStore creates a new instance of Store

--- a/sensor/kubernetes/listener/resources/rbac/store_impl.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl.go
@@ -1,7 +1,6 @@
 package rbac
 
 import (
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
@@ -37,7 +36,7 @@ func (rs *storeImpl) Cleanup() {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (rs *storeImpl) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
+func (rs *storeImpl) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/rbac/store_impl.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl.go
@@ -3,6 +3,7 @@ package rbac
 import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/rbac"
 	v1 "k8s.io/api/rbac/v1"
@@ -31,6 +32,14 @@ func (rs *storeImpl) Cleanup() {
 	rs.bucketEvaluator = newBucketEvaluator(nil, nil)
 	rs.roles = make(map[namespacedRoleRef]namespacedRole)
 	rs.bindings = make(map[namespacedBindingID]*namespacedBinding)
+}
+
+// Reconcile is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state.
+func (rs *storeImpl) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+	_, _, _ = resType, resID, resHash
+	// TODO implement me
+	panic("implement me")
 }
 
 func (rs *storeImpl) GetPermissionLevelForDeployment(d rbac.NamespacedServiceAccount) storage.PermissionLevel {

--- a/sensor/kubernetes/listener/resources/rbac/store_impl.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl.go
@@ -3,7 +3,6 @@ package rbac
 import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/rbac"
 	v1 "k8s.io/api/rbac/v1"
@@ -34,9 +33,10 @@ func (rs *storeImpl) Cleanup() {
 	rs.bindings = make(map[namespacedBindingID]*namespacedBinding)
 }
 
-// Reconcile is called after Sensor reconnects with Central and receives its state hashes.
-// Reconciliacion ensures that Sensor and Central have the same state.
-func (rs *storeImpl) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+// ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
+// shall be deleted from Central.
+func (rs *storeImpl) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/rbac/store_impl.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl.go
@@ -1,6 +1,7 @@
 package rbac
 
 import (
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
@@ -39,7 +40,7 @@ func (rs *storeImpl) Cleanup() {
 func (rs *storeImpl) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
-	panic("implement me")
+	return "", errors.New("Not implemented")
 }
 
 func (rs *storeImpl) GetPermissionLevelForDeployment(d rbac.NamespacedServiceAccount) storage.PermissionLevel {

--- a/sensor/kubernetes/listener/resources/rbac/store_impl.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl.go
@@ -1,6 +1,7 @@
 package rbac
 
 import (
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
@@ -36,7 +37,7 @@ func (rs *storeImpl) Cleanup() {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (rs *storeImpl) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
+func (rs *storeImpl) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/service_store.go
+++ b/sensor/kubernetes/listener/resources/service_store.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	routeV1 "github.com/openshift/api/route/v1"
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/selector"
@@ -33,7 +32,7 @@ type serviceStore struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (ss *serviceStore) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
+func (ss *serviceStore) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/service_store.go
+++ b/sensor/kubernetes/listener/resources/service_store.go
@@ -3,6 +3,7 @@ package resources
 import (
 	routeV1 "github.com/openshift/api/route/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/selector"
 	"github.com/stackrox/rox/sensor/common/service"
@@ -27,6 +28,12 @@ type serviceStore struct {
 
 	// Protects all fields
 	lock sync.RWMutex
+}
+
+func (ss *serviceStore) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+	_, _, _ = resType, resID, resHash
+	// TODO implement me
+	panic("implement me")
 }
 
 // newServiceStore creates and returns a new service store.

--- a/sensor/kubernetes/listener/resources/service_store.go
+++ b/sensor/kubernetes/listener/resources/service_store.go
@@ -35,7 +35,7 @@ type serviceStore struct {
 // shall be deleted from Central.
 func (ss *serviceStore) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
-	// TODO implement me
+	// TODO(ROX-20071): Implement me
 	return "", errors.New("Not implemented")
 }
 

--- a/sensor/kubernetes/listener/resources/service_store.go
+++ b/sensor/kubernetes/listener/resources/service_store.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	routeV1 "github.com/openshift/api/route/v1"
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/selector"
@@ -32,7 +33,7 @@ type serviceStore struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (ss *serviceStore) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
+func (ss *serviceStore) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/service_store.go
+++ b/sensor/kubernetes/listener/resources/service_store.go
@@ -3,7 +3,6 @@ package resources
 import (
 	routeV1 "github.com/openshift/api/route/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/selector"
 	"github.com/stackrox/rox/sensor/common/service"
@@ -30,7 +29,10 @@ type serviceStore struct {
 	lock sync.RWMutex
 }
 
-func (ss *serviceStore) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+// ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
+// shall be deleted from Central.
+func (ss *serviceStore) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/service_store.go
+++ b/sensor/kubernetes/listener/resources/service_store.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	routeV1 "github.com/openshift/api/route/v1"
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/selector"
@@ -35,7 +36,7 @@ type serviceStore struct {
 func (ss *serviceStore) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
-	panic("implement me")
+	return "", errors.New("Not implemented")
 }
 
 // newServiceStore creates and returns a new service store.

--- a/sensor/kubernetes/listener/resources/serviceaccount_store.go
+++ b/sensor/kubernetes/listener/resources/serviceaccount_store.go
@@ -21,7 +21,7 @@ type ServiceAccountStore struct {
 // shall be deleted from Central.
 func (sas *ServiceAccountStore) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
-	// TODO implement me
+	// TODO(ROX-20057): Implement me
 	return "", errors.New("Not implemented")
 }
 

--- a/sensor/kubernetes/listener/resources/serviceaccount_store.go
+++ b/sensor/kubernetes/listener/resources/serviceaccount_store.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -19,7 +18,7 @@ type ServiceAccountStore struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (sas *ServiceAccountStore) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
+func (sas *ServiceAccountStore) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/serviceaccount_store.go
+++ b/sensor/kubernetes/listener/resources/serviceaccount_store.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/deduper"
 )
 
 type serviceAccountKey struct {
@@ -21,7 +22,7 @@ type ServiceAccountStore struct {
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
 func (sas *ServiceAccountStore) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
-	if resType != "ServiceAccount" {
+	if resType != deduper.TypeServiceAccount.String() {
 		return "", nil
 	}
 	// Resource exists on central but not on Sensor, send delete event

--- a/sensor/kubernetes/listener/resources/serviceaccount_store.go
+++ b/sensor/kubernetes/listener/resources/serviceaccount_store.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -21,7 +22,7 @@ type ServiceAccountStore struct {
 func (sas *ServiceAccountStore) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
-	panic("implement me")
+	return "", errors.New("Not implemented")
 }
 
 func newServiceAccountStore() *ServiceAccountStore {

--- a/sensor/kubernetes/listener/resources/serviceaccount_store.go
+++ b/sensor/kubernetes/listener/resources/serviceaccount_store.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -18,7 +19,7 @@ type ServiceAccountStore struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (sas *ServiceAccountStore) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
+func (sas *ServiceAccountStore) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/serviceaccount_store.go
+++ b/sensor/kubernetes/listener/resources/serviceaccount_store.go
@@ -21,7 +21,7 @@ type ServiceAccountStore struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (sas *ServiceAccountStore) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
+func (sas *ServiceAccountStore) ReconcileDelete(resType, resID string, _ uint64) (string, error) {
 	if resType != deduper.TypeServiceAccount.String() {
 		return "", nil
 	}

--- a/sensor/kubernetes/listener/resources/serviceaccount_store.go
+++ b/sensor/kubernetes/listener/resources/serviceaccount_store.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -16,9 +15,10 @@ type ServiceAccountStore struct {
 	serviceAccountToPullSecrets map[serviceAccountKey][]string
 }
 
-// Reconcile is called after Sensor reconnects with Central and receives its state hashes.
-// Reconciliacion ensures that Sensor and Central have the same state.
-func (sas *ServiceAccountStore) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+// ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
+// shall be deleted from Central.
+func (sas *ServiceAccountStore) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/listener/resources/serviceaccount_store.go
+++ b/sensor/kubernetes/listener/resources/serviceaccount_store.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -13,6 +14,14 @@ type serviceAccountKey struct {
 type ServiceAccountStore struct {
 	lock                        sync.RWMutex
 	serviceAccountToPullSecrets map[serviceAccountKey][]string
+}
+
+// Reconcile is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state.
+func (sas *ServiceAccountStore) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+	_, _, _ = resType, resID, resHash
+	// TODO implement me
+	panic("implement me")
 }
 
 func newServiceAccountStore() *ServiceAccountStore {

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -78,6 +78,7 @@ func InitializeStore() *InMemoryStoreProvider {
 	}
 	p.reconcilableStores = map[string]reconcile.Reconcilable{
 		"Deployment": p.deploymentStore,
+		"Pod":        p.podStore,
 	}
 
 	return p

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/registrymirror"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
+	"github.com/stackrox/rox/sensor/common/deduper"
 	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
@@ -77,8 +78,8 @@ func InitializeStore() *InMemoryStoreProvider {
 		p.registryMirrorStore,
 	}
 	p.reconcilableStores = map[string]reconcile.Reconcilable{
-		TypeDeployment.String(): p.deploymentStore,
-		TypePod.String():        p.podStore,
+		deduper.TypeDeployment.String(): p.deploymentStore,
+		deduper.TypePod.String():        p.podStore,
 	}
 
 	return p

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -2,10 +2,8 @@ package resources
 
 import (
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/registrymirror"
-	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/common/store"
@@ -147,36 +145,40 @@ func (p *InMemoryStoreProvider) RegistryMirrors() registrymirror.Store {
 	return p.registryMirrorStore
 }
 
-// ProcessHashes orchestrates the sensor-side reconciliation after a reconnect. It returns a slice of resource IDs that
-// should be deleted in Central to keep the state of Sensor and Central in sync.
-func (p *InMemoryStoreProvider) ProcessHashes(h map[string]uint64) []central.MsgFromSensor {
-	events := make([]central.MsgFromSensor, 0)
-	for typeWithID, hashValue := range h {
-		resType, resID := stringutils.Split2(typeWithID, ":")
-		if resID == "" {
-			log.Errorf("malformed hash key: %s", typeWithID)
-			continue
-		}
-		resEvent, err := p.ReconcileDelete(resType, resID, hashValue)
-		if err != nil {
-			log.Errorf("reconciliation error: %s", err)
-		}
-		if resEvent == nil {
-			log.Error("empty reconciliation result")
-			continue
-		}
-
-		events = append(events, *resEvent)
-	}
-	return events
-}
+//// ProcessHashes orchestrates the sensor-side reconciliation after a reconnect. It returns a slice of resource IDs that
+//// should be deleted in Central to keep the state of Sensor and Central in sync.
+// func (p *InMemoryStoreProvider) ProcessHashes(h map[string]uint64) []central.MsgFromSensor {
+//	events := make([]central.MsgFromSensor, 0)
+//	for typeWithID, hashValue := range h {
+//		resType, resID := stringutils.Split2(typeWithID, ":")
+//		if resID == "" {
+//			log.Errorf("malformed hash key: %s", typeWithID)
+//			continue
+//		}
+//		toDeleteID, err := p.ReconcileDelete(resType, resID, hashValue)
+//		if err != nil {
+//			log.Errorf("reconciliation error: %s", err)
+//		}
+//		if toDeleteID == "" {
+//			// Resource was found on Sensor and Central, continue to next item
+//			continue
+//		}
+//		delMsg, err := p.resourceToMessage(resType, toDeleteID)
+//		if err != nil {
+//			log.Errorf("converting resource to MsgFromSensor: %s", err)
+//			continue
+//		}
+//		events = append(events, *delMsg)
+//	}
+//	return events
+//}
 
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
-// Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
+// Reconciliation ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (p *InMemoryStoreProvider) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
+func (p *InMemoryStoreProvider) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	if resStore, found := p.reconcilableStores[resType]; found {
 		return resStore.ReconcileDelete(resType, resID, resHash)
 	}
-	return nil, errors.Wrapf(errUnableToReconcile, "Don't know how to reconcile resource type %q", resType)
+	return "", errors.Wrapf(errUnableToReconcile, "Don't know how to reconcile resource type %q", resType)
 }

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -77,8 +77,8 @@ func InitializeStore() *InMemoryStoreProvider {
 		p.registryMirrorStore,
 	}
 	p.reconcilableStores = map[string]reconcile.Reconcilable{
-		"Deployment": p.deploymentStore,
-		"Pod":        p.podStore,
+		TypeDeployment.String(): p.deploymentStore,
+		TypePod.String():        p.podStore,
 	}
 
 	return p

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -78,8 +78,9 @@ func InitializeStore() *InMemoryStoreProvider {
 		p.registryMirrorStore,
 	}
 	p.reconcilableStores = map[string]reconcile.Reconcilable{
-		deduper.TypeDeployment.String(): p.deploymentStore,
-		deduper.TypePod.String():        p.podStore,
+		deduper.TypeDeployment.String():     p.deploymentStore,
+		deduper.TypePod.String():            p.podStore,
+		deduper.TypeServiceAccount.String(): p.serviceAccountStore,
 	}
 
 	return p

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -145,34 +145,6 @@ func (p *InMemoryStoreProvider) RegistryMirrors() registrymirror.Store {
 	return p.registryMirrorStore
 }
 
-//// ProcessHashes orchestrates the sensor-side reconciliation after a reconnect. It returns a slice of resource IDs that
-//// should be deleted in Central to keep the state of Sensor and Central in sync.
-// func (p *InMemoryStoreProvider) ProcessHashes(h map[string]uint64) []central.MsgFromSensor {
-//	events := make([]central.MsgFromSensor, 0)
-//	for typeWithID, hashValue := range h {
-//		resType, resID := stringutils.Split2(typeWithID, ":")
-//		if resID == "" {
-//			log.Errorf("malformed hash key: %s", typeWithID)
-//			continue
-//		}
-//		toDeleteID, err := p.ReconcileDelete(resType, resID, hashValue)
-//		if err != nil {
-//			log.Errorf("reconciliation error: %s", err)
-//		}
-//		if toDeleteID == "" {
-//			// Resource was found on Sensor and Central, continue to next item
-//			continue
-//		}
-//		delMsg, err := p.resourceToMessage(resType, toDeleteID)
-//		if err != nil {
-//			log.Errorf("converting resource to MsgFromSensor: %s", err)
-//			continue
-//		}
-//		events = append(events, *delMsg)
-//	}
-//	return events
-//}
-
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliation ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.

--- a/sensor/kubernetes/orchestratornamespaces/store.go
+++ b/sensor/kubernetes/orchestratornamespaces/store.go
@@ -1,7 +1,6 @@
 package orchestratornamespaces
 
 import (
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
@@ -16,7 +15,7 @@ type OrchestratorNamespaces struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (n *OrchestratorNamespaces) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
+func (n *OrchestratorNamespaces) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/orchestratornamespaces/store.go
+++ b/sensor/kubernetes/orchestratornamespaces/store.go
@@ -2,6 +2,7 @@ package orchestratornamespaces
 
 import (
 	"github.com/stackrox/rox/pkg/kubernetes"
+	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -10,6 +11,14 @@ import (
 type OrchestratorNamespaces struct {
 	nsSet set.StringSet
 	lock  sync.RWMutex
+}
+
+// Reconcile is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state.
+func (n *OrchestratorNamespaces) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+	_, _, _ = resType, resID, resHash
+	// TODO implement me
+	panic("implement me")
 }
 
 // NewOrchestratorNamespaces returns a new OrchestratorNamespaces store

--- a/sensor/kubernetes/orchestratornamespaces/store.go
+++ b/sensor/kubernetes/orchestratornamespaces/store.go
@@ -2,7 +2,6 @@ package orchestratornamespaces
 
 import (
 	"github.com/stackrox/rox/pkg/kubernetes"
-	"github.com/stackrox/rox/pkg/reconcile"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -13,9 +12,10 @@ type OrchestratorNamespaces struct {
 	lock  sync.RWMutex
 }
 
-// Reconcile is called after Sensor reconnects with Central and receives its state hashes.
-// Reconciliacion ensures that Sensor and Central have the same state.
-func (n *OrchestratorNamespaces) Reconcile(resType, resID string, resHash uint64) (map[string]reconcile.SensorReconciliationEvent, error) {
+// ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
+// Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
+// shall be deleted from Central.
+func (n *OrchestratorNamespaces) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/orchestratornamespaces/store.go
+++ b/sensor/kubernetes/orchestratornamespaces/store.go
@@ -1,6 +1,7 @@
 package orchestratornamespaces
 
 import (
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
@@ -15,7 +16,7 @@ type OrchestratorNamespaces struct {
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (n *OrchestratorNamespaces) ReconcileDelete(resType, resID string, resHash uint64) ([]string, error) {
+func (n *OrchestratorNamespaces) ReconcileDelete(resType, resID string, resHash uint64) (*central.MsgFromSensor, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
 	panic("implement me")

--- a/sensor/kubernetes/orchestratornamespaces/store.go
+++ b/sensor/kubernetes/orchestratornamespaces/store.go
@@ -1,6 +1,7 @@
 package orchestratornamespaces
 
 import (
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
@@ -18,7 +19,7 @@ type OrchestratorNamespaces struct {
 func (n *OrchestratorNamespaces) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	_, _, _ = resType, resID, resHash
 	// TODO implement me
-	panic("implement me")
+	return "", errors.New("Not implemented")
 }
 
 // NewOrchestratorNamespaces returns a new OrchestratorNamespaces store

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -67,6 +67,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	}
 
 	storeProvider := resources.InitializeStore()
+	hashReconciliator := resources.NewInMemoryStoreReconciler(storeProvider)
 
 	admCtrlSettingsMgr := admissioncontroller.NewSettingsManager(storeProvider.Deployments(), storeProvider.Pods())
 
@@ -202,6 +203,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		policyDetector,
 		imageService,
 		cfg.centralConnFactory,
+		hashReconciliator,
 		components...,
 	)
 

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -67,7 +67,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	}
 
 	storeProvider := resources.InitializeStore()
-	hashReconciliator := resources.NewInMemoryStoreReconciler(storeProvider)
+	hashReconciliator := resources.NewResourceStoreReconciler(storeProvider)
 
 	admCtrlSettingsMgr := admissioncontroller.NewSettingsManager(storeProvider.Deployments(), storeProvider.Pods())
 


### PR DESCRIPTION
## Description

⚠️  **This PR is based on #7981 which needs to be merged first** ⚠️ 
This PR adds the implementation for `ReconcileDelete` for the ServiceAccount Store.
As the SAS doesn't expose direct access to IDs, I have added a `StringSet` which tracks Add/Delete operations and is wiped on Clean.
For this PR, the most important commits to review are 3d5ad919599214e749f2569b7ee7dbb417362849 for the implementation and 59185d57deffcba0f42dfb9a5d385e1afc17bb18 for tests.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
As this code is currently not called by our production code, I rely on the added unit tests in `hash_reconciliation_test.go`.


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
