### PR TITLE
ROX-20102: Use a disk with a more decent performance.

### DIFF
--- a/scripts/ci/jobs/gke_upgrade_tests.py
+++ b/scripts/ci/jobs/gke_upgrade_tests.py
@@ -15,7 +15,7 @@ from post_tests import PostClusterTest, FinalPost
 # out of support those bits can be removed.
 
 ClusterTestRunner(
-    cluster=GKECluster("upgrade-test", machine_type="e2-standard-8"),
+    cluster=GKECluster("upgrade-test", machine_type="e2-standard-8", disk_gb=1600),
     pre_test=PreSystemTests(),
     test=UpgradeTest(),
     post_test=PostClusterTest(),


### PR DESCRIPTION
## Description

Not sure whether this will be sufficient to overcome all timeouts, but it's certainly necessary for reasonable performance of scanner-db init-db. This is inspired by #8255

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

See the PR mentioned above for a general overview - I didn't look at this specific test, but I assume the cause is the same.
Overall, CI should be sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
