### PR TITLE
ROX-20073: Implement Network Policy Store Reconciliation

### DIFF
--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -31,7 +31,7 @@ func (hr *ResourceStoreReconciler) ProcessHashes(h map[deduper.Key]uint64) []cen
 			log.Debug("empty reconciliation result - not found on Sensor")
 			continue
 		}
-		delMsg, err := hr.resourceToMessage(hash.ResourceType.String(), toDeleteID)
+		delMsg, err := resourceToMessage(hash.ResourceType.String(), toDeleteID)
 		if err != nil {
 			log.Errorf("converting resource to MsgFromSensor: %s", err)
 			continue
@@ -41,7 +41,7 @@ func (hr *ResourceStoreReconciler) ProcessHashes(h map[deduper.Key]uint64) []cen
 	return events
 }
 
-func (hr *ResourceStoreReconciler) resourceToMessage(resType string, resID string) (*central.MsgFromSensor, error) {
+func resourceToMessage(resType string, resID string) (*central.MsgFromSensor, error) {
 	switch resType {
 	case deduper.TypeDeployment.String():
 		msg := central.MsgFromSensor_Event{
@@ -88,17 +88,12 @@ func (hr *ResourceStoreReconciler) resourceToMessage(resType string, resID strin
 		}
 		return &central.MsgFromSensor{Msg: &msg}, nil
 	case deduper.TypeNetworkPolicy.String():
-		pol := hr.storeProvider.networkPolicyStore.Get(resID)
-		if pol == nil {
-			return nil, errors.Errorf("could not find policy with ID %s in Network Policy store", resID)
-		}
 		msg := central.MsgFromSensor_Event{
 			Event: &central.SensorEvent{
 				Id:     resID,
 				Action: central.ResourceAction_REMOVE_RESOURCE,
 				Resource: &central.SensorEvent_NetworkPolicy{
-					NetworkPolicy: pol,
-				},
+					NetworkPolicy: &storage.NetworkPolicy{Id: resID}},
 			},
 		}
 		return &central.MsgFromSensor{Msg: &msg}, nil

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -31,7 +31,7 @@ func (hr *ResourceStoreReconciler) ProcessHashes(h map[deduper.Key]uint64) []cen
 			log.Debug("empty reconciliation result - not found on Sensor")
 			continue
 		}
-		delMsg, err := resourceToMessage(hash.ResourceType.String(), toDeleteID)
+		delMsg, err := hr.resourceToMessage(hash.ResourceType.String(), toDeleteID)
 		if err != nil {
 			log.Errorf("converting resource to MsgFromSensor: %s", err)
 			continue
@@ -41,7 +41,7 @@ func (hr *ResourceStoreReconciler) ProcessHashes(h map[deduper.Key]uint64) []cen
 	return events
 }
 
-func resourceToMessage(resType string, resID string) (*central.MsgFromSensor, error) {
+func (hr *ResourceStoreReconciler) resourceToMessage(resType string, resID string) (*central.MsgFromSensor, error) {
 	switch resType {
 	case deduper.TypeDeployment.String():
 		msg := central.MsgFromSensor_Event{
@@ -83,6 +83,21 @@ func resourceToMessage(resType string, resID string) (*central.MsgFromSensor, er
 				Action: central.ResourceAction_REMOVE_RESOURCE,
 				Resource: &central.SensorEvent_Secret{
 					Secret: &storage.Secret{Id: resID},
+				},
+			},
+		}
+		return &central.MsgFromSensor{Msg: &msg}, nil
+	case deduper.TypeNetworkPolicy.String():
+		pol := hr.storeProvider.networkPolicyStore.Get(resID)
+		if pol == nil {
+			return nil, errors.Errorf("could not find policy with ID %s in Network Policy store", resID)
+		}
+		msg := central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     resID,
+				Action: central.ResourceAction_REMOVE_RESOURCE,
+				Resource: &central.SensorEvent_NetworkPolicy{
+					NetworkPolicy: pol,
 				},
 			},
 		}

--- a/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
@@ -122,8 +122,8 @@ func initStore() *InMemoryStoreProvider {
 	s.podStore.addOrUpdatePod(&storage.Pod{Id: "4"})
 	s.nodeStore.addOrUpdateNode(makeNode("42"))
 	s.nodeStore.addOrUpdateNode(makeNode("43"))
-	s.networkPolicyStore.Upsert(&storage.NetworkPolicy{Id: "1", Namespace: "space"})
-	s.networkPolicyStore.Upsert(&storage.NetworkPolicy{Id: "2", Namespace: "space"})
+	s.networkPolicyStore.Upsert(&storage.NetworkPolicy{Id: "1"})
+	s.networkPolicyStore.Upsert(&storage.NetworkPolicy{Id: "2"})
 	s.serviceAccountStore.Add(&storage.ServiceAccount{
 		Id:               "5",
 		Name:             "Acc1",

--- a/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
@@ -59,7 +59,7 @@ func (s *HashReconciliationSuite) TestResourceToMessage() {
 		},
 		"NetworkPolicy": {
 			resType:       deduper.TypeNetworkPolicy.String(),
-			expectedMsg:   &central.MsgFromSensor_Event{Event: &central.SensorEvent{Id: testResID, Action: central.ResourceAction_REMOVE_RESOURCE, Resource: &central.SensorEvent_NetworkPolicy{NetworkPolicy: &storage.NetworkPolicy{Id: testResID, Namespace: testResID}}}},
+			expectedMsg:   &central.MsgFromSensor_Event{Event: &central.SensorEvent{Id: testResID, Action: central.ResourceAction_REMOVE_RESOURCE, Resource: &central.SensorEvent_NetworkPolicy{NetworkPolicy: &storage.NetworkPolicy{Id: testResID}}}},
 			expectedError: nil,
 		},
 		"Unknown should throw error": {
@@ -70,12 +70,8 @@ func (s *HashReconciliationSuite) TestResourceToMessage() {
 	}
 
 	for name, c := range cases {
-		st := InitializeStore()
-		st.networkPolicyStore.Upsert(&storage.NetworkPolicy{Id: testResID, Namespace: testResID})
-		r := NewResourceStoreReconciler(st)
-
 		s.Run(name, func() {
-			actual, err := r.resourceToMessage(c.resType, testResID)
+			actual, err := resourceToMessage(c.resType, testResID)
 			if c.expectedError != nil {
 				s.Require().Error(err)
 				return

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -83,8 +83,6 @@ func InitializeStore() *InMemoryStoreProvider {
 		deduper.TypeServiceAccount.String(): p.serviceAccountStore,
 		deduper.TypeSecret.String():         p.registryStore,
 		deduper.TypeNode.String():           p.nodeStore,
-		deduper.TypeDeployment.String():     p.deploymentStore,
-		deduper.TypePod.String():            p.podStore,
 		deduper.TypeNetworkPolicy.String():  p.networkPolicyStore,
 	}
 

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -83,6 +83,9 @@ func InitializeStore() *InMemoryStoreProvider {
 		deduper.TypeServiceAccount.String(): p.serviceAccountStore,
 		deduper.TypeSecret.String():         p.registryStore,
 		deduper.TypeNode.String():           p.nodeStore,
+		deduper.TypeDeployment.String():     p.deploymentStore,
+		deduper.TypePod.String():            p.podStore,
+		deduper.TypeNetworkPolicy.String():  p.networkPolicyStore,
 	}
 
 	return p


### PR DESCRIPTION
## Description

This PR adds the implementation for ReconcileDelete for the NetworkPolicy Store.
Central only requires the ID of a NetworkPolicy to delete a given resource ([here](https://github.com/stackrox/stackrox/blob/ef44f9f9ec950fa18c7bee4bd8200d9067b8fe9b/central/sensor/service/pipeline/networkpolicies/pipeline.go#L153C1-L154)).

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

As this code is currently not called by our production code, I rely on the added unit tests in hash_reconciliation_test.go.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
