### PR TITLE
ROX-20352: Reconcile ocp resources

### DIFF
--- a/sensor/common/store/reconciliation/store.go
+++ b/sensor/common/store/reconciliation/store.go
@@ -1,0 +1,75 @@
+package reconciliation
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/reconcile"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+type Store interface {
+	reconcile.Reconcilable
+	Cleanup()
+	Add(resType, id string)
+	Remove(resType, id string)
+}
+
+type store struct {
+	lock      sync.Mutex
+	resources map[string]set.StringSet
+}
+
+func NewStore() Store {
+	return &store{
+		resources: make(map[string]set.StringSet),
+	}
+}
+
+func (s *store) Cleanup() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.resources = make(map[string]set.StringSet)
+}
+
+func (s *store) ReconcileDelete(resType, resID string, _ uint64) (string, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if ids, found := s.resources[resType]; found {
+		if ids.Contains(resID) {
+			return "", nil
+		}
+		return resID, nil
+	}
+	return "", errors.Errorf("resource type %s not supported", resType)
+}
+
+var _ Store = (*store)(nil)
+
+func (s *store) Add(resType, id string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.addResourceNoLock(resType, id)
+}
+
+func (s *store) Remove(resType, id string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.removeResourceNoLock(resType, id)
+}
+
+func (s *store) addResourceNoLock(resType, id string) {
+	if ids, found := s.resources[resType]; !found {
+		s.resources[resType] = set.NewStringSet(id)
+	} else {
+		ids.Add(id)
+	}
+}
+
+func (s *store) removeResourceNoLock(resType, id string) {
+	if ids, found := s.resources[resType]; found {
+		ids.Remove(id)
+	}
+	if len(s.resources[resType]) == 0 {
+		delete(s.resources, resType)
+	}
+}

--- a/sensor/common/store/reconciliation/store.go
+++ b/sensor/common/store/reconciliation/store.go
@@ -35,7 +35,7 @@ func (s *store) Cleanup() {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.resources = make(map[string]set.StringSet)
-	for resType, _ := range s.resourceTypes {
+	for resType := range s.resourceTypes {
 		s.resources[resType] = set.NewStringSet()
 	}
 }

--- a/sensor/common/store/reconciliation/store.go
+++ b/sensor/common/store/reconciliation/store.go
@@ -7,10 +7,12 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 )
 
+// Store the reconciliation store stores a map if resource types and ids.
+// This allows Sensor to reconcile resources after connecting with Central.
 type Store interface {
 	reconcile.Reconcilable
 	Cleanup()
-	Add(resType, id string)
+	Upsert(resType, id string)
 	Remove(resType, id string)
 }
 
@@ -19,6 +21,7 @@ type store struct {
 	resources map[string]set.StringSet
 }
 
