### PR TITLE
ROX-19004: Compress Repo Mapping JSON files for Easier Communication

### DIFF
--- a/.github/workflows/repo2cpe-download.yaml
+++ b/.github/workflows/repo2cpe-download.yaml
@@ -3,9 +3,6 @@ name: Download and Upload Repository Mappings
 on:
   schedule:
     - cron: "0 0 * * *"
-  push:
-    branches:
-      - "yli3/*"
 
 jobs:
   download-and-upload:
@@ -36,7 +33,7 @@ jobs:
       run: |
         # Zip the files into mapping.zip
         zip mapping.zip repomapping-tmp/*
-        
+
         mkdir -p redhat-repository-mappings && mv mapping.zip redhat-repository-mappings/
         # Upload mapping.zip to Google Cloud Storage
         gsutil cp -r "redhat-repository-mappings" "gs://scanner-v4-test/"

--- a/.github/workflows/repo2cpe-download.yaml
+++ b/.github/workflows/repo2cpe-download.yaml
@@ -3,6 +3,9 @@ name: Download and Upload Repository Mappings
 on:
   schedule:
     - cron: "0 0 * * *"
+  push:
+    branches:
+      - "yli3/*"
 
 jobs:
   download-and-upload:
@@ -28,6 +31,9 @@ jobs:
         for f in redhat-repository-mappings/*; do
           jq empty "$f"
         done
+        
+        # Zip the files into repomapping.zip
+        zip repomapping.zip redhat-repository-mappings/*
 
     - name: Upload repository mappings to Google Cloud Storage
       run: |

--- a/.github/workflows/repo2cpe-download.yaml
+++ b/.github/workflows/repo2cpe-download.yaml
@@ -37,7 +37,7 @@ jobs:
         # Zip the files into mapping.zip
         zip mapping.zip repomapping-tmp/*
         
-        mkdir -p redhat-repository-mappings && mv repomapping.zip redhat-repository-mappings/
+        mkdir -p redhat-repository-mappings && mv mapping.zip redhat-repository-mappings/
         # Upload mapping.zip to Google Cloud Storage
         gsutil cp -r "redhat-repository-mappings" "gs://scanner-v4-test/"
 

--- a/.github/workflows/repo2cpe-download.yaml
+++ b/.github/workflows/repo2cpe-download.yaml
@@ -34,11 +34,11 @@ jobs:
 
     - name: Upload repository mappings to Google Cloud Storage
       run: |
-        # Zip the files into repomapping.zip
-        zip repomapping.zip repomapping-tmp/*
+        # Zip the files into mapping.zip
+        zip mapping.zip repomapping-tmp/*
         
         mkdir -p redhat-repository-mappings && mv repomapping.zip redhat-repository-mappings/
-        # Upload repomapping.zip to Google Cloud Storage
+        # Upload mapping.zip to Google Cloud Storage
         gsutil cp -r "redhat-repository-mappings" "gs://scanner-v4-test/"
 
     - name: Send Slack notification on workflow failure

--- a/.github/workflows/repo2cpe-download.yaml
+++ b/.github/workflows/repo2cpe-download.yaml
@@ -26,17 +26,19 @@ jobs:
     - name: Download repository mappings
       run: |
         curl --fail --silent --show-error --max-time 60 --retry 3 --create-dirs \
-          -o 'redhat-repository-mappings/#1' \
+          -o 'repomapping-tmp/#1' \
           'https://access.redhat.com/security/data/metrics/{repository-to-cpe.json,container-name-repos-map.json}'
-        for f in redhat-repository-mappings/*; do
+        for f in repomapping-tmp/*; do
           jq empty "$f"
         done
-        
-        # Zip the files into repomapping.zip
-        zip repomapping.zip redhat-repository-mappings/*
 
     - name: Upload repository mappings to Google Cloud Storage
       run: |
+        # Zip the files into repomapping.zip
+        zip repomapping.zip repomapping-tmp/*
+        
+        mkdir -p redhat-repository-mappings && mv repomapping.zip redhat-repository-mappings/
+        # Upload repomapping.zip to Google Cloud Storage
         gsutil cp -r "redhat-repository-mappings" "gs://scanner-v4-test/"
 
     - name: Send Slack notification on workflow failure


### PR DESCRIPTION
## Description

The decision to compress two json files into one is because we want make it easier for central to pull data from google bucket.
After this change, we can avoid loop call in central and potential data lost caused by rate limiting and http request failures

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
