### PR TITLE
fix(perf): Only load processes if there is a locked baseline

### DIFF
--- a/central/processbaseline/evaluator/evaluator_impl.go
+++ b/central/processbaseline/evaluator/evaluator_impl.go
@@ -57,6 +57,8 @@ func (e *evaluator) persistResults(ctx context.Context, deployment *storage.Depl
 func (e *evaluator) EvaluateBaselinesAndPersistResult(deployment *storage.Deployment) (violatingProcesses []*storage.ProcessIndicator, err error) {
 	containerNameToBaselineedProcesses := make(map[string]*set.StringSet)
 	containerNameToBaselineResults := make(map[string]*storage.ContainerNameAndBaselineStatus)
+
+	var hasAtLeastOneLockedBaseline bool
 	for _, container := range deployment.GetContainers() {
 		baseline, exists, err := e.baselines.GetProcessBaseline(evaluatorCtx, &storage.ProcessBaselineKey{
 			DeploymentId:  deployment.GetId(),
@@ -66,6 +68,10 @@ func (e *evaluator) EvaluateBaselinesAndPersistResult(deployment *storage.Deploy
 		})
 		if err != nil {
 			return nil, errors.Wrapf(err, "fetching process baseline for deployment %s/%s/%s", deployment.GetClusterName(), deployment.GetNamespace(), deployment.GetName())
+		}
+		baselineStatus := getBaselineStatus(baseline)
+		if baselineStatus == storage.ContainerNameAndBaselineStatus_LOCKED {
+			hasAtLeastOneLockedBaseline = true
 		}
 		containerNameToBaselineResults[container.GetName()] = &storage.ContainerNameAndBaselineStatus{
 			ContainerName:  container.GetName(),
@@ -78,14 +84,15 @@ func (e *evaluator) EvaluateBaselinesAndPersistResult(deployment *storage.Deploy
 		if processSet != nil {
 			containerNameToBaselineedProcesses[container.GetName()] = processSet
 		}
-
 	}
 
-	processes, err := e.indicators.SearchRawProcessIndicators(evaluatorCtx, search.NewQueryBuilder().AddExactMatches(search.DeploymentID, deployment.GetId()).ProtoQuery())
-	if err != nil {
-		return nil, errors.Wrapf(err, "searching process indicators for deployment %s/%s/%s", deployment.GetClusterName(), deployment.GetNamespace(), deployment.GetName())
+	var processes []*storage.ProcessIndicator
+	if hasAtLeastOneLockedBaseline {
+		processes, err = e.indicators.SearchRawProcessIndicators(evaluatorCtx, search.NewQueryBuilder().AddExactMatches(search.DeploymentID, deployment.GetId()).ProtoQuery())
+		if err != nil {
+			return nil, errors.Wrapf(err, "searching process indicators for deployment %s/%s/%s", deployment.GetClusterName(), deployment.GetNamespace(), deployment.GetName())
+		}
 	}
-
 	for _, process := range processes {
 		processSet, exists := containerNameToBaselineedProcesses[process.GetContainerName()]
 		// If no explicit baseline, then all processes are valid.

--- a/central/processbaseline/evaluator/evaluator_impl.go
+++ b/central/processbaseline/evaluator/evaluator_impl.go
@@ -55,7 +55,7 @@ func (e *evaluator) persistResults(ctx context.Context, deployment *storage.Depl
 }
 
 func (e *evaluator) EvaluateBaselinesAndPersistResult(deployment *storage.Deployment) (violatingProcesses []*storage.ProcessIndicator, err error) {
-	containerNameToBaselineedProcesses := make(map[string]*set.StringSet)
+	containerNameToBaselinedProcesses := make(map[string]*set.StringSet)
 	containerNameToBaselineResults := make(map[string]*storage.ContainerNameAndBaselineStatus)
 
 	var hasAtLeastOneLockedBaseline bool
@@ -82,7 +82,7 @@ func (e *evaluator) EvaluateBaselinesAndPersistResult(deployment *storage.Deploy
 		}
 		processSet := processbaseline.Processes(baseline, processbaseline.RoxOrUserLocked)
 		if processSet != nil {
-			containerNameToBaselineedProcesses[container.GetName()] = processSet
+			containerNameToBaselinedProcesses[container.GetName()] = processSet
 		}
 	}
 
@@ -94,7 +94,7 @@ func (e *evaluator) EvaluateBaselinesAndPersistResult(deployment *storage.Deploy
 		}
 	}
 	for _, process := range processes {
-		processSet, exists := containerNameToBaselineedProcesses[process.GetContainerName()]
+		processSet, exists := containerNameToBaselinedProcesses[process.GetContainerName()]
 		// If no explicit baseline, then all processes are valid.
 		if !exists {
 			continue

--- a/central/processbaseline/evaluator/evaluator_test.go
+++ b/central/processbaseline/evaluator/evaluator_test.go
@@ -51,17 +51,8 @@ func TestProcessBaselineEvaluator(t *testing.T) {
 			shouldBePersisted:          true,
 		},
 		{
-			name:     "Process Baseline exists, but not locked",
-			baseline: &storage.ProcessBaseline{},
-			indicators: []*storage.ProcessIndicator{
-				{
-					Signal: &storage.ProcessSignal{
-						Name: "apt-get",
-						Args: "install nmap",
-					},
-					ContainerName: deployment.GetContainers()[0].GetName(),
-				},
-			},
+			name:                       "Process Baseline exists, but not locked",
+			baseline:                   &storage.ProcessBaseline{},
 			baselineStatuses:           makeBaselineStatuses(t, "UNLOCKED", "UNLOCKED"),
 			anomalousProcessesExecuted: []bool{false, false},
 			currentBaselineResults:     nil,
@@ -277,7 +268,9 @@ func TestProcessBaselineEvaluator(t *testing.T) {
 			mockResults := processBaselineResultMocks.NewMockDataStore(mockCtrl)
 
 			mockBaselines.EXPECT().GetProcessBaseline(gomock.Any(), gomock.Any()).MaxTimes(len(deployment.GetContainers())).Return(c.baseline, c.baseline != nil, c.baselineErr)
-			mockIndicators.EXPECT().SearchRawProcessIndicators(gomock.Any(), gomock.Any()).Return(c.indicators, c.indicatorErr)
+			if c.indicators != nil {
+				mockIndicators.EXPECT().SearchRawProcessIndicators(gomock.Any(), gomock.Any()).Return(c.indicators, c.indicatorErr)
+			}
 
 			expectedBaselineResult := &storage.ProcessBaselineResults{
 				DeploymentId: deployment.GetId(),


### PR DESCRIPTION
## Description

When processing only unlocked baselines, there is no chance that a process is anomalous so avoid fetching from the DB.

Scale test results:
```


sensor_event_duration | Action=UNSET_ACTION_RESOURCE Type=ReprocessDeployment | (68797.62/3982) 17.28 | (57946.85/4013) 14.44 | -16.4227%

```


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

e2e tests should check that risk still performs properly, but scale testing will tell us the most

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
