### PR TITLE
fix(bug): Fix ECR logspam by debouncing client refreshes

### DIFF
--- a/pkg/registries/ecr/ecr.go
+++ b/pkg/registries/ecr/ecr.go
@@ -97,11 +97,11 @@ func (e *ecr) refreshDockerClient() error {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
-	defer e.setLastRefreshAttempt()
-
-	if e.expiryTime.After(time.Now()) && time.Since(e.lastRefreshAttempt) > refreshAttemptInterval {
+	if e.expiryTime.After(time.Now()) || time.Since(e.lastRefreshAttempt) < refreshAttemptInterval {
 		return nil
 	}
+	defer e.setLastRefreshAttempt()
+
 	if e.integration.GetEcr().GetAuthorizationData() != nil {
 		// This integration has static authorization data, and we never refresh the
 		// tokens in central, rather we wait for sensor to update them.


### PR DESCRIPTION
## Description

ECR integration can create lots of logspam when it fails to refresh. This is due to the fact that each request tries to refresh the client but it can error so the expiryTime is never updated. This adds the concept of the last time we attempted to refresh so that we won't try more than the interval

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Pretty challenging to test this one, but will rely on code review

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
