### PR TITLE
ROX-20288: Audit log without permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-19566: The results of registry TLS checks made by Sensor are now cached (for 15 minutes by default, which can be changed by setting the `ROX_SENSOR_REGISTRY_TLS_CHECK_CACHE_TTL` environment variable). This will result in faster Sensor startup times in clusters with a large number of pull secrets.
 - Risk reprocessing has been shifted from being potentially computed every 15 seconds to 10 minutes. This will improve system performance by debouncing expensive risk calculations.
 - ROX-20303: Fixed a bug that may have incorrectly matched an image to an image integration during scanning.
+- ROX:20288: A new environment variable `ROX_AUDIT_LOG_WITHOUT_PERMISSIONS` has been added to Central (defaults to `false`).
+  When set to `true`, audit log messages will not contain the detailed permissions of the user associated with the request.
+  Instead, only the associated role names will be there. Enabling this will lower the verbosity of the audit log messages,
+  but investigating associated permissions for a requester might be harder (i.e. the associated role would have be known at the time of the request).
+  Thus, it is generally not recommended to set this to `true`.
 
 ## [4.2.0]
 

--- a/central/audit/audit_test.go
+++ b/central/audit/audit_test.go
@@ -6,9 +6,13 @@ import (
 
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/grpc/authn"
+	identityMocks "github.com/stackrox/rox/pkg/grpc/authn/mocks"
 	"github.com/stackrox/rox/pkg/grpc/authz/interceptor"
 	notifierMocks "github.com/stackrox/rox/pkg/notifier/mocks"
 	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
@@ -18,17 +22,13 @@ import (
 type AuditLogTestSuite struct {
 	suite.Suite
 
-	mockCtrl     *gomock.Controller
 	notifierMock *notifierMocks.MockProcessor
+	identityMock *identityMocks.MockIdentity
 }
 
 func (suite *AuditLogTestSuite) SetupTest() {
-	suite.mockCtrl = gomock.NewController(suite.T())
-	suite.notifierMock = notifierMocks.NewMockProcessor(suite.mockCtrl)
-}
-
-func (suite *AuditLogTestSuite) TearDownTest() {
-	suite.mockCtrl.Finish()
+	suite.notifierMock = notifierMocks.NewMockProcessor(gomock.NewController(suite.T()))
+	suite.identityMock = identityMocks.NewMockIdentity(gomock.NewController(suite.T()))
 }
 
 func TestAuditLog(t *testing.T) {
@@ -79,6 +79,54 @@ func (suite *AuditLogTestSuite) TestCalculateAuditStatus() {
 	_, _ = interceptorFunc(ctxAuthorised, nil, serverInfo, handler(nil))
 	wg.Wait()
 	suite.Equal(v1.Audit_REQUEST_SUCCEEDED, auditMessage.Status)
+}
+
+func (suite *AuditLogTestSuite) TestPermissionsRemoval() {
+	userInfo := &storage.UserInfo{
+		Username:     "sample-user",
+		FriendlyName: "friendly-sample-user",
+		Permissions: &storage.UserInfo_ResourceToAccess{
+			ResourceToAccess: map[string]storage.Access{
+				resources.Administration.String(): storage.Access_READ_ACCESS,
+				resources.Integration.String():    storage.Access_READ_WRITE_ACCESS,
+				resources.Access.String():         storage.Access_NO_ACCESS,
+			},
+		},
+		Roles: []*storage.UserInfo_Role{
+			{
+				Name: "sample-role",
+				ResourceToAccess: map[string]storage.Access{
+					resources.Administration.String(): storage.Access_READ_ACCESS,
+				},
+			},
+			{
+				Name: "yet-another-sample-role",
+				ResourceToAccess: map[string]storage.Access{
+					resources.Integration.String(): storage.Access_READ_WRITE_ACCESS,
+				},
+			},
+		},
+	}
+	suite.identityMock.EXPECT().Service().Return(nil).AnyTimes()
+	suite.identityMock.EXPECT().User().Return(userInfo).AnyTimes()
+
+	ctxWithMockIdentity := authn.ContextWithIdentity(context.Background(), suite.identityMock,
+		suite.T())
+
+	a := &audit{}
+	withPermissions := a.newAuditMessage(ctxWithMockIdentity, "this is a test", "/v1./Test",
+		interceptor.AuthStatus{Error: nil}, nil)
+
+	suite.Equal(userInfo, withPermissions.GetUser())
+
+	a = &audit{withoutPermissions: true}
+	withoutPermissions := a.newAuditMessage(ctxWithMockIdentity, "this is a test", "/v1./Test",
+		interceptor.AuthStatus{Error: nil}, nil)
+	suite.NotEqual(userInfo, withoutPermissions.GetUser())
+	suite.Empty(withoutPermissions.GetUser().GetPermissions())
+	for _, userRole := range withoutPermissions.GetUser().GetRoles() {
+		suite.Empty(userRole.GetResourceToAccess())
+	}
 }
 
 func handler(err error) func(ctx context.Context, req interface{}) (interface{}, error) {

--- a/pkg/env/audit.go
+++ b/pkg/env/audit.go
@@ -1,0 +1,7 @@
+package env
+
+var (
+	// AuditLogWithoutPermissions allows to alter the message sent for audit logs to _not_ include detailed permissions
+	// for the user.
+	AuditLogWithoutPermissions = RegisterBooleanSetting("ROX_AUDIT_LOG_WITHOUT_PERMISSIONS", false)
+)


### PR DESCRIPTION
## Description

This PR introduces `ROX_AUDIT_LOG_WITHOUT_PERMISSIONS` to conditionally remove resolved permissions for audit log messages to reduced the amount of information exposed within audit log messages.

This isn't recommended in all cases, since it may make investigation harder when wanting to figure out the current permissions for a requester at a specific point. Setting this environment variable will mean
the user has to check the associated role's permission set at the point of the request to get the permissions associated with the role.

The reason we decided to introduce this variable was:
a) on a user request.
b) requiring the user to look up the _exact_ permissions is _anyways_ required, since access scopes are currently not added in the audit log message and are required to get a full picture of permissions.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see the added unit test.

One additional manual test to see the audit log in action:

1. Deploy Central
```bash
./deploy/deploy.sh
```
2. (shameless plug) Add a notifier with audit logging enabled:
```bash
# This deploys a sample webhook server which logs audit log events.
kubectl apply -f https://raw.githubusercontent.com/dhaus67/webhook/main/hack/deployment.yaml
# This creates a declarative config for a notifier that has audit logging enabled + uses the previously deployed webhook server.
kubectl apply -f https://raw.githubusercontent.com/dhaus67/webhook/main/hack/audit-log-config.yaml
```

3. Observe the audit logs, they should look as-is.
```bash
kubectl logs -l app=webhook -n stackrox
```
Sample audit log message:
```json
{
    "audit": {
...
        "time": "2023-10-19T03:23:10.736347379Z",
        "user": {
            "friendlyName": "admin",
            "permissions": {
                "resourceToAccess": {
                    "Access": "READ_WRITE_ACCESS",
                    "Administration": "READ_WRITE_ACCESS",
                    "Alert": "READ_WRITE_ACCESS",
                    "CVE": "READ_WRITE_ACCESS",
                    "Cluster": "READ_WRITE_ACCESS",
                    "Compliance": "READ_WRITE_ACCESS",
                    "Deployment": "READ_WRITE_ACCESS",
                    "DeploymentExtension": "READ_WRITE_ACCESS",
                    "Detection": "READ_WRITE_ACCESS",
                    "Image": "READ_WRITE_ACCESS",
                    "Integration": "READ_WRITE_ACCESS",
                    "K8sRole": "READ_WRITE_ACCESS",
                    "K8sRoleBinding": "READ_WRITE_ACCESS",
                    "K8sSubject": "READ_WRITE_ACCESS",
                    "Namespace": "READ_WRITE_ACCESS",
                    "NetworkGraph": "READ_WRITE_ACCESS",
                    "NetworkPolicy": "READ_WRITE_ACCESS",
                    "Node": "READ_WRITE_ACCESS",
                    "Secret": "READ_WRITE_ACCESS",
                    "ServiceAccount": "READ_WRITE_ACCESS",
                    "VulnerabilityManagementApprovals": "READ_WRITE_ACCESS",
                    "VulnerabilityManagementRequests": "READ_WRITE_ACCESS",
                    "WatchedImage": "READ_WRITE_ACCESS",
                    "WorkflowAdministration": "READ_WRITE_ACCESS"
                }
            },
            "roles": [
                {
                    "name": "Admin",
                    "resourceToAccess": {
                        "Access": "READ_WRITE_ACCESS",
                        "Administration": "READ_WRITE_ACCESS",
                        "Alert": "READ_WRITE_ACCESS",
                        "CVE": "READ_WRITE_ACCESS",
                        "Cluster": "READ_WRITE_ACCESS",
                        "Compliance": "READ_WRITE_ACCESS",
                        "Deployment": "READ_WRITE_ACCESS",
                        "DeploymentExtension": "READ_WRITE_ACCESS",
                        "Detection": "READ_WRITE_ACCESS",
                        "Image": "READ_WRITE_ACCESS",
                        "Integration": "READ_WRITE_ACCESS",
                        "K8sRole": "READ_WRITE_ACCESS",
                        "K8sRoleBinding": "READ_WRITE_ACCESS",
                        "K8sSubject": "READ_WRITE_ACCESS",
                        "Namespace": "READ_WRITE_ACCESS",
                        "NetworkGraph": "READ_WRITE_ACCESS",
                        "NetworkPolicy": "READ_WRITE_ACCESS",
                        "Node": "READ_WRITE_ACCESS",
                        "Secret": "READ_WRITE_ACCESS",
                        "ServiceAccount": "READ_WRITE_ACCESS",
                        "VulnerabilityManagementApprovals": "READ_WRITE_ACCESS",
                        "VulnerabilityManagementRequests": "READ_WRITE_ACCESS",
                        "WatchedImage": "READ_WRITE_ACCESS",
                        "WorkflowAdministration": "READ_WRITE_ACCESS"
                    }
                }
            ]
        }
    }
}
```

4. Enable the new environment variable:
```bash
kubectl set env -n stackrox deploy/central ROX_AUDIT_LOG_WITHOUT_PERMISSIONS=true
```

5. Observe the audit logs, they should now not expose the permissions:
```bash
kubectl logs -l app=webhook -n stackrox
```
Sample audit log message:
```json
{
    "audit": {
        "interaction": "CREATE",
        "method": "UI",
        "request": {
            "endpoint": "/v1/imageintegrations",
            "method": "POST",
            "payload": {
                "@type": "storage.ImageIntegration",
                "categories": [
                    "REGISTRY"
                ],
                "docker": {
                    "endpoint": "register-1.docker.io"
                },
                "name": "testing",
                "type": "docker"
            }
        },
        "status": "REQUEST_FAILED",
        "statusReason": "registry integration: Get \"https://register-1.docker.io/v2/\": dial tcp: lookup register-1.docker.io on 10.43.0.10:53: no such host: invalid arguments: invalid arguments: invalid arguments",
        "time": "2023-10-19T03:24:46.359174379Z",
        "user": {
            "friendlyName": "admin",
            "roles": [
                {
                    "name": "Admin"
                }
            ]
        }
    }
}
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
