### PR TITLE
ROX-18285: Fix data race when calling .Stop() on sensor pipeline

### DIFF
--- a/sensor/kubernetes/eventpipeline/output/output.go
+++ b/sensor/kubernetes/eventpipeline/output/output.go
@@ -1,8 +1,7 @@
 package output
 
 import (
-	"sync/atomic"
-
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
@@ -16,7 +15,7 @@ func New(detector detector.Detector, queueSize int) component.OutputQueue {
 		detector:     detector,
 		innerQueue:   ch,
 		forwardQueue: forwardQueue,
-		stopped:      &atomic.Bool{},
+		stopSig:      concurrency.NewSignal(),
 	}
 	return outputQueue
 }

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -56,7 +56,6 @@ func wrapSensorEvent(update *central.SensorEvent) *central.MsgFromSensor {
 // runOutputQueue reads messages from the inner queue, forwards them to the forwardQueue channel
 // and sends the deployments (if needed) to Detector
 func (q *outputQueueImpl) runOutputQueue() {
-	close(q.forwardQueue)
 	for {
 		select {
 		case <-q.stopSig.Done():

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -56,6 +56,7 @@ func wrapSensorEvent(update *central.SensorEvent) *central.MsgFromSensor {
 // runOutputQueue reads messages from the inner queue, forwards them to the forwardQueue channel
 // and sends the deployments (if needed) to Detector
 func (q *outputQueueImpl) runOutputQueue() {
+	close(q.forwardQueue)
 	for {
 		select {
 		case <-q.stopSig.Done():

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -110,7 +110,6 @@ func (p *eventPipeline) Start() error {
 
 // Stop implements common.SensorComponent
 func (p *eventPipeline) Stop(_ error) {
-	defer close(p.eventsC)
 	// The order is important here, we need to stop the components
 	// that send messages to other components first
 	p.listener.Stop(nil)
@@ -145,6 +144,7 @@ func (p *eventPipeline) Notify(e common.SensorComponentEvent) {
 
 // forwardMessages from listener component to responses channel
 func (p *eventPipeline) forwardMessages() {
+	defer close(p.eventsC)
 	for {
 		select {
 		case <-p.stopSig.Done():

--- a/sensor/kubernetes/eventpipeline/resolver/resolver.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver.go
@@ -1,8 +1,7 @@
 package resolver
 
 import (
-	"sync/atomic"
-
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
@@ -13,6 +12,6 @@ func New(outputQueue component.OutputQueue, provider store.Provider, queueSize i
 		outputQueue:   outputQueue,
 		innerQueue:    make(chan *component.ResourceEvent, queueSize),
 		storeProvider: provider,
-		stopped:       &atomic.Bool{},
+		stopSig:       concurrency.NewSignal(),
 	}
 }

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -1,10 +1,9 @@
 package resolver
 
 import (
-	"sync/atomic"
-
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/common/store"
@@ -20,7 +19,7 @@ type resolverImpl struct {
 	innerQueue  chan *component.ResourceEvent
 
 	storeProvider store.Provider
-	stopped       *atomic.Bool
+	stopSig       concurrency.Signal
 }
 
 // Start the resolverImpl component
@@ -31,27 +30,28 @@ func (r *resolverImpl) Start() error {
 
 // Stop the resolverImpl component
 func (r *resolverImpl) Stop(_ error) {
-	defer close(r.innerQueue)
-	r.stopped.Store(true)
+	r.stopSig.Signal()
 }
 
 // Send a ResourceEvent message to the inner queue
 func (r *resolverImpl) Send(event *component.ResourceEvent) {
-	if !r.stopped.Load() {
-		r.innerQueue <- event
-		metrics.IncResolverChannelSize()
-	}
+	r.innerQueue <- event
+	metrics.IncResolverChannelSize()
 }
 
 // runResolver reads messages from the inner queue and process the message
 func (r *resolverImpl) runResolver() {
 	for {
-		msg, more := <-r.innerQueue
-		if !more {
+		select {
+		case msg, more := <-r.innerQueue:
+			if !more {
+				return
+			}
+			r.processMessage(msg)
+			metrics.DecResolverChannelSize()
+		case <-r.stopSig.Done():
 			return
 		}
-		r.processMessage(msg)
-		metrics.DecResolverChannelSize()
 	}
 }
 

--- a/sensor/tests/connection/connection_test.go
+++ b/sensor/tests/connection/connection_test.go
@@ -26,6 +26,8 @@ func Test_SensorHello(t *testing.T) {
 		CertFilePath:          "../../../tools/local-sensor/certs/",
 	})
 
+	t.Cleanup(c.Stop)
+
 	require.NoError(t, err)
 
 	c.RunTest(t, helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {
@@ -37,7 +39,6 @@ func Test_SensorHello(t *testing.T) {
 		require.NotNil(t, hello2)
 		assert.Equal(t, central.SensorHello_RECONNECT, hello2.GetSensorState())
 	}))
-
 }
 
 func Test_SensorReconnects(t *testing.T) {


### PR DESCRIPTION
## Description

Sensor has a race condition when closing channels when `.Stop()` is called in the `eventpipeline`. This PR makes sure that all goroutines are stopped on a signal, and leaves the channels unclosed. This isn't a problem in this case because the references to these structs will not be used anymore, and the [channels will garbage collected](https://groups.google.com/g/golang-nuts/c/pZwdYRGxCIk/m/rGr1D-uTQMEJ). 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Call `.Stop()` on integration test. 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
