### PR TITLE
ROX-19401: Add vuln state tabs to workload cve detail pages

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -46,6 +46,8 @@ import DeploymentVulnerabilitiesTable, {
     DeploymentWithVulnerabilities,
 } from '../Tables/DeploymentVulnerabilitiesTable';
 import { Resource } from '../components/FilterResourceDropdown';
+import VulnerabilityStateTabs from '../components/VulnerabilityStateTabs';
+import useVulnerabilityState from '../hooks/useVulnerabilityState';
 
 const summaryQuery = gql`
     ${resourceCountByCveSeverityAndStatusFragment}
@@ -79,6 +81,8 @@ export type DeploymentPageVulnerabilitiesProps = {
 };
 
 function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabilitiesProps) {
+    const currentVulnerabilityState = useVulnerabilityState();
+
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
 
@@ -96,7 +100,7 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
     const hiddenSeverities = getHiddenSeverities(querySearchFilter);
     const hiddenStatuses = getHiddenStatuses(querySearchFilter);
 
-    const query = getVulnStateScopedQueryString(querySearchFilter);
+    const query = getVulnStateScopedQueryString(querySearchFilter, currentVulnerabilityState);
 
     const summaryRequest = useQuery<
         {
@@ -163,6 +167,7 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
                 className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
                 component="div"
             >
+                <VulnerabilityStateTabs isBox />
                 <div className="pf-u-px-sm pf-u-background-color-100">
                     <WorkloadTableToolbar
                         autocompleteSearchContext={{

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -43,6 +43,8 @@ import {
 import BySeveritySummaryCard from '../SummaryCards/BySeveritySummaryCard';
 import { imageMetadataContextFragment, ImageMetadataContext } from '../Tables/table.utils';
 import { Resource } from '../components/FilterResourceDropdown';
+import VulnerabilityStateTabs from '../components/VulnerabilityStateTabs';
+import useVulnerabilityState from '../hooks/useVulnerabilityState';
 
 const imageVulnerabilitiesQuery = gql`
     ${imageMetadataContextFragment}
@@ -70,6 +72,8 @@ export type ImagePageVulnerabilitiesProps = {
 };
 
 function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
+    const currentVulnerabilityState = useVulnerabilityState();
+
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const { page, perPage, setPage, setPerPage } = useURLPagination(20);
@@ -103,7 +107,7 @@ function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
     >(imageVulnerabilitiesQuery, {
         variables: {
             id: imageId,
-            query: getVulnStateScopedQueryString(querySearchFilter),
+            query: getVulnStateScopedQueryString(querySearchFilter, currentVulnerabilityState),
             pagination,
         },
     });
@@ -208,6 +212,7 @@ function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
                 className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
                 component="div"
             >
+                <VulnerabilityStateTabs isBox />
                 <div className="pf-u-px-sm pf-u-background-color-100">
                     <WorkloadTableToolbar
                         supportedResourceFilters={imageResourceFilters}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -8,9 +8,6 @@ import {
     Card,
     CardBody,
     Button,
-    Tab,
-    TabTitleText,
-    Tabs,
 } from '@patternfly/react-core';
 import { useApolloClient, useQuery } from '@apollo/client';
 
@@ -22,7 +19,6 @@ import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import usePermissions from 'hooks/usePermissions';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useAnalytics, { WATCH_IMAGE_MODAL_OPENED } from 'hooks/useAnalytics';
-import { vulnerabilityStates } from 'types/cve.proto';
 import { VulnMgmtLocalStorage, entityTabValues } from '../types';
 import { parseQuerySearchFilter, getVulnStateScopedQueryString } from '../searchUtils';
 import { entityTypeCountsQuery } from '../components/EntityTypeToggleGroup';
@@ -31,6 +27,8 @@ import DeploymentsTableContainer from './DeploymentsTableContainer';
 import ImagesTableContainer, { imageListQuery } from './ImagesTableContainer';
 import WatchedImagesModal from '../WatchedImages/WatchedImagesModal';
 import UnwatchImageModal from '../WatchedImages/UnwatchImageModal';