+// NewStore creates a new reconciliation Store
 func NewStore() Store {
 	return &store{
 		resources: make(map[string]set.StringSet),
@@ -45,12 +48,14 @@ func (s *store) ReconcileDelete(resType, resID string, _ uint64) (string, error)
 
 var _ Store = (*store)(nil)
 
-func (s *store) Add(resType, id string) {
+// Upsert a resource type and id
+func (s *store) Upsert(resType, id string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.addResourceNoLock(resType, id)
 }
 
+// Remove a resource type and id
 func (s *store) Remove(resType, id string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/sensor/common/store/reconciliation/store_test.go
+++ b/sensor/common/store/reconciliation/store_test.go
@@ -3,6 +3,7 @@ package reconciliation
 import (
 	"testing"
 
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -64,6 +65,7 @@ func (s *storeSuite) Test_Upsert() {
 	}
 	for name, tc := range testCases {
 		s.Run(name, func() {
+			s.resourceStore.resources = make(map[string]set.StringSet)
 			for inputType, input := range tc.inputResources {
 				for _, res := range input {
 					s.resourceStore.Upsert(inputType, res)

--- a/sensor/common/store/reconciliation/store_test.go
+++ b/sensor/common/store/reconciliation/store_test.go
@@ -1,0 +1,170 @@
+package reconciliation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	resourceTypeA = "resource_type_A"
+	resourceTypeB = "resource_type_B"
+	fixtureID1    = "1"
+	fixtureID2    = "2"
+)
+
+type storeSuite struct {
+	suite.Suite
+	resourceStore *store
+}
+
+var _ suite.SetupTestSuite = (*storeSuite)(nil)
+
+func (s *storeSuite) SetupTest() {
+	var ok bool
+	s.resourceStore, ok = NewStore().(*store)
+	s.Assert().True(ok)
+}
+
+func Test_StoreSuite(t *testing.T) {
+	suite.Run(t, new(storeSuite))
+}
+
+func (s *storeSuite) Test_Upsert() {
+	testCases := map[string]struct {
+		inputResources    map[string][]string
+		expectedResources map[string][]string
+	}{
+		"One resource": {
+			inputResources: map[string][]string{
+				resourceTypeA: {fixtureID1},
+			},
+			expectedResources: map[string][]string{
+				resourceTypeA: {fixtureID1},
+			},
+		},
+		"Same resource is only added once": {
+			inputResources: map[string][]string{
+				resourceTypeA: {fixtureID1, fixtureID1},
+			},
+			expectedResources: map[string][]string{
+				resourceTypeA: {fixtureID1},
+			},
+		},
+		"Multiple resource types": {
+			inputResources: map[string][]string{
+				resourceTypeA: {fixtureID1, fixtureID2},
+				resourceTypeB: {fixtureID1},
+			},
+			expectedResources: map[string][]string{
+				resourceTypeA: {fixtureID1, fixtureID2},
+				resourceTypeB: {fixtureID1},
+			},
+		},
+	}
+	for name, tc := range testCases {
+		s.Run(name, func() {
+			for inputType, input := range tc.inputResources {
+				for _, res := range input {
+					s.resourceStore.Upsert(inputType, res)
+				}
+			}
+			for resType, expectedResources := range tc.expectedResources {
+				resources, found := s.resourceStore.resources[resType]
+				s.Require().True(found)
+				s.Assert().Len(expectedResources, len(resources))
+				for _, resource := range expectedResources {
+					s.Assert().Contains(resources, resource)
+				}
+			}
+		})
+	}
+}
+
+func (s *storeSuite) initializeStore() {
+	s.resourceStore.Cleanup()
+	s.resourceStore.Upsert(resourceTypeA, fixtureID1)
+	s.resourceStore.Upsert(resourceTypeA, fixtureID2)
+	s.resourceStore.Upsert(resourceTypeB, fixtureID1)
+	s.resourceStore.Upsert(resourceTypeB, fixtureID2)
+}
+
+func (s *storeSuite) Test_Remove() {
+	testCases := map[string]struct {
+		resourcesToRemove map[string][]string
+		expectedResources map[string][]string
+	}{
+		"Remove one": {
+			resourcesToRemove: map[string][]string{
+				resourceTypeA: {fixtureID1},
+			},
+			expectedResources: map[string][]string{
+				resourceTypeA: {fixtureID2},
+				resourceTypeB: {fixtureID1, fixtureID2},
+			},
+		},
+		"Remove twice": {
+			resourcesToRemove: map[string][]string{
+				resourceTypeA: {fixtureID1, fixtureID1},
+			},
+			expectedResources: map[string][]string{
+				resourceTypeA: {fixtureID2},
+				resourceTypeB: {fixtureID1, fixtureID2},
+			},
+		},
+		"Remove with incorrect id": {
+			resourcesToRemove: map[string][]string{
+				resourceTypeA: {"incorrect id"},
+			},
+			expectedResources: map[string][]string{
+				resourceTypeA: {fixtureID1, fixtureID2},
+				resourceTypeB: {fixtureID1, fixtureID2},
+			},
+		},
+		"Remove with incorrect type": {
+			resourcesToRemove: map[string][]string{
+				"incorrect type": {fixtureID1},
+			},
+			expectedResources: map[string][]string{
+				resourceTypeA: {fixtureID1, fixtureID2},
+				resourceTypeB: {fixtureID1, fixtureID2},
+			},
+		},
+		"Remove all": {
+			resourcesToRemove: map[string][]string{
+				resourceTypeA: {fixtureID1, fixtureID2},
+				resourceTypeB: {fixtureID1, fixtureID2},
+			},
+			expectedResources: map[string][]string{},
+		},
+	}
+	for name, tc := range testCases {
+		s.Run(name, func() {
+			s.initializeStore()
+			for inputType, input := range tc.resourcesToRemove {
+				for _, res := range input {
+					s.resourceStore.Remove(inputType, res)
+				}
+			}
+			for resType, expectedResources := range tc.expectedResources {
+				resources, found := s.resourceStore.resources[resType]
+				s.Require().True(found)
+				s.Assert().Len(expectedResources, len(resources))
+				for _, resource := range expectedResources {
+					s.Assert().Contains(resources, resource)
+				}
+			}
+		})
+	}
+}
+
+func (s *storeSuite) Test_Cleanup() {
+	s.resourceStore.Upsert(resourceTypeA, fixtureID1)
+	s.resourceStore.Upsert(resourceTypeA, fixtureID2)
+	s.resourceStore.Upsert(resourceTypeB, fixtureID1)
+	s.resourceStore.Upsert(resourceTypeB, fixtureID2)
+
+	s.resourceStore.Cleanup()
+
+	s.Assert().Len(s.resourceStore.resources, 0)
+}

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorprofiles.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorprofiles.go
@@ -69,7 +69,7 @@ func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.Reso
 	if action == central.ResourceAction_REMOVE_RESOURCE {
 		c.reconciliationStore.Remove(deduper.TypeComplianceOperatorProfile.String(), protoProfile.GetId())
 	} else {
-		c.reconciliationStore.Add(deduper.TypeComplianceOperatorProfile.String(), protoProfile.GetId())
+		c.reconciliationStore.Upsert(deduper.TypeComplianceOperatorProfile.String(), protoProfile.GetId())
 	}
 	return component.NewEvent(events...)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorprofiles.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorprofiles.go
@@ -5,6 +5,8 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/sensor/common/deduper"
+	"github.com/stackrox/rox/sensor/common/store/reconciliation"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -15,11 +17,15 @@ var (
 )
 
 // ProfileDispatcher handles compliance operator profile objects
-type ProfileDispatcher struct{}
+type ProfileDispatcher struct {
+	reconciliationStore reconciliation.Store
+}
 
 // NewProfileDispatcher creates and returns a new profile dispatcher
-func NewProfileDispatcher() *ProfileDispatcher {
-	return &ProfileDispatcher{}
+func NewProfileDispatcher(store reconciliation.Store) *ProfileDispatcher {
+	return &ProfileDispatcher{
+		reconciliationStore: store,
+	}
 }
 
 // ProcessEvent processes a compliance operator profile
@@ -59,6 +65,11 @@ func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.Reso
 				ComplianceOperatorProfile: protoProfile,
 			},
 		},
+	}
+	if action == central.ResourceAction_REMOVE_RESOURCE {
+		c.reconciliationStore.Remove(deduper.TypeComplianceOperatorProfile.String(), protoProfile.GetId())
+	} else {
+		c.reconciliationStore.Add(deduper.TypeComplianceOperatorProfile.String(), protoProfile.GetId())
 	}
 	return component.NewEvent(events...)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorresults.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorresults.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stackrox/rox/sensor/common/deduper"
+	"github.com/stackrox/rox/sensor/common/store/reconciliation"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,11 +24,14 @@ var (
 
 // ResultDispatcher handles compliance check result objects
 type ResultDispatcher struct {
+	reconciliationStore reconciliation.Store
 }
 
 // NewResultDispatcher creates and returns a new compliance check result dispatcher.
-func NewResultDispatcher() *ResultDispatcher {
-	return &ResultDispatcher{}
+func NewResultDispatcher(store reconciliation.Store) *ResultDispatcher {
+	return &ResultDispatcher{
+		reconciliationStore: store,
+	}
 }
 
 func statusToProtoStatus(status v1alpha1.ComplianceCheckStatus) storage.ComplianceOperatorCheckResult_CheckStatus {
@@ -143,6 +148,11 @@ func (c *ResultDispatcher) ProcessEvent(obj, _ interface{}, action central.Resou
 				},
 			},
 		}
+		if action == central.ResourceAction_REMOVE_RESOURCE {
+			c.reconciliationStore.Remove(deduper.TypeComplianceOperatorResult.String(), id)
+		} else {
+			c.reconciliationStore.Add(deduper.TypeComplianceOperatorResult.String(), id)
+		}
 		return component.NewEvent(events...)
 	}
 
@@ -163,6 +173,11 @@ func (c *ResultDispatcher) ProcessEvent(obj, _ interface{}, action central.Resou
 				},
 			},
 		},
+	}
+	if action == central.ResourceAction_REMOVE_RESOURCE {
+		c.reconciliationStore.Remove(deduper.TypeComplianceOperatorResult.String(), id)
+	} else {
+		c.reconciliationStore.Add(deduper.TypeComplianceOperatorResult.String(), id)
 	}
 	return component.NewEvent(events...)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorresults.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorresults.go
@@ -151,7 +151,7 @@ func (c *ResultDispatcher) ProcessEvent(obj, _ interface{}, action central.Resou
 		if action == central.ResourceAction_REMOVE_RESOURCE {
 			c.reconciliationStore.Remove(deduper.TypeComplianceOperatorResult.String(), id)
 		} else {
-			c.reconciliationStore.Add(deduper.TypeComplianceOperatorResult.String(), id)
+			c.reconciliationStore.Upsert(deduper.TypeComplianceOperatorResult.String(), id)
 		}
 		return component.NewEvent(events...)
 	}
@@ -177,7 +177,7 @@ func (c *ResultDispatcher) ProcessEvent(obj, _ interface{}, action central.Resou
 	if action == central.ResourceAction_REMOVE_RESOURCE {
 		c.reconciliationStore.Remove(deduper.TypeComplianceOperatorResult.String(), id)
 	} else {
-		c.reconciliationStore.Add(deduper.TypeComplianceOperatorResult.String(), id)
+		c.reconciliationStore.Upsert(deduper.TypeComplianceOperatorResult.String(), id)
 	}
 	return component.NewEvent(events...)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorrules.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorrules.go
@@ -59,7 +59,7 @@ func (c *RulesDispatcher) ProcessEvent(obj, _ interface{}, action central.Resour
 	if action == central.ResourceAction_REMOVE_RESOURCE {
 		c.reconciliationStore.Remove(deduper.TypeComplianceOperatorRule.String(), id)
 	} else {
-		c.reconciliationStore.Add(deduper.TypeComplianceOperatorRule.String(), id)
+		c.reconciliationStore.Upsert(deduper.TypeComplianceOperatorRule.String(), id)
 	}
 	return component.NewEvent(events...)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscans.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscans.go
@@ -4,17 +4,23 @@ import (
 	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/sensor/common/deduper"
+	"github.com/stackrox/rox/sensor/common/store/reconciliation"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // ScanDispatcher handles compliance operator scan objects
-type ScanDispatcher struct{}
+type ScanDispatcher struct {
+	reconciliationStore reconciliation.Store
+}
 
 // NewScanDispatcher creates and returns a new scan dispatcher
-func NewScanDispatcher() *ScanDispatcher {
-	return &ScanDispatcher{}
+func NewScanDispatcher(store reconciliation.Store) *ScanDispatcher {
+	return &ScanDispatcher{
+		reconciliationStore: store,
+	}
 }
 
 // ProcessEvent processes a compliance operator scan
@@ -47,6 +53,11 @@ func (c *ScanDispatcher) ProcessEvent(obj, _ interface{}, action central.Resourc
 				ComplianceOperatorScan: protoScan,
 			},
 		},
+	}
+	if action == central.ResourceAction_REMOVE_RESOURCE {
+		c.reconciliationStore.Remove(deduper.TypeComplianceOperatorScan.String(), string(complianceScan.GetUID()))
+	} else {
+		c.reconciliationStore.Add(deduper.TypeComplianceOperatorScan.String(), string(complianceScan.GetUID()))
 	}
 	return component.NewEvent(events...)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscans.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscans.go
@@ -57,7 +57,7 @@ func (c *ScanDispatcher) ProcessEvent(obj, _ interface{}, action central.Resourc
 	if action == central.ResourceAction_REMOVE_RESOURCE {
 		c.reconciliationStore.Remove(deduper.TypeComplianceOperatorScan.String(), string(complianceScan.GetUID()))
 	} else {
-		c.reconciliationStore.Add(deduper.TypeComplianceOperatorScan.String(), string(complianceScan.GetUID()))
+		c.reconciliationStore.Upsert(deduper.TypeComplianceOperatorScan.String(), string(complianceScan.GetUID()))
 	}
 	return component.NewEvent(events...)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscansettingbindings.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscansettingbindings.go
@@ -64,7 +64,7 @@ func (c *ScanSettingBindings) ProcessEvent(obj, _ interface{}, action central.Re
 	if action == central.ResourceAction_REMOVE_RESOURCE {
 		c.reconciliationStore.Remove(deduper.TypeComplianceOperatorScanSettingBinding.String(), id)
 	} else {
-		c.reconciliationStore.Add(deduper.TypeComplianceOperatorScanSettingBinding.String(), id)
+		c.reconciliationStore.Upsert(deduper.TypeComplianceOperatorScanSettingBinding.String(), id)
 	}
 	return component.NewEvent(events...)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscansettingbindings.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscansettingbindings.go
@@ -4,6 +4,8 @@ import (
 	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/sensor/common/deduper"
+	"github.com/stackrox/rox/sensor/common/store/reconciliation"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -11,11 +13,14 @@ import (
 
 // ScanSettingBindings handles compliance operator scan setting bindings
 type ScanSettingBindings struct {
+	reconciliationStore reconciliation.Store
 }
 
 // NewScanSettingBindingsDispatcher creates and returns a new scan setting binding dispatcher
-func NewScanSettingBindingsDispatcher() *ScanSettingBindings {
-	return &ScanSettingBindings{}
+func NewScanSettingBindingsDispatcher(store reconciliation.Store) *ScanSettingBindings {
+	return &ScanSettingBindings{
+		reconciliationStore: store,
+	}
 }
 
 // ProcessEvent processes a scan setting binding event
@@ -55,6 +60,11 @@ func (c *ScanSettingBindings) ProcessEvent(obj, _ interface{}, action central.Re
 				},
 			},
 		},
+	}
+	if action == central.ResourceAction_REMOVE_RESOURCE {
+		c.reconciliationStore.Remove(deduper.TypeComplianceOperatorScanSettingBinding.String(), id)
+	} else {
+		c.reconciliationStore.Add(deduper.TypeComplianceOperatorScanSettingBinding.String(), id)
 	}
 	return component.NewEvent(events...)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/stringutils"
+	"github.com/stackrox/rox/sensor/common/deduper"
+	"github.com/stackrox/rox/sensor/common/store/reconciliation"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,13 +16,15 @@ import (
 
 // TailoredProfileDispatcher handles compliance operator tailored profile objects
 type TailoredProfileDispatcher struct {
-	profileLister cache.GenericLister
+	profileLister       cache.GenericLister
+	reconciliationStore reconciliation.Store
 }
 
 // NewTailoredProfileDispatcher creates and returns a new tailored profile dispatcher
-func NewTailoredProfileDispatcher(profileLister cache.GenericLister) *TailoredProfileDispatcher {
+func NewTailoredProfileDispatcher(store reconciliation.Store, profileLister cache.GenericLister) *TailoredProfileDispatcher {
 	return &TailoredProfileDispatcher{
-		profileLister: profileLister,
+		profileLister:       profileLister,
+		reconciliationStore: store,
 	}
 }
 
@@ -97,6 +101,11 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 				ComplianceOperatorProfile: protoProfile,
 			},
 		},
+	}
+	if action == central.ResourceAction_REMOVE_RESOURCE {
+		c.reconciliationStore.Remove(deduper.TypeComplianceOperatorProfile.String(), protoProfile.GetId())
+	} else {
+		c.reconciliationStore.Add(deduper.TypeComplianceOperatorProfile.String(), protoProfile.GetId())
 	}
 	return component.NewEvent(events...)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -105,7 +105,7 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 	if action == central.ResourceAction_REMOVE_RESOURCE {
 		c.reconciliationStore.Remove(deduper.TypeComplianceOperatorProfile.String(), protoProfile.GetId())
 	} else {
-		c.reconciliationStore.Add(deduper.TypeComplianceOperatorProfile.String(), protoProfile.GetId())
+		c.reconciliationStore.Upsert(deduper.TypeComplianceOperatorProfile.String(), protoProfile.GetId())
 	}
 	return component.NewEvent(events...)
 }

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -95,12 +95,12 @@ func NewDispatcherRegistry(
 
 		traceWriter: traceWriter,
 
-		complianceOperatorResultDispatcher:              complianceOperatorDispatchers.NewResultDispatcher(),
-		complianceOperatorRulesDispatcher:               complianceOperatorDispatchers.NewRulesDispatcher(),
-		complianceOperatorProfileDispatcher:             complianceOperatorDispatchers.NewProfileDispatcher(),
-		complianceOperatorScanSettingBindingsDispatcher: complianceOperatorDispatchers.NewScanSettingBindingsDispatcher(),
-		complianceOperatorScanDispatcher:                complianceOperatorDispatchers.NewScanDispatcher(),
-		complianceOperatorTailoredProfileDispatcher:     complianceOperatorDispatchers.NewTailoredProfileDispatcher(profileLister),
+		complianceOperatorResultDispatcher:              complianceOperatorDispatchers.NewResultDispatcher(storeProvider.reconciliationStore),
+		complianceOperatorRulesDispatcher:               complianceOperatorDispatchers.NewRulesDispatcher(storeProvider.reconciliationStore),
+		complianceOperatorProfileDispatcher:             complianceOperatorDispatchers.NewProfileDispatcher(storeProvider.reconciliationStore),
+		complianceOperatorScanSettingBindingsDispatcher: complianceOperatorDispatchers.NewScanSettingBindingsDispatcher(storeProvider.reconciliationStore),
+		complianceOperatorScanDispatcher:                complianceOperatorDispatchers.NewScanDispatcher(storeProvider.reconciliationStore),
+		complianceOperatorTailoredProfileDispatcher:     complianceOperatorDispatchers.NewTailoredProfileDispatcher(storeProvider.reconciliationStore, profileLister),
 	}
 }
 

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -182,7 +183,13 @@ func resourceToMessage(resType string, resID string) (*central.MsgFromSensor, er
 				Id:     resID,
 				Action: central.ResourceAction_REMOVE_RESOURCE,
 				Resource: &central.SensorEvent_ComplianceOperatorRule{
-					ComplianceOperatorRule: &storage.ComplianceOperatorRule{Id: resID},
+					ComplianceOperatorRule: &storage.ComplianceOperatorRule{
+						Id: resID,
+						Annotations: map[string]string{
+							// This annotation is needed, otherwise central ignores this message
+							v1alpha1.RuleIDAnnotationKey: v1alpha1.RuleIDAnnotationKey,
+						},
+					},
 				},
 			},
 		}

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/sensor/common/deduper"
 )
 
@@ -137,6 +138,73 @@ func resourceToMessage(resType string, resID string) (*central.MsgFromSensor, er
 				Action: central.ResourceAction_REMOVE_RESOURCE,
 				Resource: &central.SensorEvent_Namespace{
 					Namespace: &storage.NamespaceMetadata{Id: resID},
+				},
+			},
+		}
+		return &central.MsgFromSensor{Msg: &msg}, nil
+	case deduper.TypeComplianceOperatorProfile.String():
+		msg := central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     resID,
+				Action: central.ResourceAction_REMOVE_RESOURCE,
+				Resource: &central.SensorEvent_ComplianceOperatorProfile{
+					ComplianceOperatorProfile: &storage.ComplianceOperatorProfile{Id: resID},
+				},
+			},
+		}
+		return &central.MsgFromSensor{Msg: &msg}, nil
+	case deduper.TypeComplianceOperatorResult.String():
+		if features.ComplianceEnhancements.Enabled() {
+			msg := central.MsgFromSensor_Event{
+				Event: &central.SensorEvent{
+					Id:     resID,
+					Action: central.ResourceAction_REMOVE_RESOURCE,
+					Resource: &central.SensorEvent_ComplianceOperatorResultV2{
+						ComplianceOperatorResultV2: &central.ComplianceOperatorCheckResultV2{Id: resID},
+					},
+				},
+			}
+			return &central.MsgFromSensor{Msg: &msg}, nil
+		}
+		msg := central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     resID,
+				Action: central.ResourceAction_REMOVE_RESOURCE,
+				Resource: &central.SensorEvent_ComplianceOperatorResult{
+					ComplianceOperatorResult: &storage.ComplianceOperatorCheckResult{Id: resID},
+				},
+			},
+		}
+		return &central.MsgFromSensor{Msg: &msg}, nil
+	case deduper.TypeComplianceOperatorRule.String():
+		msg := central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     resID,
+				Action: central.ResourceAction_REMOVE_RESOURCE,
+				Resource: &central.SensorEvent_ComplianceOperatorRule{
+					ComplianceOperatorRule: &storage.ComplianceOperatorRule{Id: resID},
+				},
+			},
+		}
+		return &central.MsgFromSensor{Msg: &msg}, nil
+	case deduper.TypeComplianceOperatorScan.String():
+		msg := central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     resID,
+				Action: central.ResourceAction_REMOVE_RESOURCE,
+				Resource: &central.SensorEvent_ComplianceOperatorScan{
+					ComplianceOperatorScan: &storage.ComplianceOperatorScan{Id: resID},
+				},
+			},
+		}
+		return &central.MsgFromSensor{Msg: &msg}, nil
+	case deduper.TypeComplianceOperatorScanSettingBinding.String():
+		msg := central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     resID,
+				Action: central.ResourceAction_REMOVE_RESOURCE,
+				Resource: &central.SensorEvent_ComplianceOperatorScanSettingBinding{
+					ComplianceOperatorScanSettingBinding: &storage.ComplianceOperatorScanSettingBinding{Id: resID},
 				},
 			},
 		}

