### PR TITLE
ROX-20356: Add conditional RBAC for Baseline tab in Network Graph

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -61,6 +61,7 @@ function DeploymentSideBar({
 }: DeploymentSideBarProps) {
     // component state
     const { hasReadAccess } = usePermissions();
+    const hasReadAccessForDeploymentExtension = hasReadAccess('DeploymentExtension');
     const hasReadAccessForNetworkPolicy = hasReadAccess('NetworkPolicy');
     const { deployment, isLoading: isLoadingDeployment, error } = useFetchDeployment(deploymentId);
     const { activeKeyTab, onSelectTab, setActiveKeyTab } = useTabs({
@@ -177,11 +178,13 @@ function DeploymentSideBar({
                                 title={<TabTitleText>{deploymentTabs.FLOWS}</TabTitleText>}
                                 disabled={isBaselineSimulationOn}
                             />
-                            <Tab
-                                eventKey={deploymentTabs.BASELINE}
-                                tabContentId={deploymentTabs.BASELINE}
-                                title={<TabTitleText>{deploymentTabs.BASELINE}</TabTitleText>}
-                            />
+                            {hasReadAccessForDeploymentExtension && (
+                                <Tab
+                                    eventKey={deploymentTabs.BASELINE}
+                                    tabContentId={deploymentTabs.BASELINE}
+                                    title={<TabTitleText>{deploymentTabs.BASELINE}</TabTitleText>}
+                                />
+                            )}
                             {hasReadAccessForNetworkPolicy && (
                                 <Tab
                                     eventKey={deploymentTabs.NETWORK_POLICIES}


### PR DESCRIPTION
## Description

### Problem

Follow up #7909

After we reduced resource access requirements for Network Graph:
* If user role does not have DeploymentExtension resource:
* **Baseline** tab of deployment side panel makes request that has 403 Forbidden status.
    GET /v1/networkbaseline/id

### Analysis

DeploymentExtension
* DeploymentSideBar.tsx file renders tabs and DeploymentBaseline.tsx file encapsulates request.
* It selects **Baseline** tab and disables other tabs if baseline simulation mode is on.
* However, BaselineSimulationButton is an orphan component. So, apparent deadlock in rendering is double theoretical.

### Solution

Add conditional rendering.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js: 0 = 3911320 - 3911320
        total: 30 = 10187138 - 10187108
    * `ls -al build/static/js/*.js | wc -l`
        0 = 85 - 85 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/network-graph, select **stackrox** namespace, and then click **admission-control** deployment with temporary code change to simulate NO_ACCESS for DeploymentExtension resource:
    * See absence of **Baseline** tab.
    * See requests:
        GET /v1/deployments/79a4b2ef-660f-42fc-8c14-5852218b22cb
        GET /v1/networkpolicies/5394fd57-1531-416a-9677-b739121356ed
        ![Sidebar_without_request](https://github.com/stackrox/stackrox/assets/11862657/1048b948-ebdb-4b10-9b20-05ac86ba9de8)

2. Remove temporary code change.
    * See presence of **Baseline** tab.

3. Click **Baseline** tab.
    * See request:
        GET /v1/networkbaseline/79a4b2ef-660f-42fc-8c14-5852218b22cb
        ![Baseline_with_request](https://github.com/stackrox/stackrox/assets/11862657/0ebfcad8-e86d-4757-adf6-54ab75e2925e)

### Integration testing

* networkGraph/networkDeploymentSidebar.test.js
* networkGraph/networkGraph.test.js
