### PR TITLE
ROX-20203: Bump helm operator plugin version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -454,7 +454,7 @@ replace (
 
 	// github.com/stackrox/helm-operator is a modified fork of github.com/operator-framework/helm-operator-plugins that
 	// we currently depend on.
-	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.12-0.20230804132854-090c1105ecf3
+	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.12-0.20230825152000-1361e2f7db46
 
 	github.com/sigstore/cosign/v2 => github.com/stackrox/cosign/v2 v2.0.0-20230524131509-aa1a890d9fb7
 

--- a/go.sum
+++ b/go.sum
@@ -1495,8 +1495,8 @@ github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd h1:vEjp7Q6
 github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd/go.mod h1:HILeV3i/EyJz844GcrC3+oU7oZONhjfujaIYBMJ/bZE=
 github.com/stackrox/external-network-pusher v0.0.0-20210419192707-074af92bbfa7 h1:F4Gq3G5G07HQ/ECrg/+EQxFBmCTcq9ZDyLPI5LaDUKI=
 github.com/stackrox/external-network-pusher v0.0.0-20210419192707-074af92bbfa7/go.mod h1:faUw9vx/mA7ql41Ftlst5MYar2DT3nnS6oK94lbaW0g=
-github.com/stackrox/helm-operator v0.0.12-0.20230804132854-090c1105ecf3 h1:ig/ciIccwfJA0bkQR6Ma3PekILgvSPYyilN5kGyujzE=
-github.com/stackrox/helm-operator v0.0.12-0.20230804132854-090c1105ecf3/go.mod h1:UjuwzzD8XHxLkFylwCcmhHAgqbjll+66xc0NOERZUfc=
+github.com/stackrox/helm-operator v0.0.12-0.20230825152000-1361e2f7db46 h1:yIuOPeiaOyQidGtgEtccvEAhUescUfO/l3r9h6Q5l/U=
+github.com/stackrox/helm-operator v0.0.12-0.20230825152000-1361e2f7db46/go.mod h1:UjuwzzD8XHxLkFylwCcmhHAgqbjll+66xc0NOERZUfc=
 github.com/stackrox/helmtest v0.0.0-20230920075407-d83ac0b1e48e h1:W41soaV5mmk928VZJ43n+EPHrCx/qsJoZ6cEbN9fyr8=
 github.com/stackrox/helmtest v0.0.0-20230920075407-d83ac0b1e48e/go.mod h1:WQXEbv5AEkj3Td7D8IDyARaAk2LWHmpKmsZ4274BSXY=
 github.com/stackrox/istio-cves v0.0.0-20221007013142-0bde9b541ec8 h1:rUIvoAHokPcd92aJT2gJwVeyE8tMuaqS5l5s3cEgXFY=


### PR DESCRIPTION
## Description
Use the latest github.com/stackrox/helm-operator which has fixed label selector bug
Follow up for #7695 

## Checklist
- [x] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

```
# Run two operators locally
CENTRAL_LABEL_SELECTOR="foo=bar" MAIN_IMAGE_TAG=4.2.1 make install run
3CENTRAL_LABEL_SELECTOR="foo=baz" MAIN_IMAGE_TAG=4.2.1 make install run

# Create and apply a central CR with label selector and check operator logs
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
