### PR TITLE
ROX-20351: Add separator as a type of child in NavigationSidebar

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { matchPath, useLocation } from 'react-router-dom';
-import { Nav, NavExpandable, NavList, PageSidebar } from '@patternfly/react-core';
+import { Nav, NavExpandable, NavItemSeparator, NavList, PageSidebar } from '@patternfly/react-core';
 
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import { HasReadAccess } from 'hooks/usePermissions';
@@ -18,6 +18,7 @@ import {
     configManagementPath,
     dashboardPath,
     exceptionConfigurationPath,
+    exceptionManagementPath,
     integrationsPath,
     isRouteEnabled, // predicate function
     listeningEndpointsBasePath,
@@ -32,7 +33,6 @@ import {
     vulnManagementRiskAcceptancePath,
     vulnerabilitiesWorkloadCvesPath,
     vulnerabilityReportsPath,
-    exceptionManagementPath,
 } from 'routePaths';
 
 import NavigationContent from './NavigationContent';
@@ -53,8 +53,8 @@ const keyForVulnerabilityManagement2 = 'Vulnerability Management (2.0)';
 const keyForCompliance2 = 'Compliance (2.0)';
 type IsActiveCallback = (pathname: string) => boolean;
 
-type ChildDescription = {
-    type: 'child';
+type LinkDescription = {
+    type: 'link';
     content: string | TitleCallback | ReactElement;
     path: string;
     routeKey: RouteKey;
@@ -62,9 +62,16 @@ type ChildDescription = {
 };
 
 // Encapsulate whether path match for child is specific or generic.
-function isActiveChild(pathname: string, { isActive, path }: ChildDescription) {
+function isActiveLink(pathname: string, { isActive, path }: LinkDescription) {
     return typeof isActive === 'function' ? isActive(pathname) : Boolean(matchPath(pathname, path));
 }
+
+type SeparatorDescription = {
+    type: 'separator';
+    key: string; // corresponds to React key prop
+};
+
+type ChildDescription = LinkDescription | SeparatorDescription;
 
 type ParentDescription = {
     type: 'parent';
@@ -73,11 +80,11 @@ type ParentDescription = {
     children: ChildDescription[];
 };
 
-type NavDescription = ChildDescription | ParentDescription;
+type NavDescription = LinkDescription | ParentDescription;
 
 const navDescriptions: NavDescription[] = [
     {
-        type: 'child',
+        type: 'link',
         content: 'Dashboard',
         path: dashboardPath,
         routeKey: 'dashboard',
@@ -88,13 +95,13 @@ const navDescriptions: NavDescription[] = [
         key: keyForNetwork,
         children: [
             {
-                type: 'child',
+                type: 'link',
                 content: 'Network Graph',
                 path: networkBasePath,
                 routeKey: 'network-graph',
             },
             {
-                type: 'child',
+                type: 'link',
                 content: 'Listening Endpoints',
                 path: listeningEndpointsBasePath,
                 routeKey: 'listening-endpoints',
@@ -102,7 +109,7 @@ const navDescriptions: NavDescription[] = [
         ],
     },
     {
-        type: 'child',
+        type: 'link',
         content: 'Violations',
         path: violationsBasePath,
         routeKey: 'violations',
@@ -112,20 +119,20 @@ const navDescriptions: NavDescription[] = [
         title: (navDescriptionsFiltered) =>
             navDescriptionsFiltered.some(
                 (navDescription) =>
-                    navDescription.type === 'child' && navDescription.routeKey === 'compliance'
+                    navDescription.type === 'link' && navDescription.routeKey === 'compliance'
             )
                 ? 'Compliance (2.0)'
                 : 'Compliance',
         key: keyForCompliance2,
         children: [
             {
-                type: 'child',
+                type: 'link',
                 content: 'Compliance Status',
                 path: complianceEnhancedStatusPath,
                 routeKey: 'compliance-enhanced',
             },
             {
-                type: 'child',
+                type: 'link',
                 content: 'Scheduling',
                 path: complianceEnhancedScanConfigsBasePath,
                 routeKey: 'compliance-enhanced',
@@ -133,7 +140,7 @@ const navDescriptions: NavDescription[] = [
         ],
     },
     {
-        type: 'child',
+        type: 'link',
         content: (navDescriptionsFiltered) =>
             navDescriptionsFiltered.some(
                 (navDescription) =>
@@ -157,19 +164,23 @@ const navDescriptions: NavDescription[] = [
         key: keyForVulnerabilityManagement2,
         children: [
             {
-                type: 'child',
+                type: 'link',
                 content: <NavigationContent variant="TechPreview">Workload CVEs</NavigationContent>,
                 path: vulnerabilitiesWorkloadCvesPath,
                 routeKey: 'workload-cves',
             },
             {
-                type: 'child',
+                type: 'separator',
+                key: 'following-cves',
+            },
+            {
+                type: 'link',
                 content: 'Exception Management',
                 path: exceptionManagementPath,
                 routeKey: 'exception-management',
             },
             {
-                type: 'child',
+                type: 'link',
                 content: 'Vulnerability Reporting',
                 path: vulnerabilityReportsPath,
                 routeKey: 'vulnerabilities/reports',
@@ -189,7 +200,7 @@ const navDescriptions: NavDescription[] = [
                 : 'Vulnerability Management',
         children: [
             {
-                type: 'child',
+                type: 'link',
                 content: 'Dashboard',
                 path: vulnManagementPath,
                 routeKey: 'vulnerability-management',
@@ -197,13 +208,13 @@ const navDescriptions: NavDescription[] = [
                     Boolean(matchPath(pathname, { vulnManagementPath, exact: true })),
             },
             {
-                type: 'child',
+                type: 'link',
                 content: 'Risk Acceptance',
                 path: vulnManagementRiskAcceptancePath,
                 routeKey: 'vulnerability-management/risk-acceptance',
             },
             {
-                type: 'child',
+                type: 'link',
                 content: 'Reporting',
                 path: vulnManagementReportsPath,
                 routeKey: 'vulnerability-management/reports',
@@ -211,13 +222,13 @@ const navDescriptions: NavDescription[] = [
         ],
     },
     {
-        type: 'child',
+        type: 'link',
         content: 'Configuration Management',
         path: configManagementPath,
         routeKey: 'configmanagement',
     },
     {
-        type: 'child',
+        type: 'link',
         content: 'Risk',
         path: riskBasePath,
         routeKey: 'risk',
@@ -228,55 +239,55 @@ const navDescriptions: NavDescription[] = [
         title: keyForPlatformConfiguration,
         children: [
             {
-                type: 'child',
+                type: 'link',
                 content: 'Clusters',
                 path: clustersBasePath,
                 routeKey: 'clusters',
             },
             {
-                type: 'child',
+                type: 'link',
                 content: 'Policy Management',
                 path: policyManagementBasePath,
                 routeKey: 'policy-management',
             },
             {
-                type: 'child',
+                type: 'link',
                 content: 'Collections',
                 path: collectionsBasePath,
                 routeKey: 'collections',
             },
             {
-                type: 'child',
+                type: 'link',
                 content: 'Integrations',
                 path: integrationsPath,
                 routeKey: 'integrations',
             },
             {
-                type: 'child',
+                type: 'link',
                 content: 'Exception Configuration',
                 path: exceptionConfigurationPath,
                 routeKey: 'exception-configuration',
             },
             {
-                type: 'child',
+                type: 'link',
                 content: 'Access Control',
                 path: accessControlBasePath,
                 routeKey: 'access-control',
             },
             {
-                type: 'child',
+                type: 'link',
                 content: 'System Configuration',
                 path: systemConfigPath,
                 routeKey: 'systemconfig',
             },
             {
-                type: 'child',
+                type: 'link',
                 content: 'Administration Events',
                 path: administrationEventsBasePath,
                 routeKey: 'administration-events',
             },
             {
-                type: 'child',
+                type: 'link',
                 content: 'System Health',
                 path: systemHealthPath,
                 routeKey: 'system-health',
@@ -296,6 +307,24 @@ function NavigationSidebar({
 }: NavigationSidebarProps): ReactElement {
     const { pathname } = useLocation();
     const routePredicates = { hasReadAccess, isFeatureFlagEnabled };
+
+    function isChildLinkEnabled(childDescription: ChildDescription) {
+        return childDescription.type === 'link'
+            ? isRouteEnabled(routePredicates, childDescription.routeKey)
+            : true;
+    }
+
+    function isChildSeparatorRelevant(
+        childDescription: ChildDescription,
+        index: number,
+        array: ChildDescription[]
+    ) {
+        // A separator is relevant if it is preceded and followed by a link whose route is enabled.
+        return childDescription.type === 'separator'
+            ? index !== 0 && index !== array.length - 1 && array[index + 1].type === 'link'
+            : true;
+    }
+
     const navDescriptionsFiltered = navDescriptions
         .map((navDescription) => {
             switch (navDescription.type) {
@@ -303,9 +332,9 @@ function NavigationSidebar({
                     // Filter second-level children.
                     return {
                         ...navDescription,
-                        children: navDescription.children.filter(({ routeKey }) =>
-                            isRouteEnabled(routePredicates, routeKey)
-                        ),
+                        children: navDescription.children
+                            .filter(isChildLinkEnabled)
+                            .filter(isChildSeparatorRelevant),
                     };
                 }
                 default: {
@@ -336,8 +365,10 @@ function NavigationSidebar({
                             // when another child elsewhere becomes active.
                             // This depends on generic matchPath instead of specific isActive callback,
                             // otherwise Vulnerability Management closes for classic pages other than Dashboard.
-                            const hasChildMatchPath = children.some(({ path }) =>
-                                Boolean(matchPath(pathname, path))
+                            const hasChildMatchPath = children.some(
+                                (childDescription) =>
+                                    childDescription.type === 'link' &&
+                                    Boolean(matchPath(pathname, childDescription.path))
                             );
                             return (
                                 <NavExpandable
@@ -351,19 +382,25 @@ function NavigationSidebar({
                                     }
                                 >
                                     {navDescription.children.map((childDescription) => {
-                                        const { content, path } = childDescription;
-                                        return (
-                                            <NavigationItem
-                                                key={path}
-                                                isActive={isActiveChild(pathname, childDescription)}
-                                                path={path}
-                                                content={
-                                                    typeof content === 'function'
-                                                        ? content(navDescriptionsFiltered)
-                                                        : content
-                                                }
-                                            />
-                                        );
+                                        if (childDescription.type === 'link') {
+                                            const { content, path } = childDescription;
+                                            return (
+                                                <NavigationItem
+                                                    key={path}
+                                                    isActive={isActiveLink(
+                                                        pathname,
+                                                        childDescription
+                                                    )}
+                                                    path={path}
+                                                    content={
+                                                        typeof content === 'function'
+                                                            ? content(navDescriptionsFiltered)
+                                                            : content
+                                                    }
+                                                />
+                                            );
+                                        }
+                                        return <NavItemSeparator key={childDescription.key} />;
                                     })}
                                 </NavExpandable>
                             );
@@ -373,7 +410,7 @@ function NavigationSidebar({
                             return (
                                 <NavigationItem
                                     key={path}
-                                    isActive={isActiveChild(pathname, navDescription)}
+                                    isActive={isActiveLink(pathname, navDescription)}
                                     path={path}
                                     content={
                                         typeof content === 'function'


### PR DESCRIPTION
## Description

Related to access control because conditional rendering of separator depends whether links have enabled routes.

1. Generalize child items.
    * Replace `ChildDescription` and `type: 'child'` with `LinkDescription` type and `type: 'link'` prop.
    * Add `SeparatorDescription` type and `type: 'separator'` prop.
2. Filter second-level children.
    * Factor out `isChildLinkEnabled` callback function.
    * Add `isChildSeparatorRelevant` callback function.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

| link                    | featureFlagRequirements              |
| :---                    | :---                                 |
| Workload CVEs           | ROX_VULN_MGMT_WORKLOAD_CVES          |
| Exception Management    | ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL   |
| Vulnerability Reporting | ROX_VULN_MGMT_REPORTING_ENHANCEMENTS |

1. Visit /main/dashboard and click to expand **Vulnerability Management 2.0** in navigation sidebar.

    * With ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL and ROX_VULN_MGMT_REPORTING_ENHANCEMENTS.
        See presence of separator because link preceding and following.
        See absence of warnings about absence of `key` prop (pardon double negative).
        ![presence_2](https://github.com/stackrox/stackrox/assets/11862657/6348c1e7-2c24-414a-8a13-3761b52e9f0e)

    * Without ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL and with ROX_VULN_MGMT_REPORTING_ENHANCEMENTS.
        Ditto.
        ![presence_1](https://github.com/stackrox/stackrox/assets/11862657/234e8493-83ef-4dd5-acd8-e55d616bb2f7)

    * Without ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL nor ROX_VULN_MGMT_REPORTING_ENHANCEMENTS.
        See absence of separator because both `index !== 0` and `index !== array.length - 1` conditions.
        ![absence](https://github.com/stackrox/stackrox/assets/11862657/ee2dd51b-abab-49f4-b6fc-35900c4e44b5)
