### PR TITLE
fix(sensor-startup): Do not panic if listener was stopped by Sensor

### DIFF
--- a/sensor/kubernetes/listener/resources/store_provider_test.go
+++ b/sensor/kubernetes/listener/resources/store_provider_test.go
@@ -7,11 +7,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const (
-	resourceTypeA = "resource_type_A"
-	resourceTypeB = "resource_type_B"
-)
-
 type providerSuite struct {
 	suite.Suite
 	provider *InMemoryStoreProvider


### PR DESCRIPTION
## Description

If we stop Sensor while the k8s handlers are being initialize (`handleAllEvents` is still running), we can panic while trying to add a new handler [here](https://github.com/stackrox/stackrox/blob/4a7152b37ccdda2f670247dc19172db4dbaadce2/sensor/kubernetes/listener/resource_event_handler.go#L322). This PR solves this by introducing a new function that check whether the listener was stopped or not before calling `utils.Should`. 

* **Note**: This was only affecting development builds.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

I've tried to create a test for this but it was failing very rarely even without the changes introduced in this PR (this is issue is very very much an edge case).

A way to manually test this is by introducing a `Sleep(2 * time.Second)` in `handleAllEvents`.
For example after this [wait group](https://github.com/stackrox/stackrox/blob/09554eb3e07c31c201add9e98894cff19034697b/sensor/kubernetes/listener/resource_event_handler.go#L275):

```golang
podWaitGroup := &concurrency.WaitGroup{}
time.Sleep(2 * time.Second)
handle(k.context, podInformer.Informer(), dispatchers.ForDeployments(kubernetesPkg.Pod), k.outputQueue, &syncingResources, podWaitGroup, stopSignal, &eventLock)
```

Without the changes in this PR the following test should fail consistently:

```golang
func Test_StartStop(t *testing.T) {
	// Initialization
	t.Setenv("ROX_MTLS_CERT_FILE", "../../../tools/local-sensor/certs/cert.pem")
	t.Setenv("ROX_MTLS_KEY_FILE", "../../../tools/local-sensor/certs/key.pem")
	t.Setenv("ROX_MTLS_CA_FILE", "../../../tools/local-sensor/certs/caCert.pem")
	t.Setenv("ROX_MTLS_CA_KEY_FILE", "../../../tools/local-sensor/certs/caKey.pem")
	mockCtrl := gomock.NewController(t)
	k8sClient := k8s.MakeFakeClient()
	resolver := mockComponent.NewMockResolver(mockCtrl)
	config := mockHandler.NewMockHandler(mockCtrl)
	storeProvider := resources.InitializeStore()
	listener := New(k8sClient,
		config,
		"test-node",
		noResyncPeriod,
		nil,
		resolver,
		storeProvider)
	resolver.EXPECT().Send(gomock.Any()).AnyTimes()
	config.EXPECT().GetConfig().AnyTimes()
	// End of initialization
	listener.StartWithContext(context.Background())
	// Wait here to let handleAllEvents to arrive to the sleep
	time.Sleep(time.Second)
	listener.Stop(nil)
	// Some extra time to let the sleep in the handleAllEvents finish
	time.Sleep(4 * time.Second)
}
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
