### PR TITLE
ROX-17653: add pods names to pod restart junit

### DIFF
--- a/scripts/ci/logcheck/check-restart-logs.sh
+++ b/scripts/ci/logcheck/check-restart-logs.sh
@@ -48,7 +48,7 @@ patterns=$(jq -c '.[]' "$DIR/restart-ok-patterns.json")
             echo "This restart does not match any ignore patterns"
             if [[ -n "${ARTIFACT_DIR:-}" ]]; then
                 cp "${logfile}" "${ARTIFACT_DIR}" || true
-                echo "$(basename "${logfile}") copied to Artifacts"
+                echo "$(basename "${logfile}") copied to Artifacts" # do not change - required by pod restart check
             fi
             all_ok=false
         fi

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -550,7 +550,7 @@ check_for_stackrox_restarts() {
         # shellcheck disable=SC2086
         if ! check_out="$(scripts/ci/logcheck/check-restart-logs.sh "${CI_JOB_NAME}" $previous_logs)"; then
             pods=$(echo $check_out | grep "copied to Artifacts" | cut -d- -f1,3 | sort -u | tr '\n' ' ')
-            save_junit_failure "Pod Restarts" "${file}" "${check_out}"
+            save_junit_failure "Pod Restarts" "${pods}" "${check_out}"
             die "ERROR: Found at least one unexplained pod restart. ${check_out}"
         fi
         info "Restarts were considered benign"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -549,7 +549,8 @@ check_for_stackrox_restarts() {
         local check_out=""
         # shellcheck disable=SC2086
         if ! check_out="$(scripts/ci/logcheck/check-restart-logs.sh "${CI_JOB_NAME}" $previous_logs)"; then
-            save_junit_failure "Pod Restarts" "Check for unexplained pod restart" "${check_out}"
+            pods=$(echo $check_out | grep "copied to Artifacts" | cut -d- -f1,3 | sort -u | tr '\n' ' ')
+            save_junit_failure "Pod Restarts" "${file}" "${check_out}"
             die "ERROR: Found at least one unexplained pod restart. ${check_out}"
         fi
         info "Restarts were considered benign"


### PR DESCRIPTION
## Description

Add pod names in junit restarted pod report. This will result in different tickets for different pods.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Manually run script on payload I found in Jira. It correctly reports pod names

```bash
cat <<EOF  | grep "copied to Artifacts" | cut -d- -f1,3 | sort -u | tr '\n' ' '
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/collector-2njt5-collector-previous.log
Ignoring this restart due to: collector restart due to sensor connection failure (likely slow start)
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/collector-2njt5-compliance-previous.log
This restart does not match any ignore patterns
collector-2njt5-compliance-previous.log copied to Artifacts
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/collector-7qvmk-collector-previous.log
Ignoring this restart due to: collector restart due to sensor connection failure (likely slow start)
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/collector-7qvmk-compliance-previous.log
This restart does not match any ignore patterns
collector-7qvmk-compliance-previous.log copied to Artifacts
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/collector-8q2m9-collector-previous.log
Ignoring this restart due to: collector restart due to sensor connection failure (likely slow start)
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/collector-8q2m9-compliance-previous.log
This restart does not match any ignore patterns
collector-8q2m9-compliance-previous.log copied to Artifacts
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/collector-d4gxw-collector-previous.log
Ignoring this restart due to: collector restart due to sensor connection failure (likely slow start)
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/collector-d4gxw-compliance-previous.log
This restart does not match any ignore patterns
collector-d4gxw-compliance-previous.log copied to Artifacts
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/collector-kbx77-collector-previous.log
Ignoring this restart due to: collector restart due to sensor connection failure (likely slow start)
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/collector-kbx77-compliance-previous.log
This restart does not match any ignore patterns
collector-kbx77-compliance-previous.log copied to Artifacts
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/collector-kflg8-collector-previous.log
Ignoring this restart due to: collector restart due to sensor connection failure (likely slow start)
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/collector-kflg8-compliance-previous.log
This restart does not match any ignore patterns
collector-kflg8-compliance-previous.log copied to Artifacts
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/collector-vqtv5-collector-previous.log
Ignoring this restart due to: collector restart due to sensor connection failure (likely slow start)
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/collector-vqtv5-compliance-previous.log
This restart does not match any ignore patterns
collector-vqtv5-compliance-previous.log copied to Artifacts
Checking for a restart exception in: /tmp/k8s-service-logs/stackrox/pods/sensor-6c85864f79-cdn2c-sensor-previous.log
This restart does not match any ignore patterns
sensor-6c85864f79-cdn2c-sensor-previous.log copied to Artifacts
EOF
```
```
collector-compliance sensor-cdn2c 
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
