### PR TITLE
chore(scanner): misc. Makefile updates

### DIFF
--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -22,18 +22,14 @@ ifeq ($(TAG),)
 	TAG := $(shell $(MAKE) -C ../ --quiet --no-print-directory tag)
 endif
 
-UNAME_S := $(shell uname -s)
-UNAME_M := $(shell uname -m)
-
 GOOS := $(DEFAULT_GOOS)
 HOST_OS := linux
-ifeq ($(UNAME_S),Darwin)
+ifeq ($(shell uname -s),Darwin)
 	HOST_OS := darwin
 endif
 
 GO_VERSION := $(firstword $(subst go version ,,$(shell go version)))
 EXPECTED_GO_VERSION := $(shell cat ../EXPECTED_GO_VERSION)
-
 
 GO_BUILD_FLAGS := CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH}
 GO_BUILD_CMD := $(GO_BUILD_FLAGS) go build \
@@ -47,7 +43,7 @@ DOCKERBUILD := $(CURDIR)/../scripts/docker-build.sh
 SCANNER_NAMESPACE ?= stackrox
 
 .PHONY: all
-all: deps scanner-go-build images
+all: images
 
 ###############################################################
 ###### Binaries we depend on (need to be defined on top) ######
@@ -57,12 +53,6 @@ OSSLS_BIN := $(GOBIN)/ossls
 $(OSSLS_BIN): | scanner-go-check-ver
 	@echo "+ $@"
 	$(SILENT)cd tools/ && go install github.com/stackrox/ossls
-
-.PHONY: scanner-go-check-ver
-scanner-go-check-ver:
-ifneq ($(GO_VERSION),$(EXPECTED_GO_VERSION))
-	$(error 'Go version "$(GO_VERSION)" does not match the expected "$(EXPECTED_GO_VERSION)" version.')
-endif
 
 #########
 ## Tag ##
@@ -88,6 +78,26 @@ $(build-t): deps
 	@echo "+ $@"
 	$(build-cmd) -o $@ ./cmd/$(@F)
 
+.PHONY: build-local
+build-local:
+	@echo "+ $@"
+	$(MAKE) SILENT=$(SILENT) GOOS=${HOST_OS} build
+
+.PHONY: build-local-scanner
+build-local-scanner:
+	@echo "+ $@"
+	$(MAKE) SILENT=$(SILENT) GOOS=${HOST_OS} bin/scanner
+
+.PHONY: build-local-scannerctl
+build-local-scannerctl:
+	@echo "+ $@"
+	$(MAKE) SILENT=$(SILENT) GOOS=${HOST_OS} bin/scannerctl
+
+.PHONY: build-local-updater
+build-local-updater:
+	@echo "+ $@"
+	$(MAKE) SILENT=$(SILENT) GOOS=${HOST_OS} bin/updater
+
 .PHONY: clean-build
 clean-build:
 	@echo "+ $@"
@@ -106,11 +116,6 @@ image/scanner/bin/scanner: bin/scanner
 	@echo "+ $@"
 	cp $< $@
 
-.PHONY: scanner-go-build-local
-scanner-go-build-local:
-	@echo "+ $@"
-	$(MAKE) SILENT=$(SILENT) GOOS=${HOST_OS} image/scanner/bin/scanner
-
 OSSLS_NOTICE_DEP := ossls-notice
 ifdef CI
 	OSSLS_NOTICE_DEP := ossls-notice-no-download
@@ -125,6 +130,11 @@ db-image: copy-db-scripts copy-db-image-scripts copy-db-sigs
 	@echo "+ $@"
 	$(DOCKERBUILD) -t stackrox/$(image-prefix)-db:$(TAG) -f image/db/Dockerfile image/db
 
+.PHONY: clean-image
+clean-image:
+	@echo "+ $@"
+	$(SILENT)git clean -xdf image/scanner/bin
+
 ###########
 ## Tests ##
 ###########
@@ -132,6 +142,14 @@ db-image: copy-db-scripts copy-db-image-scripts copy-db-sigs
 ###########
 ## Tools ##
 ###########
+
+.PHONY: scanner-go-check-ver
+scanner-go-check-ver:
+ifdef CI
+ifneq ($(GO_VERSION),$(EXPECTED_GO_VERSION))
+	$(error 'Go version "$(GO_VERSION)" does not match the expected "$(EXPECTED_GO_VERSION)" version.')
+endif
+endif
 
 deps: ../go.mod | scanner-go-check-ver
 	@echo "+ $@"
@@ -362,11 +380,6 @@ $(e2e-files-d)/ca.pem: $(certs-d)/ca/root.pem
 .PHONY: clean
 clean: clean-image clean-gobin clean-deps clean-e2e clean-certs clean-build
 	@echo "+ $@"
