### PR TITLE
ROX-17348: ocp4.14 interop upgrade operator timeout

### DIFF
--- a/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
+++ b/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
@@ -4,4 +4,4 @@ commands:
 # We invoke the upgrade script via make such that we do not need to redefine here or plumb through
 # from the parent make: the namespace and operator version string (which are arguments to upgrade script).
 - script: make -C ../../.. upgrade-via-olm
-  timeout: 1
+  timeout: 900


### PR DESCRIPTION
For ocp4.14 interop testing, the operator upgrade appears to sometimes timeout. There are minimized resources for the test, and so it will likely hit the 10min timeout again.
https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-stackrox-stackrox-master-ocp-4-14-lp-interop-acs-tests-aws