### PR TITLE
ROX-19358: Add formik validation and state tracking to deferral form

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionScopeField.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionScopeField.tsx
@@ -1,15 +1,22 @@
 import React from 'react';
 import { FormGroup, FormGroupProps, Radio } from '@patternfly/react-core';
 
-import { ScopeContext } from './utils';
+import { useFormik } from 'formik';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { DeferralValues, ScopeContext } from './utils';
+
+const ALL = '.*';
 
 export type ExceptionScopeFieldProps = {
     fieldId: FormGroupProps['fieldId'];
     label: FormGroupProps['label'];
     scopeContext: ScopeContext;
+    formik: ReturnType<typeof useFormik<DeferralValues>>;
 };
 
-function ExceptionScopeField({ fieldId, label, scopeContext }: ExceptionScopeFieldProps) {
+function ExceptionScopeField({ fieldId, label, scopeContext, formik }: ExceptionScopeFieldProps) {
+    const { values } = formik;
+
     return (
         <FormGroup fieldId={fieldId} label={label} isRequired>
             {scopeContext === 'GLOBAL' && (
@@ -17,7 +24,12 @@ function ExceptionScopeField({ fieldId, label, scopeContext }: ExceptionScopeFie
                     id="scope-global"
                     name="scope-global"
                     isDisabled
-                    isChecked
+                    isChecked={
+                        values.scope.imageScope.registry === ALL &&
+                        values.scope.imageScope.remote === ALL &&
+                        values.scope.imageScope.tag === ALL
+                    }
+                    onChange={() => {}}
                     label="Selected CVEs across all images and deployments"
                 />
             )}
@@ -26,15 +38,22 @@ function ExceptionScopeField({ fieldId, label, scopeContext }: ExceptionScopeFie
                     <Radio
                         id="scope-single-image"
                         name="scope-single-image"
-                        isChecked={false}
+                        isChecked={
+                            values.scope.imageScope.registry === ALL &&
+                            values.scope.imageScope.remote === scopeContext.image.name &&
+                            values.scope.imageScope.tag === ALL
+                        }
                         onChange={() => {}}
                         label={`All tags within ${scopeContext.image.name}}`}
                     />
                     <Radio
                         id="scope-single-image-single-tag"
                         name="scope-single-image-single-tag"
-                        isChecked={false}
-                        onChange={() => {}}
+                        isChecked={
+                            values.scope.imageScope.registry === ALL &&
+                            values.scope.imageScope.remote === scopeContext.image.name &&
+                            values.scope.imageScope.tag === scopeContext.image.tag
+                        }
                         label={`Only ${scopeContext.image.name}:${scopeContext.image.tag}`}
                     />
                 </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/utils.ts
@@ -1,1 +1,37 @@
+import { isAfter } from 'date-fns';
+import * as yup from 'yup';
+
 export type ScopeContext = 'GLOBAL' | { image: { name: string; tag: string } };
+
+export const deferralValidationSchema = yup.object({
+    cves: yup.array().of(yup.string()).min(1, 'At least one CVE must be selected'),
+    comment: yup.string().required('A rationale is required'),
+});
+
+export type DeferralValues = {
+    cves: string[];
+    comment: string;
+    scope: {
+        imageScope: {
+            registry: string;
+            remote: string;
+            tag: string;
+        };
+    };
+    expiry?:
+        | {
+              type: 'TIME';
+              days: number;
+          }
+        | {
+              type: 'ALL_CVE_FIXABLE' | 'ANY_CVE_FIXABLE' | 'INDEFINITE';
+          }
+        | {
+              type: 'CUSTOM_DATE';
+              date: string;
+          };
+};
+
+export function futureDateValidator(date: Date): string {
+    return isAfter(new Date(), date) ? 'Date must be in the future' : '';
+}

--- a/ui/apps/platform/src/services/ExceptionConfigService.ts
+++ b/ui/apps/platform/src/services/ExceptionConfigService.ts
@@ -16,9 +16,9 @@ export type VulnerabilitiesExceptionConfig = {
     };
 };
 
-export function fetchVulnerabilitiesExceptionConfig(): Promise<VulnerabilitiesExceptionConfig | null> {
+export function fetchVulnerabilitiesExceptionConfig(): Promise<VulnerabilitiesExceptionConfig> {
     return axios
-        .get<{ config: VulnerabilitiesExceptionConfig | null }>(vulnBaseUrl)
+        .get<{ config: VulnerabilitiesExceptionConfig }>(vulnBaseUrl)
         .then(({ data }) => data.config);
 }
 


### PR DESCRIPTION
## Description

As titled. Builds on top of https://github.com/stackrox/stackrox/pull/8160


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the deferral form and test that the different options can be tracked with formik state:
![image](https://github.com/stackrox/stackrox/assets/1292638/f4f12db3-2a6c-4b0b-8771-d9ded061baa2)
![image](https://github.com/stackrox/stackrox/assets/1292638/38859185-971d-4d33-b2be-97d1bd82c910)
![image](https://github.com/stackrox/stackrox/assets/1292638/568b0fa9-8d3c-4325-92ef-3baf4ba3fa1c)

The date picker defaults to "tomorrow" and only allows selection of dates in the future:
![image](https://github.com/stackrox/stackrox/assets/1292638/8635d8f4-64a3-4782-a606-4686714f0485)

Manually entering a date in the past invalidates the form:
![image](https://github.com/stackrox/stackrox/assets/1292638/2aa62be6-e2d9-4c6c-9baa-545320c69d2e)

Entering an invalid date string invalidates the form:
![image](https://github.com/stackrox/stackrox/assets/1292638/d0db8cd0-a847-4343-8404-1ecefb6d7ebf)

Blurring the comment field without entering a value invalidates the form:
![image](https://github.com/stackrox/stackrox/assets/1292638/737ce5d3-9e12-4078-a064-c75dd4c0ce84)
![image](https://github.com/stackrox/stackrox/assets/1292638/af9b124a-56c9-4eed-bdbb-5a711c7adf7b)
