### PR TITLE
ROX-20623: Allow non-admins to delegate scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Technical Changes
 - Increased default memory request for scanner-db from 200MiB to 512MiB,
   to prevent OOMs during DB initialization in case of memory pressure on the node.
+- ROX-20623: Fixed bug mistakenly requiring admin access to delegate ad-hoc scan requests to secured clusters.
 
 ## [4.3.0]
 


### PR DESCRIPTION
## Description

Fixes a bug that mistakenly required `Administration` permission to delegate scans.

Alternatively considered removing the [Administration check](https://github.com/stackrox/stackrox/blob/b614826867f333c00141f9cbd69f7381b84d5493/central/delegatedregistryconfig/datastore/datastore.go#L37-L41) from delegated registry config datastore, because the [service](https://github.com/stackrox/stackrox/blob/b614826867f333c00141f9cbd69f7381b84d5493/central/delegatedregistryconfig/service/service.go#L34) performs the appropriate access check this would have allowed internal components to access the config without modifying the request's context.

Both mechanisms are used throughout ACS (elevating context and removing the check from the datastore). I am OK using either if there is a strong opinion one way or the other.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Deleted the default `docker.io` integration (for test purposes) and setup delegated scanning as follows:

![image](https://github.com/stackrox/stackrox/assets/119438707/56810b15-d935-459d-baa8-348f916ea038)

Using the following token:

```sh
$ roxctl central whoami
UserID:
	auth-token:7332a78c-dfb1-4ec3-803d-9937a30277bf
User name:
	anonymous bearer token "RO" with roles [RO] (jti: 7332a78c-dfb1-4ec3-803d-9937a30277bf, expires: 2024-11-01T19:19:09Z)
Roles:
	- RO
Access:
	-- Access
	-- Administration
	-- Alert
	-- CVE
	-- Cluster
	-- Compliance
	-- Deployment
	-- DeploymentExtension
	-- Detection
	rw Image
	-- Integration
	-- K8sRole
	-- K8sRoleBinding
	-- K8sSubject
	-- Namespace
	-- NetworkGraph
	-- NetworkPolicy
	-- Node
	-- Secret
	-- ServiceAccount
	-- VulnerabilityManagementApprovals
	-- VulnerabilityManagementRequests
	-- WatchedImage
	-- WorkflowAdministration
```
Before fix:

```sh
$ roxctl image scan --image=nginx:latest
ERROR:	Scanning image failed: could not scan image: "nginx:latest": rpc error: code = Internal desc = image enrichment error: error getting metadata for image: docker.io/library/nginx:latest error: no matching image registries found: please add an image integration for docker.io. Retrying after 3 seconds...
```

After fix:

```sh
$ roxctl image scan --image=nginx:latest
{
  "id": "sha256:d2e65182b5fd330470eca9b8e23e8a1a0d87cc9b820eb1fb3f034bf8248d37ee",
  "name": {
    "registry": "docker.io",
    "remote": "library/nginx",
    "tag": "latest",
    "fullName": "docker.io/library/nginx:latest"
  },
...
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
