### PR TITLE
Disbale v1 reporting api in 4.3

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -398,9 +398,7 @@ func servicesToRegister() []pkgGRPC.APIService {
 		processBaselineService.Singleton(),
 		administrationUsageService.Singleton(),
 		rbacService.Singleton(),
-		reportConfigurationService.Singleton(),
 		roleService.Singleton(),
-		reportService.Singleton(),
 		searchService.Singleton(),
 		secretService.Singleton(),
 		sensorService.New(connection.ManagerSingleton(), all.Singleton(), clusterDataStore.Singleton(), installationStore.Singleton()),
@@ -422,8 +420,9 @@ func servicesToRegister() []pkgGRPC.APIService {
 	}
 
 	if features.VulnReportingEnhancements.Enabled() {
-		// TODO Remove (deprecated) v1 report configuration service when Reporting 2.0 is GA.
 		servicesToRegister = append(servicesToRegister, reportServiceV2.Singleton())
+	} else {
+		servicesToRegister = append(servicesToRegister, reportService.Singleton(), reportConfigurationService.Singleton())
 	}
 
 	if features.ComplianceEnhancements.Enabled() {


### PR DESCRIPTION
[##](url) Description
This change disables v1 reporting api based on vuln reporting 2.0 feature flag

## Testing Performed
<img width="1339" alt="Screenshot 2023-10-17 at 10 50 26 AM" src="https://github.com/stackrox/stackrox/assets/8596931/17a5122a-162d-4654-8286-83397d4efc33">

Tested with v1 reporting endpoints. Endpoint returns Not found

