### PR TITLE
ROX-19420: Adding search filters for pending requests

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -4,6 +4,7 @@ import {
     Pagination,
     Toolbar,
     ToolbarContent,
+    ToolbarGroup,
     ToolbarItem,
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
@@ -11,6 +12,10 @@ import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-tab
 import useURLPagination from 'hooks/useURLPagination';
 import { VulnerabilityException } from 'services/VulnerabilityExceptionService';
 
+import useURLSearch from 'hooks/useURLSearch';
+import { SearchOption } from 'Containers/Vulnerabilities/ExceptionManagement/components/SearchOptionsDropdown';
+
+import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import {
     ExpiresTableCell,
     RequestIDTableCell,
@@ -20,6 +25,7 @@ import {
     RequesterTableCell,
     ScopeTableCell,
 } from './components/ExceptionRequestTableCells';
+import FilterAutocompleteSelect from './components/FilterAutocomplete';
 
 // @TODO: Use API data instead of hardcoded data
 const vulnerabilityExceptions: VulnerabilityException[] = [
@@ -69,13 +75,46 @@ const vulnerabilityExceptions: VulnerabilityException[] = [
     },
 ];
 
+const searchOptions: SearchOption[] = [
+    {
+        label: 'Request ID',
+        value: 'REQUEST_ID',
+        category: 'VULN_REQUEST', // This might need to change
+    },
+    {
+        label: 'CVE',
+        value: 'CVE',
+        category: 'IMAGE_VULNERABILITIES',
+    },
+    {
+        label: 'Requester',
+        value: 'REQUESTER',
+        category: 'VULN_REQUEST', // This might need to change
+    },
+    {
+        label: 'Image',
+        value: 'IMAGE',
+        category: 'IMAGES',
+    },
+];
+
 function PendingApprovals() {
+    const { searchFilter, setSearchFilter } = useURLSearch();
     const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+
+    function onFilterChange() {
+        setPage(1);
+    }
 
     return (
         <PageSection>
             <Toolbar>
                 <ToolbarContent>
+                    <FilterAutocompleteSelect
+                        searchFilter={searchFilter}
+                        setSearchFilter={setSearchFilter}
+                        searchOptions={searchOptions}
+                    />
                     <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
                         <Pagination
                             itemCount={1}
@@ -86,6 +125,17 @@ function PendingApprovals() {
                             isCompact
                         />
                     </ToolbarItem>
+                    <ToolbarGroup aria-label="applied search filters" className="pf-u-w-100">
+                        <SearchFilterChips
+                            onFilterChange={onFilterChange}
+                            filterChipGroupDescriptors={searchOptions.map(({ label, value }) => {
+                                return {
+                                    displayName: label,
+                                    searchFilterName: value,
+                                };
+                            })}
+                        />
+                    </ToolbarGroup>
                 </ToolbarContent>
             </Toolbar>
             <TableComposable borders={false}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/FilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/FilterAutocomplete.tsx
@@ -1,0 +1,132 @@
+import React, { useState, useMemo } from 'react';
+import { debounce, Select, SelectOption, ToolbarGroup } from '@patternfly/react-core';
+import { useQuery } from '@apollo/client';
+
+import { SearchFilter } from 'types/search';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import SEARCH_AUTOCOMPLETE_QUERY from 'queries/searchAutocomplete';
+import SearchOptionsDropdown, { SearchOption } from './SearchOptionsDropdown';
+
+function getOptions(data: string[] | undefined): React.ReactElement[] | undefined {
+    return data?.map((value) => <SelectOption key={value} value={value} />);
+}
+
+function getAutocompleteOptionsQueryString(searchFilter: SearchFilter): string {
+    return Object.entries(searchFilter)
+        .map(([key, value]) => {
+            let returnValue = '';
+            if (value) {
+                returnValue = `${Array.isArray(value) ? value.join(',') : value}`;
+            }
+            return `${key}:${returnValue}`;
+        })
+        .join('+');
+}
+
+export type FilterAutocompleteSelectProps = {
+    searchFilter: SearchFilter;
+    setSearchFilter: (s) => void;
+    searchOptions: SearchOption[];
+    autocompleteSearchContext?:
+        | { 'Image SHA': string }
+        | { 'Deployment ID': string }
+        | { 'CVE ID': string }
+        | Record<string, never>;
+};
+
+function FilterAutocompleteSelect({
+    searchFilter,
+    setSearchFilter,
+    searchOptions,
+    autocompleteSearchContext = {},
+}: FilterAutocompleteSelectProps) {
+    const [searchOption, setSearchOption] = useState<SearchOption>(() => {
+        return searchOptions[0];
+    });
+    const [typeahead, setTypeahead] = useState('');
+    const { isOpen, onToggle } = useSelectToggle();
+
+    // TODO Autocomplete requests for "Cluster" never return results if there is a 'CVE ID' or 'Severity' search filter
+    // included in the query. In this case we don't include the additional filters at all which leaves the cluster results
+    // unfiltered. Not ideal, but better than no results.
+    const autocompleteSearchFilter =
+        searchOption.value === 'CLUSTER' && autocompleteSearchContext['CVE ID']
+            ? { [searchOption.value]: typeahead }
+            : {
+                  ...autocompleteSearchContext,
+                  ...searchFilter,
+                  [searchOption.value]: typeahead,
+              };
+
+    const variables = {
+        query: getAutocompleteOptionsQueryString(autocompleteSearchFilter),
+        categories: searchOption.category,
+    };
+
+    const { data } = useQuery(SEARCH_AUTOCOMPLETE_QUERY, { variables });
+
+    function onSelect(newValue) {
+        const oldValue = searchFilter[searchOption.value] as string[];
+        setTypeahead('');
+        if (oldValue?.includes(newValue)) {
+            setSearchFilter({
+                ...searchFilter,
+                [searchOption.value]: oldValue.filter((fil: string) => fil !== newValue),
+            });
+        } else {
+            setSearchFilter({
+                ...searchFilter,
+                [searchOption.value]: oldValue ? [...oldValue, newValue] : [newValue],
+            });
+        }
+    }
+
+    // Debounce the autocomplete requests to not overload the backend
+    const updateTypeahead = useMemo(
+        () => debounce((value: string) => setTypeahead(value), 800),
+        []
+    );
+
+    return (
+        <ToolbarGroup variant="filter-group" className="pf-u-display-flex pf-u-flex-grow-1">
+            <SearchOptionsDropdown
+                setSearchOption={(selection) => {
+                    const newSearchOption = searchOptions.find(
+                        (option) => option.value === selection
+                    );
+                    if (newSearchOption) {
+                        setSearchOption(newSearchOption);
+                    }
+                }}
+                searchOption={searchOption}
+            >
+                {searchOptions.map(({ label, value }) => {
+                    return <SelectOption value={value}>{label}</SelectOption>;
+                })}
+            </SearchOptionsDropdown>
+            <Select
+                typeAheadAriaLabel={`Filter by ${searchOption.label}`}
+                aria-label={`Filter by ${searchOption.label}`}
+                onSelect={(e, value) => {
+                    onSelect(value);
+                }}
+                onToggle={onToggle}
+                isOpen={isOpen}
+                placeholderText={`Filter results by ${searchOption.label}`}
+                variant="typeaheadmulti"
+                isCreatable
+                createText="Add"
+                // We set this as empty because we want to use SearchFilterChips to display the search values
+                selections={[]}
+                onTypeaheadInputChanged={(val: string) => {
+                    updateTypeahead(val);
+                }}
+                className="pf-u-flex-grow-1"
+            >
+                {getOptions(data?.searchAutocomplete)}
+            </Select>
+        </ToolbarGroup>
+    );
+}
+
+export default FilterAutocompleteSelect;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/SearchOptionsDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/SearchOptionsDropdown.tsx
@@ -1,0 +1,44 @@
+// @TODO: Replace the usage of FilterResourceDropdown with this
+
+import React, { ReactElement } from 'react';
+import { Select, SelectOption } from '@patternfly/react-core';
+
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { SearchCategory } from 'services/SearchService';
+
+export type SearchOption = { label: string; value: string; category: SearchCategory };
+
+export type SearchOptionsDropdownProps = {
+    setSearchOption: (selection) => void;
+    searchOption: SearchOption;
+    children: ReactElement<typeof SelectOption>[];
+};
+
+function SearchOptionsDropdown({
+    setSearchOption,
+    searchOption,
+    children,
+}: SearchOptionsDropdownProps) {
+    const { isOpen, onToggle } = useSelectToggle();
+
+    function onSearchOptionSelect(e, selection) {
+        setSearchOption(selection);
+    }
+
+    return (
+        <Select
+            variant="single"
+            toggleAriaLabel="exception request filter menu toggle"
+            aria-label="exception request filter menu items"
+            onToggle={onToggle}
+            onSelect={onSearchOptionSelect}
+            selections={searchOption.value}
+            isOpen={isOpen}
+            className="pf-u-flex-basis-0"
+        >
+            {children}
+        </Select>
+    );
+}
+
+export default SearchOptionsDropdown;


### PR DESCRIPTION
## Description

This PR takes the `FilterAutocomplete` and `FilterResourceDropdown` Components and re-purposes them for the Exception Management section. To not break anything, I decided to create a copy of the Components (renamed to `FilterAutocomplete` and `SearchOptionsDropdown`). The `SearchOptionsDropdown` was made more generic to be reused for other cases. The `FilterAutocomplete` was slightly modified as well to make it easier to reuse. 

Note: I plan to revisit and refactor the two components to incorporate the new ones in an upcoming PR.