### PR TITLE
ci: Fix "Help menu API Reference" UI test

### DIFF
--- a/ui/apps/platform/cypress/integration/main/HelpMenu.test.js
+++ b/ui/apps/platform/cypress/integration/main/HelpMenu.test.js
@@ -21,14 +21,15 @@ const routeMatcherMapForMetadata = {
 describe('Help menu API Reference', () => {
     withAuth();
 
-    const title = 'API Reference (v1)';
+    const button = 'API Reference (v1)';
+    const title = 'API Reference';
 
     it('should visit via menu on top nav', () => {
         visitMainDashboard();
 
         interactAndWaitForResponses(() => {
             cy.get('button[aria-label="Help menu"]').click();
-            cy.get(`a:contains("${title}")`).click();
+            cy.get(`a:contains("${button}")`).click();
         }, routeMatcherMapForReference);
 
         cy.location('pathname').should('eq', apiReferencePath);

--- a/ui/apps/platform/cypress/integration/main/HelpMenu.test.js
+++ b/ui/apps/platform/cypress/integration/main/HelpMenu.test.js
@@ -21,7 +21,7 @@ const routeMatcherMapForMetadata = {
 describe('Help menu API Reference', () => {
     withAuth();
 
-    const title = 'API Reference';
+    const title = 'API Reference (v1)';
 
     it('should visit via menu on top nav', () => {
         visitMainDashboard();


### PR DESCRIPTION
## Description

Help menu API Reference UI test started failing after merging PR #8305 

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI is enough

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
