### PR TITLE
chore: Update labels again and set some value to version and url

### DIFF
--- a/image/roxctl/rhtap.Dockerfile
+++ b/image/roxctl/rhtap.Dockerfile
@@ -38,21 +38,21 @@ RUN microdnf upgrade -y --nobest && \
 
 LABEL \
     com.redhat.component="rhacs-roxctl-container" \
-    name="rhacs-roxctl-rhel8" \
-    maintainer="Red Hat, Inc." \
-    source-location="https://github.com/stackrox/stackrox" \
-    # These labels are added to override the base image values.
-    description="The CLI for ACS" \
-    io.k8s.description="The CLI for ACS" \
+    com.redhat.license_terms="https://www.redhat.com/agreements" \
+    description="The CLI for RHACS" \
+    io.k8s.description="The CLI for RHACS" \
     io.k8s.display-name="roxctl" \
     io.openshift.tags="rhacs,roxctl,stackrox" \
-    summary="The CLI for ACS" \
-    # If we don't reset the following labels, we inherit values from the base container which will be incorrect.
-    # At the same time, we can't configure correct values yet. E.g. see the following thread about version:
+    maintainer="Red Hat, Inc." \
+    name="rhacs-roxctl-rhel8" \
+    source-location="https://github.com/stackrox/stackrox" \
+    summary="The CLI for RHACS" \
+    url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
+    # We must set version label to prevent inheriting value set in the base stage.
+    # It's not possible to inject dynamic value at the moment, see the following thread
     # https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1697127151309229
-    com.redhat.license_terms="" \
-    url="" \
-    version=""
+    # TODO: configure version when it becomes possible.
+    version="0.0.1-todo"
 
 ENV ROX_ROXCTL_IN_MAIN_IMAGE="true"
 


### PR DESCRIPTION
I saw that enterprise contract started failing more after I set empty values on inherited labels.
![image](https://github.com/stackrox/stackrox/assets/537715/fa89fc89-58a7-426a-adc8-286b06934042)

Therefore, I set `version` to a dummy value.

`url` seems to be set to container page:
```
$ docker inspect registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:4.2.1 | grep -F '"url"'
                "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/rhacs-main-rhel8/images/4.2.1-3",
```
Funny, that the page does not work at the moment. I gave a link to RHACS in the software catalog instead, this is a parent level above images.

I also set `com.redhat.license_terms` to what our containers get during builds:
```
$ docker inspect registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:4.2.1 | grep -F 'com.redhat.license_terms'
                "com.redhat.license_terms": "https://www.redhat.com/agreements",
```

Also, sorted labels alphabetically (excluding `version`).