### PR TITLE
ROX-20493, ROX-20494, ROX-20495: Miscellaneous vulnerability exception validations

### DIFF
--- a/central/vulnerabilityrequest/datastore/datastore.go
+++ b/central/vulnerabilityrequest/datastore/datastore.go
@@ -59,8 +59,8 @@ type DataStore interface {
 	MarkRequestInactive(ctx context.Context, id string, comment string) (*storage.VulnerabilityRequest, error)
 
 	// RemoveRequest removes the request with specified ID from the database. Only pending exceptions and pending updates
-	// to an enforced exception can be deleted through API. All other types of exceptions can only is cancelled. Exceptions
-	// are retained in the system according to the retention configuration.
+	// to an enforced exception can be deleted through API. All other types of exceptions can only be cancelled.
+	// Exceptions are retained in the system according to the retention configuration.
 	RemoveRequest(ctx context.Context, id string) error
 
 	//// FOR INTERNAL USE ONLY.

--- a/central/vulnerabilityrequest/datastore/datastore.go
+++ b/central/vulnerabilityrequest/datastore/datastore.go
@@ -58,7 +58,9 @@ type DataStore interface {
 	// 2. VulnerabilityManagementRequests write permission and is the requester of the original exception.
 	MarkRequestInactive(ctx context.Context, id string, comment string) (*storage.VulnerabilityRequest, error)
 
-	// RemoveRequest removes the request with specified ID from the database.
+	// RemoveRequest removes the request with specified ID from the database. Only pending exceptions and pending updates
+	// to an enforced exception can be deleted through API. All other types of exceptions can only is cancelled. Exceptions
+	// are retained in the system according to the retention configuration.
 	RemoveRequest(ctx context.Context, id string) error
 
 	//// FOR INTERNAL USE ONLY.

--- a/central/vulnerabilityrequest/datastore/datastore_impl.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl.go
@@ -270,7 +270,11 @@ func (ds *datastoreImpl) UpdateRequest(ctx context.Context, id string, update *c
 
 	if (req.GetTargetState() == storage.VulnerabilityState_DEFERRED && update.FalsePositiveUpdate != nil) ||
 		(req.GetTargetState() == storage.VulnerabilityState_FALSE_POSITIVE && update.DeferralUpdate != nil) {
-		return nil, errors.Errorf("exception %s cannot be updated. Exception type(defer/false positive) cannot be changed.", req.GetId())
+		return nil, errors.Errorf("exception %s cannot be updated. Exception type(defer/false positive) cannot be changed", req.GetId())
+	}
+
+	if utils.IsUpdateNoOp(req, update) {
+		return nil, errors.Errorf("the update does not change the exception %s", req.GetId())
 	}
 
 	req.LastUpdated = types.TimestampNow()

--- a/central/vulnerabilityrequest/datastore/datastore_impl.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl.go
@@ -393,20 +393,24 @@ func (ds *datastoreImpl) RemoveRequest(ctx context.Context, id string) error {
 		return errors.Wrap(sac.ErrResourceAccessDenied, "requests can only be cancelled by the original requester")
 	}
 
+	// Only pending exceptions and pending updates to an existing exception can be deleted through API. All other
+	// exceptions can only is cancelled and are retained in the system according to the retention configuration.
 	switch req.GetStatus() {
 	case storage.RequestStatus_PENDING:
 		if err := ds.store.Delete(ctx, id); err != nil {
-			return err
+			return errors.Wrapf(err, "could not delete vulnerability exception %s", id)
 		}
 
 	case storage.RequestStatus_APPROVED_PENDING_UPDATE:
-		// Removing a request should take it back to its previous state. In the case of a pending update, that means
-		// back to original deferral. Since the original request object maintains the original state, it can't be simply removed
+		// Removing an update should take it back to its previous state. Since the original request object maintains
+		// the original state, it can't be simply removed.
 		req.Status = storage.RequestStatus_APPROVED
 		req.UpdatedReq = nil
 		if err := ds.store.Upsert(ctx, req); err != nil {
-			return err
+			return errors.Wrapf(err, "could not delete vulnerability exception %s update", id)
 		}
+	default:
+		return errors.Errorf("cannot delete exception %s. Only vulnerability exceptions or updates in pending state can be deleted", id)
 	}
 	return nil
 }

--- a/central/vulnerabilityrequest/datastore/datastore_impl.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl.go
@@ -268,6 +268,11 @@ func (ds *datastoreImpl) UpdateRequest(ctx context.Context, id string, update *c
 		return nil, errors.Errorf("request %s cannot be updated because it has expired or has been denied", req.GetId())
 	}
 
+	if (req.GetTargetState() == storage.VulnerabilityState_DEFERRED && update.FalsePositiveUpdate != nil) ||
+		(req.GetTargetState() == storage.VulnerabilityState_FALSE_POSITIVE && update.DeferralUpdate != nil) {
+		return nil, errors.Errorf("exception %s cannot be updated. Exception type(defer/false positive) cannot be changed.", req.GetId())
+	}
+
 	req.LastUpdated = types.TimestampNow()
 	req.Comments = append(req.Comments, utils.CreateRequestCommentProto(ctx, update.Comment))
 	if update.DeferralUpdate != nil {

--- a/central/vulnerabilityrequest/datastore/datastore_impl_test.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl_test.go
@@ -439,7 +439,7 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestFailsIfTypeIsDifferent(
 
 	s.mockStore.EXPECT().Get(gomock.Any(), "id").Return(req, true, nil)
 	_, err := s.datastore.UpdateRequest(authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()), "id", update)
-	s.EqualError(err, fmt.Sprintf("exception %s cannot be updated. Exception type(defer/false positive) cannot be changed.", req.GetId()))
+	s.EqualError(err, fmt.Sprintf("exception %s cannot be updated. Exception type(defer/false positive) cannot be changed", req.GetId()))
 
 	// Test false positive update on deferral request.
 	update = &common.UpdateRequest{
@@ -453,8 +453,44 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestFailsIfTypeIsDifferent(
 
 	s.mockStore.EXPECT().Get(gomock.Any(), "id").Return(req, true, nil)
 	_, err = s.datastore.UpdateRequest(authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()), "id", update)
-	s.EqualError(err, fmt.Sprintf("exception %s cannot be updated. Exception type(defer/false positive) cannot be changed.", req.GetId()))
+	s.EqualError(err, fmt.Sprintf("exception %s cannot be updated. Exception type(defer/false positive) cannot be changed", req.GetId()))
 
+}
+
+func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestFailsIfNoOp() {
+	if !features.UnifiedCVEDeferral.Enabled() {
+		s.T().SkipNow()
+	}
+
+	// Test deferral update on false positive request.
+	update := &common.UpdateRequest{
+		DeferralUpdate: &storage.DeferralUpdate{
+			CVEs:   []string{"cve-1"},
+			Expiry: &storage.RequestExpiry{Expiry: &storage.RequestExpiry_ExpiresWhenFixed{ExpiresWhenFixed: true}},
+		},
+	}
+
+	req := fixtures.GetGlobalDeferralRequestV2("cve-1")
+	req.Status = storage.RequestStatus_APPROVED
+	req.GetDeferralReq().Expiry = update.DeferralUpdate.GetExpiry()
+
+	s.mockStore.EXPECT().Get(gomock.Any(), "id").Return(req, true, nil)
+	_, err := s.datastore.UpdateRequest(authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()), "id", update)
+	s.EqualError(err, fmt.Sprintf("the update does not change the exception %s", req.GetId()))
+
+	// Test false positive update on deferral request.
+	update = &common.UpdateRequest{
+		FalsePositiveUpdate: &storage.FalsePositiveUpdate{
+			CVEs: []string{"cve-1"},
+		},
+	}
+
+	req = fixtures.GetGlobalFPRequestV2("cve-1")
+	req.Status = storage.RequestStatus_APPROVED
+
+	s.mockStore.EXPECT().Get(gomock.Any(), "id").Return(req, true, nil)
+	_, err = s.datastore.UpdateRequest(authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()), "id", update)
+	s.EqualError(err, fmt.Sprintf("the update does not change the exception %s", req.GetId()))
 }
 
 func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestFailsIfRequestWasExpired() {

--- a/central/vulnerabilityrequest/datastore/datastore_impl_test.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl_test.go
@@ -472,7 +472,7 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestFailsIfNoOp() {
 
 	req := fixtures.GetGlobalDeferralRequestV2("cve-1")
 	req.Status = storage.RequestStatus_APPROVED
-	req.GetDeferralReq().Expiry = update.DeferralUpdate.GetExpiry()
+	req.GetDeferralReq().Expiry = update.DeferralUpdate.GetExpiry().Clone()
 
 	s.mockStore.EXPECT().Get(gomock.Any(), "id").Return(req, true, nil)
 	_, err := s.datastore.UpdateRequest(authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()), "id", update)

--- a/central/vulnerabilityrequest/datastore/datastore_impl_test.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl_test.go
@@ -413,12 +413,48 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestFailsIfRequestWasDenied
 		},
 	}
 