-
-.PHONY: clean-image
-clean-image:
-	@echo "+ $@"
-	$(SILENT)git clean -xdf image/scanner/bin
 
 .PHONY: clean-gobin
 clean-gobin:

--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -22,20 +22,21 @@ ifeq ($(TAG),)
 	TAG := $(shell $(MAKE) -C ../ --quiet --no-print-directory tag)
 endif
 
-GOOS := $(DEFAULT_GOOS)
 HOST_OS := linux
 ifeq ($(shell uname -s),Darwin)
 	HOST_OS := darwin
 endif
 
+GOOS := $(HOST_OS)
+
 GO_VERSION := $(firstword $(subst go version ,,$(shell go version)))
 EXPECTED_GO_VERSION := $(shell cat ../EXPECTED_GO_VERSION)
 
-GO_BUILD_FLAGS := CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH}
-GO_BUILD_CMD := $(GO_BUILD_FLAGS) go build \
-                 -trimpath \
-                 -ldflags="-X github.com/stackrox/rox/scanner/internal/version.Version=$(TAG)"
-GO_TEST_CMD := $(GO_BUILD_FLAGS) go test
+GO_BUILD_FLAGS = CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH}
+GO_BUILD_CMD   = $(GO_BUILD_FLAGS) go build \
+                   -trimpath \
+                   -ldflags="-X github.com/stackrox/rox/scanner/internal/version.Version=$(TAG)"
+GO_TEST_CMD    = $(GO_BUILD_FLAGS) go test
 
 DOCKERBUILD := $(CURDIR)/../scripts/docker-build.sh
 
@@ -66,9 +67,11 @@ tag:
 ## Go Builds ##
 ###############
 
