### PR TITLE
ROX-20394: Separate administration events filters

### DIFF
--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsToolbar.tsx
@@ -73,6 +73,8 @@ function AdministrationEventsToolbar({
                             setDomain={setDomain}
                         />
                     </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarGroup variant="filter-group">
                     <ToolbarItem>
                         <SearchFilterResourceType
                             isDisabled={isDisabled}
@@ -80,6 +82,8 @@ function AdministrationEventsToolbar({
                             setResourceType={setResourceType}
                         />
                     </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarGroup variant="filter-group">
                     <ToolbarItem>
                         <SearchFilterLevel
                             isDisabled={isDisabled}


### PR DESCRIPTION
## Description

Change request from Mansur to separate toolbar filters similar to Workload CVEs:
![workload-cves](https://github.com/stackrox/stackrox/assets/11862657/e1376eb7-e18d-4014-8497-df0f13b0856c)

Although PatternFly guidelines have one `ToolbarGroup` elements for multiple search filter items:
https://www.patternfly.org/components/toolbar/design-guidelines#filter-group

One group per item is a way to separate items visually:
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx#L87-L90

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Visit /main/administration-events

    * Original without spacing between search filter items
        ![Group_for_all_items](https://github.com/stackrox/stackrox/assets/11862657/64e55dc0-389f-4717-94a2-c44981fce874)

    * Improved with spacing between search filter items
        ![Group_for_each_Item](https://github.com/stackrox/stackrox/assets/11862657/f4d421a8-15b4-4fee-b6bc-4e8aaf9bf188)

### Integration testing

* administration/events/eventsTable.test.js
