### PR TITLE
ROX-19105: fix release cluster access script for Mac users

### DIFF
--- a/scripts/release-tools/lib.sh
+++ b/scripts/release-tools/lib.sh
@@ -10,7 +10,10 @@ download_cluster_artifacts() {
 }
 
 fetch_cluster_credentials() {
-    readarray -t DATA < <(kubectl get secret/access-rhacs -n stackrox -o jsonpath='{.data}' 2>/dev/null | jq -r '(.central_url|@base64d) +" "+ (.username|@base64d) +" "+(.password|@base64d)')
+    DATA=()
+    while IFS=' ' read -ra item; do
+        DATA+=("${item[@]}")
+    done < <(kubectl get secret/access-rhacs -n stackrox -o jsonpath='{.data}' 2>/dev/null | jq -r '(.central_url|@base64d) +" "+ (.username|@base64d) +" "+(.password|@base64d)')
 }
 
 print_cluster_credentials() {
@@ -21,5 +24,5 @@ To use the downloaded kubeconfig, run:
 \t${C_PURPLE}export KUBECONFIG=${KUBECONFIG}${C_OFF}
 
 Access Central at ${C_PURPLE}${DATA[0]}${C_OFF}.
-Login with user ${C_PURPLE}${DATA[1]}${C_OFF}, password ${C_PURPLE}${DATA[2]}${C_OFF}."
+Login with user '${C_PURPLE}${DATA[1]}${C_OFF}', password '${C_PURPLE}${DATA[2]}${C_OFF}'."
 }

--- a/scripts/release-tools/lib.sh
+++ b/scripts/release-tools/lib.sh
@@ -5,6 +5,14 @@ export C_PURPLE='\033[0;35m'
 export C_OFF='\033[0m'
 
 download_cluster_artifacts() {
+    if [ "$(infractl whoami)" = "Anonymous" ]; then
+        echo "ERROR: Ensure that your infractl is authenticated."
+        exit 1
+    fi
+    if ! infractl list --all | grep -F "${CLUSTER_NAME}" > /dev/null; then
+        echo "ERROR: Requested cluster does not exist."
+        exit 1
+    fi
     mkdir -p "${ARTIFACTS_DIR}"
     infractl artifacts "${CLUSTER_NAME}" -d "${ARTIFACTS_DIR}" > /dev/null 2>&1
 }

