### PR TITLE
ROX-19670: add timeout when waiting for the DeduperState

### DIFF
--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -48,4 +48,7 @@ var (
 	// This is meant to be a 'kill switch' that allows for local scanning to continue (ie: for OCP internal repos)
 	// in the event the delegated scanning capabilities are causing unforeseen issues.
 	DelegatedScanningDisabled = RegisterBooleanSetting("ROX_DELEGATED_SCANNING_DISABLED", false)
+
+	// DeduperStateSyncTimeout defines the maximum time Sensor will wait for the expected deduper state coming from Central
+	DeduperStateSyncTimeout = registerDurationSetting("ROX_DEDUPER_STATE_TIMEOUT", 30*time.Second)
 )

--- a/sensor/common/sensor/central_communication.go
+++ b/sensor/common/sensor/central_communication.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
-
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"

--- a/sensor/common/sensor/central_communication.go
+++ b/sensor/common/sensor/central_communication.go
@@ -1,10 +1,9 @@
 package sensor
 
 import (
-	"time"
-
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/config"
@@ -30,6 +29,6 @@ func NewCentralCommunication(reconnect bool, clientReconcile bool, components ..
 		stopper:         concurrency.NewStopper(),
 		isReconnect:     reconnect,
 		clientReconcile: clientReconcile,
-		syncTimeout:     10 * time.Second,
+		syncTimeout:     env.DeduperStateSyncTimeout.DurationSetting(),
 	}
 }

--- a/sensor/common/sensor/central_communication.go
+++ b/sensor/common/sensor/central_communication.go
@@ -1,7 +1,10 @@
 package sensor
 
 import (
+	"time"
+
 	"github.com/stackrox/rox/generated/internalapi/central"
+
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
@@ -28,5 +31,6 @@ func NewCentralCommunication(reconnect bool, clientReconcile bool, components ..
 		stopper:         concurrency.NewStopper(),
 		isReconnect:     reconnect,
 		clientReconcile: clientReconcile,
+		syncTimeout:     10 * time.Second,
 	}
 }

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -51,7 +51,8 @@ type centralCommunicationImpl struct {
 }
 
 var (
-	errCantReconcile                 = errors.New("unable to reconcile due to deduper payload too large")
+	errCantReconcile                 = errors.New("unable to reconcile")
+	errLargePayload                  = errors.Wrap(errCantReconcile, "deduper payload too large")
 	errTimeoutWaitingForDeduperState = errors.Wrap(errCantReconcile, "timeout reached while waiting for the DeduperState")
 )
 
