### PR TITLE
ROX-19561: Add API rate limit for gRPC, HTTP and Stream requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-18525, ROX-19158: A new `cluster` flag has been added to the `roxctl` commands and APIs that perform image scans, this enables delegating scans to specific secured clusters on demand.
 - ROX-19156: Ad-hoc image scanning is now enabled for images in the OCP integrated registry.
   - RHACS attempts to infer the OCP project name from the image path and utilize the project secrets for registry authentication.
-- ROX-19561: Few new environment variables have been introduced in Central. They can be used to rate limit API requests and sensor communications.
-  - `ROX_CENTRAL_MAX_INIT_SYNC_SENSORS` functions as a restriction on the quantity of sensors engaged in their initial synchronization process. It is set to a default value `0` (unlimited).
-    This synchronization occurs once sensors establish a connection with Central. It is recommended to set this limit when a significant number of secured clusters are connected to a single Central instance to avoid resource exhaustion.
+- ROX-19561: Few new environment variables have been introduced in Central. They can be used to rate limit API requests and Sensor communications.
+  - `ROX_CENTRAL_MAX_INIT_SYNC_SENSORS` functions as a restriction on the quantity of Sensors engaged in their initial synchronization process. It is set to a default value `0` (unlimited).
+    This synchronization occurs once Sensor establishes a connection with Central. It is recommended to set this limit when a significant number of secured clusters are connected to a single Central instance to avoid resource exhaustion.
   - `ROX_CENTRAL_API_RATE_LIMIT_PER_SECOND` setting functions as a global rate limiter for all API requests directed to Central. It is set to a default value `0` (unlimited).
     The primary objective of this configuration is to serve as a protective measure against Distributed Denial of Service (DDoS) attacks on Central.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-18525, ROX-19158: A new `cluster` flag has been added to the `roxctl` commands and APIs that perform image scans, this enables delegating scans to specific secured clusters on demand.
 - ROX-19156: Ad-hoc image scanning is now enabled for images in the OCP integrated registry.
   - RHACS attempts to infer the OCP project name from the image path and utilize the project secrets for registry authentication.
-
-- ROX-19561: A new environment variable, `ROX_CENTRAL_MAX_INIT_SYNC_SENSORS`, has been introduced in Central, with a default value of `0` (unlimited).
-  When a value greater than `0` is assigned to it, it serves as a limit on the number of sensors performing initial synchronization.
-  This synchronization occurs once sensors establish a connection with Central. It is recommended to set this limit when a significant
-  number of secured clusters are connected to a single Central instance.
+- ROX-19561: Few new environment variables have been introduced in Central. They can be used to rate limit API requests and sensor communications.
+  - `ROX_CENTRAL_MAX_INIT_SYNC_SENSORS` functions as a restriction on the quantity of sensors engaged in their initial synchronization process. It is set to a default value `0` (unlimited).
+    This synchronization occurs once sensors establish a connection with Central. It is recommended to set this limit when a significant number of secured clusters are connected to a single Central instance to avoid resource exhaustion.
+  - `ROX_CENTRAL_API_RATE_LIMIT_PER_SECOND` setting functions as a global rate limiter for all API requests directed to Central. It is set to a default value `0` (unlimited).
+    The primary objective of this configuration is to serve as a protective measure against Distributed Denial of Service (DDoS) attacks on Central.
 
 ### Removed Features
 

