### PR TITLE
fix(ui): Filter images list during watched image tests

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -54,6 +54,7 @@ export function selectResourceFilterType(entityType) {
  * @param {string} value
  */
 export function typeAndSelectResourceFilterValue(entityType, value) {
+    selectResourceFilterType(entityType);
     cy.get(selectors.searchOptionsValueTypeahead(entityType)).click();
     cy.get(selectors.searchOptionsValueTypeahead(entityType)).type(value);
     cy.get(selectors.searchOptionsValueMenuItem(entityType))
@@ -68,6 +69,7 @@ export function typeAndSelectResourceFilterValue(entityType, value) {
  * @param {string} value
  */
 export function typeAndSelectCustomResourceFilterValue(entityType, value) {
+    selectResourceFilterType(entityType);
     cy.get(selectors.searchOptionsValueTypeahead(entityType)).click();
     cy.get(selectors.searchOptionsValueTypeahead(entityType)).type(value);
     cy.get(selectors.searchOptionsValueMenuItem(entityType)).contains(`Add "${value}"`).click();

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveSingle.test.js
@@ -2,7 +2,6 @@ import withAuth from '../../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../../helpers/features';
 import {
     applyLocalSeverityFilters,
-    selectResourceFilterType,
     typeAndSelectResourceFilterValue,
     typeAndSelectCustomResourceFilterValue as typeAndCreateResourceFilterValue,
     visitWorkloadCveOverview,
@@ -93,7 +92,6 @@ describe('Workload CVE Image CVE Single page', () => {
         cy.get(`${selectors.firstTableRow} td[data-label="Namespace"]`).then(([$namespace]) => {
             const namespace = $namespace.innerText;
 
-            selectResourceFilterType('Namespace');
             typeAndCreateResourceFilterValue('Namespace', `bogus-${namespace}`);
 
             cy.get(`table tbody tr td[data-label="Namespace"]:contains("${namespace}")`).should(

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.js
@@ -5,7 +5,6 @@ import { hasFeatureFlag } from '../../../helpers/features';
 
 import {
     applyLocalSeverityFilters,
-    selectResourceFilterType,
     typeAndSelectResourceFilterValue,
     selectEntityTab,
     visitWorkloadCveOverview,
@@ -178,8 +177,6 @@ describe('Workload CVE Image Single page', () => {
             .first()
             .then(([$cveNameCell]) => {
                 const cveName = $cveNameCell.innerText;
-                // Select CVE from the entity dropdown
-                selectResourceFilterType('CVE');
                 // Enter the CVE name into the CVE filter
                 typeAndSelectResourceFilterValue('CVE', cveName);
                 // Check that the header above the table shows only one result

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
@@ -7,6 +7,7 @@ import {
     selectUnwatchedImageTextFromTable,
     watchImageFlowFromModal,
     unwatchImageFromModal,
+    typeAndSelectCustomResourceFilterValue,
 } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 
@@ -35,6 +36,7 @@ describe('Workload CVE watched images flow', () => {
         () => {
             visitWorkloadCveOverview();
             selectEntityTab('Image');
+            typeAndSelectCustomResourceFilterValue('Namespace', 'stack');
 
             selectUnwatchedImageTextFromTable().then(([, nameAndTag, fullName]) => {
                 cy.get(`${selectors.firstUnwatchedImageRow} *[aria-label="Actions"]`).click();
@@ -54,6 +56,7 @@ describe('Workload CVE watched images flow', () => {
         () => {
             visitWorkloadCveOverview();
             selectEntityTab('Image');
+            typeAndSelectCustomResourceFilterValue('Namespace', 'stack');
 
             selectUnwatchedImageTextFromTable().then(([, nameAndTag, fullName]) => {
                 // Open the modal and watch the image
@@ -82,6 +85,7 @@ describe('Workload CVE watched images flow', () => {
     it('should not allow adding a blank or invalid image name to the watch list', () => {
         visitWorkloadCveOverview();
         selectEntityTab('Image');
+        typeAndSelectCustomResourceFilterValue('Namespace', 'stack');
 
         cy.get(selectors.manageWatchedImagesButton).click();
 
@@ -114,6 +118,7 @@ describe('Workload CVE watched images flow', () => {
         () => {
             visitWorkloadCveOverview();
             selectEntityTab('Image');
+            typeAndSelectCustomResourceFilterValue('Namespace', 'stack');
 
             selectUnwatchedImageTextFromTable().then(([, nameAndTag, fullName]) => {
                 cy.get(`${selectors.firstUnwatchedImageRow} *[aria-label="Actions"]`).click();


### PR DESCRIPTION
## Description

The watched images tests previously would select whatever the first image on the page was for the watched image flow. Recently, this test was failing due to images not being available on gke.gcr.io.

This fix pre-filters the image list to only include images in the central deployment reduce the reliance on 3rd party changes.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Local Cypress CI run.
