### PR TITLE
ROX-20046: Stop patching service account.

### DIFF
--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -26,11 +26,6 @@ function create_pull_secret() {
   log "Creating image pull secret..."
   "${ROOT_DIR}/deploy/common/pull-secret.sh" "${pull_secret}" "${registry_hostname}" \
     | kubectl -n "${operator_ns}" apply -f -
-
-  log "Adding pull secret to service account..."
-  # This can be removed once we no longer need to support OpenShift 4.6.
-  # OLM in OpenShift 4.7 properly propagates the image pull secret from `CatalogSource` to the index pod.
-  kubectl -n "${operator_ns}" patch serviceaccount default -p '{"imagePullSecrets": [{"name": "'${pull_secret}'"}]}'
 }
 
 function apply_operator_manifests() {


### PR DESCRIPTION
## Description

This `patch` often races with default service account creation. But judging from the comment, it's obsolete altogether.
Let's try just dropping it.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