-	req := fixtures.GetGlobalDeferralRequest("cve-a-b-c")
+	req := fixtures.GetGlobalDeferralRequestV2("cve-a-b-c")
 	req.Status = storage.RequestStatus_DENIED
 
 	s.mockStore.EXPECT().Get(gomock.Any(), "id").Return(req, true, nil)
 	_, err := s.datastore.UpdateRequest(authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()), "id", update)
 	s.EqualError(err, fmt.Sprintf("request %s cannot be updated because it has expired or has been denied", req.GetId()))
+}
+
+func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestFailsIfTypeIsDifferent() {
+	if !features.UnifiedCVEDeferral.Enabled() {
+		s.T().SkipNow()
+	}
+
+	// Test deferral update on false positive request.
+	update := &common.UpdateRequest{
+		DeferralUpdate: &storage.DeferralUpdate{
+			CVEs:   []string{"cve-1"},
+			Expiry: &storage.RequestExpiry{Expiry: &storage.RequestExpiry_ExpiresWhenFixed{ExpiresWhenFixed: true}},
+		},
+	}
+
+	req := fixtures.GetGlobalFPRequestV2("cve-a-b-c")
+	req.Status = storage.RequestStatus_APPROVED
+
+	s.mockStore.EXPECT().Get(gomock.Any(), "id").Return(req, true, nil)
+	_, err := s.datastore.UpdateRequest(authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()), "id", update)
+	s.EqualError(err, fmt.Sprintf("exception %s cannot be updated. Exception type(defer/false positive) cannot be changed.", req.GetId()))
+
+	// Test false positive update on deferral request.
+	update = &common.UpdateRequest{
+		FalsePositiveUpdate: &storage.FalsePositiveUpdate{
+			CVEs: []string{"cve-1"},
+		},
+	}
+
+	req = fixtures.GetGlobalDeferralRequestV2("cve-a-b-c")
+	req.Status = storage.RequestStatus_APPROVED
+
+	s.mockStore.EXPECT().Get(gomock.Any(), "id").Return(req, true, nil)
+	_, err = s.datastore.UpdateRequest(authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()), "id", update)
+	s.EqualError(err, fmt.Sprintf("exception %s cannot be updated. Exception type(defer/false positive) cannot be changed.", req.GetId()))
+
 }
 
 func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestFailsIfRequestWasExpired() {
@@ -431,7 +467,7 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestFailsIfRequestWasExpire
 			Expiry: &storage.RequestExpiry{Expiry: &storage.RequestExpiry_ExpiresWhenFixed{ExpiresWhenFixed: true}},
 		},
 	}
