### PR TITLE
refactor(CI): have a single source of GKE defaults

### DIFF
--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -32,7 +32,7 @@ class GKECluster:
     REFRESH_PATH = "scripts/ci/gke.sh"
     TEARDOWN_PATH = "scripts/ci/gke.sh"
 
-    def __init__(self, cluster_id, num_nodes=3, machine_type="e2-standard-4", disk_gb=40):
+    def __init__(self, cluster_id, num_nodes=None, machine_type=None, disk_gb=None):
         self.cluster_id = cluster_id
         self.num_nodes = num_nodes
         self.machine_type = machine_type
@@ -40,15 +40,18 @@ class GKECluster:
         self.refresh_token_cmd = None
 
     def provision(self):
+        if self.num_nodes is not None:
+            os.environ["NUM_NODES"] = str(self.num_nodes)
+        if self.machine_type is not None:
+            os.environ["MACHINE_TYPE"] = str(self.machine_type)
+        if self.disk_gb is not None:
+            os.environ["DISK_SIZE_GB"] = str(self.disk_gb)
+
         with subprocess.Popen(
             [
                 GKECluster.PROVISION_PATH,
                 "provision_gke_cluster",
-                self.cluster_id,
-                str(self.num_nodes),
-                self.machine_type,
-                str(self.disk_gb),
-            ]
+                self.cluster_id,            ]
         ) as cmd:
 
             try:

--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -51,7 +51,8 @@ class GKECluster:
             [
                 GKECluster.PROVISION_PATH,
                 "provision_gke_cluster",
-                self.cluster_id,            ]
+                self.cluster_id,
+            ]
         ) as cmd:
 
             try:
@@ -125,6 +126,7 @@ class AutomationFlavorsCluster:
 
     def teardown(self):
         pass
+
 
 class OpenShiftScaleWorkersCluster:
     SCALE_CHANGE_TIMEOUT = 15 * 60

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -26,9 +26,6 @@ assign_env_variables() {
     fi
 
     local cluster_id="$1"
-    local num_nodes="${2:-3}"
-    local machine_type="${3:-e2-standard-4}"
-    local disk_gb="${4:-40}"
 
     ensure_CI
 
@@ -47,15 +44,6 @@ assign_env_variables() {
     cluster_name="${cluster_name:0:40}" # (for GKE name limit)
     ci_export CLUSTER_NAME "$cluster_name"
     echo "Assigned cluster name is $cluster_name"
-
-    ci_export NUM_NODES "$num_nodes"
-    echo "Number of nodes for cluster is $num_nodes"
-
-    ci_export MACHINE_TYPE "$machine_type"
-    echo "Machine type is set as to $machine_type"
-
-    ci_export DISK_SIZE_GB "$disk_gb"
-    echo "Disk size is set to $disk_gb"
 
     choose_release_channel
     choose_cluster_version

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -21,7 +21,7 @@ provision_gke_cluster() {
 assign_env_variables() {
     info "Assigning environment variables for later steps"
 
-    if [[ "$#" -lt 1 ]]; then
+    if [[ "$#" -ne 1 ]]; then
         die "missing args. usage: assign_env_variables <cluster-id>"
     fi
 

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -22,7 +22,7 @@ assign_env_variables() {
     info "Assigning environment variables for later steps"
 
     if [[ "$#" -lt 1 ]]; then
-        die "missing args. usage: assign_env_variables <cluster-id> [<num-nodes> <machine-type> <disk_gb>]"
+        die "missing args. usage: assign_env_variables <cluster-id>"
     fi
 
     local cluster_id="$1"


### PR DESCRIPTION
## Description

Per title. The existing logic has 3 locations for defaults and is confusing.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Ensure tests with parameter overrides get the correct values:
- [x] gke-scale
- [x] gke-upgrade - failed but the cluster was correct:
```
NAME                                     LOCATION       MASTER_VERSION      MASTER_IP       MACHINE_TYPE   NODE_VERSION        NUM_NODES  STATUS
rox-ci-upgrade-test-1717954958445252608  us-central1-b  1.26.9-gke.1507000  35.224.183.162  e2-standard-8  1.26.9-gke.1507000  3          RUNNING
```