### PR TITLE
ROX-20316: Add conditional RBAC for ShowAdministrationUsage

### DIFF
--- a/ui/apps/platform/src/Containers/SystemHealth/DashboardPage.js
+++ b/ui/apps/platform/src/Containers/SystemHealth/DashboardPage.js
@@ -40,23 +40,23 @@ const SystemHealthDashboardPage = () => {
 
     return (
         <>
-            <PageSection variant="light">
+            <PageSection variant="light" component="div">
                 <Flex>
                     <FlexItem>
                         <Title headingLevel="h1">System Health</Title>
                     </FlexItem>
-                    <FlexItem align={{ default: 'alignRight' }}>
-                        <Flex>
-                            <FlexItem>
-                                <ShowAdministrationUsage />
-                            </FlexItem>
-                            {hasReadAccessForAdministration && (
+                    {hasReadAccessForAdministration && (
+                        <FlexItem align={{ default: 'alignRight' }}>
+                            <Flex>
+                                <FlexItem>
+                                    <ShowAdministrationUsage />
+                                </FlexItem>
                                 <FlexItem>
                                     <GenerateDiagnosticBundle />
                                 </FlexItem>
-                            )}
-                        </Flex>
-                    </FlexItem>
+                            </Flex>
+                        </FlexItem>
+                    )}
                 </Flex>
             </PageSection>
             <PageSection>


### PR DESCRIPTION
## Description

### Problem

Follow up #7435

To avoid merge conflicts close to 4.2 release, we waited to add conditional rendering.

### Analysis

Both `ShowAdministrationUsage` and `GenerateDiagnosticBundle` encapsulate requests which require READ_ACCESS for Administration resource.

### Solution

Lift up conditional rendering to include both buttons.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Visit /main/system-health

    * With READ_ACCESS for Administration resource.
        ![READ_ACCESS](https://github.com/stackrox/stackrox/assets/11862657/5d793a77-65b9-4626-b514-ae8e487db2ac)

    * With NO_ACCESS for Administration resource (temporarily edit code to simulate).
        See absence of buttons and also **Vulnerability definitions** card.
        ![NO_ACCESS](https://github.com/stackrox/stackrox/assets/11862657/fd58bc0e-f63b-4cad-b23e-7b087ac6b4aa)

### Integration testing

* systemHealth/bundle.test.js
* systemHealth/systemHealthGeneral.test.js