-	req := fixtures.GetGlobalDeferralRequest("cve-a-b-c")
+	req := fixtures.GetGlobalDeferralRequestV2("cve-a-b-c")
 	req.Expired = true
 
 	s.mockStore.EXPECT().Get(gomock.Any(), "id").Return(req, true, nil)
@@ -449,7 +485,7 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestSucceedsIfDeferralReque
 			Expiry: &storage.RequestExpiry{Expiry: &storage.RequestExpiry_ExpiresWhenFixed{ExpiresWhenFixed: true}},
 		},
 	}
-	req := fixtures.GetGlobalDeferralRequest("cve-a-b-c")
+	req := fixtures.GetGlobalDeferralRequestV2("cve-a-b-c")
 	req.Requestor = &storage.SlimUser{Id: fakeUserID}
 	req.Status = storage.RequestStatus_PENDING
 
@@ -474,7 +510,7 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestSucceedsIfDeferralUpdat
 			Expiry: &storage.RequestExpiry{Expiry: &storage.RequestExpiry_ExpiresWhenFixed{ExpiresWhenFixed: true}},
 		},
 	}
-	req := fixtures.GetGlobalDeferralRequest("cve-a-b-c")
+	req := fixtures.GetGlobalDeferralRequestV2("cve-a-b-c")
 	req.UpdatedReq = &storage.VulnerabilityRequest_UpdatedDeferralReq{UpdatedDeferralReq: req.GetDeferralReq().Clone()}
 	req.Requestor = &storage.SlimUser{Id: fakeUserID}
 	req.Status = storage.RequestStatus_APPROVED_PENDING_UPDATE
