### PR TITLE
chore(testing): New scaffolding for Compliance 2.0 ui-e2e-tests

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -134,6 +134,7 @@ export_test_environment() {
     ci_export ROX_MOVE_INIT_BUNDLES_UI "${ROX_MOVE_INIT_BUNDLES_UI:-true}"
     ci_export ROX_COMPLIANCE_ENHANCEMENTS "${ROX_COMPLIANCE_ENHANCEMENTS:-true}"
     ci_export ROX_ADMINISTRATION_EVENTS "${ROX_ADMINISTRATION_EVENTS:-true}"
+    ci_export ROX_POLICY_CRITERIA_MODAL "${ROX_POLICY_CRITERIA_MODAL:-true}"
     ci_export ROX_TELEMETRY_STORAGE_KEY_V1 "DISABLED"
 
     if is_in_PR_context && pr_has_label ci-fail-fast; then

--- a/ui/apps/platform/cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
@@ -1,0 +1,14 @@
+import { visit } from '../../helpers/visit';
+
+// path
+
+export const basePath = '/main/compliance-enhanced';
+
+// visit
+
+export function visitComplianceEnhancedDashboard() {
+    // TODO: (vjw, 1 Nov 2023) add routes matchers to this function, after API is available for Status
+    visit(`${basePath}/status`);
+
+    cy.get(`h1:contains("Compliance")`);
+}

--- a/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedDashboard.test.js
@@ -1,0 +1,30 @@
+import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
+import { getRegExpForTitleWithBranding } from '../../helpers/title';
+
+import { visitComplianceEnhancedDashboard } from './ComplianceEnhanced.helpers';
+
+describe('Compliance Dashboard', () => {
+    withAuth();
+
+    before(function () {
+        if (!hasFeatureFlag('ROX_COMPLIANCE_ENHANCEMENTS')) {
+            this.skip();
+        }
+    });
+
+    it('should have title', () => {
+        visitComplianceEnhancedDashboard();
+
+        cy.title().should('match', getRegExpForTitleWithBranding('Compliance Status Dashboard'));
+
+        cy.get('.pf-c-card__header:contains("Compliance by cluster")');
+        cy.get('.pf-c-card__header:contains("Compliance by profile")');
+
+        cy.get('th[scope="col"]:contains("Scan")');
+        cy.get('th[scope="col"]:contains("Clusters")');
+        cy.get('th[scope="col"]:contains("Profiles")');
+        cy.get('th[scope="col"]:contains("Failing Controls")');
+        cy.get('th[scope="col"]:contains("Last Scanned")');
+    });
+});

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Status/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Status/Dashboard/ComplianceDashboardPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Flex, FlexItem, Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
 
+import PageTitle from 'Components/PageTitle';
 import ComplianceByCluster from './Widgets/ComplianceByCluster';
 import ComplianceByProfile from './Widgets/ComplianceByProfile';
 import ScanResultsOverviewTable from './ScanResultsOverviewTable';
@@ -8,6 +9,7 @@ import ScanResultsOverviewTable from './ScanResultsOverviewTable';
 function ComplianceDashboardPage() {
     return (
         <>
+            <PageTitle title="Compliance Status Dashboard" />
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
                 <Flex direction={{ default: 'column' }} className="pf-u-py-lg pf-u-pl-lg">
                     <FlexItem>


### PR DESCRIPTION
## Description

This adds the scaffolding, and the most basic assertions, for ui-e2e-tests for the new Compliance 2.0 section. Only the landing page, `/main/compliance-enhanced/status`, is tested here.

In writing the test, I noticed that we were not setting a page title on the tab when visiting this page. In order to write this basic test, I fixed that oversight.

Caveats:

1. The data on the state is static for now, because the API and Compliance Operator integration are still in development.
2. Because there can be no API calls yet, the route matching/mock data is not included in this PR.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added


## Testing Performed

1. Will observe results of this test in CI
2. Ran the test locally, to see it passing.
![Screen Shot 2023-11-01 at 2 39 29 PM](https://github.com/stackrox/stackrox/assets/715729/84b631cf-4344-4df5-b145-6c244f1e20df)



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
