### PR TITLE
ROX-20136: Reduce cost of resource alert processing

### DIFF
--- a/central/detection/alertmanager/alert_manager_impl_test.go
+++ b/central/detection/alertmanager/alert_manager_impl_test.go
@@ -219,7 +219,7 @@ func (suite *AlertManagerTestSuite) TestGetAlertsByClusterAndNotResourceType() {
 		testutils.PredMatcher("query for violation state, cluster id and resource type", queryHasFields(search.ViolationState, search.ClusterID, search.ResourceType)),
 	).Return(([]*storage.Alert)(nil), nil)
 
-	modified, err := suite.alertManager.AlertAndNotify(suite.ctx, nil, WithClusterID("cid"), WithoutResourceType(storage.ListAlert_DEPLOYMENT))
+	modified, err := suite.alertManager.AlertAndNotify(suite.ctx, nil, WithClusterID("cid"), WithResource(storage.ListAlert_DEPLOYMENT))
 	suite.False(modified.Cardinality() > 0)
 	suite.NoError(err, "update should succeed")
 }

--- a/central/detection/alertmanager/alert_manager_impl_test.go
+++ b/central/detection/alertmanager/alert_manager_impl_test.go
@@ -214,12 +214,12 @@ func (suite *AlertManagerTestSuite) TestGetAlertsByDeployment() {
 	suite.NoError(err, "update should succeed")
 }
 
-func (suite *AlertManagerTestSuite) TestGetAlertsByClusterAndNotResourceType() {
+func (suite *AlertManagerTestSuite) TestGetAlertsByClusterAndResource() {
 	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx,
 		testutils.PredMatcher("query for violation state, cluster id and resource type", queryHasFields(search.ViolationState, search.ClusterID, search.ResourceType)),
 	).Return(([]*storage.Alert)(nil), nil)
 
-	modified, err := suite.alertManager.AlertAndNotify(suite.ctx, nil, WithClusterID("cid"), WithResource(storage.ListAlert_DEPLOYMENT))
+	modified, err := suite.alertManager.AlertAndNotify(suite.ctx, nil, WithLifecycleStage(storage.LifecycleStage_RUNTIME), WithClusterID("cid"), WithNamespace("nn"), WithResource("rn", storage.Alert_Resource_SECRETS))
 	suite.False(modified.Cardinality() > 0)
 	suite.NoError(err, "update should succeed")
 }

--- a/central/detection/alertmanager/filter_options.go
+++ b/central/detection/alertmanager/filter_options.go
@@ -63,10 +63,10 @@ func WithClusterID(clusterID string) AlertFilterOption {
 }
 
 // WithNamespace returns an AlertFilterOption that filters for the specified namespace.
-func WithNamespace(namespaceID string) AlertFilterOption {
+func WithNamespace(namespace string) AlertFilterOption {
 	return &alertFilterOptionImpl{
 		applyFunc: func(qb *search.QueryBuilder) {
-			qb.AddExactMatches(search.NamespaceID, namespaceID)
+			qb.AddExactMatches(search.Namespace, namespace)
 		},
 	}
 }

--- a/central/detection/alertmanager/filter_options.go
+++ b/central/detection/alertmanager/filter_options.go
@@ -62,11 +62,21 @@ func WithClusterID(clusterID string) AlertFilterOption {
 	}
 }
 
-// WithoutResourceType returns an AlertFilterOption that filters _out_ the specified resource type.
-func WithoutResourceType(resourceType storage.ListAlert_ResourceType) AlertFilterOption {
+// WithNamespace returns an AlertFilterOption that filters for the specified namespace.
+func WithNamespace(namespaceID string) AlertFilterOption {
 	return &alertFilterOptionImpl{
 		applyFunc: func(qb *search.QueryBuilder) {
-			qb.AddStrings(search.ResourceType, search.NegateQueryString(resourceType.String()))
+			qb.AddExactMatches(search.NamespaceID, namespaceID)
+		},
+	}
+}
+
+// WithResource returns an AlertFilterOption that filters for the specified resource.
+func WithResource(resourceName string, resourceType storage.Alert_Resource_ResourceType) AlertFilterOption {
+	return &alertFilterOptionImpl{
+		applyFunc: func(qb *search.QueryBuilder) {
+			qb.AddExactMatches(search.ResourceName, resourceName)
+			qb.AddExactMatches(search.ResourceType, resourceType.String())
 		},
 	}
 }

--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -390,7 +390,6 @@ func (m *managerImpl) HandleResourceAlerts(clusterID string, alerts []*storage.A
 		}
 		alertGroups[key] = append(alertGroups[key], alert)
 	}
