### PR TITLE
ROX-19363: Add false positive CVE modal to workload cves

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionRequestModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionRequestModal.tsx
@@ -5,11 +5,18 @@ import { FormikHelpers } from 'formik';
 import {
     BaseVulnerabilityException,
     createDeferralVulnerabilityException,
+    createFalsePositiveVulnerabilityException,
 } from 'services/VulnerabilityExceptionService';
 import useRestMutation from 'hooks/useRestMutation';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { CveExceptionRequestType } from '../../types';
-import { DeferralValues, ScopeContext, formValuesToDeferralRequest } from './utils';
+import {
+    DeferralValues,
+    FalsePositiveValues,
+    ScopeContext,
+    formValuesToDeferralRequest,
+    formValuesToFalsePositiveRequest,
+} from './utils';
 import ExceptionRequestForm, { ExceptionRequestFormProps } from './ExceptionRequestForm';
 
 export type ExceptionRequestModalOptions = {
@@ -38,12 +45,13 @@ function ExceptionRequestModal({
             ? `Request deferral for ${cveCountText}`
             : `Mark ${cveCountText} as false positive`;
 
-    const { mutate, error: deferralError } = useRestMutation(createDeferralVulnerabilityException);
+    const createDeferralMutation = useRestMutation(createDeferralVulnerabilityException);
+    const createFalsePositiveMutation = useRestMutation(createFalsePositiveVulnerabilityException);
 
     function onDeferralSubmit(formValues: DeferralValues, helpers: FormikHelpers<DeferralValues>) {
         if (formValues.expiry) {
             const payload = formValuesToDeferralRequest(formValues, formValues.expiry);
-            mutate(payload, {
+            createDeferralMutation.mutate(payload, {
                 onSuccess: onExceptionRequestSuccess,
                 onError: () => helpers.setSubmitting(false),
             });
@@ -52,7 +60,33 @@ function ExceptionRequestModal({
         }
     }
 
-    const submissionError = deferralError;
+    function onFalsePositiveSubmit(
+        formValues: FalsePositiveValues,
+        helpers: FormikHelpers<FalsePositiveValues>
+    ) {
+        const payload = formValuesToFalsePositiveRequest(formValues);
+        createFalsePositiveMutation.mutate(payload, {
+            onSuccess: onExceptionRequestSuccess,
+            onError: () => helpers.setSubmitting(false),
+        });
+    }
+
+    const formProps =
+        type === 'DEFERRAL'
+            ? {
+                  formHeaderText: `CVEs will be marked as deferred after approval`,
+                  commentFieldLabel: `Deferral rationale`,
+                  onSubmit: onDeferralSubmit,
+                  showExpiryField: true,
+              }
+            : {
+                  formHeaderText: `CVEs will be marked as false positive after approval`,
+                  commentFieldLabel: `False positive rationale`,
+                  onSubmit: onFalsePositiveSubmit,
+                  showExpiryField: false,
+              };
+
+    const submissionError = createDeferralMutation.error ?? createFalsePositiveMutation.error;
 
     return (
         <Modal
@@ -73,17 +107,12 @@ function ExceptionRequestModal({
                         {getAxiosErrorMessage(submissionError)}
                     </Alert>
                 )}
-                {type === 'DEFERRAL' && (
-                    <ExceptionRequestForm
-                        cves={cves}
-                        scopeContext={scopeContext}
-                        onSubmit={onDeferralSubmit}
-                        onCancel={onClose}
-                        showExpiryField
-                        formHeaderText="CVEs will be marked as deferred after approval"
-                        commentFieldLabel="Deferral rationale"
-                    />
-                )}
+                <ExceptionRequestForm
+                    cves={cves}
+                    scopeContext={scopeContext}
+                    onCancel={onClose}
+                    {...formProps}
+                />
             </ModalBoxBody>
         </Modal>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/utils.ts
@@ -1,7 +1,10 @@
 import { addDays, isAfter } from 'date-fns';
 import * as yup from 'yup';
 
-import { CreateDeferVulnerabilityExceptionRequest } from 'services/VulnerabilityExceptionService';
+import {
+    CreateDeferVulnerabilityExceptionRequest,
+    CreateFalsePositiveVulnerabilityExceptionRequest,
+} from 'services/VulnerabilityExceptionService';
 import { ensureExhaustive } from 'utils/type.utils';
 
 export type ScopeContext = 'GLOBAL' | { image: { name: string; tag: string } };
@@ -82,4 +85,14 @@ export function formValuesToDeferralRequest(
         default:
             return ensureExhaustive(expiryType);
     }
+}
+
+export function formValuesToFalsePositiveRequest(
+    formValues: FalsePositiveValues
+): CreateFalsePositiveVulnerabilityExceptionRequest {
+    return {
+        cves: formValues.cves,
+        comment: formValues.comment,
+        scope: formValues.scope,
+    };
 }

--- a/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
+++ b/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
@@ -117,3 +117,18 @@ export function createDeferralVulnerabilityException(
         .post<{ exception: VulnerabilityDeferralException }>(url, payload)
         .then((response) => response.data.exception);
 }
+
+export type CreateFalsePositiveVulnerabilityExceptionRequest = {
+    cves: string[];
+    comment: string;
+    scope: VulnerabilityExceptionScope;
+};
+
+export function createFalsePositiveVulnerabilityException(
+    payload: CreateFalsePositiveVulnerabilityExceptionRequest
+): Promise<VulnerabilityFalsePositiveException> {
+    const url = `${baseUrl}/false-positive`;
+    return axios
+        .post<{ exception: VulnerabilityFalsePositiveException }>(url, payload)
+        .then((response) => response.data.exception);
+}


### PR DESCRIPTION
## Description

As titled.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Select one or more workload CVEs and "Mark as false positive" from the menu.
![image](https://github.com/stackrox/stackrox/assets/1292638/35991650-e491-4408-b6d8-32fac5df4229)
![image](https://github.com/stackrox/stackrox/assets/1292638/9ecbb8fc-eddc-4a61-a2cc-9a5827b1880e)
