### PR TITLE
fix(scanner): set default scanner config

### DIFF
--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -40,7 +40,7 @@ type Backends struct {
 }
 
 func main() {
-	configPath := flag.String("conf", "", "Path to scanner's configuration file.")
+	configPath := flag.String("conf", "/etc/scanner/config.yaml", "Path to scanner's configuration file.")
 	flag.Parse()
 	cfg, err := config.Read(*configPath)
 	if err != nil {


### PR DESCRIPTION
## Description

Sets a default ScannerV4 config file path.

The path used is what the current helm deployments expect.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

TBD

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
