### PR TITLE
ROX-20291: Sensor reconciler component

### DIFF
--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -20,6 +20,9 @@ const (
 
 	// SensorComponentEventOfflineMode denotes that Sensor-Central connection is broken and sensor should operate in offline mode
 	SensorComponentEventOfflineMode SensorComponentEvent = "offline-mode"
+
+	// SensorComponentEventSyncFinished denotes that Sensor finished initial sync.
+	SensorComponentEventSyncFinished SensorComponentEvent = "sync-finished"
 )
 
 // LogSensorComponentEvent returns a unified string for logging the transition between component states/

--- a/sensor/common/reconciliation/component.go
+++ b/sensor/common/reconciliation/component.go
@@ -1,0 +1,113 @@
+package reconciliation
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/deduper"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/store"
+)
+
+var (
+	log = logging.LoggerForModule()
+)
+
+var _ common.SensorComponent = (*DeduperStateProcessor)(nil)
+
+type DeduperStateProcessor struct {
+	responseC      chan *message.ExpiringMessage
+	deduperState   map[deduper.Key]uint64
+	stateLock      sync.RWMutex
+	contextLock    sync.RWMutex
+	reconciler     store.HashReconciler
+	stateReceived  atomic.Bool
+	currentContext context.Context
+	cancelContext  func()
+}
+
+func NewDeduperStateProcessor(reconciler store.HashReconciler) *DeduperStateProcessor {
+	return &DeduperStateProcessor{
+		responseC:    make(chan *message.ExpiringMessage),
+		stateLock:    sync.RWMutex{},
+		deduperState: make(map[deduper.Key]uint64),
+		reconciler:   reconciler,
+	}
+}
+
+func (c *DeduperStateProcessor) SetDeduperState(state map[deduper.Key]uint64) {
+	if len(c.deduperState) != 0 {
+		log.Warnf("SetDeduperState called but current deduperState is not empty (%d entries being overwritten)", len(state))
+	}
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+	c.deduperState = state
+	c.stateReceived.Store(true)
+}
+
+func (c *DeduperStateProcessor) Notify(e common.SensorComponentEvent) {
+	if e == common.SensorComponentEventSyncFinished {
+		if !c.stateReceived.Load() {
+			log.Warnf("Processing sync event in reconciler without having received a deduper state. No deletes will be generated.")
+		}
+
+		c.stateLock.RLock()
+		defer c.stateLock.RUnlock()
+		messages := c.reconciler.ProcessHashes(c.deduperState)
+		log.Infof("Hashes reconciled: %d messages generated", len(messages))
+		for _, msg := range messages {
+			c.responseC <- c.generateMessageWithCurrentContext(&msg)
+		}
+		log.Infof("Client reconciliation done")
+	} else if e == common.SensorComponentEventOfflineMode {
+		c.swapContext()
+		c.cleanState()
+	}
+}
+
+func (c *DeduperStateProcessor) cleanState() {
+	c.stateReceived.Store(false)
+
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+	c.deduperState = make(map[deduper.Key]uint64)
+}
+
+func (c *DeduperStateProcessor) swapContext() {
+	c.contextLock.Lock()
+	defer c.contextLock.Unlock()
+
+	c.cancelContext()
+	c.currentContext, c.cancelContext = context.WithCancel(context.Background())
+}
+
+func (c *DeduperStateProcessor) generateMessageWithCurrentContext(msg *central.MsgFromSensor) *message.ExpiringMessage {
+	c.contextLock.RLock()
+	defer c.contextLock.RUnlock()
+
+	return message.NewExpiring(c.currentContext, msg)
+}
+
+func (c *DeduperStateProcessor) Start() error {
+	c.currentContext, c.cancelContext = context.WithCancel(context.Background())
+	return nil
+}
+
+func (c *DeduperStateProcessor) Stop(_ error) {}
+
+func (c *DeduperStateProcessor) Capabilities() []centralsensor.SensorCapability {
+	return nil
+}
+
+func (c *DeduperStateProcessor) ProcessMessage(_ *central.MsgToSensor) error {
+	return nil
+}
+
+func (c *DeduperStateProcessor) ResponsesC() <-chan *message.ExpiringMessage {
+	return c.responseC
+}

--- a/sensor/common/reconciliation/component.go
+++ b/sensor/common/reconciliation/component.go
@@ -61,6 +61,7 @@ func (c *DeduperStateProcessor) Notify(e common.SensorComponentEvent) {
 		messages := c.reconciler.ProcessHashes(c.deduperState)
 		log.Infof("Hashes reconciled: %d messages generated", len(messages))
 		for _, msg := range messages {
+			msg := msg
 			c.responseC <- c.generateMessageWithCurrentContext(&msg)
 		}
 		log.Infof("Client reconciliation done")

--- a/sensor/common/sensor/central_communication.go
+++ b/sensor/common/sensor/central_communication.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/detector"
+	"github.com/stackrox/rox/sensor/common/reconciliation"
 )
 
 // CentralCommunication interface allows you to start and stop the consumption/production loops.
