### PR TITLE
ROX-16669: change enc notifier feature flag to match operator

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -107,7 +107,7 @@ spec:
         {{- end }}
         {{- if ._rox.central.notifierSecretsEncryption }}
         {{- if ._rox.central.notifierSecretsEncryption.enabled }}
-        - name: ROX_ENCRYPT_NOTIFIER_SECRETS
+        - name: ROX_ENC_NOTIFIER_CREDS
           value: "true"
         {{- end }}
         {{- end }}

--- a/pkg/env/notifier_secret_encryption.go
+++ b/pkg/env/notifier_secret_encryption.go
@@ -2,8 +2,8 @@ package env
 
 var (
 	// EncNotifierCreds controls if notifier creds encryption
-	EncNotifierCreds = RegisterBooleanSetting("ROX_ENCRYPT_NOTIFIER_SECRETS", false)
+	EncNotifierCreds = RegisterBooleanSetting("ROX_ENC_NOTIFIER_CREDS", false)
 
 	// CleanupNotifierCreds controls the cleanup of secrets
-	CleanupNotifierCreds = RegisterBooleanSetting("ROX_CLEANUP_NOTIFIER_SECRETS", false)
+	CleanupNotifierCreds = RegisterBooleanSetting("ROX_CLEANUP_NOTIFIER_CREDS", false)
 )

--- a/pkg/env/notifier_secret_encryption.go
+++ b/pkg/env/notifier_secret_encryption.go
@@ -2,8 +2,8 @@ package env
 
 var (
 	// EncNotifierCreds controls if notifier creds encryption
-	EncNotifierCreds = RegisterBooleanSetting("ROX_ENC_NOTIFIER_CREDS", false)
+	EncNotifierCreds = RegisterBooleanSetting("ROX_ENCRYPT_NOTIFIER_SECRETS", false)
 
 	// CleanupNotifierCreds controls the cleanup of secrets
-	CleanupNotifierCreds = RegisterBooleanSetting("ROX_CLEANUP_NOTIFIER_CREDS", false)
+	CleanupNotifierCreds = RegisterBooleanSetting("ROX_CLEANUP_NOTIFIER_SECRETS", false)
 )


### PR DESCRIPTION
## Description

We've used different feature flag names in the helm/operator changes compared to the central changes for the encryption notifier secrets feature.

This PR changes that to use what's defined in helm/operator.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
