### PR TITLE
ROX-18840: Remove sunburst widgets from Compliance dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Added Features
 
 ### Removed Features
+- ROX-18840: Sunburst widgets in the Compliance section have been removed (deprecation announced in version 4.2 release notes)
 
 ### Deprecated Fatures
 

--- a/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
@@ -33,7 +33,6 @@ const opnamesWithoutStandards = [
     'getAggregatedResultsByEntity_CLUSTER',
     'getAggregatedResultsAcrossEntity_NAMESPACE',
     'getAggregatedResultsAcrossEntity_NODE',
-    'getComplianceStandards',
 ];
 
 export const routeMatcherMapWithoutStandards =

--- a/ui/apps/platform/cypress/integration/compliance/complianceDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/compliance/complianceDashboard.test.js
@@ -17,10 +17,6 @@ function getStandardAcrossEntitiesLink(entityNameOrdinaryCasePlural) {
     return `${getWidgetSelector(`Passing standards across ${entityNameOrdinaryCasePlural}`)} a`;
 }
 
-function getStandardSunburstControlsLink(standardName) {
-    return `${getWidgetSelector(standardName)} .widget-detail-bullet span:contains("Controls")`;
-}
-
 describe('Compliance Dashboard', () => {
     withAuth();
 
@@ -89,14 +85,5 @@ describe('Compliance Dashboard', () => {
         cy.location('search').should('contain', '?s[groupBy]=NODE'); // followed by a standard
         cy.get('[data-testid="panel-header"]').contains('node');
         cy.get(selectors.list.table.firstGroup).should('be.visible');
-    });
-
-    it('should link to controls list when clicking on "# controls" in sunburst', () => {
-        visitComplianceDashboard();
-
-        interactAndWaitForComplianceStandard(() => {
-            cy.get(getStandardSunburstControlsLink('PCI DSS 3.2.1 Compliance')).first().click();
-        });
-        cy.location('search').should('eq', '?s[standard]=PCI DSS 3.2.1'.replace(/ /g, '%20'));
     });
 });

--- a/ui/apps/platform/cypress/integration/compliance/hideScanResults.test.js
+++ b/ui/apps/platform/cypress/integration/compliance/hideScanResults.test.js
@@ -5,7 +5,6 @@ import { triggerScan, visitComplianceDashboard } from './Compliance.helpers';
 import {
     clickSaveAndWaitForPatchComplianceStandards,
     openModal,
-    selectorForWidget,
     selectorForModal,
     selectorInModal,
     selectorInWidget,
@@ -18,30 +17,26 @@ const forHIPAA = {
     standardId: 'HIPAA_164',
     barLink: 'a:contains("HIPAA")',
     checkboxLabel: 'HIPAA 164',
-    sunburstTitle: 'HIPAA 164 Compliance',
 };
 
 const forNIST190 = {
     standardId: 'NIST_800_190',
     barLink: 'a:contains("NIST SP 800-190")',
     checkboxLabel: 'NIST SP 800-190',
-    sunburstTitle: 'NIST SP 800-190 Compliance',
 };
 
 const forNIST53 = {
     standardId: 'NIST_SP_800_53_Rev_4',
     barLink: 'a:contains("NIST SP 800-53")',
     checkboxLabel: 'NIST SP 800-53',
-    sunburstTitle: 'NIST SP 800-53 Compliance',
 };
 
 function assertExistenceOfStandard(forStandard, existence) {
-    const { barLink, sunburstTitle } = forStandard;
+    const { barLink } = forStandard;
     const existOrNot = existence ? 'exist' : 'not.exist';
 
     cy.get(selectorInWidget(titleAcrossClusters, barLink)).should(existOrNot);
     cy.get(selectorInWidget(titleAcrossNamespaces, barLink)).should(existOrNot);
-    cy.get(selectorForWidget(sunburstTitle)).should(existOrNot);
 
     // TODO columns in entity tables
 }

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -18,7 +18,6 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import ScanButton from '../ScanButton';
 import StandardsByEntity from '../widgets/StandardsByEntity';
 import StandardsAcrossEntity from '../widgets/StandardsAcrossEntity';
-import ComplianceByStandards from '../widgets/ComplianceByStandards';
 
 import ManageStandardsError from './ManageStandardsError';
 import ManageStandardsModal from './ManageStandardsModal';
@@ -125,7 +124,7 @@ function ComplianceDashboardPage(): ReactElement {
             </PageHeader>
             <div className="flex-1 relative p-6 xxxl:p-8 bg-base-200" id="capture-dashboard">
                 <div
-                    className="grid grid-gap-6 xxxl:grid-gap-8 md:grid-auto-fit xxl:grid-auto-fit-wide md:grid-dense"
+                    className="grid grid-gap-6 xxxl:grid-gap-8 md:grid-auto-fit xxl:grid-auto-fit-wide md:grid-dense pf-u-pb-lg"
                     // style={{ '--min-tile-height': '160px' }}
                 >
                     <StandardsAcrossEntity
@@ -148,7 +147,6 @@ function ComplianceDashboardPage(): ReactElement {
                         bodyClassName="pr-4 py-1"
                         className="pdf-page"
                     />
-                    <ComplianceByStandards />
                 </div>
             </div>
             {isExporting && <BackdropExporting />}

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
@@ -17,9 +17,9 @@ type StandardsQueryDataType = {
 };
 
 type ComplianceByStandardsProps = {
-    entityId?: string;
-    entityName?: string;
-    entityType?: ComplianceStandardScope;
+    entityId: string;
+    entityName: string;
+    entityType: ComplianceStandardScope;
 };
 
 function ComplianceByStandards({


### PR DESCRIPTION
## Description

The removal of these sunburst widgets for the individual compliance standards was announced in the 4.2 release notes.

> - Red Hat will remove the following widgets from the Compliance dashboard in RHACS 4.4:
>   - CIS Docker v1.2.0 Compliance
>   - PCI DSS 3.2.1 Compliance
>   - CIS Kubernetes v1.5 Compliance
>   - NIST SP 800-53 Compliance
>   - NIST SP 800-190 Compliance
>   - HIPAA 164 Compliance
 
https://docs.openshift.com/acs/4.2/release_notes/42-release-notes.html#notice-for-upcoming-changes

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests ~added~ removed

## Testing Performed

### Here I tell how I validated my change

1. Removed the checks for both the rendered components in the UI, and the waits on API calls that are now no longer made, from the ui-e2e-tests
2. Visually verified that the widgets were there before the change, and are no longer there after the change.

(note: I had to add margin to the containing element, because previously the margin for the whole page was contained by the widget section, which is now gone.)

Before
<img width="1513" alt="Screen Shot 2023-10-27 at 1 20 18 PM" src="https://github.com/stackrox/stackrox/assets/715729/3b4e060d-02ea-4ae1-84cc-3057d526066a">

After
<img width="1513" alt="Screen Shot 2023-10-27 at 1 20 42 PM" src="https://github.com/stackrox/stackrox/assets/715729/27406ff4-3f39-423a-9d96-90a6c068b27b">


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
