### PR TITLE
chore: Enable portion of "TestVulnRequestManager"

### DIFF
--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
@@ -50,9 +50,6 @@ var (
 )
 
 func TestVulnRequestManager(t *testing.T) {
-	// TODO: Renable once fixed ROX-18182
-	t.Skipf("This test is flaky on master builds for some reason. Skip until fixed: ROX-18182")
-	t.Parallel()
 	suite.Run(t, new(VulnRequestManagerTestSuite))
 }
 
@@ -331,6 +328,8 @@ func (s *VulnRequestManagerTestSuite) verifySearchByCVEState(state storage.Vulne
 }
 
 func (s *VulnRequestManagerTestSuite) TestReObserveExpiredDeferralsMarksAllAsInactive() {
+	// TODO: Renable once fixed ROX-18182
+	s.T().Skipf("This test is flaky on master builds for some reason. Skip until fixed: ROX-18182")
 	expiredInThePast := protoconv.ConvertTimeToTimestamp(time.Now().Add(-96 * time.Hour))
 	expiresInFuture := protoconv.ConvertTimeToTimestamp(time.Now().Add(30 * 24 * time.Hour))
 
@@ -453,6 +452,9 @@ func getImageWithVulnerableComponents(registry, remote, tag, id string) *storage
 }
 
 func (s *VulnRequestManagerTestSuite) TestReObserveFixableDeferrals() {
+	// TODO: Renable once fixed ROX-18182
+	s.T().Skipf("This test is flaky on master builds for some reason. Skip until fixed: ROX-18182")
+
 	img := getImageWithVulnerableComponents("stackrox.io", "srox/mongo", "latest", "sha256:SHA2")
 	imgDiffTag := getImageWithVulnerableComponents("stackrox.io", "srox/mongo", "0.0.0.1", "sha256:sha3")
 	diffImage := getImageWithVulnerableComponents("stackrox.io", "srox/nginx", "latest", "sha256:SHAAAAAA")
@@ -563,6 +565,9 @@ func (s *VulnRequestManagerTestSuite) TestReObserveFixableDeferrals() {
 }
 
 func (s *VulnRequestManagerTestSuite) TestProcessorDoesntExpireOnceStopped() {
+	// TODO: Renable once fixed ROX-18182
+	s.T().Skipf("This test is flaky on master builds for some reason. Skip until fixed: ROX-18182")
+
 	s.manager.Start()
 	time.Sleep(expiryLoopDurationForTest) // wait for it to run at least once
 
@@ -585,6 +590,9 @@ func (s *VulnRequestManagerTestSuite) TestProcessorDoesntExpireOnceStopped() {
 }
 
 func (s *VulnRequestManagerTestSuite) TestBuildCacheActiveRequests() {
+	// TODO: Renable once fixed ROX-18182
+	s.T().Skipf("This test is flaky on master builds for some reason. Skip until fixed: ROX-18182")
+
 	reqs := []*storage.VulnerabilityRequest{
 		newFalsePositive("approved-fp", "cve-approved-fp", false, storage.RequestStatus_APPROVED, nil),
 		newFalsePositive("approved-pending-update-fp", "cve-approved-pending-update-fp", false, storage.RequestStatus_APPROVED_PENDING_UPDATE, nil),
@@ -612,6 +620,9 @@ func (s *VulnRequestManagerTestSuite) TestBuildCacheActiveRequests() {
 }
 
 func (s *VulnRequestManagerTestSuite) TestEffectiveVulnReq() {
+	// TODO: Renable once fixed ROX-18182
+	s.T().Skipf("This test is flaky on master builds for some reason. Skip until fixed: ROX-18182")
+
 	globalReq := fixtures.GetGlobalDeferralRequest("cve1")
 	imageScopeAllTagsReq := fixtures.GetImageScopeDeferralRequest("reg", "remote", ".*", "cve1")
 	imageScopeOneTagsReq := fixtures.GetImageScopeDeferralRequest("reg", "remote", "tag", "cve1")


### PR DESCRIPTION
## Description
Seems like this test has been disabled for quite some time now. I am enabling a portion of the test which is not excepted to be flaky but let's see. Eventually, the full test will be enabled.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
