### PR TITLE
ROX-19375: Add request details link to workload cves tables

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -267,6 +267,7 @@ function ImagePageVulnerabilities({ imageId, imageName }: ImagePageVulnerabiliti
                             isFiltered={isFiltered}
                             selectedCves={selectedCves}
                             canSelectRows={canSelectRows}
+                            vulnerabilityState={currentVulnerabilityState}
                             createTableActions={createTableActions}
                         />
                     </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -158,6 +158,7 @@ function CVEsTableContainer({
                         filteredSeverities={searchFilter.Severity as VulnerabilitySeverityLabel[]}
                         selectedCves={selectedCves}
                         canSelectRows={canSelectRows}
+                        vulnerabilityState={vulnerabilityState}
                         createTableActions={createTableActions}
                     />
                 </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -17,6 +17,7 @@ import LinkShim from 'Components/PatternFly/LinkShim';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import useSet from 'hooks/useSet';
 import useMap from 'hooks/useMap';
+import { VulnerabilityState } from 'types/cve.proto';
 import { VulnerabilitySeverityLabel } from '../types';
 import { getEntityPagePath } from '../searchUtils';
 import TooltipTh from '../components/TooltipTh';
@@ -36,6 +37,7 @@ import EmptyTableResults from '../components/EmptyTableResults';
 import { CveSelectionsProps } from '../components/ExceptionRequestModal/CveSelections';
 import CVESelectionTh from '../components/CVESelectionTh';
 import CVESelectionTd from '../components/CVESelectionTd';
+import ExceptionDetailsCell from '../components/ExceptionDetailsCell';
 
 export const cveListQuery = gql`
     query getImageCVEList($query: String, $pagination: Pagination) {
@@ -102,6 +104,7 @@ export type CVEsTableProps = {
     canSelectRows: boolean;
     selectedCves: ReturnType<typeof useMap<string, CveSelectionsProps['cves'][number]>>;
     createTableActions?: (cve: { cve: string; summary: string }) => IAction[];
+    vulnerabilityState: VulnerabilityState | undefined; // TODO Make Required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
 };
 
 function CVEsTable({
@@ -113,10 +116,16 @@ function CVEsTable({
     canSelectRows,
     selectedCves,
     createTableActions,
+    vulnerabilityState,
 }: CVEsTableProps) {
     const expandedRowSet = useSet<string>();
+    const showExceptionDetailsLink = vulnerabilityState && vulnerabilityState !== 'OBSERVED';
 
-    const colSpan = 6 + (canSelectRows ? 1 : 0) + (createTableActions ? 1 : 0);
+    const colSpan =
+        6 +
+        (canSelectRows ? 1 : 0) +
+        (createTableActions ? 1 : 0) +
+        (showExceptionDetailsLink ? 1 : 0);
 
     return (
         <TableComposable borders={false} variant="compact">
@@ -149,6 +158,11 @@ function CVEsTable({
                         First discovered
                         {isFiltered && <DynamicColumnIcon />}
                     </TooltipTh>
+                    {showExceptionDetailsLink && (
+                        <TooltipTh tooltip="View information about this exception request">
+                            Request details
+                        </TooltipTh>
+                    )}
                     {createTableActions && <Th aria-label="CVE actions" />}
                 </Tr>
             </Thead>
@@ -235,6 +249,12 @@ function CVEsTable({
                                 <Td dataLabel="First discovered">
                                     <DateDistanceTd date={firstDiscoveredInSystem} />
                                 </Td>
+                                {showExceptionDetailsLink && (
+                                    <ExceptionDetailsCell
+                                        cve={cve}
+                                        vulnerabilityState={vulnerabilityState}
+                                    />
+                                )}
                                 {createTableActions && (
                                     <Td className="pf-u-px-0">
                                         <ActionsColumn

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionDetailsCell.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionDetailsCell.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Button } from '@patternfly/react-core';
+import { Td } from '@patternfly/react-table';
+
+import LinkShim from 'Components/PatternFly/LinkShim';
+import { exceptionManagementPath } from 'routePaths';
+import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
+import { VulnerabilityState } from 'types/cve.proto';
+import { ensureExhaustive } from 'utils/type.utils';
+
+function getExceptionManagementURL(
+    cve: string,
+    vulnerabilityState: Exclude<VulnerabilityState, 'OBSERVED'>
+): string {
+    const query = getUrlQueryStringForSearchFilter({ cve });
+
+    switch (vulnerabilityState) {
+        case 'DEFERRED':
+            return `${exceptionManagementPath}/approved-deferrals?${query}`;
+        case 'FALSE_POSITIVE':
+            return `${exceptionManagementPath}/approved-false-positives?${query}`;
+        default:
+            return ensureExhaustive(vulnerabilityState);
+    }
+}
+
+export type ExceptionDetailsCellProps = {
+    cve: string;
+    vulnerabilityState: Exclude<VulnerabilityState, 'OBSERVED'>;
+};
+
+function ExceptionDetailsCell({ cve, vulnerabilityState }: ExceptionDetailsCellProps) {
+    return (
+        <Td dataLabel="Request details">
+            <Button
+                variant="link"
+                isInline
+                component={LinkShim}
+                href={getExceptionManagementURL(cve, vulnerabilityState)}
+            >
+                View
+            </Button>
+        </Td>
+    );
+}
+
+export default ExceptionDetailsCell;


### PR DESCRIPTION
## Description

Adds a link on the Workload CVE list table and Image page CVEs table to the exception management page, filtered by the relevant CVE.

Note that the search is applied to the URL, but implementation of the tables and filtering on the target pages are not complete at this point.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Create and approve at least one deferral and one false positive.

Visit the workload cve list page and view the deferral tab. Click the link and verify that the CVE search filter is applied in the URL.
![image](https://github.com/stackrox/stackrox/assets/1292638/9b5916fc-27b4-4f4a-bccb-0b57e8f12d45)
<img width="1678" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/69a7d49f-fd74-4f75-a936-e8c0f8fee59c">

Repeat this process for the false positive tab.
![image](https://github.com/stackrox/stackrox/assets/1292638/08860ad8-a58e-49ac-8701-2902cd6770cc)
<img width="1678" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/e8b807ae-fdaf-4dd4-9957-cc67d9b1def3">

Repeat this process for the deferral tab on the image page.
![image](https://github.com/stackrox/stackrox/assets/1292638/ab82a39f-57a8-435c-a1df-6bc7441618c3)
<img width="1678" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/7696cbec-9948-4fec-81a4-40c883e5f5d5">

Repeat this process for the false positive tab.
![image](https://github.com/stackrox/stackrox/assets/1292638/57735df0-3ddc-4764-b0ed-94e0a92b6f0e)
<img width="1678" alt="image" src="https://github.com/stackrox/stackrox/assets/1292638/5b48e090-a73f-48d3-80a2-ce5fce392a9f">


