### PR TITLE
ROX-20482: Enable Go mod prefetching

### DIFF
--- a/.tekton/roxctl-pull-request.yaml
+++ b/.tekton/roxctl-pull-request.yaml
@@ -229,9 +229,9 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(params.hermetic)
-        operator: in
-        values: [ "true" ]
+      - input: $(params.prefetch-input)
+        operator: notin
+        values: [ "" ]
       workspaces:
       - name: source
         workspace: workspace

--- a/.tekton/roxctl-pull-request.yaml
+++ b/.tekton/roxctl-pull-request.yaml
@@ -38,9 +38,8 @@ spec:
   # TODO(ROX-20234): Enable hermetic builds
   # - name: hermetic
   #   value: "true"
-  # TODO(ROX-20482): Enable dependencies prefetch
-  # - name: prefetch-input
-  #   value: '{"type": "gomod", "path": "."}'
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
 
   workspaces:
   - name: workspace
@@ -52,7 +51,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 1Gi
+            storage: 10Gi
       status: { }
   - name: git-auth
     secret:

--- a/.tekton/roxctl-pull-request.yaml
+++ b/.tekton/roxctl-pull-request.yaml
@@ -228,10 +228,6 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-      when:
-      - input: $(params.prefetch-input)
-        operator: notin
-        values: [ "" ]
       workspaces:
       - name: source
         workspace: workspace

--- a/.tekton/roxctl-push.yaml
+++ b/.tekton/roxctl-push.yaml
@@ -229,9 +229,9 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(params.hermetic)
-        operator: in
-        values: [ "true" ]
+      - input: $(params.prefetch-input)
+        operator: notin
+        values: [ "" ]
       workspaces:
       - name: source
         workspace: workspace

--- a/.tekton/roxctl-push.yaml
+++ b/.tekton/roxctl-push.yaml
@@ -38,9 +38,8 @@ spec:
   # TODO(ROX-20234): Enable hermetic builds
   # - name: hermetic
   #   value: "true"
-  # TODO(ROX-20482): Enable dependencies prefetch
-  # - name: prefetch-input
-  #   value: '{"type": "gomod", "path": "."}'
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
 
   workspaces:
   - name: workspace
@@ -52,7 +51,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 1Gi
+            storage: 10Gi
       status: { }
   - name: git-auth
     secret:

--- a/.tekton/roxctl-push.yaml
+++ b/.tekton/roxctl-push.yaml
@@ -228,10 +228,6 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-      when:
-      - input: $(params.prefetch-input)
-        operator: notin
-        values: [ "" ]
       workspaces:
       - name: source
         workspace: workspace

--- a/image/roxctl/rhtap.Dockerfile
+++ b/image/roxctl/rhtap.Dockerfile
@@ -12,16 +12,7 @@ WORKDIR /go/src/github.com/stackrox/rox/app
 
 COPY . .
 
-# When dependencies prefetch is on, RHTAP modifies this Dockerfile which would fail the following check.
-# This should stop happening after https://issues.redhat.com/browse/STONEBLD-1847
-# Since changes to the Dockerfile aren't needed (in its copy inside the build context), we revert changes.
-# This is only done when in RHTAP which is checked by the presence of cachi2.env file in absence of anything better.
-RUN if [[ -f /cachi2/cachi2.env ]]; then git restore image/roxctl/rhtap.Dockerfile; fi
-
-RUN echo "Checking that files in git are not modified." && \
-    echo "If the following command fails, it will also print modified files." && \
-    echo "You need to figure the reason and prevent that because otherwise the build results will be inconsistent." && \
-    git status --porcelain | { ! grep '.' >&2 ; }
+RUN scripts/rhtap/fail-build-if-git-is-dirty.sh
 
 RUN mkdir -p image/bin
 

--- a/image/roxctl/rhtap.Dockerfile
+++ b/image/roxctl/rhtap.Dockerfile
@@ -12,6 +12,11 @@ WORKDIR /go/src/github.com/stackrox/rox/app
 
 COPY . .
 
+RUN echo "Checking that files in git are not modified." && \
+    echo "If the following command fails, it will also print modified files." && \
+    echo "You need to figure the reason and prevent that because otherwise the build results will be inconsistent." && \
+    git status --porcelain | { ! grep '.' >&2 ; }
+
 RUN mkdir -p image/bin
 
 # TODO(ROX-20240): enable non-release development builds.

--- a/image/roxctl/rhtap.Dockerfile
+++ b/image/roxctl/rhtap.Dockerfile
@@ -12,6 +12,12 @@ WORKDIR /go/src/github.com/stackrox/rox/app
 
 COPY . .
 