-build-cmd := $(GO_BUILD_CMD)
+build-cmd  = $(GO_BUILD_CMD)
 build-d   := bin
 build-t   := $(addprefix $(build-d)/,$(notdir $(wildcard cmd/*)))
+
+build-deps-t := deps
 
 .PHONY: build
 build: $(build-t)
@@ -78,30 +81,31 @@ $(build-t): deps
 	@echo "+ $@"
 	$(build-cmd) -o $@ ./cmd/$(@F)
 
-.PHONY: build-local
-build-local:
-	@echo "+ $@"
-	$(MAKE) SILENT=$(SILENT) GOOS=${HOST_OS} build
-
-.PHONY: build-local-scanner
-build-local-scanner:
-	@echo "+ $@"
-	$(MAKE) SILENT=$(SILENT) GOOS=${HOST_OS} bin/scanner
-
-.PHONY: build-local-scannerctl
-build-local-scannerctl:
-	@echo "+ $@"
-	$(MAKE) SILENT=$(SILENT) GOOS=${HOST_OS} bin/scannerctl
-
-.PHONY: build-local-updater
-build-local-updater:
-	@echo "+ $@"
-	$(MAKE) SILENT=$(SILENT) GOOS=${HOST_OS} bin/updater
-
 .PHONY: clean-build
 clean-build:
 	@echo "+ $@"
 	$(SILENT)rm -rf bin/
+
+$(build-deps-t): ../go.mod | scanner-go-check-ver
+	@echo "+ $@"
+	$(SILENT)go mod tidy
+ifdef CI
+	$(SILENT)git diff --exit-code -- go.mod go.sum || { \
+		echo "go.mod/go.sum files were updated after running 'go mod tidy': run this command on your local machine and commit the results." ; \
+		exit 1 ; \
+	}
+endif
+	$(SILENT)go mod verify
+	$(SILENT)touch $@
+
+.PHONY: scanner-go-check-ver
+scanner-go-check-ver:
+ifdef CI
+	@echo "+ $@"
+ifneq ($(GO_VERSION),$(EXPECTED_GO_VERSION))
+	$(error 'Go version "$(GO_VERSION)" does not match the expected "$(EXPECTED_GO_VERSION)" version.')
+endif
+endif
 
 ############
 ## Images ##
@@ -112,6 +116,7 @@ image-prefix := scanner-v4
 .PHONY: images
 images: scanner-image db-image
 
+image/scanner/bin/scanner: GOOS=$(DEFAULT_GOOS)
 image/scanner/bin/scanner: bin/scanner
 	@echo "+ $@"
 	cp $< $@
@@ -130,11 +135,6 @@ db-image: copy-db-scripts copy-db-image-scripts copy-db-sigs
 	@echo "+ $@"
 	$(DOCKERBUILD) -t stackrox/$(image-prefix)-db:$(TAG) -f image/db/Dockerfile image/db
 
-.PHONY: clean-image
-clean-image:
-	@echo "+ $@"
-	$(SILENT)git clean -xdf image/scanner/bin
-
 ###########
 ## Tests ##
 ###########
@@ -142,26 +142,6 @@ clean-image:
 ###########
 ## Tools ##
 ###########
-
-.PHONY: scanner-go-check-ver
-scanner-go-check-ver:
-ifdef CI
-ifneq ($(GO_VERSION),$(EXPECTED_GO_VERSION))
-	$(error 'Go version "$(GO_VERSION)" does not match the expected "$(EXPECTED_GO_VERSION)" version.')
-endif
-endif
-
-deps: ../go.mod | scanner-go-check-ver
-	@echo "+ $@"
-	$(SILENT)go mod tidy
-ifdef CI
-	$(SILENT)git diff --exit-code -- go.mod go.sum || { \
-		echo "go.mod/go.sum files were updated after running 'go mod tidy': run this command on your local machine and commit the results." ; \
-		exit 1 ; \
-	}
-endif
-	$(SILENT)go mod verify
-	$(SILENT)touch $@
 
 .PHONY: ossls-notice-no-download
 ossls-notice-no-download: deps
@@ -380,6 +360,11 @@ $(e2e-files-d)/ca.pem: $(certs-d)/ca/root.pem
 .PHONY: clean
 clean: clean-image clean-gobin clean-deps clean-e2e clean-certs clean-build
 	@echo "+ $@"
+
+.PHONY: clean-image
+clean-image:
+	@echo "+ $@"
+	$(SILENT)git clean -xdf image/scanner/bin
 
 .PHONY: clean-gobin
 clean-gobin:

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -1,16 +1,11 @@
 # StackRox Scanner
 
-The container image scanner.  Built with ClairCore technology.
+The container image scanner.  Built with [ClairCore](https://github.com/quay/claircore) technology.
 
 ## Development
 
-Scanner requires the Go version to be aligned with the [EXPECTED_GO_VERSION](../EXPECTED_GO_VERSION).  This is verified using Scanner's `make` targets that depend on go tooling.
-
-For local development, you can overwrite this restriction by specifying `EXPECTED_GO_VERSION` in the make targets that will depend on go tools, for example:
-
-```
-make build EXPECTED_GO_VERSION=$(go version | { read _ _ v _; echo $v; })
-```
+It is recommended to use the [EXPECTED_GO_VERSION](../EXPECTED_GO_VERSION), but this is not enforced for development.
+It is, however, enforced in CI.
 
 ### Running locally
 
@@ -20,7 +15,7 @@ To run Scanner locally for development, copy the sample config and edit it to yo
 cp config.yaml.sample config.yaml
 ```
 
-Build Scanner and generate the development TLS certificates:
+Build Scanner binaries and generate the development TLS certificates:
 
 ```sh
 make build certs
@@ -32,17 +27,15 @@ Run:
 ./bin/scanner -conf config.yaml
 ```
 
-The build system by default builds for `GOOS=linux`.  If you are running a non-Linux OS specify the `GOOS` yourself, or use `HOST_OS`.
-
-```sh
-make GOOS='$(HOST_OS)' build
-```
+**Note**: Scanner requires a PostgreSQL database, so be sure one is running and `config.yaml` points to it.
 
 ### Running standalone in Kubernetes
 
 Scanner contains a testing helm chart to deploy it standalone.  This is used for E2E testing or development.
 
-```
+Run Scanner and Scanner DB:
+
+```sh
 make e2e-deploy
 ```
 
@@ -58,7 +51,7 @@ make build
 
 Or, specifically:
 
-```
+```sh
 make bin/scannerctl
 ```
 
@@ -68,7 +61,7 @@ There are options to control how to run `scannerctl`.  See `scannerctl help`.
 
 #### Example 1: Connecting to local Scanner 
 
-A common use case is testing Scanner locally.  Once you have the local scanner build, certificates, and Scanner running with those certificates, you can run `scannerctl`:
+A common use case is testing Scanner locally.  Once you have built local Scanner, certificates, and Scanner running with those certificates, you can run `scannerctl`:
 
 ```sh
 ./bin/scannerctl scan \


### PR DESCRIPTION
## Description

Updates include the following:

* Changes to `make all`
  * Previous `make all` did not work, as `scanner-go-build` target no longer exists. It is now just equivalent to `make images`
* Default `GOOS` to `$HOST_OS` so `make build` builds Go binaries to use locally. `make images` will set `GOOS=$(DEFAULT_GOOS)` so the image's go binary is always built for `linux`
* Moved a few targets around
* Only check the expected Go version in CI. The current way caused more headaches than intended. The idea was to ensure developers updated to the latest Go versions, but instead caused developers to have to downgrade Go versions (or locally modify `EXPECTED_GO_VERSION`). Keeping this in CI to ensure our CI images are the correct version.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Try out the new targets

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