--- a/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -85,8 +86,13 @@ func (s *HashReconciliationSuite) TestResourceToMessage() {
 			expectedError: nil,
 		},
 		"ComplianceOperatorRule": {
-			resType:       deduper.TypeComplianceOperatorRule.String(),
-			expectedMsg:   &central.MsgFromSensor_Event{Event: &central.SensorEvent{Id: testResID, Action: central.ResourceAction_REMOVE_RESOURCE, Resource: &central.SensorEvent_ComplianceOperatorRule{ComplianceOperatorRule: &storage.ComplianceOperatorRule{Id: testResID}}}},
+			resType: deduper.TypeComplianceOperatorRule.String(),
+			expectedMsg: &central.MsgFromSensor_Event{Event: &central.SensorEvent{Id: testResID, Action: central.ResourceAction_REMOVE_RESOURCE, Resource: &central.SensorEvent_ComplianceOperatorRule{ComplianceOperatorRule: &storage.ComplianceOperatorRule{
+				Id: testResID,
+				Annotations: map[string]string{
+					v1alpha1.RuleIDAnnotationKey: v1alpha1.RuleIDAnnotationKey,
+				},
+			}}}},
 			expectedError: nil,
 		},
 		"ComplianceOperatorScan": {

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/deduper"
 	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/common/store"
+	"github.com/stackrox/rox/sensor/common/store/reconciliation"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
 )
