### PR TITLE
ROX-20552: Adding deployment scale to the resource list for the VWC

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -191,6 +191,7 @@ webhooks:
         resources:
           - pods
           - deployments
+          - deployments/scale
           - replicasets
           - replicationcontrollers
           - statefulsets


### PR DESCRIPTION
## Description
Adding deployment scale to the resource list for the VWC

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed
Manual testing on openshift and GKE cluster. Created a deployment with nginx latest, enforced Latest Tag default policy, and scaled it up and down to see that the operation is blocked by the admission controller.