### PR TITLE
ROX-20317: Add CodeBlockCode for administration event message

### DIFF
--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventHintMessage.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventHintMessage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { CodeBlock, Flex } from '@patternfly/react-core';
+import { CodeBlock, CodeBlockCode, Flex } from '@patternfly/react-core';
 
 import { AdministrationEvent } from 'services/AdministrationEventsService';
 
@@ -17,7 +17,9 @@ function AdministrationEventHintMessage({
     return (
         <Flex direction={{ default: 'column' }}>
             {hint && <AdministrationEventHint hint={hint} />}
-            <CodeBlock>{message}</CodeBlock>
+            <CodeBlock>
+                <CodeBlockCode>{message}</CodeBlockCode>
+            </CodeBlock>
         </Flex>
     );
 }


### PR DESCRIPTION
## Description

### Problem

Somehow it escaped my attention until now that message has sans-serif font instead of monospace font that is conventional for code.

### Solution

For code rendered inside the code block: `CodeBlockCode` element.
https://www.patternfly.org/components/code-block#codeblockcode

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Visit /main/administration-events

    * Without `CodeBlockCode` element, see sans-serif font.
        ![events_CodeBlock](https://github.com/stackrox/stackrox/assets/11862657/c85fb935-1373-444c-8a78-918e12138f5e)

    * With `CodeBlockCode` element, see monospace font.
        ![events_CodeBlockCode](https://github.com/stackrox/stackrox/assets/11862657/0982f3e8-58f0-4a01-b96d-aacb1afc006e)

2. Click a link to visit administration event page.

    * With `CodeBlockCode` element, see monospace font.
        ![event_CodeBlockCode](https://github.com/stackrox/stackrox/assets/11862657/437cf7f8-0203-4979-8089-00a6763be0aa)