+# When dependencies prefetch is on, RHTAP modifies this Dockerfile which would fail the following check.
+# This should stop happening after https://issues.redhat.com/browse/STONEBLD-1847
+# Since changes to the Dockerfile aren't needed (in its copy inside the build context), we revert changes.
+# This is only done when in RHTAP which is checked by the presence of cachi2.env file in absence of anything better.
+RUN if [[ -f /cachi2/cachi2.env ]]; then git restore image/roxctl/rhtap.Dockerfile; fi
+
 RUN echo "Checking that files in git are not modified." && \
     echo "If the following command fails, it will also print modified files." && \
     echo "You need to figure the reason and prevent that because otherwise the build results will be inconsistent." && \

--- a/scripts/rhtap/fail-build-if-git-is-dirty.sh
+++ b/scripts/rhtap/fail-build-if-git-is-dirty.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# This script works around the fact that RHTAP modifies Dockerfiles provided to it when prefetching dependencies is on.
+# RHTAP changes should stop happening after https://issues.redhat.com/browse/STONEBLD-1847
+# Additionally, the script returns no-zero if it detects any other changes to the git repo.
+#
+# If this script is not called and does not fail the build, things like `make tag` will produce `-dirty` suffix
+# (as in `4.3.x-63-g09e5188ab9-dirty`) which gets embedded as the version attribute in built binaries.
+#
+# The script MUST be executed only from within the Dockerfile (not outside of it) because binaries are built inside.
+
+set -euo pipefail
+
+# When executing in RHTAP (as opposed to the script ran directly), we undo RHTAP changes to Dockerfiles.
+# I found no better way to detect RHTAP than by checking the presence of cachi2.env file.
+if [[ -f /cachi2/cachi2.env ]]; then
+    # We can safely restore dockerfiles because the modified version of dockerfile interpreted by docker/buildah stays
+    # outside, and these are local copies inside of the build context.
+    git restore image/roxctl/rhtap.Dockerfile
+fi
+
+# Next, make sure no other things that make it `-dirty` slipped through. If they did, fail the build.
+
+echo "Checking that files in git repo are not modified."
+echo "If this command fails, you should see the list of modified files below."
+echo "You need to find the reason and prevent that because otherwise the build results will be inconsistent."
+echo ""
+git status --porcelain | { ! { grep '.' >&2 && echo "ERROR: Modifies files found." >&2; } ; }
+
+echo "No modifications git repo detected."

--- a/scripts/rhtap/fail-build-if-git-is-dirty.sh
+++ b/scripts/rhtap/fail-build-if-git-is-dirty.sh
@@ -23,8 +23,8 @@ fi
 
 echo "Checking that files in git repo are not modified."
 echo "If this command fails, you should see the list of modified files below."
-echo "You need to find the reason and prevent that because otherwise the build results will be inconsistent."
+echo "You need to find the reason and prevent it because otherwise the build results will be inconsistent."
 echo ""
 git status --porcelain | { ! { grep '.' >&2 && echo "ERROR: Modifies files found." >&2; } ; }
 
-echo "No modifications git repo detected."
+echo "No modifications to git repo detected."

--- a/scripts/rhtap/fail-build-if-git-is-dirty.sh
+++ b/scripts/rhtap/fail-build-if-git-is-dirty.sh
@@ -25,6 +25,10 @@ echo "Checking that files in git repo are not modified."
 echo "If this command fails, you should see the list of modified files below."
 echo "You need to find the reason and prevent it because otherwise the build results will be inconsistent."
 echo ""
-git status --porcelain | { ! { grep '.' >&2 && echo "ERROR: Modifies files found." >&2; } ; }
 
-echo "No modifications to git repo detected."
+if git status --porcelain | grep '.' >&2 ; then
+    >&2 echo "ERROR: Modified files found."
+    exit 2
+else
+    echo "No modifications to git repo detected."
+fi


### PR DESCRIPTION
Without hermetic builds.

The problem was due to stale image hash of `quay.io/redhat-appstudio-tekton-catalog/task-prefetch-dependencies:0.1` and insufficient workspace volume.

----

How I validated the change - by comparing pipeline run logs.

A build with prefetching enabled. `prefetch-dependencies` takes 1m40s, `build-container` takes 5m31s.
Interestingly, the build system injects `. /cachi2/cachi2.env &&` into every `RUN` statement in the dockerfile.
I.e. the original
```
RUN mkdir -p image/bin
```
becomes
```
RUN . /cachi2/cachi2.env &&     mkdir -p image/bin
```
That's how, I believe, they make sure all appropriate commands (`go ...`) find cached packages.

A build without prefetching. `prefetch-dependencies` obviously gets skipped. `build-container` takes 5m29s.
No speedup in build and overall slowdown, unfortunately.
Plenty of logs like
```
go: downloading github.com/spf13/cobra v1.7.0
go: downloading github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
go: downloading github.com/pkg/errors v0.9.1
go: downloading golang.org/x/net v0.17.0
```
which were absent in the run with prefetch.

Question why prefetch doesn't make build faster https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1698838318724849 got the answer that Cachi2 at the moment is not for speeding up builds.