### PR TITLE
fix(image): use UseCachesIfPossible fetch option for image scan

### DIFF
--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -304,7 +304,7 @@ func (s *serviceImpl) enrichImage(ctx context.Context, img *storage.Image, fetch
 // ScanImage scans an image and returns the result
 func (s *serviceImpl) ScanImage(ctx context.Context, request *v1.ScanImageRequest) (*storage.Image, error) {
 	enrichmentCtx := enricher.EnrichmentContext{
-		FetchOpt:  enricher.IgnoreExistingImages,
+		FetchOpt:  enricher.UseCachesIfPossible,
 		Delegable: true,
 	}
 	if request.GetForce() {


### PR DESCRIPTION
## Description

After #5339 has landed, which "fixed" the `IgnoreExistingImages` fetch option in the image enricher, this resulted in the following behavior:
- Watched images were now correctly being re-scanned again.
- However, the `ScanImage` API would now _always_ force a re-enrichment of the image.

This seems like an unwanted consequence, and the initial issue seems to be the following:
The `ScanImage` API already allows "forcing" an update of an existing image's scan via the `force` field within the request. It doesn't make sense to always ignore cached values when such a setting exists on the request.

Furthermore, it lead to an issue with fields such as the image's `Names` field, which were now overwritten completely, due to not using the `UseImageNamesRefetchCachedValues` fetch option when ignoring cached values.

To add on top of that, the related API of the detection service also has similar semantics: [a request has a `force` field, and the default fetch option is `UseCachesIfPossible` and the "force" fetch option is `UseImageNamesRefetchCachedValues`](https://github.com/stackrox/stackrox/blob/481a0658d7f67fe5d21f90c06311fecad9128bce/central/detection/service/service_impl.go#L438-L457).

Now, both APIs are aligned in their behavior: by default assume / use cached values, if `force` is given, ignore cached values except specific ones (i.e. the image names).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
