### PR TITLE
ROX-20135: Trim cached objects

### DIFF
--- a/central/sac/authorizer/builtin_scoped_authorizer.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer.go
@@ -402,9 +402,7 @@ func fetchClustersFromCache() ([]*storage.Cluster, bool) {
 	}
 
 	result := make([]*storage.Cluster, 0, len(cachedClusters))
-	for _, c := range cachedClusters {
-		result = append(result, c)
-	}
+	result = append(result, cachedClusters...)
 	return result, true
 }
 
@@ -460,9 +458,7 @@ func fetchNamespacesFromCache() ([]*storage.NamespaceMetadata, bool) {
 	}
 
 	result := make([]*storage.NamespaceMetadata, 0, len(cachedNamespaces))
-	for _, ns := range cachedNamespaces {
-		result = append(result, ns)
-	}
+	result = append(result, cachedNamespaces...)
 	return result, true
 }
 

--- a/pkg/sac/effectiveaccessscope/trim_objects.go
+++ b/pkg/sac/effectiveaccessscope/trim_objects.go
@@ -1,0 +1,29 @@
+package effectiveaccessscope
+
+import (
+	"github.com/stackrox/rox/generated/storage"
+)
+
+// TrimCluster removes all attributes from the input object, except the ones
+// that are used in effective access scope computation and the raw type ones.
+func TrimCluster(cluster *storage.Cluster) {
+	cluster.MainImage = ""
+	cluster.CollectorImage = ""
+	cluster.CentralApiEndpoint = ""
+	cluster.Status = nil
+	cluster.DynamicConfig = nil
+	cluster.TolerationsConfig = nil
+	cluster.HealthStatus = nil
+	cluster.HelmConfig = nil
+	cluster.MostRecentSensorId = nil
+	cluster.AuditLogState = nil
+	cluster.InitBundleId = ""
+}
+
+// TrimNamespace removes all attributes from the input object, except the ones
+// that are used in effective access scope computation and the raw type ones.
+func TrimNamespace(namespace *storage.NamespaceMetadata) {
+	namespace.ClusterId = ""
+	namespace.CreationTime = nil
+	namespace.Annotations = nil
+}


### PR DESCRIPTION
## Description

In order to further reduce the memory pressure, the clusters and namespaces retrieved from cache are reduced to a minimum size (goal is to give the garbage collector back the data that is not used to compute access scopes).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
