### PR TITLE
fix(perf): Dedupe component risk upserts

### DIFF
--- a/central/risk/manager/manager.go
+++ b/central/risk/manager/manager.go
@@ -242,13 +242,13 @@ func (e *managerImpl) reprocessImageComponentRisk(imageComponent *storage.Embedd
 	oldScore := e.imageComponentRanker.GetScoreForID(
 		scancomponent.ComponentID(imageComponent.GetName(), imageComponent.GetVersion(), os))
 
-	// Image risk results are not currently used so if the score is the same then no need to upsert
-	if oldScore == risk.GetScore() {
+	// Image component risk results are currently unused so if the score is the same then no need to upsert
+	if risk.GetScore() == oldScore {
 		return
 	}
 
 	if err := e.riskStorage.UpsertRisk(riskReprocessorCtx, risk); err != nil {
-		log.Errorf("Error reprocessing risk for image component %s v%s: %v", imageComponent.GetName(), imageComponent.GetVersion(), err)
+		log.Errorf("Error reprocessing risk for image component %s %s: %v", imageComponent.GetName(), imageComponent.GetVersion(), err)
 	}
 
 	imageComponent.RiskScore = risk.Score
@@ -268,13 +268,13 @@ func (e *managerImpl) reprocessNodeComponentRisk(nodeComponent *storage.Embedded
 	oldScore := e.nodeComponentRanker.GetScoreForID(
 		scancomponent.ComponentID(nodeComponent.GetName(), nodeComponent.GetVersion(), os))
 
-	// Node risk results are not currently used so if the score is the same then no need to upsert
-	if oldScore == risk.GetScore() {
+	// Node component risk results are not currently used so if the score is the same then no need to upsert
+	if risk.GetScore() == oldScore {
 		return
 	}
 
 	if err := e.riskStorage.UpsertRisk(riskReprocessorCtx, risk); err != nil {
-		log.Errorf("Error reprocessing risk for node component %s v%s: %v", nodeComponent.GetName(), nodeComponent.GetVersion(), err)
+		log.Errorf("Error reprocessing risk for node component %s %s: %v", nodeComponent.GetName(), nodeComponent.GetVersion(), err)
 	}
 
 	nodeComponent.RiskScore = risk.Score


### PR DESCRIPTION
## Description

Image and component risk factors are not actually used currently so only insert the values if the score has changed, which will reduce the number of writes on the database

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Scale test + comparison of QA metrics

Before 

cat stackrox_debug_2023_10_24_06_48_08/metrics-1 | grep postgres_op_duration_count | grep Risk
rox_central_postgres_op_duration_count{Operation="Get",Type="Risk"} 21616
rox_central_postgres_op_duration_count{Operation="Remove",Type="Risk"} 3842
rox_central_postgres_op_duration_count{Operation="Upsert",Type="Risk"} 10811

After:
cat stackrox_debug_2023_10_24_17_43_27/metrics-1 | grep postgres_op_duration_count | grep Risk
rox_central_postgres_op_duration_count{Operation="Get",Type="Risk"} 21136
rox_central_postgres_op_duration_count{Operation="Remove",Type="Risk"} 3711
rox_central_postgres_op_duration_count{Operation="Upsert",Type="Risk"} 5615

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
