### PR TITLE
ROX-20243: Add conditional RBAC to tab and button for NetworkPolicy

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -78,7 +78,8 @@ function NetworkGraphPage() {
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForBlocks =
         hasReadAccess('Administration') && hasReadWriteAccess('NetworkGraph');
-    const hasReadAccessForGenerator = hasReadAccess('Integration');
+    const hasReadAccessForGenerator =
+        hasReadAccess('Integration') && hasReadAccess('NetworkPolicy');
 
     const history = useHistory();
     const [edgeState, setEdgeState] = useState<EdgeState>('active');
@@ -299,9 +300,10 @@ function NetworkGraphPage() {
                             <ToolbarGroup
                                 variant="button-group"
                                 alignment={{ default: 'alignRight' }}
+                                spaceItems={{ default: 'spaceItemsMd' }}
                             >
                                 {hasWriteAccessForBlocks && (
-                                    <ToolbarItem spacer={{ default: 'spacerMd' }}>
+                                    <ToolbarItem>
                                         <Button
                                             variant="secondary"
                                             onClick={toggleCIDRBlockForm}
@@ -312,7 +314,7 @@ function NetworkGraphPage() {
                                     </ToolbarItem>
                                 )}
                                 {hasReadAccessForGenerator && (
-                                    <ToolbarItem spacer={{ default: 'spacerNone' }}>
+                                    <ToolbarItem>
                                         <SimulateNetworkPolicyButton
                                             simulation={simulation}
                                             isDisabled={scopeHierarchy.cluster.id === ''}
@@ -389,7 +391,7 @@ function NetworkGraphPage() {
                 variant={hasClusterNamespaceSelected ? 'default' : 'light'}
                 padding={{ default: 'noPadding' }}
             >
-                {!hasClusterNamespaceSelected && (
+                {hasReadAccessForGenerator && !hasClusterNamespaceSelected && (
                     <Drawer isExpanded={simulation.isOn} isInline>
                         <DrawerContent
                             panelContent={

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -16,6 +16,7 @@ import {
 
 import { networkBasePath } from 'routePaths';
 import useFetchDeploymentCount from 'hooks/useFetchDeploymentCount';
+import usePermissions from 'hooks/usePermissions';
 import DeploymentSideBar from './deployment/DeploymentSideBar';
 import NamespaceSideBar from './namespace/NamespaceSideBar';
 import CidrBlockSideBar from './cidr/CidrBlockSideBar';
@@ -73,6 +74,9 @@ const TopologyComponent = ({
     edgeState,
     scopeHierarchy,
 }: TopologyComponentProps) => {
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForNetworkPolicy = hasReadAccess('NetworkPolicy');
+
     const firstRenderRef = useRef(true);
     const history = useHistory();
     const controller = useVisualizationController();
@@ -173,14 +177,16 @@ const TopologyComponent = ({
         <TopologyView
             sideBar={
                 <TopologySideBar resizable onClose={closeSidebar}>
-                    {simulation.isOn && simulation.type === 'networkPolicy' && (
-                        <NetworkPolicySimulatorSidePanel
-                            simulator={simulator}
-                            setNetworkPolicyModification={setNetworkPolicyModification}
-                            scopeHierarchy={scopeHierarchy}
-                            scopeDeploymentCount={deploymentCount ?? 0}
-                        />
-                    )}
+                    {hasReadAccessForNetworkPolicy &&
+                        simulation.isOn &&
+                        simulation.type === 'networkPolicy' && (
+                            <NetworkPolicySimulatorSidePanel
+                                simulator={simulator}
+                                setNetworkPolicyModification={setNetworkPolicyModification}
+                                scopeHierarchy={scopeHierarchy}
+                                scopeDeploymentCount={deploymentCount ?? 0}
+                            />
+                        )}
                     {selectedNode && selectedNode?.data?.type === 'NAMESPACE' && (
                         <NamespaceSideBar
                             namespaceId={selectedNode.id}

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -19,6 +19,7 @@ import {
 
 import useTabs from 'hooks/patternfly/useTabs';
 import useFetchDeployment from 'hooks/useFetchDeployment';
+import usePermissions from 'hooks/usePermissions';
 import {
     getListenPorts,
     getNodeById,
@@ -59,6 +60,8 @@ function DeploymentSideBar({
     defaultDeploymentTab,
 }: DeploymentSideBarProps) {
     // component state
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForNetworkPolicy = hasReadAccess('NetworkPolicy');
     const { deployment, isLoading: isLoadingDeployment, error } = useFetchDeployment(deploymentId);
     const { activeKeyTab, onSelectTab, setActiveKeyTab } = useTabs({
         defaultTab: defaultDeploymentTab,
@@ -179,14 +182,18 @@ function DeploymentSideBar({
                                 tabContentId={deploymentTabs.BASELINE}
                                 title={<TabTitleText>{deploymentTabs.BASELINE}</TabTitleText>}
                             />
-                            <Tab
-                                eventKey={deploymentTabs.NETWORK_POLICIES}
-                                tabContentId={deploymentTabs.NETWORK_POLICIES}
-                                title={
-                                    <TabTitleText>{deploymentTabs.NETWORK_POLICIES}</TabTitleText>
-                                }
-                                disabled={isBaselineSimulationOn}
-                            />
+                            {hasReadAccessForNetworkPolicy && (
+                                <Tab
+                                    eventKey={deploymentTabs.NETWORK_POLICIES}
+                                    tabContentId={deploymentTabs.NETWORK_POLICIES}
+                                    title={
+                                        <TabTitleText>
+                                            {deploymentTabs.NETWORK_POLICIES}
+                                        </TabTitleText>
+                                    }
+                                    disabled={isBaselineSimulationOn}
+                                />
+                            )}
                         </Tabs>
                     </StackItem>
                     <StackItem isFilled style={{ overflow: 'auto' }}>
@@ -238,16 +245,18 @@ function DeploymentSideBar({
                                 />
                             )}
                         </TabContent>
-                        <TabContent
-                            eventKey={deploymentTabs.NETWORK_POLICIES}
-                            id={deploymentTabs.NETWORK_POLICIES}
-                            hidden={activeKeyTab !== deploymentTabs.NETWORK_POLICIES}
-                        >
-                            <NetworkPolicies
-                                entityName={deployment.name}
-                                policyIds={deploymentPolicyIds}
-                            />
-                        </TabContent>
+                        {hasReadAccessForNetworkPolicy && (
+                            <TabContent
+                                eventKey={deploymentTabs.NETWORK_POLICIES}
+                                id={deploymentTabs.NETWORK_POLICIES}
+                                hidden={activeKeyTab !== deploymentTabs.NETWORK_POLICIES}
+                            >
+                                <NetworkPolicies
+                                    entityName={deployment.name}
+                                    policyIds={deploymentPolicyIds}
+                                />
+                            </TabContent>
+                        )}
                     </StackItem>
                 </>
             )}


### PR DESCRIPTION
## Description

### Problem

Follow up #7909

After we reduced resource access requirements for Network Graph:
1. If user role does not have DeploymentExtension resource:
    * **Baseline** tab of deployment side panel makes request that has 403 Forbidden status.
        GET /v1/networkbaseline/id
2. If user role does not have NetworkPolicy resource:
    * For **Network policies** tab, deployment side panel makes request that has 403 Forbidden status.
        GET /v1/networkpolicies/id
    * Click **Network policy generator** makes request that has 403 Forbidden status.
        GET /v1/networkpolicies?clusterId=id&deploymentQuery=Cluster%3Aname%2BNamespace%3Aname

### Analysis

1. DeploymentExtension
    * DeploymentSideBar.tsx file renders tabs and DeploymentBaseline.tsx file encapsulates request.
    * It selects **Baseline** tab and disables other tabs if baseline simulation mode is on.
    * However, BaselineSimulationButton is an orphan component.
2. NetworkPolicy
    * DeploymentSideBar.tsx file renders tabs and NetworkPolicies.tsx file encapsulates request.
    * NetworkPolicySimulatorSidePanel.tsx file encapsulates request.
    * To prevent backdoor access via query string in page address, which components render NetworkPolicySimulatorSidePanel?
        * NetworkGraphPage.tsx file
        * TopologyComponent.tsx file

### Solution

1. DeploymentExtension deferred pending answer whether removal of baseline simulation button is temporary or permanent.
2. NetworkPolicy
    * DeploymentSideBar.tsx file: Add conditional rendering for `NetworkPolicies` element.
    * NetworkGraphPage.tsx file: Add NetworkPolicy resource to conditional rendering for `SimulateNetworkPolicyButton` element.
    * To prevent backdoor access via query string in page address, add conditional rendering for NetworkPolicySimulatorSidePanel:
        * NetworkGraphPage.tsx file
        * TopologyComponent.tsx file

### Residue

1. Confirm that `networkPolicyState` in `DeploymentData` type, which **Details** tab renders as **Network policy rules**, does **not** depend on /v1/networkpolicies endpoint.
2. Investigate conditional rendering for absence of Integration resource in NetworkPolicySimulatorSidePanel component.
3. Investigate whether multiple requests are redundant
    * Visit /main/network-graph has 2 getDeploymentCount:
        GET /v1/sac/clusters?permissions=Deployment&permissions=NetworkGraph
        POST /api/graphql?opname=getDeploymentCount with payload that includes `variables: {"query: Cluster:remote"}`
        GET /v1/sac/clusters/82ae6d74-1663-4286-9457-7c8c8358c202/namespaces?permissions=Deployment&permissions=NetworkGraph
        POST /api/graphql?opname=getDeploymentCount with payload that includes `variables: {"query: Cluster:remote"}`
    * Select **stackrox** namespace has 2 pairs of networkGraph which differ by query string:
        GET /v1/deployments?pagination.offset=0&pagination.limit=0&pagination.sortOption.field=Deployment&pagination.sortOption.reversed=false&query=Namespace%20ID%3Af3c7c2db-fea3-4686-a4be-42db16b25ebe
        GET /v1/search/metadata/options?categories=DEPLOYMENTS
        POST /api/graphql?opname=getDeploymentCount with payload that includes `variables: {query: "Cluster:remote+Namespace:stackrox"}`
        GET /v1/networkgraph/cluster/82ae6d74-1663-4286-9457-7c8c8358c202?query=Namespace%3Astackrox&since=2023-10-17T11%3A56%3A05.286Z&includePorts=true
        GET /v1/networkgraph/cluster/82ae6d74-1663-4286-9457-7c8c8358c202?query=Namespace%3Astackrox&includePorts=true&include_policies=true
        GET /v1/networkgraph/cluster/82ae6d74-1663-4286-9457-7c8c8358c202?query=Namespace%3Astackrox&since=2023-10-17T11%3A56%3A05.637Z&includePorts=true
        GET /v1/networkgraph/cluster/82ae6d74-1663-4286-9457-7c8c8358c202?query=Namespace%3Astackrox&includePorts=true&include_policies=true
4. Is rendering in both NetworkGraphPage and TopologyComponent temporarily or permanently redundant?
    * Is it tech debt left over after some features have been removed permanently?
    * Or does it need to remain because some features have been removed only temporarily?

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js: 0 = 3910659 - 3910659
        total: 129 = 10161572 - 10161443
    * `ls -al build/static/js/*.js | wc -l`
        0 = 83 - 83 files
3. `yarn start` in ui

### Manual testing

Pictures at 1440px width and 900px height like a newer laptop.

1. Visit /main/network-graph, select **stackrox** namespace, and then click **admission-control** deployment:
    * Without conditional rendering:
        GET /v1/deployments/5513dc8a-d232-4a9b-8ca3-f31e2fccf8cb
        GET /v1/networkbaseline/5513dc8a-d232-4a9b-8ca3-f31e2fccf8cb/status
        GET /v1/networkpolicies/5ea0d00e-3d69-40c2-9a10-f20e0685dbb4
    * With conditional rendering and temporary code change to simulate NO_ACCESS for NetworkPolicy resource:
        GET /v1/deployments/5513dc8a-d232-4a9b-8ca3-f31e2fccf8cb
        GET /v1/networkbaseline/5513dc8a-d232-4a9b-8ca3-f31e2fccf8cb/status

    See absence of **Network policies** tab and **Network policy generator** button.
    ![1](https://github.com/stackrox/stackrox/assets/11862657/7f03bdae-72cf-48f1-9a66-efb7642f8e00)

2. Edit page address to add `simulation=networkPolicy` in query string.
    See it does not render network policies side panel.
    * If deployment side panel was open, it remains open.
    * If cluster but no namespace selected, then network graph is in an inconsistent state:
        * NetworkPolicy has READ_ACCESS level: button is disabled, graph displays Nothing to render yet, Generate network policies side panel is open.
        * NetworkPolicy has NO_ACCESS level: button is disabled, graph is blank, side panel is not open.

### Integration testing

* networkGraph/networkDeploymentSidebar.test.js
* networkGraph/networkGraph.test.js