@@ -494,11 +530,11 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestSucceedsIfOriginalDefer
 		s.T().SkipNow()
 	}
 	update := &common.UpdateRequest{
-		FalsePositiveUpdate: &storage.FalsePositiveUpdate{
+		DeferralUpdate: &storage.DeferralUpdate{
 			CVEs: []string{"cve-1"},
 		},
 	}
-	req := fixtures.GetGlobalDeferralRequest("cve-a-b-c")
+	req := fixtures.GetGlobalDeferralRequestV2("cve-a-b-c")
 	req.Requestor = &storage.SlimUser{Id: fakeUserID}
 	req.Status = storage.RequestStatus_APPROVED
 
@@ -522,7 +558,7 @@ func (s *VulnRequestDataStoreTestSuite) TestUpdateRequestSucceedsIfOriginalFPReq
 			Expiry: &storage.RequestExpiry{Expiry: &storage.RequestExpiry_ExpiresWhenFixed{ExpiresWhenFixed: true}},
 		},
 	}
-	req := fixtures.GetGlobalDeferralRequest("cve-a-b-c")
+	req := fixtures.GetGlobalDeferralRequestV2("cve-a-b-c")
 	req.Requestor = &storage.SlimUser{Id: fakeUserID}
 	req.Status = storage.RequestStatus_APPROVED
 

--- a/central/vulnerabilityrequest/datastore/datastore_impl_test.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl_test.go
@@ -650,7 +650,20 @@ func (s *VulnRequestDataStoreTestSuite) TestOnlyRequesterWithWriteCannotRemoveOt
 	}
 }
 
