### PR TITLE
ROX-19521: add release prefix to release workflow names

### DIFF
--- a/.github/workflows/check-image-vulnerabilities.yml
+++ b/.github/workflows/check-image-vulnerabilities.yml
@@ -1,4 +1,4 @@
-name: Check image vulnerabilities
+name: "RELEASE: Check image vulnerabilities"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/create-clusters.yml
+++ b/.github/workflows/create-clusters.yml
@@ -1,4 +1,4 @@
-name: Create Clusters
+name: "RELEASE: Create Clusters"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -1,4 +1,4 @@
-name: Cut RC
+name: "RELEASE: Cut RC"
 on:
   milestone:
     types:

--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -1,4 +1,4 @@
-name: Finish Release
+name: "RELEASE: Finish Release"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -1,4 +1,4 @@
-name: Release CI
+name: "RELEASE: Release CI"
 on:
   push:
     branches:

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -1,4 +1,4 @@
-name: Start Release
+name: "RELEASE: Start Release"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -1,4 +1,4 @@
-name: Prepare manual upgrade test
+name: "RELEASE: Prepare manual upgrade test"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/variables.yml
+++ b/.github/workflows/variables.yml
@@ -1,4 +1,4 @@
-name: Parse Version
+name: "RELEASE: Parse Version"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,4 +1,4 @@
-name: Verify release
+name: "RELEASE: Verify release"
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Description

Adds a "RELEASE: " prefix to all release related GHA workflows. 
That will group them in a list and make it easier for the release engineers to find them.
Existing runs or links to them are not changed, as the latter are generated based on the workflow filename. 

Caveat: For each of the workflows, there will be two items in the list based on: 
- the old name (example `Cut RC`) 
- the new name (example `RELEASE: Cut RC)`

Question for reviewers: is it worth doing this or will the duplication not lead to confusion?

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

No testing required.