### PR TITLE
ROX-19367: Add modal for a deferral request success

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/CompletedExceptionRequestModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/CompletedExceptionRequestModal.tsx
@@ -1,6 +1,56 @@
 import React from 'react';
-import { Button, Modal } from '@patternfly/react-core';
-import { BaseVulnerabilityException } from 'services/VulnerabilityExceptionService';
+import {
+    Button,
+    ClipboardCopy,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Flex,
+    Modal,
+    Text,
+    pluralize,
+} from '@patternfly/react-core';
+import differenceInDays from 'date-fns/difference_in_days';
+
+import {
+    BaseVulnerabilityException,
+    VulnerabilityDeferralException,
+    isDeferralException,
+    isFalsePositiveException,
+} from 'services/VulnerabilityExceptionService';
+import { getDate } from 'utils/dateUtils';
+import { ensureExhaustive } from 'utils/type.utils';
+
+function scopeDisplay(scope: BaseVulnerabilityException['scope']): string {
+    if (scope.imageScope.remote === '.*') {
+        return 'All images';
+    }
+    if (scope.imageScope.tag === '.*') {
+        return `${scope.imageScope.registry}/${scope.imageScope.remote}:*`;
+    }
+    return `${scope.imageScope.registry}/${scope.imageScope.remote}:${scope.imageScope.tag}`;
+}
+
+function expiryDisplay(expiry: VulnerabilityDeferralException['deferralReq']['expiry']): string {
+    const { expiryType } = expiry;
+    switch (expiryType) {
+        case 'ALL_CVE_FIXABLE':
+            return 'When all CVEs are fixable';
+        case 'ANY_CVE_FIXABLE':
+            return 'When any CVE is fixable';
+        case 'TIME': {
+            if (expiry.expiresOn) {
+                // Since the expiry here will always be in the future, we don't need to check which date is earlier
+                const daysUntilExpiration = differenceInDays(expiry.expiresOn, new Date());
+                return `${getDate(expiry.expiresOn)} (${pluralize(daysUntilExpiration, 'day')})`;
+            }
+            return 'Never';
+        }
+        default:
+            return ensureExhaustive(expiryType);
+    }
+}
 
 export type CompletedExceptionRequestModalProps = {
     exceptionRequest: BaseVulnerabilityException;
@@ -11,7 +61,17 @@ function CompletedExceptionRequestModal({
     exceptionRequest,
     onClose,
 }: CompletedExceptionRequestModalProps) {
-    const title = 'TODO';
+    let title = '';
+    let requestedAction = '';
+
+    if (isDeferralException(exceptionRequest)) {
+        title = 'Request for deferral has been submitted';
+        requestedAction = 'Deferral';
+    }
+    if (isFalsePositiveException(exceptionRequest)) {
+        title = 'Request for false positive has been submitted';
+        requestedAction = 'False positive';
+    }
 
     return (
         <Modal
@@ -25,7 +85,46 @@ function CompletedExceptionRequestModal({
                 </Button>,
             ]}
         >
-            {exceptionRequest.id}
+            <Flex direction={{ default: 'column' }}>
+                <Text>Use this link to share and discuss your request with your approver.</Text>
+                <ClipboardCopy
+                    isReadOnly
+                    hoverTip="Copy"
+                    clickTip="Copied"
+                >{`todo.path.to.requests.page/${exceptionRequest.name}`}</ClipboardCopy>
+                <DescriptionList columnModifier={{ default: '2Col' }} className="pf-u-pt-md">
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Requested action</DescriptionListTerm>
+                        <DescriptionListDescription>{requestedAction}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Scope</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {scopeDisplay(exceptionRequest.scope)}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Requested</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {getDate(exceptionRequest.createdAt)}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>CVEs</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {exceptionRequest.cves.length}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    {isDeferralException(exceptionRequest) && (
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Expires</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                {expiryDisplay(exceptionRequest.deferralReq.expiry)}
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                    )}
+                </DescriptionList>
+            </Flex>
         </Modal>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionRequestForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionRequestForm.tsx
@@ -53,14 +53,19 @@ function prettifyDate(date = ''): string {
     return date.substring(0, 10);
 }
 
-export type DeferralFormProps = {
+export type ExceptionRequestFormProps = {
     cves: CveSelectionsProps['cves'];
     scopeContext: ScopeContext;
     onSubmit: (formValues: DeferralValues, helpers: FormikHelpers<DeferralValues>) => void;
     onCancel: () => void;
 };
 
-function DeferralForm({ cves, scopeContext, onSubmit, onCancel }: DeferralFormProps) {
+function ExceptionRequestForm({
+    cves,
+    scopeContext,
+    onSubmit,
+    onCancel,
+}: ExceptionRequestFormProps) {
     const [activeKeyTab, setActiveKeyTab] = useState<string | number>('options');
     const { data: config, loading, error } = useRestQuery(fetchVulnerabilitiesExceptionConfig);
 
@@ -215,7 +220,7 @@ function DeferralForm({ cves, scopeContext, onSubmit, onCancel }: DeferralFormPr
                                                     onChange={(_, value) =>
                                                         setExpiry({
                                                             type: 'CUSTOM_DATE',
-                                                            date: value,
+                                                            date: new Date(value).toISOString(),
                                                         })
                                                     }
                                                     validators={[futureDateValidator]}
@@ -277,4 +282,4 @@ function DeferralForm({ cves, scopeContext, onSubmit, onCancel }: DeferralFormPr
     );
 }
 
-export default DeferralForm;
+export default ExceptionRequestForm;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionRequestModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionRequestModal.tsx
@@ -9,17 +9,17 @@ import {
 import useRestMutation from 'hooks/useRestMutation';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { CveExceptionRequestType } from '../../types';
+import ExceptionRequestForm, { ExceptionRequestFormProps } from './ExceptionRequestForm';
 import { DeferralValues, ScopeContext, formValuesToDeferralRequest } from './utils';
-import DeferralForm, { DeferralFormProps } from './DeferralForm';
 
 export type ExceptionRequestModalOptions = {
     type: CveExceptionRequestType;
-    cves: DeferralFormProps['cves'];
+    cves: ExceptionRequestFormProps['cves'];
 } | null;
 
 export type ExceptionRequestModalProps = {
     type: CveExceptionRequestType;
-    cves: DeferralFormProps['cves'];
+    cves: ExceptionRequestFormProps['cves'];
     scopeContext: ScopeContext;
     onExceptionRequestSuccess: (vulnerabilityException: BaseVulnerabilityException) => void;
     onClose: () => void;
@@ -67,7 +67,7 @@ function ExceptionRequestModal({
                     </Alert>
                 )}
                 {type === 'DEFERRAL' && (
-                    <DeferralForm
+                    <ExceptionRequestForm
                         cves={cves}
                         scopeContext={scopeContext}
                         onSubmit={onDeferralSubmit}

--- a/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
+++ b/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
@@ -39,7 +39,6 @@ type ExceptionExpiry =
 export type BaseVulnerabilityException = {
     id: string;
     name: string;
-    targetState: VulnerabilityState;
     exceptionStatus: ExceptionStatus;
     expired: boolean;
     requester: SlimUser;
@@ -51,6 +50,7 @@ export type BaseVulnerabilityException = {
 };
 
 export type VulnerabilityDeferralException = BaseVulnerabilityException & {
+    targetState: 'DEFERRED';
     deferralReq: {
         expiry: ExceptionExpiry;
     };
@@ -60,12 +60,25 @@ export type VulnerabilityDeferralException = BaseVulnerabilityException & {
     };
 };
 
+export function isDeferralException(
+    exception: BaseVulnerabilityException
+): exception is VulnerabilityDeferralException {
+    return 'targetState' in exception && exception.targetState === 'DEFERRED';
+}
+
 export type VulnerabilityFalsePositiveException = BaseVulnerabilityException & {
+    targetState: 'FALSE_POSITIVE';
     fpRequest: Empty;
     falsePositiveUpdate?: {
         cves: string[];
     };
 };
+
+export function isFalsePositiveException(
+    exception: BaseVulnerabilityException
+): exception is VulnerabilityFalsePositiveException {
+    return 'targetState' in exception && exception.targetState === 'FALSE_POSITIVE';
+}
 
 export function getVulnerabilityExceptionById(id: string): Promise<BaseVulnerabilityException> {
     const url = generatePath(`${baseUrl}/:id`, { id });


### PR DESCRIPTION
## Description

Adds the response details to a follow up modal when a deferral request has successfully been submitted.

## Caveats/Follow Ups

- The scope `registry` and `remote` are hard coded again in this example until the API supports wildcard/global values.
- The `createdAt` timestamp returning from the API is currently `null`, which is why the date appears incorrect.
- We need to replace the provided link once that page is implemented

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Open deferral for Workload CVEs:
![image](https://github.com/stackrox/stackrox/assets/1292638/c975c75a-f141-44bf-a7b7-e6d8fc0dfebf)

Upon success, a new modal is presented with details of the submitted request:
![image](https://github.com/stackrox/stackrox/assets/1292638/1f5f64e9-dc51-4a99-8c3f-16c2d19eef59)
![image](https://github.com/stackrox/stackrox/assets/1292638/4fba6df5-2e71-42df-bfb1-9c385b6cfe52)

Note that the "Requested" field above is incorrect because the API is currently returning `null`.
