### PR TITLE
fix: manager bench test

### DIFF
--- a/central/networkgraph/entity/networktree/manager_bench_test.go
+++ b/central/networkgraph/entity/networktree/manager_bench_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/networkgraph/externalsrcs"
-	"github.com/stackrox/rox/pkg/networkgraph/tree"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,21 +44,11 @@ func BenchmarkCreateNetworkTree(b *testing.B) {
 		}
 	})
 
-	b.Run("createNetworkTree", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			b.StopTimer()
-			mgr := initialize(b, entitiesByCluster)
-			b.StartTimer()
-
-			t := mgr.CreateNetworkTree(context.Background(), "c2")
-			require.NotNil(b, t)
-		}
-	})
-
 	b.Run("insertIntoNetworkTree", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()
-			t := createNetworkTree(b, entitiesByCluster)
+			mgr := initialize(b, entitiesByCluster)
+			t := mgr.CreateNetworkTree(context.Background(), "c2")
 			b.StartTimer()
 
 			for _, entity := range entities {
@@ -67,13 +56,6 @@ func BenchmarkCreateNetworkTree(b *testing.B) {
 			}
 		}
 	})
-}
-
-func createNetworkTree(b *testing.B, entitiesByCluster map[string][]*storage.NetworkEntityInfo) tree.NetworkTree {
-	mgr := initialize(b, entitiesByCluster)
-	t := mgr.CreateNetworkTree(context.Background(), "c2")
-	require.NotNil(b, t)
-	return t
 }
 
 func initialize(b *testing.B, entitiesByCluster map[string][]*storage.NetworkEntityInfo) Manager {


### PR DESCRIPTION
## Description

This PR fixes bench test by running an operation `b.N` times. 
It also fixes following issue with this test:

> Received unexpected error: network tree for cluster "c1" already exists

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

```
BenchmarkCreateNetworkTree
BenchmarkCreateNetworkTree/createNetworkTree
BenchmarkCreateNetworkTree/createNetworkTree-8         	     182	   6465295 ns/op
BenchmarkCreateNetworkTree/insertIntoNetworkTree
BenchmarkCreateNetworkTree/insertIntoNetworkTree-8     	      64	  17993408 ns/op
PASS
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
