### PR TITLE
ROX-17927: Ignore truncated annotations in SummaryTest

### DIFF
--- a/qa-tests-backend/src/main/groovy/common/Constants.groovy
+++ b/qa-tests-backend/src/main/groovy/common/Constants.groovy
@@ -38,7 +38,7 @@ class Constants {
             "OpenShift: Advanced Cluster Security Central Admin Secret Accessed"
     ]
     static final INTERNET_EXTERNAL_SOURCE_ID = "afa12424-bde3-4313-b810-bb463cbe8f90" // pkg/networkgraph/constants.go
-    static final STACKROX_NODE_ANNOTATION_TRUNCATION_LENGTH = 254
+    static final STACKROX_ANNOTATION_TRUNCATION_LENGTH = 254
     static final CORE_IMAGE_INTEGRATION_NAME = "core quay"
     // Padding required for test feature timeouts. This is used to configure the
     // globalTimeout for long running tests. The value takes into consideration

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -98,7 +98,6 @@ class SummaryTest extends BaseSpecification {
                         orchestratorTruncated.remove(name)
                     }
                 }
-                ''
                 if (stackroxNode.annotationsMap != orchestratorTruncated) {
                     log.info "There is a node annotation difference - StackRox -v- Orchestrator:"
                     log.info javers.compare(stackroxNode.annotationsMap, orchestratorTruncated).prettyPrint()

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -88,8 +88,8 @@ class SummaryTest extends BaseSpecification {
             Map<String, String> stackroxAnnotationsMap = new HashMap<>(stackroxNode.getAnnotationsMap());
             if (stackroxAnnotationsMap != orchestratorNode.annotations) {
                 Map<String, String> orchestratorTruncated = orchestratorNode.annotations.clone()
-                orchestratorTruncated.keySet().each { name ->
-                    if (orchestratorTruncated[name].length() > Constants.STACKROX_NODE_ANNOTATION_TRUNCATION_LENGTH) {
+                orchestratorNode.annotations.keySet().each { name ->
+                    if (orchestratorNode.annotations[name].length() > Constants.STACKROX_NODE_ANNOTATION_TRUNCATION_LENGTH) {
                         // Assert that the stackrox node has an entry for that annotation
                         assert stackroxAnnotationsMap[name].length() > 0
 

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -85,11 +85,11 @@ class SummaryTest extends BaseSpecification {
                 diff = true
             }
             assert stackroxNode.labelsMap == orchestratorNode.labels
-            Map<String, String> stackroxAnnotationsMap = new HashMap<>(stackroxNode.getAnnotationsMap());
+            Map<String, String> stackroxAnnotationsMap = new HashMap<>(stackroxNode.getAnnotationsMap())
             if (stackroxAnnotationsMap != orchestratorNode.annotations) {
                 Map<String, String> orchestratorTruncated = orchestratorNode.annotations.clone()
                 orchestratorNode.annotations.keySet().each { name ->
-                    if (orchestratorNode.annotations[name].length() > Constants.STACKROX_NODE_ANNOTATION_TRUNCATION_LENGTH) {
+                    if (orchestratorTruncated[name].length() > Constants.STACKROX_ANNOTATION_TRUNCATION_LENGTH) {
                         // Assert that the stackrox node has an entry for that annotation
                         assert stackroxAnnotationsMap[name].length() > 0
 

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -89,10 +89,16 @@ class SummaryTest extends BaseSpecification {
                 Map<String, String> orchestratorTruncated = orchestratorNode.annotations.clone()
                 orchestratorTruncated.keySet().each { name ->
                     if (orchestratorTruncated[name].length() > Constants.STACKROX_NODE_ANNOTATION_TRUNCATION_LENGTH) {
-                        orchestratorTruncated[name] = orchestratorTruncated[name].substring(0,
-                                Constants.STACKROX_NODE_ANNOTATION_TRUNCATION_LENGTH - 1) + "..."
+                        // Assert that the stackrox node has an entry for that annotation
+                        assert stackroxNode.annotationsMap[name].length() > 0
+
+                        // Remove the annotation because the logic for truncation tries to maintain words and
+                        // is more complicated than we'd like to test
+                        stackroxNode.annotationsMap.remove(name)
+                        orchestratorTruncated.remove(name)
                     }
                 }
+                ''
                 if (stackroxNode.annotationsMap != orchestratorTruncated) {
                     log.info "There is a node annotation difference - StackRox -v- Orchestrator:"
                     log.info javers.compare(stackroxNode.annotationsMap, orchestratorTruncated).prettyPrint()

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -85,22 +85,24 @@ class SummaryTest extends BaseSpecification {
                 diff = true
             }
             assert stackroxNode.labelsMap == orchestratorNode.labels
-            if (stackroxNode.annotationsMap != orchestratorNode.annotations) {
+            Map<String, String> stackroxAnnotationsMap = new HashMap<>(stackroxNode.getAnnotationsMap());
+            if (stackroxAnnotationsMap != orchestratorNode.annotations) {
                 Map<String, String> orchestratorTruncated = orchestratorNode.annotations.clone()
                 orchestratorTruncated.keySet().each { name ->
                     if (orchestratorTruncated[name].length() > Constants.STACKROX_NODE_ANNOTATION_TRUNCATION_LENGTH) {
                         // Assert that the stackrox node has an entry for that annotation
-                        assert stackroxNode.annotationsMap[name].length() > 0
+                        assert stackroxAnnotationsMap[name].length() > 0
 
+                        log.info "Removing node label ${name}"
                         // Remove the annotation because the logic for truncation tries to maintain words and
                         // is more complicated than we'd like to test
-                        stackroxNode.annotationsMap.remove(name)
+                        stackroxAnnotationsMap.remove(name)
                         orchestratorTruncated.remove(name)
                     }
                 }
-                if (stackroxNode.annotationsMap != orchestratorTruncated) {
+                if (stackroxAnnotationsMap != orchestratorTruncated) {
                     log.info "There is a node annotation difference - StackRox -v- Orchestrator:"
-                    log.info javers.compare(stackroxNode.annotationsMap, orchestratorTruncated).prettyPrint()
+                    log.info javers.compare(stackroxAnnotationsMap, orchestratorTruncated).prettyPrint()
                     diff = true
                 }
             }


### PR DESCRIPTION
## Description

Ignore truncated annotations in summary test especially for nodes because the logic for annotation truncation is word oriented so it's not a blind length check. This leads to errors like

```
Test truncation:
    'could not apply update: setting node's state to Done failed. Error: error setting node's state to Done: unable to update node "&Node{ObjectMeta:{      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] []...'


Go truncation:
     'could not apply update: setting node's state to Done failed. Error: error setting node's state to Done: unable to update node "&Node{ObjectMeta:{      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [][]},Spec:NodeSpec{PodCIDR:,DoNotUseExter...']
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI test + manual annotation of node to check that test result

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