+import VulnerabilityStateTabs from '../components/VulnerabilityStateTabs';
+import useVulnerabilityState from '../hooks/useVulnerabilityState';
 
 const emptyStorage: VulnMgmtLocalStorage = {
     preferences: {
@@ -51,11 +49,7 @@ function WorkloadCvesOverviewPage() {
 
     const { analyticsTrack } = useAnalytics();
 
-    const [vulnerabilityStateKey, setVulnerabilityStateKey] = useURLStringUnion(
-        'vulnerabilityState',
-        vulnerabilityStates
-    );
-    const currentVulnerabilityState = isUnifiedDeferralsEnabled ? vulnerabilityStateKey : undefined;
+    const currentVulnerabilityState = useVulnerabilityState();
 
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
@@ -80,10 +74,6 @@ function WorkloadCvesOverviewPage() {
 
     function onWatchedImagesChange() {
         return apolloClient.refetchQueries({ include: [imageListQuery] });
-    }
-
-    function handleTabClick(e, tab) {
-        setVulnerabilityStateKey(tab);
     }
 
     return (
@@ -117,24 +107,13 @@ function WorkloadCvesOverviewPage() {
                 )}
             </PageSection>
             <PageSection padding={{ default: 'noPadding' }}>
-                {isUnifiedDeferralsEnabled && (
-                    <Tabs
-                        activeKey={vulnerabilityStateKey}
-                        onSelect={handleTabClick}
-                        component="nav"
-                        className="pf-u-pl-lg pf-u-background-color-100"
-                    >
-                        <Tab
-                            eventKey="OBSERVED"
-                            title={<TabTitleText>Observed CVEs</TabTitleText>}
-                        />
-                        <Tab eventKey="DEFERRED" title={<TabTitleText>Deferrals</TabTitleText>} />
-                        <Tab
-                            eventKey="FALSE_POSITIVE"
-                            title={<TabTitleText>False positives</TabTitleText>}
-                        />
-                    </Tabs>
-                )}
+                <PageSection
+                    padding={{ default: 'noPadding' }}
+                    component="div"
+                    className="pf-u-pl-lg pf-u-background-color-100"
+                >
+                    <VulnerabilityStateTabs />
+                </PageSection>
                 <PageSection isCenterAligned>
                     <Card>
                         <CardBody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionScopeField.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionScopeField.tsx
@@ -44,7 +44,7 @@ function ExceptionScopeField({ fieldId, label, scopeContext, formik }: Exception
                             values.scope.imageScope.tag === ALL
                         }
                         onChange={() => {}}
-                        label={`All tags within ${scopeContext.image.name}}`}
+                        label={`All tags within ${scopeContext.image.name}`}
                     />
                     <Radio
                         id="scope-single-image-single-tag"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VulnerabilityStateTabs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VulnerabilityStateTabs.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Tabs, Tab, TabTitleText, TabsProps } from '@patternfly/react-core';
+
+import { vulnerabilityStates } from 'types/cve.proto';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import useURLStringUnion from 'hooks/useURLStringUnion';
+
+export type VulnerabilityStateTabsProps = {
+    isBox?: TabsProps['isBox'];
+    titleOverrides?: {
+        observed?: string;
+        deferred?: string;
+        falsePositive?: string;
+    };
+};
+
+function VulnerabilityStateTabs({ titleOverrides, isBox = false }: VulnerabilityStateTabsProps) {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isUnifiedDeferralsEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL');
+    const [vulnerabilityStateKey, setVulnerabilityStateKey] = useURLStringUnion(
+        'vulnerabilityState',
+        vulnerabilityStates
+    );
+
+    return isUnifiedDeferralsEnabled ? (
+        <Tabs
+            activeKey={vulnerabilityStateKey}
+            onSelect={(_e, tab) => setVulnerabilityStateKey(tab)}
+            component="nav"
+            isBox={isBox}
+        >
+            <Tab
+                eventKey="OBSERVED"
+                title={<TabTitleText>{titleOverrides?.observed ?? 'Observed'}</TabTitleText>}
+            />
+            <Tab
+                eventKey="DEFERRED"
+                title={<TabTitleText>{titleOverrides?.deferred ?? 'Deferred'}</TabTitleText>}
+            />
+            <Tab
+                eventKey="FALSE_POSITIVE"
+                title={
+                    <TabTitleText>
+                        {titleOverrides?.falsePositive ?? 'False positives'}
+                    </TabTitleText>
+                }
+            />
+        </Tabs>
+    ) : null;
+}
+
+export default VulnerabilityStateTabs;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useVulnerabilityState.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useVulnerabilityState.ts
@@ -1,0 +1,11 @@
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import useURLStringUnion from 'hooks/useURLStringUnion';
+import { vulnerabilityStates } from 'types/cve.proto';
+
+export default function useVulnerabilityState() {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isUnifiedDeferralsEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL');
+    const [vulnerabilityStateKey] = useURLStringUnion('vulnerabilityState', vulnerabilityStates);
+
+    return isUnifiedDeferralsEnabled ? vulnerabilityStateKey : undefined;
+}


### PR DESCRIPTION
## Description

Splits all sections in Workload CVEs by CVE vulnerability state via tabs.

## Follow ups

When viewing a deferred/FP tab, links to other pages do not persist the vulnerability state. e.g. Viewing deferred CVEs, then clicking a CVE name takes you to the _Observed (Workload)_ tab for that single CVE.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Create and approve a deferral and false positive via the VM 1.0 flow:
![image](https://github.com/stackrox/stackrox/assets/1292638/c38221c8-a90c-4897-89aa-5671b41a2fab)
![image](https://github.com/stackrox/stackrox/assets/1292638/4aec1b74-f859-476d-a53c-d9f060f7f4b0)

Verify that CVEs that have an exception for only _some_ images are still visible on the Observed tab:
![image](https://github.com/stackrox/stackrox/assets/1292638/1596a837-9010-441b-ba54-fecedc0a7f58)

Verify that CVEs that have an exception for _all_ images are not visible on the Observed tab:
![image](https://github.com/stackrox/stackrox/assets/1292638/d11cf846-7b94-4239-8e5a-4fd74ff8b8c4)

Verify Deferrals:
![image](https://github.com/stackrox/stackrox/assets/1292638/2e08f21c-03e8-4b64-978b-e106c5f52527)

Verify False Positives:
![image](https://github.com/stackrox/stackrox/assets/1292638/4839bfab-fbf6-4f27-a13d-3d72f47f6fd5)

CVE Single page for a fully deferred CVE:
![image](https://github.com/stackrox/stackrox/assets/1292638/730750d6-81c2-44bb-aeca-11f44cdad6b5)
![image](https://github.com/stackrox/stackrox/assets/1292638/ae7a13ff-89d3-4d35-aad8-bea1a145b4d2)
![image](https://github.com/stackrox/stackrox/assets/1292638/31debf30-290b-4f89-b963-72531a011769)

CVE Single page for a partially FP'd CVE:
![image](https://github.com/stackrox/stackrox/assets/1292638/d0744620-9bf8-4fff-a83c-0b8a3723b238)
![image](https://github.com/stackrox/stackrox/assets/1292638/9bf6c4d5-4759-459e-8e3c-c06886d22588)
![image](https://github.com/stackrox/stackrox/assets/1292638/d9583ea0-18e2-4bbe-aac5-ea80ce03b624)

Image single page for an image with an approved deferral:
![image](https://github.com/stackrox/stackrox/assets/1292638/567ce2c9-1b09-449d-a7e1-50c5f383aee9)
![image](https://github.com/stackrox/stackrox/assets/1292638/8075b01b-ffd5-4526-894d-17cd6d199d13)


Image single page for an image with an approved FP:
![image](https://github.com/stackrox/stackrox/assets/1292638/d76e97cd-c1b9-4b2a-958c-273dab618ffb)
![image](https://github.com/stackrox/stackrox/assets/1292638/b1a74172-23c9-4625-84ff-600b92dccc59)

Deployment single deferred:
![image](https://github.com/stackrox/stackrox/assets/1292638/75a7e944-ba88-4da2-99d1-16548d683120)
![image](https://github.com/stackrox/stackrox/assets/1292638/b78ba2d1-afd9-47ac-9c85-d592a424edf9)

Deployment single false positive:
![image](https://github.com/stackrox/stackrox/assets/1292638/ad7086a6-36f2-48ef-bc02-fd406c0f50fb)
![image](https://github.com/stackrox/stackrox/assets/1292638/c3df473b-b456-449c-82a0-f20a666351e2)
