### PR TITLE
ROX-20089: Make changes from design review of administration events

### DIFF
--- a/ui/apps/platform/cypress/integration/administration/events/eventsTable.test.js
+++ b/ui/apps/platform/cypress/integration/administration/events/eventsTable.test.js
@@ -66,7 +66,7 @@ describe('Administration Events table', () => {
         cy.get('th:contains("Domain")');
         cy.get('th:contains("Resource type")');
         cy.get('th:contains("Level")');
-        cy.get('th:contains("Event last occurred at")');
+        cy.get('th:contains("Last occurred")');
         cy.get('th:contains("Count")');
     });
 
@@ -80,8 +80,8 @@ describe('Administration Events table', () => {
         // TODO assert absence of 'Resource ID'
         assertDescriptionListGroup('Event type', 'Log');
         assertDescriptionListGroup('Event ID', event.id);
-        assertDescriptionListGroup('Created at', event.createdAt);
-        assertDescriptionListGroup('Last occurred at', event.lastOccurredAt);
+        assertDescriptionListGroup('Created', event.createdAt);
+        assertDescriptionListGroup('Last occurred', event.lastOccurredAt);
         assertDescriptionListGroup('Count', event.numOccurrences);
     });
 });

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventDescription.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventDescription.tsx
@@ -59,11 +59,11 @@ function AdministrationEventDescription({
                     <DescriptionListDescription>{id}</DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
-                    <DescriptionListTerm>Created at</DescriptionListTerm>
+                    <DescriptionListTerm>Created</DescriptionListTerm>
                     <DescriptionListDescription>{createdAt}</DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
-                    <DescriptionListTerm>Last occurred at</DescriptionListTerm>
+                    <DescriptionListTerm>Last occurred</DescriptionListTerm>
                     <DescriptionListDescription>{lastOccurredAt}</DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventHint.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventHint.tsx
@@ -47,7 +47,7 @@ function AdministrationEventHint({ hint }: AdministrationEventHintProps): ReactE
                             </ListItem>
                         ))}
                     </List>
