### PR TITLE
ROX-20061: Stop waiting on sensor diagnostics if there's no progress

### DIFF
--- a/central/sensor/telemetry/controller_impl.go
+++ b/central/sensor/telemetry/controller_impl.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	telemetryChanGCPeriod = 5 * time.Minute
+	progressTimeout       = 5 * time.Minute
 )
 
 type controller struct {
@@ -99,6 +100,10 @@ func (c *controller) streamingRequest(ctx context.Context, dataType central.Pull
 		go c.sendCancellation(requestID)
 	}()
 
+	// In case there's no progress regarding sensor sending telemetry response data,
+	// we should stop waiting.
+	progressTicker := time.NewTicker(progressTimeout)
+	defer progressTicker.Stop()
 	for {
 		var resp *central.TelemetryResponsePayload
 		select {
@@ -106,7 +111,10 @@ func (c *controller) streamingRequest(ctx context.Context, dataType central.Pull
 			return errors.Wrap(ctx.Err(), "context error")
 		case <-c.stopSig.Done():
 			return errors.Wrap(c.stopSig.Err(), "lost connection to sensor")
+		case <-progressTicker.C:
+			return errors.New("no data was received from sensor within expected period")
 		case resp = <-retC:
+			progressTicker.Reset(progressTimeout)
 		}
 
 		if eos := resp.GetEndOfStream(); eos != nil {


### PR DESCRIPTION
## Description

Potential fix for the bug.
Currently, if single sensor stops sending data(but connection is still kept active), diagnostic bundle execution would hang.
Let's change that by introducing 5 minute window - if sensor does not send any diagnostics messages in 5 minutes, let's stop waiting on them.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

1. TBD unit test
2. Manually test "successful" path still works

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
