### PR TITLE
ROX-19669: remove ReconcileDelete from the service store

### DIFF
--- a/sensor/kubernetes/listener/resources/service_store.go
+++ b/sensor/kubernetes/listener/resources/service_store.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	routeV1 "github.com/openshift/api/route/v1"
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/selector"
@@ -28,15 +27,6 @@ type serviceStore struct {
 
 	// Protects all fields
 	lock sync.RWMutex
-}
-
-// ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
-// Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
-// shall be deleted from Central.
-func (ss *serviceStore) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
-	_, _, _ = resType, resID, resHash
-	// TODO(ROX-20071): Implement me
-	return "", errors.New("Not implemented")
 }
 
 // newServiceStore creates and returns a new service store.


### PR DESCRIPTION
## Description

Since Central does not track services or routes, the service store does not need to be reconcile.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

There is no need to validate anything. This PR only removes an unused function. 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
