### PR TITLE
ROX-20535: Rename sensor InMemory stores

### DIFF
--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -21,7 +21,7 @@ import (
 )
 
 // New instantiates the eventPipeline component
-func New(client client.Interface, configHandler config.Handler, detector detector.Detector, reprocessor reprocessor.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, storeProvider *resources.InMemoryStoreProvider, queueSize int) common.SensorComponent {
+func New(client client.Interface, configHandler config.Handler, detector detector.Detector, reprocessor reprocessor.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, storeProvider *resources.StoreProvider, queueSize int) common.SensorComponent {
 	outputQueue := output.New(detector, queueSize)
 	var depResolver component.Resolver
 	var resourceListener component.ContextListener

--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -20,7 +20,7 @@ var (
 )
 
 // New returns a new kubernetes listener.
-func New(client client.Interface, configHandler config.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, queue component.Resolver, storeProvider *resources.InMemoryStoreProvider) component.ContextListener {
+func New(client client.Interface, configHandler config.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, queue component.Resolver, storeProvider *resources.StoreProvider) component.ContextListener {
 	k := &listenerImpl{
 		client:             client,
 		stopSig:            concurrency.NewSignal(),

--- a/sensor/kubernetes/listener/listener_impl.go
+++ b/sensor/kubernetes/listener/listener_impl.go
@@ -38,7 +38,7 @@ type listenerImpl struct {
 	resyncPeriod       time.Duration
 	traceWriter        io.Writer
 	outputQueue        component.Resolver
-	storeProvider      *resources.InMemoryStoreProvider
+	storeProvider      *resources.StoreProvider
 	mayCreateHandlers  concurrency.Signal
 	context            context.Context
 }

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -63,7 +63,7 @@ func NewDispatcherRegistry(
 	configHandler config.Handler,
 	credentialsManager awscredentials.RegistryCredentialsManager,
 	traceWriter io.Writer,
-	storeProvider *InMemoryStoreProvider,
+	storeProvider *StoreProvider,
 	k8sAPI kubernetes.Interface,
 ) DispatcherRegistry {
 	serviceStore := storeProvider.serviceStore

--- a/sensor/kubernetes/listener/resources/hash_reconciliation.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation.go
@@ -11,11 +11,11 @@ import (
 
 // ResourceStoreReconciler handles sensor-side reconciliation using in-memory store
 type ResourceStoreReconciler struct {
-	storeProvider *InMemoryStoreProvider
+	storeProvider *StoreProvider
 }
 
 // NewResourceStoreReconciler builds ResourceStoreReconciler for sensor-side reconciliation
-func NewResourceStoreReconciler(storeProvider *InMemoryStoreProvider) *ResourceStoreReconciler {
+func NewResourceStoreReconciler(storeProvider *StoreProvider) *ResourceStoreReconciler {
 	return &ResourceStoreReconciler{storeProvider: storeProvider}
 }
 

--- a/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
+++ b/sensor/kubernetes/listener/resources/hash_reconciliation_test.go
@@ -215,7 +215,7 @@ func resourceTypeToFn(resType string) (func(*central.SensorEvent) string, error)
 
 }
 
-func initStore() *InMemoryStoreProvider {
+func initStore() *StoreProvider {
 	s := InitializeStore()
 	s.deploymentStore.addOrUpdateDeployment(createWrapWithID("1"))
 	s.deploymentStore.addOrUpdateDeployment(createWrapWithID("2"))

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -15,11 +15,11 @@ import (
 
 var (
 	errUnableToReconcile                        = errors.New("unable to reconcile resource")
-	_                    reconcile.Reconcilable = (*InMemoryStoreProvider)(nil)
+	_                    reconcile.Reconcilable = (*StoreProvider)(nil)
 )
 
-// InMemoryStoreProvider holds all stores used in sensor and exposes a public interface for each that can be used outside of the listeners.
-type InMemoryStoreProvider struct {
+// StoreProvider holds all stores used in sensor and exposes a public interface for each that can be used outside of the listeners.
+type StoreProvider struct {
 	deploymentStore        *DeploymentStore
 	podStore               *PodStore
 	serviceStore           *serviceStore
@@ -45,14 +45,14 @@ type CleanableStore interface {
 }
 
 // InitializeStore creates the store instances
-func InitializeStore() *InMemoryStoreProvider {
+func InitializeStore() *StoreProvider {
 	deployStore := newDeploymentStore()
 	podStore := newPodStore()
 	svcStore := newServiceStore()
 	nodeStore := newNodeStore()
 	entityStore := clusterentities.NewStore()
 	endpointManager := newEndpointManager(svcStore, deployStore, podStore, nodeStore, entityStore)
-	p := &InMemoryStoreProvider{
+	p := &StoreProvider{
 		deploymentStore:        deployStore,
 		podStore:               podStore,
 		serviceStore:           svcStore,
@@ -110,71 +110,71 @@ func InitializeStore() *InMemoryStoreProvider {
 }
 
 // CleanupStores deletes all entries from all stores
-func (p *InMemoryStoreProvider) CleanupStores() {
+func (p *StoreProvider) CleanupStores() {
 	for _, cleanable := range p.cleanableStores {
 		cleanable.Cleanup()
 	}
 }
 
 // Deployments returns the deployment store public interface
-func (p *InMemoryStoreProvider) Deployments() store.DeploymentStore {
+func (p *StoreProvider) Deployments() store.DeploymentStore {
 	return p.deploymentStore
 }
 
 // Pods returns the pod store public interface
-func (p *InMemoryStoreProvider) Pods() store.PodStore {
+func (p *StoreProvider) Pods() store.PodStore {
 	return p.podStore
 }
 
 // Services returns the service store public interface
-func (p *InMemoryStoreProvider) Services() store.ServiceStore {
+func (p *StoreProvider) Services() store.ServiceStore {
 	return p.serviceStore
 }
 
 // NetworkPolicies returns the network policy store public interface
-func (p *InMemoryStoreProvider) NetworkPolicies() store.NetworkPolicyStore {
+func (p *StoreProvider) NetworkPolicies() store.NetworkPolicyStore {
 	return p.networkPolicyStore
 }
 
 // RBAC returns the RBAC store public interface
-func (p *InMemoryStoreProvider) RBAC() store.RBACStore {
+func (p *StoreProvider) RBAC() store.RBACStore {
 	return p.rbacStore
 }
 
 // ServiceAccounts returns the ServiceAccount store public interface
-func (p *InMemoryStoreProvider) ServiceAccounts() store.ServiceAccountStore {
+func (p *StoreProvider) ServiceAccounts() store.ServiceAccountStore {
 	return p.serviceAccountStore
 }
 
 // EndpointManager returns the EndpointManager public interface
-func (p *InMemoryStoreProvider) EndpointManager() store.EndpointManager {
+func (p *StoreProvider) EndpointManager() store.EndpointManager {
 	return p.endpointManager
 }
 
 // Registries returns the Registry store public interface
-func (p *InMemoryStoreProvider) Registries() *registry.Store {
+func (p *StoreProvider) Registries() *registry.Store {
 	return p.registryStore
 }
 
 // Entities returns the cluster entities store public interface
-func (p *InMemoryStoreProvider) Entities() *clusterentities.Store {
+func (p *StoreProvider) Entities() *clusterentities.Store {
 	return p.entityStore
 }
 
 // Nodes returns the Nodes public interface
-func (p *InMemoryStoreProvider) Nodes() store.NodeStore {
+func (p *StoreProvider) Nodes() store.NodeStore {
 	return p.nodeStore
 }
 
 // RegistryMirrors returns the RegistryMirror store public interface.
-func (p *InMemoryStoreProvider) RegistryMirrors() registrymirror.Store {
+func (p *StoreProvider) RegistryMirrors() registrymirror.Store {
 	return p.registryMirrorStore
 }
 
 // ReconcileDelete is called after Sensor reconnects with Central and receives its state hashes.
 // Reconciliation ensures that Sensor and Central have the same state by checking whether a given resource
 // shall be deleted from Central.
-func (p *InMemoryStoreProvider) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
+func (p *StoreProvider) ReconcileDelete(resType, resID string, resHash uint64) (string, error) {
 	if resStore, found := p.reconcilableStores[resType]; found {
 		return resStore.ReconcileDelete(resType, resID, resHash)
 	}

--- a/sensor/kubernetes/listener/resources/store_provider_test.go
+++ b/sensor/kubernetes/listener/resources/store_provider_test.go
@@ -9,7 +9,7 @@ import (
 
 type providerSuite struct {
 	suite.Suite
-	provider *InMemoryStoreProvider
+	provider *StoreProvider
 }
 
 var _ suite.SetupTestSuite = (*providerSuite)(nil)


### PR DESCRIPTION
## Description

Since #7313 there are stores in sensor's "In-Memory" stores that are not entirely in memory. Registry mirror has information stored in the filesystem.

This shouldn't affect any reconciliation or resync behavior, as the data is in an ephemeral `emptyDir` and it's not backed by an PVC.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [ ] CI passes

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
