### PR TITLE
fix(bug): Stop V1 reports service only if flag is off

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -874,11 +874,12 @@ func waitForTerminationSignal() {
 		{centralclient.InstanceConfig().Telemeter(), "telemetry client"},
 		{administrationUsageInjector.Singleton(), "administration usage injector"},
 		{obj: apiTokenExpiration.Singleton(), name: "api token expiration notifier"},
-		{vulnReportScheduleManager.Singleton(), "vuln reports v1 schedule manager"},
 	}
 
 	if features.VulnReportingEnhancements.Enabled() {
 		stoppables = append(stoppables, stoppableWithName{vulnReportV2Scheduler.Singleton(), "vuln reports v2 scheduler"})
+	} else {
+		stoppables = append(stoppables, stoppableWithName{vulnReportScheduleManager.Singleton(), "vuln reports v1 schedule manager"})
 	}
 
 	if features.AdministrationEvents.Enabled() {


### PR DESCRIPTION
## Description

It's only started if the flag is off, so stopping will fail

## Checklist
- [ ] Investigated and inspected CI test results
~[ ] Unit test and regression tests added~
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~
~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Manually. Deployed with feature flag on, and killed central. It stopped only v2 service and it terminated in an appropriate amount of time. Deployed with it off, and repeated test. It only stopped v1 service and also terminated in an appropriate amount of time.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
