### PR TITLE
fix(gha): do not save cache on PR

### DIFF
--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -10,7 +10,17 @@ runs:
         echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
       shell: bash
 
+    - name: Restore Go Dependencies
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ${{ steps.cache-paths.outputs.GOMODCACHE }}
+          ${{ steps.cache-paths.outputs.GOCACHE }}
+        key: go-v3-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+
     - name: Cache Go Dependencies
+      if: ${{ github.ref_name == 'master' }}
       uses: actions/cache@v3
       with:
         path: |
@@ -18,4 +28,5 @@ runs:
           ${{ steps.cache-paths.outputs.GOCACHE }}
         key: go-v3-${{ github.job }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          go-v3-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          go-v3-${{ github.job }}-
+          go-v3-

--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -11,13 +11,31 @@ runs:
       shell: bash
 
     - name: Restore Go Dependencies
-      if: ${{ github.event_name == 'pull_request' }}
+      # If we are in PR but not to master then only look for exact match for cache key
+      # to prevent issues on release branches where downloading newer cache and then old
+      # dependencies might cause out of space errors.
+      if: ${{ github.event_name == 'pull_request' && github.base_ref != 'master' }}
       uses: actions/cache/restore@v3
       with:
         path: |
           ${{ steps.cache-paths.outputs.GOMODCACHE }}
           ${{ steps.cache-paths.outputs.GOCACHE }}
         key: go-v3-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+
+    - name: Restore Go Dependencies
+      # If we are in PR targeting master we can make use of all sub-keys to speedup build
+      # even if we change go.sum. This is to speedup dependabot builds or PRs for which there is
+      # no cache entry yet.
+      if: ${{ github.base_ref == 'master' }}
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ${{ steps.cache-paths.outputs.GOMODCACHE }}
+          ${{ steps.cache-paths.outputs.GOCACHE }}
+        key: go-v3-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          go-v3-${{ github.job }}-
+          go-v3-
 
     - name: Cache Go Dependencies
       if: ${{ github.ref_name == 'master' }}


### PR DESCRIPTION
## Description

This PR prevents saving cache for Go in PRs. This should reduce usage of cache and extend the time cache on master branch is available. Only master branch will store cache and only PRs will restore it. Other branches (e.g. releases) will use only exactly matching cache as it caused some problems in the past and it's better to run slowly but successfully on release. 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
