### PR TITLE
ROX-17898: Work around useless error message.

### DIFF
--- a/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
+++ b/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
@@ -3,5 +3,5 @@ kind: TestStep
 commands:
 # We invoke the upgrade script via make such that we do not need to redefine here or plumb through
 # from the parent make: the namespace and operator version string (which are arguments to upgrade script).
-- script: make -C ../../.. upgrade-via-olm
+- command: make -C ../../.. upgrade-via-olm
   timeout: 900


### PR DESCRIPTION
## Description

When upgrade fails, the message emitted to the JUnit summary file is something along the lines of:

```
 command "" exceeded 72 sec timeout, context deadline exceeded
```

Root cause is a `kuttl` [bug](https://github.com/kudobuilder/kuttl/issues/493) where - when creating an error message - only looks at the `command` field of a command object (which in this case is empty) rather than at the `script` field if it's not empty. I will address this bug upstream [separately](https://github.com/kudobuilder/kuttl/pull/494), but here we can work it around by using the `command` field, since there is nothing shell-dependent in this command so it does not need to use `script`.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI is sufficient

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
