### PR TITLE
ROX-20057: Implement reconciliation in ServiceAccount Store

### DIFF
--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -65,6 +65,17 @@ func resourceToMessage(resType string, resID string) (*central.MsgFromSensor, er
 			},
 		}
 		return &central.MsgFromSensor{Msg: &msg}, nil
+	case deduper.TypeServiceAccount.String():
+		msg := central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     resID,
+				Action: central.ResourceAction_REMOVE_RESOURCE,
+				Resource: &central.SensorEvent_ServiceAccount{
+					ServiceAccount: &storage.ServiceAccount{Id: resID},
+				},
+			},
+		}
+		return &central.MsgFromSensor{Msg: &msg}, nil
 	default:
 		return nil, errors.Errorf("Not implemented for resource type %v", resType)
 	}

--- a/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
@@ -38,6 +38,11 @@ func (s *HashReconciliationSuite) TestResourceToMessage() {
 			expectedMsg:   &central.MsgFromSensor_Event{Event: &central.SensorEvent{Id: testResID, Action: central.ResourceAction_REMOVE_RESOURCE, Resource: &central.SensorEvent_Deployment{Deployment: &storage.Deployment{Id: testResID}}}},
 			expectedError: nil,
 		},
+		"ServiceAccount": {
+			resType:       deduper.TypeServiceAccount.String(),
+			expectedMsg:   &central.MsgFromSensor_Event{Event: &central.SensorEvent{Id: testResID, Action: central.ResourceAction_REMOVE_RESOURCE, Resource: &central.SensorEvent_ServiceAccount{ServiceAccount: &storage.ServiceAccount{Id: testResID}}}},
+			expectedError: nil,
+		},
 		"Unknown should throw error": {
 			resType:       "Unknown",
 			expectedMsg:   nil,
@@ -68,6 +73,10 @@ func resourceTypeToFn(resType string) (func(*central.SensorEvent) string, error)
 		return func(event *central.SensorEvent) string {
 			return event.GetPod().GetId()
 		}, nil
+	case deduper.TypeServiceAccount.String():
+		return func(event *central.SensorEvent) string {
+			return event.GetServiceAccount().GetId()
+		}, nil
 	default:
 		return nil, errors.Errorf("not implemented for resource type %v", resType)
 	}
@@ -80,6 +89,18 @@ func initStore() *InMemoryStoreProvider {
 	s.deploymentStore.addOrUpdateDeployment(createWrapWithID("2"))
 	s.podStore.addOrUpdatePod(&storage.Pod{Id: "3"})
 	s.podStore.addOrUpdatePod(&storage.Pod{Id: "4"})
+	s.serviceAccountStore.Add(&storage.ServiceAccount{
+		Id:               "5",
+		Name:             "Acc1",
+		Namespace:        "Test",
+		ImagePullSecrets: []string{},
+	})
+	s.serviceAccountStore.Add(&storage.ServiceAccount{
+		Id:               "6",
+		Name:             "Acc2",
+		Namespace:        "Test",
+		ImagePullSecrets: []string{},
+	})
 	return s
 }
 
@@ -135,6 +156,29 @@ func (s *HashReconciliationSuite) TestProcessHashes() {
 				makeKey("100", deduper.TypePod): 87654,
 				makeKey("101", deduper.TypePod): 87654,
 				makeKey("3", deduper.TypePod):   76543,
+			},
+			deletedIDs: []string{"99", "100", "101"},
+		},
+		"No ServiceAccount": {
+			dstate: map[deduper.Key]uint64{
+				makeKey("5", deduper.TypeServiceAccount): 76543,
+				makeKey("6", deduper.TypeServiceAccount): 65432,
+			},
+			deletedIDs: []string{},
+		},
+		"Single ServiceAccount": {
+			dstate: map[deduper.Key]uint64{
+				makeKey("99", deduper.TypeServiceAccount): 87654,
+				makeKey("5", deduper.TypeServiceAccount):  76543,
+			},
+			deletedIDs: []string{"99"},
+		},
+		"Multiple ServiceAccounts": {
+			dstate: map[deduper.Key]uint64{
+				makeKey("99", deduper.TypeServiceAccount):  87654,
+				makeKey("100", deduper.TypeServiceAccount): 87654,
+				makeKey("101", deduper.TypeServiceAccount): 87654,
+				makeKey("5", deduper.TypeServiceAccount):   76543,
 			},
 			deletedIDs: []string{"99", "100", "101"},
 		},

