### PR TITLE
chore(debug): Add pg_stat_statements to debug and diagnostic bundles

### DIFF
--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -419,9 +419,9 @@ func getCentralDBData(ctx context.Context, zipWriter *zip.Writer) error {
 	if err := addJSONToZip(zipWriter, "central-db.json", dbDiagnosticData); err != nil {
 		return err
 	}
-	statements, err := stats.GetPGStatStatements(ctx, db, pgStatStatementsMax)
-	if err != nil {
-		return errors.Wrap(err, "collecting pg_stat_statements")
+	statements := stats.GetPGStatStatements(ctx, db, pgStatStatementsMax)
+	if statements.Error != "" {
+		log.Errorf("error retrieving pg_stat_statements: %s", statements.Error)
 	}
 	return addJSONToZip(zipWriter, "central-db-pg-stats.json", statements)
 }

--- a/pkg/postgres/stats/stats.go
+++ b/pkg/postgres/stats/stats.go
@@ -1,0 +1,40 @@
+package stats
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/postgres"
+)
+
+// PGStatStatement is the slimmed down data model for a single row in pg_stat_statements
+type PGStatStatement struct {
+	TotalExecTimeMS  float64
+	MaxExecTimeMS    float64
+	StddevExecTimeMS float64
+	Calls            int64
+	Rows             int64
+	Query            string
+}
+
+// PGStatStatements is a wrapper around PGStatStatement
+type PGStatStatements struct {
+	Statements []*PGStatStatement
+}
+
+// GetPGStatStatements returns a statements struct that wraps the results from the query to pg_stat_statements
+func GetPGStatStatements(ctx context.Context, db postgres.DB, limit int) (*PGStatStatements, error) {
+	rows, err := db.Query(ctx, "select total_exec_time, max_exec_time, stddev_exec_time, calls, rows, substr(query, 1, 1000) from pg_stat_statements order by total_exec_time limit $1", limit)
+	if err != nil {
+		return nil, err
+	}
+	var statements PGStatStatements
+	for rows.Next() {
+		var statement PGStatStatement
+		if err := rows.Scan(&statement.TotalExecTimeMS, &statement.MaxExecTimeMS, &statement.StddevExecTimeMS, &statement.Calls, &statement.Rows, &statement.Query); err != nil {
+			return nil, errors.Wrap(err, "error scanning rows from pg_stat_statements")
+		}
+		statements.Statements = append(statements.Statements, &statement)
+	}
+	return &statements, nil
+}

--- a/pkg/postgres/stats/stats.go
+++ b/pkg/postgres/stats/stats.go
@@ -32,6 +32,8 @@ func GetPGStatStatements(ctx context.Context, db postgres.DB, limit int) *PGStat
 		statements.Error = err.Error()
 		return &statements
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 		var statement PGStatStatement
 		if err := rows.Scan(&statement.TotalExecTimeMS, &statement.MaxExecTimeMS, &statement.MeanExecTimeMS, &statement.StddevExecTimeMS, &statement.Calls, &statement.Rows, &statement.Query); err != nil {
@@ -39,6 +41,9 @@ func GetPGStatStatements(ctx context.Context, db postgres.DB, limit int) *PGStat
 			return &statements
 		}
 		statements.Statements = append(statements.Statements, &statement)
+	}
+	if err := rows.Err(); err != nil {
+		statements.Error = err.Error()
 	}
 	return &statements
 }

--- a/pkg/postgres/stats/stats.go
+++ b/pkg/postgres/stats/stats.go
@@ -26,7 +26,7 @@ type PGStatStatements struct {
 // GetPGStatStatements returns a statements struct that wraps the results from the query to pg_stat_statements
 func GetPGStatStatements(ctx context.Context, db postgres.DB, limit int) *PGStatStatements {
 	var statements PGStatStatements
-	rows, err := db.Query(ctx, "select total_exec_time, max_exec_time, stddev_exec_time, calls, rows, substr(query, 1, 1000) from pg_stat_statements order by total_exec_time limit $1", limit)
+	rows, err := db.Query(ctx, "select total_exec_time, max_exec_time, stddev_exec_time, calls, rows, substr(query, 1, 1000) from pg_stat_statements order by total_exec_time desc limit $1", limit)
 	if err != nil {
 		statements.Error = err.Error()
 		return &statements

--- a/pkg/postgres/stats/stats.go
+++ b/pkg/postgres/stats/stats.go
@@ -11,6 +11,7 @@ import (
 type PGStatStatement struct {
 	TotalExecTimeMS  float64
 	MaxExecTimeMS    float64
+	MeanExecTimeMS   float64
 	StddevExecTimeMS float64
 	Calls            int64
 	Rows             int64
@@ -26,14 +27,14 @@ type PGStatStatements struct {
 // GetPGStatStatements returns a statements struct that wraps the results from the query to pg_stat_statements
 func GetPGStatStatements(ctx context.Context, db postgres.DB, limit int) *PGStatStatements {
 	var statements PGStatStatements
-	rows, err := db.Query(ctx, "select total_exec_time, max_exec_time, stddev_exec_time, calls, rows, substr(query, 1, 1000) from pg_stat_statements order by total_exec_time desc limit $1", limit)
+	rows, err := db.Query(ctx, "select total_exec_time, max_exec_time, mean_exec_time, stddev_exec_time, calls, rows, substr(query, 1, 1000) from pg_stat_statements order by total_exec_time desc limit $1", limit)
 	if err != nil {
 		statements.Error = err.Error()
 		return &statements
 	}
 	for rows.Next() {
 		var statement PGStatStatement
-		if err := rows.Scan(&statement.TotalExecTimeMS, &statement.MaxExecTimeMS, &statement.StddevExecTimeMS, &statement.Calls, &statement.Rows, &statement.Query); err != nil {
+		if err := rows.Scan(&statement.TotalExecTimeMS, &statement.MaxExecTimeMS, &statement.MeanExecTimeMS, &statement.StddevExecTimeMS, &statement.Calls, &statement.Rows, &statement.Query); err != nil {
 			statements.Error = errors.Wrap(err, "error scanning rows from pg_stat_statements").Error()
 			return &statements
 		}


### PR DESCRIPTION
## Description

Adds the 1000 most expensive queries in terms of exec time to the diagnostic and debug bundles. This will allow us to see where postgres is spending time and what we could optimize. The pg stat statement object is just what i think is useful for now but more data may be necessary in the future. I also limited the number of queries to 1k and the size of the query to 1k so approximate max bound should be around 1MB


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Get diag and debug and see data in there

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
