### PR TITLE
fix: set scope namespaced for create and update admission controller

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -200,6 +200,7 @@ webhooks:
           {{- if ._rox.env.openshift }}
           - deploymentconfigs
           {{- end }}
+        scope: "Namespaced"
     namespaceSelector:
       matchExpressions:
       - key: namespace.metadata.stackrox.io/name


### PR DESCRIPTION
## Description

Issue is gke says:
This cluster has an admission webhook installed that is intercepting system critical requests in the last 24 hours. Intercepting these requests can impact availability of the GKE Control Plane. 
stackrox	Intercepting resources in the kube-system namespace

analysis:
```
webhooks:
- admissionReviewVersions:
  namespaceSelector:
    matchExpressions:
    - key: namespace.metadata.stackrox.io/name
      operator: NotIn
      values:
      - stackrox
      - kube-system
      - kube-public
      - istio-system
  objectSelector: {}
  rules:
  - apiGroups:
    - '*'
    apiVersions:
    - '*'
    operations:
    - CREATE
    - UPDATE
    resources:
    - pods
    - deployments
    - replicasets
    - replicationcontrollers
    - statefulsets
    - daemonsets
    - cronjobs
    - jobs
    scope: '*'
- admissionReviewVersions:
  namespaceSelector: {}
  objectSelector: {}
  rules:
  - apiGroups:
    - '*'
    apiVersions:
    - '*'
    operations:
    - CONNECT
    resources:
    - pods
    - pods/exec
    - pods/portforward
    scope: '*'
```

so:
1. webhook for CREATE and UPDATE operations should be namespaced and should exclude following namespaces: stackrox, kube-system, kube-public, istio-system

2. webhook for CONNECT operations should be global scoped

thats how i have understood it, but in actual state, 1. webhook is also global and not namespaced because, scope is not set, and default for scope is '*'
https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#configure-admission-webhooks-on-the-fly

> The scope field specifies if only cluster-scoped resources ("Cluster") or namespace-scoped resources ("Namespaced") will match this rule. "∗" means that there are no scope restrictions.

so with this pr it should work as it was intended.

BUT warning in gke will stay, because the 2. webhook will stay without scope restrictions, because specially connects on pods in kube-system are events someone maybe wants to review.

