### PR TITLE
 ROX-20228: SummaryTest should be more lenient

### DIFF
--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -57,9 +57,9 @@ class SummaryTest extends BaseSpecification {
                 log.info "Orchestrator deployments: " + orchestratorResourceNames.join(",")
             }
 
-            assert abs(stackroxSummaryCounts.numDeployments - orchestratorResourceNames.size()) < 2
-            assert abs(stackroxSummaryCounts.numSecrets == orchestrator.getSecretCount()) < 2
-            assert abs(stackroxSummaryCounts.numNodes == orchestrator.getNodeCount()) < 2
+            assert abs(stackroxSummaryCounts.numDeployments - orchestratorResourceNames.size()) <= 2
+            assert abs(stackroxSummaryCounts.numSecrets == orchestrator.getSecretCount()) <= 2
+            assert abs(stackroxSummaryCounts.numNodes == orchestrator.getNodeCount()) <= 2
         }
     }
 

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -57,9 +57,9 @@ class SummaryTest extends BaseSpecification {
                 log.info "Orchestrator deployments: " + orchestratorResourceNames.join(",")
             }
 
-            assert abs(stackroxSummaryCounts.numDeployments - orchestratorResourceNames.size()) <= 2
-            assert abs(stackroxSummaryCounts.numSecrets - orchestrator.getSecretCount()) <= 2
-            assert abs(stackroxSummaryCounts.numNodes - orchestrator.getNodeCount()) <= 2
+            assert Math.abs(stackroxSummaryCounts.numDeployments - orchestratorResourceNames.size()) <= 2
+            assert Math.abs(stackroxSummaryCounts.numSecrets - orchestrator.getSecretCount()) <= 2
+            assert Math.abs(stackroxSummaryCounts.numNodes - orchestrator.getNodeCount()) <= 2
         }
     }
 

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -58,8 +58,8 @@ class SummaryTest extends BaseSpecification {
             }
 
             assert abs(stackroxSummaryCounts.numDeployments - orchestratorResourceNames.size()) <= 2
-            assert abs(stackroxSummaryCounts.numSecrets == orchestrator.getSecretCount()) <= 2
-            assert abs(stackroxSummaryCounts.numNodes == orchestrator.getNodeCount()) <= 2
+            assert abs(stackroxSummaryCounts.numSecrets - orchestrator.getSecretCount()) <= 2
+            assert abs(stackroxSummaryCounts.numNodes - orchestrator.getNodeCount()) <= 2
         }
     }
 

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -57,9 +57,9 @@ class SummaryTest extends BaseSpecification {
                 log.info "Orchestrator deployments: " + orchestratorResourceNames.join(",")
             }
 
-            assert stackroxSummaryCounts.numDeployments == orchestratorResourceNames.size()
-            assert stackroxSummaryCounts.numSecrets == orchestrator.getSecretCount()
-            assert stackroxSummaryCounts.numNodes == orchestrator.getNodeCount()
+            assert abs(stackroxSummaryCounts.numDeployments - orchestratorResourceNames.size()) < 2
+            assert abs(stackroxSummaryCounts.numSecrets == orchestrator.getSecretCount()) < 2
+            assert abs(stackroxSummaryCounts.numNodes == orchestrator.getNodeCount()) < 2
         }
     }
 


### PR DESCRIPTION
## Description

In many clusters, things are being created and deleted by controllers consistently. If we're within 2 objects, we should mark this as fine

e.g. sensor-upgrade gets created or catalog market pods are created on openshift


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI tests

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
