### PR TITLE
ROX-20398: process V1 and V2 compliance results when flag on

### DIFF
--- a/central/convert/internaltov1storage/compliance_check_results.go
+++ b/central/convert/internaltov1storage/compliance_check_results.go
@@ -1,0 +1,34 @@
+package internaltov1storage
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+)
+
+var (
+	internalStatusToV1 = map[central.ComplianceOperatorCheckResultV2_CheckStatus]storage.ComplianceOperatorCheckResult_CheckStatus{
+		central.ComplianceOperatorCheckResultV2_UNSET:          storage.ComplianceOperatorCheckResult_UNSET,
+		central.ComplianceOperatorCheckResultV2_PASS:           storage.ComplianceOperatorCheckResult_PASS,
+		central.ComplianceOperatorCheckResultV2_FAIL:           storage.ComplianceOperatorCheckResult_FAIL,
+		central.ComplianceOperatorCheckResultV2_ERROR:          storage.ComplianceOperatorCheckResult_ERROR,
+		central.ComplianceOperatorCheckResultV2_INFO:           storage.ComplianceOperatorCheckResult_INFO,
+		central.ComplianceOperatorCheckResultV2_MANUAL:         storage.ComplianceOperatorCheckResult_MANUAL,
+		central.ComplianceOperatorCheckResultV2_NOT_APPLICABLE: storage.ComplianceOperatorCheckResult_NOT_APPLICABLE,
+		central.ComplianceOperatorCheckResultV2_INCONSISTENT:   storage.ComplianceOperatorCheckResult_INCONSISTENT,
+	}
+)
+
+// ConvertInternalToV1Storage converts internal api V2 check result to a V1 storage check result
+func ConvertInternalToV1Storage(internalResult *central.ComplianceOperatorCheckResultV2) *storage.ComplianceOperatorCheckResult {
+	return &storage.ComplianceOperatorCheckResult{
+		Id:           internalResult.GetId(),
+		CheckId:      internalResult.GetCheckId(),
+		CheckName:    internalResult.GetCheckName(),
+		ClusterId:    internalResult.GetClusterId(),
+		Status:       internalStatusToV1[internalResult.GetStatus()],
+		Description:  internalResult.GetDescription(),
+		Instructions: internalResult.GetInstructions(),
+		Labels:       internalResult.GetLabels(),
+		Annotations:  internalResult.GetAnnotations(),
+	}
+}

--- a/central/convert/internaltov1storage/compliance_check_results.go
+++ b/central/convert/internaltov1storage/compliance_check_results.go
@@ -18,8 +18,8 @@ var (
 	}
 )
 
