### PR TITLE
chore(ui): Add analytics events for watched images

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -21,6 +21,7 @@ import useURLPagination from 'hooks/useURLPagination';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import usePermissions from 'hooks/usePermissions';
 import useFeatureFlags from 'hooks/useFeatureFlags';
+import useAnalytics, { WATCH_IMAGE_MODAL_OPENED } from 'hooks/useAnalytics';
 import { vulnerabilityStates } from 'types/cve.proto';
 import { VulnMgmtLocalStorage, entityTabValues } from '../types';
 import { parseQuerySearchFilter, getVulnStateScopedQueryString } from '../searchUtils';
@@ -47,6 +48,8 @@ function WorkloadCvesOverviewPage() {
     const hasWriteAccessForWatchedImage = hasReadWriteAccess('WatchedImage');
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isUnifiedDeferralsEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL');
+
+    const { analyticsTrack } = useAnalytics();
 
     const [vulnerabilityStateKey, setVulnerabilityStateKey] = useURLStringUnion(
         'vulnerabilityState',
@@ -105,6 +108,7 @@ function WorkloadCvesOverviewPage() {
                             onClick={() => {
                                 setDefaultWatchedImageName('');
                                 watchedImagesModalToggle.openSelect();
+                                analyticsTrack(WATCH_IMAGE_MODAL_OPENED);
                             }}
                         >
                             Manage watched images
@@ -153,6 +157,7 @@ function WorkloadCvesOverviewPage() {
                                     onWatchImage={(imageName) => {
                                         setDefaultWatchedImageName(imageName);
                                         watchedImagesModalToggle.openSelect();
+                                        analyticsTrack(WATCH_IMAGE_MODAL_OPENED);
                                     }}
                                     onUnwatchImage={(imageName) => {
                                         setUnwatchImageName(imageName);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesForm.tsx
@@ -5,6 +5,7 @@ import * as yup from 'yup';
 
 import { UseRestQueryReturn } from 'hooks/useRestQuery';
 import { UseRestMutationReturn } from 'hooks/useRestMutation';
+import useAnalytics, { WATCH_IMAGE_SUBMITTED } from 'hooks/useAnalytics';
 import { WatchedImage } from 'types/image.proto';
 
 const validationSchema = yup.object({
@@ -41,7 +42,10 @@ function WatchedImagesForm({
     const isNameFieldInvalid = !!(errors.imageName && touched.imageName);
     const nameFieldValidated = isNameFieldInvalid ? 'error' : 'default';
 
+    const { analyticsTrack } = useAnalytics();
+
     function addToWatchedImages(formValues: FormData, { setSubmitting }: FormikHelpers<FormData>) {
+        analyticsTrack(WATCH_IMAGE_SUBMITTED);
         watchImage(formValues.imageName, {
             onSuccess: () => watchedImagesRequest.refetch(),
             onSettled: () => setSubmitting(false),

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -8,6 +8,8 @@ import { selectors } from 'reducers';
 export const CLUSTER_CREATED = 'Cluster Created';
 export const INVITE_USERS_MODAL_OPENED = 'Invite Users Modal Opened';
 export const INVITE_USERS_SUBMITTED = 'Invite Users Submitted';
+export const WATCH_IMAGE_MODAL_OPENED = 'Watch Image Modal Opened';
+export const WATCH_IMAGE_SUBMITTED = 'Watch Image Submitted';
 
 const useAnalytics = () => {
     const telemetry = useSelector(selectors.publicConfigTelemetrySelector);


### PR DESCRIPTION
## Description

Adds tracking to watched images events.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

"Inspired" (stolen) from Van's testing steps:

1. Adding the dev telemetry key to a development environment, to turn on analytics tracking for that environment
2. Creating an auth provider
3. Open the watched image modal from the "Manage watch images" button as well as the table row menu (2 events)
4. Watch a single image (1 event)
5. Observed events in Amplitude

![image](https://github.com/stackrox/stackrox/assets/1292638/a2e73b66-3196-475e-b8a9-0bd31457ac4a)

