### PR TITLE
ROX-20279: Minimize resource requirements for SummaryCounts

### DIFF
--- a/ui/apps/platform/cypress/fixtures/auth/mypermissionsForAnalyst.json
+++ b/ui/apps/platform/cypress/fixtures/auth/mypermissionsForAnalyst.json
@@ -1,0 +1,28 @@
+{
+    "resourceToAccess": {
+        "Access": "READ_ACCESS",
+        "Administration": "NO_ACCESS",
+        "Alert": "READ_ACCESS",
+        "CVE": "READ_ACCESS",
+        "Cluster": "READ_ACCESS",
+        "Compliance": "READ_ACCESS",
+        "Deployment": "READ_ACCESS",
+        "DeploymentExtension": "READ_ACCESS",
+        "Detection": "READ_ACCESS",
+        "Image": "READ_ACCESS",
+        "Integration": "READ_ACCESS",
+        "K8sRole": "READ_ACCESS",
+        "K8sRoleBinding": "READ_ACCESS",
+        "K8sSubject": "READ_ACCESS",
+        "Namespace": "READ_ACCESS",
+        "NetworkGraph": "READ_ACCESS",
+        "NetworkPolicy": "READ_ACCESS",
+        "Node": "READ_ACCESS",
+        "Secret": "READ_ACCESS",
+        "ServiceAccount": "READ_ACCESS",
+        "VulnerabilityManagementApprovals": "READ_ACCESS",
+        "VulnerabilityManagementRequests": "READ_ACCESS",
+        "WatchedImage": "READ_ACCESS",
+        "WorkflowAdministration" : "READ_ACCESS"
+    }
+}

--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -17,7 +17,7 @@ export const agingImagesQueryOpname = 'agingImagesQuery';
 export const alertsSummaryCountsGroupByCategoryAlias = 'alerts/summary/counts_CATEGORY';
 export const getAggregatedResultsOpname = 'getAggregatedResults';
 
-const routeMatcherMapForSummaryCounts = getRouteMatcherMapForGraphQL([summaryCountsOpname]);
+export const routeMatcherMapForSummaryCounts = getRouteMatcherMapForGraphQL([summaryCountsOpname]);
 const routeMatcherMapForSearchFilter = getRouteMatcherMapForGraphQL([
     getAllNamespacesByClusterOpname,
 ]);

--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -1,7 +1,7 @@
 import navSelectors from '../selectors/navigation';
 
 import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from './request';
-import { visit } from './visit';
+import { visit, visitWithStaticResponseForPermissions } from './visit';
 
 /*
  * Import relevant alias constants in test files that call visitMainDashboard function
@@ -78,6 +78,32 @@ export function visitMainDashboard(staticResponseMap) {
     visit(basePath, routeMatcherMap, staticResponseMap);
 
     cy.get(`.pf-c-nav__link.pf-m-current:contains("${title}")`);
+    cy.get(`h1:contains("${title}")`);
+}
+
+/**
+ * Visit main dashboard to test conditional rendering for user role permissions specified as response or fixture.
+ * Conditional rendering for permissions might make a subset of requests.
+ *
+ * { body: { resourceToAccess: { … } } }
+ * { fixture: 'fixtures/wherever/whatever.json' }
+ *
+ * @param {{ body: { resourceToAccess: Record<string, string> } } | { fixture: string }} staticResponseForPermissions
+ * @param {Record<string, { method: string, url: string }>} [routeMatcherMapForSubsetOfRequests]
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMapForSubsetOfRequests]
+ */
+export function visitMainDashboardWithStaticResponseForPermissions(
+    staticResponseForPermissions,
+    routeMatcherMapForSubsetOfRequests,
+    staticResponseMapForSubsetOfRequests
+) {
+    visitWithStaticResponseForPermissions(
+        basePath,
+        staticResponseForPermissions,
+        routeMatcherMapForSubsetOfRequests,
+        staticResponseMapForSubsetOfRequests
+    );
+
     cy.get(`h1:contains("${title}")`);
 }
 