--- a/central/main.go
+++ b/central/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -483,7 +482,7 @@ func watchdog(signal concurrency.Waitable, timeout time.Duration) {
 func newAPIRateLimiter() ratelimit.RateLimiter {
 	apiRequestLimitPerSec := env.CentralAPIRateLimitPerSecond.IntegerSetting()
 	if apiRequestLimitPerSec < 0 {
-		panic(fmt.Sprintf("Negative number is not allowed for API request rate limit. Check env variable: %q", env.CentralAPIRateLimitPerSecond.EnvVar()))
+		log.Panicf("Negative number is not allowed for API request rate limit. Check env variable: %q", env.CentralAPIRateLimitPerSecond.EnvVar())
 	}
 
 	return ratelimit.NewRateLimiter(apiRequestLimitPerSec)

--- a/pkg/env/rate_limit.go
+++ b/pkg/env/rate_limit.go
@@ -4,4 +4,8 @@ var (
 	// CentralMaxInitSyncSensors defines maximum number of sensors that are doing initial sync in parallel.
 	// Default to 0 (no limit).
 	CentralMaxInitSyncSensors = RegisterIntegerSetting("ROX_CENTRAL_MAX_INIT_SYNC_SENSORS", 0)
+
+	// CentralAPIRateLimitPerSecond defines number of allowed API requests
+	// per second to central from all sources. Default 0 (no limit).
+	CentralAPIRateLimitPerSecond = RegisterIntegerSetting("ROX_CENTRAL_API_RATE_LIMIT_PER_SECOND", 0)
 )

--- a/pkg/grpc/ratelimit/ratelimit.go
+++ b/pkg/grpc/ratelimit/ratelimit.go
@@ -1,0 +1,36 @@
+package ratelimit
+
+import (
+	"github.com/stackrox/rox/pkg/httputil"
+	"google.golang.org/grpc"
+)
+
+// RateLimiter is an interface that defines function for obtaining
+// UnaryServer and HTTP interceptors used for rate limiting in a
+// gRPC or HTTP server.
+type RateLimiter interface {
+	// Limit returns true when the event should be rejected.
+	Limit() bool
+
+	// IncreaseLimit increases the allowed rate of events. If rate limiter
+	// is unlimited, no change is made. The argument 'limit' has to be
+	// bigger than 1, otherwise no change is made.
+	IncreaseLimit(limit int)
+
+	// DecreaseLimit decreases the allowed rate of events. If rate limiter
+	// is unlimited, no change is made. The argument 'limit' has to be
+	// bigger than 1, otherwise no change is made.
+	DecreaseLimit(limit int)
+
+	// GetUnaryServerInterceptor returns a gRPC UnaryServerInterceptor
+	// that can be used to apply rate limiting.
+	GetUnaryServerInterceptor() grpc.UnaryServerInterceptor
+
+	// GetStreamServerInterceptor returns a gRPC StreamServerInterceptor
+	// that can be used to apply rate limiting for gRPC streams.
+	GetStreamServerInterceptor() grpc.StreamServerInterceptor
+
+	// GetHTTPInterceptor returns an HTTPInterceptor that can be used
+	// to apply rate limiting to HTTP handlers.
+	GetHTTPInterceptor() httputil.HTTPInterceptor
+}

--- a/pkg/grpc/ratelimit/ratelimit.go
+++ b/pkg/grpc/ratelimit/ratelimit.go
@@ -13,14 +13,14 @@ type RateLimiter interface {
 	Limit() bool
 
 	// IncreaseLimit increases the allowed rate of events. If rate limiter
-	// is unlimited, no change is made. The argument 'limit' has to be
-	// bigger than 1, otherwise no change is made.
-	IncreaseLimit(limit int)
+	// is unlimited, no change is made. The argument 'limitDelta' has to be
+	// bigger than 0, otherwise no change is made.
+	IncreaseLimit(limitDelta int)
 
 	// DecreaseLimit decreases the allowed rate of events. If rate limiter
-	// is unlimited, no change is made. The argument 'limit' has to be
-	// bigger than 1, otherwise no change is made.
-	DecreaseLimit(limit int)
+	// is unlimited, no change is made. The argument 'limitDelta' has to be
+	// bigger than 0, otherwise no change is made.
+	DecreaseLimit(limitDelta int)
 
 	// GetUnaryServerInterceptor returns a gRPC UnaryServerInterceptor
 	// that can be used to apply rate limiting.

--- a/pkg/grpc/ratelimit/ratelimit_impl.go
+++ b/pkg/grpc/ratelimit/ratelimit_impl.go
@@ -1,0 +1,106 @@
+package ratelimit
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/ratelimit"
+	"github.com/stackrox/rox/pkg/httputil"
+	"github.com/stackrox/rox/pkg/sync"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+)
+
+type rateLimiter struct {
+	mutex              sync.Mutex
+	tokenBucketLimiter *rate.Limiter
+}
+
+// Limit implements "ratelimit.Limiter" interface.
+func (limiter *rateLimiter) Limit() bool {
+	return !limiter.tokenBucketLimiter.Allow()
+}
+
+func (limiter *rateLimiter) IncreaseLimit(limit int) {
+	if limiter.tokenBucketLimiter.Limit() == rate.Inf || limit <= 0 {
+		return
+	}
+
+	limiter.mutex.Lock()
+	defer limiter.mutex.Unlock()
+
+	newBurst := limiter.tokenBucketLimiter.Burst() + limit
+	if 0 < newBurst {
+		limiter.tokenBucketLimiter.SetBurst(newBurst)
+	}
+
+	newLimit := limiter.tokenBucketLimiter.Limit() + rate.Every(time.Second/time.Duration(limit))
+	if 0 < newLimit && newLimit < rate.Inf {
+		limiter.tokenBucketLimiter.SetLimit(newLimit)
+	}
+}
+
+func (limiter *rateLimiter) DecreaseLimit(limit int) {
+	if limiter.tokenBucketLimiter.Limit() == rate.Inf || limit <= 0 {
+		return
+	}
+
+	limiter.mutex.Lock()
+	defer limiter.mutex.Unlock()
+
+	newBurst := limiter.tokenBucketLimiter.Burst() - limit
+	if 0 < newBurst {
+		limiter.tokenBucketLimiter.SetBurst(newBurst)
+	}
+
+	newLimit := limiter.tokenBucketLimiter.Limit() - rate.Every(time.Second/time.Duration(limit))
+	if 0 < newLimit && newLimit < rate.Inf {
+		limiter.tokenBucketLimiter.SetLimit(newLimit)
+	}
+}
+
+// NewRateLimiter defines rate limiter any type of events.
+// Note: Please be aware that we're currently employing a basic token bucket
+// rate limiting approach. Once the limit is reached, any additional events
+// will be declined. It's worth noting that a more effective solution would
+// involve implementing event throttling before reaching the hard limit.
+// However, this alternative would introduce a 1ms delay for each event
+// and necessitate the creation of timers for every throttled event.
+func NewRateLimiter(maxPerSec int) *rateLimiter {
+	limit := rate.Inf
+	if maxPerSec > 0 {
+		limit = rate.Every(time.Second / time.Duration(maxPerSec))
+	}
+
+	// When no limit is set, we use "rate.Inf," and burst is disregarded.
+	limiter := &rateLimiter{
+		tokenBucketLimiter: rate.NewLimiter(limit, maxPerSec),
+	}
+
+	return limiter
+}
+
+// GetUnaryServerInterceptor returns a gRPC UnaryServerInterceptor.
+func (limiter *rateLimiter) GetUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return ratelimit.UnaryServerInterceptor(limiter)
+}
+
+// GetStreamServerInterceptor returns a gRPC StreamServerInterceptor.
+func (limiter *rateLimiter) GetStreamServerInterceptor() grpc.StreamServerInterceptor {
+	return ratelimit.StreamServerInterceptor(limiter)
+}
+
+// GetHTTPInterceptor returns a HTTPInterceptor.
+func (limiter *rateLimiter) GetHTTPInterceptor() httputil.HTTPInterceptor {
+	return func(handler http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if limiter.Limit() {
+				http.Error(w, fmt.Sprintf("APIRateLimiter call on %q is rejected by rate limiter, please retry later.", r.URL.Path), http.StatusTooManyRequests)
+				return
+			}
+
+			handler.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/grpc/ratelimit/ratelimit_impl_test.go
+++ b/pkg/grpc/ratelimit/ratelimit_impl_test.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/time/rate"
@@ -38,7 +39,7 @@ func TestIncreaseLimit(t *testing.T) {
 
 	rl.IncreaseLimit(10)
 	expectedRatePerSec += 10
-	assert.Equal(t, rate.Limit(expectedRatePerSec), rl.tokenBucketLimiter.Limit())
+	assert.Equal(t, rate.Every(time.Second/time.Duration(expectedRatePerSec)), rl.tokenBucketLimiter.Limit())
 	assert.Equal(t, expectedRatePerSec, rl.tokenBucketLimiter.Burst())
 }
 
@@ -56,7 +57,7 @@ func TestDecreaseLimit(t *testing.T) {
 
 	rl.DecreaseLimit(10)
 	expectedRatePerSec -= 10
-	assert.Equal(t, rate.Limit(expectedRatePerSec), rl.tokenBucketLimiter.Limit())
+	assert.Equal(t, rate.Every(time.Second/time.Duration(expectedRatePerSec)), rl.tokenBucketLimiter.Limit())
 	assert.Equal(t, expectedRatePerSec, rl.tokenBucketLimiter.Burst())
 }
 

--- a/pkg/grpc/ratelimit/ratelimit_impl_test.go
+++ b/pkg/grpc/ratelimit/ratelimit_impl_test.go
@@ -1,0 +1,86 @@
+package ratelimit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
+)
+
+func TestNewRateLimiterUnlimited(t *testing.T) {
+	rl := NewRateLimiter(-1)
+	assert.Equal(t, rate.Inf, rl.tokenBucketLimiter.Limit())
+
+	rl = NewRateLimiter(0)
+	assert.Equal(t, rate.Inf, rl.tokenBucketLimiter.Limit())
+}
+
+func TestNewRateLimiterLimitedValue(t *testing.T) {
+	expectedRatePerSec := 100
+	rl := NewRateLimiter(expectedRatePerSec)
+
+	assert.Equal(t, rate.Limit(expectedRatePerSec), rl.tokenBucketLimiter.Limit())
+	assert.Equal(t, expectedRatePerSec, rl.tokenBucketLimiter.Burst())
+}
+
+func TestIncreaseLimit(t *testing.T) {
+	noLimitRL := NewRateLimiter(0)
+	assert.Equal(t, rate.Inf, noLimitRL.tokenBucketLimiter.Limit())
+
+	noLimitRL.IncreaseLimit(1)
+	assert.Equal(t, rate.Inf, noLimitRL.tokenBucketLimiter.Limit())
+
+	expectedRatePerSec := 100
+	rl := NewRateLimiter(expectedRatePerSec)
+	assert.Equal(t, rate.Limit(expectedRatePerSec), rl.tokenBucketLimiter.Limit())
+	assert.Equal(t, expectedRatePerSec, rl.tokenBucketLimiter.Burst())
+
+	rl.IncreaseLimit(10)
+	expectedRatePerSec += 10
+	assert.Equal(t, rate.Limit(expectedRatePerSec), rl.tokenBucketLimiter.Limit())
+	assert.Equal(t, expectedRatePerSec, rl.tokenBucketLimiter.Burst())
+}
+
+func TestDecreaseLimit(t *testing.T) {
+	noLimitRL := NewRateLimiter(0)
+	assert.Equal(t, rate.Inf, noLimitRL.tokenBucketLimiter.Limit())
+
+	noLimitRL.DecreaseLimit(1)
+	assert.Equal(t, rate.Inf, noLimitRL.tokenBucketLimiter.Limit())
+
+	expectedRatePerSec := 100
+	rl := NewRateLimiter(expectedRatePerSec)
+	assert.Equal(t, rate.Limit(expectedRatePerSec), rl.tokenBucketLimiter.Limit())
+	assert.Equal(t, expectedRatePerSec, rl.tokenBucketLimiter.Burst())
+
+	rl.DecreaseLimit(10)
+	expectedRatePerSec -= 10
+	assert.Equal(t, rate.Limit(expectedRatePerSec), rl.tokenBucketLimiter.Limit())
+	assert.Equal(t, expectedRatePerSec, rl.tokenBucketLimiter.Burst())
+}
+
+func BenchmarkNoLimit(b *testing.B) {
+	l := NewRateLimiter(0)
+	for i := 0; i < b.N; i++ {
+		l.Limit()
+	}
+}
+
+func BenchmarkWithLimitHit(b *testing.B) {
+	limit := b.N / 10
+	if limit < 1 {
+		limit = 1
+	}
+
+	l := NewRateLimiter(limit)
+	for i := 0; i < b.N; i++ {
+		l.Limit()
+	}
+}
+
+func BenchmarkWithLimitNoHit(b *testing.B) {
+	l := NewRateLimiter(b.N + 1000)
+	for i := 0; i < b.N; i++ {
+		l.Limit()
+	}
+}

--- a/pkg/grpc/server_ratelimit_test.go
+++ b/pkg/grpc/server_ratelimit_test.go
@@ -1,0 +1,162 @@
+package grpc
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"time"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/grpc/authz/allow"
+	"github.com/stackrox/rox/pkg/grpc/ratelimit"
+	"github.com/stackrox/rox/pkg/grpc/routes"
+	"google.golang.org/grpc"
+)
+
+type testHTTPHandler struct {
+	requestCount int
+}
+
+func (h *testHTTPHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	h.requestCount++
+
+	_, _ = w.Write([]byte("Hello!"))
+}
+
+// The pingServiceTestImpl is employed for the purpose of testing GRPC API invocations.
+// It is an implementation of the Ping service.
+type pingServiceTestImpl struct {
+	v1.UnimplementedPingServiceServer
+
+	requestCount int
+}
+
+func (s *pingServiceTestImpl) RegisterServiceServer(grpcServer *grpc.Server) {
+	v1.RegisterPingServiceServer(grpcServer, s)
+}
+
+func (s *pingServiceTestImpl) RegisterServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
+	return v1.RegisterPingServiceHandler(ctx, mux, conn)
+}
+
+func (s *pingServiceTestImpl) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
+	return ctx, allow.Anonymous().Authorized(ctx, fullMethodName)
+}
+
+func (s *pingServiceTestImpl) Ping(context.Context, *v1.Empty) (*v1.PongMessage, error) {
+	s.requestCount++
+
+	result := &v1.PongMessage{
+		Status: "test",
+	}
+
+	return result, nil
+}
+
+func (a *APIServerSuite) Test_Server_RateLimit_HTTP_Integration() {
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	tests := []struct {
+		name       string
+		hasLimiter bool
+		maxPerSec  int
+		useHTTP    bool
+		useGRPC    bool
+	}{
+		{"no limiter http only", false, 0, true, false},
+		{"default unlimited http only", true, 0, true, false},
+		{"hit rate limit http only", true, 2, true, false},
+		{"no limiter grpc only", false, 0, false, true},
+		{"default unlimited grpc only", true, 0, false, true},
+		{"hit rate limit grpc only", true, 2, false, true},
+		{"no limiter http and grpc", false, 0, true, true},
+		{"default unlimited http and grpc", true, 0, true, true},
+		{"hit rate limit http and grpc", true, 2, true, true},
+	}
+
+	for _, tt := range tests {
+		a.Run(tt.name, func() {
+			cfg := defaultConf()
+			if tt.hasLimiter {
+				cfg.RateLimiter = ratelimit.NewRateLimiter(tt.maxPerSec)
+			}
+
+			httpHandler := &testHTTPHandler{}
+			cfg.CustomRoutes = []routes.CustomRoute{
+				{
+					Route:         "/test",
+					Authorizer:    allow.Anonymous(),
+					ServerHandler: httpHandler,
+				},
+			}
+
+			api := NewAPI(cfg)
+			grpcService := &pingServiceTestImpl{}
+			api.Register(grpcService)
+			a.Assert().NoError(api.Start().Wait())
+			defer func() { api.Stop() }()
+
+			var urls []string
+			if tt.useHTTP {
+				urls = append(urls, "https://localhost:8080/test")
+			}
+			if tt.useGRPC {
+				urls = append(urls, "https://localhost:8080/v1/ping")
+			}
+
+			hitLimit := false
+			requestCount := 0
+			numOfRequests := 50
+			for requestCount < numOfRequests {
+				for _, url := range urls {
+					requestCount++
+					resp, err := http.Get(url)
+					a.Require().NoError(err)
+
+					if !tt.hasLimiter || tt.maxPerSec == 0 || requestCount <= tt.maxPerSec {
+						a.Require().Equal(http.StatusOK, resp.StatusCode)
+						continue
+					}
+
+					if resp.StatusCode != 200 {
+						a.Require().Equal(http.StatusTooManyRequests, resp.StatusCode)
+						hitLimit = true
+
+						// Request was rejected because of rate limit.
+						requestCount--
+						break
+					}
+				}
+
+				if hitLimit {
+					break
+				}
+			}
+			a.Assert().Equal(requestCount, httpHandler.requestCount+grpcService.requestCount)
+
+			if tt.useHTTP {
+				a.Assert().Greater(httpHandler.requestCount, 0)
+			}
+			if tt.useGRPC {
+				a.Assert().Greater(grpcService.requestCount, 0)
+			}
+
+			if tt.hasLimiter && tt.maxPerSec > 0 {
+				a.Assert().True(hitLimit)
+
+				// Wait for rate limit to refill.
+				time.Sleep(time.Second)
+			}
+
+			for _, url := range urls {
+				requestCount++
+				resp, err := http.Get(url)
+				a.Assert().NoError(err)
+				a.Assert().Equal(http.StatusOK, resp.StatusCode)
+			}
+
+			a.Assert().Equal(requestCount, httpHandler.requestCount+grpcService.requestCount)
+		})
+	}
+}

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -1,17 +1,22 @@
 package grpc
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
+	"github.com/stackrox/rox/pkg/grpc/ratelimit"
 	"github.com/stackrox/rox/pkg/grpc/routes"
 	"github.com/stackrox/rox/pkg/mtls/verifier"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
 )
 
 type APIServerSuite struct {
@@ -88,6 +93,201 @@ func (a *APIServerSuite) Test_CustomAPI() {
 		_, err := http.Get("https://localhost:8080/test")
 		a.Require().Error(err)
 		a.Require().False(endpointReached.IsDone())
+	})
+}
+
+func (a *APIServerSuite) Test_Server_RateLimit_HTTP_Integration() {
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	a.Run("no limiter", func() {
+		cfg, endpointReached := configWithCustomRoute()
+
+		api := NewAPI(cfg)
+		a.Assert().NoError(api.Start().Wait())
+		defer func() {
+			api.Stop()
+		}()
+
+		for i := 0; i < 50; i++ {
+			resp, err := http.Get("https://localhost:8080/test")
+
+			a.Require().NoError(err)
+			a.Require().Equal(http.StatusOK, resp.StatusCode)
+		}
+		a.waitForSignal(endpointReached)
+	})
+
+	a.Run("default unlimited", func() {
+		cfg, endpointReached := configWithCustomRoute()
+		cfg.RateLimiter = ratelimit.NewRateLimiter(0)
+
+		api := NewAPI(cfg)
+		a.Assert().NoError(api.Start().Wait())
+		defer func() {
+			api.Stop()
+		}()
+
+		for i := 0; i < 50; i++ {
+			resp, err := http.Get("https://localhost:8080/test")
+
+			a.Require().NoError(err)
+			a.Require().Equal(http.StatusOK, resp.StatusCode)
+		}
+		a.waitForSignal(endpointReached)
+	})
+
+	a.Run("hit rate limit", func() {
+		cfg, endpointReached := configWithCustomRoute()
+		cfg.RateLimiter = ratelimit.NewRateLimiter(10)
+
+		api := NewAPI(cfg)
+		a.Assert().NoError(api.Start().Wait())
+		defer func() {
+			api.Stop()
+		}()
+
+		hitLimit := false
+		for i := 0; i < 30; i++ {
+			resp, err := http.Get("https://localhost:8080/test")
+			a.Require().NoError(err)
+
+			if i < 10 {
+				a.Require().Equal(http.StatusOK, resp.StatusCode)
+				continue
+			}
+
+			if resp.StatusCode != 200 {
+				a.Require().Equal(http.StatusTooManyRequests, resp.StatusCode)
+				hitLimit = true
+				break
+			}
+		}
+		a.Assert().True(hitLimit)
+
+		// Wait for rate limit to refill.
+		time.Sleep(2 * time.Second)
+
+		resp, err := http.Get("https://localhost:8080/test")
+		a.Assert().NoError(err)
+		a.Assert().Equal(http.StatusOK, resp.StatusCode)
+
+		a.waitForSignal(endpointReached)
+	})
+}
+
+// The pingServiceTestImpl is employed for the purpose of testing GRPC API invocations.
+// It is an implementation of the Ping service.
+type pingServiceTestImpl struct {
+	v1.UnimplementedPingServiceServer
+
+	RequestCount int
+}
+
+func (s *pingServiceTestImpl) RegisterServiceServer(grpcServer *grpc.Server) {
+	v1.RegisterPingServiceServer(grpcServer, s)
+}
+
+func (s *pingServiceTestImpl) RegisterServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
+	return v1.RegisterPingServiceHandler(ctx, mux, conn)
+}
+
+func (s *pingServiceTestImpl) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
+	return ctx, allow.Anonymous().Authorized(ctx, fullMethodName)
+}
+
+func (s *pingServiceTestImpl) Ping(context.Context, *v1.Empty) (*v1.PongMessage, error) {
+	s.RequestCount++
+
+	result := &v1.PongMessage{
+		Status: "test",
+	}
+
+	return result, nil
+}
+
+func (a *APIServerSuite) Test_Server_RateLimit_GRPC_Integration() {
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	a.Run("no limiter", func() {
+		cfg := defaultConf()
+
+		api := NewAPI(cfg)
+		pingService := &pingServiceTestImpl{}
+		api.Register(pingService)
+		a.Assert().NoError(api.Start().Wait())
+		defer func() { api.Stop() }()
+
+		numOfRequests := 50
+		for i := 0; i < numOfRequests; i++ {
+			resp, err := http.Get("https://localhost:8080/v1/ping")
+			a.Require().NoError(err)
+			a.Require().Equal(http.StatusOK, resp.StatusCode)
+		}
+		a.Assert().Equal(numOfRequests, pingService.RequestCount)
+	})
+
+	a.Run("default unlimited", func() {
+		cfg := defaultConf()
+		cfg.RateLimiter = ratelimit.NewRateLimiter(0)
+
+		api := NewAPI(cfg)
+		pingService := &pingServiceTestImpl{}
+		api.Register(pingService)
+		a.Assert().NoError(api.Start().Wait())
+		defer func() { api.Stop() }()
+
+		numOfRequests := 50
+		for i := 0; i < numOfRequests; i++ {
+			resp, err := http.Get("https://localhost:8080/v1/ping")
+			a.Require().NoError(err)
+			a.Require().Equal(http.StatusOK, resp.StatusCode)
+		}
+		a.Assert().Equal(numOfRequests, pingService.RequestCount)
+	})
+
+	a.Run("hit rate limit", func() {
+		cfg := defaultConf()
+		cfg.RateLimiter = ratelimit.NewRateLimiter(10)
+
+		api := NewAPI(cfg)
+		pingService := &pingServiceTestImpl{}
+		api.Register(pingService)
+		a.Assert().NoError(api.Start().Wait())
+		defer func() { api.Stop() }()
+
+		hitLimit := false
+		requestCount := 0
+		for requestCount < 30 {
+			requestCount++
+			resp, err := http.Get("https://localhost:8080/v1/ping")
+			a.Require().NoError(err)
+
+			if requestCount <= 10 {
+				a.Require().Equal(http.StatusOK, resp.StatusCode)
+				continue
+			}
+
+			if resp.StatusCode != 200 {
+				a.Require().Equal(http.StatusTooManyRequests, resp.StatusCode)
+				hitLimit = true
+
+				// Request was rejected because of rate limit.
+				requestCount--
+				break
+			}
+		}
+		a.Assert().True(hitLimit)
+		a.Assert().Equal(requestCount, pingService.RequestCount)
+
+		// Wait for rate limit to refill.
+		time.Sleep(2 * time.Second)
+
+		requestCount++
+		resp, err := http.Get("https://localhost:8080/v1/ping")
+		a.Assert().NoError(err)
+		a.Assert().Equal(http.StatusOK, resp.StatusCode)
+
+		a.Assert().Equal(requestCount, pingService.RequestCount)
 	})
 }
 

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -247,7 +247,6 @@ func (a *APIServerSuite) Test_Server_RateLimit_GRPC_Integration() {
 
 	a.Run("hit rate limit", func() {
 		cfg := defaultConf()
-		//cfg.Endpoints[0].ListenEndpoint = ''
 		cfg.RateLimiter = ratelimit.NewRateLimiter(3)
 
 		api := NewAPI(cfg)

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -138,7 +138,7 @@ func (a *APIServerSuite) Test_Server_RateLimit_HTTP_Integration() {
 
 	a.Run("hit rate limit", func() {
 		cfg, endpointReached := configWithCustomRoute()
-		cfg.RateLimiter = ratelimit.NewRateLimiter(10)
+		cfg.RateLimiter = ratelimit.NewRateLimiter(3)
 
 		api := NewAPI(cfg)
 		a.Assert().NoError(api.Start().Wait())
@@ -147,11 +147,11 @@ func (a *APIServerSuite) Test_Server_RateLimit_HTTP_Integration() {
 		}()
 
 		hitLimit := false
-		for i := 0; i < 30; i++ {
+		for i := 0; i < 50; i++ {
 			resp, err := http.Get("https://localhost:8080/test")
 			a.Require().NoError(err)
 
-			if i < 10 {
+			if i < 3 {
 				a.Require().Equal(http.StatusOK, resp.StatusCode)
 				continue
 			}
@@ -247,7 +247,8 @@ func (a *APIServerSuite) Test_Server_RateLimit_GRPC_Integration() {
 
 	a.Run("hit rate limit", func() {
 		cfg := defaultConf()
-		cfg.RateLimiter = ratelimit.NewRateLimiter(10)
+		//cfg.Endpoints[0].ListenEndpoint = ''
+		cfg.RateLimiter = ratelimit.NewRateLimiter(3)
 
 		api := NewAPI(cfg)
 		pingService := &pingServiceTestImpl{}
@@ -257,12 +258,12 @@ func (a *APIServerSuite) Test_Server_RateLimit_GRPC_Integration() {
 
 		hitLimit := false
 		requestCount := 0
-		for requestCount < 30 {
+		for requestCount < 50 {
 			requestCount++
 			resp, err := http.Get("https://localhost:8080/v1/ping")
 			a.Require().NoError(err)
 
-			if requestCount <= 10 {
+			if requestCount <= 3 {
 				a.Require().Equal(http.StatusOK, resp.StatusCode)
 				continue
 			}

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -1,22 +1,17 @@
 package grpc
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
-	"github.com/stackrox/rox/pkg/grpc/ratelimit"
 	"github.com/stackrox/rox/pkg/grpc/routes"
 	"github.com/stackrox/rox/pkg/mtls/verifier"
 	"github.com/stretchr/testify/suite"
-	"google.golang.org/grpc"
 )
 
 type APIServerSuite struct {
@@ -93,201 +88,6 @@ func (a *APIServerSuite) Test_CustomAPI() {
 		_, err := http.Get("https://localhost:8080/test")
 		a.Require().Error(err)
 		a.Require().False(endpointReached.IsDone())
-	})
-}
-
-func (a *APIServerSuite) Test_Server_RateLimit_HTTP_Integration() {
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-
-	a.Run("no limiter", func() {
-		cfg, endpointReached := configWithCustomRoute()
-
-		api := NewAPI(cfg)
-		a.Assert().NoError(api.Start().Wait())
-		defer func() {
-			api.Stop()
-		}()
-
-		for i := 0; i < 50; i++ {
-			resp, err := http.Get("https://localhost:8080/test")
-
-			a.Require().NoError(err)
-			a.Require().Equal(http.StatusOK, resp.StatusCode)
-		}
-		a.waitForSignal(endpointReached)
-	})
-
-	a.Run("default unlimited", func() {
-		cfg, endpointReached := configWithCustomRoute()
-		cfg.RateLimiter = ratelimit.NewRateLimiter(0)
-
-		api := NewAPI(cfg)
-		a.Assert().NoError(api.Start().Wait())
-		defer func() {
-			api.Stop()
-		}()
-
-		for i := 0; i < 50; i++ {
-			resp, err := http.Get("https://localhost:8080/test")
-
-			a.Require().NoError(err)
-			a.Require().Equal(http.StatusOK, resp.StatusCode)
-		}
-		a.waitForSignal(endpointReached)
-	})
-
-	a.Run("hit rate limit", func() {
-		cfg, endpointReached := configWithCustomRoute()
-		cfg.RateLimiter = ratelimit.NewRateLimiter(3)
-
-		api := NewAPI(cfg)
-		a.Assert().NoError(api.Start().Wait())
-		defer func() {
-			api.Stop()
-		}()
-
-		hitLimit := false
-		for i := 0; i < 50; i++ {
-			resp, err := http.Get("https://localhost:8080/test")
-			a.Require().NoError(err)
-
-			if i < 3 {
-				a.Require().Equal(http.StatusOK, resp.StatusCode)
-				continue
-			}
-
-			if resp.StatusCode != 200 {
-				a.Require().Equal(http.StatusTooManyRequests, resp.StatusCode)
-				hitLimit = true
-				break
-			}
-		}
-		a.Assert().True(hitLimit)
-
-		// Wait for rate limit to refill.
-		time.Sleep(2 * time.Second)
-
-		resp, err := http.Get("https://localhost:8080/test")
-		a.Assert().NoError(err)
-		a.Assert().Equal(http.StatusOK, resp.StatusCode)
-
-		a.waitForSignal(endpointReached)
-	})
-}
-
-// The pingServiceTestImpl is employed for the purpose of testing GRPC API invocations.
-// It is an implementation of the Ping service.
-type pingServiceTestImpl struct {
-	v1.UnimplementedPingServiceServer
-
-	RequestCount int
-}
-
-func (s *pingServiceTestImpl) RegisterServiceServer(grpcServer *grpc.Server) {
-	v1.RegisterPingServiceServer(grpcServer, s)
-}
-
-func (s *pingServiceTestImpl) RegisterServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
-	return v1.RegisterPingServiceHandler(ctx, mux, conn)
-}
-
-func (s *pingServiceTestImpl) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
-	return ctx, allow.Anonymous().Authorized(ctx, fullMethodName)
-}
-
-func (s *pingServiceTestImpl) Ping(context.Context, *v1.Empty) (*v1.PongMessage, error) {
-	s.RequestCount++
-
-	result := &v1.PongMessage{
-		Status: "test",
-	}
-
-	return result, nil
-}
-
-func (a *APIServerSuite) Test_Server_RateLimit_GRPC_Integration() {
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-
-	a.Run("no limiter", func() {
-		cfg := defaultConf()
-
-		api := NewAPI(cfg)
-		pingService := &pingServiceTestImpl{}
-		api.Register(pingService)
-		a.Assert().NoError(api.Start().Wait())
-		defer func() { api.Stop() }()
-
-		numOfRequests := 50
-		for i := 0; i < numOfRequests; i++ {
-			resp, err := http.Get("https://localhost:8080/v1/ping")
-			a.Require().NoError(err)
-			a.Require().Equal(http.StatusOK, resp.StatusCode)
-		}
-		a.Assert().Equal(numOfRequests, pingService.RequestCount)
-	})
-
-	a.Run("default unlimited", func() {
-		cfg := defaultConf()
-		cfg.RateLimiter = ratelimit.NewRateLimiter(0)
-
-		api := NewAPI(cfg)
-		pingService := &pingServiceTestImpl{}
-		api.Register(pingService)
-		a.Assert().NoError(api.Start().Wait())
-		defer func() { api.Stop() }()
-
-		numOfRequests := 50
-		for i := 0; i < numOfRequests; i++ {
-			resp, err := http.Get("https://localhost:8080/v1/ping")
-			a.Require().NoError(err)
-			a.Require().Equal(http.StatusOK, resp.StatusCode)
-		}
-		a.Assert().Equal(numOfRequests, pingService.RequestCount)
-	})
-
-	a.Run("hit rate limit", func() {
-		cfg := defaultConf()
-		cfg.RateLimiter = ratelimit.NewRateLimiter(3)
-
-		api := NewAPI(cfg)
-		pingService := &pingServiceTestImpl{}
-		api.Register(pingService)
-		a.Assert().NoError(api.Start().Wait())
-		defer func() { api.Stop() }()
-
-		hitLimit := false
-		requestCount := 0
-		for requestCount < 50 {
-			requestCount++
-			resp, err := http.Get("https://localhost:8080/v1/ping")
-			a.Require().NoError(err)
-
-			if requestCount <= 3 {
-				a.Require().Equal(http.StatusOK, resp.StatusCode)
-				continue
-			}
-
-			if resp.StatusCode != 200 {
-				a.Require().Equal(http.StatusTooManyRequests, resp.StatusCode)
-				hitLimit = true
-
-				// Request was rejected because of rate limit.
-				requestCount--
-				break
-			}
-		}
-		a.Assert().True(hitLimit)
-		a.Assert().Equal(requestCount, pingService.RequestCount)
-
-		// Wait for rate limit to refill.
-		time.Sleep(2 * time.Second)
-
-		requestCount++
-		resp, err := http.Get("https://localhost:8080/v1/ping")
-		a.Assert().NoError(err)
-		a.Assert().Equal(http.StatusOK, resp.StatusCode)
-
-		a.Assert().Equal(requestCount, pingService.RequestCount)
 	})
 }
 


### PR DESCRIPTION
## Description

This PR adds an API rate limiter for HTTP, gRPC, and Stream requests.

The current solution will reject requests if the rate limit is reached.

The following changes are made:
- Added env variable to set rate limit (check CHANGELOG)
- By default, we will not limit requests, and for a negative rate limit, the app will panic
- Add RateLimiter to `grpc` package
  - interface has two functions that are not used (relevant to follow-up PR)
  - implementation uses a simple token bucket rate limit method (comment for NewRateLimiter)
- gRPC server has tests for HTTP and gRPC interceptors and missing rate limiter

**Benchmark**

Introduced `Limit` function used for rate limit adds ~180 ns/call.
```
BenchmarkNoLimit-12           	 8358933	       142.9 ns/op
BenchmarkWithLimitHit-12      	 6711018	       177.6 ns/op
BenchmarkWithLimitNoHit-12    	 6831158	       176.9 ns/op
```

**Consideration**

1. Add tests for server Stream interceptor (planty of bolierplating)?

**Related to PR:** #8117 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- ~[ ] Determined and documented upgrade steps~
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

1. Add GoLang tests

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