-func (s *VulnRequestDataStoreTestSuite) TestRemoveRequestsPendingUpdate() {
+func (s *VulnRequestDataStoreTestSuite) TestRemoveRequestPending() {
+	req := &storage.VulnerabilityRequest{
+		Requestor:  &storage.SlimUser{Id: fakeUserID},
+		Expired:    false,
+		Status:     storage.RequestStatus_PENDING,
+		UpdatedReq: &storage.VulnerabilityRequest_UpdatedDeferralReq{},
+	}
+	s.mockStore.EXPECT().Get(gomock.Any(), "id").Return(req, true, nil)
+	s.mockStore.EXPECT().Delete(gomock.Any(), "id").Return(nil)
+	err := s.datastore.RemoveRequest(authn.ContextWithIdentity(selfApproverAllSac, s.mockIdentity, s.T()), "id")
+	s.NoError(err)
+}
+
+func (s *VulnRequestDataStoreTestSuite) TestRemoveRequestPendingUpdate() {
 	req := &storage.VulnerabilityRequest{
 		Requestor:  &storage.SlimUser{Id: fakeUserID},
 		Expired:    false,
@@ -665,4 +678,16 @@ func (s *VulnRequestDataStoreTestSuite) TestRemoveRequestsPendingUpdate() {
 
 	err := s.datastore.RemoveRequest(authn.ContextWithIdentity(selfApproverAllSac, s.mockIdentity, s.T()), "id")
 	s.NoError(err)
+}
+
+func (s *VulnRequestDataStoreTestSuite) TestRemoveRequestApproved() {
+	req := &storage.VulnerabilityRequest{
+		Requestor:  &storage.SlimUser{Id: fakeUserID},
+		Expired:    false,
+		Status:     storage.RequestStatus_APPROVED,
+		UpdatedReq: &storage.VulnerabilityRequest_UpdatedDeferralReq{},
+	}
+	s.mockStore.EXPECT().Get(gomock.Any(), "id").Return(req, true, nil)
+	err := s.datastore.RemoveRequest(authn.ContextWithIdentity(selfApproverAllSac, s.mockIdentity, s.T()), "id")
+	s.Error(err)
 }

--- a/central/vulnerabilityrequest/utils/util.go
+++ b/central/vulnerabilityrequest/utils/util.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/sliceutils"
+	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/uuid"
 )
 
@@ -259,7 +260,10 @@ func IsUpdateNoOp(req *storage.VulnerabilityRequest, update *common.UpdateReques
 		newCVEs := falsePositiveUpdate.GetCVEs()
 		return equal(existingCVEs, newCVEs)
 	}
-	// If we cannot determine that the update is a deferral update and false-positive, then we cannot handle it and must be treated as noop.
+
+	// If we cannot determine that the update is a deferral update and false-positive, then we cannot handle it likely
+	// because new proto message for updates was added. It must be treated as noop so that we do not reach the database.
+	utils.Should(errors.Errorf("Unhandled vulnerability exception update: %v", update))
 	return true
 }
 

--- a/central/vulnerabilityrequest/utils/util.go
+++ b/central/vulnerabilityrequest/utils/util.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"context"
+	"reflect"
+	"sort"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
@@ -11,7 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/search"
-	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/uuid"
 )
 
@@ -246,20 +248,29 @@ func IsUpdateNoOp(req *storage.VulnerabilityRequest, update *common.UpdateReques
 		return true
 	}
 
-	existingCVEs := set.NewStringSet(req.GetCves().GetCves()...)
-	if update := update.DeferralUpdate; update != nil {
-		newCVEs := set.NewStringSet(update.GetCVEs()...)
-		diff := existingCVEs.Difference(newCVEs)
-		return diff.Cardinality() == 0 && req.GetDeferralReq().GetExpiry() == update.GetExpiry()
+	existingCVEs := req.GetCves().GetCves()
+	if deferralUpdate := update.DeferralUpdate; deferralUpdate != nil {
+		newCVEs := deferralUpdate.GetCVEs()
+		return equal(existingCVEs, newCVEs) &&
+			reflect.DeepEqual(req.GetDeferralReq().GetExpiry(), deferralUpdate.GetExpiry())
 	}
 
-	if update := update.FalsePositiveUpdate; update != nil {
-		newCVEs := set.NewStringSet(update.GetCVEs()...)
-		diff := existingCVEs.Difference(newCVEs)
-		return diff.Cardinality() == 0
+	if falsePositiveUpdate := update.FalsePositiveUpdate; falsePositiveUpdate != nil {
+		newCVEs := falsePositiveUpdate.GetCVEs()
+		return equal(existingCVEs, newCVEs)
 	}
 	// If we cannot determine that the update is a deferral update and false-positive, then we cannot handle it and must be treated as noop.
 	return true
+}
+
+func equal(a, b []string) bool {
+	sort.SliceStable(a, func(i, j int) bool {
+		return a[i] < a[j]
+	})
+	sort.SliceStable(b, func(i, j int) bool {
+		return b[i] < b[j]
+	})
+	return sliceutils.Equal(a, b)
 }
 
 // Returns true if the scope of `toMatch` covers the scope of `matchWith`.

--- a/central/vulnerabilityrequest/utils/util.go
+++ b/central/vulnerabilityrequest/utils/util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/uuid"
 )
 
