### PR TITLE
ROX-20323: Create new policy criteria modal

### DIFF
--- a/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
@@ -9,6 +9,8 @@ import {
     cloneFirstPolicyFromTable,
     goToStep3,
 } from '../../helpers/policies';
+import { closeModalByButton } from '../../helpers/modal';
+import { hasFeatureFlag } from '../../helpers/features';
 
 const dataTransfer = new DndSimulatorDataTransfer();
 
@@ -200,6 +202,16 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                     cy.get(selectors.step3.policyCriteria.value.deleteBtn).should('not.exist');
                     cy.get(selectors.step3.policyCriteria.booleanOperator).should('not.exist');
                 });
+
+                // TODO: (vjw, 2023-10-30) currently, this feature flag is only _adding_ another way to add policy criteria fields
+                //       after adding fields has been thoroughly tested, this flag will indicate _whether_ to test the old way or the new way
+                if (hasFeatureFlag('ROX_POLICY_CRITERIA_MODAL')) {
+                    cy.log('flag on');
+                    cy.get('.policy-section-card button:contains("Add policy field")').click();
+                    cy.get('.pf-c-modal-box__title-text:contains("Add policy criteria field")');
+
+                    closeModalByButton('Cancel');
+                }
             });
 
             it('should not add multiple field values for the same field if not applicable', () => {

--- a/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersModal.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersModal.tsx
@@ -213,7 +213,7 @@ function InviteUsersModal(): ReactElement | null {
             isOpen={showInviteModal}
             variant={ModalVariant.small}
             onClose={onClose}
-            aria-label="Permanently delete category?"
+            aria-label="Invite users"
             hasNoBodyWrapper
         >
             <ModalBoxBody>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaModal.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import {
+    Button,
+    Flex,
+    FlexItem,
+    Modal,
+    ModalBoxBody,
+    ModalBoxFooter,
+    TreeView,
+} from '@patternfly/react-core';
+
+type PolicyCriteriaModalProps = {
+    isModalOpen: boolean;
+    onClose: () => void;
+};
+
+// TODO: remove this placeholder data
+const options = [
+    {
+        title: 'Image registry',
+        id: 'category-image-registry',
+        children: [
+            {
+                name: 'Container registry name is',
+                title: 'Image registry',
+                id: 'field-image-registry',
+            },
+            {
+                name: 'Image name is',
+                title: 'Image name',
+                id: 'field-image-name',
+            },
+            {
+                name: 'Image tag is',
+                title: 'Image tag',
+                id: 'field-image-tag',
+            },
+            {
+                name: 'Image signature is missing or wrong',
+                title: 'Image signature',
+                id: 'field-image-signature',
+            },
+        ],
+    },
+    {
+        title: 'Deployment metadata',
+        id: 'category-deployment metadata',
+        children: [
+            {
+                title: 'Disallowed annotation',
+                id: 'field-disallowed annotation',
+            },
+            {
+                name: 'Required deployment label',
+                title: 'Required label',
+                id: 'field-required-label',
+            },
+            {
+                name: 'Required deployment annotation',
+                title: 'Required annotation',
+                id: 'field-required-annotation',
+            },
+        ],
+    },
+];
+// TODO end: remove this placeholder data
+
+function PolicyCriteriaModal({ isModalOpen, onClose }: PolicyCriteriaModalProps) {
+    return (
+        <Modal
+            title="Add policy criteria field"
+            isOpen={isModalOpen}
+            variant="small"
+            onClose={onClose}
+            aria-label="Permanently delete category?"
+            hasNoBodyWrapper
+        >
+            <ModalBoxBody>
+                <Flex direction={{ default: 'column' }}>
+                    <FlexItem>Filter by criteria name</FlexItem>
+                    <FlexItem>
+                        {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+                        {/* @ts-ignore */}
+                        <TreeView data={options} variant="compact" />
+                    </FlexItem>
+                </Flex>
+            </ModalBoxBody>
+            <ModalBoxFooter>
+                <Button variant="link" onClick={onClose}>
+                    Cancel
+                </Button>
+            </ModalBoxFooter>
+        </Modal>
+    );
+}
+
+export default PolicyCriteriaModal;

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaModal.tsx
@@ -72,7 +72,7 @@ function PolicyCriteriaModal({ isModalOpen, onClose }: PolicyCriteriaModalProps)
             isOpen={isModalOpen}
             variant="small"
             onClose={onClose}
-            aria-label="Permanently delete category?"
+            aria-label="Add policy criteria field"
             hasNoBodyWrapper
         >
             <ModalBoxBody>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
@@ -14,11 +14,12 @@ import {
 } from '@patternfly/react-core';
 import { PencilAltIcon, TrashIcon, CheckIcon } from '@patternfly/react-icons';
 
+import useModal from 'hooks/useModal';
 import { Policy } from 'types/policy.proto';
 import { Descriptor } from './policyCriteriaDescriptors';
-
 import PolicyGroupCard from './PolicyGroupCard';
 import PolicySectionDropTarget from './PolicySectionDropTarget';
+import PolicyCriteriaModal from './PolicyCriteriaModal';
 
 import './PolicySection.css';
 
@@ -30,6 +31,7 @@ type PolicySectionProps = {
 
 function PolicySection({ sectionIndex, descriptors, readOnly = false }: PolicySectionProps) {
     const [isEditingName, setIsEditingName] = React.useState(false);
+    const { isModalOpen, openModal, closeModal } = useModal();
     const { values, setFieldValue, handleChange } = useFormikContext<Policy>();
     const { sectionName, policyGroups } = values.policySections[sectionIndex];
 
@@ -45,83 +47,102 @@ function PolicySection({ sectionIndex, descriptors, readOnly = false }: PolicySe
     }
 
     return (
-        <Card isFlat isCompact className={!readOnly ? 'policy-section-card' : ''}>
-            <CardHeader className="policy-section-card-header pf-u-p-0">
-                <CardTitle className="pf-u-display-flex pf-u-align-self-stretch">
-                    <Flex
-                        alignItems={{ default: 'alignItemsCenter' }}
-                        flexWrap={{ default: 'nowrap' }}
-                    >
-                        <FlexItem className="pf-u-pl-md">{sectionIndex + 1}</FlexItem>
-                        <Divider component="div" isVertical />
-                        <FlexItem>
-                            {isEditingName ? (
-                                <TextInput
-                                    id={`policySections[${sectionIndex}].sectionName`}
-                                    name={`policySections[${sectionIndex}].sectionName`}
-                                    value={values.policySections[sectionIndex].sectionName}
-                                    onChange={onEditSectionName}
+        <>
+            <Card isFlat isCompact className={!readOnly ? 'policy-section-card' : ''}>
+                <CardHeader className="policy-section-card-header pf-u-p-0">
+                    <CardTitle className="pf-u-display-flex pf-u-align-self-stretch">
+                        <Flex
+                            alignItems={{ default: 'alignItemsCenter' }}
+                            flexWrap={{ default: 'nowrap' }}
+                        >
+                            <FlexItem className="pf-u-pl-md">{sectionIndex + 1}</FlexItem>
+                            <Divider component="div" isVertical />
+                            <FlexItem>
+                                {isEditingName ? (
+                                    <TextInput
+                                        id={`policySections[${sectionIndex}].sectionName`}
+                                        name={`policySections[${sectionIndex}].sectionName`}
+                                        value={values.policySections[sectionIndex].sectionName}
+                                        onChange={onEditSectionName}
+                                    />
+                                ) : (
+                                    <div className="pf-u-py-sm" data-testid="policy-section-name">
+                                        {sectionName}
+                                    </div>
+                                )}
+                            </FlexItem>
+                        </Flex>
+                    </CardTitle>
+                    {!readOnly && (
+                        <CardActions hasNoOffset>
+                            <Button
+                                variant="plain"
+                                className="pf-u-px-sm"
+                                onClick={() => setIsEditingName(!isEditingName)}
+                            >
+                                {isEditingName ? (
+                                    <CheckIcon data-testid="save-section-name-btn" />
+                                ) : (
+                                    <PencilAltIcon data-testid="edit-section-name-btn" />
+                                )}
+                            </Button>
+                            <Divider component="div" isVertical />
+                            <Button
+                                variant="plain"
+                                className="pf-u-mr-xs pf-u-px-sm pf-u-py-md"
+                                data-testid="delete-section-btn"
+                                onClick={onDeleteSection}
+                            >
+                                <TrashIcon />
+                            </Button>
+                        </CardActions>
+                    )}
+                </CardHeader>
+                <CardBody className="policy-section-card-body">
+                    {policyGroups.map((group, groupIndex) => {
+                        const descriptor = descriptors.find(
+                            (descriptorField) =>
+                                group.fieldName === descriptorField.name ||
+                                group.fieldName === descriptorField.label
+                        );
+                        return (
+                            descriptor && (
+                                <PolicyGroupCard
+                                    key={descriptor.name}
+                                    descriptor={descriptor}
+                                    groupIndex={groupIndex}
+                                    sectionIndex={sectionIndex}
+                                    readOnly={readOnly}
                                 />
-                            ) : (
-                                <div className="pf-u-py-sm" data-testid="policy-section-name">
-                                    {sectionName}
-                                </div>
-                            )}
-                        </FlexItem>
-                    </Flex>
-                </CardTitle>
-                {!readOnly && (
-                    <CardActions hasNoOffset>
-                        <Button
-                            variant="plain"
-                            className="pf-u-px-sm"
-                            onClick={() => setIsEditingName(!isEditingName)}
+                            )
+                        );
+                    })}
+                    {!readOnly && (
+                        <PolicySectionDropTarget
+                            sectionIndex={sectionIndex}
+                            descriptors={descriptors}
+                        />
+                    )}
+                    {!readOnly && (
+                        <Flex
+                            className="pf-u-mt-md"
+                            justifyContent={{ default: 'justifyContentCenter' }}
                         >
-                            {isEditingName ? (
-                                <CheckIcon data-testid="save-section-name-btn" />
-                            ) : (
-                                <PencilAltIcon data-testid="edit-section-name-btn" />
-                            )}
-                        </Button>
-                        <Divider component="div" isVertical />
-                        <Button
-                            variant="plain"
-                            className="pf-u-mr-xs pf-u-px-sm pf-u-py-md"
-                            data-testid="delete-section-btn"
-                            onClick={onDeleteSection}
-                        >
-                            <TrashIcon />
-                        </Button>
-                    </CardActions>
-                )}
-            </CardHeader>
-            <CardBody className="policy-section-card-body">
-                {policyGroups.map((group, groupIndex) => {
-                    const descriptor = descriptors.find(
-                        (descriptorField) =>
-                            group.fieldName === descriptorField.name ||
-                            group.fieldName === descriptorField.label
-                    );
-                    return (
-                        descriptor && (
-                            <PolicyGroupCard
-                                key={descriptor.name}
-                                descriptor={descriptor}
-                                groupIndex={groupIndex}
-                                sectionIndex={sectionIndex}
-                                readOnly={readOnly}
-                            />
-                        )
-                    );
-                })}
-                {!readOnly && (
-                    <PolicySectionDropTarget
-                        sectionIndex={sectionIndex}
-                        descriptors={descriptors}
-                    />
-                )}
-            </CardBody>
-        </Card>
+                            <FlexItem>
+                                <Button
+                                    key={`policySections[${sectionIndex}].sectionName-add-policy-field`}
+                                    variant="secondary"
+                                    onClick={openModal}
+                                >
+                                    Add policy field
+                                </Button>
+                            </FlexItem>
+                        </Flex>
+                    )}
+                </CardBody>
+            </Card>
+            <PolicyCriteriaModal isModalOpen={isModalOpen} onClose={closeModal} />
+        </>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
@@ -14,6 +14,7 @@ import {
 } from '@patternfly/react-core';
 import { PencilAltIcon, TrashIcon, CheckIcon } from '@patternfly/react-icons';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useModal from 'hooks/useModal';
 import { Policy } from 'types/policy.proto';
 import { Descriptor } from './policyCriteriaDescriptors';
@@ -34,6 +35,9 @@ function PolicySection({ sectionIndex, descriptors, readOnly = false }: PolicySe
     const { isModalOpen, openModal, closeModal } = useModal();
     const { values, setFieldValue, handleChange } = useFormikContext<Policy>();
     const { sectionName, policyGroups } = values.policySections[sectionIndex];
+
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const showPolicyCriteriaModal = isFeatureFlagEnabled('ROX_POLICY_CRITERIA_MODAL');
 
     function onEditSectionName(_, e) {
         handleChange(e);
@@ -123,7 +127,7 @@ function PolicySection({ sectionIndex, descriptors, readOnly = false }: PolicySe
                             descriptors={descriptors}
                         />
                     )}
-                    {!readOnly && (
+                    {showPolicyCriteriaModal && !readOnly && (
                         <Flex
                             className="pf-u-mt-md"
                             justifyContent={{ default: 'justifyContentCenter' }}
@@ -141,7 +145,9 @@ function PolicySection({ sectionIndex, descriptors, readOnly = false }: PolicySe
                     )}
                 </CardBody>
             </Card>
-            <PolicyCriteriaModal isModalOpen={isModalOpen} onClose={closeModal} />
+            {showPolicyCriteriaModal && (
+                <PolicyCriteriaModal isModalOpen={isModalOpen} onClose={closeModal} />
+            )}
         </>
     );
 }


### PR DESCRIPTION
## Description

This is the first of a series of PRs to add the new, more accessible way of adding policy criteria to a policy.

This PR adds a button to each section card in the Policy Wizard Step 3, after any already-added fields and the current drop area.

Clicking that button opens a modal, where the available policy criteria will be listed. (Not this PR only has a static stub list of criteria as a placeholder.)

I am not hiding the drag-and-drop method of adding criteria yet, because I think the two methods can coexist during development, and having both should make testing more efficient.

## Checklist
- [x] Investigated and inspected CI test results (all flavors ui-e2e-tests passed before requested text change; one flavor failed to get infrastructure in second pass)
- [x] Unit test and regression tests added


## Testing Performed

### Here I tell how I validated my change

1. Created automated e2e tests for the button and modal, when the feature flag is on.
2. Manually verified the interaction

Button visible when feature flag is on
![Screen Shot 2023-10-30 at 2 16 54 PM](https://github.com/stackrox/stackrox/assets/715729/9720f25a-0c08-4778-a578-91e39a2c8003)

Modal open
![Screen Shot 2023-10-30 at 2 16 59 PM](https://github.com/stackrox/stackrox/assets/715729/a74b7a32-6eb9-4e6c-81eb-e44fe7537859)

Button below existing added policy field
![Screen Shot 2023-10-30 at 2 37 27 PM](https://github.com/stackrox/stackrox/assets/715729/7869b936-1d1d-47a8-ac87-c43b791b6cc1)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
