### PR TITLE
ROX-19358: Add CVE selection list to deferral form

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -121,7 +121,7 @@ export function selectSingleCveForException(exceptionType) {
         cy.wrap($row).find(selectors.tableRowMenuToggle).click();
         cy.get(selectors.menuOption(menuOption)).click();
 
-        cy.get('button:contains("CVE Selections")').click();
+        cy.get('button:contains("CVE selections")').click();
         // TODO - Update this code when modal form is completed
         cy.get(`${modalSelector}:contains("${cveName}")`);
         return Promise.resolve(cveName);
@@ -162,7 +162,7 @@ export function selectMultipleCvesForException(exceptionType) {
             cy.get(selectors.menuOption(menuOption)).click();
         })
         .then(() => {
-            cy.get('button:contains("CVE Selections")').click();
+            cy.get('button:contains("CVE selections")').click();
             // TODO - Update this code when modal form is completed
             cveNames.forEach((name) => {
                 cy.get(`${modalSelector}:contains("${name}")`);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -6,7 +6,7 @@ import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
-import useSet from 'hooks/useSet';
+import useMap from 'hooks/useMap';
 import { getHasSearchApplied } from 'utils/searchUtils';
 import { VulnerabilityState } from 'types/cve.proto';
 import CVEsTable, { cveListQuery, unfilteredImageCountQuery } from '../Tables/CVEsTable';
@@ -18,6 +18,7 @@ import { defaultCVESortFields, CVEsDefaultSort } from '../sortUtils';
 import TableEntityToolbar from '../components/TableEntityToolbar';
 import ExceptionRequestModal, {
     ExceptionRequestModalOptions,
+    ExceptionRequestModalProps,
 } from '../components/ExceptionRequestModal/ExceptionRequestModal';
 
 export type CVEsTableContainerProps = {
@@ -58,16 +59,22 @@ function CVEsTableContainer({
 
     const { data: imageCountData } = useQuery(unfilteredImageCountQuery);
 
-    const selectedCves = useSet<string>();
+    const selectedCves = useMap<string, ExceptionRequestModalProps['cves'][number]>();
     const [exceptionRequestModalOptions, setExceptionRequestModalOptions] =
         useState<ExceptionRequestModalOptions>(null);
 
     function openDeferralModal() {
-        setExceptionRequestModalOptions({ type: 'DEFERRAL', cves: selectedCves.asArray() });
+        setExceptionRequestModalOptions({
+            type: 'DEFERRAL',
+            cves: Array.from(selectedCves.values()),
+        });
     }
 
     function openFalsePositiveModal() {
-        setExceptionRequestModalOptions({ type: 'FALSE_POSITIVE', cves: selectedCves.asArray() });
+        setExceptionRequestModalOptions({
+            type: 'FALSE_POSITIVE',
+            cves: Array.from(selectedCves.values()),
+        });
     }
 
     const tableData = data ?? previousData;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/CveSelections.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/CveSelections.tsx
@@ -1,16 +1,35 @@
 import React from 'react';
+import { Link, generatePath } from 'react-router-dom';
+import { Flex, List, ListItem, Text } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
+
+const vulnerabilitiesWorkloadCveSinglePath = `${vulnerabilitiesWorkloadCvesPath}/cves/:cve`;
 
 export type CveSelectionsProps = {
-    cves: string[];
+    cves: { cve: string; summary: string }[];
 };
 
 function CveSelections({ cves }: CveSelectionsProps) {
     return (
-        <div>
-            {cves.map((cve) => (
-                <p key={cve}>{cve}</p>
+        <List isPlain isBordered>
+            {cves.map(({ cve, summary }) => (
+                <ListItem key={cve}>
+                    <Flex direction={{ default: 'column' }}>
+                        <Text>
+                            <Link
+                                target="_blank"
+                                to={generatePath(vulnerabilitiesWorkloadCveSinglePath, { cve })}
+                            >
+                                {cve} <ExternalLinkAltIcon className="pf-u-display-inline" />
+                            </Link>
+                        </Text>
+                        <Text>{summary}</Text>
+                    </Flex>
+                </ListItem>
             ))}
-        </div>
+        </List>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionRequestModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionRequestModal.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
-import { Modal, pluralize } from '@patternfly/react-core';
+import { Modal, ModalBoxBody, pluralize } from '@patternfly/react-core';
 
 import { CveExceptionRequestType } from '../../types';
-import DeferralForm from './DeferralForm';
+import DeferralForm, { DeferralFormProps } from './DeferralForm';
 import { ScopeContext } from './utils';
 
 export type ExceptionRequestModalOptions = {
     type: CveExceptionRequestType;
-    cves: string[];
+    cves: DeferralFormProps['cves'];
 } | null;
 
 export type ExceptionRequestModalProps = {
     type: CveExceptionRequestType;
-    cves: string[];
+    cves: DeferralFormProps['cves'];
     scopeContext: ScopeContext;
     onClose: () => void;
 };
@@ -25,10 +25,12 @@ function ExceptionRequestModal({ type, cves, scopeContext, onClose }: ExceptionR
             : `Mark ${cveCountText} as false positive`;
 
     return (
-        <Modal onClose={onClose} title={title} isOpen variant="medium">
-            {type === 'DEFERRAL' && (
-                <DeferralForm cves={cves} scopeContext={scopeContext} onCancel={onClose} />
-            )}
+        <Modal hasNoBodyWrapper onClose={onClose} title={title} isOpen variant="medium">
+            <ModalBoxBody className="pf-u-display-flex pf-u-flex-direction-column">
+                {type === 'DEFERRAL' && (
+                    <DeferralForm cves={cves} scopeContext={scopeContext} onCancel={onClose} />
+                )}
+            </ModalBoxBody>
         </Modal>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionScopeField.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionScopeField.tsx
@@ -5,7 +5,7 @@ import { useFormik } from 'formik';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { DeferralValues, ScopeContext } from './utils';
 
-const ALL = '.*';
+export const ALL = '.*';
 
 export type ExceptionScopeFieldProps = {
     fieldId: FormGroupProps['fieldId'];

--- a/ui/apps/platform/src/hooks/useMap.test.ts
+++ b/ui/apps/platform/src/hooks/useMap.test.ts
@@ -1,0 +1,66 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import useMap from './useMap';
+
+test('useMap should test membership via reference equality', () => {
+    const objA = { test: 'test' };
+    const objB = { test: 'test' };
+
+    const { result } = renderHook(() => {
+        const map = useMap(new Map([[objA, 'a']]));
+        return map;
+    });
+
+    expect(result.current.has(objA)).toBeTruthy();
+    expect(result.current.has(objB)).toBeFalsy();
+    expect(result.current.get(objA)).toBe('a');
+    expect(result.current.size).toBe(1);
+    expect(Array.from(result.current.values())).toEqual(['a']);
+
+    act(() => {
+        result.current.set(objA, 'b');
+        result.current.set(objB, 'b');
+    });
+
+    expect(result.current.has(objA)).toBeTruthy();
+    expect(result.current.has(objB)).toBeTruthy();
+    expect(result.current.get(objA)).toBe('b');
+    expect(result.current.get(objB)).toBe('b');
+    expect(result.current.size).toBe(2);
+    expect(Array.from(result.current.values())).toEqual(['b', 'b']);
+});
+
+test('useMap should correctly set, remove, and clear items', () => {
+    const { result } = renderHook(() => {
+        const map = useMap<string, string>();
+        return map;
+    });
+    expect(result.current.size).toBe(0);
+    expect(Array.from(result.current.values())).toEqual([]);
+
+    act(() => {
+        result.current.set('test', 'a');
+    });
+
+    expect(result.current.has('test')).toBeTruthy();
+    expect(result.current.get('test')).toBe('a');
+    expect(result.current.has('test-2')).toBeFalsy();
+    expect(result.current.size).toBe(1);
+    expect(Array.from(result.current.values())).toEqual(['a']);
+
+    act(() => {
+        result.current.set('test-2', 'b');
+        result.current.remove('test');
+    });
+
+    expect(result.current.has('test')).toBeFalsy();
+    expect(result.current.has('test-2')).toBeTruthy();
+    expect(result.current.get('test-2')).toBe('b');
+
+    act(() => {
+        result.current.clear();
+    });
+
+    expect(result.current.has('test')).toBeFalsy();
+    expect(result.current.size).toBe(0);
+    expect(Array.from(result.current.values())).toEqual([]);
+});

--- a/ui/apps/platform/src/hooks/useMap.ts
+++ b/ui/apps/platform/src/hooks/useMap.ts
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+
+export default function useMap<K, V>(initialMap: Map<K, V> = new Map()) {
+    const [itemMap, setItemMap] = useState(initialMap);
+
+    function has(key: K): boolean {
+        return itemMap.has(key);
+    }
+
+    function get(key: K): V | undefined {
+        return itemMap.get(key);
+    }
+
+    function set(key: K, value: V) {
+        setItemMap((prevMap) => {
+            const nextMap = new Map(prevMap);
+            nextMap.set(key, value);
+            return nextMap;
+        });
+    }
+
+    function remove(key: K) {
+        setItemMap((prevMap) => {
+            const nextMap = new Map(prevMap);
+            nextMap.delete(key);
+            return nextMap;
+        });
+    }
+
+    function clear() {
+        setItemMap(new Map());
+    }
+
+    function values() {
+        return itemMap.values();
+    }
+
+    return { has, get, set, remove, clear, size: itemMap.size, values };
+}


### PR DESCRIPTION
## Description

Updates the CVE selection list to contain links to individual CVE pages as well as CVE descriptions.

The majority of the changes are due to the need to move from using a `Set` to track selected CVEs, to using a `Map`. This is because we also need to retain the CVE summary in state, and there is no way to make a custom comparator for objects contained in a Set. (Reference equality only).

Additionally, in order to better control layout the TabContent has been separated from being a direct child of a `Tab`. It is easier to review this with "Hide whitespace" on.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

View the modal when deferring a single CVE:
![image](https://github.com/stackrox/stackrox/assets/1292638/f4b0b83e-6950-49c2-9cdb-fef3557e984d)

View the modal when deferring multiple CVEs. The CVE list container should fill the remaining space and scroll:
![image](https://github.com/stackrox/stackrox/assets/1292638/269a941f-ae7d-4926-bfd3-add9a0f7fd97)

Click a CVE link to verify that the correct page is opened in a new tab:
![image](https://github.com/stackrox/stackrox/assets/1292638/abebabb4-0e22-4201-b9f8-b593c97baddb)
![image](https://github.com/stackrox/stackrox/assets/1292638/a853c517-2f25-4b85-a266-5149398072ae)
