### PR TITLE
ROX-20477: Fix confusing warning in legacy cluster creation UI

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
@@ -24,7 +24,8 @@ type ClusterStatusProps = {
 function ClusterStatus({ healthStatus, isList = false }: ClusterStatusProps): ReactElement {
     const { version } = useMetadata();
 
-    const { overallHealthStatus } = healthStatus;
+    const { overallHealthStatus = 'UNAVAILABLE' } = healthStatus ?? {};
+
     const { Icon, fgColor } = healthStatusStyles[overallHealthStatus];
     const icon = <Icon className={`${isList ? 'inline' : ''} h-4 w-4`} />;
 


### PR DESCRIPTION
## Description

At some point, a change in either the UI or API opened up a situation where the cluster health object is completely undefined when displaying the status of a cluster that was just created through the legacy UI form.

The cluster entry is still created in the database, and the artifacts necessary to install the Secure Cluster Services are still available for download, but the user would only see the download option after refreshing the page.

This change fixes the confusing UX of that situation, by detecting when that cluster health object is undefined and defaulting to displaying a status of UNAVAILABLE, which is technically accurate. 

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

#### Before this change: 
Misleading "error" state displayed, after a user has clicked "Next" on the UI cluster form to add a cluster entry to the database and generate its artifacts.
<img width="1574" alt="Screen Shot 2023-10-26 at 9 21 40 AM" src="https://github.com/stackrox/stackrox/assets/715729/42fc4435-34e0-4f9a-b739-655e2502173c">

#### After this change: 
Correctly display the cluster summary with Unavailable health status, and allow the user to download the artifacts immediately.
<img width="1574" alt="Screen Shot 2023-10-26 at 9 37 54 AM" src="https://github.com/stackrox/stackrox/assets/715729/06eaf971-4f27-459e-8332-3fa4b6627390">

After closing the summary in the panel, the user still sees the entry for the cluster just created (no change from before this code change)
<img width="1574" alt="Screen Shot 2023-10-26 at 9 38 00 AM" src="https://github.com/stackrox/stackrox/assets/715729/9f9e376e-65fc-4d7f-9821-a3dbab9339aa">



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
