### PR TITLE
fix: remove logging of closed nonexistent plops

### DIFF
--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -170,11 +170,6 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 		}
 
 		if !prevExists {
-			if val.CloseTimestamp != nil {
-				// We try to close a not existing Endpoint, something is wrong
-				log.Warnf("Found no matching PLOP to close for %+v", plopToNoSecretsString(val))
-			}
-
 			plopObjects = addNewPLOP(plopObjects, indicatorID, processInfo, val)
 		}
 	}


### PR DESCRIPTION
## Description

Previously cases in which central received a message for a closed listening endpoint for which there was no existing open record were logged. However, now that listening endpoints are deleted when pods are deleted, this is a common occurrence and does not need to be logged.

## Checklist
- [ ] Investigated and inspected CI test results

If any of these don't apply, please comment below.

This just removes one logging statement.

## Testing Performed

This just removes one logging statement.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