--- a/scripts/release-tools/lib.sh
+++ b/scripts/release-tools/lib.sh
@@ -18,10 +18,11 @@ download_cluster_artifacts() {
 }
 
 fetch_cluster_credentials() {
-    DATA=()
-    while IFS=' ' read -ra item; do
-        DATA+=("${item[@]}")
-    done < <(kubectl get secret/access-rhacs -n stackrox -o jsonpath='{.data}' 2>/dev/null | jq -r '(.central_url|@base64d) +" "+ (.username|@base64d) +" "+(.password|@base64d)')
+    if ! command -v readarray > /dev/null 2>&1; then
+        echo "ERROR: readarray is a requirement for this script. Ensure that your default bash is at least v4."
+        exit 1
+    fi
+    readarray -d ' ' -t DATA < <(kubectl get secret/access-rhacs -n stackrox -o jsonpath='{.data}' | jq -r '(.central_url|@base64d) +" "+ (.username|@base64d) +" "+(.password|@base64d)' | tr -d "\n")
 }
 
 print_cluster_credentials() {

--- a/scripts/release-tools/lib.sh
+++ b/scripts/release-tools/lib.sh
@@ -19,7 +19,7 @@ download_cluster_artifacts() {
 
 fetch_cluster_credentials() {
     if ! command -v readarray > /dev/null 2>&1; then
-        echo "ERROR: readarray is a requirement for this script. Ensure that your default bash is at least v4."
+        echo "ERROR: readarray is a requirement for this script. Ensure that your default Bash is at least v4."
         exit 1
     fi
     readarray -d ' ' -t DATA < <(kubectl get secret/access-rhacs -n stackrox -o jsonpath='{.data}' | jq -r '(.central_url|@base64d) +" "+ (.username|@base64d) +" "+(.password|@base64d)' | tr -d "\n")

--- a/scripts/release-tools/setup-central-access.sh
+++ b/scripts/release-tools/setup-central-access.sh
@@ -11,6 +11,7 @@ if [[ $# -eq 0 ]]; then
     exit 1
 fi
 
+# Ensure that the cluster name is correct even if the user specified the version tag instead of the dashed name.
 # shellcheck disable=2034
 CLUSTER_NAME=${1//./-}
 ARTIFACTS_DIR="$(mktemp -d)/artifacts"

--- a/scripts/release-tools/setup-central-access.sh
+++ b/scripts/release-tools/setup-central-access.sh
@@ -13,7 +13,7 @@ fi
 
 # Ensure that the cluster name is correct even if the user specified the version tag instead of the dashed name.
 # shellcheck disable=2034
-CLUSTER_NAME=${1//./-}
+CLUSTER_NAME="${1//./-}"
 ARTIFACTS_DIR="$(mktemp -d)/artifacts"
 export KUBECONFIG="${ARTIFACTS_DIR}/kubeconfig"
 

--- a/scripts/release-tools/setup-central-access.sh
+++ b/scripts/release-tools/setup-central-access.sh
@@ -12,7 +12,7 @@ if [[ $# -eq 0 ]]; then
 fi
 
 # shellcheck disable=2034
-CLUSTER_NAME=$1
+CLUSTER_NAME=${1//./-}
 ARTIFACTS_DIR="$(mktemp -d)/artifacts"
 export KUBECONFIG="${ARTIFACTS_DIR}/kubeconfig"
 


### PR DESCRIPTION
## Description

In Bash on macOS, there isn't a built-in readarray command like there is in Bash versions 4.0 and above. 
The input from kubectl+jq is space delimited, therefore we can use `IFS` and `read` to load the values into an array. 

## Checklist
- [x] Investigated and inspected *relevant* (style checks) CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Mac OS

```
$ ./scripts/release-tools/setup-central-access.sh long-fake-load-4.2.2-rc.1
To use the downloaded kubeconfig, run:

        export KUBECONFIG=/var/folders/1y/6pk_s76n2077jvqfw9gsw9qm0000gn/T/tmp.HHowZIPUPm/artifacts/kubeconfig

Access Central at https://<REDACTED IP ADDRESS>.
Login with user 'admin', password '<REDACTED PASSWORD>'.
To access the observability stack in this cluster, forward the port of Grafana.
Example to copy & paste:

        kubectl --kubeconfig /var/folders/1y/6pk_s76n2077jvqfw9gsw9qm0000gn/T/tmp.HHowZIPUPm/artifacts/kubeconfig -n stackrox port-forward service/monitoring 48443:8443

Then access at https://localhost:48443, with with user 'admin', password 'stackrox'.
```

### Linux

Tested in Ubuntu Docker container, command: `docker run -it -v $(pwd):/stackrox ubuntu`

Setting up the container:

```
apt-get update -y && apt-get install -y jq apt-transport-https ca-certificates gnupg curl sudo python3

# infractl
curl --fail -sL https://infra.rox.systems/v1/cli/linux/amd64/upgrade \
| jq -r ".result.fileChunk" \
| base64 -d \
> /usr/local/bin/infractl
chmod +x /usr/local/bin/infractl
export INFRA_TOKEN=...

# kubectl
curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl" -o /usr/local/bin/kubectl
chmod +x /usr/local/bin/kubectl

# gcloud
echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/cloud.google.asc
sudo apt-get update && sudo apt-get install -y google-cloud-cli google-cloud-sdk-gke-gcloud-auth-plugin
export USE_GKE_GCLOUD_AUTH_PLUGIN=True
gcloud init
# Follow the flow, paste the verification key and select appropriate project.

cd /stackrox
```

Running `./scripts/release-tools/setup-central-access.sh long-fake-load-4.2.2-rc.1` yielded the same result.