### PR TITLE
ROX-20065: Improve scanner(-db) performance in operator e2e test.

### DIFF
--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -47,6 +47,7 @@ class GKECluster:
                 self.cluster_id,
                 str(self.num_nodes),
                 self.machine_type,
+                str(self.disk_gb),
             ]
         ) as cmd:
 

--- a/operator/tests/central/basic-central/10-central-cr.yaml
+++ b/operator/tests/central/basic-central/10-central-cr.yaml
@@ -35,6 +35,14 @@ spec:
         limits:
           memory: 2500Mi
           cpu: 2000m
+    db:
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+        limits:
+          cpu: 2000m
+          memory: 4Gi
   tls:
     additionalCAs:
     - name: foo.pem

--- a/operator/tests/common/central-cr.yaml
+++ b/operator/tests/common/central-cr.yaml
@@ -36,6 +36,14 @@ spec:
         limits:
           memory: 2500Mi
           cpu: 2000m
+    db:
+      resources:
+        requests:
+          cpu: 400m
+          memory: 512Mi
+        limits:
+          cpu: 2000m
+          memory: 4Gi
 ---
 apiVersion: v1
 kind: Secret

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -22,7 +22,7 @@ assign_env_variables() {
     info "Assigning environment variables for later steps"
 
     if [[ "$#" -lt 1 ]]; then
-        die "missing args. usage: assign_env_variables <cluster-id> [<num-nodes> <machine-type>]"
+        die "missing args. usage: assign_env_variables <cluster-id> [<num-nodes> <machine-type> <disk_gb>]"
     fi
 
     local cluster_id="$1"
@@ -151,7 +151,7 @@ create_cluster() {
     MACHINE_TYPE="${MACHINE_TYPE:-e2-standard-4}"
     DISK_SIZE_GB=${DISK_SIZE_GB:-40}
 
-    echo "Creating ${NUM_NODES} node cluster with image type \"${GCP_IMAGE_TYPE}\""
+    echo "Creating ${NUM_NODES} node cluster with image type \"${GCP_IMAGE_TYPE}\" and ${DISK_SIZE_GB}GB disks."
 
     if [[ -n "${GKE_CLUSTER_VERSION:-}" ]]; then
         ensure_supported_cluster_version

--- a/scripts/ci/jobs/gke_operator_e2e_tests.py
+++ b/scripts/ci/jobs/gke_operator_e2e_tests.py
@@ -11,7 +11,7 @@ from post_tests import PostClusterTest, FinalPost
 
 
 ClusterTestRunner(
-    cluster=GKECluster("operator-e2e-test", disk_gb=400),
+    cluster=GKECluster("operator-e2e-test"),
     pre_test=PreSystemTests(),
     test=OperatorE2eTest(operator_cluster_type="gke"),
     post_test=PostClusterTest(collect_central_artifacts=False),

--- a/scripts/ci/jobs/gke_upgrade_tests.py
+++ b/scripts/ci/jobs/gke_upgrade_tests.py
@@ -15,7 +15,7 @@ from post_tests import PostClusterTest, FinalPost
 # out of support those bits can be removed.
 
 ClusterTestRunner(
-    cluster=GKECluster("upgrade-test", machine_type="e2-standard-8", disk_gb=1600),
+    cluster=GKECluster("upgrade-test", machine_type="e2-standard-8"),
     pre_test=PreSystemTests(),
     test=UpgradeTest(),
     post_test=PostClusterTest(),


### PR DESCRIPTION
## Description

Because:

* Turns out the shot in the dark that https://github.com/stackrox/stackrox/pull/8072 was, was not sufficient.
* While this PR was in flight, https://github.com/stackrox/stackrox/pull/8340 changed disks to SSD which have a different performance characteristics (see ticket)

This PR now:
- no longer adjusts disk size since it is pointless with SSDs
- bumps scanner-db CPU from default 200m to 400m, which ~doubles `init-db` speed
- bumps scanner-db memory request from 200MiB at which it might OOM to apparently safe 512MiB
- reverts https://github.com/stackrox/stackrox/pull/8256 that is now unnecessary
- fix disk_gb parameter passing that was missed in  https://github.com/stackrox/stackrox/pull/8072 (causing that PR to be a no-op) and restore default disk size now that it is SSD

More details in ticket.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

See the ticket for detailed description of extensive performance experiments I did.
Ultimately, CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
