### PR TITLE
fix(ci): catch errors on sending to slack

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1313,7 +1313,7 @@ __EOM__
       "$body")"
     echo -e "About to post:\n$payload"
 
-    echo "$payload" | curl -XPOST -d @- -H 'Content-Type: application/json' "$webhook_url" || {
+    echo "$payload" | curl --location --silent --show-error --fail --data @- --header 'Content-Type: application/json' "$webhook_url" || {
         slack_error "Error posting to Slack"
         return 1
     }


### PR DESCRIPTION
## Description

`curl` does not return an error when server return non 200 OK.
This PR adds flags that should make curl reporting this kinds of errors.
Example: https://storage.googleapis.com/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-ocp-4-10-merge-ui-e2e-tests/1704350553095540736/build-log.txt

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

I've created invalid slack message in `payload.json`.
```bash
cat payload.json | curl -XPOST -d @- -H 'Content-Type: application/json' "$webhook_url"
# invalid_attachments% 
echo $?                                                                                
# 0
cat payload.json | curl -sSfl -XPOST -d @- -H 'Content-Type: application/json' "$webhook_url" 
# curl: (22) The requested URL returned error: 400
echo $?                                                                                      
# 22
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
