### PR TITLE
ROX-20074: Registry store reconciliation

### DIFF
--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -183,10 +183,12 @@ func genIntegrationName(prefix string, namespace string, registry string) string
 	return fmt.Sprintf("%v%v%v", prefix, namespace, registry)
 }
 
+// AddSecretID appends a kubernetes secret ID into a set to keep track of its existence in the cluster.
 func (rs *Store) AddSecretID(id string) {
 	rs.knownSecretIDs.Add(id)
 }
 
+// RemoveSecretID removes a kubernetes secret ID from tracking set.
 func (rs *Store) RemoveSecretID(id string) bool {
 	return rs.knownSecretIDs.Remove(id)
 }

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -35,6 +35,10 @@ type Store struct {
 	// store maps a namespace to the names of registries accessible from within the namespace.
 	store map[string]registries.Set
 
+	// knownSecretIDs keeps track of all secret IDs in the cluster. This is used to reconcile with
+	// central in case secrets were deleted while the connection was broken.
+	knownSecretIDs set.StringSet
+
 	// clusterLocalRegistryHosts contains hosts (names and/or IPs) for registries that are local
 	// to this cluster (ie: the OCP internal registry).
 	clusterLocalRegistryHosts      set.StringSet
@@ -58,12 +62,13 @@ type Store struct {
 }
 
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
-// Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
+// Reconciliation ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (rs *Store) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
-	_, _, _ = resType, resID, resHash
-	// TODO(ROX-20074): Implement me
-	return "", errors.New("Not implemented")
+func (rs *Store) ReconcileDelete(_, resID string, _ uint64) (string, error) {
+	if !rs.knownSecretIDs.Contains(resID) {
+		return resID, nil
+	}
+	return "", nil
 }
 
 // CheckTLS defines a function which checks if the given address is using TLS.
@@ -85,6 +90,7 @@ func NewRegistryStore(checkTLS CheckTLS) *Store {
 		globalRegistries:            registries.NewSet(regFactory),
 		centralRegistryIntegrations: registries.NewSet(regFactory),
 		clusterLocalRegistryHosts:   set.NewStringSet(),
+		knownSecretIDs:              set.NewStringSet(),
 	}
 
 	if checkTLS != nil {
@@ -175,6 +181,14 @@ func genIntegrationName(prefix string, namespace string, registry string) string
 	}
 
 	return fmt.Sprintf("%v%v%v", prefix, namespace, registry)
+}
+
+func (rs *Store) AddSecretID(id string) {
+	rs.knownSecretIDs.Add(id)
+}
+
+func (rs *Store) RemoveSecretID(id string) bool {
+	return rs.knownSecretIDs.Remove(id)
 }
 
 // UpsertRegistry upserts the given registry with the given credentials in the given namespace into the store.

--- a/sensor/common/registry/registry_store_test.go
+++ b/sensor/common/registry/registry_store_test.go
@@ -324,3 +324,30 @@ func TestDataRaceAtCleanup(_ *testing.T) {
 	doneSignal.Signal()
 	wg.Wait()
 }
+
+func TestReconcile(t *testing.T) {
+	regStore := NewRegistryStore(alwaysInsecureCheckTLS)
+	testCases := map[string]bool{
+		"a": false,
+		"b": true,
+		"c": true,
+	}
+
+	for secretID, isRemoved := range testCases {
+		regStore.AddSecretID(secretID)
+		if isRemoved {
+			regStore.RemoveSecretID(secretID)
+		}
+	}
+
+	for secretID, isRemoved := range testCases {
+		id, err := regStore.ReconcileDelete("", secretID, 0)
+		require.NoError(t, err)
+		if isRemoved {
+			assert.NotEmpty(t, id)
+		} else {
+			assert.Empty(t, id)
+		}
+	}
+
+}

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -76,6 +76,17 @@ func resourceToMessage(resType string, resID string) (*central.MsgFromSensor, er
 			},
 		}
 		return &central.MsgFromSensor{Msg: &msg}, nil
+	case deduper.TypeSecret.String():
+		msg := central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     resID,
+				Action: central.ResourceAction_REMOVE_RESOURCE,
+				Resource: &central.SensorEvent_Secret{
+					Secret: &storage.Secret{Id: resID},
+				},
+			},
+		}
+		return &central.MsgFromSensor{Msg: &msg}, nil
 	default:
 		return nil, errors.Errorf("Not implemented for resource type %v", resType)
 	}

--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -395,6 +395,16 @@ func (s *secretDispatcher) ProcessEvent(obj, oldObj interface{}, action central.
 		oldSecret = nil
 	}
 
+	parsedID := string(secret.GetUID())
+	switch action {
+	case central.ResourceAction_SYNC_RESOURCE, central.ResourceAction_CREATE_RESOURCE:
+		s.regStore.AddSecretID(parsedID)
+	case central.ResourceAction_REMOVE_RESOURCE:
+		if !s.regStore.RemoveSecretID(parsedID) {
+			log.Warnf("Should have secret (%s:%s) in registryStore known IDs but ID wasn't found", secret.GetName(), parsedID)
+		}
+	}
+
 	switch secret.Type {
 	case v1.SecretTypeDockerConfigJson, v1.SecretTypeDockercfg:
 		return s.processDockerConfigEvent(secret, oldSecret, action)

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -81,6 +81,7 @@ func InitializeStore() *InMemoryStoreProvider {
 		deduper.TypeDeployment.String():     p.deploymentStore,
 		deduper.TypePod.String():            p.podStore,
 		deduper.TypeServiceAccount.String(): p.serviceAccountStore,
+		deduper.TypeSecret.String():         p.registryStore,
 	}
 
 	return p


### PR DESCRIPTION
## Description

Allow registry stores to keep track of all secrets added and removed in the cluster. This is necessary to do the reconciliation between central and sensor when the connection breaks.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] CI
- [x] New unit tests

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
