### PR TITLE
fix(ui): Sync FE and BE types for exception requests

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -53,7 +53,7 @@ const vulnerabilityExceptions: VulnerabilityException[] = [
                 tag: '.*',
             },
         },
-        deferralReq: {
+        deferralRequest: {
             expiry: {
                 expiryType: 'ALL_CVE_FIXABLE',
             },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.test.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.test.tsx
@@ -47,7 +47,7 @@ describe('ExceptionRequestTableCells', () => {
                 ...baseException,
                 targetState: 'DEFERRED',
                 exceptionStatus: 'PENDING',
-                deferralReq: {
+                deferralRequest: {
                     expiry: {
                         expiryType: 'ALL_CVE_FIXABLE',
                     },
@@ -70,7 +70,7 @@ describe('ExceptionRequestTableCells', () => {
                 ...baseException,
                 targetState: 'DEFERRED',
                 exceptionStatus: 'APPROVED',
-                deferralReq: {
+                deferralRequest: {
                     expiry: {
                         expiryType: 'ALL_CVE_FIXABLE',
                     },
@@ -91,7 +91,7 @@ describe('ExceptionRequestTableCells', () => {
                 ...baseException,
                 targetState: 'DEFERRED',
                 exceptionStatus: 'APPROVED_PENDING_UPDATE',
-                deferralReq: {
+                deferralRequest: {
                     expiry: {
                         expiryType: 'ALL_CVE_FIXABLE',
                     },
@@ -119,7 +119,7 @@ describe('ExceptionRequestTableCells', () => {
                 ...baseException,
                 targetState: 'DEFERRED',
                 exceptionStatus: 'APPROVED_PENDING_UPDATE',
-                deferralReq: {
+                deferralRequest: {
                     expiry: {
                         expiryType: 'ALL_CVE_FIXABLE',
                     },
@@ -149,7 +149,7 @@ describe('ExceptionRequestTableCells', () => {
                 ...baseException,
                 targetState: 'FALSE_POSITIVE',
                 exceptionStatus: 'PENDING',
-                fpRequest: {},
+                falsePositiveRequest: {},
             };
             const context: RequestContext = 'PENDING_REQUESTS';
 
@@ -163,7 +163,7 @@ describe('ExceptionRequestTableCells', () => {
                 ...baseException,
                 targetState: 'DEFERRED',
                 exceptionStatus: 'PENDING',
-                deferralReq: {
+                deferralRequest: {
                     expiry: {
                         expiryType: 'ALL_CVE_FIXABLE',
                     },
@@ -181,7 +181,7 @@ describe('ExceptionRequestTableCells', () => {
                 ...baseException,
                 targetState: 'DEFERRED',
                 exceptionStatus: 'PENDING',
-                deferralReq: {
+                deferralRequest: {
                     expiry: {
                         expiryType: 'ANY_CVE_FIXABLE',
                     },
@@ -199,7 +199,7 @@ describe('ExceptionRequestTableCells', () => {
                 ...baseException,
                 targetState: 'DEFERRED',
                 exceptionStatus: 'PENDING',
-                deferralReq: {
+                deferralRequest: {
                     expiry: {
                         expiryType: 'TIME',
                         expiresOn: '2023-10-31T19:16:49.155480945Z',
@@ -218,7 +218,7 @@ describe('ExceptionRequestTableCells', () => {
                 ...baseException,
                 targetState: 'DEFERRED',
                 exceptionStatus: 'PENDING',
-                deferralReq: {
+                deferralRequest: {
                     expiry: {
                         expiryType: 'TIME',
                         expiresOn: null,
@@ -237,7 +237,7 @@ describe('ExceptionRequestTableCells', () => {
                 ...baseException,
                 targetState: 'DEFERRED',
                 exceptionStatus: 'APPROVED_PENDING_UPDATE',
-                deferralReq: {
+                deferralRequest: {
                     expiry: {
                         expiryType: 'TIME',
                         expiresOn: null,
@@ -263,7 +263,7 @@ describe('ExceptionRequestTableCells', () => {
                 ...baseException,
                 targetState: 'DEFERRED',
                 exceptionStatus: 'APPROVED_PENDING_UPDATE',
-                deferralReq: {
+                deferralRequest: {
                     expiry: {
                         expiryType: 'TIME',
                         expiresOn: null,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
@@ -61,7 +61,7 @@ export function getRequestedAction(
         const exceptionExpiry: ExceptionExpiry =
             shouldUseUpdatedExpiry && exception.deferralUpdate
                 ? exception.deferralUpdate.expiry
-                : exception.deferralReq.expiry;
+                : exception.deferralRequest.expiry;
         let duration = 'indefinitely';
         if (exceptionExpiry.expiryType === 'TIME' && exceptionExpiry.expiresOn) {
             duration = getDistanceStrictAsPhrase(
@@ -105,7 +105,7 @@ export function getExpiresDate(exception: VulnerabilityException, context: Reque
         const exceptionExpiry: ExceptionExpiry =
             shouldUseUpdatedExpiry && exception.deferralUpdate
                 ? exception.deferralUpdate.expiry
-                : exception.deferralReq.expiry;
+                : exception.deferralRequest.expiry;
         if (exceptionExpiry.expiryType === 'TIME' && exceptionExpiry.expiresOn) {
             return getDate(exceptionExpiry.expiresOn);
         }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/CompletedExceptionRequestModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/CompletedExceptionRequestModal.tsx
@@ -32,7 +32,9 @@ function scopeDisplay(scope: BaseVulnerabilityException['scope']): string {
     return `${scope.imageScope.registry}/${scope.imageScope.remote}:${scope.imageScope.tag}`;
 }
 
-function expiryDisplay(expiry: VulnerabilityDeferralException['deferralReq']['expiry']): string {
+function expiryDisplay(
+    expiry: VulnerabilityDeferralException['deferralRequest']['expiry']
+): string {
     const { expiryType } = expiry;
     switch (expiryType) {
         case 'ALL_CVE_FIXABLE':
@@ -119,7 +121,7 @@ function CompletedExceptionRequestModal({
                         <DescriptionListGroup>
                             <DescriptionListTerm>Expires</DescriptionListTerm>
                             <DescriptionListDescription>
-                                {expiryDisplay(exceptionRequest.deferralReq.expiry)}
+                                {expiryDisplay(exceptionRequest.deferralRequest.expiry)}
                             </DescriptionListDescription>
                         </DescriptionListGroup>
                     )}

--- a/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
+++ b/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
@@ -51,7 +51,7 @@ export type BaseVulnerabilityException = {
 
 export type VulnerabilityDeferralException = BaseVulnerabilityException & {
     targetState: 'DEFERRED';
-    deferralReq: {
+    deferralRequest: {
         expiry: ExceptionExpiry;
     };
     deferralUpdate?: {
@@ -68,7 +68,7 @@ export function isDeferralException(
 
 export type VulnerabilityFalsePositiveException = BaseVulnerabilityException & {
     targetState: 'FALSE_POSITIVE';
-    fpRequest: Empty;
+    falsePositiveRequest: Empty;
     falsePositiveUpdate?: {
         cves: string[];
     };


### PR DESCRIPTION
## Description

Updates UI expected response types to match BE type refactor in https://github.com/stackrox/stackrox/pull/8333

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Repeat testing steps for submitting a deferral or false positive requests from previous PRs.

