### PR TITLE
ROX-20542: disable http/2 in operator kube-rbac-proxy

### DIFF
--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -1088,10 +1088,11 @@ spec:
                   allowPrivilegeEscalation: false
               - args:
                 - --secure-listen-address=0.0.0.0:8443
+                - --http2-disable
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/operator/config/default/manager_auth_proxy_patch.yaml
+++ b/operator/config/default/manager_auth_proxy_patch.yaml
@@ -10,9 +10,10 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
+        - "--http2-disable"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
         - "--v=0"


### PR DESCRIPTION
## Description

As per the [Operator Remediation Guidance for CVE-2023-44487 doc](https://docs.google.com/document/d/1F99glzhX2i2Ppe5Qq3M-Po_jSSUiVssqFyWRhVm1X3o/edit?usp=sharing), HTTP/2 should be disabled in the `kube-rbac-proxy` that is part of the operator pod.

In order to do that, we need to:
- update its image tag to v0.15
- pass it the `--http2-disable` parameter

Note that downstream this image is replaced by `openshift4/ose-kube-rbac-proxy`. The [latest v4.13 release](https://catalog.redhat.com/software/containers/openshift4/ose-kube-rbac-proxy/5cdb2634dd19c778293b4d98?architecture=amd64&image=6537aafd6d3a98c9e65fcab7) supports the `--http2-disable` flag as well.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
Tested in the ACS CS integration environment (see https://github.com/stackrox/acs-fleet-manager/pull/1425).

Tested locally both the upstream and downstream images, to verify that they have the `-http2-disable` option:
```
docker run --rm  registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13 --http2-disable
docker run --rm  gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0 --http2-disable
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
