### PR TITLE
chore(cache): do not use job name for UI cache key

### DIFF
--- a/.github/actions/cache-gradle-dependencies/action.yaml
+++ b/.github/actions/cache-gradle-dependencies/action.yaml
@@ -10,8 +10,7 @@ runs:
           ~/.gradle/caches
           ~/.gradle/wrapper
           ~/.m2/repository
-        key: gradle-v2-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-${{ github.job }}
+        key: gradle-v2-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
-          gradle-v2-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-${{ github.job }}
-          gradle-v2-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-
+          gradle-v2-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           gradle-v2-

--- a/.github/actions/cache-ui-dependencies/action.yaml
+++ b/.github/actions/cache-ui-dependencies/action.yaml
@@ -15,7 +15,4 @@ runs:
           /github/home/.cache/yarn
           /github/home/.cache/Cypress
           /usr/local/share/.cache
-        key: npm-v2-${{ hashFiles(inputs.lockFile) }}-${{ github.job }}
-        restore-keys: |
-          npm-v2-${{ hashFiles(inputs.lockFile) }}-${{ github.job }}
-          npm-v2-${{ hashFiles(inputs.lockFile) }}-
+        key: npm-v2-${{ hashFiles(inputs.lockFile) }}


### PR DESCRIPTION
## Description

Gradle and UI always download all deps so there is no reason to add job name to cache key.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
