### PR TITLE
fix: ctx handling in ProcessTelemetryDataResponse

### DIFF
--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -250,7 +250,7 @@ func (c *sensorConnection) handleMessage(ctx context.Context, msg *central.MsgFr
 	case *central.MsgFromSensor_NetworkPoliciesResponse:
 		return c.networkPoliciesCtrl.ProcessNetworkPoliciesResponse(m.NetworkPoliciesResponse)
 	case *central.MsgFromSensor_TelemetryDataResponse:
-		return c.telemetryCtrl.ProcessTelemetryDataResponse(m.TelemetryDataResponse)
+		return c.telemetryCtrl.ProcessTelemetryDataResponse(ctx, m.TelemetryDataResponse)
 	case *central.MsgFromSensor_IssueLocalScannerCertsRequest:
 		return c.processIssueLocalScannerCertsRequest(ctx, m.IssueLocalScannerCertsRequest)
 	case *central.MsgFromSensor_ComplianceResponse:

--- a/central/sensor/telemetry/controller.go
+++ b/central/sensor/telemetry/controller.go
@@ -25,7 +25,7 @@ type Controller interface {
 	PullKubernetesInfo(ctx context.Context, cb KubernetesInfoChunkCallback, since time.Time) error
 	PullClusterInfo(ctx context.Context, cb ClusterInfoCallback) error
 	PullMetrics(ctx context.Context, cb MetricsInfoChunkCallback) error
-	ProcessTelemetryDataResponse(resp *central.PullTelemetryDataResponse) error
+	ProcessTelemetryDataResponse(ctx context.Context, resp *central.PullTelemetryDataResponse) error
 }
 
 // NewController creates and returns a new controller for telemetry data.


### PR DESCRIPTION
## Description

Should cancel when `ctx` is done.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

1. CI is sufficient

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
