### PR TITLE
ROX-20439: Cache clusters and namespaces used for SAC checks

### DIFF
--- a/central/sac/authorizer/builtin_scoped_authorizer.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer.go
@@ -11,7 +11,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
-	objectarraycache "github.com/stackrox/rox/pkg/cache/shallowobjectarraycache"
+	"github.com/stackrox/rox/pkg/cache/objectarraycache"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
 	"github.com/stackrox/rox/pkg/sac/observe"

--- a/central/sac/authorizer/builtin_scoped_authorizer.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer.go
@@ -26,9 +26,8 @@ var (
 	// ErrUnknownResource is returned when resource is unknown.
 	ErrUnknownResource = errors.New("unknown resource")
 
-	refreshCtx     = sac.WithAllAccess(context.Background())
-	clusterCache   = objectarraycache.NewShallowObjectArrayCache(refreshCtx, cacheRefreshPeriod, fetchClustersFromDB)
-	namespaceCache = objectarraycache.NewShallowObjectArrayCache(refreshCtx, cacheRefreshPeriod, fetchNamespacesFromDB)
+	clusterCache   = objectarraycache.NewObjectArrayCache(cacheRefreshPeriod, fetchClustersFromDB)
+	namespaceCache = objectarraycache.NewObjectArrayCache(cacheRefreshPeriod, fetchNamespacesFromDB)
 )
 
 const (
@@ -38,11 +37,13 @@ const (
 // NewBuiltInScopeChecker returns a new SAC-aware scope checker for the given
 // list of roles.
 func NewBuiltInScopeChecker(ctx context.Context, roles []permissions.ResolvedRole) (sac.ScopeCheckerCore, error) {
-	clusters, err := fetchClusters()
+	adminCtx := sac.WithGlobalAccessScopeChecker(ctx, sac.AllowAllAccessScopeChecker())
+
+	clusters, err := fetchClusters(adminCtx)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading all clusters")
 	}
-	namespaces, err := fetchNamespaces()
+	namespaces, err := fetchNamespaces(adminCtx)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading all namespaces")
 	}
@@ -370,16 +371,16 @@ func effectiveAccessScopeAllows(effectiveAccessScope *effectiveaccessscope.Scope
 	return ok && namespaceNode.State == effectiveaccessscope.Included
 }
 
-func fetchClusters() ([]*storage.Cluster, error) {
-	return clusterCache.GetObjects(), nil
+func fetchClusters(ctx context.Context) ([]*storage.Cluster, error) {
+	return clusterCache.GetObjects(ctx)
 }
 
 func fetchClustersFromDB(ctx context.Context) ([]*storage.Cluster, error) {
 	return clusterStore.Singleton().GetClusters(ctx)
 }
 
-func fetchNamespaces() ([]*storage.NamespaceMetadata, error) {
-	return namespaceCache.GetObjects(), nil
+func fetchNamespaces(ctx context.Context) ([]*storage.NamespaceMetadata, error) {
+	return namespaceCache.GetObjects(ctx)
 }
 
 func fetchNamespacesFromDB(ctx context.Context) ([]*storage.NamespaceMetadata, error) {

--- a/central/sac/authorizer/builtin_scoped_authorizer.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer.go
@@ -11,7 +11,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
-	"github.com/stackrox/rox/pkg/cache/objectarraycache"
+	objectarraycache "github.com/stackrox/rox/pkg/cache/shallowobjectarraycache"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
 	"github.com/stackrox/rox/pkg/sac/observe"

--- a/central/sac/authorizer/builtin_scoped_authorizer.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer.go
@@ -402,9 +402,7 @@ func fetchClustersFromCache() ([]*storage.Cluster, bool) {
 	}
 
 	result := make([]*storage.Cluster, 0, len(cachedClusters))
-	for _, c := range cachedClusters {
-		result = append(result, c)
-	}
+	result = append(result, cachedClusters...)
 	return result, true
 }
 
@@ -460,9 +458,7 @@ func fetchNamespacesFromCache() ([]*storage.NamespaceMetadata, bool) {
 	}
 
 	result := make([]*storage.NamespaceMetadata, 0, len(cachedNamespaces))
-	for _, ns := range cachedNamespaces {
-		result = append(result, ns)
-	}
+	result = append(result, cachedNamespaces...)
 	return result, true
 }
 

--- a/pkg/cache/objectarraycache/objectarraycache.go
+++ b/pkg/cache/objectarraycache/objectarraycache.go
@@ -78,9 +78,7 @@ func (c *ObjectArrayCache[T]) refreshCache(objects []*T) {
 		}
 	} else {
 		c.objectCache = make([]*T, 0, len(objects))
-		for _, obj := range objects {
-			c.objectCache = append(c.objectCache, obj)
-		}
+		c.objectCache = append(c.objectCache, objects...)
 	}
 }
 

