### PR TITLE
ROX-19433: Create approved false positives table

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -77,7 +77,7 @@ const vulnerabilityExceptions: VulnerabilityException[] = [
                 expiresOn: '2023-10-31T19:16:49.155480945Z',
             },
         },
-        cves: ['CVE-2018-20839'],
+        cves: ['CVE-2018-20839', 'CVE-2018-20840'],
     },
 ];
 
@@ -142,7 +142,7 @@ function ApprovedDeferrals() {
                 </Thead>
                 <Tbody>
                     {vulnerabilityExceptions.map((exception) => {
-                        const { id, name, requester, createdAt, scope, cves } = exception;
+                        const { id, name, requester, createdAt, scope } = exception;
                         return (
                             <Tr key={id}>
                                 <Td>
@@ -170,7 +170,10 @@ function ApprovedDeferrals() {
                                     <ScopeTableCell scope={scope} />
                                 </Td>
                                 <Td>
-                                    <RequestedItemsTableCell cves={cves} />
+                                    <RequestedItemsTableCell
+                                        exception={exception}
+                                        context="APPROVED_DEFERRALS"
+                                    />
                                 </Td>
                             </Tr>
                         );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -1,7 +1,171 @@
 import React from 'react';
+import {
+    PageSection,
+    Pagination,
+    Toolbar,
+    ToolbarContent,
+    ToolbarGroup,
+    ToolbarItem,
+} from '@patternfly/react-core';
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
+import useURLPagination from 'hooks/useURLPagination';
+import { VulnerabilityException } from 'services/VulnerabilityExceptionService';
+
+import useURLSearch from 'hooks/useURLSearch';
+import {
+    IMAGE_CVE_SEARCH_OPTION,
+    IMAGE_SEARCH_OPTION,
+    REQUESTER_SEARCH_OPTION,
+    REQUEST_ID_SEARCH_OPTION,
+    SearchOption,
+} from 'Containers/Vulnerabilities/components/SearchOptionsDropdown';
+
+import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
+import {
+    RequestIDTableCell,
+    RequestedActionTableCell,
+    RequestedItemsTableCell,
+    RequestedTableCell,
+    RequesterTableCell,
+    ScopeTableCell,
+} from './components/ExceptionRequestTableCells';
+import FilterAutocompleteSelect from '../components/FilterAutocomplete';
+
+// @TODO: Use API data instead of hardcoded data
+const vulnerabilityExceptions: VulnerabilityException[] = [
+    {
+        id: '5837bb34-5357-4b78-ad2b-188fc0b33e78',
+        name: '5837bb34-5357-4b78-ad2b-188fc0b33e78',
+        targetState: 'FALSE_POSITIVE',
+        exceptionStatus: 'APPROVED_PENDING_UPDATE',
+        expired: false,
+        requester: {
+            id: 'sso:4df1b98c-24ed-4073-a9ad-356aec6bb62d:admin',
+            name: 'admin',
+        },
+        createdAt: '2023-10-01T19:16:49.155480945Z',
+        lastUpdated: '2023-10-01T19:16:49.155480945Z',
+        comments: [
+            {
+                createdAt: '2023-10-23T19:16:49.155480945Z',
+                id: 'c84b3f5f-4cad-4c4e-8a4a-97b821c2c373',
+                message: 'asdf',
+                user: {
+                    id: 'sso:4df1b98c-24ed-4073-a9ad-356aec6bb62d:admin',
+                    name: 'admin',
+                },
+            },
+        ],
+        scope: {
+            imageScope: {
+                registry: 'quay.io',
+                remote: 'stackrox-io/scanner',
+                tag: '.*',
+            },
+        },
+        falsePositiveRequest: {},
+        falsePositiveUpdate: {
+            cves: ['CVE-2020-20839'],
+        },
+        cves: ['CVE-2020-20839', 'CVE-2020-20840'],
+    },
+];
+
+const searchOptions: SearchOption[] = [
+    REQUEST_ID_SEARCH_OPTION,
+    IMAGE_CVE_SEARCH_OPTION,
+    REQUESTER_SEARCH_OPTION,
+    IMAGE_SEARCH_OPTION,
+];
 
 function ApprovedFalsePositives() {
-    return <div />;
+    const { searchFilter, setSearchFilter } = useURLSearch();
+    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+
+    function onFilterChange() {
+        setPage(1);
+    }
+
+    return (
+        <PageSection>
+            <Toolbar>
+                <ToolbarContent>
+                    <FilterAutocompleteSelect
+                        searchFilter={searchFilter}
+                        setSearchFilter={setSearchFilter}
+                        searchOptions={searchOptions}
+                    />
+                    <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
+                        <Pagination
+                            itemCount={1}
+                            page={page}
+                            perPage={perPage}
+                            onSetPage={(_, newPage) => setPage(newPage)}
+                            onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                            isCompact
+                        />
+                    </ToolbarItem>
+                    <ToolbarGroup aria-label="applied search filters" className="pf-u-w-100">
+                        <SearchFilterChips
+                            onFilterChange={onFilterChange}
+                            filterChipGroupDescriptors={searchOptions.map(({ label, value }) => {
+                                return {
+                                    displayName: label,
+                                    searchFilterName: value,
+                                };
+                            })}
+                        />
+                    </ToolbarGroup>
+                </ToolbarContent>
+            </Toolbar>
+            <TableComposable borders={false}>
+                <Thead noWrap>
+                    <Tr>
+                        <Th>Request ID</Th>
+                        <Th>Requester</Th>
+                        <Th>Requested action</Th>
+                        <Th>Requested</Th>
+                        <Th>Scope</Th>
+                        <Th>Requested items</Th>
+                    </Tr>
+                </Thead>
+                <Tbody>
+                    {vulnerabilityExceptions.map((exception) => {
+                        const { id, name, requester, createdAt, scope } = exception;
+                        return (
+                            <Tr key={id}>
+                                <Td>
+                                    <RequestIDTableCell id={id} name={name} />
+                                </Td>
+                                <Td>
+                                    <RequesterTableCell requester={requester} />
+                                </Td>
+                                <Td>
+                                    <RequestedActionTableCell
+                                        exception={exception}
+                                        context="APPROVED_FALSE_POSITIVES"
+                                    />
+                                </Td>
+                                <Td>
+                                    <RequestedTableCell createdAt={createdAt} />
+                                </Td>
+                                <Td>
+                                    <ScopeTableCell scope={scope} />
+                                </Td>
+                                <Td>
+                                    <RequestedItemsTableCell
+                                        exception={exception}
+                                        context="APPROVED_FALSE_POSITIVES"
+                                    />
+                                </Td>
+                            </Tr>
+                        );
+                    })}
+                </Tbody>
+            </TableComposable>
+        </PageSection>
+    );
 }
 
 export default ApprovedFalsePositives;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -77,7 +77,43 @@ const vulnerabilityExceptions: VulnerabilityException[] = [
                 expiresOn: '2023-10-31T19:16:49.155480945Z',
             },
         },
-        cves: ['CVE-2018-20839'],
+        cves: ['CVE-2018-20839', 'CVE-2018-20840'],
+    },
+    {
+        id: '5837bb34-5357-4b78-ad2b-188fc0b33e78',
+        name: '5837bb34-5357-4b78-ad2b-188fc0b33e78',
+        targetState: 'FALSE_POSITIVE',
+        exceptionStatus: 'APPROVED_PENDING_UPDATE',
+        expired: false,
+        requester: {
+            id: 'sso:4df1b98c-24ed-4073-a9ad-356aec6bb62d:admin',
+            name: 'admin',
+        },
+        createdAt: '2023-10-01T19:16:49.155480945Z',
+        lastUpdated: '2023-10-01T19:16:49.155480945Z',
+        comments: [
+            {
+                createdAt: '2023-10-23T19:16:49.155480945Z',
+                id: 'c84b3f5f-4cad-4c4e-8a4a-97b821c2c373',
+                message: 'asdf',
+                user: {
+                    id: 'sso:4df1b98c-24ed-4073-a9ad-356aec6bb62d:admin',
+                    name: 'admin',
+                },
+            },
+        ],
+        scope: {
+            imageScope: {
+                registry: 'quay.io',
+                remote: 'stackrox-io/scanner',
+                tag: '.*',
+            },
+        },
+        falsePositiveRequest: {},
+        falsePositiveUpdate: {
+            cves: ['CVE-2020-20839'],
+        },
+        cves: ['CVE-2020-20839', 'CVE-2020-20840'],
     },
 ];
 
@@ -142,7 +178,7 @@ function PendingApprovals() {
                 </Thead>
                 <Tbody>
                     {vulnerabilityExceptions.map((exception) => {
-                        const { id, name, requester, createdAt, scope, cves } = exception;
+                        const { id, name, requester, createdAt, scope } = exception;
                         return (
                             <Tr key={id}>
                                 <Td>
@@ -170,7 +206,10 @@ function PendingApprovals() {
                                     <ScopeTableCell scope={scope} />
                                 </Td>
                                 <Td>
-                                    <RequestedItemsTableCell cves={cves} />
+                                    <RequestedItemsTableCell
+                                        exception={exception}
+                                        context="PENDING_REQUESTS"
+                                    />
                                 </Td>
                             </Tr>
                         );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.test.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.test.tsx
@@ -3,7 +3,7 @@ import {
     VulnerabilityException,
 } from 'services/VulnerabilityExceptionService';
 import {
-    getShouldUseUpdatedExpiry,
+    getShouldUseUpdatedRequest,
     getRequestedAction,
     RequestContext,
 } from './ExceptionRequestTableCells';
@@ -55,12 +55,12 @@ describe('ExceptionRequestTableCells', () => {
             };
             const context: RequestContext = 'PENDING_REQUESTS';
 
-            const shouldUseUpdatedExpiry = getShouldUseUpdatedExpiry(
+            const shouldUseUpdatedRequest = getShouldUseUpdatedRequest(
                 vulnerabilityException,
                 context
             );
 
-            expect(shouldUseUpdatedExpiry).toBe(false);
+            expect(shouldUseUpdatedRequest).toBe(false);
         });
 
         // When an approved deferral that is pending an update is finally approved, it overwrites
@@ -78,12 +78,12 @@ describe('ExceptionRequestTableCells', () => {
             };
             const context: RequestContext = 'PENDING_REQUESTS';
 
-            const shouldUseUpdatedExpiry = getShouldUseUpdatedExpiry(
+            const shouldUseUpdatedRequest = getShouldUseUpdatedRequest(
                 vulnerabilityException,
                 context
             );
 
-            expect(shouldUseUpdatedExpiry).toBe(false);
+            expect(shouldUseUpdatedRequest).toBe(false);
         });
 
         it('should use the updated expiry for an approved request pending an update', () => {
@@ -106,12 +106,12 @@ describe('ExceptionRequestTableCells', () => {
             };
             const context: RequestContext = 'PENDING_REQUESTS';
 
-            const shouldUseUpdatedExpiry = getShouldUseUpdatedExpiry(
+            const shouldUseUpdatedRequest = getShouldUseUpdatedRequest(
                 vulnerabilityException,
                 context
             );
 
-            expect(shouldUseUpdatedExpiry).toBe(true);
+            expect(shouldUseUpdatedRequest).toBe(true);
         });
 
         it('should use the original expiry for an approved request pending an update', () => {
@@ -134,12 +134,12 @@ describe('ExceptionRequestTableCells', () => {
             };
             const context: RequestContext = 'APPROVED_DEFERRALS';
 
-            const shouldUseUpdatedExpiry = getShouldUseUpdatedExpiry(
+            const shouldUseUpdatedRequest = getShouldUseUpdatedRequest(
                 vulnerabilityException,
                 context
             );
 
-            expect(shouldUseUpdatedExpiry).toBe(false);
+            expect(shouldUseUpdatedRequest).toBe(false);
         });
     });
 


### PR DESCRIPTION
## Description

This PR adds the basic table for Approved false positives. I make use of the components previously created for the Pending Requests section.

Includes: [ROX-19430](https://issues.redhat.com/browse/ROX-19430) and [ROX-19434](https://issues.redhat.com/browse/ROX-19434)

The same vuln request data is used for both the `Pending requests` section and the `Approved false positives` section (ie. Approved pending update - false positive). I made a few updates to the table cell components as well. You'll notice that the `Requested items` are different in each tab. Since you can technically remove a CVE as part of an update, you'll want to see a difference between the approved request and the updated request

<img width="1552" alt="Screenshot 2023-10-30 at 6 47 22 PM" src="https://github.com/stackrox/stackrox/assets/4805485/e901e6c4-9166-4015-8569-023f7618bbd5">
<img width="1552" alt="Screenshot 2023-10-30 at 6 47 27 PM" src="https://github.com/stackrox/stackrox/assets/4805485/3461255c-a25b-430a-b13b-6cdb83535dd6">
