### PR TITLE
ROX-20075: remove ReconcileDelete from the entityStore

### DIFF
--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -55,15 +55,6 @@ type Store struct {
 	mutex sync.RWMutex
 }
 
-// ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
-// Reconciliacion ensures that Sensor and Central have the same state by checking whether a given resource
-// shall be deleted from Central.
-func (e *Store) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
-	_, _, _ = resType, resID, resHash
-	// TODO(ROX-20075): Implement me
-	return "", errors.New("Not implemented")
-}
-
 // NewStore creates and returns a new store instance.
 // Note: Generally, you probably do not want to call this function, but use the singleton instance returned by
 // `StoreInstance()`.


### PR DESCRIPTION
## Description

Central does not track entities from the entity store directly. Nodes and Deployments get reconcile in their respective stores. Services/routes do not need to be reconcile since Central does not track them.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

There is no need to validate anything. This PR only removes an unused function.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