-                ) : lineOrList.length === 0 ? (
+                ) : lineOrList === '' ? (
                     <br key={lineOrListIndex} />
                 ) : (
                     <Text key={lineOrListIndex}>{lineOrList}</Text>

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventHint.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventHint.tsx
@@ -1,6 +1,12 @@
 import React, { ReactElement } from 'react';
 import { List, ListItem, Text } from '@patternfly/react-core';
 
+/*
+ * Split hint string for conditional rendering in component:
+ * Return adjacent lines which start with hyphen space as array for bulleted list.
+ * Return other lines as string for br element if empty else paragraph.
+ */
+
 const listItemRegExp = /^- /;
 
 type LineOrList = string | string[];
@@ -36,6 +42,7 @@ export type AdministrationEventHintProps = {
 function AdministrationEventHint({ hint }: AdministrationEventHintProps): ReactElement {
     /* eslint-disable no-nested-ternary */
     /* eslint-disable react/no-array-index-key */
+    // Remove default PatternFly margin-top for li + li to conserve vertical space.
     return (
         <div>
             {splitHint(hint).map((lineOrList, lineOrListIndex) =>

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventHint.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventHint.tsx
@@ -1,0 +1,62 @@
+import React, { ReactElement } from 'react';
+import { List, ListItem, Text } from '@patternfly/react-core';
+
+const listItemRegExp = /^- /;
+
+type LineOrList = string | string[];
+
+function splitHint(hint: string): LineOrList[] {
+    const lineOrListArray: LineOrList[] = [];
+    const listItemArray: string[] = [];
+
+    function pushListItems() {
+        if (listItemArray.length !== 0) {
+            lineOrListArray.push([...listItemArray]);
+            listItemArray.length = 0;
+        }
+    }
+
+    hint.split('\n').forEach((line) => {
+        if (listItemRegExp.test(line)) {
+            listItemArray.push(line.slice(2));
+        } else {
+            pushListItems();
+            lineOrListArray.push(line);
+        }
+    });
+    pushListItems();
+
+    return lineOrListArray;
+}
+
+export type AdministrationEventHintProps = {
+    hint: string;
+};
+
+function AdministrationEventHint({ hint }: AdministrationEventHintProps): ReactElement {
+    /* eslint-disable no-nested-ternary */
+    /* eslint-disable react/no-array-index-key */
+    return (
+        <div>
+            {splitHint(hint).map((lineOrList, lineOrListIndex) =>
+                Array.isArray(lineOrList) ? (
+                    <List key={lineOrListIndex}>
+                        {lineOrList.map((listItem, listItemIndex) => (
+                            <ListItem key={listItemIndex} className="pf-u-mt-0">
+                                {listItem}
+                            </ListItem>
+                        ))}
+                    </List>
+                ) : lineOrList.length === 0 ? (
+                    <br key={lineOrListIndex} />
+                ) : (
+                    <Text key={lineOrListIndex}>{lineOrList}</Text>
+                )
+            )}
+        </div>
+    );
+    /* eslint-enable react/no-array-index-key */
+    /* eslint-enable no-nested-ternary */
+}
+
+export default AdministrationEventHint;

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventHintMessage.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventHintMessage.tsx
@@ -3,6 +3,8 @@ import { CodeBlock, Flex } from '@patternfly/react-core';
 
 import { AdministrationEvent } from 'services/AdministrationEventsService';
 
+import AdministrationEventHint from './AdministrationEventHint';
+
 export type AdministrationEventHintMessageProps = {
     event: AdministrationEvent;
 };
@@ -14,13 +16,7 @@ function AdministrationEventHintMessage({
 
     return (
         <Flex direction={{ default: 'column' }}>
-            {hint && (
-                <div>
-                    {hint.split('\n').map((line) => (
-                        <p key={line}>{line}</p>
-                    ))}
-                </div>
-            )}
+            {hint && <AdministrationEventHint hint={hint} />}
             <CodeBlock>{message}</CodeBlock>
         </Flex>
     );

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventPage.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventPage.tsx
@@ -4,6 +4,7 @@ import {
     Breadcrumb,
     BreadcrumbItem,
     Bullseye,
+    Divider,
     Flex,
     PageSection,
     Spinner,
@@ -50,33 +51,34 @@ function AdministrationEventPage({ id }: AdministrationEventPageProps): ReactEle
         <>
             <PageTitle title={`Administration events - ${h1}`} />
             <PageSection component="div" variant="light">
-                <Flex direction={{ default: 'column' }}>
-                    <Breadcrumb>
-                        <BreadcrumbItemLink to={administrationEventsBasePath}>
-                            Administration events
-                        </BreadcrumbItemLink>
-                        <BreadcrumbItem>{h1}</BreadcrumbItem>
-                    </Breadcrumb>
-                    <Title headingLevel="h1">{h1}</Title>
+                <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXl' }}>
+                    <Flex direction={{ default: 'column' }}>
+                        <Breadcrumb>
+                            <BreadcrumbItemLink to={administrationEventsBasePath}>
+                                Administration events
+                            </BreadcrumbItemLink>
+                            <BreadcrumbItem>{h1}</BreadcrumbItem>
+                        </Breadcrumb>
+                        <Divider component="div" />
+                        <Title headingLevel="h1">{h1}</Title>
+                    </Flex>
+                    {isLoading ? (
+                        <Bullseye>
+                            <Spinner isSVG />
+                        </Bullseye>
+                    ) : errorMessage ? (
+                        <Alert
+                            variant="warning"
+                            title="Unable to fetch administration event"
+                            component="div"
+                            isInline
+                        >
+                            {errorMessage}
+                        </Alert>
+                    ) : event ? (
+                        <AdministrationEventDescription event={event} />
+                    ) : null}
                 </Flex>
-            </PageSection>
-            <PageSection component="div" variant="light">
-                {isLoading ? (
-                    <Bullseye>
-                        <Spinner isSVG />
-                    </Bullseye>
-                ) : errorMessage ? (
-                    <Alert
-                        variant="warning"
-                        title="Unable to fetch administration event"
-                        component="div"
-                        isInline
-                    >
-                        {errorMessage}
-                    </Alert>
-                ) : event ? (
-                    <AdministrationEventDescription event={event} />
-                ) : null}
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsEmptyState.tsx
@@ -27,7 +27,7 @@ function AdministrationEventsEmptyState({
                     <Bullseye>
                         {hasFilter ? (
                             <EmptyState>
-                                {hasFilter && <EmptyStateIcon icon={SearchIcon} />}
+                                <EmptyStateIcon icon={SearchIcon} />
                                 <EmptyStateBody>
                                     <Flex direction={{ default: 'column' }}>
                                         <Title headingLevel="h2">

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsEmptyState.tsx
@@ -1,6 +1,14 @@
 import React, { ReactElement } from 'react';
-import { Bullseye, EmptyState, EmptyStateBody, EmptyStateIcon } from '@patternfly/react-core';
-import { FilterIcon } from '@patternfly/react-icons';
+import {
+    Bullseye,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateIcon,
+    Flex,
+    Text,
+    Title,
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
 import { Tbody, Td, Tr } from '@patternfly/react-table';
 
 export type AdministrationEventsEmptyStateProps = {
@@ -17,12 +25,25 @@ function AdministrationEventsEmptyState({
             <Tr>
                 <Td colSpan={colSpan}>
                     <Bullseye>
-                        <EmptyState>
-                            {hasFilter && <EmptyStateIcon icon={FilterIcon} />}
-                            <EmptyStateBody>
-                                {hasFilter ? 'No events found' : 'No events'}
-                            </EmptyStateBody>
-                        </EmptyState>
+                        {hasFilter ? (
+                            <EmptyState>
+                                {hasFilter && <EmptyStateIcon icon={SearchIcon} />}
+                                <EmptyStateBody>
+                                    <Flex direction={{ default: 'column' }}>
+                                        <Title headingLevel="h2">
+                                            No administration events found
+                                        </Title>
+                                        <Text>Modify filters and try again</Text>
+                                    </Flex>
+                                </EmptyStateBody>
+                            </EmptyState>
+                        ) : (
+                            <EmptyState>
+                                <EmptyStateBody>
+                                    <Title headingLevel="h2">No administration events</Title>
+                                </EmptyStateBody>
+                            </EmptyState>
+                        )}
                     </Bullseye>
                 </Td>
             </Tr>

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.css
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.css
@@ -1,8 +1,0 @@
-/*
- * With sort button, count column head needs more than pf-u-text-align-right utility class
- * to align at right for numeric data.
- */
-#AdministrationEventsTable th:last-child button.pf-c-table__button {
-    margin-left: auto;
-    padding-right: 0;
-}

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
@@ -23,10 +23,9 @@ import { SearchFilter } from 'types/search';
 import { getLevelIcon, getLevelText } from './AdministrationEvent';
 import AdministrationEventHintMessage from './AdministrationEventHintMessage';
 
-import './AdministrationEventsTable.css';
 import AdministrationEventsEmptyState from './AdministrationEventsEmptyState';
 
-const colSpan = 6;
+const colSpan = 5;
 
 export type AdministrationEventsTableProps = {
     events: AdministrationEvent[];
@@ -40,13 +39,13 @@ function AdministrationEventsTable({
     searchFilter,
 }: AdministrationEventsTableProps): ReactElement {
     return (
-        <TableComposable variant="compact" borders={false} id="AdministrationEventsTable">
+        <TableComposable variant="compact" borders={false}>
             <Thead>
                 <Tr>
                     <Th>Domain</Th>
                     <Th modifier="nowrap">Resource type</Th>
                     <Th>Level</Th>
-                    <Th sort={getSortParams(lastOccurredAtField)}>Event last occurred at</Th>
+                    <Th sort={getSortParams(lastOccurredAtField)}>Last occurred</Th>
                     <Th sort={getSortParams(numOccurrencesField)}>Count</Th>
                 </Tr>
             </Thead>
@@ -81,12 +80,10 @@ function AdministrationEventsTable({
                                         text={getLevelText(level)}
                                     />
                                 </Td>
-                                <Td dataLabel="Event last occurred at" modifier="nowrap">
+                                <Td dataLabel="Last occurred" modifier="nowrap">
                                     {lastOccurredAt}
                                 </Td>
-                                <Td dataLabel="Count" className="pf-u-text-align-right">
-                                    {numOccurrences}
-                                </Td>
+                                <Td dataLabel="Count">{numOccurrences}</Td>
                             </Tr>
                             <Tr>
                                 <Td colSpan={colSpan}>

--- a/ui/apps/platform/src/services/AdministrationEventsService.ts
+++ b/ui/apps/platform/src/services/AdministrationEventsService.ts
@@ -203,7 +203,7 @@ function getDateTime(arg: SearchFilterValue): string | undefined {
 
 // 20yy-mm-ddThh:mm:ssZ (excludes some but not all invalid month-day combinations).
 const isDateTimeRegExp =
-    /^20\d\d-(?:0\d|1[012])-(?:0[123456789]|1\d|2\d|3[01])T(?:0\d|1\d|2[0123]):[012345]\d:\d\d$/;
+    /^20\d\d-(?:0\d|1[012])-(?:0[123456789]|1\d|2\d|3[01])T(?:0\d|1\d|2[0123]):[012345]\d:\d\dZ$/;
 
 function isDateTime(arg: string) {
     return isDateTimeRegExp.test(arg);


### PR DESCRIPTION
## Description

Thanks to Mansur for careful and constructive critique earlier this week. Haha, alliteration and rhyme.

### Changes

1. Edit eventsTable.test.js file
    * Update table column head text.
    * Update description list type text.

2. Edit AdministrationEventDescription.tsx file.
    * Replace **Created at** with **Created** and **Last updated at** with **Last updated**.

3. Add AdministrationEventHint.tsx file.
    * Replace lines which have hyphen space prefix with bullet list items.
    * Replace empty lines with `br` elements.

4. Edit AdministrationEventHintMessage.tsx file.
    * Factor out hint as its own component.

5. Edit AdministrationEventPage.tsx file.
    * Add divider between breadcrumbs and page heading.
    * Merge page sections to decrease double padding via 24px spacer for `FlexItem` element.

6. Edit AdministrationEventsEmptyState.tsx file.
    * Replace multiple conditional rendering with ternary expression.
    * Replace **events** with **administration events** in titles.
    * Add phrase for empty state with filter.

7. Delete AdministrationEventsTable.css file.

8. Edit AdministrationEventsTable.tsx file.
    * Replace incorrect `colSpan` value.
    * Replace **Event last updated at** with **Last updated** column head text.
    * Remove right alignment from **Count** column.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated integration tests

## Testing Performed

Before `yarn deploy` in ui, do the following:

```sh
export ROX_ADMINISTRATION_EVENTS=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js: -4 = 3910663 - 3910667
        total: 1954 = 10158158 - 10156204
    * `ls -al build/static/js/*.js | wc -l`
        0 = 83 - 83 files
3. `yarn start` in ui

### Manual testing

Pictures at 1440px width and 900px height like a newer laptop.

1. Visit /main/administration-events
    * See **Last occurred** column head text.
    * See left alignment of **Count** column.
    * See bulleted list in hints.
        ![1_events](https://github.com/stackrox/stackrox/assets/11862657/48c1b591-11d1-4273-bf2d-c876fdff358a)

2. Select **Warning** for **Level** search filter.
    * See presence of SearchIcon.
    * See **No administration events found** title.
    * See **Modify filters and try again** text.
        ![2_No_administration_events_found](https://github.com/stackrox/stackrox/assets/11862657/115d4c09-037c-4eaa-a3a1-ac0faa9a0bee)

3. Temporarily edit code to similate no events.
    * See absence of SearchIcon.
    * See **No administration events** title.
        ![3_No_administration_events](https://github.com/stackrox/stackrox/assets/11862657/0d1082c5-14e5-446e-b468-a5b4ea3f5919)

4. Click a link to visit an event page.
    * See divider between breadcrumbs and page heading.
    * See bulleted list in hint.
    * See **Created** label.
    * See **Last updated** label.
        ![4_event](https://github.com/stackrox/stackrox/assets/11862657/d0c87ce2-883c-416d-b350-26fb2936d646)

### Integration testing

Before `yarn cypress-open` in ui/apps/platform, do the following:

```sh
export CYPRESS_ROX_ADMINISTRATION_EVENTS=true
```

* administation/events/eventsTable.test.js