### PR TITLE
ROX-19512: Limit Network Graph scope selectors to exact matches

### DIFF
--- a/ui/apps/platform/src/services/NetworkService.js
+++ b/ui/apps/platform/src/services/NetworkService.js
@@ -1,6 +1,7 @@
 import queryString from 'qs';
 
 import { ORCHESTRATOR_COMPONENTS_KEY } from 'utils/orchestratorComponents';
+import { convertToExactMatch } from 'utils/searchUtils';
 
 import axios from './instance';
 
@@ -232,8 +233,12 @@ export function fetchNetworkFlowGraph(
     includePolicies = false
 ) {
     const urlParams = query ? { query } : {};
-    const namespaceQuery = namespaces.length > 0 ? `Namespace:${namespaces.join(',')}` : '';
-    const deploymentQuery = deployments.length > 0 ? `Deployment:${deployments.join(',')}` : '';
+    const namespaceQuery =
+        namespaces.length > 0 ? `Namespace:${namespaces.map(convertToExactMatch).join(',')}` : '';
+    const deploymentQuery =
+        deployments.length > 0
+            ? `Deployment:${deployments.map(convertToExactMatch).join(',')}`
+            : '';
     urlParams.query = query ? `${query}+${namespaceQuery}` : namespaceQuery;
     urlParams.query = deploymentQuery ? `${urlParams.query}+${deploymentQuery}` : urlParams.query;
     if (date) {

--- a/ui/apps/platform/src/utils/searchUtils.test.js
+++ b/ui/apps/platform/src/utils/searchUtils.test.js
@@ -7,6 +7,7 @@ import {
     searchOptionsToSearchFilter,
     getListQueryParams,
     searchValueAsArray,
+    convertToExactMatch,
 } from './searchUtils';
 
 describe('searchUtils', () => {
@@ -391,6 +392,20 @@ describe('searchUtils', () => {
         it('converts an array value to an array with the same elements', () => {
             expect(searchValueAsArray([])).toEqual([]);
             expect(searchValueAsArray(['cluster', 'namespace'])).toEqual(['cluster', 'namespace']);
+        });
+    });
+
+    describe('convertToExactMatch', () => {
+        it('returns a non-string value unmodified', () => {
+            expect(convertToExactMatch(undefined)).toEqual(undefined);
+            expect(convertToExactMatch(null)).toEqual(null);
+            expect(convertToExactMatch(42)).toEqual(42);
+            expect(convertToExactMatch(['42'])).toEqual(['42']);
+            expect(convertToExactMatch({ key: 'value' })).toEqual({ key: 'value' });
+        });
+
+        it('returns a string value wrapped in bespoke regex for exact match', () => {
+            expect(convertToExactMatch('cluster')).toEqual('r/^cluster$');
         });
     });
 });

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -237,3 +237,19 @@ export function searchValueAsArray(searchValue: ValueOf<SearchFilter>): string[]
     }
     return [searchValue];
 }
+
+/**
+ * Adds the StackRox bespoke flag for regex match, plus start-of-line and end-of-line character
+ *
+ * Non-string values will be returned unchanged.
+ * String values will return as "r/^<original>$".
+ *
+ * @param {string} item
+ * @returns {string}
+ */
+export function convertToExactMatch(item): string | unknown {
+    if (typeof item !== 'string') {
+        return item;
+    }
+    return `r/^${item}$`;
+}


### PR DESCRIPTION
## Description

When the other namespaces' names start with the same name as a filtered namespace, both the filtered NS chosen and the other similar named NS show up in the Network Graph.

@Maddosaurus  from the Maple team confirmed that the Network Graph API accepts the characters `r/` at the beginning of a search string, which causes the remainder of that string to be treated as a regex.

FE-only solution:
Immediately before sending the namespace and deployment parameters for the network graph calls, iterate over the arrays of namespaces and deployments selected by the user, and map them to new values in the form `r/^{value}%`. This makes them behave as exact-match regexes.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added


## Testing Performed

### Here I tell how I validated my change


1. Added unit tests for the new function to make all Namespaces and Deployments chosen in the NG selector bar be exact matches
2. Manual testing with multiple NS and Deployments that start with the same letters
2.a. Create  an`sec` and an `sec12` namespaces with deployments in them 
2.b. Create a `unc` namespace with both a `unc` and a `unc-ch` deployment in it.
2.c. Screenshot with the namespace `sec` selected showed both **sec** and **sec12** namespaces
2.d. Screenshot with`unc` deployment selected shows both **unc** and **unc-ch** deployments.
2.e. Apply code changes
2.f. After code changes, screenshot with the namespace `sec` selected showed only **sec** namespace
2.g. After code changes, screenshot with`unc` deployment selected shows only **unc** deployment.

Namespace Before
<img width="1513" alt="ns-before" src="https://github.com/stackrox/stackrox/assets/715729/fed6d02f-2c5a-4029-b522-e23eb4fe4e3f">

Namespaces After
<img width="1513" alt="ns-after" src="https://github.com/stackrox/stackrox/assets/715729/c70b501e-46dc-406c-9c88-ea509e823a91">

Deployments Before
<img width="1513" alt="deployments-before" src="https://github.com/stackrox/stackrox/assets/715729/4d19fe06-f3c0-489f-900e-da5b56e4094c">

Deployments After
<img width="1513" alt="deployments-after" src="https://github.com/stackrox/stackrox/assets/715729/18629e9d-a340-44a0-94d7-5e87ba06b817">

Also tested with multiple namespaces selected. Here, both `sec` and `sec12` are selected and thus displayed, but `sec122` is not selected, and so that NS is not displayed.
<img width="1513" alt="mulitple-ns-params" src="https://github.com/stackrox/stackrox/assets/715729/67458bfd-ce38-431a-a440-401ffc529343">


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
