### PR TITLE
ROX-17720: Swap components to make Workload CVE links selectable

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import DateDistanceTd from '../components/DatePhraseTd';
 import EmptyTableResults from '../components/EmptyTableResults';
@@ -60,14 +59,7 @@ function DeploymentResourceTable({ data, getSortParams }: DeploymentResourceTabl
                     >
                         <Tr>
                             <Td>
-                                <Button
-                                    variant={ButtonVariant.link}
-                                    isInline
-                                    component={LinkShim}
-                                    href={getEntityPagePath('Deployment', id)}
-                                >
-                                    {name}
-                                </Button>
+                                <Link to={getEntityPagePath('Deployment', id)}>{name}</Link>
                             </Td>
                             <Td>{clusterName}</Td>
                             <Td>{namespace}</Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Flex, Button, ButtonVariant, pluralize, Truncate } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { Flex, pluralize, Truncate } from '@patternfly/react-core';
 import {
     TableComposable,
     Thead,
@@ -11,7 +12,6 @@ import {
 } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import useSet from 'hooks/useSet';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import { getEntityPagePath } from '../searchUtils';
@@ -133,14 +133,9 @@ function AffectedDeploymentsTable({
                                     direction={{ default: 'column' }}
                                     spaceItems={{ default: 'spaceItemsNone' }}
                                 >
-                                    <Button
-                                        variant={ButtonVariant.link}
-                                        isInline
-                                        component={LinkShim}
-                                        href={getEntityPagePath('Deployment', id)}
-                                    >
+                                    <Link to={getEntityPagePath('Deployment', id)}>
                                         <Truncate position="middle" content={name} />
-                                    </Button>{' '}
+                                    </Link>
                                 </Flex>
                             </Td>
                             <Td modifier="nowrap" dataLabel="Images by severity">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { gql } from '@apollo/client';
 import {
     ActionsColumn,
@@ -11,9 +12,8 @@ import {
     Thead,
     Tr,
 } from '@patternfly/react-table';
-import { Button, ButtonVariant, Text } from '@patternfly/react-core';
+import { Text } from '@patternfly/react-core';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import useSet from 'hooks/useSet';
 import useMap from 'hooks/useMap';
@@ -215,14 +215,7 @@ function CVEsTable({
                                     />
                                 )}
                                 <Td dataLabel="CVE">
-                                    <Button
-                                        variant={ButtonVariant.link}
-                                        isInline
-                                        component={LinkShim}
-                                        href={getEntityPagePath('CVE', cve)}
-                                    >
-                                        {cve}
-                                    </Button>
+                                    <Link to={getEntityPagePath('CVE', cve)}>{cve}</Link>
                                 </Td>
                                 <Td dataLabel="Images by severity">
                                     <SeverityCountLabels

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
 import {
     ExpandableRowContent,
     TableComposable,
@@ -12,7 +12,6 @@ import {
 import { gql } from '@apollo/client';
 import { min } from 'date-fns';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import useSet from 'hooks/useSet';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
@@ -186,14 +185,7 @@ function DeploymentVulnerabilitiesTable({
                                 }}
                             />
                             <Td dataLabel="CVE">
-                                <Button
-                                    variant={ButtonVariant.link}
-                                    isInline
-                                    component={LinkShim}
-                                    href={getEntityPagePath('CVE', cve)}
-                                >
-                                    {cve}
-                                </Button>
+                                <Link to={getEntityPagePath('CVE', cve)}>{cve}</Link>
                             </Td>
                             <Td modifier="nowrap" dataLabel="Severity">
                                 <VulnerabilitySeverityIconText severity={severity} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { Button, ButtonVariant, Truncate } from '@patternfly/react-core';
+import { Truncate } from '@patternfly/react-core';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import { getEntityPagePath } from '../searchUtils';
 import SeverityCountLabels from '../components/SeverityCountLabels';
@@ -112,14 +112,9 @@ function DeploymentsTable({
                         >
                             <Tr>
                                 <Td>
-                                    <Button
-                                        variant={ButtonVariant.link}
-                                        isInline
-                                        component={LinkShim}
-                                        href={getEntityPagePath('Deployment', id)}
-                                    >
+                                    <Link to={getEntityPagePath('Deployment', id)}>
                                         <Truncate position="middle" content={name} />
-                                    </Button>
+                                    </Link>
                                 </Td>
                                 <Td>
                                     <SeverityCountLabels

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
 import {
     ActionsColumn,
     ExpandableRowContent,
@@ -13,7 +13,6 @@ import {
 } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import useSet from 'hooks/useSet';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
@@ -156,14 +155,7 @@ function ImageVulnerabilitiesTable({
                                     />
                                 )}
                                 <Td dataLabel="CVE">
-                                    <Button
-                                        variant={ButtonVariant.link}
-                                        isInline
-                                        component={LinkShim}
-                                        href={getEntityPagePath('CVE', cve)}
-                                    >
-                                        {cve}
-                                    </Button>
+                                    <Link to={getEntityPagePath('CVE', cve)}>{cve}</Link>
                                 </Td>
                                 <Td modifier="nowrap" dataLabel="CVE severity">
                                     {isVulnerabilitySeverity(severity) && (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameTd.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Flex, Button, ButtonVariant, Truncate } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { Flex, Truncate } from '@patternfly/react-core';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import { getEntityPagePath } from '../searchUtils';
 
 export type ImageNameTdProps = {
@@ -17,14 +17,9 @@ export type ImageNameTdProps = {
 function ImageNameTd({ name, id, children }: ImageNameTdProps) {
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsNone' }}>
-            <Button
-                variant={ButtonVariant.link}
-                isInline
-                component={LinkShim}
-                href={getEntityPagePath('Image', id)}
-            >
+            <Link to={getEntityPagePath('Image', id)}>
                 <Truncate position="middle" content={`${name.remote}:${name.tag}`} />
-            </Button>{' '}
+            </Link>{' '}
             <span className="pf-u-color-200 pf-u-font-size-sm">in {name.registry}</span>
             <div>{children}</div>
         </Flex>


### PR DESCRIPTION
## Description

Changes the component for table links in Workload CVEs from `<Button variant="link" />` to a plain `<Link />`. This makes it so that the link text itself is selectable for copy/paste.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

For each of the following tables, verify that any link text within the table is selectable and that the link continues to go to the correct location.

- CVE List
- Image List
- Deployment List
- Image page CVE links
- Deployment page CVE links
- Deployment page nested table Image links
- CVE page Image links
- CVE page Deployment links
- CVE page nested deployment table Image links

e.g.) 
![image](https://github.com/stackrox/stackrox/assets/1292638/6a0a2343-75fc-4945-9305-62bf9405db7f)


