### PR TITLE
fix: bug in scale test process and endpoint removal

### DIFF
--- a/sensor/kubernetes/fake/deployment.go
+++ b/sensor/kubernetes/fake/deployment.go
@@ -60,8 +60,8 @@ func (p *ProcessPool) remove(containerID string) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	delete(p.Processes, containerID)
 	p.Size -= len(p.Processes[containerID])
+	delete(p.Processes, containerID)
 }
 
 func (p *ProcessPool) getRandomProcess(containerID string) *storage.ProcessSignal {

--- a/sensor/kubernetes/fake/flows.go
+++ b/sensor/kubernetes/fake/flows.go
@@ -105,8 +105,8 @@ func (p *EndpointPool) remove(containerID string) {
 	defer p.lock.Unlock()
 
 	p.EndpointsToBeClosed = append(p.EndpointsToBeClosed, p.Endpoints[containerID]...)
-	delete(p.Endpoints, containerID)
 	p.Size -= len(p.Endpoints[containerID])
+	delete(p.Endpoints, containerID)
 }
 
 func (p *EndpointPool) clearEndpointsToBeClosed() {


### PR DESCRIPTION
## Description

Fixes a bug in the scale tests that makes it so that the sizes of the process and listening endpoint pools are not calculated correctly. Currently when these pools hit their maximum capacity and elements are deleted from them the recorded size of the pools are not decreased. This in turn means that new elements cannot be added, even though it should be possible to do so.


## Checklist
- [x] Investigated and inspected CI test results
- [x] Scale tests on master
- [x] Scale tests on this branch
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

This is not a user facing feature.

## Testing Performed

### Ran scale tests

Ran the following script
```
$ cat CreateLongRunning.sh
#!/usr/bin/env bash
set -eou pipefail

cluster_name=$1
tag=$2

export CLUSTER_NAME="$cluster_name"
export MAIN_IMAGE_TAG=$tag

#infractl create gke-default $CLUSTER_NAME --lifespan 168h --arg nodes=5 --wait

infractl get $CLUSTER_NAME --json | jq '.Connect' -r | bash

export MAIN_IMAGE_REPO=quay.io/jvirtane/main
export CENTRAL_DB_IMAGE_REPO=quay.io/jvirtane/central-db
export ROXCTL_IMAGE_REPO=quay.io/jvirtane/roxctl

export API_ENDPOINT=localhost:8000

export STORAGE=pvc # Backing storage
export STORAGE_CLASS=faster # Runs on an SSD type
export STORAGE_SIZE=100 # 100G
export MONITORING_SUPPORT=true # Runs monitoring
export LOAD_BALANCER=lb

./deploy/k8s/central.sh # Launches central

kubectl -n stackrox port-forward deploy/central 8000:8443 > /dev/null 2>&1 &

sleep 20

export ROX_ADMIN_USERNAME=admin

password="$(cat deploy/k8s/central-deploy/password)"

export ROX_ADMIN_PASSWORD="$password"

./deploy/k8s/sensor.sh

kubectl -n stackrox set env deploy/sensor MUTEX_WATCHDOG_TIMEOUT_SEC=0
kubectl -n stackrox set env deploy/sensor ROX_FAKE_KUBERNETES_WORKLOAD=long-running

kubectl -n stackrox set env deploy/central MUTEX_WATCHDOG_TIMEOUT_SECS=0

./scale/launch_workload.sh medium-plop
```

The medium-plop workload is the following

```
$ cat scale/workloads/medium-plop.yaml 
deploymentWorkload:
- deploymentType: Deployment
  lifecycleDuration: 72h
  numDeployments: 1000
  numLifecycles: 0
  podWorkload:
    containerWorkload:
      numImages: 0
    lifecycleDuration: 1m0s
    numContainers: 3
    numPods: 5
    processWorkload:
      alertRate: 0.001
      processInterval: 30s
  updateInterval: 10m0s
networkWorkload:
  batchSize: 100
  flowInterval: 30s
nodeWorkload:
  numNodes: 100
rbacWorkload:
  numBindings: 100
  numRoles: 100
  numServiceAccounts: 100
```
lifecycleDuration was set to a low value of the podWorkload so that the removal of the pods and therefore processes and endpoints would be done frequently.

#### Running scale tests for master
```
./CreateLongRunning.sh jouko-1021 4.2.x-478-g9451031453
```

Checking the central-db

```
central_active=# select count(*) from listening_endpoints where closed = 'f';
 count 
-------
    30
(1 row)

central_active=# select count(*) from listening_endpoints where closed = 't';
 count 
-------
     0
(1 row)

central_active=# 
central_active=# select count(*) from listening_endpoints ;
 count 
-------
    30
(1 row)
```

Testing this repeatedly the number of rows doesn't change.

#### Running scale tests for this branch

```
central_active=# select count(*) from listening_endpoints ;
 count 
-------
    42
(1 row)

central_active=# select count(*) from listening_endpoints where closed = 'f';
 count 
-------
    60
(1 row)

central_active=# select count(*) from listening_endpoints where closed = 't';
 count 
-------
    16
(1 row)

central_active=# select count(*) from listening_endpoints ;
 count 
-------
    76
(1 row)

central_active=# select count(*) from listening_endpoints where closed = 'f';
 count 
-------
    60
(1 row)

central_active=# select count(*) from listening_endpoints where closed = 't';
 count 
-------
    16
(1 row)

central_active=# select count(*) from listening_endpoints ;
 count 
-------
   133
(1 row)

central_active=# select count(*) from listening_endpoints where closed = 'f';
 count 
-------
   133
(1 row)

central_active=# select count(*) from listening_endpoints where closed = 't';
 count 
-------
     0
(1 row)
entral_active=# select count(*) from listening_endpoints ;
 count 
-------
   181
(1 row)

central_active=# select count(*) from listening_endpoints where closed = 'f';
 count 
-------
   140
(1 row)

central_active=# select count(*) from listening_endpoints where closed = 't';
 count 
-------
    41
(1 row)
```

In this branch there is continual churn of the listening endpoints. Though for this particular workflow it is not large churn.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
