### PR TITLE
ROX-20257: Allow regex in specification of resource name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Added Features
 - Customer-provided PostgreSQL databases are now GA
 - ROX-21235: `/api/extensions/certs/backup` added to provide external database consumers a means to backup certs. `--certs-only` flag added to `roxctl central backup` to exercise that endpoint.
+- The "Kubernetes Resource Name" policy criteria now supports regex values. Note: the value must be prefixed with "r/" to activate regex matching.
 
 ### Removed Features
 - ROX-18840: Sunburst widgets in the Compliance section have been removed (deprecation announced in version 4.2 release notes)

--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -771,7 +771,7 @@ func initializeFieldMetadata() FieldMetadata {
 		fieldnames.KubeResourceName,
 		querybuilders.ForFieldLabel(augmentedobjs.KubernetesResourceNameCustomTag), nil,
 		func(*validateConfiguration) *regexp.Regexp {
-			return kubernetesNameRegex
+			return stringValueRegex
 		},
 		[]storage.EventSource{storage.EventSource_AUDIT_LOG_EVENT},
 		[]RuntimeFieldType{AuditLogEvent},

--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -769,7 +769,7 @@ func initializeFieldMetadata() FieldMetadata {
 
 	f.registerFieldMetadata(
 		fieldnames.KubeResourceName,
-		querybuilders.ForFieldLabel(augmentedobjs.KubernetesResourceNameCustomTag), nil,
+		querybuilders.ForFieldLabelRegex(augmentedobjs.KubernetesResourceNameCustomTag), nil,
 		func(*validateConfiguration) *regexp.Regexp {
 			return stringValueRegex
 		},

--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -769,7 +769,7 @@ func initializeFieldMetadata() FieldMetadata {
 
 	f.registerFieldMetadata(
 		fieldnames.KubeResourceName,
-		querybuilders.ForFieldLabelRegex(augmentedobjs.KubernetesResourceNameCustomTag), nil,
+		querybuilders.ForFieldLabel(augmentedobjs.KubernetesResourceNameCustomTag), nil,
 		func(*validateConfiguration) *regexp.Regexp {
 			return stringValueRegex
 		},

--- a/pkg/detection/runtime/detector_test.go
+++ b/pkg/detection/runtime/detector_test.go
@@ -56,6 +56,34 @@ func (s *RuntimeDetectorTestSuite) TestCreateConfigMap() {
 	s.NotNil(j)
 }
 
+func (s *RuntimeDetectorTestSuite) TestConfigMapPolicyWithRegex() {
+	policySet := detection.NewPolicySet()
+
+	cmPolicy := s.getCreateConfigmapPolicy()
+	cmPolicy.PolicySections[0].PolicyGroups = append(cmPolicy.PolicySections[0].PolicyGroups, &storage.PolicyGroup{
+		FieldName: "Kubernetes Resource Name",
+		Values: []*storage.PolicyValue{
+			{
+				Value: "r/config-.*",
+			},
+		},
+	})
+	err := policySet.UpsertPolicy(cmPolicy)
+	s.NoError(err, "upsert policy should succeed")
+
+	d := NewDetector(policySet)
+
+	kubeEvent := s.getKubeEvent(storage.KubernetesEvent_Object_CONFIGMAPS, storage.KubernetesEvent_CREATE, "cluster-id", "namespace", "config-name", true)
+	alerts, err := d.DetectForAuditEvents([]*storage.KubernetesEvent{kubeEvent})
+	s.NoError(err)
+	s.Len(alerts, 1, "incorrect number of alerts received")
+
+	kubeEvent.Object.Name = "secret-hello"
+	alerts, err = d.DetectForAuditEvents([]*storage.KubernetesEvent{kubeEvent})
+	s.NoError(err)
+	s.Len(alerts, 0, "incorrect number of alerts received")
+}
+
 func (s *RuntimeDetectorTestSuite) getKubeEvent(resource storage.KubernetesEvent_Object_Resource, verb storage.KubernetesEvent_APIVerb, clusterID, namespace, name string, isImpersonated bool) *storage.KubernetesEvent {
 	event := &storage.KubernetesEvent{
 		Id: uuid.NewV4().String(),

--- a/pkg/detection/runtime/detector_test.go
+++ b/pkg/detection/runtime/detector_test.go
@@ -64,7 +64,7 @@ func (s *RuntimeDetectorTestSuite) TestConfigMapPolicyWithRegex() {
 		FieldName: "Kubernetes Resource Name",
 		Values: []*storage.PolicyValue{
 			{
-				Value: "r/config-.*",
+				Value: "config-.*",
 			},
 		},
 	})

--- a/pkg/detection/runtime/detector_test.go
+++ b/pkg/detection/runtime/detector_test.go
@@ -64,7 +64,7 @@ func (s *RuntimeDetectorTestSuite) TestConfigMapPolicyWithRegex() {
 		FieldName: "Kubernetes Resource Name",
 		Values: []*storage.PolicyValue{
 			{
-				Value: "config-.*",
+				Value: "r/config-.*",
 			},
 		},
 	})


### PR DESCRIPTION
## Description

Allows policies to be written on resource names with a regex

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Unit test

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
