### PR TITLE
ROX-19293: Feature flag legacy image vulnerability snooze APIs

### DIFF
--- a/central/cve/image/service/service_impl.go
+++ b/central/cve/image/service/service_impl.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/and"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
@@ -57,6 +58,9 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 
 // SuppressCVEs suppresses CVEs from policy workflow and API endpoints that include cve in the responses.
 func (s *serviceImpl) SuppressCVEs(ctx context.Context, request *v1.SuppressCVERequest) (*v1.Empty, error) {
+	if features.UnifiedCVEDeferral.Enabled() {
+		return nil, errox.NotFound
+	}
 	createdAt := types.TimestampNow()
 	if len(request.GetCves()) == 0 {
 		return nil, errox.InvalidArgs.CausedBy("no cves provided to snooze")
@@ -73,6 +77,9 @@ func (s *serviceImpl) SuppressCVEs(ctx context.Context, request *v1.SuppressCVER
 
 // UnsuppressCVEs un-suppresses given image CVEs.
 func (s *serviceImpl) UnsuppressCVEs(ctx context.Context, request *v1.UnsuppressCVERequest) (*v1.Empty, error) {
+	if features.UnifiedCVEDeferral.Enabled() {
+		return nil, errox.NotFound
+	}
 	if len(request.GetCves()) == 0 {
 		return nil, errox.InvalidArgs.CausedBy("no cves provided to un-snooze")
 	}

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -188,6 +188,7 @@ class AdmissionControllerTest extends BaseSpecification {
     @Unroll
     @Tag("BAT")
     @Tag("Parallel")
+    @IgnoreIf({ Env.ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL == "true" })
     def "Verify CVE snoozing applies to images scanned by admission controller #image"() {
         given:
         "Chaos monkey is prepared"

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -17,6 +17,7 @@ import util.ApplicationHealth
 import util.ChaosMonkey
 import util.Timer
 
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Timeout

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -11,6 +11,7 @@ import services.CVEService
 import services.ImageService
 import services.PolicyService
 
+import spock.lang.IgnoreIf
 import spock.lang.Tag
 import spock.lang.Unroll
 import util.Env

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -181,6 +181,7 @@ class ImageManagementTest extends BaseSpecification {
 
     @Unroll
     @Tag("BAT")
+    @IgnoreIf({ Env.ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL == "true" })
     def "Verify CVE snoozing applies to build time detection"() {
         given:
         "Create policy looking for a specific CVE applying to build time"
@@ -279,6 +280,7 @@ class ImageManagementTest extends BaseSpecification {
 
     @Unroll
     @Tag("BAT")
+    @IgnoreIf({ Env.ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL == "true" })
     def "Verify image scan results when CVEs are suppressed: "() {
         given:
         "Scan image"


### PR DESCRIPTION
## Description

The legacy vulnerability snooze APIs are moved behind the feature flag. If the unified deferral feature is enabled, the APIs will not be available for use. The deprecation notice was released in 4.1. The final removal notice will be released in 4.4.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user-facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

