### PR TITLE
ROX-20242: Fix timing of TLS challenge test

### DIFF
--- a/scripts/ci/jobs/aks_qa_e2e_tests.py
+++ b/scripts/ci/jobs/aks_qa_e2e_tests.py
@@ -12,5 +12,6 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
+os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/aro_qa_e2e_tests.py
+++ b/scripts/ci/jobs/aro_qa_e2e_tests.py
@@ -13,5 +13,6 @@ os.environ["SENSOR_HELM_DEPLOY"] = "true"
 
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
+os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/eks_qa_e2e_tests.py
+++ b/scripts/ci/jobs/eks_qa_e2e_tests.py
@@ -13,5 +13,6 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 # don't use postgres
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
+os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/gke_qa_e2e_tests.py
+++ b/scripts/ci/jobs/gke_qa_e2e_tests.py
@@ -14,5 +14,6 @@ os.environ["GCP_IMAGE_TYPE"] = "cos_containerd"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_ACTIVE_VULN_MGMT"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
+os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
 make_qa_e2e_test_runner(cluster=GKECluster("qa-e2e-test")).run()

--- a/scripts/ci/jobs/gke_race_condition_qa_e2e_tests.py
+++ b/scripts/ci/jobs/gke_race_condition_qa_e2e_tests.py
@@ -17,5 +17,6 @@ os.environ["CENTRAL_DB_IMAGE_TAG"] = os.environ["STACKROX_BUILD_TAG"]
 os.environ["USE_LOCAL_ROXCTL"] = "true"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
+os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
 make_qa_e2e_test_runner(cluster=GKECluster("race-condition-qa-e2e-test")).run()

--- a/scripts/ci/jobs/ibmcloudz_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ibmcloudz_qa_e2e_tests.py
@@ -14,5 +14,6 @@ os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["USE_MIDSTREAM_IMAGES"] = "true"
 os.environ["REMOTE_CLUSTER_ARCH"] = "s390x"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
+os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
 make_qa_e2e_test_runner_custom(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/ocp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_qa_e2e_tests.py
@@ -12,6 +12,7 @@ os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
+os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
 # Scale up the cluster to support postgres
 cluster = OpenShiftScaleWorkersCluster(increment=1)

--- a/scripts/ci/jobs/ocp_sensor_integration_tests.py
+++ b/scripts/ci/jobs/ocp_sensor_integration_tests.py
@@ -13,6 +13,7 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_ACTIVE_VULN_MGMT"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
+os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
 ClusterTestRunner(
     pre_test=PreSystemTests(run_poll_for_system_test_images=False),

--- a/scripts/ci/jobs/osd_aws_qa_e2e_tests.py
+++ b/scripts/ci/jobs/osd_aws_qa_e2e_tests.py
@@ -13,5 +13,6 @@ os.environ["SENSOR_HELM_DEPLOY"] = "true"
 
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
+os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/osd_gcp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/osd_gcp_qa_e2e_tests.py
@@ -13,5 +13,6 @@ os.environ["SENSOR_HELM_DEPLOY"] = "true"
 
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
+os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/powervs_qa_e2e_tests.py
+++ b/scripts/ci/jobs/powervs_qa_e2e_tests.py
@@ -15,6 +15,7 @@ os.environ["USE_MIDSTREAM_IMAGES"] = "true"
 os.environ["REMOTE_CLUSTER_ARCH"] = "ppc64le"
 os.environ["COLLECTION_METHOD"] = "ebpf"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
+os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
 # Trigger tests
 make_qa_e2e_test_runner_custom(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/rosa_qa_e2e_tests.py
+++ b/scripts/ci/jobs/rosa_qa_e2e_tests.py
@@ -13,5 +13,6 @@ os.environ["SENSOR_HELM_DEPLOY"] = "true"
 
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
+os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -383,7 +383,7 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 		// suddenly broke.
 		s.centralCommunication = NewCentralCommunication(s.reconnect.Load(), s.reconcile.Load(), s.components...)
 		s.centralCommunication.Start(central.NewSensorServiceClient(s.centralConnection), centralReachable, s.configHandler, s.detector)
-		// Reset the exponential back-off if the connection successes
+		// Reset the exponential back-off if the connection succeeds
 		exponential.Reset()
 		select {
 		case <-s.centralCommunication.Stopped().WaitC():


### PR DESCRIPTION
## Description

I believe that this test fails because Sensor doesn't restart anymore so what happens is that it retries too quickly and gets too large of a backoff due to that and then never retries before the test gives us. Therefore, shorten the max amount of time on the Sensor retries for testing purposes:

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-qa-e2e-tests/1714777933635129344/artifacts/merge-gke-qa-e2e-tests/stackrox-e2e/artifacts/spec-logs/TLSChallengeTest.log

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI?

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