--- a/ui/apps/platform/cypress/integration/dashboard/dashboardSummaryCounts.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard/dashboardSummaryCounts.test.js
@@ -2,26 +2,29 @@ import { resourceToAccess as resourceToAccessForAnalyst } from '../../fixtures/a
 import { resourceToAccess as resourceToAccessForNoAccess } from '../../fixtures/auth/mypermissionsNoAccess.json';
 
 import withAuth from '../../helpers/basicAuth';
-import { visitMainDashboardWithStaticResponseForPermissions } from '../../helpers/main';
+import {
+    routeMatcherMapForSummaryCounts,
+    visitMainDashboardWithStaticResponseForPermissions,
+} from '../../helpers/main';
 
-function getDataForAnalystWithoutResources(resources) {
+function getStaticResponseForAnalystWithoutResources(resources) {
     const resourceToAccess = { ...resourceToAccessForAnalyst };
 
     resources.forEach((resource) => {
         resourceToAccess[resource] = 'NO_ACCESS';
     });
 
-    return { resourceToAccess };
+    return { body: { resourceToAccess } };
 }
 
-function getDataForNoAccessExceptResources(resources) {
+function getStaticResponseForNoAccessExceptResources(resources) {
     const resourceToAccess = { ...resourceToAccessForNoAccess };
 
     resources.forEach((resource) => {
         resourceToAccess[resource] = 'READ_ACCESS';
     });
 
-    return { resourceToAccess };
+    return { body: { resourceToAccess } };
 }
 
 function getSummaryCountSelector(noun) {
@@ -34,9 +37,10 @@ describe('Dashboard SummaryCounts', () => {
     withAuth();
 
     it('should display 6 counts for Analyst role', () => {
-        visitMainDashboardWithStaticResponseForPermissions({
-            body: getDataForAnalystWithoutResources([]),
-        });
+        visitMainDashboardWithStaticResponseForPermissions(
+            getStaticResponseForAnalystWithoutResources([]),
+            routeMatcherMapForSummaryCounts
+        );
 
         cy.get(getSummaryCountSelector('Cluster'));
         cy.get(getSummaryCountSelector('Node'));
@@ -48,9 +52,10 @@ describe('Dashboard SummaryCounts', () => {
     });
 
     it('should display 0 counts with no resources', () => {
-        visitMainDashboardWithStaticResponseForPermissions({
-            body: getDataForNoAccessExceptResources([]),
-        });
+        visitMainDashboardWithStaticResponseForPermissions(
+            getStaticResponseForNoAccessExceptResources([])
+            // no request
+        );
 
         cy.get(getSummaryCountSelector('Cluster')).should('not.exist');
         cy.get(getSummaryCountSelector('Node')).should('not.exist');
@@ -62,9 +67,10 @@ describe('Dashboard SummaryCounts', () => {
     });
 
     it('should display 5 counts without Cluster resource', () => {
-        visitMainDashboardWithStaticResponseForPermissions({
-            body: getDataForAnalystWithoutResources(['Cluster']),
-        });
+        visitMainDashboardWithStaticResponseForPermissions(
+            getStaticResponseForAnalystWithoutResources(['Cluster']),
+            routeMatcherMapForSummaryCounts
+        );
 
         cy.get(getSummaryCountSelector('Cluster')).should('not.exist');
         cy.get(getSummaryCountSelector('Node'));
@@ -76,9 +82,10 @@ describe('Dashboard SummaryCounts', () => {
     });
 
     it('should display 1 count with only Cluster resource', () => {
-        visitMainDashboardWithStaticResponseForPermissions({
-            body: getDataForNoAccessExceptResources(['Cluster']),
-        });
+        visitMainDashboardWithStaticResponseForPermissions(
+            getStaticResponseForNoAccessExceptResources(['Cluster']),
+            routeMatcherMapForSummaryCounts
+        );
 
         cy.get(getSummaryCountSelector('Cluster'));
         cy.get(getSummaryCountSelector('Node')).should('not.exist');
@@ -90,9 +97,10 @@ describe('Dashboard SummaryCounts', () => {
     });
 
     it('should display 5 counts without Node resource', () => {
-        visitMainDashboardWithStaticResponseForPermissions({
-            body: getDataForAnalystWithoutResources(['Node']),
-        });
+        visitMainDashboardWithStaticResponseForPermissions(
+            getStaticResponseForAnalystWithoutResources(['Node']),
+            routeMatcherMapForSummaryCounts
+        );
 
         cy.get(getSummaryCountSelector('Cluster'));
         cy.get(getSummaryCountSelector('Node')).should('not.exist');
@@ -104,9 +112,10 @@ describe('Dashboard SummaryCounts', () => {
     });
 
     it('should display 1 count with only Node resource', () => {
-        visitMainDashboardWithStaticResponseForPermissions({
-            body: getDataForNoAccessExceptResources(['Node']),
-        });
+        visitMainDashboardWithStaticResponseForPermissions(
+            getStaticResponseForNoAccessExceptResources(['Node']),
+            routeMatcherMapForSummaryCounts
+        );
 
         cy.get(getSummaryCountSelector('Cluster')).should('not.exist');
         cy.get(getSummaryCountSelector('Node'));
@@ -118,9 +127,10 @@ describe('Dashboard SummaryCounts', () => {
     });
 
     it('should display 5 counts without Alert resource', () => {
-        visitMainDashboardWithStaticResponseForPermissions({
-            body: getDataForAnalystWithoutResources(['Alert']),
-        });
+        visitMainDashboardWithStaticResponseForPermissions(
+            getStaticResponseForAnalystWithoutResources(['Alert']),
+            routeMatcherMapForSummaryCounts
+        );
 
         cy.get(getSummaryCountSelector('Cluster'));
         cy.get(getSummaryCountSelector('Node'));
@@ -132,9 +142,10 @@ describe('Dashboard SummaryCounts', () => {
     });
 
     it('should display 1 count with only Alert resource', () => {
-        visitMainDashboardWithStaticResponseForPermissions({
-            body: getDataForNoAccessExceptResources(['Alert']),
-        });
+        visitMainDashboardWithStaticResponseForPermissions(
+            getStaticResponseForNoAccessExceptResources(['Alert']),
+            routeMatcherMapForSummaryCounts
+        );
 
         cy.get(getSummaryCountSelector('Cluster')).should('not.exist');
         cy.get(getSummaryCountSelector('Node')).should('not.exist');
@@ -146,9 +157,10 @@ describe('Dashboard SummaryCounts', () => {
     });
 
     it('should display 5 counts without Deployment resource', () => {
-        visitMainDashboardWithStaticResponseForPermissions({
-            body: getDataForAnalystWithoutResources(['Deployment']),
-        });
+        visitMainDashboardWithStaticResponseForPermissions(
+            getStaticResponseForAnalystWithoutResources(['Deployment']),
+            routeMatcherMapForSummaryCounts
+        );
 
         cy.get(getSummaryCountSelector('Cluster'));
         cy.get(getSummaryCountSelector('Node'));
@@ -160,9 +172,10 @@ describe('Dashboard SummaryCounts', () => {
     });
 
     it('should display 1 count with only Deployment resource', () => {
-        visitMainDashboardWithStaticResponseForPermissions({
-            body: getDataForNoAccessExceptResources(['Deployment']),
-        });
+        visitMainDashboardWithStaticResponseForPermissions(
+            getStaticResponseForNoAccessExceptResources(['Deployment']),
+            routeMatcherMapForSummaryCounts
+        );
 
         cy.get(getSummaryCountSelector('Cluster')).should('not.exist');
         cy.get(getSummaryCountSelector('Node')).should('not.exist');
@@ -174,9 +187,10 @@ describe('Dashboard SummaryCounts', () => {
     });
 
     it('should display 5 counts without Image resource', () => {
-        visitMainDashboardWithStaticResponseForPermissions({
-            body: getDataForAnalystWithoutResources(['Image']),
-        });
+        visitMainDashboardWithStaticResponseForPermissions(
+            getStaticResponseForAnalystWithoutResources(['Image']),
+            routeMatcherMapForSummaryCounts
+        );
 
         cy.get(getSummaryCountSelector('Cluster'));
         cy.get(getSummaryCountSelector('Node'));
@@ -188,9 +202,10 @@ describe('Dashboard SummaryCounts', () => {
     });
 
     it('should display 1 count with only Image resource', () => {
-        visitMainDashboardWithStaticResponseForPermissions({
-            body: getDataForNoAccessExceptResources(['Image']),
-        });
+        visitMainDashboardWithStaticResponseForPermissions(
+            getStaticResponseForNoAccessExceptResources(['Image']),
+            routeMatcherMapForSummaryCounts
+        );
 
         cy.get(getSummaryCountSelector('Cluster')).should('not.exist');
         cy.get(getSummaryCountSelector('Node')).should('not.exist');
@@ -202,9 +217,10 @@ describe('Dashboard SummaryCounts', () => {
     });
 
     it('should display 5 counts without Secret resource', () => {
-        visitMainDashboardWithStaticResponseForPermissions({
-            body: getDataForAnalystWithoutResources(['Secret']),
-        });
+        visitMainDashboardWithStaticResponseForPermissions(
+            getStaticResponseForAnalystWithoutResources(['Secret']),
+            routeMatcherMapForSummaryCounts
+        );
 
         cy.get(getSummaryCountSelector('Cluster'));
         cy.get(getSummaryCountSelector('Node'));
@@ -216,9 +232,10 @@ describe('Dashboard SummaryCounts', () => {
     });
 
     it('should display 1 count with only Secret resource', () => {
-        visitMainDashboardWithStaticResponseForPermissions({
-            body: getDataForNoAccessExceptResources(['Secret']),
-        });
+        visitMainDashboardWithStaticResponseForPermissions(
+            getStaticResponseForNoAccessExceptResources(['Secret']),
+            routeMatcherMapForSummaryCounts
+        );
 
         cy.get(getSummaryCountSelector('Cluster')).should('not.exist');
         cy.get(getSummaryCountSelector('Node')).should('not.exist');

--- a/ui/apps/platform/cypress/integration/dashboard/dashboardSummaryCounts.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard/dashboardSummaryCounts.test.js
@@ -1,0 +1,231 @@
+import { resourceToAccess as resourceToAccessForAnalyst } from '../../fixtures/auth/mypermissionsForAnalyst.json';
+import { resourceToAccess as resourceToAccessForNoAccess } from '../../fixtures/auth/mypermissionsNoAccess.json';
+
+import withAuth from '../../helpers/basicAuth';
+import { visitMainDashboardWithStaticResponseForPermissions } from '../../helpers/main';
+
+function getDataForAnalystWithoutResources(resources) {
+    const resourceToAccess = { ...resourceToAccessForAnalyst };
+
+    resources.forEach((resource) => {
+        resourceToAccess[resource] = 'NO_ACCESS';
+    });
+
+    return { resourceToAccess };
+}
+
+function getDataForNoAccessExceptResources(resources) {
+    const resourceToAccess = { ...resourceToAccessForNoAccess };
+
+    resources.forEach((resource) => {
+        resourceToAccess[resource] = 'READ_ACCESS';
+    });
+
+    return { resourceToAccess };
+}
+
+function getSummaryCountSelector(noun) {
+    return `main section:first-child a.pf-c-button.pf-m-link:contains("${noun}")`;
+}
+
+const lastUpdatedSelector = 'main section:first-child div:contains("Last updated")';
+
+describe('Dashboard SummaryCounts', () => {
+    withAuth();
+
+    it('should display 6 counts for Analyst role', () => {
+        visitMainDashboardWithStaticResponseForPermissions({
+            body: getDataForAnalystWithoutResources([]),
+        });
+
+        cy.get(getSummaryCountSelector('Cluster'));
+        cy.get(getSummaryCountSelector('Node'));
+        cy.get(getSummaryCountSelector('Violation'));
+        cy.get(getSummaryCountSelector('Deployment'));
+        cy.get(getSummaryCountSelector('Image'));
+        cy.get(getSummaryCountSelector('Secret'));
+        cy.get(lastUpdatedSelector);
+    });
+
+    it('should display 0 counts with no resources', () => {
+        visitMainDashboardWithStaticResponseForPermissions({
+            body: getDataForNoAccessExceptResources([]),
+        });
+
+        cy.get(getSummaryCountSelector('Cluster')).should('not.exist');
+        cy.get(getSummaryCountSelector('Node')).should('not.exist');
+        cy.get(getSummaryCountSelector('Violation')).should('not.exist');
+        cy.get(getSummaryCountSelector('Deployment')).should('not.exist');
+        cy.get(getSummaryCountSelector('Image')).should('not.exist');
+        cy.get(getSummaryCountSelector('Secret')).should('not.exist');
+        cy.get(lastUpdatedSelector).should('not.exist');
+    });
+
+    it('should display 5 counts without Cluster resource', () => {
+        visitMainDashboardWithStaticResponseForPermissions({
+            body: getDataForAnalystWithoutResources(['Cluster']),
+        });
+
+        cy.get(getSummaryCountSelector('Cluster')).should('not.exist');
+        cy.get(getSummaryCountSelector('Node'));
+        cy.get(getSummaryCountSelector('Violation'));
+        cy.get(getSummaryCountSelector('Deployment'));
+        cy.get(getSummaryCountSelector('Image'));
+        cy.get(getSummaryCountSelector('Secret'));
+        cy.get(lastUpdatedSelector);
+    });
+
+    it('should display 1 count with only Cluster resource', () => {
+        visitMainDashboardWithStaticResponseForPermissions({
+            body: getDataForNoAccessExceptResources(['Cluster']),
+        });
+
+        cy.get(getSummaryCountSelector('Cluster'));
+        cy.get(getSummaryCountSelector('Node')).should('not.exist');
+        cy.get(getSummaryCountSelector('Violation')).should('not.exist');
+        cy.get(getSummaryCountSelector('Deployment')).should('not.exist');
+        cy.get(getSummaryCountSelector('Image')).should('not.exist');
+        cy.get(getSummaryCountSelector('Secret')).should('not.exist');
+        cy.get(lastUpdatedSelector);
+    });
+
+    it('should display 5 counts without Node resource', () => {
+        visitMainDashboardWithStaticResponseForPermissions({
+            body: getDataForAnalystWithoutResources(['Node']),
+        });
+
+        cy.get(getSummaryCountSelector('Cluster'));
+        cy.get(getSummaryCountSelector('Node')).should('not.exist');
+        cy.get(getSummaryCountSelector('Violation'));
+        cy.get(getSummaryCountSelector('Deployment'));
+        cy.get(getSummaryCountSelector('Image'));
+        cy.get(getSummaryCountSelector('Secret'));
+        cy.get(lastUpdatedSelector);
+    });
+
+    it('should display 1 count with only Node resource', () => {
+        visitMainDashboardWithStaticResponseForPermissions({
+            body: getDataForNoAccessExceptResources(['Node']),
+        });
+
+        cy.get(getSummaryCountSelector('Cluster')).should('not.exist');
+        cy.get(getSummaryCountSelector('Node'));
+        cy.get(getSummaryCountSelector('Violation')).should('not.exist');
+        cy.get(getSummaryCountSelector('Deployment')).should('not.exist');
+        cy.get(getSummaryCountSelector('Image')).should('not.exist');
+        cy.get(getSummaryCountSelector('Secret')).should('not.exist');
+        cy.get(lastUpdatedSelector);
+    });
+
+    it('should display 5 counts without Alert resource', () => {
+        visitMainDashboardWithStaticResponseForPermissions({
+            body: getDataForAnalystWithoutResources(['Alert']),
+        });
+
+        cy.get(getSummaryCountSelector('Cluster'));
+        cy.get(getSummaryCountSelector('Node'));
+        cy.get(getSummaryCountSelector('Violation')).should('not.exist');
+        cy.get(getSummaryCountSelector('Deployment'));
+        cy.get(getSummaryCountSelector('Image'));
+        cy.get(getSummaryCountSelector('Secret'));
+        cy.get(lastUpdatedSelector);
+    });
+
+    it('should display 1 count with only Alert resource', () => {
+        visitMainDashboardWithStaticResponseForPermissions({
+            body: getDataForNoAccessExceptResources(['Alert']),
+        });
+
+        cy.get(getSummaryCountSelector('Cluster')).should('not.exist');
+        cy.get(getSummaryCountSelector('Node')).should('not.exist');
+        cy.get(getSummaryCountSelector('Violation'));
+        cy.get(getSummaryCountSelector('Deployment')).should('not.exist');
+        cy.get(getSummaryCountSelector('Image')).should('not.exist');
+        cy.get(getSummaryCountSelector('Secret')).should('not.exist');
+        cy.get(lastUpdatedSelector);
+    });
+
+    it('should display 5 counts without Deployment resource', () => {
+        visitMainDashboardWithStaticResponseForPermissions({
+            body: getDataForAnalystWithoutResources(['Deployment']),
+        });
+
+        cy.get(getSummaryCountSelector('Cluster'));
+        cy.get(getSummaryCountSelector('Node'));
+        cy.get(getSummaryCountSelector('Violation'));
+        cy.get(getSummaryCountSelector('Deployment')).should('not.exist');
+        cy.get(getSummaryCountSelector('Image'));
+        cy.get(getSummaryCountSelector('Secret'));
+        cy.get(lastUpdatedSelector);
+    });
+
+    it.only('should display 1 count with only Deployment resource', () => {
+        visitMainDashboardWithStaticResponseForPermissions({
+            body: getDataForNoAccessExceptResources(['Deployment']),
+        });
+
+        cy.get(getSummaryCountSelector('Cluster')).should('not.exist');
+        cy.get(getSummaryCountSelector('Node')).should('not.exist');
+        cy.get(getSummaryCountSelector('Violation')).should('not.exist');
+        cy.get(getSummaryCountSelector('Deployment'));
+        cy.get(getSummaryCountSelector('Image')).should('not.exist');
+        cy.get(getSummaryCountSelector('Secret')).should('not.exist');
+        cy.get(lastUpdatedSelector);
+    });
+
+    it('should display 5 counts without Image resource', () => {
+        visitMainDashboardWithStaticResponseForPermissions({
+            body: getDataForAnalystWithoutResources(['Image']),
+        });
+
+        cy.get(getSummaryCountSelector('Cluster'));
+        cy.get(getSummaryCountSelector('Node'));
+        cy.get(getSummaryCountSelector('Violation'));
+        cy.get(getSummaryCountSelector('Deployment'));
+        cy.get(getSummaryCountSelector('Image')).should('not.exist');
+        cy.get(getSummaryCountSelector('Secret'));
+        cy.get(lastUpdatedSelector);
+    });
+
+    it('should display 1 count with only Image resource', () => {
+        visitMainDashboardWithStaticResponseForPermissions({
+            body: getDataForNoAccessExceptResources(['Image']),
+        });
+
+        cy.get(getSummaryCountSelector('Cluster')).should('not.exist');
+        cy.get(getSummaryCountSelector('Node')).should('not.exist');
+        cy.get(getSummaryCountSelector('Violation')).should('not.exist');
+        cy.get(getSummaryCountSelector('Deployment')).should('not.exist');
+        cy.get(getSummaryCountSelector('Image'));
+        cy.get(getSummaryCountSelector('Secret')).should('not.exist');
+        cy.get(lastUpdatedSelector);
+    });
+
+    it('should display 5 counts without Secret resource', () => {
+        visitMainDashboardWithStaticResponseForPermissions({
+            body: getDataForAnalystWithoutResources(['Secret']),
+        });
+
+        cy.get(getSummaryCountSelector('Cluster'));
+        cy.get(getSummaryCountSelector('Node'));
+        cy.get(getSummaryCountSelector('Violation'));
+        cy.get(getSummaryCountSelector('Deployment'));
+        cy.get(getSummaryCountSelector('Image'));
+        cy.get(getSummaryCountSelector('Secret')).should('not.exist');
+        cy.get(lastUpdatedSelector);
+    });
+
+    it('should display 1 count with only Secret resource', () => {
+        visitMainDashboardWithStaticResponseForPermissions({
+            body: getDataForNoAccessExceptResources(['Secret']),
+        });
+
+        cy.get(getSummaryCountSelector('Cluster')).should('not.exist');
+        cy.get(getSummaryCountSelector('Node')).should('not.exist');
+        cy.get(getSummaryCountSelector('Violation')).should('not.exist');
+        cy.get(getSummaryCountSelector('Deployment')).should('not.exist');
+        cy.get(getSummaryCountSelector('Image')).should('not.exist');
+        cy.get(getSummaryCountSelector('Secret'));
+        cy.get(lastUpdatedSelector);
+    });
+});

--- a/ui/apps/platform/cypress/integration/dashboard/dashboardSummaryCounts.test.js
+++ b/ui/apps/platform/cypress/integration/dashboard/dashboardSummaryCounts.test.js
@@ -159,7 +159,7 @@ describe('Dashboard SummaryCounts', () => {
         cy.get(lastUpdatedSelector);
     });
 
-    it.only('should display 1 count with only Deployment resource', () => {
+    it('should display 1 count with only Deployment resource', () => {
         visitMainDashboardWithStaticResponseForPermissions({
             body: getDataForNoAccessExceptResources(['Deployment']),
         });

--- a/ui/apps/platform/src/Containers/Dashboard/DashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/DashboardPage.tsx
@@ -42,12 +42,14 @@ function DashboardPage() {
                 <>
                     <PageSection variant="light" padding={{ default: 'noPadding' }}>
                         <SummaryCounts
-                            Cluster={hasReadAccessForCluster}
-                            Node={hasReadAccessForNode}
-                            Violation={hasReadAccessForAlert}
-                            Deployment={hasReadAccessForDeployment}
-                            Image={hasReadAccessForImage}
-                            Secret={hasReadAccessForSecret}
+                            hasReadAccessForResource={{
+                                Alert: hasReadAccessForAlert,
+                                Cluster: hasReadAccessForCluster,
+                                Deployment: hasReadAccessForDeployment,
+                                Image: hasReadAccessForImage,
+                                Node: hasReadAccessForNode,
+                                Secret: hasReadAccessForSecret,
+                            }}
                         />
                     </PageSection>
                     <Divider component="div" />

--- a/ui/apps/platform/src/Containers/Dashboard/DashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/DashboardPage.tsx
@@ -28,17 +28,31 @@ function DashboardPage() {
     const hasReadAccessForNode = hasReadAccess('Node');
     const hasReadAccessForSecret = hasReadAccess('Secret');
 
+    const hasReadAccessForSummaryCounts =
+        hasReadAccessForAlert ||
+        hasReadAccessForCluster ||
+        hasReadAccessForDeployment ||
+        hasReadAccessForImage ||
+        hasReadAccessForNode ||
+        hasReadAccessForSecret;
+
     return (
         <>
-            <PageSection variant="light" padding={{ default: 'noPadding' }}>
-                {hasReadAccessForAlert &&
-                    hasReadAccessForCluster &&
-                    hasReadAccessForDeployment &&
-                    hasReadAccessForImage &&
-                    hasReadAccessForNode &&
-                    hasReadAccessForSecret && <SummaryCounts />}
-            </PageSection>
-            <Divider component="div" />
+            {hasReadAccessForSummaryCounts && (
+                <>
+                    <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                        <SummaryCounts
+                            Cluster={hasReadAccessForCluster}
+                            Node={hasReadAccessForNode}
+                            Violation={hasReadAccessForAlert}
+                            Deployment={hasReadAccessForDeployment}
+                            Image={hasReadAccessForImage}
+                            Secret={hasReadAccessForSecret}
+                        />
+                    </PageSection>
+                    <Divider component="div" />
+                </>
+            )}
             <PageSection variant="light">
                 <Flex
                     direction={{ default: 'column', lg: 'row' }}

--- a/ui/apps/platform/src/Containers/Dashboard/SummaryCount.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/SummaryCount.tsx
@@ -1,0 +1,28 @@
+import React, { ReactElement } from 'react';
+import pluralize from 'pluralize';
+import { Button, Stack } from '@patternfly/react-core';
+
+import LinkShim from 'Components/PatternFly/LinkShim';
+
+export type SummaryCountProps = {
+    count: number;
+    href: string;
+    noun: string;
+};
+
+function SummaryCount({ count, href, noun }: SummaryCountProps): ReactElement {
+    return (
+        <Button variant="link" component={LinkShim} href={href}>
+            <Stack className="pf-u-px-xs pf-u-px-sm-on-xl pf-u-align-items-center">
+                <span className="pf-u-font-size-lg-on-md pf-u-font-size-sm pf-u-font-weight-bold">
+                    {count}
+                </span>
+                <span className="pf-u-font-size-md-on-md pf-u-font-size-xs">
+                    {pluralize(noun, count)}
+                </span>
+            </Stack>
+        </Button>
+    );
+}
+
+export default SummaryCount;

--- a/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
@@ -50,11 +50,11 @@ const timeFormatter = new Intl.DateTimeFormat(locale, { hour: 'numeric', minute:
 
 export type SummaryCountsProps = Record<TileEntity, boolean>;
 
-function SummaryCounts(props: SummaryCountsProps): ReactElement {
+function SummaryCounts(hasReadAccessForTileEntity: SummaryCountsProps): ReactElement {
     const query = gql`
         query summary_counts {
             ${tileEntityTypes
-                .filter((tileEntity) => props[tileEntity])
+                .filter((tileEntity) => hasReadAccessForTileEntity[tileEntity])
                 .map((tileEntity) => dataKey[tileEntity])
                 .join('\n')}
         }


### PR DESCRIPTION
## Description

### Problem

Follow up #7381

To prevent **There was an error loading system summary counts** in summary counts bar of main dashboard, the initial conditional rendering was all or nothing.

### Solution

1. Edit DashboardPage.tsx file.
    * Replace `&&` with `||` in conditional rendering.
    * Add `hasReadAccessForResource` prop to `SummaryCounts` element.
2. Add SummaryCount.tsx file.
3. Edit SummaryCounts.tsx file.
    * Based on review question, I refactored with resources as keys and rendered nouns via `tileNouns` object.
    * Conditionally include in query only properties for which user role has permission.
    * Conditionally render counts.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Added integration tests

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js: 0 = 3910905 - 3910905
        total: 126 = 10177590 - 10177464
    * `ls -al build/static/js/*.js | wc -l`
        0 = 82 - 82 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/dashboard

2. Click a summary count link, and then click browser back button.

### Integration testing

1. dashboard/dashboardSummaryCounts.test.js

    * `it('should display 0 counts with no resources'`
        ![0_counts](https://github.com/stackrox/stackrox/assets/11862657/9e26efea-7f72-4aca-af07-e752bd655857)

    * `it('should display 5 counts without Node resource'`
        ![5_counts](https://github.com/stackrox/stackrox/assets/11862657/139e8ef5-3857-41cc-92f9-ac342944dbdb)

    * `it('should display 1 count with only Deployment resource'`
        ![1_count](https://github.com/stackrox/stackrox/assets/11862657/e53c2197-1a19-4847-bf92-f258070951a0)
