### PR TITLE
ROX-20610: v2 workflow to revert vulnerability exception

### DIFF
--- a/central/convert/v2tostorage/vuln_exception_service.go
+++ b/central/convert/v2tostorage/vuln_exception_service.go
@@ -211,11 +211,15 @@ func requestExpiry(expiry *v2.ExceptionExpiry) *storage.RequestExpiry {
 	ret := &storage.RequestExpiry{
 		ExpiryType: requestExpiryType(expiry.GetExpiryType()),
 	}
-	if expiry.GetExpiryType() == v2.ExceptionExpiry_TIME {
+	switch expiry.GetExpiryType() {
+	case v2.ExceptionExpiry_TIME:
 		ret.Expiry = &storage.RequestExpiry_ExpiresOn{
 			ExpiresOn: expiry.GetExpiresOn(),
 		}
-	} else {
+	case v2.ExceptionExpiry_ANY_CVE_FIXABLE:
+		// Set the legacy field for backward compatibility.
+		// In v1, a vulnerability request could have only one CVE at a time. For expiry based on CVE fixability,
+		// the request expired if at least one CVE in the request was fixable which maps to ANY_CVE_FIXABLE behaviour in the v2.
 		ret.Expiry = &storage.RequestExpiry_ExpiresWhenFixed{
 			ExpiresWhenFixed: true,
 		}

--- a/central/convert/v2tostorage/vuln_exception_service_test.go
+++ b/central/convert/v2tostorage/vuln_exception_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/central/convert/testutils"
+	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	mockIdentity "github.com/stackrox/rox/pkg/grpc/authn/mocks"
@@ -42,6 +43,45 @@ func TestVulnerabilityRequest(t *testing.T) {
 		t,
 		testutils.GetTestVulnRequestWithUpdate(t),
 		VulnerabilityRequest(testutils.GetTestVulnExceptionWithUpdate(t)),
+	)
+
+	assert.EqualValues(
+		t,
+		func() *storage.VulnerabilityRequest {
+			req := testutils.GetTestVulnRequestWithUpdate(t)
+			req.GetDeferralReq().Expiry = &storage.RequestExpiry{
+				ExpiryType: storage.RequestExpiry_ALL_CVE_FIXABLE,
+			}
+			return req
+		}(),
+		func() *storage.VulnerabilityRequest {
+			req := testutils.GetTestVulnExceptionWithUpdate(t)
+			req.GetDeferralRequest().Expiry = &v2.ExceptionExpiry{
+				ExpiryType: v2.ExceptionExpiry_ALL_CVE_FIXABLE,
+			}
+			return VulnerabilityRequest(req)
+		}(),
+	)
+
+	assert.EqualValues(
+		t,
+		func() *storage.VulnerabilityRequest {
+			req := testutils.GetTestVulnRequestWithUpdate(t)
+			req.GetDeferralReq().Expiry = &storage.RequestExpiry{
+				ExpiryType: storage.RequestExpiry_ANY_CVE_FIXABLE,
+				Expiry: &storage.RequestExpiry_ExpiresWhenFixed{
+					ExpiresWhenFixed: true,
+				},
+			}
+			return req
+		}(),
+		func() *storage.VulnerabilityRequest {
+			req := testutils.GetTestVulnExceptionWithUpdate(t)
+			req.GetDeferralRequest().Expiry = &v2.ExceptionExpiry{
+				ExpiryType: v2.ExceptionExpiry_ANY_CVE_FIXABLE,
+			}
+			return VulnerabilityRequest(req)
+		}(),
 	)
 
 	id := mockIdentity.NewMockIdentity(gomock.NewController(t))

--- a/central/graphql/resolvers/vulnerability_requests_test.go
+++ b/central/graphql/resolvers/vulnerability_requests_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/stackrox/rox/central/audit"
-	componentCVEEdgeDS "github.com/stackrox/rox/central/componentcveedge/datastore"
+	imageCVEDS "github.com/stackrox/rox/central/cve/image/datastore"
 	deploymentMockDS "github.com/stackrox/rox/central/deployment/datastore/mocks"
 	imageDS "github.com/stackrox/rox/central/image/datastore"
 	imagePG "github.com/stackrox/rox/central/image/datastore/store/postgres"
@@ -129,14 +129,14 @@ type VulnRequestResolverTestSuite struct {
 	ctx    context.Context
 	testDB *pgtest.TestPostgres
 
-	vulnReqDataStore      vulnReqDS.DataStore
-	deployments           *deploymentMockDS.MockDataStore
-	imageDataStore        imageDS.DataStore
-	componentCVEDataStore componentCVEEdgeDS.DataStore
-	sensorConnMgrMocks    *sensorConnMgrMocks.MockManager
-	riskManager           *riskManager.MockManager
-	reprocessor           *reprocessorMocks.MockLoop
-	vulnReqManager        vulnReqManager.Manager
+	vulnReqDataStore   vulnReqDS.DataStore
+	deployments        *deploymentMockDS.MockDataStore
+	imageDataStore     imageDS.DataStore
+	imageCVEDataStore  imageCVEDS.DataStore
+	sensorConnMgrMocks *sensorConnMgrMocks.MockManager
+	riskManager        *riskManager.MockManager
+	reprocessor        *reprocessorMocks.MockLoop
+	vulnReqManager     vulnReqManager.Manager
 
 	resolver *Resolver
 	schema   *graphql.Schema
@@ -185,7 +185,7 @@ func (s *VulnRequestResolverTestSuite) SetupTest() {
 		pendingReqCache,
 		vulnReqCache.New(),
 		s.imageDataStore,
-		s.componentCVEDataStore,
+		s.imageCVEDataStore,
 		s.sensorConnMgrMocks,
 		s.reprocessor,
 	)
@@ -214,8 +214,8 @@ func (s *VulnRequestResolverTestSuite) createImageDataStore() {
 }
 
 func (s *VulnRequestResolverTestSuite) createComponentCVEDataStore() {
-	ds := componentCVEEdgeDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
-	s.componentCVEDataStore = ds
+	ds := imageCVEDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
+	s.imageCVEDataStore = ds
 }
 
 func (s *VulnRequestResolverTestSuite) createVulnRequestDataStore(pendingReqCache vulnReqCache.VulnReqCache, activeReqCache vulnReqCache.VulnReqCache) {

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	componentCVEEdgeDataStore "github.com/stackrox/rox/central/componentcveedge/datastore"
+	imgCVEDataStore "github.com/stackrox/rox/central/cve/image/datastore"
 	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
 	imgDataStore "github.com/stackrox/rox/central/image/datastore"
 	"github.com/stackrox/rox/central/reprocessor"
@@ -23,6 +23,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/batcher"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/cve"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
@@ -53,19 +54,19 @@ var (
 )
 
 type managerImpl struct {
-	deployments       deploymentDataStore.DataStore
-	images            imgDataStore.DataStore
-	componentCVEEdges componentCVEEdgeDataStore.DataStore
-	vulnReqs          vulnReqDataStore.DataStore
-	connManager       connection.Manager
-	reprocessor       reprocessor.Loop
-	activeReqCache    cache.VulnReqCache
-	pendingReqCache   cache.VulnReqCache
+	deployments     deploymentDataStore.DataStore
+	images          imgDataStore.DataStore
+	imageCVEs       imgCVEDataStore.DataStore
+	vulnReqs        vulnReqDataStore.DataStore
+	connManager     connection.Manager
+	reprocessor     reprocessor.Loop
+	activeReqCache  cache.VulnReqCache
+	pendingReqCache cache.VulnReqCache
 	// Stores the UTC month and seq num for that month for most recently created request, if any.
 	lastKnownSeqNumInfo *monthSeqNumPair
 
-	reObserveTimedDeferralsTickerDuration     time.Duration
-	reObserveWhenFixedDeferralsTickerDuration time.Duration
+	revertTimedDeferralsTickerDuration      time.Duration
+	revertFixableCVEDeferralsTickerDuration time.Duration
 
 	stopper    concurrency.Stopper
 	upsertSem  *semaphore.Weighted
@@ -500,7 +501,7 @@ func (m *managerImpl) getExpiredDeferrals() ([]*storage.VulnerabilityRequest, er
 	return results, nil
 }
 
-func (m *managerImpl) reObserveExpiredDeferrals() {
+func (m *managerImpl) revertPastDueDeferralExceptions() {
 	if m.stopper.Client().Stopped().IsDone() {
 		return
 	}
@@ -522,6 +523,10 @@ func (m *managerImpl) reObserveExpiredDeferrals() {
 }
 
 func (m *managerImpl) getFixableDeferrals() ([]*storage.VulnerabilityRequest, error) {
+	if features.UnifiedCVEDeferral.Enabled() {
+		return m.getFixableCVEDeferrals()
+	}
+
 	q := search.ConjunctionQuery(
 		search.NewQueryBuilder().AddGenericTypeLinkedFields([]search.FieldLabel{search.ExpiredRequest, search.RequestExpiresWhenFixed}, []interface{}{false, true}).ProtoQuery(),
 		search.NewQueryBuilder().AddExactMatches(search.RequestStatus, storage.RequestStatus_APPROVED.String(), storage.RequestStatus_APPROVED_PENDING_UPDATE.String()).ProtoQuery(),
@@ -544,12 +549,11 @@ func (m *managerImpl) getFixableDeferrals() ([]*storage.VulnerabilityRequest, er
 			if err != nil {
 				return nil, err
 			}
-			count, err := m.componentCVEEdges.Count(ctx, fixableQuery)
+			count, err := m.imageCVEs.Count(ctx, fixableQuery)
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not fetch cve component edge for cve %q for request %q", cve, res.GetId())
 			}
-
-			if count != 0 { // This CVE is fixable for this image (or for all images in the query)
+			if count > 0 { // This CVE is fixable for this image (or for all images in the query)
 				fixableReqs = append(fixableReqs, res)
 			}
 		}
@@ -558,14 +562,70 @@ func (m *managerImpl) getFixableDeferrals() ([]*storage.VulnerabilityRequest, er
 	return fixableReqs, nil
 }
 
-func (m *managerImpl) reObserveFixableDeferrals() {
+func (m *managerImpl) getFixableCVEDeferrals() ([]*storage.VulnerabilityRequest, error) {
+	ctx := sac.WithAllAccess(context.Background())
+
+	q := search.ConjunctionQuery(
+		search.NewQueryBuilder().
+			AddBools(search.ExpiredRequest, false).
+			AddExactMatches(search.ExpiryType, storage.RequestExpiry_ANY_CVE_FIXABLE.String(), storage.RequestExpiry_ALL_CVE_FIXABLE.String()).
+			AddExactMatches(search.RequestStatus, storage.RequestStatus_APPROVED.String(), storage.RequestStatus_APPROVED_PENDING_UPDATE.String()).
+			ProtoQuery(),
+	)
+
+	requests, err := m.vulnReqs.SearchRawRequests(allVulnApproverAccessSac, q)
+	if err != nil || len(requests) == 0 {
+		return nil, err
+	}
+	var fixableReqs []*storage.VulnerabilityRequest
+	for _, request := range requests {
+		expiryType := request.GetDeferralReq().GetExpiry().GetExpiryType()
+		query := search.NewQueryBuilder().
+			AddBools(search.Fixable, true).
+			AddExactMatches(search.CVE, request.GetCves().GetCves()...).ProtoQuery()
+
+		// Add image scope to the query.
+		fixableQuery, err := utils.GetAffectedImagesQuery(request, query)
+		if err != nil {
+			return nil, err
+		}
+
+		if expiryType == storage.RequestExpiry_ANY_CVE_FIXABLE {
+			count, err := m.imageCVEs.Count(ctx, fixableQuery)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to count on image cves for request %q", request.GetId())
+			}
+
+			if count > 0 {
+				fixableReqs = append(fixableReqs, request)
+			}
+		} else if expiryType == storage.RequestExpiry_ALL_CVE_FIXABLE {
+			results, err := m.imageCVEs.Search(ctx, fixableQuery)
+			if err != nil {
+				return nil, errors.Wrapf(err, "could not search image cves for request %q", request.GetId())
+			}
+			cveSet := set.NewStringSet()
+			for _, id := range search.ResultsToIDs(results) {
+				cve, _ := cve.IDToParts(id)
+				cveSet.Add(cve)
+			}
+			if cveSet.Cardinality() == len(request.GetCves().GetCves()) {
+				fixableReqs = append(fixableReqs, request)
+			}
+		}
+	}
+
+	return fixableReqs, nil
+}
+
+func (m *managerImpl) revertFixableCVEDeferralExceptions() {
 	if m.stopper.Client().Stopped().IsDone() {
 		return
 	}
 
 	deferrals, err := m.getFixableDeferrals()
 	if err != nil {
-		log.Errorf("error retrieving deferral requests that are now fixable for reprocessing: %v", err)
+		log.Errorf("Failed to determine if deferral exception can be reverted: %v", err)
 		return
 	}
 	if len(deferrals) == 0 {
@@ -573,31 +633,31 @@ func (m *managerImpl) reObserveFixableDeferrals() {
 	}
 
 	if err := m.expireDeferrals(deferrals); err != nil {
-		log.Errorf("Failed to retire now-fixable deferral requests and re-observe associated vulnerabilities with error(s): %+v", err)
+		log.Errorf("Failed to revert vulnerability deferral exceptions: %+v", err)
 	} else {
-		log.Infof("Completed retiring %d newly fixable deferral requests and re-observing deferred vulnerabilities", len(deferrals))
+		log.Infof("Reverted %d vulnerability deferral exceptions", len(deferrals))
 	}
 }
 
 func (m *managerImpl) runExpiredDeferralsProcessor() {
 	defer m.stopper.Flow().ReportStopped()
-	reObserveTimedDeferralsTicker := time.NewTicker(m.reObserveTimedDeferralsTickerDuration)
+	reObserveTimedDeferralsTicker := time.NewTicker(m.revertTimedDeferralsTickerDuration)
 	defer reObserveTimedDeferralsTicker.Stop()
-	reObserveWhenFixedDeferralsTicker := time.NewTicker(m.reObserveWhenFixedDeferralsTickerDuration)
+	reObserveWhenFixedDeferralsTicker := time.NewTicker(m.revertFixableCVEDeferralsTickerDuration)
 	defer reObserveWhenFixedDeferralsTicker.Stop()
 
 	// Kick off a run to start
-	go m.reObserveExpiredDeferrals()
-	go m.reObserveFixableDeferrals()
+	go m.revertPastDueDeferralExceptions()
+	go m.revertFixableCVEDeferralExceptions()
 
 	for {
 		select {
 		case <-m.stopper.Flow().StopRequested():
 			return
 		case <-reObserveTimedDeferralsTicker.C:
-			go m.reObserveExpiredDeferrals()
+			go m.revertPastDueDeferralExceptions()
 		case <-reObserveWhenFixedDeferralsTicker.C:
-			go m.reObserveFixableDeferrals()
+			go m.revertFixableCVEDeferralExceptions()
 		}
 	}
 }

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	componentCVEEdgeDSMocks "github.com/stackrox/rox/central/componentcveedge/datastore/mocks"
+	imageCVEDSMocks "github.com/stackrox/rox/central/cve/image/datastore/mocks"
 	imageDSMocks "github.com/stackrox/rox/central/image/datastore/mocks"
 	reprocessorMocks "github.com/stackrox/rox/central/reprocessor/mocks"
 	sensorConnMgrMocks "github.com/stackrox/rox/central/sensor/service/connection/mocks"
@@ -174,8 +174,8 @@ func TestApproval(t *testing.T) {
 	imageDataStore := imageDSMocks.NewMockDataStore(mockCtrl)
 	sensorConnMgrMocks := sensorConnMgrMocks.NewMockManager(mockCtrl)
 	reprocessor := reprocessorMocks.NewMockLoop(mockCtrl)
-	componentCVEEdgeDataStore := componentCVEEdgeDSMocks.NewMockDataStore(mockCtrl)
-	manager := New(nil, datastore, pendingReqCache, activeReqCache, imageDataStore, componentCVEEdgeDataStore, sensorConnMgrMocks, reprocessor)
+	imageCVEDataStore := imageCVEDSMocks.NewMockDataStore(mockCtrl)
+	manager := New(nil, datastore, pendingReqCache, activeReqCache, imageDataStore, imageCVEDataStore, sensorConnMgrMocks, reprocessor)
 
 	globalCVE1DefReq := fixtures.GetGlobalDeferralRequest("cve-1")
 	globalCVE1FPReq := fixtures.GetGlobalFPRequest("cve-1")

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_reobserve_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_reobserve_test.go
@@ -1,0 +1,403 @@
+//go:build sql_integration
+
+package requestmgr
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	imageCVEDS "github.com/stackrox/rox/central/cve/image/datastore"
+	deploymentMockDS "github.com/stackrox/rox/central/deployment/datastore/mocks"
+	imageDS "github.com/stackrox/rox/central/image/datastore"
+	imageCVEEdgeDS "github.com/stackrox/rox/central/imagecveedge/datastore"
+	reprocessorMocks "github.com/stackrox/rox/central/reprocessor/mocks"
+	sensorConnMgrMocks "github.com/stackrox/rox/central/sensor/service/connection/mocks"
+	vulnReqCache "github.com/stackrox/rox/central/vulnerabilityrequest/cache"
+	vulnReqDS "github.com/stackrox/rox/central/vulnerabilityrequest/datastore"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/sync/semaphore"
+)
+
+func TestVulnRequestManagerRevertExceptionWithUnifiedDeferral(t *testing.T) {
+	t.Setenv(features.UnifiedCVEDeferral.EnvVar(), "true")
+	if !features.UnifiedCVEDeferral.Enabled() {
+		t.Skipf("%s=false. Skipping test", features.UnifiedCVEDeferral.EnvVar())
+	}
+
+	suite.Run(t, new(VulnRequestManagerRevertExceptionTestSuite))
+}
+
+func TestVulnRequestManagerRevertExceptionWithoutUnifiedDeferral(t *testing.T) {
+	t.Setenv(features.UnifiedCVEDeferral.EnvVar(), "false")
+	if features.UnifiedCVEDeferral.Enabled() {
+		t.Skipf("%s=true. Skipping test", features.UnifiedCVEDeferral.EnvVar())
+	}
+
+	suite.Run(t, new(VulnRequestManagerRevertExceptionTestSuite))
+}
+
+type VulnRequestManagerRevertExceptionTestSuite struct {
+	mockCtrl *gomock.Controller
+	suite.Suite
+
+	ctx    context.Context
+	testDB *pgtest.TestPostgres
+
+	vulnReqDataStore      vulnReqDS.DataStore
+	deployments           *deploymentMockDS.MockDataStore
+	imageDataStore        imageDS.DataStore
+	imageCVEDataStore     imageCVEDS.DataStore
+	imageCVEEdgeDataStore imageCVEEdgeDS.DataStore
+	sensorConnMgrMocks    *sensorConnMgrMocks.MockManager
+	reprocessor           *reprocessorMocks.MockLoop
+	manager               *managerImpl
+	pendingReqCache       vulnReqCache.VulnReqCache
+	activeReqCache        vulnReqCache.VulnReqCache
+}
+
+func (s *VulnRequestManagerRevertExceptionTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.mockCtrl = gomock.NewController(s.T())
+	s.testDB = pgtest.ForT(s.T())
+
+	s.pendingReqCache, s.activeReqCache = vulnReqCache.New(), vulnReqCache.New()
+	s.setupDataStores(s.pendingReqCache, s.activeReqCache)
+
+	s.deployments = deploymentMockDS.NewMockDataStore(s.mockCtrl)
+	s.sensorConnMgrMocks = sensorConnMgrMocks.NewMockManager(s.mockCtrl)
+	s.reprocessor = reprocessorMocks.NewMockLoop(s.mockCtrl)
+	s.manager = &managerImpl{
+		deployments:                             s.deployments,
+		images:                                  s.imageDataStore,
+		imageCVEs:                               s.imageCVEDataStore,
+		vulnReqs:                                s.vulnReqDataStore,
+		connManager:                             s.sensorConnMgrMocks,
+		reprocessor:                             s.reprocessor,
+		pendingReqCache:                         s.pendingReqCache,
+		activeReqCache:                          s.activeReqCache,
+		revertTimedDeferralsTickerDuration:      expiryLoopDurationForTest,
+		revertFixableCVEDeferralsTickerDuration: expiryLoopDurationForTest,
+		stopper:                                 concurrency.NewStopper(),
+		upsertSem:                               semaphore.NewWeighted(1),
+	}
+}
+
+func (s *VulnRequestManagerRevertExceptionTestSuite) TearDownTest() {
+	s.testDB.Teardown(s.T())
+}
+
+func (s *VulnRequestManagerRevertExceptionTestSuite) setupDataStores(pendingReqCache vulnReqCache.VulnReqCache, activeReqCache vulnReqCache.VulnReqCache) {
+	var err error
+	s.imageDataStore = imageDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
+	s.imageCVEDataStore = imageCVEDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
+	s.Require().NoError(err)
+	s.imageCVEEdgeDataStore = imageCVEEdgeDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
+	s.vulnReqDataStore = vulnReqDS.GetTestPostgresDataStore(s.T(), s.testDB.DB, pendingReqCache, activeReqCache)
+}
+
+func (s *VulnRequestManagerTestSuite) TestReObserveExpiredDeferralsMarksAllAsInactive() {
+	expiredInThePast := protoconv.ConvertTimeToTimestamp(time.Now().Add(-96 * time.Hour))
+	expiresInFuture := protoconv.ConvertTimeToTimestamp(time.Now().Add(30 * 24 * time.Hour))
+
+	fpRequest := fixtures.GetGlobalFPRequest("cve-a-b")
+	fpRequest.Status = storage.RequestStatus_APPROVED
+	fpRequest.Comments = []*storage.RequestComment{} // clear out the comment to make testing the one added by expiry easier
+
+	cases := []struct {
+		name             string
+		vulnRequest      *storage.VulnerabilityRequest
+		shouldBeActive   bool
+		shouldGetComment bool
+	}{
+		{
+			name:             "Active and approved deferral with expiry in the past should be marked inactive with comment",
+			vulnRequest:      newDeferral("req-active-def", false, storage.RequestStatus_APPROVED, expiredInThePast),
+			shouldBeActive:   false,
+			shouldGetComment: true,
+		},
+		{
+			name:             "Active and approved deferral with a pending request should still be inactive if expiry is in past",
+			vulnRequest:      newDeferral("req-updated-def", false, storage.RequestStatus_APPROVED_PENDING_UPDATE, expiredInThePast),
+			shouldBeActive:   false,
+			shouldGetComment: true,
+		},
+		{
+			name:             "Inactive deferral should remain inactive but with no additional comment",
+			vulnRequest:      newDeferral("req-inactive-def", true, storage.RequestStatus_APPROVED, expiredInThePast),
+			shouldBeActive:   false,
+			shouldGetComment: false,
+		},
+		{
+			name:             "Pending deferral should not be marked as inactive",
+			vulnRequest:      newDeferral("req-pending-def", false, storage.RequestStatus_PENDING, expiredInThePast),
+			shouldBeActive:   true,
+			shouldGetComment: false,
+		},
+		{
+			name:             "Denied deferral should not be marked as inactive",
+			vulnRequest:      newDeferral("req-denied-def", false, storage.RequestStatus_DENIED, expiredInThePast),
+			shouldBeActive:   true,
+			shouldGetComment: false,
+		},
+		{
+			name:             "Deferral with expiry in future should not be marked as inactive",
+			vulnRequest:      newDeferral("req-unexpired-def", false, storage.RequestStatus_APPROVED, expiresInFuture),
+			shouldBeActive:   true,
+			shouldGetComment: false,
+		},
+		{
+			name:             "Deferrals with expires when fixed should not be marked as inactive",
+			vulnRequest:      newDeferralExpiresWhenFixable("req-whenfixed-def", false, storage.RequestStatus_APPROVED, nil, false, "req-whenfixed-def"),
+			shouldBeActive:   true,
+			shouldGetComment: false,
+		},
+		{
+			name:             "False positive requests should not be marked as inactive",
+			vulnRequest:      fpRequest,
+			shouldBeActive:   true,
+			shouldGetComment: false,
+		},
+	}
+	for _, c := range cases {
+		s.T().Run(c.name, func(t *testing.T) {
+			err := s.vulnReqDataStore.AddRequest(allAllowedCtx, c.vulnRequest)
+			assert.NoError(t, err)
+
+			s.manager.revertPastDueDeferralExceptions()
+
+			r, ok, err := s.vulnReqDataStore.Get(allAllowedCtx, c.vulnRequest.GetId())
+			assert.NoError(t, err)
+			assert.True(t, ok)
+			assert.Equal(t, c.shouldBeActive, !r.Expired)
+
+			if c.shouldGetComment {
+				assert.Len(t, r.Comments, 1)
+				assert.Equal(t, r.Comments[0].Message, "[System Generated] Request expired")
+				assert.Nil(t, r.Comments[0].User) // system generated so no user identity
+			} else {
+				assert.Len(t, r.Comments, 0)
+			}
+		})
+	}
+}
+
+func (s *VulnRequestManagerRevertExceptionTestSuite) TestReObserveFixableDeferrals() {
+	fixableMongo1 := getImageWithVulnerableComponents("stackrox.io", "srox/mongo", "latest", "sha256:SHA2", 2)
+	fixableMongo2 := getImageWithVulnerableComponents("stackrox.io", "srox/mongo", "0.0.0.1", "sha256:sha3", 2)
+	fixableNginx := getImageWithVulnerableComponents("stackrox.io", "srox/nginx", "latest", "sha256:SHAAAAAA", 2)
+
+	// Both of these images have a different component but with the exact same CVE as the previous ones that is unfixable
+	unfixableMongo := getImageWithVulnerableComponents("stackrox.io", "srox/mongo", "0.0.0.2", "sha256:sha4", 2)
+	unfixableMongo.GetScan().GetComponents()[0].Version = "89.9"
+	unfixableMongo.GetScan().GetComponents()[0].GetVulns()[0].SetFixedBy = nil
+	unfixableMonitoring := getImageWithVulnerableComponents("stackrox.io", "stackrox/monitoring", "67.0", "sha256:SHBBBBBBB", 2)
+	unfixableMonitoring.GetScan().GetComponents()[0].Version = "99.9"
+	unfixableMonitoring.GetScan().GetComponents()[0].GetVulns()[0].SetFixedBy = nil
+
+	s.NoError(s.imageDataStore.UpsertImage(allAllowedCtx, fixableMongo1))
+	s.NoError(s.imageDataStore.UpsertImage(allAllowedCtx, fixableMongo2))
+	s.NoError(s.imageDataStore.UpsertImage(allAllowedCtx, fixableNginx))
+	s.NoError(s.imageDataStore.UpsertImage(allAllowedCtx, unfixableMongo))
+	s.NoError(s.imageDataStore.UpsertImage(allAllowedCtx, unfixableMonitoring))
+
+	fixableCVE1 := fixableMongo1.GetScan().GetComponents()[0].GetVulns()[0].GetCve()
+	unfixableCVE := fixableMongo1.GetScan().GetComponents()[0].GetVulns()[2].GetCve()
+
+	timedDeferral := newDeferral("timed-deferral", false, storage.RequestStatus_DENIED, protoconv.ConvertTimeToTimestamp(time.Now().Add(1*time.Hour)), fixableCVE1)
+	fixableDeferralPendingUpdate := newDeferralExpiresWhenFixable("fixable-deferral-pending-update", false, storage.RequestStatus_APPROVED, nil, false, fixableCVE1)
+	fixableDeferralPendingUpdate.UpdatedReq = getDeferralExpiryTimeUpdate(1 * time.Hour)
+	timedDeferralPendingUpdate := newDeferral("timed-deferral-pending-update", false, storage.RequestStatus_APPROVED_PENDING_UPDATE, protoconv.ConvertTimeToTimestamp(time.Now().Add(30*24*time.Hour)), fixableCVE1)
+	timedDeferralPendingUpdate.UpdatedReq = getDeferralExpiryFixableUpdate(true)
+
+	shouldExpireReqs := []*storage.VulnerabilityRequest{
+		// Deferral on a specific image for a fixable cve -> expire
+		newDeferralExpiresWhenFixable("specific-image-fixable", false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, false), false, fixableCVE1),
+		// Deferral globally for a fixable cve -> expire
+		newDeferralExpiresWhenFixable("global-image-fixable", false, storage.RequestStatus_APPROVED, nil, false, fixableCVE1),
+		// Deferral for all tags of an image for a fixable cve -> expire
+		newDeferralExpiresWhenFixable("all-tags-image-fixable", false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, true), false, fixableCVE1),
+		// Deferral for an image where diff components have the same fixable vuln -> expire
+		newDeferralExpiresWhenFixable("multi-components-same-fixable", false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, false), false, fixableMongo1.GetScan().GetComponents()[0].GetVulns()[5].GetCve()),
+		// Deferral for an image where both components have the same vuln but is fixable only in one -> expire
+		newDeferralExpiresWhenFixable("multi-components-only-one-fixable", false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, false), false, fixableMongo1.GetScan().GetComponents()[0].GetVulns()[6].GetCve()),
+		// When fixable deferral for fixable CVE that is pending update to a timed deferral -> expire
+		fixableDeferralPendingUpdate,
+	}
+
+	shouldNotExpireReqs := []*storage.VulnerabilityRequest{
+		// Deferral on a specific image for an unfixable cve -> DON'T expire
+		newDeferralExpiresWhenFixable("specific-image-unfixable", false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, false), false, unfixableCVE),
+		// Deferral globally for an unfixable cve-> DON'T expire
+		newDeferralExpiresWhenFixable("global-image-unfixable", false, storage.RequestStatus_APPROVED, nil, false, unfixableCVE),
+		// Deferral for all tags of an image for an unfixable cve-> DON'T expire
+		newDeferralExpiresWhenFixable("all-tags-image-unfixable", false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, true), false, unfixableCVE),
+		// FP globally -> DON'T expire
+		newFalsePositive("global-image-fp", fixableCVE1, false, storage.RequestStatus_APPROVED, nil),
+		// FP specific image -> DON'T expire
+		newFalsePositive("specific-image-fp", fixableCVE1, false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, false)),
+		// FP all tags -> DON'T expire
+		newFalsePositive("all-tags-image-fp", fixableCVE1, false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, true)),
+		// Denied deferral -> DON'T expire
+		newDeferralExpiresWhenFixable("denied-deferral", false, storage.RequestStatus_DENIED, vulnScopeFromImage(fixableMongo1, false), false, fixableCVE1),
+		// Timed deferral for fixable CVE -> DON'T expire
+		timedDeferral,
+		// Timed deferral for fixable CVE that is pending update to when fixable -> DON'T expire
+		timedDeferralPendingUpdate,
+	}
+
+	for _, req := range append(shouldExpireReqs, shouldNotExpireReqs...) {
+		err := s.vulnReqDataStore.AddRequest(allAllowedCtx, req)
+		s.NoError(err)
+	}
+
+	s.sensorConnMgrMocks.EXPECT().BroadcastMessage(gomock.Any()).AnyTimes()
+	s.deployments.EXPECT().SearchDeployments(gomock.Any(), gomock.Any()).Return([]*v1.SearchResult{}, nil).AnyTimes()
+	s.reprocessor.EXPECT().ReprocessRiskForDeployments(gomock.Any()).AnyTimes()
+
+	s.manager.revertFixableCVEDeferralExceptions()
+
+	for _, req := range shouldExpireReqs {
+		s.T().Run(req.GetId()+" - should expire", func(t *testing.T) {
+			r, _, err := s.vulnReqDataStore.Get(allAllowedCtx, req.GetId())
+			assert.NoError(t, err)
+			assert.NotNil(t, r)
+			assert.Truef(t, r.Expired, req.GetId())
+
+			assert.Len(t, r.Comments, 1)
+			assert.Equal(t, r.Comments[0].Message, "[System Generated] Request expired")
+			assert.Nil(t, r.Comments[0].User) // system generated so no user identity
+		})
+	}
+
+	for _, req := range shouldNotExpireReqs {
+		s.T().Run(req.GetId()+" - should not expire", func(t *testing.T) {
+			r, _, err := s.vulnReqDataStore.Get(allAllowedCtx, req.GetId())
+			assert.NoError(t, err)
+			assert.NotNil(t, r)
+			assert.False(t, r.Expired, req.GetId())
+			assert.Len(t, r.Comments, 0)
+		})
+	}
+}
+
+func (s *VulnRequestManagerRevertExceptionTestSuite) TestReObserveFixableDeferralsBulkCVEs() {
+	fixableMongo1 := getImageWithVulnerableComponents("stackrox.io", "srox/mongo", "latest", "sha256:SHA2", 3)
+	fixableMongo2 := getImageWithVulnerableComponents("stackrox.io", "srox/mongo", "0.0.0.1", "sha256:sha3", 3)
+	fixableNginx := getImageWithVulnerableComponents("stackrox.io", "srox/nginx", "latest", "sha256:SHAAAAAA", 3)
+
+	// Both of these images have a different component but with the exact same CVE as the previous ones that is unfixable
+	unfixableMongo := getImageWithVulnerableComponents("stackrox.io", "srox/mongo", "0.0.0.2", "sha256:sha4", 3)
+	unfixableMongo.GetScan().GetComponents()[0].Version = "89.9"
+	unfixableMongo.GetScan().GetComponents()[0].GetVulns()[2].SetFixedBy = nil
+	unfixableMonitoring := getImageWithVulnerableComponents("stackrox.io", "stackrox/monitoring", "67.0", "sha256:SHBBBBBBB", 3)
+	unfixableMonitoring.GetScan().GetComponents()[0].Version = "99.9"
+	unfixableMonitoring.GetScan().GetComponents()[0].GetVulns()[2].SetFixedBy = nil
+	s.NoError(s.imageDataStore.UpsertImage(allAllowedCtx, fixableMongo1))
+	s.NoError(s.imageDataStore.UpsertImage(allAllowedCtx, fixableMongo2))
+	s.NoError(s.imageDataStore.UpsertImage(allAllowedCtx, fixableNginx))
+	s.NoError(s.imageDataStore.UpsertImage(allAllowedCtx, unfixableMongo))
+	s.NoError(s.imageDataStore.UpsertImage(allAllowedCtx, unfixableMonitoring))
+
+	// Fixable globally.
+	fixableCVE1 := fixableMongo1.GetScan().GetComponents()[0].GetVulns()[0].GetCve()
+	// Fixable globally.
+	fixableCVE2 := fixableMongo1.GetScan().GetComponents()[0].GetVulns()[1].GetCve()
+	// Fixable in a few images.
+	fixableCVE3 := fixableMongo1.GetScan().GetComponents()[0].GetVulns()[2].GetCve()
+	unfixableCVE := fixableMongo1.GetScan().GetComponents()[0].GetVulns()[3].GetCve()
+
+	timedDeferral := newDeferral("timed-deferral", false, storage.RequestStatus_DENIED, protoconv.ConvertTimeToTimestamp(time.Now().Add(1*time.Hour)), fixableCVE1, fixableCVE2)
+	fixableDeferralPendingUpdate := newDeferralExpiresWhenFixable("fixable-deferral-pending-update", false, storage.RequestStatus_APPROVED, nil, false, fixableCVE1, fixableCVE2)
+	fixableDeferralPendingUpdate.UpdatedReq = getDeferralExpiryTimeUpdate(1 * time.Hour)
+	timedDeferralPendingUpdate := newDeferral("timed-deferral-pending-update", false, storage.RequestStatus_APPROVED_PENDING_UPDATE, protoconv.ConvertTimeToTimestamp(time.Now().Add(30*24*time.Hour)), fixableCVE1)
+	timedDeferralPendingUpdate.UpdatedReq = getDeferralExpiryFixableUpdate(true)
+
+	shouldExpireReqs := []*storage.VulnerabilityRequest{
+		// Deferral on a specific image for a fixable cve and at least one CVE must be fixable -> expire
+		newDeferralExpiresWhenFixable("specific-image-fixable-any-cve-fixable-expiry", false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, false), false, fixableCVE1, fixableCVE2),
+		// Deferral for all tags of an image for a fixable cve and at least one CVE must be fixable -> expire
+		newDeferralExpiresWhenFixable("all-tags-image-fixable-any-cve-fixable-expiry", false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, true), false, fixableCVE1, unfixableCVE),
+		// Deferral for an image where diff components have the same fixable vuln -> expire
+		newDeferralExpiresWhenFixable("multi-components-same-fixable", false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, false), false, fixableMongo1.GetScan().GetComponents()[0].GetVulns()[5].GetCve()),
+		// Deferral for an image where both components have the same vuln but is fixable only in one -> expire
+		newDeferralExpiresWhenFixable("multi-components-only-one-fixable", false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, false), false, fixableMongo1.GetScan().GetComponents()[0].GetVulns()[6].GetCve()),
+		// When fixable deferral for fixable CVE that is pending update to a timed deferral -> expire
+		fixableDeferralPendingUpdate,
+	}
+
+	shouldNotExpireReqs := []*storage.VulnerabilityRequest{
+		// Deferral on a specific image for an unfixable cve -> DON'T expire
+		newDeferralExpiresWhenFixable("specific-image-unfixable-all-cve-fixable-expiry", false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, false), true, unfixableCVE),
+		// Deferral globally for an unfixable cve-> DON'T expire
+		newDeferralExpiresWhenFixable("global-image-unfixable-all-cve-fixable-expiry-1", false, storage.RequestStatus_APPROVED, nil, true, fixableCVE1, unfixableCVE),
+		// Deferral globally for an unfixable cve-> DON'T expire
+		newDeferralExpiresWhenFixable("global-image-unfixable-all-cve-fixable-expiry-2", false, storage.RequestStatus_APPROVED, nil, true, fixableCVE3, unfixableCVE),
+		// Deferral for all tags of an image for an unfixable cve-> DON'T expire
+		newDeferralExpiresWhenFixable("all-tags-image-unfixable", false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, true), false, unfixableCVE),
+		// FP globally -> DON'T expire
+		newFalsePositive("global-image-fp", fixableCVE1, false, storage.RequestStatus_APPROVED, nil),
+		// FP specific image -> DON'T expire
+		newFalsePositive("specific-image-fp", fixableCVE1, false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, false)),
+		// FP all tags -> DON'T expire
+		newFalsePositive("all-tags-image-fp", fixableCVE1, false, storage.RequestStatus_APPROVED, vulnScopeFromImage(fixableMongo1, true)),
+		// Denied deferral -> DON'T expire
+		newDeferralExpiresWhenFixable("denied-deferral", false, storage.RequestStatus_DENIED, vulnScopeFromImage(fixableMongo1, false), false, fixableCVE1),
+		// Timed deferral for fixable CVE -> DON'T expire
+		timedDeferral,
+		// Timed deferral for fixable CVE that is pending update to when fixable -> DON'T expire
+		timedDeferralPendingUpdate,
+	}
+
+	globalScopeAllFixable := newDeferralExpiresWhenFixable("global-image-fixable-all-cve-fixable-expiry", false, storage.RequestStatus_APPROVED, nil, true, fixableCVE1, fixableCVE2)
+	if features.UnifiedCVEDeferral.Enabled() {
+		// Deferral globally for a fixable cve and all CVEs must be fixable -> expire
+		shouldExpireReqs = append(shouldExpireReqs, globalScopeAllFixable)
+	} else {
+		// Deferral globally for a fixable cve and all CVEs must be fixable -> DON't expire because v1 cannot handle all CVE must be fixable expiry type.
+		shouldNotExpireReqs = append(shouldNotExpireReqs, globalScopeAllFixable)
+	}
+
+	for _, req := range append(shouldExpireReqs, shouldNotExpireReqs...) {
+		err := s.vulnReqDataStore.AddRequest(allAllowedCtx, req)
+		s.NoError(err)
+	}
+
+	s.sensorConnMgrMocks.EXPECT().BroadcastMessage(gomock.Any()).AnyTimes()
+	s.deployments.EXPECT().SearchDeployments(gomock.Any(), gomock.Any()).Return([]*v1.SearchResult{}, nil).AnyTimes()
+	s.reprocessor.EXPECT().ReprocessRiskForDeployments(gomock.Any()).AnyTimes()
+
+	s.manager.revertFixableCVEDeferralExceptions()
+
+	for _, req := range shouldExpireReqs {
+		s.T().Run(req.GetId()+" - should expire", func(t *testing.T) {
+			r, _, err := s.vulnReqDataStore.Get(allAllowedCtx, req.GetId())
+			assert.NoError(t, err)
+			assert.NotNil(t, r)
+			assert.Truef(t, r.Expired, req.GetId())
+
+			assert.Len(t, r.Comments, 1)
+			assert.Equal(t, r.Comments[0].Message, "[System Generated] Request expired")
+			assert.Nil(t, r.Comments[0].User) // system generated so no user identity
+		})
+	}
+
+	for _, req := range shouldNotExpireReqs {
+		s.T().Run(req.GetId()+" - should not expire", func(t *testing.T) {
+			r, _, err := s.vulnReqDataStore.Get(allAllowedCtx, req.GetId())
+			assert.NoError(t, err)
+			assert.NotNil(t, r)
+			assert.False(t, r.Expired, req.GetId())
+			assert.Len(t, r.Comments, 0)
+		})
+	}
+}

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
-	componentCVEEdgeDS "github.com/stackrox/rox/central/componentcveedge/datastore"
 	imageCVEDS "github.com/stackrox/rox/central/cve/image/datastore"
 	deploymentMockDS "github.com/stackrox/rox/central/deployment/datastore/mocks"
 	imageDS "github.com/stackrox/rox/central/image/datastore"
