### PR TITLE
fix(ci): use correct name for nightly comparison bucket

### DIFF
--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -115,7 +115,7 @@ compare_with_stored_metrics() {
 store_metrics() {
     local debug_dump_dir="$1"
     local this_run_metrics
-    local gs_path="gs://stackrox-ci-metrics/${STORE_METRICS}"
+    local gs_path="gs://stackrox-ci-scale-test-results/${STORE_METRICS}"
 
     this_run_metrics=$(echo "${debug_dump_dir}"/stackrox_debug*.zip)
     gsutil cp "${this_run_metrics}" "${gs_path}"


### PR DESCRIPTION
## Description

The nightly store did not get the update to the bucket name.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Only stores in nightlies.