### PR TITLE
ROX-20345: Reconcile namespaces in sensor

### DIFF
--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -71,7 +71,7 @@ func NewDispatcherRegistry(
 	serviceAccountStore := storeProvider.serviceAccountStore
 	deploymentStore := storeProvider.deploymentStore
 	podStore := storeProvider.podStore
-	nsStore := newNamespaceStore()
+	nsStore := storeProvider.nsStore
 	netPolicyStore := storeProvider.networkPolicyStore
 	endpointManager := storeProvider.endpointManager
 	portExposureReconciler := newPortExposureReconciler(deploymentStore, storeProvider.Services())

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -130,6 +130,17 @@ func resourceToMessage(resType string, resID string) (*central.MsgFromSensor, er
 			},
 		}
 		return &central.MsgFromSensor{Msg: &msg}, nil
+	case deduper.TypeNamespace.String():
+		msg := central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     resID,
+				Action: central.ResourceAction_REMOVE_RESOURCE,
+				Resource: &central.SensorEvent_Namespace{
+					Namespace: &storage.NamespaceMetadata{Id: resID},
+				},
+			},
+		}
+		return &central.MsgFromSensor{Msg: &msg}, nil
 	default:
 		return nil, errors.Errorf("Not implemented for resource type %v", resType)
 	}

--- a/sensor/kubernetes/listener/resources/namespace_store.go
+++ b/sensor/kubernetes/listener/resources/namespace_store.go
@@ -1,8 +1,10 @@
 package resources
 
 import (
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/deduper"
 )
 
 // A namespace store stores a mapping of namespace names to their ids.
@@ -10,6 +12,26 @@ type namespaceStore struct {
 	lock sync.RWMutex
 
 	namespaceNamesToIDs map[string]string
+}
+
+func (n *namespaceStore) Cleanup() {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	n.namespaceNamesToIDs = make(map[string]string)
+}
+
+func (n *namespaceStore) ReconcileDelete(resType, resID string, _ uint64) (string, error) {
+	if resType != deduper.TypeNamespace.String() {
+		return "", errors.Errorf("resource type %s not supported", resType)
+	}
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	for _, id := range n.namespaceNamesToIDs {
+		if id == resID {
+			return "", nil
+		}
+	}
+	return resID, nil
 }
 
 func newNamespaceStore() *namespaceStore {
@@ -23,6 +45,13 @@ func (n *namespaceStore) addNamespace(ns *storage.NamespaceMetadata) {
 	defer n.lock.Unlock()
 
 	n.namespaceNamesToIDs[ns.GetName()] = ns.GetId()
+}
+
+func (n *namespaceStore) removeNamespace(ns *storage.NamespaceMetadata) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
+	delete(n.namespaceNamesToIDs, ns.GetName())
 }
 
 func (n *namespaceStore) lookupNamespaceID(name string) (string, bool) {

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -31,6 +31,7 @@ type InMemoryStoreProvider struct {
 	orchestratorNamespaces *orchestratornamespaces.OrchestratorNamespaces
 	registryStore          *registry.Store
 	registryMirrorStore    registrymirror.Store
+	nsStore                *namespaceStore
 
 	cleanableStores    []CleanableStore
 	reconcilableStores map[string]reconcile.Reconcilable
@@ -62,6 +63,7 @@ func InitializeStore() *InMemoryStoreProvider {
 		orchestratorNamespaces: orchestratornamespaces.NewOrchestratorNamespaces(),
 		registryStore:          registry.NewRegistryStore(nil),
 		registryMirrorStore:    registrymirror.NewFileStore(),
+		nsStore:                newNamespaceStore(),
 	}
 
 	p.cleanableStores = []CleanableStore{
@@ -76,6 +78,7 @@ func InitializeStore() *InMemoryStoreProvider {
 		p.orchestratorNamespaces,
 		p.registryStore,
 		p.registryMirrorStore,
+		p.nsStore,
 	}
 	p.reconcilableStores = map[string]reconcile.Reconcilable{
 		deduper.TypeDeployment.String():     p.deploymentStore,
@@ -86,6 +89,7 @@ func InitializeStore() *InMemoryStoreProvider {
 		deduper.TypeNetworkPolicy.String():  p.networkPolicyStore,
 		deduper.TypeRole.String():           p.rbacStore,
 		deduper.TypeBinding.String():        p.rbacStore,
+		deduper.TypeNamespace.String():      p.nsStore,
 	}
 
 	return p


### PR DESCRIPTION
## Description

If sensor is capable of doing the reconciliation, it should be doing namespace reconciliation as well.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

* [x] CI
* [x] New unit tests added
* [x] Manual tests
  * Deploy ACS in a cluster with `ROX_SENSOR_RECONCILIATION=true`
  * Create a few namespaces
  * You should see the namespaces in the UI
  * Scale sensor to zero
  * Delete a few namespaces
  * Scale sensor to one again
  * You should see the deleted namespaces disappear in the UI 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
