### PR TITLE
ROX-19879: Cleanup notifiers on startup and during CRUD

### DIFF
--- a/central/notifiers/generic/generic.go
+++ b/central/notifiers/generic/generic.go
@@ -76,12 +76,13 @@ func (g *generic) NetworkPolicyYAMLNotify(ctx context.Context, yaml string, clus
 	return g.postMessageWithRetry(ctx, msg, networkPolicyMessageKey)
 }
 
-func validateConfig(generic *storage.Generic) error {
+// Validate Generic notifier
+func Validate(generic *storage.Generic, validateSecret bool) error {
 	errList := errorhelpers.NewErrorList("Generic webhook validation")
 	if generic.GetEndpoint() == "" {
 		errList.AddString("endpoint is required")
 	}
-	if generic.GetUsername() != generic.GetPassword() && stringutils.AtLeastOneEmpty(generic.GetUsername(), generic.GetPassword()) {
+	if validateSecret && generic.GetUsername() != generic.GetPassword() && stringutils.AtLeastOneEmpty(generic.GetUsername(), generic.GetPassword()) {
 		errList.AddString("both username and password must be defined together")
 	}
 	for _, f := range generic.GetHeaders() {
@@ -113,13 +114,8 @@ func getExtraFieldJSON(fields []*storage.KeyValuePair) (string, error) {
 }
 
 func newGeneric(notifier *storage.Notifier, cryptoCodec cryptocodec.CryptoCodec, cryptoKey string) (*generic, error) {
-	genericConfig, ok := notifier.Config.(*storage.Notifier_Generic)
-
-	if !ok {
-		return nil, validateConfig(&storage.Generic{})
-	}
-	conf := genericConfig.Generic
-	if err := validateConfig(conf); err != nil {
+	conf := notifier.GetGeneric()
+	if err := Validate(conf, !env.EncNotifierCreds.BooleanSetting()); err != nil {
 		return nil, err
 	}
 	fullyQualifiedEndpoint := urlfmt.FormatURL(conf.GetEndpoint(), urlfmt.HTTPS, urlfmt.HonorInputSlash)
@@ -250,6 +246,11 @@ func (g *generic) AuditLoggingEnabled() bool {
 }
 
 func (g *generic) getPassword() (string, error) {
+	if g.GetGeneric().GetUsername() == "" {
+		// Both username and password can be empty for unauthenticated generic notifier integration
+		return "", nil
+	}
+
 	if g.creds != "" {
 		return g.creds, nil
 	}

--- a/central/notifiers/jira/jira.go
+++ b/central/notifiers/jira/jira.go
@@ -236,7 +236,8 @@ func (j *jira) NetworkPolicyYAMLNotify(ctx context.Context, yaml string, cluster
 	return err
 }
 
-func validate(jira *storage.Jira) error {
+// Validate Jira notifier
+func Validate(jira *storage.Jira, validateSecret bool) error {
 	errorList := errorhelpers.NewErrorList("Jira validation")
 	if jira.GetIssueType() == "" {
 		errorList.AddString("Issue Type must be specified")
@@ -247,7 +248,7 @@ func validate(jira *storage.Jira) error {
 	if jira.GetUsername() == "" {
 		errorList.AddString("Username must be specified")
 	}
-	if jira.GetPassword() == "" {
+	if validateSecret && jira.GetPassword() == "" {
 		errorList.AddString("Password or API Token must be specified")
 	}
 
@@ -272,7 +273,7 @@ func newJira(notifier *storage.Notifier, metadataGetter notifiers.MetadataGetter
 	if conf == nil {
 		return nil, errors.New("Jira configuration required")
 	}
-	if err := validate(conf); err != nil {
+	if err := Validate(conf, !env.EncNotifierCreds.BooleanSetting()); err != nil {
 		return nil, err
 	}
 

--- a/central/notifiers/pagerduty/pagerduty.go
+++ b/central/notifiers/pagerduty/pagerduty.go
@@ -55,12 +55,8 @@ type pagerDuty struct {
 }
 
 func newPagerDuty(notifier *storage.Notifier, cryptoCodec cryptocodec.CryptoCodec, cryptoKey string) (*pagerDuty, error) {
-	pagerDutyConfig, ok := notifier.GetConfig().(*storage.Notifier_Pagerduty)
-	if !ok {
-		return nil, errors.New("PagerDuty configuration required")
-	}
-	conf := pagerDutyConfig.Pagerduty
-	if err := validate(conf); err != nil {
+	conf := notifier.GetPagerduty()
+	if err := Validate(conf, !env.EncNotifierCreds.BooleanSetting()); err != nil {
 		return nil, err
 	}
 
@@ -87,8 +83,9 @@ func newPagerDuty(notifier *storage.Notifier, cryptoCodec cryptocodec.CryptoCode
 	}, nil
 }
 
-func validate(conf *storage.PagerDuty) error {
-	if len(conf.ApiKey) == 0 {
+// Validate PagerDuty notifier
+func Validate(conf *storage.PagerDuty, validateSecret bool) error {
+	if validateSecret && len(conf.ApiKey) == 0 {
 		return errors.New("PagerDuty API key must be specified")
 	}
 	return nil

--- a/central/notifiers/splunk/splunk.go
+++ b/central/notifiers/splunk/splunk.go
@@ -231,10 +231,7 @@ func init() {
 
 func newSplunk(notifier *storage.Notifier, cryptoCodec cryptocodec.CryptoCodec, cryptoKey string) (*splunk, error) {
 	conf := notifier.GetSplunk()
-	if conf == nil {
-		return nil, errors.New("Splunk configuration required")
-	}
-	if err := validate(conf); err != nil {
+	if err := Validate(conf, !env.EncNotifierCreds.BooleanSetting()); err != nil {
 		return nil, err
 	}
 	url := urlfmt.FormatURL(conf.GetHttpEndpoint(), urlfmt.HTTPS, urlfmt.NoTrailingSlash)
@@ -261,9 +258,13 @@ func newSplunk(notifier *storage.Notifier, cryptoCodec cryptocodec.CryptoCodec, 
 	}, nil
 }
 
-func validate(conf *storage.Splunk) error {
+// Validate Splunk notifier
+func Validate(conf *storage.Splunk, validateSecret bool) error {
+	if conf == nil {
+		return errors.New("Splunk configuration required")
+	}
 	errorList := errorhelpers.NewErrorList("Splunk config validation")
-	if len(conf.HttpToken) == 0 {
+	if validateSecret && len(conf.HttpToken) == 0 {
 		errorList.AddString("Splunk HTTP Event Collector(HEC) token must be specified")
 	}
 	if len(conf.HttpEndpoint) == 0 {

--- a/central/notifiers/validation/validate.go
+++ b/central/notifiers/validation/validate.go
@@ -1,0 +1,49 @@
+package validation
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/notifiers/awssh"
+	"github.com/stackrox/rox/central/notifiers/cscc"
+	"github.com/stackrox/rox/central/notifiers/email"
+	"github.com/stackrox/rox/central/notifiers/generic"
+	"github.com/stackrox/rox/central/notifiers/jira"
+	"github.com/stackrox/rox/central/notifiers/pagerduty"
+	"github.com/stackrox/rox/central/notifiers/splunk"
+	"github.com/stackrox/rox/generated/storage"
+	pkgNotifiers "github.com/stackrox/rox/pkg/notifiers"
+)
+
+// ValidateNotifierConfig validates notifier configuration based on the given notifier's type
+func ValidateNotifierConfig(notifier *storage.Notifier, validateSecret bool) error {
+	switch notifier.GetType() {
+	case pkgNotifiers.AWSSecurityHubType:
+		if err := awssh.Validate(notifier.GetAwsSecurityHub(), validateSecret); err != nil {
+			return errors.Wrap(err, "failed to validate AWS SecurityHub config")
+		}
+	case pkgNotifiers.CSCCType:
+		if err := cscc.Validate(notifier.GetCscc(), validateSecret); err != nil {
+			return errors.Wrap(err, "failed to validate CSCC config")
+		}
+	case pkgNotifiers.JiraType:
+		if err := jira.Validate(notifier.GetJira(), validateSecret); err != nil {
+			return errors.Wrap(err, "failed to validate Jira config")
+		}
+	case pkgNotifiers.EmailType:
+		if err := email.Validate(notifier.GetEmail(), validateSecret); err != nil {
+			return errors.Wrap(err, "failed to validate Email config")
+		}
+	case pkgNotifiers.GenericType:
+		if err := generic.Validate(notifier.GetGeneric(), validateSecret); err != nil {
+			return errors.Wrap(err, "failed to validate Generic config")
+		}
+	case pkgNotifiers.PagerDutyType:
+		if err := pagerduty.Validate(notifier.GetPagerduty(), validateSecret); err != nil {
+			return errors.Wrap(err, "failed to validate PagerDuty config")
+		}
+	case pkgNotifiers.SplunkType:
+		if err := splunk.Validate(notifier.GetSplunk(), validateSecret); err != nil {
+			return errors.Wrap(err, "failed to validate Splunk config")
+		}
+	}
+	return nil
+}

--- a/pkg/secrets/scrub.go
+++ b/pkg/secrets/scrub.go
@@ -36,9 +36,7 @@ func ScrubSecretsFromStructWithReplacement(obj interface{}, replacement string) 
 			if field.Type() != reflect.TypeOf(replacement) {
 				utils.CrashOnError(errors.Errorf("field type mismatch %s!=%s", field.Type(), reflect.TypeOf(replacement)))
 			}
-			if field.String() != "" {
-				field.Set(reflect.ValueOf(replacement))
-			}
+			field.Set(reflect.ValueOf(replacement))
 		case scrubTagMapValues:
 			if field.Kind() != reflect.Map {
 				utils.CrashOnError(errors.Errorf("expected map kind, got %s", field.Kind()))

--- a/pkg/secrets/scrub_test.go
+++ b/pkg/secrets/scrub_test.go
@@ -230,7 +230,7 @@ func TestScrubEmbeddedConfig(t *testing.T) {
 func TestScrubSecretsWithoutPasswordSetWithReplacement(t *testing.T) {
 	testStruct := &toplevel{Name: "name", Password: ""}
 	ScrubSecretsFromStructWithReplacement(testStruct, ScrubReplacementStr)
-	assert.Empty(t, testStruct.Password)
+	assert.NotEmpty(t, testStruct.Password)
 	assert.Equal(t, testStruct.Name, "name")
 }
 


### PR DESCRIPTION
## Description

- Cleanup notifiers on startup and during create/update
- Refactor validation so that notifiers are validated before cleanup

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Manual Testing

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