@@ -24,6 +23,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/cve"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protoconv"
@@ -32,7 +32,6 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/semaphore"
@@ -62,7 +61,6 @@ type VulnRequestManagerTestSuite struct {
 	deployments           *deploymentMockDS.MockDataStore
 	imageDataStore        imageDS.DataStore
 	imageCVEDataStore     imageCVEDS.DataStore
-	componentCVEDataStore componentCVEEdgeDS.DataStore
 	imageCVEEdgeDataStore imageCVEEdgeDS.DataStore
 	sensorConnMgrMocks    *sensorConnMgrMocks.MockManager
 	reprocessor           *reprocessorMocks.MockLoop
@@ -83,18 +81,18 @@ func (s *VulnRequestManagerTestSuite) SetupTest() {
 	s.sensorConnMgrMocks = sensorConnMgrMocks.NewMockManager(s.mockCtrl)
 	s.reprocessor = reprocessorMocks.NewMockLoop(s.mockCtrl)
 	s.manager = &managerImpl{
-		deployments:                           s.deployments,
-		images:                                s.imageDataStore,
-		vulnReqs:                              s.vulnReqDataStore,
-		componentCVEEdges:                     s.componentCVEDataStore,
-		connManager:                           s.sensorConnMgrMocks,
-		reprocessor:                           s.reprocessor,
-		pendingReqCache:                       s.pendingReqCache,
-		activeReqCache:                        s.activeReqCache,
-		reObserveTimedDeferralsTickerDuration: expiryLoopDurationForTest,
-		reObserveWhenFixedDeferralsTickerDuration: expiryLoopDurationForTest,
-		stopper:   concurrency.NewStopper(),
-		upsertSem: semaphore.NewWeighted(1),
+		deployments:                             s.deployments,
+		images:                                  s.imageDataStore,
+		imageCVEs:                               s.imageCVEDataStore,
+		vulnReqs:                                s.vulnReqDataStore,
+		connManager:                             s.sensorConnMgrMocks,
+		reprocessor:                             s.reprocessor,
+		pendingReqCache:                         s.pendingReqCache,
+		activeReqCache:                          s.activeReqCache,
+		revertTimedDeferralsTickerDuration:      expiryLoopDurationForTest,
+		revertFixableCVEDeferralsTickerDuration: expiryLoopDurationForTest,
+		stopper:                                 concurrency.NewStopper(),
+		upsertSem:                               semaphore.NewWeighted(1),
 	}
 }
 
@@ -107,7 +105,6 @@ func (s *VulnRequestManagerTestSuite) setupDataStores(pendingReqCache vulnReqCac
 	s.imageDataStore = imageDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
 	s.imageCVEDataStore = imageCVEDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
 	s.Require().NoError(err)
-	s.componentCVEDataStore = componentCVEEdgeDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
 	s.imageCVEEdgeDataStore = imageCVEEdgeDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
 	s.vulnReqDataStore = vulnReqDS.GetTestPostgresDataStore(s.T(), s.testDB.DB, pendingReqCache, activeReqCache)
 }
@@ -291,202 +288,6 @@ func (s *VulnRequestManagerTestSuite) verifyImageCVESearchByCVEState(state stora
 	s.ElementsMatch(expected, search.ResultsToIDs(results))
 }
 
-func (s *VulnRequestManagerTestSuite) TestReObserveExpiredDeferralsMarksAllAsInactive() {
-	expiredInThePast := protoconv.ConvertTimeToTimestamp(time.Now().Add(-96 * time.Hour))
-	expiresInFuture := protoconv.ConvertTimeToTimestamp(time.Now().Add(30 * 24 * time.Hour))
-
-	fpRequest := fixtures.GetGlobalFPRequest("cve-a-b")
-	fpRequest.Status = storage.RequestStatus_APPROVED
-	fpRequest.Comments = []*storage.RequestComment{} // clear out the comment to make testing the one added by expiry easier
-
-	cases := []struct {
-		name             string
-		vulnRequest      *storage.VulnerabilityRequest
-		shouldBeActive   bool
-		shouldGetComment bool
-	}{
-		{
-			name:             "Active and approved deferral with expiry in past should be marked inactive with comment",
-			vulnRequest:      newDeferral("req-active-def", false, storage.RequestStatus_APPROVED, expiredInThePast),
-			shouldBeActive:   false,
-			shouldGetComment: true,
-		},
-		{
-			name:             "Active and approved deferral with a pending request should still be inactive if expiry is in past",
-			vulnRequest:      newDeferral("req-updated-def", false, storage.RequestStatus_APPROVED_PENDING_UPDATE, expiredInThePast),
-			shouldBeActive:   false,
-			shouldGetComment: true,
-		},
-		{
-			name:             "Inactive deferral should remain inactive but with no additional comment",
-			vulnRequest:      newDeferral("req-inactive-def", true, storage.RequestStatus_APPROVED, expiredInThePast),
-			shouldBeActive:   false,
-			shouldGetComment: false,
-		},
-		{
-			name:             "Pending deferral should not be marked as inactive",
-			vulnRequest:      newDeferral("req-pending-def", false, storage.RequestStatus_PENDING, expiredInThePast),
-			shouldBeActive:   true,
-			shouldGetComment: false,
-		},
-		{
-			name:             "Denied deferral should not be marked as inactive",
-			vulnRequest:      newDeferral("req-denied-def", false, storage.RequestStatus_DENIED, expiredInThePast),
-			shouldBeActive:   true,
-			shouldGetComment: false,
-		},
-		{
-			name:             "Deferral with expiry in future should not be marked as inactive",
-			vulnRequest:      newDeferral("req-unexpired-def", false, storage.RequestStatus_APPROVED, expiresInFuture),
-			shouldBeActive:   true,
-			shouldGetComment: false,
-		},
-		{
-			name:             "Deferrals with expires when fixed should not be marked as inactive",
-			vulnRequest:      newDeferralExpiresWhenFixed("req-whenfixed-def", "req-whenfixed-def", false, storage.RequestStatus_APPROVED, nil),
-			shouldBeActive:   true,
-			shouldGetComment: false,
-		},
-		{
-			name:             "False positive requests should not be marked as inactive",
-			vulnRequest:      fpRequest,
-			shouldBeActive:   true,
-			shouldGetComment: false,
-		},
-	}
-	for _, c := range cases {
-		s.T().Run(c.name, func(t *testing.T) {
-			err := s.vulnReqDataStore.AddRequest(allAllowedCtx, c.vulnRequest)
-			assert.NoError(t, err)
-
-			s.manager.reObserveExpiredDeferrals()
-
-			r, ok, err := s.vulnReqDataStore.Get(allAllowedCtx, c.vulnRequest.GetId())
-			assert.NoError(t, err)
-			assert.True(t, ok)
-			assert.Equal(t, c.shouldBeActive, !r.Expired)
-
-			if c.shouldGetComment {
-				assert.Len(t, r.Comments, 1)
-				assert.Equal(t, r.Comments[0].Message, "[System Generated] Request expired")
-				assert.Nil(t, r.Comments[0].User) // system generated so no user identity
-			} else {
-				assert.Len(t, r.Comments, 0)
-			}
-		})
-	}
-}
-
-func (s *VulnRequestManagerTestSuite) TestReObserveFixableDeferrals() {
-	img := getImageWithVulnerableComponents("stackrox.io", "srox/mongo", "latest", "sha256:SHA2")
-	imgDiffTag := getImageWithVulnerableComponents("stackrox.io", "srox/mongo", "0.0.0.1", "sha256:sha3")
-	diffImage := getImageWithVulnerableComponents("stackrox.io", "srox/nginx", "latest", "sha256:SHAAAAAA")
-
-	// Both of these images have a different component but with the exact same CVE as the previous ones that is unfixable
-	imgDiffTagUnfixable := getImageWithVulnerableComponents("stackrox.io", "srox/mongo", "0.0.0.2", "sha256:sha4")
-	imgDiffTagUnfixable.GetScan().GetComponents()[0].Version = "89.9"
-	imgDiffTagUnfixable.GetScan().GetComponents()[0].GetVulns()[0].SetFixedBy = nil
-	diffImageUnfixable := getImageWithVulnerableComponents("stackrox.io", "stackrox/monitoring", "67.0", "sha256:SHBBBBBBB")
-	diffImageUnfixable.GetScan().GetComponents()[0].Version = "99.9"
-	diffImageUnfixable.GetScan().GetComponents()[0].GetVulns()[0].SetFixedBy = nil
-
-	err := s.imageDataStore.UpsertImage(allAllowedCtx, img)
-	s.NoError(err)
-	err = s.imageDataStore.UpsertImage(allAllowedCtx, imgDiffTag)
-	s.NoError(err)
-	err = s.imageDataStore.UpsertImage(allAllowedCtx, diffImage)
-	s.NoError(err)
-	err = s.imageDataStore.UpsertImage(allAllowedCtx, imgDiffTagUnfixable)
-	s.NoError(err)
-	err = s.imageDataStore.UpsertImage(allAllowedCtx, diffImageUnfixable)
-	s.NoError(err)
-
-	fixableCVE := img.GetScan().GetComponents()[0].GetVulns()[0].GetCve()
-	unfixableCVE := img.GetScan().GetComponents()[0].GetVulns()[2].GetCve()
-
-	timedDeferral := newDeferral("timed-deferral", false, storage.RequestStatus_DENIED, protoconv.ConvertTimeToTimestamp(time.Now().Add(1*time.Hour)))
-	timedDeferral.Entities = &storage.VulnerabilityRequest_Cves{Cves: &storage.VulnerabilityRequest_CVEs{Cves: []string{fixableCVE}}}
-
-	fixableDeferralPendingUpdate := newDeferralExpiresWhenFixed("fixable-defferal-pending-update", fixableCVE, false, storage.RequestStatus_APPROVED, nil)
-	fixableDeferralPendingUpdate.UpdatedReq =
-		&storage.VulnerabilityRequest_UpdatedDeferralReq{UpdatedDeferralReq: &storage.DeferralRequest{Expiry: &storage.RequestExpiry{Expiry: &storage.RequestExpiry_ExpiresOn{ExpiresOn: protoconv.ConvertTimeToTimestamp(time.Now().Add(1 * time.Hour))}}}}
-
-	timedDeferralPendingUpdate := newDeferral("timed-deferral-pending-update", false, storage.RequestStatus_APPROVED_PENDING_UPDATE, protoconv.ConvertTimeToTimestamp(time.Now().Add(30*24*time.Hour)))
-	timedDeferralPendingUpdate.Entities = &storage.VulnerabilityRequest_Cves{Cves: &storage.VulnerabilityRequest_CVEs{Cves: []string{fixableCVE}}}
-	timedDeferralPendingUpdate.UpdatedReq =
-		&storage.VulnerabilityRequest_UpdatedDeferralReq{UpdatedDeferralReq: &storage.DeferralRequest{Expiry: &storage.RequestExpiry{Expiry: &storage.RequestExpiry_ExpiresWhenFixed{ExpiresWhenFixed: true}}}}
-
-	shouldExpireReqs := []*storage.VulnerabilityRequest{
-		// Deferral on a specific image for a fixable cve -> expire
-		newDeferralExpiresWhenFixed("specific-image-fixable", fixableCVE, false, storage.RequestStatus_APPROVED, vulnScopeFromImage(img, false)),
-		// Deferral globally for a fixable cve -> expire
-		newDeferralExpiresWhenFixed("global-image-fixable", fixableCVE, false, storage.RequestStatus_APPROVED, nil),
-		// Deferral for all tags of an image for a fixable cve -> expire
-		newDeferralExpiresWhenFixed("all-tags-image-fixable", fixableCVE, false, storage.RequestStatus_APPROVED, vulnScopeFromImage(img, true)),
-		// Deferral for an image where diff components have the same fixable vuln -> expire
-		newDeferralExpiresWhenFixed("multi-components-same-fixable", img.GetScan().GetComponents()[0].GetVulns()[5].GetCve(), false, storage.RequestStatus_APPROVED, vulnScopeFromImage(img, false)),
-		// Deferral for an image where both components have the same vuln but is fixable only in one -> expire
-		newDeferralExpiresWhenFixed("multi-components-only-one-fixable", img.GetScan().GetComponents()[0].GetVulns()[6].GetCve(), false, storage.RequestStatus_APPROVED, vulnScopeFromImage(img, false)),
-		// When fixable deferral for fixable CVE that is pending update to a timed deferral -> expire
-		fixableDeferralPendingUpdate,
-	}
-
-	shouldNotExpireReqs := []*storage.VulnerabilityRequest{
-		// Deferral on a specific image for an unfixable cve -> DON'T expire
-		newDeferralExpiresWhenFixed("specific-image-unfixable", unfixableCVE, false, storage.RequestStatus_APPROVED, vulnScopeFromImage(img, false)),
-		// Deferral globally for an unfixable cve-> DON'T expire
-		newDeferralExpiresWhenFixed("global-image-unfixable", unfixableCVE, false, storage.RequestStatus_APPROVED, nil),
-		// Deferral for all tags of an image for an unfixable cve-> DON'T expire
-		newDeferralExpiresWhenFixed("all-tags-image-unfixable", unfixableCVE, false, storage.RequestStatus_APPROVED, vulnScopeFromImage(img, true)),
-		// FP globally -> DON'T expire
-		newFalsePositive("global-image-fp", fixableCVE, false, storage.RequestStatus_APPROVED, nil),
-		// FP specific image -> DON'T expire
-		newFalsePositive("specific-image-fp", fixableCVE, false, storage.RequestStatus_APPROVED, vulnScopeFromImage(img, false)),
-		// FP all tags -> DON'T expire
-		newFalsePositive("all-tags-image-fp", fixableCVE, false, storage.RequestStatus_APPROVED, vulnScopeFromImage(img, true)),
-		// Denied deferral -> DON'T expire
-		newDeferralExpiresWhenFixed("denied-deferral", fixableCVE, false, storage.RequestStatus_DENIED, vulnScopeFromImage(img, false)),
-		// Timed deferral for fixable CVE -> DON'T expire
-		timedDeferral,
-		// Timed deferral for fixable CVE that is pending update to when fixable -> DON'T expire
-		timedDeferralPendingUpdate,
-	}
-
-	for _, req := range append(shouldExpireReqs, shouldNotExpireReqs...) {
-		err := s.vulnReqDataStore.AddRequest(allAllowedCtx, req)
-		s.NoError(err)
-	}
-
-	s.sensorConnMgrMocks.EXPECT().BroadcastMessage(gomock.Any()).AnyTimes()
-	s.deployments.EXPECT().SearchDeployments(gomock.Any(), gomock.Any()).Return([]*v1.SearchResult{}, nil).AnyTimes()
-	s.reprocessor.EXPECT().ReprocessRiskForDeployments(gomock.Any()).AnyTimes()
-
-	s.manager.reObserveFixableDeferrals()
-
-	for _, req := range shouldExpireReqs {
-		s.T().Run(req.GetId()+" - should expire", func(t *testing.T) {
-			r, ok, err := s.vulnReqDataStore.Get(allAllowedCtx, req.GetId())
-			assert.NoError(t, err)
-			assert.True(t, ok)
-			assert.Truef(t, r.Expired, req.GetId())
-
-			assert.Len(t, r.Comments, 1)
-			assert.Equal(t, r.Comments[0].Message, "[System Generated] Request expired")
-			assert.Nil(t, r.Comments[0].User) // system generated so no user identity
-		})
-	}
-
-	for _, req := range shouldNotExpireReqs {
-		s.T().Run(req.GetId()+" - should not expire", func(t *testing.T) {
-			r, ok, err := s.vulnReqDataStore.Get(allAllowedCtx, req.GetId())
-			assert.NoError(t, err)
-			assert.True(t, ok)
-			assert.False(t, r.Expired, req.GetId())
-			assert.Len(t, r.Comments, 0)
-		})
-	}
-}
-
 func (s *VulnRequestManagerTestSuite) TestProcessorDoesntExpireOnceStopped() {
 	// TODO: Renable once fixed ROX-18182
 	s.T().Skipf("This test is flaky on master builds for some reason. Skip until fixed: ROX-18182")
@@ -539,9 +340,11 @@ func (s *VulnRequestManagerTestSuite) TestBuildCacheActiveRequests() {
 	s.Equal(states["cve-approved-pending-update-fp"], storage.VulnerabilityState_FALSE_POSITIVE)
 }
 
-func newDeferral(id string, expired bool, status storage.RequestStatus, expiry *types.Timestamp) *storage.VulnerabilityRequest {
+//// start test utilities
+
+func newDeferral(id string, expired bool, status storage.RequestStatus, expiry *types.Timestamp, cves ...string) *storage.VulnerabilityRequest {
 	id = id + "-" + uuid.NewV4().String()
-	return &storage.VulnerabilityRequest{
+	ret := &storage.VulnerabilityRequest{
 		Id:          id,
 		Name:        id,
 		Status:      status,
@@ -558,9 +361,17 @@ func newDeferral(id string, expired bool, status storage.RequestStatus, expiry *
 			},
 		},
 	}
+	if len(cves) > 0 {
+		ret.Entities = &storage.VulnerabilityRequest_Cves{
+			Cves: &storage.VulnerabilityRequest_CVEs{
+				Cves: cves,
+			},
+		}
+	}
+	return ret
 }
 
-func newDeferralExpiresWhenFixed(id, cve string, expired bool, status storage.RequestStatus, imgScope *storage.VulnerabilityRequest_Scope) *storage.VulnerabilityRequest {
+func newDeferralExpiresWhenFixable(id string, expired bool, status storage.RequestStatus, imgScope *storage.VulnerabilityRequest_Scope, allFixable bool, cves ...string) *storage.VulnerabilityRequest {
 	req := &storage.VulnerabilityRequest{
 		Id:          id,
 		Name:        id,
@@ -569,17 +380,41 @@ func newDeferralExpiresWhenFixed(id, cve string, expired bool, status storage.Re
 		TargetState: storage.VulnerabilityState_DEFERRED,
 		Req: &storage.VulnerabilityRequest_DeferralReq{
 			DeferralReq: &storage.DeferralRequest{
-				Expiry: &storage.RequestExpiry{Expiry: &storage.RequestExpiry_ExpiresWhenFixed{ExpiresWhenFixed: true}},
+				Expiry: &storage.RequestExpiry{
+					Expiry: &storage.RequestExpiry_ExpiresWhenFixed{
+						// In v1, only any fixable was supported.
+						ExpiresWhenFixed: !allFixable,
+					},
+					ExpiryType: func() storage.RequestExpiry_ExpiryType {
+						if allFixable {
+							return storage.RequestExpiry_ALL_CVE_FIXABLE
+						}
+						return storage.RequestExpiry_ANY_CVE_FIXABLE
+					}(),
+				},
 			},
 		},
-		Scope: &storage.VulnerabilityRequest_Scope{
-			Info: &storage.VulnerabilityRequest_Scope_GlobalScope{
-				GlobalScope: &storage.VulnerabilityRequest_Scope_Global{},
-			},
-		},
+		Scope: func() *storage.VulnerabilityRequest_Scope {
+			if features.UnifiedCVEDeferral.Enabled() {
+				return &storage.VulnerabilityRequest_Scope{
+					Info: &storage.VulnerabilityRequest_Scope_ImageScope{
+						ImageScope: &storage.VulnerabilityRequest_Scope_Image{
+							Registry: common.MatchAll,
+							Remote:   common.MatchAll,
+							Tag:      common.MatchAll,
+						},
+					},
+				}
+			}
+			return &storage.VulnerabilityRequest_Scope{
+				Info: &storage.VulnerabilityRequest_Scope_GlobalScope{
+					GlobalScope: &storage.VulnerabilityRequest_Scope_Global{},
+				},
+			}
+		}(),
 		Entities: &storage.VulnerabilityRequest_Cves{
 			Cves: &storage.VulnerabilityRequest_CVEs{
-				Cves: []string{cve},
+				Cves: cves,
 			},
 		},
 	}
@@ -664,7 +499,38 @@ func getBulkFalsePositiveVulnReq(registry, remote, tag string, cvesToDefer []str
 	return req
 }
 
-func getImageWithVulnerableComponents(registry, remote, tag, id string) *storage.Image {
+func getDeferralExpiryTimeUpdate(addHrToNow time.Duration) *storage.VulnerabilityRequest_UpdatedDeferralReq {
+	return &storage.VulnerabilityRequest_UpdatedDeferralReq{
+		UpdatedDeferralReq: &storage.DeferralRequest{
+			Expiry: &storage.RequestExpiry{
+				Expiry: &storage.RequestExpiry_ExpiresOn{
+					ExpiresOn: protoconv.ConvertTimeToTimestamp(time.Now().Add(addHrToNow)),
+				},
+				ExpiryType: storage.RequestExpiry_TIME,
+			},
+		},
+	}
+}
+
+func getDeferralExpiryFixableUpdate(anyFixable bool) *storage.VulnerabilityRequest_UpdatedDeferralReq {
+	return &storage.VulnerabilityRequest_UpdatedDeferralReq{
+		UpdatedDeferralReq: &storage.DeferralRequest{
+			Expiry: &storage.RequestExpiry{
+				Expiry: &storage.RequestExpiry_ExpiresWhenFixed{
+					ExpiresWhenFixed: anyFixable,
+				},
+				ExpiryType: func() storage.RequestExpiry_ExpiryType {
+					if anyFixable {
+						return storage.RequestExpiry_ANY_CVE_FIXABLE
+					}
+					return storage.RequestExpiry_ALL_CVE_FIXABLE
+				}(),
+			},
+		},
+	}
+}
+
+func getImageWithVulnerableComponents(registry, remote, tag, id string, fixableCVECount int) *storage.Image {
 	img := fixtures.GetImageWithUniqueComponents(5)
 	img.Name = &storage.ImageName{
 		Registry: registry,
@@ -679,20 +545,22 @@ func getImageWithVulnerableComponents(registry, remote, tag, id string) *storage
 	// First two vulns are fixable, the rest are not
 	for _, comp := range components {
 		for i, vuln := range comp.GetVulns() {
-			if i != 0 && i != 1 {
+			if i >= fixableCVECount {
 				vuln.SetFixedBy = nil
 			}
 		}
 	}
 
+	// Add a new fixable vuln that's same across both components
 	clonedVuln := components[0].GetVulns()[1].Clone()
 	clonedVuln.Cve = "CVE-SAME-VULN"
-	// Add a new fixable vuln that's same across both components
 	components[0].Vulns = append(components[0].Vulns, clonedVuln.Clone())
-	components[0].Vulns = append(components[0].Vulns, clonedVuln.Clone())
+	components[1].Vulns = append(components[1].Vulns, clonedVuln.Clone())
 
 	// Add another vuln that's same across both components but is fixable only for the 1st component
-	components[1].Vulns = append(components[1].Vulns, clonedVuln.Clone())
+	clonedVuln = components[0].GetVulns()[1].Clone()
+	clonedVuln.Cve = "CVE-SAME-VULN-2"
+	components[0].Vulns = append(components[0].Vulns, clonedVuln.Clone())
 	v := clonedVuln.Clone()
 	v.SetFixedBy = nil
 	components[1].Vulns = append(components[1].Vulns, v)
@@ -714,3 +582,5 @@ func getSensorMsg(img *storage.Image) *central.MsgToSensor {
 		},
 	}
 }
+
+//// end test utilities

--- a/central/vulnerabilityrequest/manager/requestmgr/singleton.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/singleton.go
@@ -1,7 +1,7 @@
 package requestmgr
 
 import (
-	componentCVEEdgeDataStore "github.com/stackrox/rox/central/componentcveedge/datastore"
+	imageCVEDataStore "github.com/stackrox/rox/central/cve/image/datastore"
 	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
 	imageDataStore "github.com/stackrox/rox/central/image/datastore"
 	"github.com/stackrox/rox/central/reprocessor"
@@ -29,7 +29,7 @@ func initialize() {
 		cache.PendingReqsCacheSingleton(),
 		cache.ActiveReqsCacheSingleton(),
 		imageDataStore.Singleton(),
-		componentCVEEdgeDataStore.Singleton(),
+		imageCVEDataStore.Singleton(),
 		connection.ManagerSingleton(),
 		reprocessor.Singleton(),
 	)
@@ -48,14 +48,14 @@ func New(
 	pendingVulnReqsCache cache.VulnReqCache,
 	activeVulnReqsCache cache.VulnReqCache,
 	images imageDataStore.DataStore,
-	componentCVEEdges componentCVEEdgeDataStore.DataStore,
+	imageCVEs imageCVEDataStore.DataStore,
 	sensorConnMgr connection.Manager,
 	reprocessor reprocessor.Loop,
 ) Manager {
 	return &managerImpl{
 		deployments:         deployments,
 		images:              images,
-		componentCVEEdges:   componentCVEEdges,
+		imageCVEs:           imageCVEs,
 		vulnReqs:            vulnReqs,
 		connManager:         sensorConnMgr,
 		reprocessor:         reprocessor,
@@ -63,9 +63,9 @@ func New(
 		activeReqCache:      activeVulnReqsCache,
 		lastKnownSeqNumInfo: &monthSeqNumPair{},
 
-		reObserveTimedDeferralsTickerDuration:     env.VulnDeferralTimedReObserveInterval.DurationSetting(),
-		reObserveWhenFixedDeferralsTickerDuration: env.VulnDeferralFixableReObserveInterval.DurationSetting(),
-		stopper: concurrency.NewStopper(),
+		revertTimedDeferralsTickerDuration:      env.VulnDeferralTimedReObserveInterval.DurationSetting(),
+		revertFixableCVEDeferralsTickerDuration: env.VulnDeferralFixableReObserveInterval.DurationSetting(),
+		stopper:                                 concurrency.NewStopper(),
 
 		upsertSem: semaphore.NewWeighted(1),
 	}


### PR DESCRIPTION
## Description

This PR implements a v1 workflow to revert vulnerability exceptions having expiry based on the fixability of CVEs. In v2, a request can contain one or more CVEs, and the request can be set to expire if:
- past expiry time, or
- all CVEs in the requests are fixable, or
- at least one CVE in the request is fixable

In v1, a request could have only one CVE and the request can be set to expire if:
- past expiry time, or
- the CVE in the request is fixable

For backward compatibility, the legacy field is also set to `at least one` expiry kind because legacy implementation was so. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Unit Test