@@ -32,6 +33,7 @@ type InMemoryStoreProvider struct {
 	registryStore          *registry.Store
 	registryMirrorStore    registrymirror.Store
 	nsStore                *namespaceStore
+	reconciliationStore    reconciliation.Store
 
 	cleanableStores    []CleanableStore
 	reconcilableStores map[string]reconcile.Reconcilable
@@ -64,6 +66,7 @@ func InitializeStore() *InMemoryStoreProvider {
 		registryStore:          registry.NewRegistryStore(nil),
 		registryMirrorStore:    registrymirror.NewFileStore(),
 		nsStore:                newNamespaceStore(),
+		reconciliationStore:    reconciliation.NewStore(),
 	}
 
 	p.cleanableStores = []CleanableStore{
@@ -81,15 +84,20 @@ func InitializeStore() *InMemoryStoreProvider {
 		p.nsStore,
 	}
 	p.reconcilableStores = map[string]reconcile.Reconcilable{
-		deduper.TypeDeployment.String():     p.deploymentStore,
-		deduper.TypePod.String():            p.podStore,
-		deduper.TypeServiceAccount.String(): p.serviceAccountStore,
-		deduper.TypeSecret.String():         p.registryStore,
-		deduper.TypeNode.String():           p.nodeStore,
-		deduper.TypeNetworkPolicy.String():  p.networkPolicyStore,
-		deduper.TypeRole.String():           p.rbacStore,
-		deduper.TypeBinding.String():        p.rbacStore,
-		deduper.TypeNamespace.String():      p.nsStore,
+		deduper.TypeDeployment.String():                           p.deploymentStore,
+		deduper.TypePod.String():                                  p.podStore,
+		deduper.TypeServiceAccount.String():                       p.serviceAccountStore,
+		deduper.TypeSecret.String():                               p.registryStore,
+		deduper.TypeNode.String():                                 p.nodeStore,
+		deduper.TypeNetworkPolicy.String():                        p.networkPolicyStore,
+		deduper.TypeRole.String():                                 p.rbacStore,
+		deduper.TypeBinding.String():                              p.rbacStore,
+		deduper.TypeNamespace.String():                            p.nsStore,
+		deduper.TypeComplianceOperatorProfile.String():            p.reconciliationStore,
+		deduper.TypeComplianceOperatorResult.String():             p.reconciliationStore,
+		deduper.TypeComplianceOperatorRule.String():               p.reconciliationStore,
+		deduper.TypeComplianceOperatorScan.String():               p.reconciliationStore,
+		deduper.TypeComplianceOperatorScanSettingBinding.String(): p.reconciliationStore,
 	}
 
 	return p

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -82,7 +82,13 @@ func InitializeStore() *InMemoryStoreProvider {
 		p.registryStore,
 		p.registryMirrorStore,
 		p.nsStore,
+		p.reconciliationStore,
 	}
+	p.reconciliationStore.UpsertType(deduper.TypeComplianceOperatorProfile.String())
+	p.reconciliationStore.UpsertType(deduper.TypeComplianceOperatorResult.String())
+	p.reconciliationStore.UpsertType(deduper.TypeComplianceOperatorRule.String())
+	p.reconciliationStore.UpsertType(deduper.TypeComplianceOperatorScan.String())
+	p.reconciliationStore.UpsertType(deduper.TypeComplianceOperatorScanSettingBinding.String())
 	p.reconcilableStores = map[string]reconcile.Reconcilable{
 		deduper.TypeDeployment.String():                           p.deploymentStore,
 		deduper.TypePod.String():                                  p.podStore,

--- a/sensor/kubernetes/listener/resources/store_provider_test.go
+++ b/sensor/kubernetes/listener/resources/store_provider_test.go
@@ -1,0 +1,71 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/sensor/common/deduper"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	resourceTypeA = "resource_type_A"
+	resourceTypeB = "resource_type_B"
+)
+
+type providerSuite struct {
+	suite.Suite
+	provider *InMemoryStoreProvider
+}
+
+var _ suite.SetupTestSuite = (*providerSuite)(nil)
+
+func (s *providerSuite) SetupTest() {
+	s.provider = InitializeStore()
+}
+
+func Test_StoreProvider(t *testing.T) {
+	suite.Run(t, new(providerSuite))
+}
+
+func (s *providerSuite) Test_ReconciliationStoreInitialization() {
+	testCases := map[string]struct {
+		resType       string
+		expectedError bool
+	}{
+		deduper.TypeComplianceOperatorProfile.String(): {
+			resType:       deduper.TypeComplianceOperatorProfile.String(),
+			expectedError: false,
+		},
+		deduper.TypeComplianceOperatorResult.String(): {
+			resType:       deduper.TypeComplianceOperatorResult.String(),
+			expectedError: false,
+		},
+		deduper.TypeComplianceOperatorRule.String(): {
+			resType:       deduper.TypeComplianceOperatorRule.String(),
+			expectedError: false,
+		},
+		deduper.TypeComplianceOperatorScan.String(): {
+			resType:       deduper.TypeComplianceOperatorScan.String(),
+			expectedError: false,
+		},
+		deduper.TypeComplianceOperatorScanSettingBinding.String(): {
+			resType:       deduper.TypeComplianceOperatorScanSettingBinding.String(),
+			expectedError: false,
+		},
+		"Invalid type": {
+			resType:       "Not_supported_type",
+			expectedError: true,
+		},
+	}
+	for name, tc := range testCases {
+		s.Run(name, func() {
+			_, err := s.provider.reconciliationStore.ReconcileDelete(tc.resType, "1", 1111)
+			if tc.expectedError {
+				s.Assert().Error(err)
+			} else {
+				s.Assert().NoError(err)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
## Description

Sensor was not tracking `compliance operator` resources. This PR aims to introduce a new store to track these resources and upon connection with Central, Sensor will do the reconciliation of these resources.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* [x] CI
* [x] New unit tests added
* [x] Manual
   * In an OCP cluster, install the [compliance-operator](https://docs.openshift.com/acs/operating/manage-compliance-operator/compliance-operator-rhacs.html)
   * Deploy ACS
   * Perform an scan with ACS: Compliance -> Scan environment
   * Check central-db and see that the following tables are populated:
     * compliance_operator_check_results
     * compliance_operator_profiles
     * compliance_operator_rules
     * compliance_operator_scan_setting_bindings
     * compliance_operator_scans
   * Scale down sensor
   * Delete the `compliance-operator`
   * Scale up sensor
   * The tables listed above should be empty

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
