### PR TITLE
fix(tests): Ignore intermittent error in Sensor k8s library

### DIFF
--- a/scripts/ci/logcheck/allowlist-patterns
+++ b/scripts/ci/logcheck/allowlist-patterns
@@ -27,3 +27,6 @@ apps\.openshift\.io\/v1 DeploymentConfig is deprecated in v4\.14\+, unavailable 
 # Image enrichment errors are expected in some test (i.e. testing for non-existing images).
 # Skip those specifically.
 Error: error enriching image
+# Network flakiness can lead to this error occurring in Sensor k8s libraries. All tests pass and it is not
+# an indication of a Sensor issue
+request.go:1116] Unexpected error when reading response body: context deadline exceeded


### PR DESCRIPTION
## Description

This error does not seem to propagate into Sensor errors and appears to be contained in the k8s library code. The tests pass and Sensor does not seem worse for wear. We should stop failing tests over this

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI will tell us

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
