### PR TITLE
ROX-20221: Message converters for v2 vulnerability exception service

### DIFF
--- a/central/convert/storagetov2/user.go
+++ b/central/convert/storagetov2/user.go
@@ -1,0 +1,33 @@
+package storagetov2
+
+import (
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/generated/storage"
+)
+
+func convertUsers(users []*storage.SlimUser) []*v2.SlimUser {
+	if len(users) == 0 {
+		return nil
+	}
+
+	var ret []*v2.SlimUser
+	for _, user := range users {
+		if user == nil {
+			continue
+		}
+		ret = append(ret, convertUser(user))
+	}
+
+	return ret
+}
+
+func convertUser(user *storage.SlimUser) *v2.SlimUser {
+	if user == nil {
+		return nil
+	}
+
+	return &v2.SlimUser{
+		Id:   user.GetId(),
+		Name: user.GetName(),
+	}
+}

--- a/central/convert/storagetov2/vuln_exception_service.go
+++ b/central/convert/storagetov2/vuln_exception_service.go
@@ -46,47 +46,6 @@ func VulnerabilityException(inp *storage.VulnerabilityRequest) *v2.Vulnerability
 	return out
 }
 
-func convertUsers(users []*storage.SlimUser) []*v2.SlimUser {
-	if len(users) == 0 {
-		return nil
-	}
-
-	var ret []*v2.SlimUser
-	for _, user := range users {
-		if user == nil {
-			continue
-		}
-		ret = append(ret, convertUser(user))
-	}
-
-	return ret
-}
-
-func convertUser(user *storage.SlimUser) *v2.SlimUser {
-	if user == nil {
-		return nil
-	}
-
-	return &v2.SlimUser{
-		Id:   user.GetId(),
-		Name: user.GetName(),
-	}
-}
-
-func convertVulnerabilityState(state storage.VulnerabilityState) v2.VulnerabilityState {
-	switch state {
-	case storage.VulnerabilityState_OBSERVED:
-		return v2.VulnerabilityState_OBSERVED
-	case storage.VulnerabilityState_DEFERRED:
-		return v2.VulnerabilityState_DEFERRED
-	case storage.VulnerabilityState_FALSE_POSITIVE:
-		return v2.VulnerabilityState_FALSE_POSITIVE
-	default:
-		utils.Should(errors.Errorf("unhandled vulnerability state encountered %s", state))
-		return v2.VulnerabilityState_OBSERVED
-	}
-}
-
 func convertRequestStatus(status storage.RequestStatus) v2.ExceptionStatus {
 	switch status {
 	case storage.RequestStatus_PENDING:

--- a/central/convert/storagetov2/vuln_exception_service.go
+++ b/central/convert/storagetov2/vuln_exception_service.go
@@ -1,0 +1,168 @@
+package storagetov2
+
+import (
+	"github.com/pkg/errors"
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+// VulnerabilityException converts *storage.VulnerabilityRequest to *v2.VulnerabilityException.
+func VulnerabilityException(inp *storage.VulnerabilityRequest) *v2.VulnerabilityException {
+	if inp == nil {
+		return nil
+	}
+
+	out := &v2.VulnerabilityException{
+		Id:          inp.GetId(),
+		Name:        inp.GetName(),
+		TargetState: convertVulnerabilityState(inp.GetTargetState()),
+		Status:      convertRequestStatus(inp.GetStatus()),
+		Expired:     inp.GetExpired(),
+		Requester:   convertUser(inp.GetRequestor()),
+		Approvers:   convertUsers(inp.GetApprovers()),
+		LastUpdated: inp.GetLastUpdated(),
+		Comments:    convertRequestComments(inp.GetComments()),
+		Scope:       convertScope(inp.GetScope()),
+		Cves:        inp.GetCves().GetCves(),
+	}
+
+	if inp.GetDeferralReq() != nil {
+		out.Req = &v2.VulnerabilityException_DeferralReq{
+			DeferralReq: convertDeferralReq(inp.GetDeferralReq()),
+		}
+	} else if inp.GetFpRequest() != nil {
+		out.Req = &v2.VulnerabilityException_FpRequest{
+			FpRequest: &v2.FalsePositiveRequest{},
+		}
+	}
+
+	if inp.GetUpdatedDeferralReq() != nil {
+		out.UpdatedReq = &v2.VulnerabilityException_DeferralReqUpdate{
+			DeferralReqUpdate: convertDeferralReq(inp.GetUpdatedDeferralReq()),
+		}
+	}
+
+	return out
+}
+
+func convertUsers(users []*storage.SlimUser) []*v2.SlimUser {
+	if len(users) == 0 {
+		return nil
+	}
+
+	var ret []*v2.SlimUser
+	for _, user := range users {
+		if user == nil {
+			continue
+		}
+		ret = append(ret, convertUser(user))
+	}
+
+	return ret
+}
+
+func convertUser(user *storage.SlimUser) *v2.SlimUser {
+	if user == nil {
+		return nil
+	}
+
+	return &v2.SlimUser{
+		Id:   user.GetId(),
+		Name: user.GetName(),
+	}
+}
+
+func convertVulnerabilityState(state storage.VulnerabilityState) v2.VulnerabilityState {
+	switch state {
+	case storage.VulnerabilityState_OBSERVED:
+		return v2.VulnerabilityState_OBSERVED
+	case storage.VulnerabilityState_DEFERRED:
+		return v2.VulnerabilityState_DEFERRED
+	case storage.VulnerabilityState_FALSE_POSITIVE:
+		return v2.VulnerabilityState_FALSE_POSITIVE
+	default:
+		utils.Should(errors.Errorf("unhandled vulnerability state encountered %s", state))
+		return v2.VulnerabilityState_OBSERVED
+	}
+}
+
+func convertRequestStatus(status storage.RequestStatus) v2.ExceptionStatus {
+	switch status {
+	case storage.RequestStatus_PENDING:
+		return v2.ExceptionStatus_PENDING
+	case storage.RequestStatus_APPROVED:
+		return v2.ExceptionStatus_APPROVED
+	case storage.RequestStatus_DENIED:
+		return v2.ExceptionStatus_DENIED
+	case storage.RequestStatus_APPROVED_PENDING_UPDATE:
+		return v2.ExceptionStatus_APPROVED_PENDING_UPDATE
+	default:
+		utils.Should(errors.Errorf("unhandled request status encountered %s", status))
+		return v2.ExceptionStatus_PENDING
+	}
+}
+
+func convertRequestComments(comments []*storage.RequestComment) []*v2.Comment {
+	if len(comments) == 0 {
+		return nil
+	}
+
+	var ret []*v2.Comment
+	for _, comment := range comments {
+		if comment == nil {
+			continue
+		}
+		ret = append(ret, &v2.Comment{
+			Id:        comment.GetId(),
+			Message:   comment.GetMessage(),
+			User:      convertUser(comment.GetUser()),
+			CreatedAt: comment.GetCreatedAt(),
+		})
+	}
+	return ret
+}
+
+func convertScope(scope *storage.VulnerabilityRequest_Scope) *v2.VulnerabilityException_Scope {
+	if scope == nil || scope.GetImageScope() == nil {
+		return nil
+	}
+
+	return &v2.VulnerabilityException_Scope{
+		ImageScope: &v2.VulnerabilityException_Scope_Image{
+			Registry: scope.GetImageScope().GetRegistry(),
+			Remote:   scope.GetImageScope().GetRemote(),
+			Tag:      scope.GetImageScope().GetTag(),
+		},
+	}
+}
+
+func convertDeferralReq(r *storage.DeferralRequest) *v2.DeferralRequest {
+	if r == nil {
+		return nil
+	}
+	return &v2.DeferralRequest{
+		Expiry: convertRequestExpiry(r.GetExpiry()),
+	}
+}
+
+func convertRequestExpiry(expiry *storage.RequestExpiry) *v2.ExceptionExpiry {
+	return &v2.ExceptionExpiry{
+		ExpiryType: convertExpiryType(expiry.GetExpiryType()),
+		ExpiresOn:  expiry.GetExpiresOn(),
+	}
+}
+
+func convertExpiryType(t storage.RequestExpiry_ExpiryType) v2.ExceptionExpiry_ExpiryType {
+	switch t {
+	case storage.RequestExpiry_TIME:
+		return v2.ExceptionExpiry_TIME
+	case storage.RequestExpiry_ALL_CVE_FIXABLE:
+		return v2.ExceptionExpiry_ALL_CVE_FIXABLE
+	case storage.RequestExpiry_ANY_CVE_FIXABLE:
+		return v2.ExceptionExpiry_ANY_CVE_FIXABLE
+	default:
+		utils.Should(errors.Errorf("unhandled expiry type encountered %s", t))
+		return v2.ExceptionExpiry_TIME
+	}
+}

--- a/central/convert/storagetov2/vuln_exception_service_test.go
+++ b/central/convert/storagetov2/vuln_exception_service_test.go
@@ -1,0 +1,40 @@
+package storagetov2
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/central/convert/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVulnerabilityException(t *testing.T) {
+	assert.EqualValues(
+		t,
+		testutils.GetTestVulnDeferralExceptionFull(t),
+		VulnerabilityException(testutils.GetTestVulnDeferralRequestFull(t)),
+	)
+
+	assert.EqualValues(
+		t,
+		testutils.GetTestVulnFPExceptionFull(t),
+		VulnerabilityException(testutils.GetTestVulnFPRequestFull(t)),
+	)
+
+	assert.EqualValues(
+		t,
+		testutils.GetTestVulnExceptionNoComments(t),
+		VulnerabilityException(testutils.GetTestVulnRequestNoComments(t)),
+	)
+
+	assert.EqualValues(
+		t,
+		testutils.GetTestVulnExceptionNoUsers(t),
+		VulnerabilityException(testutils.GetTestVulnRequestNoUsers(t)),
+	)
+
+	assert.EqualValues(
+		t,
+		testutils.GetTestVulnExceptionWithUpdate(t),
+		VulnerabilityException(testutils.GetTestVulnRequestWithUpdate(t)),
+	)
+}

--- a/central/convert/storagetov2/vulnerability.go
+++ b/central/convert/storagetov2/vulnerability.go
@@ -1,0 +1,22 @@
+package storagetov2
+
+import (
+	"github.com/pkg/errors"
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+func convertVulnerabilityState(state storage.VulnerabilityState) v2.VulnerabilityState {
+	switch state {
+	case storage.VulnerabilityState_OBSERVED:
+		return v2.VulnerabilityState_OBSERVED
+	case storage.VulnerabilityState_DEFERRED:
+		return v2.VulnerabilityState_DEFERRED
+	case storage.VulnerabilityState_FALSE_POSITIVE:
+		return v2.VulnerabilityState_FALSE_POSITIVE
+	default:
+		utils.Should(errors.Errorf("unhandled vulnerability state encountered %s", state))
+		return v2.VulnerabilityState_OBSERVED
+	}
+}

--- a/central/convert/testutils/vuln_exception.go
+++ b/central/convert/testutils/vuln_exception.go
@@ -1,0 +1,97 @@
+package testutils
+
+import (
+	"testing"
+
+	timestamp "github.com/gogo/protobuf/types"
+	v2 "github.com/stackrox/rox/generated/api/v2"
+)
+
+var (
+	ts1 = timestamp.TimestampNow()
+)
+
+// GetTestVulnDeferralExceptionFull returns a mock *v2.VulnerabilityException of deferral kind.
+func GetTestVulnDeferralExceptionFull(_ *testing.T) *v2.VulnerabilityException {
+	return &v2.VulnerabilityException{
+		Id:          "id",
+		Name:        "name",
+		TargetState: v2.VulnerabilityState_OBSERVED,
+		Status:      v2.ExceptionStatus_PENDING,
+		Expired:     false,
+		Requester: &v2.SlimUser{
+			Id:   "userID",
+			Name: "userName",
+		},
+		Approvers: []*v2.SlimUser{
+			{
+				Id:   "userID",
+				Name: "userName",
+			},
+		},
+		Comments: []*v2.Comment{
+			{
+				Id:      "commentID",
+				Message: "message",
+				User: &v2.SlimUser{
+					Id:   "userID",
+					Name: "userName",
+				},
+			},
+		},
+		Req: &v2.VulnerabilityException_DeferralReq{
+			DeferralReq: &v2.DeferralRequest{
+				Expiry: &v2.ExceptionExpiry{
+					ExpiryType: v2.ExceptionExpiry_TIME,
+					ExpiresOn:  ts1,
+				},
+			},
+		},
+		Scope: &v2.VulnerabilityException_Scope{
+			ImageScope: &v2.VulnerabilityException_Scope_Image{
+				Registry: "reg",
+				Remote:   "remote",
+				Tag:      "tag",
+			},
+		},
+		Cves: []string{"cve1"},
+	}
+}
+
+// GetTestVulnFPExceptionFull returns a mock *v2.VulnerabilityException of false-positive kind.
+func GetTestVulnFPExceptionFull(t *testing.T) *v2.VulnerabilityException {
+	ret := GetTestVulnDeferralExceptionFull(t)
+	ret.Req = &v2.VulnerabilityException_FpRequest{
+		FpRequest: &v2.FalsePositiveRequest{},
+	}
+	return ret
+}
+
+// GetTestVulnExceptionNoUsers returns a mock *v2.VulnerabilityException with nil `.requester` and `.approvers` fields.
+func GetTestVulnExceptionNoUsers(t *testing.T) *v2.VulnerabilityException {
+	ret := GetTestVulnDeferralExceptionFull(t)
+	ret.Requester = nil
+	ret.Approvers = nil
+	return ret
+}
+
+// GetTestVulnExceptionNoComments returns a mock *v2.VulnerabilityException with nil `.comments` field.
+func GetTestVulnExceptionNoComments(t *testing.T) *v2.VulnerabilityException {
+	ret := GetTestVulnDeferralExceptionFull(t)
+	ret.Comments = nil
+	return ret
+}
+
+// GetTestVulnExceptionWithUpdate returns a mock *v2.VulnerabilityException with non-nil `.updateReq` field.
+func GetTestVulnExceptionWithUpdate(t *testing.T) *v2.VulnerabilityException {
+	ret := GetTestVulnDeferralExceptionFull(t)
+	ret.UpdatedReq = &v2.VulnerabilityException_DeferralReqUpdate{
+		DeferralReqUpdate: &v2.DeferralRequest{
+			Expiry: &v2.ExceptionExpiry{
+				ExpiryType: v2.ExceptionExpiry_TIME,
+				ExpiresOn:  ts1,
+			},
+		},
+	}
+	return ret
+}

--- a/central/convert/testutils/vuln_request.go
+++ b/central/convert/testutils/vuln_request.go
@@ -1,0 +1,102 @@
+package testutils
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+)
+
+// GetTestVulnDeferralRequestFull returns a mock *storage.VulnerabilityRequest of deferral kind.
+func GetTestVulnDeferralRequestFull(_ *testing.T) *storage.VulnerabilityRequest {
+	return &storage.VulnerabilityRequest{
+		Id:          "id",
+		Name:        "name",
+		TargetState: storage.VulnerabilityState_OBSERVED,
+		Status:      storage.RequestStatus_PENDING,
+		Expired:     false,
+		Requestor: &storage.SlimUser{
+			Id:   "userID",
+			Name: "userName",
+		},
+		Approvers: []*storage.SlimUser{
+			{
+				Id:   "userID",
+				Name: "userName",
+			},
+		},
+		Comments: []*storage.RequestComment{
+			{
+				Id:      "commentID",
+				Message: "message",
+				User: &storage.SlimUser{
+					Id:   "userID",
+					Name: "userName",
+				},
+			},
+		},
+		Req: &storage.VulnerabilityRequest_DeferralReq{
+			DeferralReq: &storage.DeferralRequest{
+				Expiry: &storage.RequestExpiry{
+					ExpiryType: storage.RequestExpiry_TIME,
+					Expiry: &storage.RequestExpiry_ExpiresOn{
+						ExpiresOn: ts1,
+					},
+				},
+			},
+		},
+		Scope: &storage.VulnerabilityRequest_Scope{
+			Info: &storage.VulnerabilityRequest_Scope_ImageScope{
+				ImageScope: &storage.VulnerabilityRequest_Scope_Image{
+					Registry: "reg",
+					Remote:   "remote",
+					Tag:      "tag",
+				},
+			},
+		},
+		Entities: &storage.VulnerabilityRequest_Cves{
+			Cves: &storage.VulnerabilityRequest_CVEs{
+				Cves: []string{"cve1"},
+			},
+		},
+	}
+}
+
+// GetTestVulnFPRequestFull returns a mock *storage.VulnerabilityRequest of false-positive kind.
+func GetTestVulnFPRequestFull(t *testing.T) *storage.VulnerabilityRequest {
+	ret := GetTestVulnDeferralRequestFull(t)
+	ret.Req = &storage.VulnerabilityRequest_FpRequest{
+		FpRequest: &storage.FalsePositiveRequest{},
+	}
+	return ret
+}
+
+// GetTestVulnRequestNoUsers returns a mock *storage.VulnerabilityRequest with nil `.requester` and `.approvers` fields.
+func GetTestVulnRequestNoUsers(t *testing.T) *storage.VulnerabilityRequest {
+	ret := GetTestVulnDeferralRequestFull(t)
+	ret.Requestor = nil
+	ret.Approvers = nil
+	return ret
+}
+
+// GetTestVulnRequestNoComments returns a mock *storage.VulnerabilityRequest with nil `.comments` field.
+func GetTestVulnRequestNoComments(t *testing.T) *storage.VulnerabilityRequest {
+	ret := GetTestVulnDeferralRequestFull(t)
+	ret.Comments = nil
+	return ret
+}
+
+// GetTestVulnRequestWithUpdate returns a mock *storage.VulnerabilityRequest with non-nil `.updateReq` field.
+func GetTestVulnRequestWithUpdate(t *testing.T) *storage.VulnerabilityRequest {
+	ret := GetTestVulnDeferralRequestFull(t)
+	ret.UpdatedReq = &storage.VulnerabilityRequest_UpdatedDeferralReq{
+		UpdatedDeferralReq: &storage.DeferralRequest{
+			Expiry: &storage.RequestExpiry{
+				ExpiryType: storage.RequestExpiry_TIME,
+				Expiry: &storage.RequestExpiry_ExpiresOn{
+					ExpiresOn: ts1,
+				},
+			},
+		},
+	}
+	return ret
+}

--- a/central/convert/v2tostorage/user.go
+++ b/central/convert/v2tostorage/user.go
@@ -1,0 +1,33 @@
+package storagetov2
+
+import (
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/generated/storage"
+)
+
+func convertUsers(users []*v2.SlimUser) []*storage.SlimUser {
+	if len(users) == 0 {
+		return nil
+	}
+
+	var ret []*storage.SlimUser
+	for _, user := range users {
+		if user == nil {
+			continue
+		}
+		ret = append(ret, convertUser(user))
+	}
+
+	return ret
+}
+
+func convertUser(user *v2.SlimUser) *storage.SlimUser {
+	if user == nil {
+		return nil
+	}
+
+	return &storage.SlimUser{
+		Id:   user.GetId(),
+		Name: user.GetName(),
+	}
+}

--- a/central/convert/v2tostorage/vuln_exception_service.go
+++ b/central/convert/v2tostorage/vuln_exception_service.go
@@ -1,0 +1,184 @@
+package storagetov2
+
+import (
+	"github.com/pkg/errors"
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+// VulnerabilityRequest converts *v2.VulnerabilityException to *storage.VulnerabilityRequest.
+func VulnerabilityRequest(inp *v2.VulnerabilityException) *storage.VulnerabilityRequest {
+	if inp == nil {
+		return nil
+	}
+
+	out := &storage.VulnerabilityRequest{
+		Id:          inp.GetId(),
+		Name:        inp.GetName(),
+		TargetState: convertVulnerabilityState(inp.GetTargetState()),
+		Status:      convertRequestStatus(inp.GetStatus()),
+		Expired:     inp.GetExpired(),
+		Requestor:   convertUser(inp.GetRequester()),
+		Approvers:   convertUsers(inp.GetApprovers()),
+		LastUpdated: inp.GetLastUpdated(),
+		Comments:    convertRequestComments(inp.GetComments()),
+		Scope:       convertScope(inp.GetScope()),
+		Entities: &storage.VulnerabilityRequest_Cves{
+			Cves: &storage.VulnerabilityRequest_CVEs{
+				Cves: inp.GetCves(),
+			},
+		},
+		UpdatedReq: nil,
+	}
+
+	if inp.GetDeferralReq() != nil {
+		out.Req = &storage.VulnerabilityRequest_DeferralReq{
+			DeferralReq: convertDeferralReq(inp.GetDeferralReq()),
+		}
+	} else if inp.GetFpRequest() != nil {
+		out.Req = &storage.VulnerabilityRequest_FpRequest{
+			FpRequest: &storage.FalsePositiveRequest{},
+		}
+	}
+
+	if inp.GetDeferralReqUpdate() != nil {
+		out.UpdatedReq = &storage.VulnerabilityRequest_UpdatedDeferralReq{
+			UpdatedDeferralReq: convertDeferralReq(inp.GetDeferralReqUpdate()),
+		}
+	}
+
+	return out
+}
+
+func convertUsers(users []*v2.SlimUser) []*storage.SlimUser {
+	if len(users) == 0 {
+		return nil
+	}
+
+	var ret []*storage.SlimUser
+	for _, user := range users {
+		if user == nil {
+			continue
+		}
+		ret = append(ret, convertUser(user))
+	}
+
+	return ret
+}
+
+func convertUser(user *v2.SlimUser) *storage.SlimUser {
+	if user == nil {
+		return nil
+	}
+
+	return &storage.SlimUser{
+		Id:   user.GetId(),
+		Name: user.GetName(),
+	}
+}
+
+func convertVulnerabilityState(state v2.VulnerabilityState) storage.VulnerabilityState {
+	switch state {
+	case v2.VulnerabilityState_OBSERVED:
+		return storage.VulnerabilityState_OBSERVED
+	case v2.VulnerabilityState_DEFERRED:
+		return storage.VulnerabilityState_DEFERRED
+	case v2.VulnerabilityState_FALSE_POSITIVE:
+		return storage.VulnerabilityState_FALSE_POSITIVE
+	default:
+		utils.Should(errors.Errorf("unhandled vulnerability state encountered %s", state))
+		return storage.VulnerabilityState_OBSERVED
+	}
+}
+
+func convertRequestStatus(status v2.ExceptionStatus) storage.RequestStatus {
+	switch status {
+	case v2.ExceptionStatus_PENDING:
+		return storage.RequestStatus_PENDING
+	case v2.ExceptionStatus_APPROVED:
+		return storage.RequestStatus_APPROVED
+	case v2.ExceptionStatus_DENIED:
+		return storage.RequestStatus_DENIED
+	case v2.ExceptionStatus_APPROVED_PENDING_UPDATE:
+		return storage.RequestStatus_APPROVED_PENDING_UPDATE
+	default:
+		utils.Should(errors.Errorf("unhandled request status encountered %s", status))
+		return storage.RequestStatus_PENDING
+	}
+}
+
+func convertRequestComments(comments []*v2.Comment) []*storage.RequestComment {
+	if len(comments) == 0 {
+		return nil
+	}
+
+	var ret []*storage.RequestComment
+	for _, comment := range comments {
+		if comment == nil {
+			continue
+		}
+		ret = append(ret, &storage.RequestComment{
+			Id:        comment.GetId(),
+			Message:   comment.GetMessage(),
+			User:      convertUser(comment.GetUser()),
+			CreatedAt: comment.GetCreatedAt(),
+		})
+	}
+	return ret
+}
+
+func convertScope(scope *v2.VulnerabilityException_Scope) *storage.VulnerabilityRequest_Scope {
+	if scope == nil || scope.GetImageScope() == nil {
+		return nil
+	}
+
+	return &storage.VulnerabilityRequest_Scope{
+		Info: &storage.VulnerabilityRequest_Scope_ImageScope{
+			ImageScope: &storage.VulnerabilityRequest_Scope_Image{
+				Registry: scope.GetImageScope().GetRegistry(),
+				Remote:   scope.GetImageScope().GetRemote(),
+				Tag:      scope.GetImageScope().GetTag(),
+			},
+		},
+	}
+}
+
+func convertDeferralReq(r *v2.DeferralRequest) *storage.DeferralRequest {
+	if r == nil {
+		return nil
+	}
+	return &storage.DeferralRequest{
+		Expiry: convertRequestExpiry(r.GetExpiry()),
+	}
+}
+
+func convertRequestExpiry(expiry *v2.ExceptionExpiry) *storage.RequestExpiry {
+	ret := &storage.RequestExpiry{
+		ExpiryType: convertExpiryType(expiry.GetExpiryType()),
+	}
+	if expiry.GetExpiryType() == v2.ExceptionExpiry_TIME {
+		ret.Expiry = &storage.RequestExpiry_ExpiresOn{
+			ExpiresOn: expiry.GetExpiresOn(),
+		}
+	} else {
+		ret.Expiry = &storage.RequestExpiry_ExpiresWhenFixed{
+			ExpiresWhenFixed: true,
+		}
+	}
+	return ret
+}
+
+func convertExpiryType(t v2.ExceptionExpiry_ExpiryType) storage.RequestExpiry_ExpiryType {
+	switch t {
+	case v2.ExceptionExpiry_TIME:
+		return storage.RequestExpiry_TIME
+	case v2.ExceptionExpiry_ALL_CVE_FIXABLE:
+		return storage.RequestExpiry_ALL_CVE_FIXABLE
+	case v2.ExceptionExpiry_ANY_CVE_FIXABLE:
+		return storage.RequestExpiry_ANY_CVE_FIXABLE
+	default:
+		utils.Should(errors.Errorf("unhandled expiry type encountered %s", t))
+		return storage.RequestExpiry_TIME
+	}
+}

--- a/central/convert/v2tostorage/vuln_exception_service.go
+++ b/central/convert/v2tostorage/vuln_exception_service.go
@@ -51,47 +51,6 @@ func VulnerabilityRequest(inp *v2.VulnerabilityException) *storage.Vulnerability
 	return out
 }
 
-func convertUsers(users []*v2.SlimUser) []*storage.SlimUser {
-	if len(users) == 0 {
-		return nil
-	}
-
-	var ret []*storage.SlimUser
-	for _, user := range users {
-		if user == nil {
-			continue
-		}
-		ret = append(ret, convertUser(user))
-	}
-
-	return ret
-}
-
-func convertUser(user *v2.SlimUser) *storage.SlimUser {
-	if user == nil {
-		return nil
-	}
-
-	return &storage.SlimUser{
-		Id:   user.GetId(),
-		Name: user.GetName(),
-	}
-}
-
-func convertVulnerabilityState(state v2.VulnerabilityState) storage.VulnerabilityState {
-	switch state {
-	case v2.VulnerabilityState_OBSERVED:
-		return storage.VulnerabilityState_OBSERVED
-	case v2.VulnerabilityState_DEFERRED:
-		return storage.VulnerabilityState_DEFERRED
-	case v2.VulnerabilityState_FALSE_POSITIVE:
-		return storage.VulnerabilityState_FALSE_POSITIVE
-	default:
-		utils.Should(errors.Errorf("unhandled vulnerability state encountered %s", state))
-		return storage.VulnerabilityState_OBSERVED
-	}
-}
-
 func convertRequestStatus(status v2.ExceptionStatus) storage.RequestStatus {
 	switch status {
 	case v2.ExceptionStatus_PENDING:

--- a/central/convert/v2tostorage/vuln_exception_service_test.go
+++ b/central/convert/v2tostorage/vuln_exception_service_test.go
@@ -1,0 +1,40 @@
+package storagetov2
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/central/convert/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVulnerabilityRequest(t *testing.T) {
+	assert.EqualValues(
+		t,
+		testutils.GetTestVulnDeferralRequestFull(t),
+		VulnerabilityRequest(testutils.GetTestVulnDeferralExceptionFull(t)),
+	)
+
+	assert.EqualValues(
+		t,
+		testutils.GetTestVulnFPRequestFull(t),
+		VulnerabilityRequest(testutils.GetTestVulnFPExceptionFull(t)),
+	)
+
+	assert.EqualValues(
+		t,
+		testutils.GetTestVulnRequestNoComments(t),
+		VulnerabilityRequest(testutils.GetTestVulnExceptionNoComments(t)),
+	)
+
+	assert.EqualValues(
+		t,
+		testutils.GetTestVulnRequestNoUsers(t),
+		VulnerabilityRequest(testutils.GetTestVulnExceptionNoUsers(t)),
+	)
+
+	assert.EqualValues(
+		t,
+		testutils.GetTestVulnRequestWithUpdate(t),
+		VulnerabilityRequest(testutils.GetTestVulnExceptionWithUpdate(t)),
+	)
+}

--- a/central/convert/v2tostorage/vulnerability.go
+++ b/central/convert/v2tostorage/vulnerability.go
@@ -1,0 +1,22 @@
+package storagetov2
+
+import (
+	"github.com/pkg/errors"
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+func convertVulnerabilityState(state v2.VulnerabilityState) storage.VulnerabilityState {
+	switch state {
+	case v2.VulnerabilityState_OBSERVED:
+		return storage.VulnerabilityState_OBSERVED
+	case v2.VulnerabilityState_DEFERRED:
+		return storage.VulnerabilityState_DEFERRED
+	case v2.VulnerabilityState_FALSE_POSITIVE:
+		return storage.VulnerabilityState_FALSE_POSITIVE
+	default:
+		utils.Should(errors.Errorf("unhandled vulnerability state encountered %s", state))
+		return storage.VulnerabilityState_OBSERVED
+	}
+}


### PR DESCRIPTION
## Description
Message converters to convert `storage.Vulnerability` to `v2.VulnerabilityException` and vice-versa.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
Unit Test