### PR TITLE
fix(test): Increase mutex watchdog to 10s to increase CI stability

### DIFF
--- a/pkg/sync/mutex_dev.go
+++ b/pkg/sync/mutex_dev.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultLockTimeout = 5 * time.Second
+	defaultLockTimeout = 10 * time.Second
 
 	// We omit the `ROX_` prefix as this is fairly general (potential open-sourcing). Also, this is not a setting in the
 	// classical sense that is read by roxctl and propagated to deploying. It is a debug setting that normally should


### PR DESCRIPTION
## Description

The watchdog is the cause of many CI flakes. A timeout of 10s should stabilize things and if we hit 10s then something is seriously wrong that needs to be debugged


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Trivial

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