-	log.Infof("Number of groups: %d", len(alertGroups))
 	for key, alerts := range alertGroups {
 		opts := []alertmanager.AlertFilterOption{
 			alertmanager.WithLifecycleStage(stage),

--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -372,15 +372,37 @@ func (m *managerImpl) HandleResourceAlerts(clusterID string, alerts []*storage.A
 	if len(alerts) == 0 && stage == storage.LifecycleStage_RUNTIME {
 		return nil
 	}
-	// These alerts are all for a single cluster but may belong to any number of namespaces or resource types (except deployment)
-	// Ideally search filters should be for lifecycle stage && (namespace1 || namespace2...) && resource_type!=DEPLOYMENT
-	// But with these filters they are all ANDs
-	// Therefore for now, we will have to pull all non-deployment alerts for this lifecycle stage within specified cluster.
-	if _, err := m.alertManager.AlertAndNotify(lifecycleMgrCtx, alerts,
-		alertmanager.WithLifecycleStage(stage), alertmanager.WithClusterID(clusterID), alertmanager.WithoutResourceType(storage.ListAlert_DEPLOYMENT)); err != nil {
-		return err
-	}
 
+	// Split the alerts into unique groups so that we can do targeted lookups of alerts that need to be merged.
+	// Based on the current Sensor logic, this should only ever result in a single group as the alert results are
+	// multiple policy evaluations against the same audit event which only ever references a single resource type and name.
+	type alertKey struct {
+		namespace    string
+		resourceName string
+		resourceType storage.Alert_Resource_ResourceType
+	}
+	alertGroups := make(map[alertKey][]*storage.Alert)
+	for _, alert := range alerts {
+		key := alertKey{
+			namespace:    alert.GetNamespace(),
+			resourceName: alert.GetResource().GetName(),
+			resourceType: alert.GetResource().GetResourceType(),
+		}
+		alertGroups[key] = append(alertGroups[key], alert)
+	}
+	log.Infof("Number of groups: %d", len(alertGroups))
+	for key, alerts := range alertGroups {
+		opts := []alertmanager.AlertFilterOption{
+			alertmanager.WithLifecycleStage(stage),
+			// Use cluster id and namespace name to align with sac filters
+			alertmanager.WithClusterID(clusterID),
+			alertmanager.WithNamespace(key.namespace),
+			alertmanager.WithResource(key.resourceName, key.resourceType),
+		}
+		if _, err := m.alertManager.AlertAndNotify(lifecycleMgrCtx, alerts, opts...); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/central/detection/lifecycle/manager_impl_test.go
+++ b/central/detection/lifecycle/manager_impl_test.go
@@ -156,7 +156,7 @@ func (suite *ManagerTestSuite) TestHandleResourceAlerts() {
 
 	// unfortunately because the filters are in a different package and have unexported functions it cannot be tested here. Alert Manager tests should cover it
 	suite.alertManager.EXPECT().
-		AlertAndNotify(gomock.Any(), alerts, gomock.Any(), gomock.Any(), gomock.Any()).
+		AlertAndNotify(gomock.Any(), alerts, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(set.NewStringSet(), nil)
 
 	// reprocessor.ReprocessRiskForDeployments should _not_ be called for resource alerts


### PR DESCRIPTION
## Description

Scope the merging for resource requests

```
     New PR:
     central_active=# select total_exec_time, mean_exec_time, rows, calls, rows/calls as avg, query from pg_stat_statements where query ilike 'select%alerts%' order by calls desc limit 20;
   total_exec_time    |    mean_exec_time    | rows  | calls | avg |                                                                                                                         query                                                                       
                                                   
----------------------+----------------------+-------+-------+-----+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------------------------------
   49104.993686999915 |   13.168408068382996 | 29816 |  3729 |   7 | select "alerts".serialized from alerts where (alerts.ClusterId = $1 and (alerts.LifecycleStage = $2) and alerts.Namespace = $3 and alerts.Resource_Name = $4 and (alerts.Resource_ResourceType = $5)
 and ((alerts.State = $6) or (alerts.State = $7)))
(6 rows)

Master:
central_active=# select total_exec_time, mean_exec_time, rows, calls, rows/calls as avg, query from pg_stat_statements where query ilike 'select%alerts%' order by calls desc limit 20;
   total_exec_time   |   mean_exec_time    |   rows   | calls |  avg  |                                                                                                                                                                                                  
                              query                                                                                                                                                                                                                                 
---------------------+---------------------+----------+-------+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   363841.2265790002 |  1095.9073089728913 | 27506200 |   332 | 82850 | select "alerts".serialized from alerts where (alerts.ClusterId = $1 and (alerts.LifecycleStage = $2) and (alerts.Resource_ResourceType = $3 or alerts.Resource_ResourceType = $4 or alerts.Resour
ce_ResourceType = $5 or alerts.Resource_ResourceType = $6 or alerts.Resource_ResourceType = $7 or alerts.Resource_ResourceType = $8 or alerts.Resource_ResourceType = $9 or alerts.Resource_ResourceType = $10) and ((alerts.State = $11) or (alerts.State = $12)))
(4 rows)
```

The query time and the number of alerts is greatly reduced even without an index

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

See perf test above

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
