### PR TITLE
test(ui): Add e2e tests for image single page exception flows

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -215,13 +215,24 @@ export function verifySelectedCvesInModal(cveNames) {
     });
 }
 
+export function visitAnyImageSinglePage() {
+    visitWorkloadCveOverview();
+    selectEntityTab('Image');
+    cy.get('tbody tr td[data-label="Image"] a').first().click();
+
+    return cy.get('h1').then(($h1) => {
+        return $h1.text().split(':');
+    });
+}
+
 /**
  * Fill out the exception form and submit it
- * @param {string} comment
- * @param {string=} scopeLabel
- * @param {string=} expiryLabel
+ * @param {Object} param
+ * @param {string} param.comment
+ * @param {string=} param.scopeLabel
+ * @param {string=} param.expiryLabel
  */
-export function fillAndSubmitExceptionForm(comment, scopeLabel, expiryLabel) {
+export function fillAndSubmitExceptionForm({ comment, scopeLabel, expiryLabel }) {
     cy.get(selectors.exceptionOptionsTab).click();
     if (expiryLabel) {
         cy.get(`label:contains('${expiryLabel}')`).click();
@@ -236,12 +247,14 @@ export function fillAndSubmitExceptionForm(comment, scopeLabel, expiryLabel) {
 
 /**
  * Verify that the confirmation details for an exception are correct
- * @param {('Deferral' | 'False positive')} expectedAction
- * @param {string[]} cves
- * @param {string} scope
- * @param {string=} expiry
+ * @param {Object} params
+ * @param {('Deferral' | 'False positive')} params.expectedAction
+ * @param {string[]} params.cves
+ * @param {string} params.scope
+ * @param {string=} params.expiry
  */
-export function verifyExceptionConfirmationDetails(expectedAction, cves, scope, expiry) {
+export function verifyExceptionConfirmationDetails(params) {
+    const { expectedAction, cves, scope, expiry } = params;
     getDescriptionListGroup('Requested action', expectedAction);
     getDescriptionListGroup('Requested', getDateString(new Date()));
     getDescriptionListGroup('CVEs', String(cves.length));

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/cveListExceptionFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/cveListExceptionFlow.test.js
@@ -80,13 +80,16 @@ describe('Workload CVE List deferral and false positive flows', () => {
 
         selectSingleCveForException('DEFERRAL').then((cveName) => {
             verifySelectedCvesInModal([cveName]);
-            fillAndSubmitExceptionForm('Test comment', 'When all CVEs are fixable');
-            verifyExceptionConfirmationDetails(
-                'Deferral',
-                [cveName],
-                'All images',
-                'When all CVEs are fixable'
-            );
+            fillAndSubmitExceptionForm({
+                comment: 'Test comment',
+                expiryLabel: 'When all CVEs are fixable',
+            });
+            verifyExceptionConfirmationDetails({
+                expectedAction: 'Deferral',
+                cves: [cveName],
+                scope: 'All images',
+                expiry: 'When all CVEs are fixable',
+            });
         });
     });
 
@@ -95,14 +98,14 @@ describe('Workload CVE List deferral and false positive flows', () => {
 
         selectMultipleCvesForException('DEFERRAL').then((cveNames) => {
             verifySelectedCvesInModal(cveNames);
-            fillAndSubmitExceptionForm('Test comment', '30 days');
+            fillAndSubmitExceptionForm({ comment: 'Test comment', expiryLabel: '30 days' });
 
-            verifyExceptionConfirmationDetails(
-                'Deferral',
-                cveNames,
-                'All images',
-                `${getDateString(getFutureDateByDays(30))} (30 days)`
-            );
+            verifyExceptionConfirmationDetails({
+                expectedAction: 'Deferral',
+                cves: cveNames,
+                scope: 'All images',
+                expiry: `${getDateString(getFutureDateByDays(30))} (30 days)`,
+            });
         });
     });
 
@@ -111,8 +114,12 @@ describe('Workload CVE List deferral and false positive flows', () => {
 
         selectSingleCveForException('FALSE_POSITIVE').then((cveName) => {
             verifySelectedCvesInModal([cveName]);
-            fillAndSubmitExceptionForm('Test comment');
-            verifyExceptionConfirmationDetails('False positive', [cveName], 'All images');
+            fillAndSubmitExceptionForm({ comment: 'Test comment' });
+            verifyExceptionConfirmationDetails({
+                expectedAction: 'False positive',
+                cves: [cveName],
+                scope: 'All images',
+            });
         });
     });
 
@@ -121,8 +128,12 @@ describe('Workload CVE List deferral and false positive flows', () => {
 
         selectMultipleCvesForException('FALSE_POSITIVE').then((cveNames) => {
             verifySelectedCvesInModal(cveNames);
-            fillAndSubmitExceptionForm('Test comment');
-            verifyExceptionConfirmationDetails('False positive', cveNames, 'All images');
+            fillAndSubmitExceptionForm({ comment: 'Test comment' });
+            verifyExceptionConfirmationDetails({
+                expectedAction: 'False positive',
+                cves: cveNames,
+                scope: 'All images',
+            });
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveListExceptionFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveListExceptionFlow.test.js
@@ -1,0 +1,100 @@
+import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
+
+import {
+    cancelAllCveExceptions,
+    fillAndSubmitExceptionForm,
+    getDateString,
+    getFutureDateByDays,
+    selectMultipleCvesForException,
+    selectSingleCveForException,
+    verifyExceptionConfirmationDetails,
+    verifySelectedCvesInModal,
+    visitAnyImageSinglePage,
+} from './WorkloadCves.helpers';
+
+describe('Workload CVE Image page deferral and false positive flows', () => {
+    withAuth();
+
+    before(function () {
+        if (
+            !hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES') ||
+            !hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL')
+        ) {
+            this.skip();
+        }
+    });
+
+    beforeEach(() => {
+        cancelAllCveExceptions();
+    });
+
+    it('should defer a single CVE', () => {
+        visitAnyImageSinglePage().then(([image]) => {
+            selectSingleCveForException('DEFERRAL').then((cveName) => {
+                verifySelectedCvesInModal([cveName]);
+                fillAndSubmitExceptionForm({
+                    comment: 'Test comment',
+                    expiryLabel: 'When all CVEs are fixable',
+                });
+                verifyExceptionConfirmationDetails({
+                    expectedAction: 'Deferral',
+                    cves: [cveName],
+                    scope: `${image}:*`,
+                    expiry: 'When all CVEs are fixable',
+                });
+            });
+        });
+    });
+
+    it('should defer multiple selected CVEs', () => {
+        visitAnyImageSinglePage().then(([image, tag]) => {
+            selectMultipleCvesForException('DEFERRAL').then((cveNames) => {
+                verifySelectedCvesInModal(cveNames);
+                fillAndSubmitExceptionForm({
+                    comment: 'Test comment',
+                    expiryLabel: '30 days',
+                    scopeLabel: `Only ${image}:${tag}`,
+                });
+
+                verifyExceptionConfirmationDetails({
+                    expectedAction: 'Deferral',
+                    cves: cveNames,
+                    scope: `${image}:${tag}`,
+                    expiry: `${getDateString(getFutureDateByDays(30))} (30 days)`,
+                });
+            });
+        });
+    });
+
+    it('should mark a single CVE as false positive', () => {
+        visitAnyImageSinglePage().then(([image]) => {
+            selectSingleCveForException('FALSE_POSITIVE').then((cveName) => {
+                verifySelectedCvesInModal([cveName]);
+                fillAndSubmitExceptionForm({ comment: 'Test comment' });
+                verifyExceptionConfirmationDetails({
+                    expectedAction: 'False positive',
+                    cves: [cveName],
+                    scope: `${image}:*`,
+                });
+            });
+        });
+    });
+
+    it('should mark multiple selected CVEs as false positive', () => {
+        visitAnyImageSinglePage().then(([image, tag]) => {
+            selectMultipleCvesForException('FALSE_POSITIVE').then((cveNames) => {
+                verifySelectedCvesInModal(cveNames);
+                fillAndSubmitExceptionForm({
+                    comment: 'Test comment',
+                    scopeLabel: `Only ${image}:${tag}`,
+                });
+                verifyExceptionConfirmationDetails({
+                    expectedAction: 'False positive',
+                    cves: cveNames,
+                    scope: `${image}:${tag}`,
+                });
+            });
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -260,7 +260,12 @@ function ImagePageVulnerabilities({ imageId, imageName }: ImagePageVulnerabiliti
                             />
                         </SplitItem>
                     </Split>
-                    <div className="workload-cves-table-container">
+                    <div
+                        className="workload-cves-table-container"
+                        role="region"
+                        aria-live="polite"
+                        aria-busy={loading ? 'true' : 'false'}
+                    >
                         <ImageVulnerabilitiesTable
                             image={vulnerabilityData.image}
                             getSortParams={getSortParams}


### PR DESCRIPTION
## Description

Adds e2e tests for exception workflows in VM 2.0 from the image single page.

Also refactors existing e2e test helpers to use an object parameters instead of many positional parameters.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local e2e test runs + CI