### PR TITLE
ROX-20181: Apply noResyncPeriod to Openshift resources

### DIFF
--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -55,22 +55,23 @@ func (k *listenerImpl) handleAllEvents() {
 	defer k.mayCreateHandlers.Signal()
 	// TODO(ROX-14194): remove resyncingSif once all resources are adapted
 	var resyncingSif informers.SharedInformerFactory
+
+	resyncPeriod := k.resyncPeriod
 	if env.ResyncDisabled.BooleanSetting() {
-		resyncingSif = informers.NewSharedInformerFactory(k.client.Kubernetes(), noResyncPeriod)
-	} else {
-		resyncingSif = informers.NewSharedInformerFactory(k.client.Kubernetes(), k.resyncPeriod)
+		resyncPeriod = noResyncPeriod
 	}
+	resyncingSif = informers.NewSharedInformerFactory(k.client.Kubernetes(), resyncPeriod)
 	sif := informers.NewSharedInformerFactory(k.client.Kubernetes(), noResyncPeriod)
 
 	// Create informer factories for needed orchestrators.
 	var osAppsFactory osAppsExtVersions.SharedInformerFactory
 	if k.client.OpenshiftApps() != nil {
-		osAppsFactory = osAppsExtVersions.NewSharedInformerFactory(k.client.OpenshiftApps(), k.resyncPeriod)
+		osAppsFactory = osAppsExtVersions.NewSharedInformerFactory(k.client.OpenshiftApps(), resyncPeriod)
 	}
 
 	var osRouteFactory osRouteExtVersions.SharedInformerFactory
 	if k.client.OpenshiftRoute() != nil {
-		osRouteFactory = osRouteExtVersions.NewSharedInformerFactory(k.client.OpenshiftRoute(), k.resyncPeriod)
+		osRouteFactory = osRouteExtVersions.NewSharedInformerFactory(k.client.OpenshiftRoute(), resyncPeriod)
 	}
 
 	// We want creates to be treated as updates while existing objects are loaded.


### PR DESCRIPTION
## Description

The resync period of 0 was not being applied to routes and deployment configs so they were being resynced every minute. The change in routes was propagating to the deployments they referenced and causing far too many changes to deployments (e.g. what this PR was fixing: https://github.com/stackrox/stackrox/pull/7956) and causing extra stress on Sensor and detection. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Will run on openshift cluster

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
