### PR TITLE
chore(log): Add more context to clusterinit bundle errors

### DIFF
--- a/central/clusterinit/backend/backend_impl.go
+++ b/central/clusterinit/backend/backend_impl.go
@@ -140,7 +140,7 @@ func (b *backendImpl) Revoke(ctx context.Context, id string) error {
 	}
 
 	if err := b.store.Revoke(ctx, id); err != nil {
-		return errors.Wrap(err, "revoking init bundle")
+		return errors.Wrapf(err, "revoking init bundle %q", id)
 	}
 
 	return nil
@@ -153,7 +153,7 @@ func (b *backendImpl) CheckRevoked(ctx context.Context, id string) error {
 
 	bundleMeta, err := b.store.Get(ctx, id)
 	if err != nil {
-		return errors.Wrap(err, "retrieving init bundle")
+		return errors.Wrapf(err, "retrieving init bundle %q", id)
 	}
 
 	if bundleMeta.GetIsRevoked() {
@@ -187,7 +187,7 @@ func (b *backendImpl) ValidateClientCertificate(ctx context.Context, chain []mtl
 			log.Errorf("init bundle cert is revoked: %q", bundleID)
 			return errors.Wrapf(err, "init bundle verification failed %q", bundleID[0])
 		}
-		return errors.Wrap(err, "failed checking init bundle status")
+		return errors.Wrapf(err, "failed checking init bundle status %q", bundleID[0])
 	}
 
 	return nil

--- a/central/clusterinit/backend/backend_test.go
+++ b/central/clusterinit/backend/backend_test.go
@@ -310,7 +310,7 @@ func (s *clusterInitBackendTestSuite) TestValidateClientCertificateNotFound() {
 
 	err := s.backend.ValidateClientCertificate(ctx, certs)
 	s.Require().Error(err)
-	s.Equal("failed checking init bundle status: retrieving init bundle: init bundle not found", err.Error())
+	s.Equal(fmt.Sprintf("failed checking init bundle status %[1]q: retrieving init bundle %[1]q: init bundle not found", id), err.Error())
 }
 
 func (s *clusterInitBackendTestSuite) TestValidateClientCertificateEphemeralInitBundle() {


### PR DESCRIPTION
## Description

Add clusterid context to logs. We are trying to debug something and the logs are too generic

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Trivial

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
