### PR TITLE
chore(ui): Refactor DeferralForm for more general use

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionRequestModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionRequestModal.tsx
@@ -9,8 +9,8 @@ import {
 import useRestMutation from 'hooks/useRestMutation';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { CveExceptionRequestType } from '../../types';
-import ExceptionRequestForm, { ExceptionRequestFormProps } from './ExceptionRequestForm';
 import { DeferralValues, ScopeContext, formValuesToDeferralRequest } from './utils';
+import ExceptionRequestForm, { ExceptionRequestFormProps } from './ExceptionRequestForm';
 
 export type ExceptionRequestModalOptions = {
     type: CveExceptionRequestType;
@@ -55,7 +55,14 @@ function ExceptionRequestModal({
     const submissionError = deferralError;
 
     return (
-        <Modal hasNoBodyWrapper onClose={onClose} title={title} isOpen variant="medium">
+        <Modal
+            aria-label={title}
+            title={title}
+            hasNoBodyWrapper
+            onClose={onClose}
+            isOpen
+            variant="medium"
+        >
             <ModalBoxBody className="pf-u-display-flex pf-u-flex-direction-column">
                 {submissionError && (
                     <Alert
@@ -72,6 +79,9 @@ function ExceptionRequestModal({
                         scopeContext={scopeContext}
                         onSubmit={onDeferralSubmit}
                         onCancel={onClose}
+                        showExpiryField
+                        formHeaderText="CVEs will be marked as deferred after approval"
+                        commentFieldLabel="Deferral rationale"
                     />
                 )}
             </ModalBoxBody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExpiryField.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExpiryField.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import {
+    Bullseye,
+    DatePicker,
+    FormGroup,
+    FormHelperText,
+    Flex,
+    HelperText,
+    HelperTextItem,
+    Radio,
+    Spinner,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { addDays } from 'date-fns';
+import { useFormik } from 'formik';
+
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+import useRestQuery from 'hooks/useRestQuery';
+import { fetchVulnerabilitiesExceptionConfig } from 'services/ExceptionConfigService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { DeferralValues, futureDateValidator } from './utils';
+
+/**
+ * Returns the date portion of an ISO date string
+ * @param date - ISO date string
+ * @returns Date portion of the ISO date string, or an empty string if the date is falsy
+ */
+function prettifyDate(date = ''): string {
+    return date.substring(0, 10);
+}
+
+export type ExpiryFieldProps = {
+    formik: ReturnType<typeof useFormik<DeferralValues>>;
+};
+
+function ExpiryField({ formik }: ExpiryFieldProps) {
+    const { data: config, loading, error } = useRestQuery(fetchVulnerabilitiesExceptionConfig);
+    const { values, errors, setValues } = formik;
+
+    function setExpiry(expiry: DeferralValues['expiry']) {
+        return setValues((prev) => ({ ...prev, expiry }));
+    }
+
+    if (loading || !config) {
+        return (
+            <Bullseye>
+                <Spinner isSVG />
+            </Bullseye>
+        );
+    }
+
+    if (error) {
+        return (
+            <Bullseye>
+                <EmptyStateTemplate
+                    headingLevel="h2"
+                    title="There was an error loading the vulnerability exception configuration"
+                    icon={ExclamationCircleIcon}
+                    iconClassName="pf-u-danger-color-100"
+                >
+                    {getAxiosErrorMessage(error)}
+                </EmptyStateTemplate>
+            </Bullseye>
+        );
+    }
+
+    return (
+        <FormGroup label="How long should the CVEs be deferred?" isRequired>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXs' }}>
+                {config.expiryOptions.fixableCveOptions.anyFixable && (
+                    <Radio
+                        id="any-cve-fixable"
+                        name="any-cve-fixable"
+                        isChecked={values.expiry?.type === 'ANY_CVE_FIXABLE'}
+                        onChange={() => setExpiry({ type: 'ANY_CVE_FIXABLE' })}
+                        label="When any CVE is fixable"
+                    />
+                )}
+                {config.expiryOptions.fixableCveOptions.allFixable && (
+                    <Radio
+                        id="all-cve-fixable"
+                        name="all-cve-fixable"
+                        isChecked={values.expiry?.type === 'ALL_CVE_FIXABLE'}
+                        onChange={() => setExpiry({ type: 'ALL_CVE_FIXABLE' })}
+                        label="When all CVEs are fixable"
+                    />
+                )}
+                {config.expiryOptions.dayOptions
+                    .filter((option) => option.enabled)
+                    .map(({ numDays }) => (
+                        <Radio
+                            id={`fixed-duration-${numDays}`}
+                            name={`fixed-duration-${numDays}`}
+                            key={`fixed-duration-${numDays}`}
+                            isChecked={
+                                values.expiry?.type === 'TIME' && values.expiry?.days === numDays
+                            }
+                            onChange={() =>
+                                setExpiry({
+                                    type: 'TIME',
+                                    days: numDays,
+                                })
+                            }
+                            label={`For ${numDays} days`}
+                        />
+                    ))}
+                {/* TODO - Awaiting backend support for indefinite deferrals
+                                         config.expiryOptions.indefinite && (
+                                            <Radio
+                                                id="indefinite"
+                                                name="indefinite"
+                                                isChecked={values.expiry?.type === 'INDEFINITE'}
+                                                onChange={() => {}}
+                                                label="Indefinitely"
+                                            />
+                                        )
+                                        */}
+                {config.expiryOptions.customDate && (
+                    <Radio
+                        id="custom-date"
+                        name="custom-date"
+                        isChecked={values.expiry?.type === 'CUSTOM_DATE'}
+                        onChange={() =>
+                            setExpiry({
+                                type: 'CUSTOM_DATE',
+                                date: addDays(new Date(), 1).toISOString(),
+                            })
+                        }
+                        label="Until a specific date"
+                    />
+                )}
+
+                {config.expiryOptions.customDate && values.expiry?.type === 'CUSTOM_DATE' && (
+                    <div>
+                        <DatePicker
+                            name="custom-date-picker"
+                            value={prettifyDate(values.expiry.date)}
+                            onChange={(_, value) =>
+                                setExpiry({
+                                    type: 'CUSTOM_DATE',
+                                    date: new Date(value).toISOString(),
+                                })
+                            }
+                            validators={[futureDateValidator]}
+                        />
+                    </div>
+                )}
+                {errors.expiry && (
+                    <FormHelperText isError isHidden={false}>
+                        <HelperText>
+                            <HelperTextItem
+                                variant="error"
+                                icon={<ExclamationCircleIcon />}
+                                className="pf-u-display-flex pf-u-align-items-center"
+                            >
+                                {errors.expiry}
+                            </HelperTextItem>
+                        </HelperText>
+                    </FormHelperText>
+                )}
+            </Flex>
+        </FormGroup>
+    );
+}
+
+export default ExpiryField;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/utils.ts
@@ -6,12 +6,12 @@ import { ensureExhaustive } from 'utils/type.utils';
 
 export type ScopeContext = 'GLOBAL' | { image: { name: string; tag: string } };
 
-export const deferralValidationSchema = yup.object({
+export const exceptionValidationSchema = yup.object({
     cves: yup.array().of(yup.string()).min(1, 'At least one CVE must be selected'),
     comment: yup.string().required('A rationale is required'),
 });
 
-export type DeferralValues = {
+export type ExceptionValues = {
     cves: string[];
     comment: string;
     scope: {
@@ -21,6 +21,11 @@ export type DeferralValues = {
             tag: string;
         };
     };
+};
+
+export type FalsePositiveValues = ExceptionValues;
+
+export type DeferralValues = ExceptionValues & {
     expiry?:
         | { type: 'TIME'; days: number }
         | { type: 'ALL_CVE_FIXABLE' | 'ANY_CVE_FIXABLE' | 'INDEFINITE' }


### PR DESCRIPTION
## Description

Updates the `DeferralForm` component to be more generic in order to support both Deferrals and False Positives without a lot of duplicate code. As a bonus, this only makes a request to the exception config endpoint when the request type is a deferral, since it isn't needed for false positives.

1. Extract the exception config request and "Expiry" fields into a new component
2. Conditionally render the ExpiryField component only when the request is a deferral request
3. Pass some text strings in as props instead of hard coding in the form

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Repeat testing steps from previous deferral exception form flows in preceding PR.