### PR TITLE
ROX-20121: set gRPC & http2 max concurrent streams to 100

### DIFF
--- a/pkg/grpc/endpoints.go
+++ b/pkg/grpc/endpoints.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/grpc/alpn"
 	"github.com/stackrox/rox/pkg/mtls/verifier"
 	"github.com/stackrox/rox/pkg/netutil"
@@ -20,6 +21,22 @@ import (
 	downgradingServer "golang.stackrox.io/grpc-http1/server"
 	"google.golang.org/grpc"
 )
+
+const (
+	defaultMaxHTTP2ConcurrentStreams = 100 // HTTP/2 spec recommendation for minimum value
+)
+
+var (
+	maxHTTP2ConcurrentStreamsSetting = env.RegisterIntegerSetting("ROX_HTTP2_MAX_CONCURRENT_STREAMS", defaultMaxHTTP2ConcurrentStreams)
+)
+
+func maxHTTP2ConcurrentStreams() uint32 {
+	if maxHTTP2ConcurrentStreamsSetting.IntegerSetting() <= 0 {
+		return defaultMaxHTTP2ConcurrentStreams
+	}
+
+	return uint32(maxHTTP2ConcurrentStreamsSetting.IntegerSetting())
+}
 
 // EndpointConfig configures an endpoint through which the server is exposed.
 type EndpointConfig struct {
@@ -178,7 +195,9 @@ func (c *EndpointConfig) instantiate(httpHandler http.Handler, grpcSrv *grpc.Ser
 			ErrorLog:  golog.New(httpErrorLogger{}, "", golog.LstdFlags),
 		}
 		if !c.NoHTTP2 {
-			var h2Srv http2.Server
+			h2Srv := http2.Server{
+				MaxConcurrentStreams: maxHTTP2ConcurrentStreams(),
+			}
 			if err := http2.ConfigureServer(httpSrv, &h2Srv); err != nil {
 				log.Warnf("Failed to instantiate endpoint listening at %q for HTTP/2", c.ListenEndpoint)
 			} else {

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -43,8 +43,9 @@ import (
 )
 
 const (
-	defaultMaxMsgSize         = 12 * 1024 * 1024
-	defaultMaxResponseMsgSize = 256 * 1024 * 1024 // 256MB
+	defaultMaxMsgSize               = 12 * 1024 * 1024
+	defaultMaxResponseMsgSize       = 256 * 1024 * 1024 // 256MB
+	defaultMaxGrpcConcurrentStreams = 100               // HTTP/2 spec recommendation for minimum value
 )
 
 func init() {
@@ -55,9 +56,10 @@ func init() {
 var (
 	log = logging.LoggerForModule()
 
-	maxResponseMsgSizeSetting = env.RegisterSetting("ROX_GRPC_MAX_RESPONSE_SIZE")
-	maxMsgSizeSetting         = env.RegisterIntegerSetting("ROX_GRPC_MAX_MESSAGE_SIZE", defaultMaxMsgSize)
-	enableRequestTracing      = env.RegisterBooleanSetting("ROX_GRPC_ENABLE_REQUEST_TRACING", false)
+	maxResponseMsgSizeSetting       = env.RegisterSetting("ROX_GRPC_MAX_RESPONSE_SIZE")
+	maxMsgSizeSetting               = env.RegisterIntegerSetting("ROX_GRPC_MAX_MESSAGE_SIZE", defaultMaxMsgSize)
+	maxGrpcConcurrentStreamsSetting = env.RegisterIntegerSetting("ROX_GRPC_MAX_CONCURRENT_STREAMS", defaultMaxGrpcConcurrentStreams)
+	enableRequestTracing            = env.RegisterBooleanSetting("ROX_GRPC_ENABLE_REQUEST_TRACING", false)
 )
 
 func maxResponseMsgSize() int {
@@ -69,6 +71,14 @@ func maxResponseMsgSize() int {
 		log.Warnf("Invalid value %q for %s: %v", setting, maxResponseMsgSizeSetting.EnvVar(), err)
 	}
 	return defaultMaxResponseMsgSize
+}
+
+func maxGrpcConcurrentStreams() uint32 {
+	if maxGrpcConcurrentStreamsSetting.IntegerSetting() <= 0 {
+		return defaultMaxGrpcConcurrentStreams
+	}
+
+	return uint32(maxGrpcConcurrentStreamsSetting.IntegerSetting())
 }
 
 type server interface {
@@ -345,6 +355,7 @@ func (a *apiImpl) run(startedSig *concurrency.Signal) {
 			MinTime:             5 * time.Second,
 			PermitWithoutStream: true,
 		}),
+		grpc.MaxConcurrentStreams(maxGrpcConcurrentStreams()),
 	)
 
 	for _, service := range a.apiServices {


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/stackrox/stackrox/pull/8124 into the `release-3.74` branch.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