--- a/sensor/kubernetes/listener/resources/serviceaccount_store.go
+++ b/sensor/kubernetes/listener/resources/serviceaccount_store.go
@@ -33,9 +33,9 @@ func (sas *ServiceAccountStore) ReconcileDelete(resType, resID string, _ uint64)
 }
 
 func newServiceAccountStore() *ServiceAccountStore {
-	return &ServiceAccountStore{
-		serviceAccountToPullSecrets: make(map[serviceAccountKey][]string),
-	}
+	sas := &ServiceAccountStore{}
+	sas.initMaps()
+	return sas
 }
 
 func key(namespace, name string) serviceAccountKey {
@@ -45,13 +45,17 @@ func key(namespace, name string) serviceAccountKey {
 	}
 }
 
+func (sas *ServiceAccountStore) initMaps() {
+	sas.serviceAccountToPullSecrets = make(map[serviceAccountKey][]string)
+	sas.serviceAccountIDs = set.NewStringSet()
+}
+
 // Cleanup deletes all entries from store
 func (sas *ServiceAccountStore) Cleanup() {
 	sas.lock.Lock()
 	defer sas.lock.Unlock()
 
-	sas.serviceAccountToPullSecrets = make(map[serviceAccountKey][]string)
-	sas.serviceAccountIDs = set.NewStringSet()
+	sas.initMaps()
 }
 
 // GetImagePullSecrets get the image pull secrets for a namespace and secret name pair

--- a/sensor/kubernetes/listener/resources/serviceaccount_store.go
+++ b/sensor/kubernetes/listener/resources/serviceaccount_store.go
@@ -1,9 +1,10 @@
 package resources
 
 import (
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/deduper"
 )
 
 type serviceAccountKey struct {
@@ -14,15 +15,21 @@ type serviceAccountKey struct {
 type ServiceAccountStore struct {
 	lock                        sync.RWMutex
 	serviceAccountToPullSecrets map[serviceAccountKey][]string
+	serviceAccountIDs           set.StringSet
 }
 
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (sas *ServiceAccountStore) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
-	_, _, _ = resType, resID, resHash
-	// TODO(ROX-20057): Implement me
-	return "", errors.New("Not implemented")
+func (sas *ServiceAccountStore) ReconcileDelete(resType, resID string, _ uint64) (string, error) {
+	if resType != deduper.TypeServiceAccount.String() {
+		return "", nil
+	}
+	// Resource exists on central but not on Sensor, send delete event
+	if !sas.serviceAccountIDs.Contains(resID) {
+		return resID, nil
+	}
+	return "", nil
 }
 
 func newServiceAccountStore() *ServiceAccountStore {
@@ -44,6 +51,7 @@ func (sas *ServiceAccountStore) Cleanup() {
 	defer sas.lock.Unlock()
 
 	sas.serviceAccountToPullSecrets = make(map[serviceAccountKey][]string)
+	sas.serviceAccountIDs = set.NewStringSet()
 }
 
 // GetImagePullSecrets get the image pull secrets for a namespace and secret name pair
@@ -58,6 +66,7 @@ func (sas *ServiceAccountStore) Add(sa *storage.ServiceAccount) {
 	sas.lock.Lock()
 	defer sas.lock.Unlock()
 	sas.serviceAccountToPullSecrets[key(sa.GetNamespace(), sa.GetName())] = sa.GetImagePullSecrets()
+	sas.serviceAccountIDs.Add(sa.Id)
 }
 
 // Remove removes the service account from the map
@@ -65,4 +74,5 @@ func (sas *ServiceAccountStore) Remove(sa *storage.ServiceAccount) {
 	sas.lock.Lock()
 	defer sas.lock.Unlock()
 	delete(sas.serviceAccountToPullSecrets, key(sa.GetNamespace(), sa.GetName()))
+	sas.serviceAccountIDs.Remove(sa.Id)
 }

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -78,8 +78,9 @@ func InitializeStore() *InMemoryStoreProvider {
 		p.registryMirrorStore,
 	}
 	p.reconcilableStores = map[string]reconcile.Reconcilable{
-		deduper.TypeDeployment.String(): p.deploymentStore,
-		deduper.TypePod.String():        p.podStore,
+		deduper.TypeDeployment.String():     p.deploymentStore,
+		deduper.TypePod.String():            p.podStore,
+		deduper.TypeServiceAccount.String(): p.serviceAccountStore,
 	}
 
 	return p


### PR DESCRIPTION
## Description

This PR adds the implementation for ReconcileDelete for the ServiceAccount Store.
As the SAS doesn't expose direct access to IDs, I have added a StringSet which tracks Add/Delete operations and is wiped on Clean.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

As this code is currently not called by our production code, I rely on the added unit tests in hash_reconciliation_test.go.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
