### PR TITLE
chore(scanner): Bump default min RAM, and for devs CPU too.

### DIFF
--- a/deploy/common/local-dev-values.yaml
+++ b/deploy/common/local-dev-values.yaml
@@ -35,3 +35,10 @@ scanner:
     limits:
       memory: "2500Mi"
       cpu: "2000m"
+  dbResources:
+    requests:
+      cpu: "400m"
+      memory: "512Mi"
+    limits:
+      cpu: "2000m"
+      memory: "4Gi"

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -157,7 +157,7 @@ defaults:
         memory: "4Gi"
       requests:
         cpu: "200m"
-        memory: "200Mi"
+        memory: "512Mi"
 
     dbImage:
       name: [< required "" .ScannerDBImageRemote >]

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/70-scanner.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/70-scanner.yaml
@@ -23,7 +23,7 @@ scanner:
       memory: "4Gi"
     requests:
       cpu: "200m"
-      memory: "200Mi"
+      memory: "512Mi"
 
   slimImage:
     name: ""


### PR DESCRIPTION
## Description

Lately we've seen scanner-db's init-db initContainer OOM at its default 200MiB memory request (either when there is memory crunch on the node or the limit is explicitly set to the same value). This change makes sure it gets at least 512MiB at which it seems fairly stable.

Also, for development setups, double the default minimum CPU request which effectively halves scanner-db DB setup time.

Related to #8256 and #8255.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [ ] Evaluated and added CHANGELOG entry if required: **do you think it makes sense to mention this?**
- [x] ~Determined and documented upgrade steps~: none required
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs)): **[TODO](https://github.com/openshift/openshift-docs/blob/rhacs-docs/modules/default-requirements-central-services.adoc)** once we agree on the value here

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI should be sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
