### PR TITLE
ROX-20609: Migrate legacy vuln exception expiry into v2 expiry

### DIFF
--- a/migrator/migrations/m_195_to_m_196_vuln_request_users/migration_impl.go
+++ b/migrator/migrations/m_195_to_m_196_vuln_request_users/migration_impl.go
@@ -40,6 +40,13 @@ func updateGlobalScope(ctx context.Context, database *types.Databases) error {
 		if approvers := obj.GetApprovers(); len(approvers) > 0 {
 			updated.ApproversV2 = convertSlimUserToApprovers(obj.GetApprovers())
 		}
+		if obj.GetDeferralReq() != nil && obj.GetDeferralReq().GetExpiry() != nil {
+			if obj.GetDeferralReq().GetExpiry().GetExpiresWhenFixed() {
+				updated.GetDeferralReq().Expiry.ExpiryType = storage.RequestExpiry_ANY_CVE_FIXABLE
+			} else {
+				updated.GetDeferralReq().Expiry.ExpiryType = storage.RequestExpiry_TIME
+			}
+		}
 
 		updatedObjs = append(updatedObjs, updated)
 		count++


### PR DESCRIPTION
## Description

Migrate legacy vuln exception expiry into v2 expiry. In v2, a request can contain one or more CVEs, and the request can be set to expire if:
- past expiry time, or
- all CVEs in the requests are fixable, or
- at least one CVE in the request is fixable

In v1, a request could have only one CVE and the request can be set to expire if:
- past expiry time, or
- the CVE in the request is fixable

The legacy field is migrated to `at least one` expiry kind because legacy implementation was so.

Note: Added the changes to the previous migration pushed earlier this morning through #8464.
 
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Unit