@@ -18,13 +19,14 @@ type CentralCommunication interface {
 }
 
 // NewCentralCommunication returns a new CentralCommunication.
-func NewCentralCommunication(reconnect bool, clientReconcile bool, components ...common.SensorComponent) CentralCommunication {
+func NewCentralCommunication(deduperStateProcessor *reconciliation.DeduperStateProcessor, reconnect bool, clientReconcile bool, components ...common.SensorComponent) CentralCommunication {
 	finished := sync.WaitGroup{}
 	return &centralCommunicationImpl{
-		allFinished: &finished,
-		receiver:    NewCentralReceiver(&finished, components...),
-		sender:      NewCentralSender(&finished, components...),
-		components:  components,
+		allFinished:           &finished,
+		receiver:              NewCentralReceiver(&finished, components...),
+		sender:                NewCentralSender(&finished, components...),
+		components:            components,
+		deduperStateProcessor: deduperStateProcessor,
 
 		stopper:         concurrency.NewStopper(),
 		isReconnect:     reconnect,

--- a/sensor/common/sensor/central_sender.go
+++ b/sensor/common/sensor/central_sender.go
@@ -13,6 +13,7 @@ type CentralSender interface {
 	Start(stream central.SensorService_CommunicateClient, initialDeduperState map[deduper.Key]uint64, onStops ...func(error))
 	Stop(err error)
 	Stopped() concurrency.ReadOnlyErrorSignal
+	OnSync(func())
 }
 
 // NewCentralSender returns a new instance of a CentralSender.

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/image"
+	"github.com/stackrox/rox/sensor/common/reconciliation"
 	"github.com/stackrox/rox/sensor/common/scannerdefinitions"
 )
 
@@ -74,21 +75,30 @@ type Sensor struct {
 
 	stoppedSig concurrency.ErrorSignal
 
-	notifyList []common.Notifiable
-	reconnect  atomic.Bool
-	reconcile  atomic.Bool
+	notifyList            []common.Notifiable
+	reconnect             atomic.Bool
+	reconcile             atomic.Bool
+	deduperStateProcessor *reconciliation.DeduperStateProcessor
 }
 
 // NewSensor initializes a Sensor, including reading configurations from the environment.
-func NewSensor(configHandler config.Handler, detector detector.Detector, imageService image.Service, centralConnectionFactory centralclient.CentralConnectionFactory, components ...common.SensorComponent) *Sensor {
+func NewSensor(
+	configHandler config.Handler,
+	detector detector.Detector,
+	imageService image.Service,
+	centralConnectionFactory centralclient.CentralConnectionFactory,
+	deduperStateProcessor *reconciliation.DeduperStateProcessor,
+	components ...common.SensorComponent,
+) *Sensor {
 	return &Sensor{
 		centralEndpoint:    env.CentralEndpoint.Setting(),
 		advertisedEndpoint: env.AdvertisedEndpoint.Setting(),
 
-		configHandler: configHandler,
-		detector:      detector,
-		imageService:  imageService,
-		components:    append(components, detector, configHandler), // Explicitly add the config handler
+		configHandler:         configHandler,
+		detector:              detector,
+		imageService:          imageService,
+		deduperStateProcessor: deduperStateProcessor,
+		components:            append(components, detector, configHandler, deduperStateProcessor), // Explicitly add the config handler
 
 		centralConnectionFactory: centralConnectionFactory,
 		centralConnection:        grpcUtil.NewLazyClientConn(),
@@ -316,7 +326,7 @@ func (s *Sensor) Stop() {
 }
 
 func (s *Sensor) communicationWithCentral(centralReachable *concurrency.Flag) {
-	s.centralCommunication = NewCentralCommunication(false, false, s.components...)
+	s.centralCommunication = NewCentralCommunication(s.deduperStateProcessor, false, false, s.components...)
 
 	s.centralCommunication.Start(central.NewSensorServiceClient(s.centralConnection), centralReachable, s.configHandler, s.detector)
 
@@ -381,7 +391,7 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 		// At this point, we know that connection factory reported that connection is up.
 		// Try to create a central communication component. This component will fail (Stopped() signal) if the connection
 		// suddenly broke.
-		s.centralCommunication = NewCentralCommunication(s.reconnect.Load(), s.reconcile.Load(), s.components...)
+		s.centralCommunication = NewCentralCommunication(s.deduperStateProcessor, s.reconnect.Load(), s.reconcile.Load(), s.components...)
 		s.centralCommunication.Start(central.NewSensorServiceClient(s.centralConnection), centralReachable, s.configHandler, s.detector)
 		// Reset the exponential back-off if the connection succeeds
 		exponential.Reset()

--- a/sensor/common/store/mocks/types.go
+++ b/sensor/common/store/mocks/types.go
@@ -11,8 +11,10 @@ package mocks
 import (
 	reflect "reflect"
 
+	central "github.com/stackrox/rox/generated/internalapi/central"
 	storage "github.com/stackrox/rox/generated/storage"
 	clusterentities "github.com/stackrox/rox/sensor/common/clusterentities"
+	deduper "github.com/stackrox/rox/sensor/common/deduper"
 	rbac "github.com/stackrox/rox/sensor/common/rbac"
 	registry "github.com/stackrox/rox/sensor/common/registry"
 	selector "github.com/stackrox/rox/sensor/common/selector"
@@ -666,4 +668,41 @@ func (m *MockNodeStore) GetNode(nodeName string) *storage.Node {
 func (mr *MockNodeStoreMockRecorder) GetNode(nodeName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockNodeStore)(nil).GetNode), nodeName)
+}
+
+// MockHashReconciler is a mock of HashReconciler interface.
+type MockHashReconciler struct {
+	ctrl     *gomock.Controller
+	recorder *MockHashReconcilerMockRecorder
+}
+
+// MockHashReconcilerMockRecorder is the mock recorder for MockHashReconciler.
+type MockHashReconcilerMockRecorder struct {
+	mock *MockHashReconciler
+}
+
+// NewMockHashReconciler creates a new mock instance.
+func NewMockHashReconciler(ctrl *gomock.Controller) *MockHashReconciler {
+	mock := &MockHashReconciler{ctrl: ctrl}
+	mock.recorder = &MockHashReconcilerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockHashReconciler) EXPECT() *MockHashReconcilerMockRecorder {
+	return m.recorder
+}
+
+// ProcessHashes mocks base method.
+func (m *MockHashReconciler) ProcessHashes(h map[deduper.Key]uint64) []central.MsgFromSensor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProcessHashes", h)
+	ret0, _ := ret[0].([]central.MsgFromSensor)
+	return ret0
+}
+
+// ProcessHashes indicates an expected call of ProcessHashes.
+func (mr *MockHashReconcilerMockRecorder) ProcessHashes(h any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessHashes", reflect.TypeOf((*MockHashReconciler)(nil).ProcessHashes), h)
 }

--- a/sensor/common/store/types.go
+++ b/sensor/common/store/types.go
@@ -1,8 +1,10 @@
 package store
 
 import (
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
+	"github.com/stackrox/rox/sensor/common/deduper"
 	"github.com/stackrox/rox/sensor/common/rbac"
 	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/common/selector"
@@ -88,4 +90,9 @@ type EndpointManager interface {
 // NodeStore represents a collection of Nodes
 type NodeStore interface {
 	GetNode(nodeName string) *storage.Node
+}
+
+// HashReconciler is the logic that will generate sensor messages based on a deduper state.
+type HashReconciler interface {
+	ProcessHashes(h map[deduper.Key]uint64) []central.MsgFromSensor
 }

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/networkflow/service"
 	"github.com/stackrox/rox/sensor/common/processfilter"
 	"github.com/stackrox/rox/sensor/common/processsignal"
+	"github.com/stackrox/rox/sensor/common/reconciliation"
 	"github.com/stackrox/rox/sensor/common/reprocessor"
 	"github.com/stackrox/rox/sensor/common/scan"
 	"github.com/stackrox/rox/sensor/common/sensor"
@@ -196,11 +197,15 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 			localscanner.NewLocalScannerTLSIssuer(cfg.k8sClient.Kubernetes(), sensorNamespace, podName))
 	}
 
+	hashReconciler := resources.NewResourceStoreReconciler(storeProvider)
+	deduperStateProcessor := reconciliation.NewDeduperStateProcessor(hashReconciler)
+
 	s := sensor.NewSensor(
 		configHandler,
 		policyDetector,
 		imageService,
 		cfg.centralConnFactory,
+		deduperStateProcessor,
 		components...,
 	)
 


### PR DESCRIPTION
## Description

This component is responsible for making sure that the deduper state is passed to `hash_reconciler` and that sensor messages are produced and emitted to central. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [ ] CI
- [ ] Manual tests 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