@@ -289,7 +290,7 @@ func (s *centralCommunicationImpl) initialDeduperSync(stream central.SensorServi
 	if err != nil {
 		if e, ok := status.FromError(err); ok {
 			if e.Code() == codes.ResourceExhausted {
-				return errors.Wrap(errCantReconcile, e.String())
+				return errors.Wrap(errLargePayload, e.String())
 			}
 		}
 		return errors.Wrap(err, "receiving initial deduper sync")

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -52,7 +52,7 @@ type centralCommunicationImpl struct {
 
 var (
 	errCantReconcile                 = errors.New("unable to reconcile due to deduper payload too large")
-	errTimeoutWaitingForDeduperState = errors.Wrapf(errCantReconcile, "timeout reached while waiting for the DeduperState")
+	errTimeoutWaitingForDeduperState = errors.Wrap(errCantReconcile, "timeout reached while waiting for the DeduperState")
 )
 
 func (s *centralCommunicationImpl) Start(client central.SensorServiceClient, centralReachable *concurrency.Flag, configHandler config.Handler, detector detector.Detector) {

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -2,6 +2,7 @@ package sensor
 
 import (
 	"context"
+	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/pkg/errors"
@@ -39,6 +40,7 @@ type centralCommunicationImpl struct {
 	components          []common.SensorComponent
 	clientReconcile     bool
 	initialDeduperState map[deduper.Key]uint64
+	syncTimeout         time.Duration
 
 	stopper concurrency.Stopper
 
@@ -49,7 +51,8 @@ type centralCommunicationImpl struct {
 }
 
 var (
-	errCantReconcile = errors.New("unable to reconcile due to deduper payload too large")
+	errCantReconcile                 = errors.New("unable to reconcile due to deduper payload too large")
+	errTimeoutWaitingForDeduperState = errors.Wrapf(errCantReconcile, "timeout reached while waiting for the DeduperState")
 )
 
 func (s *centralCommunicationImpl) Start(client central.SensorServiceClient, centralReachable *concurrency.Flag, configHandler config.Handler, detector detector.Detector) {
@@ -270,7 +273,19 @@ func (s *centralCommunicationImpl) initialDeduperSync(stream central.SensorServi
 	}
 	log.Info("Waiting for deduper state from Central")
 
-	msg, err := stream.Recv()
+	done := make(chan struct{})
+	var err error
+	var msg *central.MsgToSensor
+	go func() {
+		msg, err = stream.Recv()
+		close(done)
+	}()
+	select {
+	case <-time.After(s.syncTimeout):
+		return errTimeoutWaitingForDeduperState
+	case <-done:
+		break
+	}
 	if err != nil {
 		if e, ok := status.FromError(err); ok {
 			if e.Code() == codes.ResourceExhausted {

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -220,7 +220,7 @@ func (c *centralCommunicationSuite) Test_TimeoutWaitingForDeduperState() {
 	reachable := concurrency.Flag{}
 	c.comm.(*centralCommunicationImpl).syncTimeout = 10 * time.Millisecond
 	// Start the go routine with the mocked client
-	go c.comm.(*centralCommunicationImpl).sendEvents(c.mockService, &reachable, c.mockHandler, c.mockDetector, c.comm.(*centralCommunicationImpl).receiver.Stop, c.comm.(*centralCommunicationImpl).sender.Stop)
+	c.comm.Start(c.mockService, &reachable, c.mockHandler, c.mockDetector)
 	c.mockService.connected.Wait()
 
 	select {

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -88,7 +88,7 @@ var centralSyncMessages = []*central.MsgToSensor{
 func (c *centralCommunicationSuite) Test_StartCentralCommunication() {
 	responsesC, closeFn := c.createCentralCommunication(false)
 	defer closeFn()
-	expectSyncMessages(centralSyncMessages, c.mockService)
+	expectSyncMessagesNoBlockRecv(centralSyncMessages, c.mockService)
 	ch := make(chan struct{})
 	c.mockService.client.EXPECT().Send(gomock.Any()).Times(1).DoAndReturn(func(msg *central.MsgFromSensor) error {
 		defer close(ch)
@@ -114,7 +114,7 @@ func (c *centralCommunicationSuite) Test_StartCentralCommunication() {
 func (c *centralCommunicationSuite) Test_StopCentralCommunication() {
 	_, closeFn := c.createCentralCommunication(false)
 	defer closeFn()
-	expectSyncMessages(centralSyncMessages, c.mockService)
+	expectSyncMessagesNoBlockRecv(centralSyncMessages, c.mockService)
 	ch := make(chan struct{})
 	c.mockService.client.EXPECT().CloseSend().Times(1).DoAndReturn(func() error {
 		defer close(ch)
@@ -183,7 +183,7 @@ func (c *centralCommunicationSuite) Test_ClientReconciliation() {
 			responsesC, closeFn := c.createCentralCommunication(true)
 			defer closeFn()
 			syncMessages := append(centralSyncMessages, debuggerMessage.DeduperState(tc.deduperState))
-			expectSyncMessages(syncMessages, c.mockService)
+			expectSyncMessagesNoBlockRecv(syncMessages, c.mockService)
 
 			c.mockService.client.EXPECT().Send(tc.expectedMessages).Times(len(tc.expectedMessages.messagesToMatch))
 			c.mockService.client.EXPECT().CloseSend().AnyTimes()
@@ -210,7 +210,7 @@ func (c *centralCommunicationSuite) Test_ClientReconciliation() {
 func (c *centralCommunicationSuite) Test_TimeoutWaitingForDeduperState() {
 	_, closeFn := c.createCentralCommunication(true)
 	defer closeFn()
-	expectSyncMessages(centralSyncMessages, c.mockService)
+	recvSignal := expectSyncMessages(centralSyncMessages, true, c.mockService)
 	ch := make(chan struct{})
 	c.mockService.client.EXPECT().CloseSend().Times(1).DoAndReturn(func() error {
 		defer close(ch)
@@ -218,16 +218,19 @@ func (c *centralCommunicationSuite) Test_TimeoutWaitingForDeduperState() {
 	})
 
 	reachable := concurrency.Flag{}
+	c.comm.(*centralCommunicationImpl).syncTimeout = 10 * time.Millisecond
 	// Start the go routine with the mocked client
 	go c.comm.(*centralCommunicationImpl).sendEvents(c.mockService, &reachable, c.mockHandler, c.mockDetector, c.comm.(*centralCommunicationImpl).receiver.Stop, c.comm.(*centralCommunicationImpl).sender.Stop)
 	c.mockService.connected.Wait()
 
 	select {
 	case <-ch:
+		c.Assert().ErrorIs(c.comm.Stopped().Err(), errTimeoutWaitingForDeduperState)
 		break
 	case <-time.After(5 * time.Second):
 		c.Fail("timeout reached waiting for the connection to timeout if the deduper state is not received")
 	}
+	recvSignal.Signal()
 }
 
 type messagesMatcher struct {
@@ -294,7 +297,12 @@ func (c *centralCommunicationSuite) createCentralCommunication(clientReconcile b
 	return ret, func() { close(ret) }
 }
 
-func expectSyncMessages(messages []*central.MsgToSensor, service *MockSensorServiceClient) {
+func expectSyncMessagesNoBlockRecv(messages []*central.MsgToSensor, service *MockSensorServiceClient) {
+	_ = expectSyncMessages(messages, false, service)
+}
+
+func expectSyncMessages(messages []*central.MsgToSensor, blockRecv bool, service *MockSensorServiceClient) concurrency.Signal {
+	signal := concurrency.NewSignal()
 	md := metadata.MD{
 		strings.ToLower(centralsensor.SensorHelloMetadataKey): []string{"true"},
 	}
@@ -305,8 +313,17 @@ func expectSyncMessages(messages []*central.MsgToSensor, service *MockSensorServ
 	for _, m := range messages {
 		orderedCalls = append(orderedCalls, service.client.EXPECT().Recv().Times(1).Return(m, nil))
 	}
-	orderedCalls = append(orderedCalls, service.client.EXPECT().Recv().AnyTimes())
+	if !blockRecv {
+		orderedCalls = append(orderedCalls, service.client.EXPECT().Recv().AnyTimes())
+	} else {
+		orderedCalls = append(orderedCalls, service.client.EXPECT().Recv().AnyTimes().DoAndReturn(func() (*central.MsgToSensor, error) {
+			// This will block the Recv() calls until the signal is triggered. Otherwise, we process constantly Recv()
+			signal.Wait()
+			return nil, nil
+		}))
+	}
 	gomock.InOrder(orderedCalls...)
+	return signal
 }
 
 func deploymentKey(id string) string {

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -389,8 +389,12 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 		case <-s.centralCommunication.Stopped().WaitC():
 			if err := s.centralCommunication.Stopped().Err(); err != nil {
 				if errors.Is(err, errCantReconcile) {
-					log.Warnf("Deduper payload is too large for sensor to handle. Sensor will reconnect without client reconciliation." +
-						"Consider increasing the maximum receive message size in sensor 'ROX_GRPC_MAX_MESSAGE_SIZE'")
+					if errors.Is(err, errLargePayload) {
+						log.Warnf("Deduper payload is too large for sensor to handle. Sensor will reconnect without client reconciliation." +
+							"Consider increasing the maximum receive message size in sensor 'ROX_GRPC_MAX_MESSAGE_SIZE'")
+					} else {
+						log.Warnf("Sensor cannot reconcile due to: %v", err)
+					}
 					s.reconcile.Store(false)
 				}
 				log.Infof("Communication with Central stopped with error: %s. Retrying.", err)


### PR DESCRIPTION
## Description

We now timeout if the `DeduperState` is not received after a while. Timing-out falls back into the old behavior, so central will do the reconciliation in the next retry.

Depends on:

* #8084 (for the unit tests refactors)

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

* [x] Unit tests added
* [x] CI
* [x] Manual test:
  * Deploy ACS and scale sensor to 0
  * Use local-sensor with a modify timeout of 10 nanoseconds
  * See sensor timing out waiting for the deduper state and then reconnecting with `reconciliation = false`:
```
[...]
common/sensor: 2023/10/16 12:17:21.899534 sensor.go:258: Info: Running Sensor with connection retry: preventing sensor restart on disconnect
common/sensor: 2023/10/16 12:17:21.899594 sensor.go:370: Info: Attempting connection setup (client reconciliation = true)
[...]
common/sensor: 2023/10/16 12:17:22.547110 central_communication_impl.go:144: Info: Sensor is capable of doing client reconciliation
[...]
common/sensor: 2023/10/16 12:17:23.464128 central_communication_impl.go:275: Info: Waiting for deduper state from Central
common/sensor: 2023/10/16 12:17:23.464254 sensor.go:396: Warn: Sensor cannot reconcile due to: timeout reached while waiting for the DeduperState: unable to reconcile
common/sensor: 2023/10/16 12:17:23.464349 sensor.go:400: Info: Communication with Central stopped with error: timeout reached while waiting for the DeduperState: unable to reconcile. Retrying.
common/sensor: 2023/10/16 12:17:23.464360 sensor.go:336: Info: Updating Sensor State to: offline-mode
[...]
common/sensor: 2023/10/16 12:17:37.933754 sensor.go:370: Info: Attempting connection setup (client reconciliation = false)
[...]
common/sensor: 2023/10/16 12:17:37.934340 central_communication_impl.go:147: Info: Sensor has client reconciliation disabled
[...]
common/sensor: 2023/10/16 12:17:38.343460 central_communication_impl.go:196: Info: Communication with central started.
kubernetes/listener: 2023/10/16 12:17:38.460187 resource_event_handler.go:206: Info: Successfully synced role bindings
kubernetes/listener: 2023/10/16 12:17:38.460237 resource_event_handler.go:216: Info: Successfully synced k8s pod cache
kubernetes/listener: 2023/10/16 12:17:38.661504 resource_event_handler.go:246: Info: Successfully synced network policies, nodes, services, jobs, replica sets, and replication controllers
common/config: 2023/10/16 12:17:38.788522 handler.go:78: Info: Received audit log sync state from Central: {
  "nodeAuditLogFileStates": {
  }
}
kubernetes/listener: 2023/10/16 12:17:38.989786 resource_event_handler.go:271: Info: Successfully synced daemonsets, deployments, stateful sets and cronjobs
kubernetes/listener: 2023/10/16 12:17:39.012766 resource_event_handler.go:280: Info: Successfully synced pods
common/sensor: 2023/10/16 12:17:39.015540 central_sender_impl.go:110: Info: Sending synced signal to Central
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