@@ -234,6 +235,31 @@ func V2GlobalScope(scope *storage.VulnerabilityRequest_Scope) bool {
 	return imgScope.GetRegistry() == common.MatchAll &&
 		imgScope.GetRemote() == common.MatchAll &&
 		imgScope.GetTag() == common.MatchAll
+}
+
+// IsUpdateNoOp returns true if the exception update does not change the original exception.
+func IsUpdateNoOp(req *storage.VulnerabilityRequest, update *common.UpdateRequest) bool {
+	if req == nil || update == nil {
+		return true
+	}
+	if update.FalsePositiveUpdate == nil && update.DeferralUpdate == nil {
+		return true
+	}
+
+	existingCVEs := set.NewStringSet(req.GetCves().GetCves()...)
+	if update := update.DeferralUpdate; update != nil {
+		newCVEs := set.NewStringSet(update.GetCVEs()...)
+		diff := existingCVEs.Difference(newCVEs)
+		return diff.Cardinality() == 0 && req.GetDeferralReq().GetExpiry() == update.GetExpiry()
+	}
+
+	if update := update.FalsePositiveUpdate; update != nil {
+		newCVEs := set.NewStringSet(update.GetCVEs()...)
+		diff := existingCVEs.Difference(newCVEs)
+		return diff.Cardinality() == 0
+	}
+	// If we cannot determine that the update is a deferral update and false-positive, then we cannot handle it and must be treated as noop.
+	return true
 }
 
 // Returns true if the scope of `toMatch` covers the scope of `matchWith`.

--- a/central/vulnerabilityrequest/utils/util_test.go
+++ b/central/vulnerabilityrequest/utils/util_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"testing"
 
+	"github.com/stackrox/rox/central/vulnerabilityrequest/common"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
@@ -167,6 +168,74 @@ func testFirstIndexMatchingScope(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			idx := FirstIndexMatchingScope(tc.toMatch, tc.matchWith)
 			assert.Equal(t, tc.expectedFirstIndex, idx)
+		})
+	}
+}
+
+func TestIsUpdateNoOp(t *testing.T) {
+	globalCVE1DefReq := fixtures.GetGlobalDeferralRequestV2("cve-1")
+	globalCVE1FPReq := fixtures.GetGlobalFPRequestV2("cve-1")
+
+	for _, tc := range []struct {
+		desc    string
+		request *storage.VulnerabilityRequest
+		update  *common.UpdateRequest
+		noop    bool
+	}{
+		{
+			desc:    "no-op deferral update",
+			request: globalCVE1DefReq,
+			update: &common.UpdateRequest{
+				DeferralUpdate: &storage.DeferralUpdate{
+					CVEs:   []string{"cve-1"},
+					Expiry: globalCVE1DefReq.GetDeferralReq().GetExpiry(),
+				},
+			},
+			noop: true,
+		},
+		{
+			desc:    "no-op false positive update",
+			request: globalCVE1FPReq,
+			update: &common.UpdateRequest{
+				FalsePositiveUpdate: &storage.FalsePositiveUpdate{
+					CVEs: []string{"cve-1"},
+				},
+			},
+			noop: true,
+		},
+		{
+			desc:    "allow deferral update",
+			request: fixtures.GetGlobalDeferralRequestV2("cve-1", "cve-2"),
+			update: &common.UpdateRequest{
+				DeferralUpdate: &storage.DeferralUpdate{
+					CVEs:   []string{"cve-1"},
+					Expiry: &storage.RequestExpiry{Expiry: &storage.RequestExpiry_ExpiresWhenFixed{ExpiresWhenFixed: true}},
+				},
+			},
+			noop: false,
+		},
+		{
+			desc:    "allow false positive update",
+			request: fixtures.GetGlobalFPRequestV2("cve-1"),
+			update: &common.UpdateRequest{
+				FalsePositiveUpdate: &storage.FalsePositiveUpdate{
+					CVEs: []string{"cve-1", "cve-2"},
+				},
+			},
+			noop: false,
+		},
+		{
+			desc: "nil",
+			noop: true,
+		},
+		{
+			desc:    "nil again",
+			request: fixtures.GetGlobalDeferralRequestV2("cve-1", "cve-2"),
+			noop:    true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			assert.Equal(t, tc.noop, IsUpdateNoOp(tc.request, tc.update))
 		})
 	}
 }

