### PR TITLE
ROX-20328: Dedupe deployment dependencies

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -68,4 +68,7 @@ var (
 
 	// PolicyCriteriaModal enables a modal for selecting policy criteria when editing a policy
 	PolicyCriteriaModal = registerFeature("Enable modal to select policy criteria when editing a policy", "ROX_POLICY_CRITERIA_MODAL", false)
+
+	// SensorDeploymentBuildOptimization enables a performance improvement by skipping deployments processing when no dependency or spec changed
+	SensorDeploymentBuildOptimization = registerFeature("Enables a performance improvement by skipping deployments processing when no dependency or spec changed", "ROX_DEPLOYMENT_BUILD_OPTIMIZATION", true)
 )

--- a/sensor/common/store/deployment_dependency.go
+++ b/sensor/common/store/deployment_dependency.go
@@ -3,6 +3,7 @@ package store
 import (
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/sensor/common/service"
 )
 
@@ -11,6 +12,7 @@ import (
 type Dependencies struct {
 	PermissionLevel storage.PermissionLevel
 	Exposures       []map[service.PortRef][]*storage.PortConfig_ExposureInfo
+	LocalImages     set.StringSet
 }
 
 func (d *Dependencies) GetHash() (uint64, error) {

--- a/sensor/common/store/deployment_dependency.go
+++ b/sensor/common/store/deployment_dependency.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"github.com/mitchellh/hashstructure/v2"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/sensor/common/service"
 )
@@ -10,4 +11,12 @@ import (
 type Dependencies struct {
 	PermissionLevel storage.PermissionLevel
 	Exposures       []map[service.PortRef][]*storage.PortConfig_ExposureInfo
+}
+
+func (d *Dependencies) GetHash() (uint64, error) {
+	return hashstructure.Hash(d, hashstructure.FormatV2, &hashstructure.HashOptions{
+		ZeroNil:         true,
+		IgnoreZeroValue: true,
+		SlicesAsSets:    true,
+	})
 }

--- a/sensor/common/store/deployment_dependency.go
+++ b/sensor/common/store/deployment_dependency.go
@@ -15,6 +15,7 @@ type Dependencies struct {
 	LocalImages     set.StringSet
 }
 
+// GetHash generates a hash value for the Dependencies struct.
 func (d *Dependencies) GetHash() (uint64, error) {
 	return hashstructure.Hash(d, hashstructure.FormatV2, &hashstructure.HashOptions{
 		ZeroNil:         true,

--- a/sensor/common/store/mocks/types.go
+++ b/sensor/common/store/mocks/types.go
@@ -47,12 +47,13 @@ func (m *MockDeploymentStore) EXPECT() *MockDeploymentStoreMockRecorder {
 }
 
 // BuildDeploymentWithDependencies mocks base method.
-func (m *MockDeploymentStore) BuildDeploymentWithDependencies(id string, dependencies store.Dependencies) (*storage.Deployment, error) {
+func (m *MockDeploymentStore) BuildDeploymentWithDependencies(id string, dependencies store.Dependencies) (*storage.Deployment, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BuildDeploymentWithDependencies", id, dependencies)
 	ret0, _ := ret[0].(*storage.Deployment)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // BuildDeploymentWithDependencies indicates an expected call of BuildDeploymentWithDependencies.

--- a/sensor/common/store/types.go
+++ b/sensor/common/store/types.go
@@ -21,7 +21,7 @@ type DeploymentStore interface {
 	FindDeploymentIDsWithServiceAccount(namespace, sa string) []string
 	FindDeploymentIDsByLabels(namespace string, sel selector.Selector) []string
 	FindDeploymentIDsByImages([]*storage.Image) []string
-	BuildDeploymentWithDependencies(id string, dependencies Dependencies) (*storage.Deployment, error)
+	BuildDeploymentWithDependencies(id string, dependencies Dependencies) (*storage.Deployment, bool, error)
 	CountDeploymentsForNamespace(namespaceName string) int
 }
 

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -123,7 +123,7 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 
 				// Skip generating an event and sending the deployment to the detector if the object is not
 				// new and detection isn't forced.
-				if !deploymentReference.ForceDetection && newObject {
+				if deploymentReference.ForceDetection || newObject {
 					msg.AddSensorEvent(toEvent(deploymentReference.ParentResourceAction, d, msg.DeploymentTiming)).
 						AddDeploymentForDetection(component.DetectorMessage{Object: d, Action: deploymentReference.ParentResourceAction})
 				}

--- a/sensor/kubernetes/listener/resources/convert_mutating_test.go
+++ b/sensor/kubernetes/listener/resources/convert_mutating_test.go
@@ -312,7 +312,7 @@ func TestConvertDifferentContainerNumbers(t *testing.T) {
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
-			actual := newDeploymentEventFromResource(c.inputObj, &c.action, c.deploymentType, testClusterID, c.podLister, mockNamespaceStore, hierarchyFromPodLister(c.podLister), "", c.systemNamespaces, c.registryStore).GetDeployment()
+			actual := newDeploymentEventFromResource(c.inputObj, &c.action, c.deploymentType, testClusterID, c.podLister, mockNamespaceStore, hierarchyFromPodLister(c.podLister), "", c.systemNamespaces).GetDeployment()
 			if actual != nil {
 				actual.StateTimestamp = 0
 			}

--- a/sensor/kubernetes/listener/resources/convert_override_test.go
+++ b/sensor/kubernetes/listener/resources/convert_override_test.go
@@ -173,7 +173,7 @@ func TestConvertWithRegistryOverride(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			actual := newDeploymentEventFromResource(c.inputObj, &c.action, c.deploymentType, testClusterID,
 				c.podLister, mockNamespaceStore, hierarchyFromPodLister(c.podLister), c.registryOverride,
-				storeProvider.orchestratorNamespaces, storeProvider.Registries()).GetDeployment()
+				storeProvider.orchestratorNamespaces).GetDeployment()
 			if actual != nil {
 				actual.StateTimestamp = 0
 			}

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/deduper"
@@ -269,28 +270,32 @@ func (ds *DeploymentStore) GetBuiltDeployment(id string) (*storage.Deployment, b
 }
 
 // BuildDeploymentWithDependencies creates storage.Deployment object using external object dependencies.
-func (ds *DeploymentStore) BuildDeploymentWithDependencies(id string, dependencies store.Dependencies) (*storage.Deployment, error) {
+func (ds *DeploymentStore) BuildDeploymentWithDependencies(id string, dependencies store.Dependencies) (*storage.Deployment, bool, error) {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
 	// Get wrap with no lock since ds.lock.Lock() was already requested above
 	wrap, found := ds.deployments[id]
 	if !found || wrap == nil {
-		return nil, errors.Errorf("deployment with ID %s doesn't exist in the internal deployment store", id)
+		return nil, false, errors.Errorf("deployment with ID %s doesn't exist in the internal deployment store", id)
 	}
 
-	snapshot, exists := ds.deploymentSnapshots[wrap.GetId()]
+	var dependencyHash uint64
+	if features.SensorDeploymentBuildOptimization.Enabled() {
+		var err error
+		snapshot, exists := ds.deploymentSnapshots[wrap.GetId()]
 
-	dependencyHash, err := dependencies.GetHash()
-	if err != nil {
-		return nil, errors.Wrap(err, "hashing deployment dependencies")
-	}
+		dependencyHash, err = dependencies.GetHash()
+		if err != nil {
+			return nil, false, errors.Wrap(err, "hashing deployment dependencies")
+		}
 
-	if wrap.isBuilt {
-		// check if dependencies changed, otherwise return an existing deployment object without needing to clone
-		// or check for hashes.
-		if exists && dependencyHash == snapshot.dependenciesHash {
-			return snapshot.builtDeployment, nil
+		if wrap.isBuilt {
+			// check if dependencies changed, otherwise return an existing deployment object without needing to clone
+			// or check for hashes.
+			if exists && dependencyHash == snapshot.dependenciesHash {
+				return snapshot.builtDeployment, false, nil
+			}
 		}
 	}
 
@@ -304,7 +309,7 @@ func (ds *DeploymentStore) BuildDeploymentWithDependencies(id string, dependenci
 	wrap.populateDataFromPods(dependencies.LocalImages, wrap.pods...)
 
 	if err := wrap.updateHash(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	wrap.isBuilt = true
@@ -312,9 +317,13 @@ func (ds *DeploymentStore) BuildDeploymentWithDependencies(id string, dependenci
 	// If it's the first time we are building, or the snapshot is different, then update and clone the deployment
 	ds.addOrUpdateDeploymentNoLock(wrap)
 	clone := wrap.GetDeployment().Clone()
-	ds.deploymentSnapshots[clone.GetId()] = snapshotEntry{
-		dependenciesHash: dependencyHash,
-		builtDeployment:  clone,
+
+	if features.SensorDeploymentBuildOptimization.Enabled() {
+		ds.deploymentSnapshots[clone.GetId()] = snapshotEntry{
+			dependenciesHash: dependencyHash,
+			builtDeployment:  clone,
+		}
 	}
-	return clone, nil
+
+	return clone, true, nil
 }

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -301,7 +301,7 @@ func (ds *DeploymentStore) BuildDeploymentWithDependencies(id string, dependenci
 	// influence its values, we need to call this again with the same pods from the wrap. Inside this function we call
 	// the registry store and update `IsClusterLocal` and `NotPullable` based on it. Meaning that if a pull secret was
 	// updated, the value from this properties might need to be updated.
-	wrap.populateDataFromPods(wrap.pods...)
+	wrap.populateDataFromPods(dependencies.LocalImages, wrap.pods...)
 
 	if err := wrap.updateHash(); err != nil {
 		return nil, err

--- a/sensor/kubernetes/listener/resources/deployment_store_bench_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_bench_test.go
@@ -43,7 +43,7 @@ func BenchmarkBuildDeployments_NoChange(b *testing.B) {
 		exposureInfo := generateExposureInfos(5, 5)
 		b.StartTimer()
 		for i := 0; i < 100; i++ {
-			d, err := benchStore.BuildDeploymentWithDependencies(deployment1.GetId(), store.Dependencies{
+			d, _, err := benchStore.BuildDeploymentWithDependencies(deployment1.GetId(), store.Dependencies{
 				PermissionLevel: storage.PermissionLevel_NONE,
 				Exposures:       exposureInfo,
 			})
@@ -69,7 +69,7 @@ func BenchmarkBuildDeployments_Change(b *testing.B) {
 		b.StartTimer()
 		for i := 0; i < 100; i++ {
 
-			d, err := benchStore.BuildDeploymentWithDependencies(deployment1.GetId(), store.Dependencies{
+			d, _, err := benchStore.BuildDeploymentWithDependencies(deployment1.GetId(), store.Dependencies{
 				PermissionLevel: permLevles[i%2],
 				Exposures:       exposureInfo,
 			})

--- a/sensor/kubernetes/listener/resources/deployment_store_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_test.go
@@ -195,7 +195,7 @@ func (s *deploymentStoreSuite) Test_BuildDeployments_CachedDependencies() {
 			objs := make([]*storage.Deployment, len(testCase.orderedDependencies))
 			var err error
 			for i := 0; i < len(testCase.orderedDependencies); i++ {
-				objs[i], err = s.deploymentStore.BuildDeploymentWithDependencies(uid, testCase.orderedDependencies[i])
+				objs[i], _, err = s.deploymentStore.BuildDeploymentWithDependencies(uid, testCase.orderedDependencies[i])
 				s.Require().NoError(err)
 			}
 
@@ -226,7 +226,7 @@ func (s *deploymentStoreSuite) Test_BuildDeploymentWithDependencies() {
 	_, isBuilt := s.deploymentStore.GetBuiltDeployment(uid)
 	s.Assert().False(isBuilt, "deployment should not be fully built yet")
 
-	deployment, err := s.deploymentStore.BuildDeploymentWithDependencies(uid, store.Dependencies{
+	deployment, _, err := s.deploymentStore.BuildDeploymentWithDependencies(uid, store.Dependencies{
 		PermissionLevel: storage.PermissionLevel_CLUSTER_ADMIN,
 		Exposures: []map[service.PortRef][]*storage.PortConfig_ExposureInfo{
 			{
@@ -248,7 +248,7 @@ func (s *deploymentStoreSuite) Test_BuildDeploymentWithDependencies() {
 }
 
 func (s *deploymentStoreSuite) Test_BuildDeploymentWithDependencies_NoDeployment() {
-	_, err := s.deploymentStore.BuildDeploymentWithDependencies("some-uuid", store.Dependencies{
+	_, _, err := s.deploymentStore.BuildDeploymentWithDependencies("some-uuid", store.Dependencies{
 		PermissionLevel: storage.PermissionLevel_CLUSTER_ADMIN,
 		Exposures:       []map[service.PortRef][]*storage.PortConfig_ExposureInfo{},
 	})

--- a/sensor/kubernetes/listener/resources/deployment_store_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_test.go
@@ -113,6 +113,106 @@ func (s *deploymentStoreSuite) Test_FindDeploymentIDsWithServiceAccount() {
 	}
 }
 
+func (s *deploymentStoreSuite) Test_BuildDeployments_CachedDependencies() {
+	defaultExposure := []map[service.PortRef][]*storage.PortConfig_ExposureInfo{
+		{
+			service.PortRefOf(stubService()): []*storage.PortConfig_ExposureInfo{&storage.PortConfig_ExposureInfo{
+				Level:       storage.PortConfig_EXTERNAL,
+				ServiceName: "test.service",
+				ServicePort: 5432,
+			}},
+		},
+		{
+			service.PortRefOf(stubService()): []*storage.PortConfig_ExposureInfo{&storage.PortConfig_ExposureInfo{
+				Level:       storage.PortConfig_HOST,
+				ServiceName: "test2.service",
+				ServicePort: 2345,
+				ExternalIps: []string{"a.com", "b.com"},
+			}},
+		},
+	}
+
+	defaultExposureUnordered := []map[service.PortRef][]*storage.PortConfig_ExposureInfo{
+		{
+			service.PortRefOf(stubService()): []*storage.PortConfig_ExposureInfo{&storage.PortConfig_ExposureInfo{
+				Level:       storage.PortConfig_HOST,
+				ServiceName: "test2.service",
+				ServicePort: 2345,
+				ExternalIps: []string{"b.com", "a.com"},
+			}},
+		},
+		{
+			service.PortRefOf(stubService()): []*storage.PortConfig_ExposureInfo{&storage.PortConfig_ExposureInfo{
+				Level:       storage.PortConfig_EXTERNAL,
+				ServiceName: "test.service",
+				ServicePort: 5432,
+			}},
+		},
+	}
+
+	dependenciesX := store.Dependencies{
+		PermissionLevel: storage.PermissionLevel_CLUSTER_ADMIN,
+		Exposures:       defaultExposure,
+	}
+
+	dependenciesXUnordered := store.Dependencies{
+		PermissionLevel: storage.PermissionLevel_CLUSTER_ADMIN,
+		Exposures:       defaultExposureUnordered,
+	}
+
+	dependenciesY := store.Dependencies{
+		PermissionLevel: storage.PermissionLevel_NONE,
+		Exposures:       defaultExposure,
+	}
+
+	testCases := map[string]struct {
+		orderedDependencies        []store.Dependencies
+		orderedExpectedPointerSame []bool
+	}{
+		"No dependencies changed returns cached deployment": {
+			orderedDependencies:        []store.Dependencies{dependenciesX, dependenciesX},
+			orderedExpectedPointerSame: []bool{true},
+		},
+		"Dependency changed returns a new deployment object": {
+			orderedDependencies:        []store.Dependencies{dependenciesX, dependenciesY},
+			orderedExpectedPointerSame: []bool{false},
+		},
+		"Multiple events with only one dependency change doesn't cause multiple clones": {
+			orderedDependencies:        []store.Dependencies{dependenciesX, dependenciesY, dependenciesY, dependenciesY},
+			orderedExpectedPointerSame: []bool{false, true, true}, // should build new object once and then return it for subsequent calls
+		},
+		"Dependencies with mixed ordered in fields should not cause new object to be built": {
+			orderedDependencies:        []store.Dependencies{dependenciesX, dependenciesXUnordered},
+			orderedExpectedPointerSame: []bool{true},
+		},
+	}
+
+	for name, testCase := range testCases {
+		s.Run(name, func() {
+			uid := uuid.NewV4().String()
+			wrap := s.createDeploymentWrap(makeDeploymentObject("test-deployment", "test-ns", types.UID(uid)))
+			s.deploymentStore.addOrUpdateDeployment(wrap)
+
+			objs := make([]*storage.Deployment, len(testCase.orderedDependencies))
+			var err error
+			for i := 0; i < len(testCase.orderedDependencies); i++ {
+				objs[i], err = s.deploymentStore.BuildDeploymentWithDependencies(uid, testCase.orderedDependencies[i])
+				s.Require().NoError(err)
+			}
+
+			for i, exp := range testCase.orderedExpectedPointerSame {
+				if exp {
+					s.Assert().Samef(objs[i], objs[i+1], "Comparing objects %d and %d failed", i, i+1)
+				} else {
+					s.Assert().NotSamef(objs[i], objs[i+1], "Comparing objects %d and %d failed", i, i+1)
+				}
+			}
+
+			s.deploymentStore.Cleanup()
+		})
+	}
+}
+
 func (s *deploymentStoreSuite) Test_BuildDeploymentWithDependencies() {
 	uid := uuid.NewV4().String()
 	wrap := s.createDeploymentWrap(makeDeploymentObject("test-deployment", "test-ns", types.UID(uid)))

--- a/sensor/kubernetes/listener/resources/deployment_store_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_test.go
@@ -115,14 +115,14 @@ func (s *deploymentStoreSuite) Test_FindDeploymentIDsWithServiceAccount() {
 func (s *deploymentStoreSuite) Test_BuildDeployments_CachedDependencies() {
 	defaultExposure := []map[service.PortRef][]*storage.PortConfig_ExposureInfo{
 		{
-			service.PortRefOf(stubService()): []*storage.PortConfig_ExposureInfo{&storage.PortConfig_ExposureInfo{
+			service.PortRefOf(stubService()): []*storage.PortConfig_ExposureInfo{{
 				Level:       storage.PortConfig_EXTERNAL,
 				ServiceName: "test.service",
 				ServicePort: 5432,
 			}},
 		},
 		{
-			service.PortRefOf(stubService()): []*storage.PortConfig_ExposureInfo{&storage.PortConfig_ExposureInfo{
+			service.PortRefOf(stubService()): []*storage.PortConfig_ExposureInfo{{
 				Level:       storage.PortConfig_HOST,
 				ServiceName: "test2.service",
 				ServicePort: 2345,
@@ -133,7 +133,7 @@ func (s *deploymentStoreSuite) Test_BuildDeployments_CachedDependencies() {
 
 	defaultExposureUnordered := []map[service.PortRef][]*storage.PortConfig_ExposureInfo{
 		{
-			service.PortRefOf(stubService()): []*storage.PortConfig_ExposureInfo{&storage.PortConfig_ExposureInfo{
+			service.PortRefOf(stubService()): []*storage.PortConfig_ExposureInfo{{
 				Level:       storage.PortConfig_HOST,
 				ServiceName: "test2.service",
 				ServicePort: 2345,
@@ -141,7 +141,7 @@ func (s *deploymentStoreSuite) Test_BuildDeployments_CachedDependencies() {
 			}},
 		},
 		{
-			service.PortRefOf(stubService()): []*storage.PortConfig_ExposureInfo{&storage.PortConfig_ExposureInfo{
+			service.PortRefOf(stubService()): []*storage.PortConfig_ExposureInfo{{
 				Level:       storage.PortConfig_EXTERNAL,
 				ServiceName: "test.service",
 				ServicePort: 5432,

--- a/sensor/kubernetes/listener/resources/deployment_store_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common/deduper"
-	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/common/selector"
 	"github.com/stackrox/rox/sensor/common/service"
 	"github.com/stackrox/rox/sensor/common/store"
@@ -48,7 +47,7 @@ func (s *deploymentStoreSuite) SetupTest() {
 func (s *deploymentStoreSuite) createDeploymentWrap(deploymentObj interface{}) *deploymentWrap {
 	action := central.ResourceAction_CREATE_RESOURCE
 	wrap := newDeploymentEventFromResource(deploymentObj, &action,
-		"deployment", "", s.mockPodLister, s.namespaceStore, hierarchyFromPodLister(s.mockPodLister), "", orchestratornamespaces.NewOrchestratorNamespaces(), registry.NewRegistryStore(nil))
+		"deployment", "", s.mockPodLister, s.namespaceStore, hierarchyFromPodLister(s.mockPodLister), "", orchestratornamespaces.NewOrchestratorNamespaces())
 	return wrap
 }
 
@@ -611,7 +610,6 @@ func TestDeploymentStore_ReconcileDelete(t *testing.T) {
 		original:         nil,
 		portConfigs:      nil,
 		pods:             nil,
-		registryStore:    nil,
 		isBuilt:          false,
 		mutex:            sync.RWMutex{},
 	}

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -121,7 +121,7 @@ func newDeploymentHandler(
 
 func (d *deploymentHandler) processWithType(obj, oldObj interface{}, action central.ResourceAction, deploymentType string) *component.ResourceEvent {
 	deploymentWrap := newDeploymentEventFromResource(obj, &action, deploymentType, d.clusterID, d.podLister, d.namespaceStore,
-		d.hierarchy, d.config.GetConfig().GetRegistryOverride(), d.orchestratorNamespaces, d.registryStore)
+		d.hierarchy, d.config.GetConfig().GetRegistryOverride(), d.orchestratorNamespaces)
 	// Note: deploymentWrap may be nil. Typically, this means that this is not a top-level object that we track --
 	// either it's an object we don't track, or we track its parent.
 	// (For example, we don't track replicasets if they are owned by a deployment.)


### PR DESCRIPTION
## Description

Rather than deduping entire deployments at the detector level, this proposal is to generated hashes out of the `store.Dependencies` object that is used to enrich the deployment spec into a `storage.Deployment`. If neither the deployment spec nor the 
dependencies changed, there is no reason to process a deployment further. 

**Overview**

On a deploy-time path (i.e. Kubernetes events) the only reasons to process a deployment on an `UPDATE` (send a `SensorEvent_Resource` message to central and check violations) is when either of these two happen:
1. The deployment spec changed
2. Some adjacent resource changed (e.g. RBAC or Route)

Whenever a deployment event is received, we store the spec in deployment store as `built=false`. Meaning that the present deployment is yet to be resolved against its dependencies. This deployment is then sent to the `resolver`, which will gather the dependencies (from RBAC, Pod and Services stores) and build the `storage.Deployment` object that will be sent to Central and to the detector.

Whenever an adjacent resource changes, a deployment reference is sent to the `resolver` as well. Signalling that the deployment has to be processed again since a dependency changed.

The way we make sure we don't over process deployments is by deduping the `storage.Deployment` object at the detector, after building it against its dependencies. However, this still incur some two costly operations: **hashing** and **cloning** the deployment object.

**The proposal**

The key change is how sensor identifies if a deployment has to be processed. At the `resolver` component, we have two key pieces of information that could be used to avoid processing the deployment: the `built` property, which determines if there were changes in the deployment spec since last processed. And the `dependencies` parameter, which are the properties that deployments will be enriched on. 

- Hash `dependencies` struct
- Introduce a snapshot map, which holds the latest `storage.Deployment` built and its dependency hash value
- Whenever a deployment reference is received, if `built=true` and the dependency hash is the same, there is no need to process the deployment.
- If the detection was forced (e.g. image cache updated or reprocess requested) grab the latest built deployment from the snapshot map and send to the detector.

**Hypothesis**

This change would make the deduper in the detector unnecessary. Since there are no reasons why a deployment should be processed against deploy-time policies if neither the spec nor the dependencies changed. Deployments will only be passed if there is a relevant change (which would then result in a dedupe check miss anyway) or if they are forced. 

**Example scenarios:**

|Scenario|Old behavior|Proposed behavior|
|---|---|---|
|Secret changed, but no deployment is affected|All deployments are processed by resolver; deployments are hashed and cloned; detector dedupes them and skip processing| All deployment processed by resolver; `store.Dependencies` are identical from previous built deployment; no deployments are processed|
|Service spec changed, but deployment is not affected|Matching deployment processed by resolver; deployments are hashed and cloned; detector dedupes them and skips processing | Matching deployment processed by resolver; `store.Dependencies` are identical from previous built deployment; no deployments are processed|
|Central requested all deployments to be reprocessed |All deployment processed by resolver; deduper reset|All deployment processed by resolver; deduper reset|
|Deployment spec changed|`isBuilt` is set to false; deployment fully processed|`isBuilt` is set to false; deployment fully processed|

**Results**

Reducing allocations by 98% on a path were multiple resource updates would trigger deployment that we don't care about.


## Checklist

- [x] Implement improvement (present PR)
- [x] Benchmark results
- [ ] ~~Validate that detector's deduper is no longer needed~~
- [ ] Compare pprof results from real workloads
- [ ] ~~Remove deduper from detector~~
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Unit test cases were added to make sure that `BuildDeploymentWithDependencies` will return generate the new deployment object when necessary. 

**Benchmarks**

Two benchmark cases were ran, one where the deployment has to be reprocessed; and one where no reprocessing would be needed. In both test cases, 100 deployment updates were triggered.

|Deployment reprocessing required|Allocations (current)|Allocations (new)| Allocations (new + removing hashes)|
|---|---|---|---|
|No|14MB|520K (-96%)|511K(-96%)|
|Yes|14MB|15MB (+3%)|916K(-93%)|

Notice that the current implementation makes the case where updates are always relevant worse by 3%. This is because we hash the dependencies store **and** the entire deployment object. 

Benchmark results:

```pkg: github.com/stackrox/rox/sensor/kubernetes/listener/resources
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
                             │ ./benchtest_build_deployment_old.txt │  benchtest_build_deployment_new.txt  │ ./benchtest_build_deployment_new_no_hash.txt │
                             │                sec/op                │    sec/op      vs base               │        sec/op          vs base               │
BuildDeployments_NoChange-12                           863.86m ± 2%    38.87m ± 12%  -95.50% (p=0.002 n=6)             34.27m ± 1%  -96.03% (p=0.002 n=6)
BuildDeployments_Change-12                             861.58m ± 2%   895.38m ±  2%   +3.92% (p=0.002 n=6)             66.50m ± 1%  -92.28% (p=0.002 n=6)
geomean                                                 862.7m         186.6m        -78.38%                           47.74m       -94.47%

                             │ ./benchtest_build_deployment_old.txt │  benchtest_build_deployment_new.txt  │ ./benchtest_build_deployment_new_no_hash.txt │
                             │                 B/op                 │     B/op       vs base               │         B/op           vs base               │
BuildDeployments_NoChange-12                         237.349Mi ± 0%    7.690Mi ± 0%  -96.76% (p=0.002 n=6)            7.565Mi ± 0%  -96.81% (p=0.002 n=6)
BuildDeployments_Change-12                            237.38Mi ± 0%   244.85Mi ± 0%   +3.15% (p=0.002 n=6)            41.62Mi ± 0%  -82.47% (p=0.002 n=6)
geomean                                                237.4Mi         43.39Mi       -81.72%                          17.74Mi       -92.52%

                             │ ./benchtest_build_deployment_old.txt │  benchtest_build_deployment_new.txt  │ ./benchtest_build_deployment_new_no_hash.txt │
                             │              allocs/op               │   allocs/op    vs base               │       allocs/op        vs base               │
BuildDeployments_NoChange-12                          14777.2k ± 0%     520.0k ± 0%  -96.48% (p=0.002 n=6)             511.1k ± 0%  -96.54% (p=0.002 n=6)
BuildDeployments_Change-12                            14779.0k ± 0%   15286.6k ± 0%   +3.43% (p=0.002 n=6)             916.7k ± 0%  -93.80% (p=0.002 n=6)
geomean                                                 14.78M          2.819M       -80.92%                           684.5k       -95.37%
```

**Detector deduper**

It's currently not possible to remove the deduper because there are pod updates that will cause deployments to be processed (with `isBuilt=false` since spec changed) but the resulting hash will be the same. Fixing this will require a more elaborate change in the deployment handler.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