--- a/pkg/cache/objectarraycache/objectarraycache.go
+++ b/pkg/cache/objectarraycache/objectarraycache.go
@@ -30,6 +30,8 @@ func NewObjectArrayCache[T any](validityPeriod time.Duration, refreshFn RefreshF
 	}
 }
 
+// GetObjects retrieves the array of objects, either from cache (when not
+// expired), or using the refresh function (when the cache is expired).
 func (c *ObjectArrayCache[T]) GetObjects(ctx context.Context) ([]*T, error) {
 	objects, valid := c.getObjectsFromCache()
 	if valid {
@@ -82,6 +84,7 @@ func (c *ObjectArrayCache[T]) refreshCache(objects []*T) {
 	}
 }
 
+// Refresh triggers a manual refresh of the cache.
 func (c *ObjectArrayCache[T]) Refresh(ctx context.Context) error {
 	objects, err := c.refreshFn(ctx)
 	if err != nil {

--- a/pkg/cache/objectarraycache/objectarraycache.go
+++ b/pkg/cache/objectarraycache/objectarraycache.go
@@ -73,15 +73,8 @@ func (c *ObjectArrayCache[T]) refreshCache(objects []*T) {
 		return
 	}
 	c.lastRefreshed = refreshTime
-	if len(c.objectCache) == len(objects) {
-		// Save the re-allocation of the object array
-		for i := 0; i < len(c.objectCache); i++ {
-			c.objectCache[i] = objects[i]
-		}
-	} else {
-		c.objectCache = make([]*T, 0, len(objects))
-		c.objectCache = append(c.objectCache, objects...)
-	}
+	c.objectCache = c.objectCache[:0]
+	c.objectCache = append(c.objectCache, objects...)
 }
 
 // Refresh triggers a manual refresh of the cache.

--- a/pkg/cache/objectarraycache/objectarraycache.go
+++ b/pkg/cache/objectarraycache/objectarraycache.go
@@ -1,0 +1,94 @@
+package objectarraycache
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+// RefreshFunction is a function that retrieves an array of objects.
+type RefreshFunction[T any] func(ctx context.Context) ([]*T, error)
+
+// ObjectArrayCache is a cache for an array of objects.
+// The object array in the cache instance are valid for a pre-defined period,
+// and are retrieved from the source when they are not valid anymore.
+type ObjectArrayCache[T any] struct {
+	mutex          sync.RWMutex
+	lastRefreshed  time.Time
+	validityPeriod time.Duration
+	objectCache    []*T
+	refreshFn      RefreshFunction[T]
+}
+
+// NewObjectArrayCache returns a cache for an object array where the cached
+// objects are retrieved using refreshFn and are valid for validityPeriod.
+func NewObjectArrayCache[T any](validityPeriod time.Duration, refreshFn RefreshFunction[T]) *ObjectArrayCache[T] {
+	return &ObjectArrayCache[T]{
+		validityPeriod: validityPeriod,
+		refreshFn:      refreshFn,
+	}
+}
+
+func (c *ObjectArrayCache[T]) GetObjects(ctx context.Context) ([]*T, error) {
+	objects, valid := c.getObjectsFromCache()
+	if valid {
+		return objects, nil
+	}
+
+	objects, err := c.refreshFn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c.refreshCache(objects)
+	return objects, nil
+}
+
+func (c *ObjectArrayCache[T]) getObjectsFromCache() ([]*T, bool) {
+	now := time.Now()
+
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	if now.After(c.lastRefreshed.Add(c.validityPeriod)) {
+		// Cache expired, notify that the cache should be refreshed
+		return nil, false
+	}
+
+	res := make([]*T, 0, len(c.objectCache))
+	res = append(res, c.objectCache...)
+	return res, true
+}
+
+func (c *ObjectArrayCache[T]) refreshCache(objects []*T) {
+	refreshTime := time.Now()
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if refreshTime.Before(c.lastRefreshed.Add(c.validityPeriod)) {
+		// The cache was refreshed in the meantime, skip cache refresh
+		return
+	}
+	c.lastRefreshed = refreshTime
+	if len(c.objectCache) == len(objects) {
+		// Save the re-allocation of the object array
+		for i := 0; i < len(c.objectCache); i++ {
+			c.objectCache[i] = objects[i]
+		}
+	} else {
+		c.objectCache = make([]*T, 0, len(objects))
+		for _, obj := range objects {
+			c.objectCache = append(c.objectCache, obj)
+		}
+	}
+}
+
+func (c *ObjectArrayCache[T]) Refresh(ctx context.Context) error {
+	objects, err := c.refreshFn(ctx)
+	if err != nil {
+		return err
+	}
+	c.refreshCache(objects)
+	return nil
+}

--- a/pkg/cache/objectarraycache/objectarraycache.go
+++ b/pkg/cache/objectarraycache/objectarraycache.go
@@ -10,95 +10,60 @@ import (
 // RefreshFunction is a function that retrieves an array of objects.
 type RefreshFunction[T any] func(ctx context.Context) ([]*T, error)
 
-// ShallowObjectArrayCache is a cache for an array of objects.
+// ObjectArrayCache is a cache for an array of objects.
 // The object array in the cache instance are valid for a pre-defined period,
 // and are retrieved from the source when they are not valid anymore.
-type ShallowObjectArrayCache[T any] struct {
-	mutex              sync.RWMutex
-	lastRefreshTrigger time.Time
-	lastRefreshed      time.Time
-	validityPeriod     time.Duration
-	objectCache        []*T
-	refreshFn          RefreshFunction[T]
-	refreshCtx         context.Context
+type ObjectArrayCache[T any] struct {
+	mutex          sync.RWMutex
+	lastRefreshed  time.Time
+	validityPeriod time.Duration
+	objectCache    []*T
+	refreshFn      RefreshFunction[T]
 }
 
-// NewShallowObjectArrayCache returns a cache for an object array where the cached
+// NewObjectArrayCache returns a cache for an object array where the cached
 // objects are retrieved using refreshFn and are valid for validityPeriod.
-func NewShallowObjectArrayCache[T any](
-	refreshCtx context.Context,
-	validityPeriod time.Duration,
-	refreshFn RefreshFunction[T],
-) *ShallowObjectArrayCache[T] {
-	return &ShallowObjectArrayCache[T]{
+func NewObjectArrayCache[T any](validityPeriod time.Duration, refreshFn RefreshFunction[T]) *ObjectArrayCache[T] {
+	return &ObjectArrayCache[T]{
 		validityPeriod: validityPeriod,
 		refreshFn:      refreshFn,
-		refreshCtx:     refreshCtx,
 	}
 }
 
 // GetObjects retrieves the array of objects, either from cache (when not
 // expired), or using the refresh function (when the cache is expired).
-// The returned objects are not copied, and could be subject to concurrent
-// modifications. If the functional flow modifies the retrieved objects,
-// concurrency has to be handled at object level.
-func (c *ShallowObjectArrayCache[T]) GetObjects() []*T {
+func (c *ObjectArrayCache[T]) GetObjects(ctx context.Context) ([]*T, error) {
 	objects, valid := c.getObjectsFromCache()
-
-	if !valid {
-		// Cache is not fresh anymore, refresh it in the background
-		go c.doBackgroundRefresh()
-		if len(objects) == 0 {
-			objects, _ = c.refreshFn(c.refreshCtx)
-		}
+	if valid {
+		return objects, nil
 	}
 
-	return objects
+	objects, err := c.refreshFn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c.refreshCache(objects)
+	return objects, nil
 }
 
-func (c *ShallowObjectArrayCache[T]) getObjectsFromCache() ([]*T, bool) {
+func (c *ObjectArrayCache[T]) getObjectsFromCache() ([]*T, bool) {
 	now := time.Now()
-	valid := true
 
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 
 	if now.After(c.lastRefreshed.Add(c.validityPeriod)) {
 		// Cache expired, notify that the cache should be refreshed
-		valid = false
+		return nil, false
 	}
 
 	res := make([]*T, 0, len(c.objectCache))
 	res = append(res, c.objectCache...)
-	return res, valid
+	return res, true
 }
 
-func (c *ShallowObjectArrayCache[T]) doBackgroundRefresh() {
-	shouldRefresh := c.triggerBackgroundRefresh()
-	if !shouldRefresh {
-		return
-	}
-	_ = c.Refresh(c.refreshCtx)
-	return
-}
-
-func (c *ShallowObjectArrayCache[T]) triggerBackgroundRefresh() bool {
-	now := time.Now()
-
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	if now.Before(c.lastRefreshTrigger.Add(c.validityPeriod)) {
-		// Another execution picked the refresh request, stop here.
-		return false
-	}
-
-	c.lastRefreshTrigger = now
-
-	return true
-}
-
-func (c *ShallowObjectArrayCache[T]) refreshCache(objects []*T) {
+func (c *ObjectArrayCache[T]) refreshCache(objects []*T) {
 	refreshTime := time.Now()
 
 	c.mutex.Lock()
@@ -107,19 +72,20 @@ func (c *ShallowObjectArrayCache[T]) refreshCache(objects []*T) {
 		// The cache was refreshed in the meantime, skip cache refresh
 		return
 	}
-	c.lastRefreshTrigger = refreshTime
 	c.lastRefreshed = refreshTime
 	if len(c.objectCache) == len(objects) {
 		// Save the re-allocation of the object array
-		c.objectCache = c.objectCache[:0]
+		for i := 0; i < len(c.objectCache); i++ {
+			c.objectCache[i] = objects[i]
+		}
 	} else {
 		c.objectCache = make([]*T, 0, len(objects))
+		c.objectCache = append(c.objectCache, objects...)
 	}
-	c.objectCache = append(c.objectCache, objects...)
 }
 
 // Refresh triggers a manual refresh of the cache.
-func (c *ShallowObjectArrayCache[T]) Refresh(ctx context.Context) error {
+func (c *ObjectArrayCache[T]) Refresh(ctx context.Context) error {
 	objects, err := c.refreshFn(ctx)
 	if err != nil {
 		return err

--- a/pkg/cache/objectarraycache/objectarraycache.go
+++ b/pkg/cache/objectarraycache/objectarraycache.go
@@ -10,60 +10,95 @@ import (
 // RefreshFunction is a function that retrieves an array of objects.
 type RefreshFunction[T any] func(ctx context.Context) ([]*T, error)
 
-// ObjectArrayCache is a cache for an array of objects.
+// ShallowObjectArrayCache is a cache for an array of objects.
 // The object array in the cache instance are valid for a pre-defined period,
 // and are retrieved from the source when they are not valid anymore.
-type ObjectArrayCache[T any] struct {
-	mutex          sync.RWMutex
-	lastRefreshed  time.Time
-	validityPeriod time.Duration
-	objectCache    []*T
-	refreshFn      RefreshFunction[T]
+type ShallowObjectArrayCache[T any] struct {
+	mutex              sync.RWMutex
+	lastRefreshTrigger time.Time
+	lastRefreshed      time.Time
+	validityPeriod     time.Duration
+	objectCache        []*T
+	refreshFn          RefreshFunction[T]
+	refreshCtx         context.Context
 }
 
-// NewObjectArrayCache returns a cache for an object array where the cached
+// NewShallowObjectArrayCache returns a cache for an object array where the cached
 // objects are retrieved using refreshFn and are valid for validityPeriod.
-func NewObjectArrayCache[T any](validityPeriod time.Duration, refreshFn RefreshFunction[T]) *ObjectArrayCache[T] {
-	return &ObjectArrayCache[T]{
+func NewShallowObjectArrayCache[T any](
+	refreshCtx context.Context,
+	validityPeriod time.Duration,
+	refreshFn RefreshFunction[T],
+) *ShallowObjectArrayCache[T] {
+	return &ShallowObjectArrayCache[T]{
 		validityPeriod: validityPeriod,
 		refreshFn:      refreshFn,
+		refreshCtx:     refreshCtx,
 	}
 }
 
 // GetObjects retrieves the array of objects, either from cache (when not
 // expired), or using the refresh function (when the cache is expired).
-func (c *ObjectArrayCache[T]) GetObjects(ctx context.Context) ([]*T, error) {
+// The returned objects are not copied, and could be subject to concurrent
+// modifications. If the functional flow modifies the retrieved objects,
+// concurrency has to be handled at object level.
+func (c *ShallowObjectArrayCache[T]) GetObjects() []*T {
 	objects, valid := c.getObjectsFromCache()
-	if valid {
-		return objects, nil
+
+	if !valid {
+		// Cache is not fresh anymore, refresh it in the background
+		go c.doBackgroundRefresh()
+		if len(objects) == 0 {
+			objects, _ = c.refreshFn(c.refreshCtx)
+		}
 	}
 
-	objects, err := c.refreshFn(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	c.refreshCache(objects)
-	return objects, nil
+	return objects
 }
 
-func (c *ObjectArrayCache[T]) getObjectsFromCache() ([]*T, bool) {
+func (c *ShallowObjectArrayCache[T]) getObjectsFromCache() ([]*T, bool) {
 	now := time.Now()
+	valid := true
 
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 
 	if now.After(c.lastRefreshed.Add(c.validityPeriod)) {
 		// Cache expired, notify that the cache should be refreshed
-		return nil, false
+		valid = false
 	}
 
 	res := make([]*T, 0, len(c.objectCache))
 	res = append(res, c.objectCache...)
-	return res, true
+	return res, valid
 }
 
-func (c *ObjectArrayCache[T]) refreshCache(objects []*T) {
+func (c *ShallowObjectArrayCache[T]) doBackgroundRefresh() {
+	shouldRefresh := c.triggerBackgroundRefresh()
+	if !shouldRefresh {
+		return
+	}
+	_ = c.Refresh(c.refreshCtx)
+	return
+}
+
+func (c *ShallowObjectArrayCache[T]) triggerBackgroundRefresh() bool {
+	now := time.Now()
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if now.Before(c.lastRefreshTrigger.Add(c.validityPeriod)) {
+		// Another execution picked the refresh request, stop here.
+		return false
+	}
+
+	c.lastRefreshTrigger = now
+
+	return true
+}
+
+func (c *ShallowObjectArrayCache[T]) refreshCache(objects []*T) {
 	refreshTime := time.Now()
 
 	c.mutex.Lock()
@@ -72,20 +107,19 @@ func (c *ObjectArrayCache[T]) refreshCache(objects []*T) {
 		// The cache was refreshed in the meantime, skip cache refresh
 		return
 	}
+	c.lastRefreshTrigger = refreshTime
 	c.lastRefreshed = refreshTime
 	if len(c.objectCache) == len(objects) {
 		// Save the re-allocation of the object array
-		for i := 0; i < len(c.objectCache); i++ {
-			c.objectCache[i] = objects[i]
-		}
+		c.objectCache = c.objectCache[:0]
 	} else {
 		c.objectCache = make([]*T, 0, len(objects))
-		c.objectCache = append(c.objectCache, objects...)
 	}
+	c.objectCache = append(c.objectCache, objects...)
 }
 
 // Refresh triggers a manual refresh of the cache.
-func (c *ObjectArrayCache[T]) Refresh(ctx context.Context) error {
+func (c *ShallowObjectArrayCache[T]) Refresh(ctx context.Context) error {
 	objects, err := c.refreshFn(ctx)
 	if err != nil {
 		return err

--- a/pkg/cache/objectarraycache/objectarraycache.go
+++ b/pkg/cache/objectarraycache/objectarraycache.go
@@ -73,8 +73,7 @@ func (c *ObjectArrayCache[T]) refreshCache(objects []*T) {
 		return
 	}
 	c.lastRefreshed = refreshTime
-	c.objectCache = c.objectCache[:0]
-	c.objectCache = append(c.objectCache, objects...)
+	c.objectCache = objects
 }
 
 // Refresh triggers a manual refresh of the cache.

--- a/pkg/cache/objectarraycache/objectarraycache.go
+++ b/pkg/cache/objectarraycache/objectarraycache.go
@@ -79,6 +79,7 @@ func (c *ShallowObjectArrayCache[T]) doBackgroundRefresh() {
 		return
 	}
 	_ = c.Refresh(c.refreshCtx)
+	return
 }
 
 func (c *ShallowObjectArrayCache[T]) triggerBackgroundRefresh() bool {

--- a/pkg/cache/shallowobjectarraycache/shallowobjectarraycache.go
+++ b/pkg/cache/shallowobjectarraycache/shallowobjectarraycache.go
@@ -79,7 +79,6 @@ func (c *ShallowObjectArrayCache[T]) doBackgroundRefresh() {
 		return
 	}
 	_ = c.Refresh(c.refreshCtx)
-	return
 }
 
 func (c *ShallowObjectArrayCache[T]) triggerBackgroundRefresh() bool {


### PR DESCRIPTION
## Description

Some customers with large setups are facing OOM Kills with Central. One big contributor to the memory allocations are clusters and namespaces.

The changes here aim at limiting the amount of data pulled when enriching the request context for later SAC checks.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

This change is impacting any service call that is performed by a user whose identity has a restricted scope. The functional part is already covered by a number of end-to-end tests.

Creating such an identity requires a few steps when testing locally:
- Create a restricted access scope (from the UI in the `Platform Configuration` > `Access Control` panel, navigate to `Access Scopes`, then create a simple access scope targeting the namespace `stackrox` in the cluster `remote` of the local deployment).
- Create a role using the access scope created above (navigate to `Roles` and create a role with the above access scope and the `Analyst` permission set)
- Create an API token with the role created above (from the UI in the `Platform Configuration` > `Integrations` panel, navigate to `API Tokens`, create a token using the above role, save the returned token in an environment variable named `TOKEN`).

Testing with the identity against the local cluster:
- `curl --insecure -XGET --header "Authorization: Bearer $TOKEN" https://localhost:8000/v1/namespaces` (this returns only the `stackrox` namespace).
- The same `curl` request using the admin credentials returns a larger data set

Performance testing was done against a demo cluster with 10k namespaces created, and 4 clients requesting the same deployment in a loop.
![Screenshot 2023-10-23 at 13 50 30](https://github.com/stackrox/stackrox/assets/91869377/edc365a5-fe10-41a7-b449-ae8737ddf7fe)
The above screenshot shows between 1PM and 1:30PM the CPU and memory usage of release 4.2.1, then between 1:30PM and 1:50PM the behaviour of the same cluster with this fix included. With this fix, CPU workload is reduced, and the memory footprint does not show any bump.
With 4.2, CPU usage spikes at 0.8 and memory climbs from 0.24GiB to 0.5 GiB.
With the fix, CPU usage goes up to 0.4, and memory remains stable below 0.24 GiB

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
