### PR TITLE
ROX-16930: Re-enable skipped ImageManagementTest sub-tests on P/Z

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -13,7 +13,6 @@ import services.PolicyService
 
 import spock.lang.Tag
 import spock.lang.Unroll
-import spock.lang.IgnoreIf
 import util.Env
 
 @Tag("Parallel")
@@ -322,7 +321,6 @@ class ImageManagementTest extends BaseSpecification {
 
     @Tag("BAT")
     @Tag("Integration")
-    @IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
     def "Verify CI/CD Integration Endpoint with notifications"() {
         when:
         "Clone and scope the policy for test"
@@ -347,7 +345,7 @@ class ImageManagementTest extends BaseSpecification {
 
         and:
         "Request Image Scan with sendNotifications"
-        def scanResults = Services.requestBuildImageScan("quay.io", "quay/busybox", "latest", true)
+        def scanResults = Services.requestBuildImageScan("quay.io", "rhacs-eng/qa-multi-arch-busybox", "latest", true)
 
         then:
         "verify violation matches expected violation status and notification sent"
@@ -360,9 +358,9 @@ class ImageManagementTest extends BaseSpecification {
             assert alert["policy"]["name"] == clone.name
             assert alert["image"] != null
             assert alert["deployment"] == null
-            assert alert["image"]["name"]["fullName"] == "quay.io/quay/busybox:latest"
+            assert alert["image"]["name"]["fullName"] == "quay.io/rhacs-eng/qa-multi-arch-busybox:latest"
             assert alert["image"]["name"]["registry"] == "quay.io"
-            assert alert["image"]["name"]["remote"] == "quay/busybox"
+            assert alert["image"]["name"]["remote"] == "rhacs-eng/qa-multi-arch-busybox"
             assert alert["image"]["name"]["tag"] == "latest"
         }
 


### PR DESCRIPTION
This PR intends to add multi-arch support for the `ImageManagementTest` QA test.
Test code changes & images used in the test are update to enable test execution on 3 platforms viz. `x86_64`, `ppc64le` and `s390x`.
Few of the sub-tests skipped earlier on P/Z, have been re-enabled in this PR.

Changes are verified manually using `./gradlew test --tests=ImageManagementTest`