--- a/generated/api/v2/vuln_exception_service.pb.go
+++ b/generated/api/v2/vuln_exception_service.pb.go
@@ -2091,7 +2091,9 @@ type VulnerabilityExceptionServiceClient interface {
 	// enforced. Cancelled exceptions are garbage collected as per the retention configuration
 	// `.expiredVulnReqRetentionDurationDays` (GET `/v1/config/`).
 	CancelVulnerabilityException(ctx context.Context, in *ResourceByID, opts ...grpc.CallOption) (*CancelVulnerabilityExceptionResponse, error)
-	// DeleteVulnerabilityException deletes a vulnerability exception.
+	// DeleteVulnerabilityException deletes a vulnerability exception. Only pending exceptions and pending updates
+	// to an enforced exception can be deleted. To revert an exception use cancel API. All exceptions are retained
+	// in the system according to the retention configuration.
 	DeleteVulnerabilityException(ctx context.Context, in *ResourceByID, opts ...grpc.CallOption) (*Empty, error)
 }
 
@@ -2214,7 +2216,9 @@ type VulnerabilityExceptionServiceServer interface {
 	// enforced. Cancelled exceptions are garbage collected as per the retention configuration
 	// `.expiredVulnReqRetentionDurationDays` (GET `/v1/config/`).
 	CancelVulnerabilityException(context.Context, *ResourceByID) (*CancelVulnerabilityExceptionResponse, error)
-	// DeleteVulnerabilityException deletes a vulnerability exception.
+	// DeleteVulnerabilityException deletes a vulnerability exception. Only pending exceptions and pending updates
+	// to an enforced exception can be deleted. To revert an exception use cancel API. All exceptions are retained
+	// in the system according to the retention configuration.
 	DeleteVulnerabilityException(context.Context, *ResourceByID) (*Empty, error)
 }
 

--- a/proto/api/v2/vuln_exception_service.proto
+++ b/proto/api/v2/vuln_exception_service.proto
@@ -274,7 +274,9 @@ service VulnerabilityExceptionService {
         };
     }
 
-    // DeleteVulnerabilityException deletes a vulnerability exception.
+    // DeleteVulnerabilityException deletes a vulnerability exception. Only pending exceptions and pending updates
+    // to an enforced exception can be deleted. To revert an exception use cancel API. All exceptions are retained
+    // in the system according to the retention configuration.
     rpc DeleteVulnerabilityException (ResourceByID) returns (Empty) {
         option (google.api.http) = {
             delete: "/v2/vulnerability-exceptions/{id}"


### PR DESCRIPTION
## Description
- ROX-20493: Prohibit changing a deferral vuln exception to false-positive and vice-versa. The updated function `UpdateRequest` is protected by the feature flag and is used by v2 APIs only.
- ROX-20494: Only allow deleting vulnerability exceptions or updates in pending state.
- ROX-20495: Prohibit updates that do not change exceptions. Updates go through the approval process, so the updates that do not change the original exception can be annoying for admin, so prohibit such updates.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Unit test