### PR TITLE
chore(image-enricher): add unit tests for image names

### DIFF
--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -1248,3 +1248,92 @@ func TestFetchFromDatabase_ForceFetch(t *testing.T) {
 	assert.Nil(t, img.GetSignature())
 	assert.Nil(t, img.GetSignatureVerificationData())
 }
+
+func TestFetchFromDatabase_RetainImageNames(t *testing.T) {
+	cimg, err := utils.GenerateImageFromString("docker.io/test")
+	require.NoError(t, err)
+	img := imgTypes.ToImage(cimg)
+	img.Id = "sample-SHA"
+	testImageName, _, err := utils.GenerateImageNameFromString(img.GetName().GetFullName())
+	require.NoError(t, err)
+
+	cimg, err = utils.GenerateImageFromString("docker.io/test2")
+	require.NoError(t, err)
+	existingImg := imgTypes.ToImage(cimg)
+	existingImg.Id = "sample-SHA"
+	existingTestImageName, _, err := utils.GenerateImageNameFromString(existingImg.GetName().GetFullName())
+	require.NoError(t, err)
+
+	e := &enricherImpl{
+		imageGetter: func(_ context.Context, _ string) (*storage.Image, bool, error) {
+			return existingImg, true, nil
+		},
+	}
+
+	cases := map[string]struct {
+		expectedImageNames []*storage.ImageName
+		opt                FetchOption
+	}{
+		"UseCachesIfPossible should retain image names and merge them": {
+			expectedImageNames: []*storage.ImageName{
+				testImageName,
+				existingTestImageName,
+			},
+			opt: UseCachesIfPossible,
+		},
+		"NoExternalMetadata should retain image names and merge them": {
+			expectedImageNames: []*storage.ImageName{
+				testImageName,
+				existingTestImageName,
+			},
+			opt: NoExternalMetadata,
+		},
+		"IgnoreExistingImages should not retain image names": {
+			expectedImageNames: []*storage.ImageName{
+				testImageName,
+			},
+			opt: IgnoreExistingImages,
+		},
+		"ForceRefetch should not retain image names": {
+			expectedImageNames: []*storage.ImageName{
+				testImageName,
+			},
+			opt: ForceRefetch,
+		},
+		"ForceRefetchScansOnly should retain image names": {
+			expectedImageNames: []*storage.ImageName{
+				testImageName,
+				existingTestImageName,
+			},
+			opt: ForceRefetchScansOnly,
+		},
+		"ForceRefetchSignaturesOnly should retain image names": {
+			expectedImageNames: []*storage.ImageName{
+				testImageName,
+				existingTestImageName,
+			},
+			opt: ForceRefetchSignaturesOnly,
+		},
+		"ForceRefetchCachedValuesOnly should not retain image names": {
+			expectedImageNames: []*storage.ImageName{
+				testImageName,
+			},
+			opt: ForceRefetchCachedValuesOnly,
+		},
+		"UseImageNamesRefetchCachedValues should retain image names": {
+			expectedImageNames: []*storage.ImageName{
+				testImageName,
+				existingTestImageName,
+			},
+			opt: UseImageNamesRefetchCachedValues,
+		},
+	}
+
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			testImg := img.Clone()
+			_ = e.updateImageFromDatabase(context.Background(), testImg, testCase.opt)
+			assert.ElementsMatch(t, testImg.GetNames(), testCase.expectedImageNames)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds more unit tests to ensure image names are correctly retained.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see tests.
### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
