### PR TITLE
chore(deprecation): Remove Docker CIS from UI

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
@@ -41,7 +41,6 @@ export const routeMatcherMapWithoutStandards =
 // TODO are these reliable after hideScanResults feature?
 /*
 const opnamesOfStandards = [
-    'complianceStandards_CIS_Docker_v1_2_0',
     'complianceStandards_CIS_Kubernetes_v1_5',
     'complianceStandards_HIPAA_164',
     'complianceStandards_NIST_800_190',

--- a/ui/apps/platform/cypress/integration/compliance/complianceList.test.js
+++ b/ui/apps/platform/cypress/integration/compliance/complianceList.test.js
@@ -67,7 +67,7 @@ describe('Compliance entities list', () => {
     });
 
     it('should be sorted by version in standards list', () => {
-        visitComplianceStandard('CIS Docker v1.2.0');
+        visitComplianceStandard('CIS Kubernetes v1.5');
 
         cy.get(selectors.list.table.firstRowName)
             .invoke('text')

--- a/ui/apps/platform/cypress/integration/configmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/dashboard.test.js
@@ -328,18 +328,4 @@ describe('Configuration Management Dashboard', () => {
         }, entitiesKey);
     });
 
-    it('switching clusters in the "CIS Standard Across Clusters" widget\'s should change the data', () => {
-        visitConfigurationManagementDashboard();
-
-        cy.get(selectors.cisStandardsAcrossClusters.select.value).should('contain', 'CIS Docker');
-        cy.get(selectors.cisStandardsAcrossClusters.select.input).click();
-        cy.get(`${selectors.cisStandardsAcrossClusters.select.options}:last`)
-            .last()
-            .click({ force: true });
-        cy.wait('@complianceByControls'); // assume alias from visit function
-        cy.get(selectors.cisStandardsAcrossClusters.select.value).should(
-            'contain',
-            'CIS Kubernetes'
-        );
-    });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/dashboard.test.js
@@ -327,5 +327,4 @@ describe('Configuration Management Dashboard', () => {
                 .click();
         }, entitiesKey);
     });
-
 });

--- a/ui/apps/platform/src/Components/ControlDetails.js
+++ b/ui/apps/platform/src/Components/ControlDetails.js
@@ -11,7 +11,6 @@ import CIS from 'images/cis.svg';
 import Widget from 'Components/Widget';
 
 const svgMapping = {
-    [entityTypes.CIS_Docker_v1_2_0]: CIS,
     [entityTypes.CIS_Kubernetes_v1_5]: CIS,
     [entityTypes.PCI_DSS_3_2]: PCI,
     [entityTypes.HIPAA_164]: HIPAA,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Status/Dashboard/Widgets/ComplianceByProfile.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Status/Dashboard/Widgets/ComplianceByProfile.tsx
@@ -24,11 +24,6 @@ const mockComplianceData: ComplianceByProfileData = [
         link: generatePath(complianceEnhancedStatusProfilesPath, { id: '123456' }),
     },
     {
-        name: 'CIS Docker',
-        passing: 73,
-        link: generatePath(complianceEnhancedStatusProfilesPath, { id: '123456' }),
-    },
-    {
         name: 'CIS K8s',
         passing: 69,
         link: generatePath(complianceEnhancedStatusProfilesPath, { id: '123456' }),

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Page.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Page.js
@@ -26,7 +26,7 @@ const ConfigManagementDashboardPage = () => {
                 <ComplianceByControls
                     className="pdf-page"
                     standardOptions={[
-                        standardTypes.CIS_Kubernetes_v1_5,
+                        standardTypes.CIS_Kubernetes_v1_5
                     ]}
                 />
                 <UsersWithMostClusterAdminRoles />

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Page.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Page.js
@@ -26,7 +26,6 @@ const ConfigManagementDashboardPage = () => {
                 <ComplianceByControls
                     className="pdf-page"
                     standardOptions={[
-                        standardTypes.CIS_Docker_v1_2_0,
                         standardTypes.CIS_Kubernetes_v1_5,
                     ]}
                 />

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Page.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Page.js
@@ -25,9 +25,7 @@ const ConfigManagementDashboardPage = () => {
                 <PolicyViolationsBySeverity />
                 <ComplianceByControls
                     className="pdf-page"
-                    standardOptions={[
-                        standardTypes.CIS_Kubernetes_v1_5
-                    ]}
+                    standardOptions={[standardTypes.CIS_Kubernetes_v1_5]}
                 />
                 <UsersWithMostClusterAdminRoles />
                 <SecretsMostUsedAcrossDeployments />

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -18,7 +18,6 @@ tests compared to a direct hard coding in the mocked response below.
 id: [name, numFailing, numPassing]
 */
 const standards = {
-    CIS_Docker_v1_2_0: ['CIS Docker v1.2.0', 9, 1],
     CIS_Kubernetes_v1_5: ['CIS Kubernetes v1.5', 8, 2],
     HIPAA_164: ['HIPAA 164', 7, 3],
     NIST_800_190: ['NIST SP 800-190', 6, 4],

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -98,7 +98,6 @@ describe('Compliance levels by standard dashboard widget', () => {
         expect(ascendingData).toHaveLength(6);
         expect(ascendingData).toStrictEqual(
             expect.arrayContaining([
-                'CIS Docker v1.2.0',
                 'CIS Kubernetes v1.5',
                 'HIPAA 164',
                 'NIST SP 800-190',
@@ -137,7 +136,7 @@ describe('Compliance levels by standard dashboard widget', () => {
         await user.click(await screen.findByText('View all'));
         expect(history.location.pathname).toBe(complianceBasePath);
 
-        const standard = 'CIS Docker v1.2.0';
+        const standard = 'CIS Kubernetes v1.5';
         await user.click(await screen.findByText(standard));
         expect(history.location.pathname).toBe(
             `${complianceBasePath}/${urlEntityListTypes[standardEntityTypes.CONTROL]}`

--- a/ui/apps/platform/src/constants/entityTypes.ts
+++ b/ui/apps/platform/src/constants/entityTypes.ts
@@ -71,8 +71,6 @@ export const standardBaseTypes = {
     [standardTypes.NIST_800_190]: 'NIST SP 800-190',
     [standardTypes.NIST_SP_800_53_Rev_4]: 'NIST SP 800-53',
     [standardTypes.HIPAA_164]: 'HIPAA',
-    [standardTypes.CIS_Docker_v1_1_0]: 'CIS Docker',
-    [standardTypes.CIS_Docker_v1_2_0]: 'CIS Docker',
     [standardTypes.CIS_Kubernetes_v1_5]: 'CIS K8s',
 };
 

--- a/ui/apps/platform/src/constants/tableColumns.test.js
+++ b/ui/apps/platform/src/constants/tableColumns.test.js
@@ -15,11 +15,6 @@ function expectColumnsNotToContain(columns, shouldNotContain) {
 
 const standards = [
     {
-        id: 'CIS_Docker_v1_2_0',
-        name: 'CIS Docker v1.2.0',
-        scopes: ['CLUSTER', 'NAMESPACE', 'DEPLOYMENT', 'NODE'],
-    },
-    {
         id: 'CIS_Kubernetes_v1_5',
         name: 'CIS Kubernetes v1.5',
         scopes: ['CLUSTER', 'NODE'],

--- a/ui/apps/platform/src/messages/standards.js
+++ b/ui/apps/platform/src/messages/standards.js
@@ -6,8 +6,6 @@ export const standardLabels = {
     [standardTypes.NIST_SP_800_53_Rev_4]: 'NIST SP 800-53',
     [standardTypes.HIPAA_164]: 'HIPAA 164',
     [standardTypes.CIS_Kubernetes_v1_5]: 'CIS Kubernetes v1.5',
-    [standardTypes.CIS_Docker_v1_1_0]: 'CIS Docker v1.1.0',
-    [standardTypes.CIS_Docker_v1_2_0]: 'CIS Docker v1.2.0',
 };
 
 export const standardShortLabels = {

--- a/ui/apps/platform/src/messages/standards.js
+++ b/ui/apps/platform/src/messages/standards.js
@@ -5,7 +5,7 @@ export const standardLabels = {
     [standardTypes.NIST_800_190]: 'NIST SP 800-190',
     [standardTypes.NIST_SP_800_53_Rev_4]: 'NIST SP 800-53',
     [standardTypes.HIPAA_164]: 'HIPAA 164',
-    [standardTypes.CIS_Kubernetes_v1_5]: 'CIS Kubernetes v1.5'
+    [standardTypes.CIS_Kubernetes_v1_5]: 'CIS Kubernetes v1.5',
 };
 
 export const standardShortLabels = {

--- a/ui/apps/platform/src/messages/standards.js
+++ b/ui/apps/platform/src/messages/standards.js
@@ -5,7 +5,7 @@ export const standardLabels = {
     [standardTypes.NIST_800_190]: 'NIST SP 800-190',
     [standardTypes.NIST_SP_800_53_Rev_4]: 'NIST SP 800-53',
     [standardTypes.HIPAA_164]: 'HIPAA 164',
-    [standardTypes.CIS_Kubernetes_v1_5]: 'CIS Kubernetes v1.5',
+    [standardTypes.CIS_Kubernetes_v1_5]: 'CIS Kubernetes v1.5'
 };
 
 export const standardShortLabels = {


### PR DESCRIPTION
## Description

Removes Docker CIS from the FE after already removing it from the backend

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

UI e2e

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
