### PR TITLE
ROX-19394: Add deferral flow to image single page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -146,7 +146,16 @@ function ImagePage() {
                             eventKey="Vulnerabilities"
                             title={<TabTitleText>Vulnerabilities</TabTitleText>}
                         >
-                            <ImagePageVulnerabilities imageId={imageId} />
+                            <ImagePageVulnerabilities
+                                imageId={imageId}
+                                imageName={
+                                    imageData?.name ?? {
+                                        registry: '',
+                                        remote: '',
+                                        tag: '',
+                                    }
+                                }
+                            />
                         </Tab>
                         <Tab
                             className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react';
 import {
     Bullseye,
     Divider,
+    DropdownItem,
     Flex,
     Grid,
     GridItem,
@@ -24,6 +25,9 @@ import { Pagination as PaginationParam } from 'services/types';
 import { getHasSearchApplied } from 'utils/searchUtils';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import useMap from 'hooks/useMap';
+import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 import WorkloadTableToolbar from '../components/WorkloadTableToolbar';
 import CvesByStatusSummaryCard, {
     ResourceCountByCveSeverityAndStatus,
@@ -45,6 +49,11 @@ import { imageMetadataContextFragment, ImageMetadataContext } from '../Tables/ta
 import { Resource } from '../components/FilterResourceDropdown';
 import VulnerabilityStateTabs from '../components/VulnerabilityStateTabs';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
+import ExceptionRequestModal, {
+    ExceptionRequestModalProps,
+} from '../components/ExceptionRequestModal/ExceptionRequestModal';
+import CompletedExceptionRequestModal from '../components/ExceptionRequestModal/CompletedExceptionRequestModal';
+import useExceptionRequestModal from '../hooks/useExceptionRequestModal';
 
 const imageVulnerabilitiesQuery = gql`
     ${imageMetadataContextFragment}
@@ -69,9 +78,17 @@ const imageResourceFilters = new Set<Resource>(['CVE']);
 
 export type ImagePageVulnerabilitiesProps = {
     imageId: string;
+    imageName: {
+        registry: string;
+        remote: string;
+        tag: string;
+    };
 };
 
-function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
+function ImagePageVulnerabilities({ imageId, imageName }: ImagePageVulnerabilitiesProps) {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isUnifiedDeferralsEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL');
+
     const currentVulnerabilityState = useVulnerabilityState();
 
     const { searchFilter } = useURLSearch();
@@ -114,9 +131,23 @@ function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
 
     const isFiltered = getHasSearchApplied(querySearchFilter);
 
+    const selectedCves = useMap<string, ExceptionRequestModalProps['cves'][number]>();
+    const {
+        exceptionRequestModalOptions,
+        completedException,
+        showModal,
+        closeModals,
+        createExceptionModalActions,
+    } = useExceptionRequestModal();
+
     let mainContent: ReactNode | null = null;
 
     const vulnerabilityData = data ?? previousData;
+
+    const showDeferralUI = isUnifiedDeferralsEnabled && currentVulnerabilityState === 'OBSERVED';
+    const canSelectRows = showDeferralUI;
+
+    const createTableActions = showDeferralUI ? createExceptionModalActions : undefined;
 
     if (error) {
         mainContent = (
@@ -175,6 +206,42 @@ function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
                                 {isFiltered && <DynamicTableLabel />}
                             </Flex>
                         </SplitItem>
+                        {canSelectRows && (
+                            <>
+                                <SplitItem>
+                                    <BulkActionsDropdown isDisabled={selectedCves.size === 0}>
+                                        <DropdownItem
+                                            key="bulk-defer-cve"
+                                            component="button"
+                                            onClick={() =>
+                                                showModal({
+                                                    type: 'DEFERRAL',
+                                                    cves: Array.from(selectedCves.values()),
+                                                })
+                                            }
+                                        >
+                                            Defer CVEs
+                                        </DropdownItem>
+                                        <DropdownItem
+                                            key="bulk-mark-false-positive"
+                                            component="button"
+                                            onClick={() =>
+                                                showModal({
+                                                    type: 'FALSE_POSITIVE',
+                                                    cves: Array.from(selectedCves.values()),
+                                                })
+                                            }
+                                        >
+                                            Mark as false positives
+                                        </DropdownItem>
+                                    </BulkActionsDropdown>
+                                </SplitItem>
+                                <Divider
+                                    className="pf-u-px-lg"
+                                    orientation={{ default: 'vertical' }}
+                                />
+                            </>
+                        )}
                         <SplitItem>
                             <Pagination
                                 itemCount={totalVulnerabilityCount}
@@ -195,6 +262,9 @@ function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
                             image={vulnerabilityData.image}
                             getSortParams={getSortParams}
                             isFiltered={isFiltered}
+                            selectedCves={selectedCves}
+                            canSelectRows={canSelectRows}
+                            createTableActions={createTableActions}
                         />
                     </div>
                 </div>
@@ -204,6 +274,24 @@ function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
 
     return (
         <>
+            {exceptionRequestModalOptions && (
+                <ExceptionRequestModal
+                    cves={exceptionRequestModalOptions.cves}
+                    type={exceptionRequestModalOptions.type}
+                    scopeContext={{ imageName }}
+                    onExceptionRequestSuccess={(exception) => {
+                        selectedCves.clear();
+                        showModal({ type: 'COMPLETION', exception });
+                    }}
+                    onClose={closeModals}
+                />
+            )}
+            {completedException && (
+                <CompletedExceptionRequestModal
+                    exceptionRequest={completedException}
+                    onClose={closeModals}
+                />
+            )}
             <PageSection component="div" variant="light" className="pf-u-py-md pf-u-px-xl">
                 <Text>Review and triage vulnerability data scanned on this image</Text>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useQuery } from '@apollo/client';
 import { Bullseye, Divider, DropdownItem, Spinner, ToolbarItem } from '@patternfly/react-core';
 
@@ -9,7 +9,6 @@ import useURLSearch from 'hooks/useURLSearch';
 import useMap from 'hooks/useMap';
 import { getHasSearchApplied } from 'utils/searchUtils';
 import { VulnerabilityState } from 'types/cve.proto';
-import { BaseVulnerabilityException } from 'services/VulnerabilityExceptionService';
 import CVEsTable, { cveListQuery, unfilteredImageCountQuery } from '../Tables/CVEsTable';
 import TableErrorComponent from '../components/TableErrorComponent';
 import { EntityCounts } from '../components/EntityTypeToggleGroup';
@@ -18,10 +17,10 @@ import { getVulnStateScopedQueryString, parseQuerySearchFilter } from '../search
 import { defaultCVESortFields, CVEsDefaultSort } from '../sortUtils';
 import TableEntityToolbar from '../components/TableEntityToolbar';
 import ExceptionRequestModal, {
-    ExceptionRequestModalOptions,
     ExceptionRequestModalProps,
 } from '../components/ExceptionRequestModal/ExceptionRequestModal';
 import CompletedExceptionRequestModal from '../components/ExceptionRequestModal/CompletedExceptionRequestModal';
+import useExceptionRequestModal from '../hooks/useExceptionRequestModal';
 
 export type CVEsTableContainerProps = {
     defaultFilters: DefaultFilters;
@@ -62,26 +61,17 @@ function CVEsTableContainer({
     const { data: imageCountData } = useQuery(unfilteredImageCountQuery);
 
     const selectedCves = useMap<string, ExceptionRequestModalProps['cves'][number]>();
-    const [exceptionRequestModalOptions, setExceptionRequestModalOptions] =
-        useState<ExceptionRequestModalOptions>(null);
+    const {
+        exceptionRequestModalOptions,
+        completedException,
+        showModal,
+        closeModals,
+        createExceptionModalActions,
+    } = useExceptionRequestModal();
+    const showDeferralUI = isUnifiedDeferralsEnabled && vulnerabilityState === 'OBSERVED';
+    const canSelectRows = showDeferralUI;
 
-    const [completedException, setCompletedException] = useState<BaseVulnerabilityException | null>(
-        null
-    );
-
-    function openDeferralModal() {
-        setExceptionRequestModalOptions({
-            type: 'DEFERRAL',
-            cves: Array.from(selectedCves.values()),
-        });
-    }
-
-    function openFalsePositiveModal() {
-        setExceptionRequestModalOptions({
-            type: 'FALSE_POSITIVE',
-            cves: Array.from(selectedCves.values()),
-        });
-    }
+    const createTableActions = showDeferralUI ? createExceptionModalActions : undefined;
 
     const tableData = data ?? previousData;
     return (
@@ -91,18 +81,17 @@ function CVEsTableContainer({
                     cves={exceptionRequestModalOptions.cves}
                     type={exceptionRequestModalOptions.type}
                     scopeContext="GLOBAL"
-                    onExceptionRequestSuccess={(vulnerabilityException) => {
-                        setExceptionRequestModalOptions(null);
+                    onExceptionRequestSuccess={(exception) => {
                         selectedCves.clear();
-                        setCompletedException(vulnerabilityException);
+                        showModal({ type: 'COMPLETION', exception });
                     }}
-                    onClose={() => setExceptionRequestModalOptions(null)}
+                    onClose={closeModals}
                 />
             )}
             {completedException && (
                 <CompletedExceptionRequestModal
                     exceptionRequest={completedException}
-                    onClose={() => setCompletedException(null)}
+                    onClose={closeModals}
                 />
             )}
             <TableEntityToolbar
@@ -113,24 +102,36 @@ function CVEsTableContainer({
                 tableRowCount={countsData.imageCVECount}
                 isFiltered={isFiltered}
             >
-                <ToolbarItem alignment={{ default: 'alignRight' }}>
-                    <BulkActionsDropdown isDisabled={selectedCves.size === 0}>
-                        <DropdownItem
-                            key="bulk-defer-cve"
-                            component="button"
-                            onClick={openDeferralModal}
-                        >
-                            Defer CVEs
-                        </DropdownItem>
-                        <DropdownItem
-                            key="bulk-mark-false-positive"
-                            component="button"
-                            onClick={openFalsePositiveModal}
-                        >
-                            Mark as false positives
-                        </DropdownItem>
-                    </BulkActionsDropdown>
-                </ToolbarItem>
+                {canSelectRows && (
+                    <ToolbarItem alignment={{ default: 'alignRight' }}>
+                        <BulkActionsDropdown isDisabled={selectedCves.size === 0}>
+                            <DropdownItem
+                                key="bulk-defer-cve"
+                                component="button"
+                                onClick={() =>
+                                    showModal({
+                                        type: 'DEFERRAL',
+                                        cves: Array.from(selectedCves.values()),
+                                    })
+                                }
+                            >
+                                Defer CVEs
+                            </DropdownItem>
+                            <DropdownItem
+                                key="bulk-mark-false-positive"
+                                component="button"
+                                onClick={() =>
+                                    showModal({
+                                        type: 'FALSE_POSITIVE',
+                                        cves: Array.from(selectedCves.values()),
+                                    })
+                                }
+                            >
+                                Mark as false positives
+                            </DropdownItem>
+                        </BulkActionsDropdown>
+                    </ToolbarItem>
+                )}
                 <ToolbarItem alignment={{ default: 'alignRight' }} variant="separator" />
             </TableEntityToolbar>
             <Divider component="div" />
@@ -156,10 +157,8 @@ function CVEsTableContainer({
                         isFiltered={isFiltered}
                         filteredSeverities={searchFilter.Severity as VulnerabilitySeverityLabel[]}
                         selectedCves={selectedCves}
-                        cveTableActionHandler={setExceptionRequestModalOptions}
-                        showExceptionMenuItems={
-                            isUnifiedDeferralsEnabled && vulnerabilityState === 'OBSERVED'
-                        }
+                        canSelectRows={canSelectRows}
+                        createTableActions={createTableActions}
                     />
                 </div>
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import {
+    ActionsColumn,
     ExpandableRowContent,
+    IAction,
     TableComposable,
     Tbody,
     Td,
@@ -17,6 +19,7 @@ import { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
 import { isVulnerabilitySeverity } from 'types/cve.proto';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
+import useMap from 'hooks/useMap';
 import { getEntityPagePath } from '../searchUtils';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
 import ImageComponentVulnerabilitiesTable, {
@@ -29,6 +32,10 @@ import EmptyTableResults from '../components/EmptyTableResults';
 import DateDistanceTd from '../components/DatePhraseTd';
 import CvssTd from '../components/CvssTd';
 import { getAnyVulnerabilityIsFixable } from './table.utils';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { CveSelectionsProps } from '../components/ExceptionRequestModal/CveSelections';
+import CVESelectionTh from '../components/CVESelectionTh';
+import CVESelectionTd from '../components/CVESelectionTd';
 
 export const imageVulnerabilitiesFragment = gql`
     ${imageComponentVulnerabilitiesFragment}
@@ -61,20 +68,29 @@ export type ImageVulnerabilitiesTableProps = {
     };
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
+    canSelectRows: boolean;
+    selectedCves: ReturnType<typeof useMap<string, CveSelectionsProps['cves'][number]>>;
+    createTableActions?: (cve: { cve: string; summary: string }) => IAction[];
 };
 
 function ImageVulnerabilitiesTable({
     image,
     getSortParams,
     isFiltered,
+    canSelectRows,
+    selectedCves,
+    createTableActions,
 }: ImageVulnerabilitiesTableProps) {
     const expandedRowSet = useSet<string>();
+
+    const colSpan = 6 + (canSelectRows ? 1 : 0) + (createTableActions ? 1 : 0);
 
     return (
         <TableComposable variant="compact">
             <Thead noWrap>
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>
+                    {canSelectRows && <CVESelectionTh selectedCves={selectedCves} />}
                     <Th sort={getSortParams('CVE')}>CVE</Th>
                     <Th sort={getSortParams('Severity')}>CVE Severity</Th>
                     <Th>
@@ -87,6 +103,7 @@ function ImageVulnerabilitiesTable({
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
                     <Th>First discovered</Th>
+                    {createTableActions && <Th aria-label="CVE actions" />}
                 </Tr>
             </Thead>
             {image.imageVulnerabilities.length === 0 && <EmptyTableResults colSpan={7} />}
@@ -116,6 +133,14 @@ function ImageVulnerabilitiesTable({
                                         onToggle: () => expandedRowSet.toggle(cve),
                                     }}
                                 />
+                                {canSelectRows && (
+                                    <CVESelectionTd
+                                        selectedCves={selectedCves}
+                                        rowIndex={rowIndex}
+                                        cve={cve}
+                                        summary={summary}
+                                    />
+                                )}
                                 <Td dataLabel="CVE">
                                     <Button
                                         variant={ButtonVariant.link}
@@ -145,10 +170,17 @@ function ImageVulnerabilitiesTable({
                                 <Td dataLabel="First discovered">
                                     <DateDistanceTd date={discoveredAtImage} />
                                 </Td>
+                                {createTableActions && (
+                                    <Td className="pf-u-px-0">
+                                        <ActionsColumn
+                                            items={createTableActions({ cve, summary })}
+                                        />
+                                    </Td>
+                                )}
                             </Tr>
                             <Tr isExpanded={isExpanded}>
                                 <Td />
-                                <Td colSpan={6}>
+                                <Td colSpan={colSpan}>
                                     <ExpandableRowContent>
                                         <p className="pf-u-mb-md">{summary}</p>
                                         <ImageComponentVulnerabilitiesTable

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CVESelectionTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CVESelectionTd.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Td } from '@patternfly/react-table';
+
+import useMap from 'hooks/useMap';
+
+export type CVESelectionTdProps = {
+    selectedCves: ReturnType<typeof useMap<string, { cve: string; summary: string }>>;
+    rowIndex: number;
+    cve: string;
+    summary: string;
+};
+
+function CVESelectionTd({ selectedCves, rowIndex, cve, summary }: CVESelectionTdProps) {
+    return (
+        <Td
+            select={{
+                rowIndex,
+                onSelect: () => {
+                    if (selectedCves.has(cve)) {
+                        selectedCves.remove(cve);
+                    } else {
+                        selectedCves.set(cve, { cve, summary });
+                    }
+                },
+                isSelected: selectedCves.has(cve),
+            }}
+        />
+    );
+}
+
+export default CVESelectionTd;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CVESelectionTh.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CVESelectionTh.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { pluralize } from '@patternfly/react-core';
+import { Th } from '@patternfly/react-table';
+
+import useMap from 'hooks/useMap';
+
+export type CVESelectionThProps = {
+    selectedCves: ReturnType<typeof useMap<string, { cve: string; summary: string }>>;
+};
+
+function CVESelectionTh({ selectedCves }: CVESelectionThProps) {
+    return (
+        <Th
+            title={
+                selectedCves.size > 0
+                    ? `Clear ${pluralize(selectedCves.size, 'selected CVE')}`
+                    : undefined
+            }
+            select={{
+                isSelected: selectedCves.size !== 0,
+                isDisabled: selectedCves.size === 0,
+                onSelect: selectedCves.clear,
+            }}
+        />
+    );
+}
+
+export default CVESelectionTh;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/CompletedExceptionRequestModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/CompletedExceptionRequestModal.tsx
@@ -21,6 +21,7 @@ import {
 } from 'services/VulnerabilityExceptionService';
 import { getDate } from 'utils/dateUtils';
 import { ensureExhaustive } from 'utils/type.utils';
+import { exceptionManagementPath } from 'routePaths';
 
 function scopeDisplay(scope: BaseVulnerabilityException['scope']): string {
     if (scope.imageScope.remote === '.*') {
@@ -75,6 +76,8 @@ function CompletedExceptionRequestModal({
         requestedAction = 'False positive';
     }
 
+    const exceptionRequestURL = `${window.location.origin}${exceptionManagementPath}/requests/${exceptionRequest.id}`;
+
     return (
         <Modal
             onClose={onClose}
@@ -89,11 +92,9 @@ function CompletedExceptionRequestModal({
         >
             <Flex direction={{ default: 'column' }}>
                 <Text>Use this link to share and discuss your request with your approver.</Text>
-                <ClipboardCopy
-                    isReadOnly
-                    hoverTip="Copy"
-                    clickTip="Copied"
-                >{`todo.path.to.requests.page/${exceptionRequest.name}`}</ClipboardCopy>
+                <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied">
+                    {exceptionRequestURL}
+                </ClipboardCopy>
                 <DescriptionList columnModifier={{ default: '2Col' }} className="pf-u-pt-md">
                     <DescriptionListGroup>
                         <DescriptionListTerm>Requested action</DescriptionListTerm>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionRequestForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionRequestForm.tsx
@@ -21,7 +21,11 @@ function getDefaultValues(cves: string[], scopeContext: ScopeContext): Exception
     const imageScope =
         scopeContext === 'GLOBAL'
             ? { registry: ALL, remote: ALL, tag: ALL }
-            : { registry: ALL, remote: scopeContext.image.name, tag: ALL };
+            : {
+                  registry: scopeContext.imageName.registry,
+                  remote: scopeContext.imageName.remote,
+                  tag: ALL,
+              };
 
     return { cves, comment: '', scope: { imageScope } };
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionScopeField.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionScopeField.tsx
@@ -15,7 +15,7 @@ export type ExceptionScopeFieldProps = {
 };
 
 function ExceptionScopeField({ fieldId, label, scopeContext, formik }: ExceptionScopeFieldProps) {
-    const { values } = formik;
+    const { values, setFieldValue } = formik;
 
     return (
         <FormGroup fieldId={fieldId} label={label} isRequired>
@@ -29,7 +29,6 @@ function ExceptionScopeField({ fieldId, label, scopeContext, formik }: Exception
                         values.scope.imageScope.remote === ALL &&
                         values.scope.imageScope.tag === ALL
                     }
-                    onChange={() => {}}
                     label="Selected CVEs across all images and deployments"
                 />
             )}
@@ -39,22 +38,32 @@ function ExceptionScopeField({ fieldId, label, scopeContext, formik }: Exception
                         id="scope-single-image"
                         name="scope-single-image"
                         isChecked={
-                            values.scope.imageScope.registry === ALL &&
-                            values.scope.imageScope.remote === scopeContext.image.name &&
+                            values.scope.imageScope.registry === scopeContext.imageName.registry &&
+                            values.scope.imageScope.remote === scopeContext.imageName.remote &&
                             values.scope.imageScope.tag === ALL
                         }
-                        onChange={() => {}}
-                        label={`All tags within ${scopeContext.image.name}`}
+                        onChange={() =>
+                            setFieldValue('scope.imageScope', {
+                                ...scopeContext.imageName,
+                                tag: ALL,
+                            })
+                        }
+                        label={`All tags within ${scopeContext.imageName.registry}/${scopeContext.imageName.remote}`}
                     />
                     <Radio
                         id="scope-single-image-single-tag"
                         name="scope-single-image-single-tag"
                         isChecked={
-                            values.scope.imageScope.registry === ALL &&
-                            values.scope.imageScope.remote === scopeContext.image.name &&
-                            values.scope.imageScope.tag === scopeContext.image.tag
+                            values.scope.imageScope.registry === scopeContext.imageName.registry &&
+                            values.scope.imageScope.remote === scopeContext.imageName.remote &&
+                            values.scope.imageScope.tag === scopeContext.imageName.tag
                         }
-                        label={`Only ${scopeContext.image.name}:${scopeContext.image.tag}`}
+                        onChange={() =>
+                            setFieldValue('scope.imageScope', {
+                                ...scopeContext.imageName,
+                            })
+                        }
+                        label={`Only ${scopeContext.imageName.registry}/${scopeContext.imageName.remote}:${scopeContext.imageName.tag}`}
                     />
                 </>
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/utils.ts
@@ -7,7 +7,9 @@ import {
 } from 'services/VulnerabilityExceptionService';
 import { ensureExhaustive } from 'utils/type.utils';
 
-export type ScopeContext = 'GLOBAL' | { image: { name: string; tag: string } };
+export type ScopeContext =
+    | 'GLOBAL'
+    | { imageName: { registry: string; remote: string; tag: string } };
 
 export const exceptionValidationSchema = yup.object({
     cves: yup.array().of(yup.string()).min(1, 'At least one CVE must be selected'),

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useExceptionRequestModal.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useExceptionRequestModal.ts
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { BaseVulnerabilityException } from 'services/VulnerabilityExceptionService';
+import { ExceptionRequestModalOptions } from '../components/ExceptionRequestModal/ExceptionRequestModal';
+
+export type ShowExceptionModalAction =
+    | {
+          type: 'DEFERRAL' | 'FALSE_POSITIVE';
+          cves: { cve: string; summary: string }[];
+      }
+    | {
+          type: 'COMPLETION';
+          exception: BaseVulnerabilityException;
+      };
+
+export type UseExceptionRequestModalReturn = {
+    exceptionRequestModalOptions: ExceptionRequestModalOptions | null;
+    completedException: BaseVulnerabilityException | null;
+    showModal: (action: ShowExceptionModalAction) => void;
+    closeModals: () => void;
+    createExceptionModalActions: (options: {
+        cve: string;
+        summary: string;
+    }) => { title: string; onClick: () => void }[];
+};
+
+/**
+ * Manages the state of the exception request modal and the completion modal.
+ */
+export default function useExceptionRequestModal(): UseExceptionRequestModalReturn {
+    const [exceptionRequestOptions, setExceptionRequestOptions] =
+        useState<ExceptionRequestModalOptions | null>(null);
+
+    const [completedException, setCompletedException] = useState<BaseVulnerabilityException | null>(
+        null
+    );
+
+    function showModal(action: ShowExceptionModalAction) {
+        if (action.type === 'COMPLETION') {
+            setExceptionRequestOptions(null);
+            setCompletedException(action.exception);
+        } else {
+            setCompletedException(null);
+            setExceptionRequestOptions(action);
+        }
+    }
+
+    return {
+        exceptionRequestModalOptions: exceptionRequestOptions,
+        completedException,
+        showModal,
+        closeModals: () => {
+            setExceptionRequestOptions(null);
+            setCompletedException(null);
+        },
+        createExceptionModalActions: ({ cve, summary }) => [
+            {
+                title: 'Defer CVE',
+                onClick: () => showModal({ type: 'DEFERRAL', cves: [{ cve, summary }] }),
+            },
+            {
+                title: 'Mark as false positive',
+                onClick: () => showModal({ type: 'FALSE_POSITIVE', cves: [{ cve, summary }] }),
+            },
+        ],
+    };
+}


### PR DESCRIPTION
## Description

Adds the deferral and false positive flow to the Workload CVE Image page. As part of this change, common code used here as well as in the main Workload CVE list page has been factored out.

1. Modal state management for the form modal and follow up success modal has been moved into a hook [useExceptionRequestModal.ts](https://github.com/stackrox/stackrox/pull/8390/files#diff-c20d33a8e9c8710bcaea6a008e98ae0572770a859d7b2e07f2d6305b9a15bcea)
2. Common table cells for selection have been moved to [CVESelectionTh](https://github.com/stackrox/stackrox/pull/8390/files#diff-6b64b4b45d04db0adfe210778f92b8055b0f4e114d908e6b76c88ec8f03dcbb3) and [CVESelectionTd](https://github.com/stackrox/stackrox/pull/8390/files#diff-67030b6f5a59fb6d69adc2e967e61349e3e36913fd94f07f34a2ee824928f5ad) components
3. Duplicate table action code is provided via an [action creation function](https://github.com/stackrox/stackrox/pull/8390/files#diff-c20d33a8e9c8710bcaea6a008e98ae0572770a859d7b2e07f2d6305b9a15bceaR55) in the hook


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit an image page and select multiple CVEs across pages:
![image](https://github.com/stackrox/stackrox/assets/1292638/78056627-92a5-4978-a203-cc7ada750278)
![image](https://github.com/stackrox/stackrox/assets/1292638/041b48e1-f870-4d52-b24d-654bfb79127f)

Bulk action defer CVEs:
![image](https://github.com/stackrox/stackrox/assets/1292638/8935813f-9305-481c-8d88-063b32389430)
![image](https://github.com/stackrox/stackrox/assets/1292638/536d921d-c70e-4b8b-ad9c-cc1c6431884f)
![image](https://github.com/stackrox/stackrox/assets/1292638/bbdcb8fb-c2a6-4597-8bec-bc9087e0d476)
![image](https://github.com/stackrox/stackrox/assets/1292638/e56ea453-50ae-4b20-944b-a059bd1a2044)
![image](https://github.com/stackrox/stackrox/assets/1292638/dbba54fc-a151-4141-ae78-b607471f7651)

Mark a single CVE as false positive:
![image](https://github.com/stackrox/stackrox/assets/1292638/df5b592d-5250-4703-bb17-5d4fedca483e)
![image](https://github.com/stackrox/stackrox/assets/1292638/ae9507ec-3814-49bd-8690-4d48eba0c70c)
![image](https://github.com/stackrox/stackrox/assets/1292638/a5e893f2-9e2c-4b2d-95ce-ab56f18c546c)
![image](https://github.com/stackrox/stackrox/assets/1292638/85370f6a-d1f4-4067-ab62-7e9880d93658)

Repeat the above tests, deferring a single CVE and bulk marking false positive instead.

Perform the above tests on the Workload CVE overview list page as well.