-// ConvertInternalToV1Storage converts internal api V2 check result to a V1 storage check result
-func ConvertInternalToV1Storage(internalResult *central.ComplianceOperatorCheckResultV2) *storage.ComplianceOperatorCheckResult {
+// ComplianceOperatorCheckResult converts internal api V2 check result to a V1 storage check result
+func ComplianceOperatorCheckResult(internalResult *central.ComplianceOperatorCheckResultV2) *storage.ComplianceOperatorCheckResult {
 	return &storage.ComplianceOperatorCheckResult{
 		Id:           internalResult.GetId(),
 		CheckId:      internalResult.GetCheckId(),

--- a/central/convert/internaltov2storage/compliance_check_results.go
+++ b/central/convert/internaltov2storage/compliance_check_results.go
@@ -1,0 +1,46 @@
+package internaltov2storage
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+)
+
+var (
+	statusToV2 = map[central.ComplianceOperatorCheckResultV2_CheckStatus]storage.ComplianceOperatorCheckResultV2_CheckStatus{
+		central.ComplianceOperatorCheckResultV2_UNSET:          storage.ComplianceOperatorCheckResultV2_UNSET,
+		central.ComplianceOperatorCheckResultV2_PASS:           storage.ComplianceOperatorCheckResultV2_PASS,
+		central.ComplianceOperatorCheckResultV2_FAIL:           storage.ComplianceOperatorCheckResultV2_FAIL,
+		central.ComplianceOperatorCheckResultV2_ERROR:          storage.ComplianceOperatorCheckResultV2_ERROR,
+		central.ComplianceOperatorCheckResultV2_INFO:           storage.ComplianceOperatorCheckResultV2_INFO,
+		central.ComplianceOperatorCheckResultV2_MANUAL:         storage.ComplianceOperatorCheckResultV2_MANUAL,
+		central.ComplianceOperatorCheckResultV2_NOT_APPLICABLE: storage.ComplianceOperatorCheckResultV2_NOT_APPLICABLE,
+		central.ComplianceOperatorCheckResultV2_INCONSISTENT:   storage.ComplianceOperatorCheckResultV2_INCONSISTENT,
+	}
+
+	severityToV2 = map[central.ComplianceOperatorRuleSeverity]storage.RuleSeverity{
+		central.ComplianceOperatorRuleSeverity_UNSET_RULE_SEVERITY:   storage.RuleSeverity_UNSET_RULE_SEVERITY,
+		central.ComplianceOperatorRuleSeverity_UNKNOWN_RULE_SEVERITY: storage.RuleSeverity_UNKNOWN_RULE_SEVERITY,
+		central.ComplianceOperatorRuleSeverity_INFO_RULE_SEVERITY:    storage.RuleSeverity_INFO_RULE_SEVERITY,
+		central.ComplianceOperatorRuleSeverity_LOW_RULE_SEVERITY:     storage.RuleSeverity_LOW_RULE_SEVERITY,
+		central.ComplianceOperatorRuleSeverity_MEDIUM_RULE_SEVERITY:  storage.RuleSeverity_MEDIUM_RULE_SEVERITY,
+		central.ComplianceOperatorRuleSeverity_HIGH_RULE_SEVERITY:    storage.RuleSeverity_HIGH_RULE_SEVERITY,
+	}
+)
+
+// ComplianceOperatorCheckResult converts internal api V2 check result to a V2 storage check result
+func ComplianceOperatorCheckResult(sensorData *central.ComplianceOperatorCheckResultV2, clusterID string) *storage.ComplianceOperatorCheckResultV2 {
+	return &storage.ComplianceOperatorCheckResultV2{
+		Id:             sensorData.GetId(),
+		CheckId:        sensorData.GetCheckId(),
+		CheckName:      sensorData.GetCheckName(),
+		ClusterId:      clusterID,
+		Status:         statusToV2[sensorData.GetStatus()],
+		Severity:       severityToV2[sensorData.GetSeverity()],
+		Description:    sensorData.GetDescription(),
+		Instructions:   sensorData.GetInstructions(),
+		Labels:         sensorData.GetLabels(),
+		Annotations:    sensorData.GetAnnotations(),
+		CreatedTime:    sensorData.GetCreatedTime(),
+		ScanConfigName: sensorData.GetSuiteName(),
+	}
+}

--- a/central/sensor/service/connection/sensorevents.go
+++ b/central/sensor/service/connection/sensorevents.go
@@ -115,11 +115,8 @@ func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.Ms
 		// Due to needing both V1 and V2 compliance to run at the same time and due to how the
 		// reconciliation keys are used we need to use the V1 key for reconciliation.  This could
 		// have been avoided by sending both messages from sensor during the transition, but
-		// that seemed like a lot of extra traffic.  Could have also been simpler of the reconciliationMap
-		// simply used a key instead of taking in a type and using reflection to get the string to use as the key.
-		// Leaving the key defintion to the caller may have simplified this as well as we could have simply used
-		// workerType when adding to the map.  This essentially matches how the sensor side is implemented.
-		workerType = reflectutils.Type(event.Resource)
+		// that seemed like a lot of extra traffic.
+		workerType = reflectutils.Type(&central.SensorEvent_ComplianceOperatorResult{})
 		if !s.reconciliationMap.IsClosed() {
 			s.reconciliationMap.Add(&central.SensorEvent_ComplianceOperatorResult{}, event.Id)
 		}

--- a/central/sensor/service/pipeline/complianceoperatorresults/pipeline.go
+++ b/central/sensor/service/pipeline/complianceoperatorresults/pipeline.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/central/complianceoperator/checkresults/datastore"
 	v2 "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore"
 	"github.com/stackrox/rox/central/convert/internaltov1storage"
+	"github.com/stackrox/rox/central/convert/internaltov2storage"
 	countMetrics "github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/sensor/service/common"
 	"github.com/stackrox/rox/central/sensor/service/pipeline"
@@ -23,26 +24,6 @@ import (
 
 var (
 	_ pipeline.Fragment = (*pipelineImpl)(nil)
-
-	statusToV2 = map[central.ComplianceOperatorCheckResultV2_CheckStatus]storage.ComplianceOperatorCheckResultV2_CheckStatus{
-		central.ComplianceOperatorCheckResultV2_UNSET:          storage.ComplianceOperatorCheckResultV2_UNSET,
-		central.ComplianceOperatorCheckResultV2_PASS:           storage.ComplianceOperatorCheckResultV2_PASS,
-		central.ComplianceOperatorCheckResultV2_FAIL:           storage.ComplianceOperatorCheckResultV2_FAIL,
-		central.ComplianceOperatorCheckResultV2_ERROR:          storage.ComplianceOperatorCheckResultV2_ERROR,
-		central.ComplianceOperatorCheckResultV2_INFO:           storage.ComplianceOperatorCheckResultV2_INFO,
-		central.ComplianceOperatorCheckResultV2_MANUAL:         storage.ComplianceOperatorCheckResultV2_MANUAL,
-		central.ComplianceOperatorCheckResultV2_NOT_APPLICABLE: storage.ComplianceOperatorCheckResultV2_NOT_APPLICABLE,
-		central.ComplianceOperatorCheckResultV2_INCONSISTENT:   storage.ComplianceOperatorCheckResultV2_INCONSISTENT,
-	}
-
-	severityToV2 = map[central.ComplianceOperatorRuleSeverity]storage.RuleSeverity{
-		central.ComplianceOperatorRuleSeverity_UNSET_RULE_SEVERITY:   storage.RuleSeverity_UNSET_RULE_SEVERITY,
-		central.ComplianceOperatorRuleSeverity_UNKNOWN_RULE_SEVERITY: storage.RuleSeverity_UNKNOWN_RULE_SEVERITY,
-		central.ComplianceOperatorRuleSeverity_INFO_RULE_SEVERITY:    storage.RuleSeverity_INFO_RULE_SEVERITY,
-		central.ComplianceOperatorRuleSeverity_LOW_RULE_SEVERITY:     storage.RuleSeverity_LOW_RULE_SEVERITY,
-		central.ComplianceOperatorRuleSeverity_MEDIUM_RULE_SEVERITY:  storage.RuleSeverity_MEDIUM_RULE_SEVERITY,
-		central.ComplianceOperatorRuleSeverity_HIGH_RULE_SEVERITY:    storage.RuleSeverity_HIGH_RULE_SEVERITY,
-	}
 
 	log = logging.LoggerForModule()
 )
@@ -157,27 +138,10 @@ func (s *pipelineImpl) processV2ComplianceResult(ctx context.Context, event *cen
 		return s.v2Datastore.DeleteResult(ctx, event.GetId())
 	default:
 		// Still need to store the V1 version to maintain both
-		if err := s.datastore.Upsert(ctx, internaltov1storage.ConvertInternalToV1Storage(checkResult)); err != nil {
+		if err := s.datastore.Upsert(ctx, internaltov1storage.ComplianceOperatorCheckResult(checkResult)); err != nil {
 			return err
 		}
 
-		return s.v2Datastore.UpsertResult(ctx, s.convertSensorMsgToV2Storage(checkResult, clusterID))
-	}
-}
-
-func (s *pipelineImpl) convertSensorMsgToV2Storage(sensorData *central.ComplianceOperatorCheckResultV2, clusterID string) *storage.ComplianceOperatorCheckResultV2 {
-	return &storage.ComplianceOperatorCheckResultV2{
-		Id:             sensorData.GetId(),
-		CheckId:        sensorData.GetCheckId(),
-		CheckName:      sensorData.GetCheckName(),
-		ClusterId:      clusterID,
-		Status:         statusToV2[sensorData.GetStatus()],
-		Severity:       severityToV2[sensorData.GetSeverity()],
-		Description:    sensorData.GetDescription(),
-		Instructions:   sensorData.GetInstructions(),
-		Labels:         sensorData.GetLabels(),
-		Annotations:    sensorData.GetAnnotations(),
-		CreatedTime:    sensorData.GetCreatedTime(),
-		ScanConfigName: sensorData.GetSuiteName(),
+		return s.v2Datastore.UpsertResult(ctx, internaltov2storage.ComplianceOperatorCheckResult(checkResult, clusterID))
 	}
 }

--- a/central/sensor/service/pipeline/complianceoperatorresults/pipeline_test.go
+++ b/central/sensor/service/pipeline/complianceoperatorresults/pipeline_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gogo/protobuf/types"
 	v1ResultMocks "github.com/stackrox/rox/central/complianceoperator/checkresults/datastore/mocks"
 	v2ResultMocks "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore/mocks"
-	v2ConfigMocks "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore/mocks"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
@@ -38,7 +37,6 @@ type PipelineTestSuite struct {
 
 	v1ResultDS *v1ResultMocks.MockDataStore
 	v2ResultDS *v2ResultMocks.MockDataStore
-	v2ConfigDS *v2ConfigMocks.MockDataStore
 	mockCtrl   *gomock.Controller
 }
 
@@ -54,7 +52,6 @@ func (suite *PipelineTestSuite) SetupTest() {
 	suite.mockCtrl = gomock.NewController(suite.T())
 	suite.v1ResultDS = v1ResultMocks.NewMockDataStore(suite.mockCtrl)
 	suite.v2ResultDS = v2ResultMocks.NewMockDataStore(suite.mockCtrl)
-	suite.v2ConfigDS = v2ConfigMocks.NewMockDataStore(suite.mockCtrl)
 }
 
 func (suite *PipelineTestSuite) TearDownTest() {
@@ -66,7 +63,7 @@ func (suite *PipelineTestSuite) TestRunCreate() {
 
 	suite.v1ResultDS.EXPECT().Upsert(ctx, getV1TestRec(fixtureconsts.Cluster1)).Return(nil).Times(1)
 	suite.v2ResultDS.EXPECT().UpsertResult(ctx, getTestRec(fixtureconsts.Cluster1)).Return(nil).Times(1)
-	pipeline := NewPipeline(suite.v1ResultDS, suite.v2ResultDS, suite.v2ConfigDS)
+	pipeline := NewPipeline(suite.v1ResultDS, suite.v2ResultDS)
 
 	msg := &central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_Event{
@@ -103,7 +100,7 @@ func (suite *PipelineTestSuite) TestRunDelete() {
 
 	suite.v1ResultDS.EXPECT().Delete(ctx, id).Return(nil).Times(1)
 	suite.v2ResultDS.EXPECT().DeleteResult(ctx, id).Return(nil).Times(1)
-	pipeline := NewPipeline(suite.v1ResultDS, suite.v2ResultDS, suite.v2ConfigDS)
+	pipeline := NewPipeline(suite.v1ResultDS, suite.v2ResultDS)
 
 	msg := &central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_Event{
@@ -139,7 +136,7 @@ func (suite *PipelineTestSuite) TestRunV1Create() {
 	ctx := context.Background()
 
 	suite.v1ResultDS.EXPECT().Upsert(ctx, getV1TestRec(fixtureconsts.Cluster1)).Return(nil).Times(1)
-	pipeline := NewPipeline(suite.v1ResultDS, suite.v2ResultDS, suite.v2ConfigDS)
+	pipeline := NewPipeline(suite.v1ResultDS, suite.v2ResultDS)
 
 	msg := &central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_Event{
@@ -171,7 +168,7 @@ func (suite *PipelineTestSuite) TestRunV1Delete() {
 	ctx := context.Background()
 
 	suite.v1ResultDS.EXPECT().Delete(ctx, id).Return(nil).Times(1)
-	pipeline := NewPipeline(suite.v1ResultDS, suite.v2ResultDS, suite.v2ConfigDS)
+	pipeline := NewPipeline(suite.v1ResultDS, suite.v2ResultDS)
 
 	msg := &central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_Event{

--- a/central/sensor/service/pipeline/complianceoperatorresults/pipeline_test.go
+++ b/central/sensor/service/pipeline/complianceoperatorresults/pipeline_test.go
@@ -66,10 +66,12 @@ func (suite *PipelineTestSuite) TearDownTest() {
 func (suite *PipelineTestSuite) TestRunCreate() {
 	ctx := context.Background()
 
+	suite.v1ResultDS.EXPECT().Upsert(ctx, getV1TestRec(fixtureconsts.Cluster1)).Return(nil).Times(1)
 	suite.v2ConfigDS.EXPECT().GetScanConfigurations(ctx, search.NewQueryBuilder().
 		AddExactMatches(search.ComplianceOperatorScanName, mockSuiteName).ProtoQuery()).Return([]*storage.ComplianceOperatorScanConfigurationV2{
 		{
-			Id: scanConfigID,
+			Id:       scanConfigID,
+			ScanName: mockSuiteName,
 		},
 	}, nil)
 	suite.v2ResultDS.EXPECT().UpsertResult(ctx, getTestRec(fixtureconsts.Cluster1)).Return(nil).Times(1)
@@ -86,7 +88,7 @@ func (suite *PipelineTestSuite) TestRunCreate() {
 						CheckId:      checkID,
 						CheckName:    mockCheckRuleName,
 						ClusterId:    fixtureconsts.Cluster1,
-						Status:       central.ComplianceOperatorCheckResultV2_INCONSISTENT,
+						Status:       central.ComplianceOperatorCheckResultV2_FAIL,
 						Severity:     central.ComplianceOperatorRuleSeverity_HIGH_RULE_SEVERITY,
 						Description:  "this is a test",
 						Instructions: "this is a test",
@@ -108,6 +110,7 @@ func (suite *PipelineTestSuite) TestRunCreate() {
 func (suite *PipelineTestSuite) TestRunDelete() {
 	ctx := context.Background()
 
+	suite.v1ResultDS.EXPECT().Delete(ctx, id).Return(nil).Times(1)
 	suite.v2ResultDS.EXPECT().DeleteResult(ctx, id).Return(nil).Times(1)
 	pipeline := NewPipeline(suite.v1ResultDS, suite.v2ResultDS, suite.v2ConfigDS)
 
@@ -122,7 +125,7 @@ func (suite *PipelineTestSuite) TestRunDelete() {
 						CheckId:      checkID,
 						CheckName:    mockCheckRuleName,
 						ClusterId:    fixtureconsts.Cluster1,
-						Status:       central.ComplianceOperatorCheckResultV2_INCONSISTENT,
+						Status:       central.ComplianceOperatorCheckResultV2_FAIL,
 						Severity:     central.ComplianceOperatorRuleSeverity_HIGH_RULE_SEVERITY,
 						Description:  "this is a test",
 						Instructions: "this is a test",
@@ -207,18 +210,19 @@ func (suite *PipelineTestSuite) TestRunV1Delete() {
 
 func getTestRec(clusterID string) *storage.ComplianceOperatorCheckResultV2 {
 	return &storage.ComplianceOperatorCheckResultV2{
-		Id:           id,
-		CheckId:      checkID,
-		CheckName:    mockCheckRuleName,
-		ClusterId:    clusterID,
-		Status:       storage.ComplianceOperatorCheckResultV2_INCONSISTENT,
-		Severity:     storage.RuleSeverity_HIGH_RULE_SEVERITY,
-		Description:  "this is a test",
-		Instructions: "this is a test",
-		Labels:       nil,
-		Annotations:  nil,
-		CreatedTime:  createdTime,
-		ScanConfigId: scanConfigID,
+		Id:             id,
+		CheckId:        checkID,
+		CheckName:      mockCheckRuleName,
+		ClusterId:      clusterID,
+		Status:         storage.ComplianceOperatorCheckResultV2_FAIL,
+		Severity:       storage.RuleSeverity_HIGH_RULE_SEVERITY,
+		Description:    "this is a test",
+		Instructions:   "this is a test",
+		Labels:         nil,
+		Annotations:    nil,
+		CreatedTime:    createdTime,
+		ScanConfigId:   scanConfigID,
+		ScanConfigName: mockSuiteName,
 	}
 }
 

--- a/central/sensor/service/pipeline/complianceoperatorresults/pipeline_test.go
+++ b/central/sensor/service/pipeline/complianceoperatorresults/pipeline_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
-	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
@@ -25,10 +24,9 @@ const (
 )
 
 var (
-	createdTime  = types.TimestampNow()
-	id           = uuid.NewV4().String()
-	scanConfigID = uuid.NewV4().String()
-	checkID      = uuid.NewV4().String()
+	createdTime = types.TimestampNow()
+	id          = uuid.NewV4().String()
+	checkID     = uuid.NewV4().String()
 )
 
 func TestPipeline(t *testing.T) {
@@ -67,13 +65,6 @@ func (suite *PipelineTestSuite) TestRunCreate() {
 	ctx := context.Background()
 
 	suite.v1ResultDS.EXPECT().Upsert(ctx, getV1TestRec(fixtureconsts.Cluster1)).Return(nil).Times(1)
-	suite.v2ConfigDS.EXPECT().GetScanConfigurations(ctx, search.NewQueryBuilder().
-		AddExactMatches(search.ComplianceOperatorScanName, mockSuiteName).ProtoQuery()).Return([]*storage.ComplianceOperatorScanConfigurationV2{
-		{
-			Id:       scanConfigID,
-			ScanName: mockSuiteName,
-		},
-	}, nil)
 	suite.v2ResultDS.EXPECT().UpsertResult(ctx, getTestRec(fixtureconsts.Cluster1)).Return(nil).Times(1)
 	pipeline := NewPipeline(suite.v1ResultDS, suite.v2ResultDS, suite.v2ConfigDS)
 
@@ -221,7 +212,6 @@ func getTestRec(clusterID string) *storage.ComplianceOperatorCheckResultV2 {
 		Labels:         nil,
 		Annotations:    nil,
 		CreatedTime:    createdTime,
-		ScanConfigId:   scanConfigID,
 		ScanConfigName: mockSuiteName,
 	}
 }

--- a/tests/e2e/run-compliance-e2e.sh
+++ b/tests/e2e/run-compliance-e2e.sh
@@ -23,8 +23,6 @@ test_compliance_e2e() {
     export DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}"
 
     export_test_environment
-    # TODO(ROX-18827) turn off new compliance for now
-    ci_export ROX_COMPLIANCE_ENHANCEMENTS "false"
 
     setup_deployment_env false false
     remove_existing_stackrox_resources

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -22,8 +22,6 @@ test_e2e() {
     require_environment "KUBECONFIG"
 
     export_test_environment
-    # TODO(ROX-18827) turn off new compliance for now
-    ci_export ROX_COMPLIANCE_ENHANCEMENTS "false"
 
     export SENSOR_HELM_DEPLOY=true
     export ROX_ACTIVE_VULN_REFRESH_INTERVAL=1m


### PR DESCRIPTION
## Description

Nextgen compliance MVP only pulls over part of the compliance functionality.  So V1 compliance needs to remain fully functional until feature parity is met by nextgen compliance.  So the results need to be stored in both V1 and V2 means to ensure a fully functional experience.  Since the message from sensor to central is changing the pipeline has to handle both old and new version as it is possible that central could be running with the nextgen compliance flag while a sensor may not be.  In such cases, compliance messages from a sensor without the feature flag set or an older sensor will only be processed as V1 compliance.  Additionally V2 messages need to be converted and stored as V1.  The simplest path here would have been to simply have sensor send both V1 and V2 messages.  That felt unnecessary and would cause extra traffic.  Thus the pipeline was updated to make that conversion.  Additionally the reconciliation key was changed to use the V1 reconciliation key to ensure that keys were added and that data was removed properly.

For V2 results we are not doing reconciliation at this time as there will be requirements for historical data.  So that clean up will occur during pruning with retention configs, eventually.

Additionally I realized looking up the scanconfig id in the pipeline ran the risk of unnecessarily failing the pipeline and it is looked up on the retrieve so I don't need to store it at this point in the flow.

Also turned the flag on for the tests.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Turned the flag back on for CI.  This ensured that tests executing the V1 endpoints can still execute successfully while the flag is enabled.

Additionally ran in local cluster with flag on and off to ensure the results were received as expected.  This included bouncing sensors to force resync.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
