### PR TITLE
ROX-17494: Reimplement fixability filters in workload CVEs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
@@ -8,7 +8,7 @@ import { DefaultFilters, FixableStatus, VulnerabilitySeverityLabel } from '../ty
 
 type DefaultFilterModalProps = {
     defaultFilters: DefaultFilters;
-    setLocalStorage: (values) => void;
+    setLocalStorage: (values: DefaultFilters) => void;
 };
 
 function DefaultFilterModal({ defaultFilters, setLocalStorage }: DefaultFilterModalProps) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.css
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.css
@@ -1,0 +1,4 @@
+/* Fixes the issue where badge counts in select components wrap to a new line */
+.workload-table-toolbar .pf-c-select__toggle-wrapper {
+  flex-wrap: nowrap;
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
@@ -12,7 +12,13 @@ import { getQueryString } from 'utils/queryStringUtils';
 import { searchValueAsArray, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { ensureExhaustive } from 'utils/type.utils';
 
-import { FixableStatus, QuerySearchFilter } from './types';
+import {
+    FixableStatus,
+    QuerySearchFilter,
+    VulnerabilitySeverityLabel,
+    isFixableStatus,
+    isVulnerabilitySeverityLabel,
+} from './types';
 
 export type EntityTab = 'CVE' | 'Image' | 'Deployment';
 
@@ -54,6 +60,25 @@ export function getEntityPagePath(
     }
 }
 
+export function fixableStatusToFixability(fixableStatus: FixableStatus): 'true' | 'false' {
+    return fixableStatus === 'Fixable' ? 'true' : 'false';
+}
+
+export function severityLabelToSeverity(label: VulnerabilitySeverityLabel): VulnerabilitySeverity {
+    switch (label) {
+        case 'Critical':
+            return 'CRITICAL_VULNERABILITY_SEVERITY';
+        case 'Important':
+            return 'IMPORTANT_VULNERABILITY_SEVERITY';
+        case 'Moderate':
+            return 'MODERATE_VULNERABILITY_SEVERITY';
+        case 'Low':
+            return 'LOW_VULNERABILITY_SEVERITY';
+        default:
+            return ensureExhaustive(label);
+    }
+}
+
 /**
  * Parses an open `SearchFilter` obtained from the URL into a restricted `SearchFilter` that
  * matches the fields and values expected by the backend.
@@ -64,43 +89,16 @@ export function parseQuerySearchFilter(rawSearchFilter: SearchFilter): QuerySear
     // SearchFilter values that can be directly translated over to the backend equivalent
     const unprocessedSearchKeys = ['CVE', 'IMAGE', 'DEPLOYMENT', 'NAMESPACE', 'CLUSTER'] as const;
     unprocessedSearchKeys.forEach((key) => {
-        if (rawSearchFilter[key]) {
-            cleanSearchFilter[key] = searchValueAsArray(rawSearchFilter[key]);
-        }
+        cleanSearchFilter[key] = searchValueAsArray(rawSearchFilter[key]);
     });
 
-    if (rawSearchFilter.Fixable) {
-        const rawFixable = searchValueAsArray(rawSearchFilter.Fixable);
-        const cleanFixable: ('true' | 'false')[] = [];
+    cleanSearchFilter.Fixable = searchValueAsArray(rawSearchFilter.Fixable)
+        .filter(isFixableStatus)
+        .map(fixableStatusToFixability);
 
-        rawFixable.forEach((status) => {
-            if (status === 'Fixable') {
-                cleanFixable.push('true');
-            } else if (status === 'Not fixable') {
-                cleanFixable.push('false');
-            }
-        });
-
-        // TODO We are explicitly excluding "Fixable" from the search filter until this functionality is re-enabled
-        // cleanSearchFilter.Fixable = cleanFixable;
-    }
-
-    if (rawSearchFilter.Severity) {
-        const rawSeverities = searchValueAsArray(rawSearchFilter.Severity);
-        cleanSearchFilter.Severity = [];
-
-        rawSeverities.forEach((rs) => {
-            if (rs === 'Critical') {
-                cleanSearchFilter.Severity?.push('CRITICAL_VULNERABILITY_SEVERITY');
-            } else if (rs === 'Important') {
-                cleanSearchFilter.Severity?.push('IMPORTANT_VULNERABILITY_SEVERITY');
-            } else if (rs === 'Moderate') {
-                cleanSearchFilter.Severity?.push('MODERATE_VULNERABILITY_SEVERITY');
-            } else if (rs === 'Low') {
-                cleanSearchFilter.Severity?.push('LOW_VULNERABILITY_SEVERITY');
-            }
-        });
-    }
+    cleanSearchFilter.Severity = searchValueAsArray(rawSearchFilter.Severity)
+        .filter(isVulnerabilitySeverityLabel)
+        .map(severityLabelToSeverity);
 
     return cleanSearchFilter;
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
@@ -1,12 +1,17 @@
 import { VulnerabilitySeverity } from 'types/cve.proto';
+import * as yup from 'yup';
 
-export type VulnerabilitySeverityLabel = 'Critical' | 'Important' | 'Moderate' | 'Low';
-export type FixableStatus = 'Fixable' | 'Not fixable';
+const vulnerabilitySeverityLabels = ['Critical', 'Important', 'Moderate', 'Low'] as const;
+export type VulnerabilitySeverityLabel = (typeof vulnerabilitySeverityLabels)[number];
+export function isVulnerabilitySeverityLabel(value: unknown): value is VulnerabilitySeverityLabel {
+    return vulnerabilitySeverityLabels.some((severity) => severity === value);
+}
 
-export type DefaultFilters = {
-    Severity: VulnerabilitySeverityLabel[];
-    Fixable: FixableStatus[];
-};
+const fixableStatuses = ['Fixable', 'Not fixable'] as const;
+export type FixableStatus = (typeof fixableStatuses)[number];
+export function isFixableStatus(value: unknown): value is FixableStatus {
+    return fixableStatuses.some((status) => status === value);
+}
 
 // `QuerySearchFilter` is a restricted subset of the `SearchFilter` obtained from the URL that only
 // supports search keys that are valid in the Workload CVE section of the app
@@ -20,11 +25,29 @@ export type QuerySearchFilter = Partial<{
     CLUSTER: string[];
 }>;
 
-export type VulnMgmtLocalStorage = {
-    preferences: {
-        defaultFilters: DefaultFilters;
-    };
-};
+const vulnMgmtLocalStorageSchema = yup.object({
+    preferences: yup.object({
+        defaultFilters: yup.object({
+            Severity: yup
+                .array(yup.string().required().oneOf(vulnerabilitySeverityLabels))
+                .required(),
+            Fixable: yup.array(yup.string().required().oneOf(fixableStatuses)).required(),
+        }),
+    }),
+});
+
+export type VulnMgmtLocalStorage = yup.InferType<typeof vulnMgmtLocalStorageSchema>;
+
+export type DefaultFilters = VulnMgmtLocalStorage['preferences']['defaultFilters'];
+
+export function isVulnMgmtLocalStorage(value: unknown): value is VulnMgmtLocalStorage {
+    try {
+        vulnMgmtLocalStorageSchema.validateSync(value);
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
 
 export const detailsTabValues = ['Vulnerabilities', 'Resources'] as const;
 

--- a/ui/apps/platform/src/hooks/useLocalStorage.test.ts
+++ b/ui/apps/platform/src/hooks/useLocalStorage.test.ts
@@ -1,0 +1,63 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import useLocalStorage from './useLocalStorage';
+
+beforeEach(() => {
+    window.localStorage.clear();
+});
+
+test('should safely read and write local storage', () => {
+    const { result } = renderHook(() =>
+        useLocalStorage('test', 'initial', (v: unknown): v is string => typeof v === 'string')
+    );
+    expect(result.current[0]).toBe('initial');
+
+    act(() => {
+        result.current[1]('new value');
+    });
+    expect(result.current[0]).toBe('new value');
+});
+
+test('should reject loading invalid values into memory when saved via raw localStorage', () => {
+    // Set an invalid value in localStorage before the hook is initialized
+    window.localStorage.setItem('test', '4');
+    const { result } = renderHook(() =>
+        useLocalStorage('test', 'initial', (v: unknown): v is string => typeof v === 'string')
+    );
+    // Check that the hook initializes with the initial value instead of the invalid value
+    expect(result.current[0]).toBe('initial');
+    expect(window.localStorage.getItem('test')).toBe('4');
+
+    // Set a valid value via the hook
+    act(() => {
+        result.current[1]('new value');
+    });
+    expect(result.current[0]).toBe('new value');
+    expect(window.localStorage.getItem('test')).toBe('"new value"');
+});
+
+test('should update in memory values when multiple hooks are used with the same key', () => {
+    const predicate = (v: unknown): v is { a: string } =>
+        typeof v === 'object' && v !== null && 'a' in v && typeof v.a === 'string';
+
+    // Initialize two hooks with the same key
+    const { result: result1 } = renderHook(() =>
+        useLocalStorage('test-1', { a: 'init' }, predicate)
+    );
+    const { result: result2 } = renderHook(() =>
+        useLocalStorage('test-1', { a: 'init' }, predicate)
+    );
+
+    expect(result1.current[0]).toEqual({ a: 'init' });
+    expect(result1.current[0]).toEqual({ a: 'init' });
+
+    const newVal = { a: 'new value', b: 'ignored' };
+
+    // Only update the value in the first hook
+    act(() => {
+        result1.current[1](newVal);
+    });
+
+    // Both hooks should update via the storage event
+    expect(result1.current[0].a).toEqual('new value');
+    expect(result2.current[0].a).toEqual('new value');
+});

--- a/ui/apps/platform/src/hooks/useLocalStorage.ts
+++ b/ui/apps/platform/src/hooks/useLocalStorage.ts
@@ -1,0 +1,96 @@
+/* eslint-disable no-console */
+import { useEffect, useState } from 'react';
+import { JsonValue } from 'utils/type.utils';
+
+declare global {
+    interface WindowEventMap {
+        'use-local-storage': StorageEvent;
+    }
+}
+
+type StateUpdater<State> = State | ((previousValue: State) => State);
+
+export type UseLocalStorageReturn<Storage> = [Storage, (t: StateUpdater<Storage>) => void];
+
+/**
+ * A hook that allows you to store a value in local storage and have it automatically
+ * synced across all instances of the hook on the page. If a previous stored value exists and
+ * is valid, it will be used instead of the initial value.
+ *
+ * @param key
+ *      The key to use for the local storage item
+ * @param initialValue
+ *      The initial value to use if no value is stored
+ * @param isValidPredicate
+ *      A type predicate that returns true if the stored value is valid, ensuring that the returned value
+ *      is of the correct type at runtime.
+ * @returns
+ *      A tuple containing the stored value and a function to update it
+ */
+function useLocalStorage<Storage extends JsonValue>(
+    key: string,
+    initialValue: Storage,
+    isValidPredicate: (rawValue: JsonValue) => rawValue is Storage
+): UseLocalStorageReturn<Storage> {
+    const [storedValue, setInternalStoredValue] = useState<Storage>(() => {
+        try {
+            // Load any previously stored value, if it exists and is valid
+            const item = window.localStorage.getItem(key);
+            const parsedItem = JSON.parse(item ?? 'null');
+            return isValidPredicate(parsedItem) ? parsedItem : initialValue;
+        } catch (error) {
+            // On error, return the initial value
+            return initialValue;
+        }
+    });
+
+    function setStoredValue(newValue: StateUpdater<Storage>): unknown {
+        try {
+            const valueToStore = newValue instanceof Function ? newValue(storedValue) : newValue;
+            const stringifiedValue = JSON.stringify(valueToStore);
+            // Save to local storage and dispatch custom event to notify other hook instances
+            window.localStorage.setItem(key, stringifiedValue);
+            window.dispatchEvent(
+                new StorageEvent('use-local-storage', { key, newValue: stringifiedValue })
+            );
+            return undefined;
+        } catch (error: unknown) {
+            return error;
+        }
+    }
+
+    // Subscribe to storage events from other instances of this hook
+    function storageChangeListener(event: StorageEvent) {
+        if (event.key !== key) {
+            return;
+        }
+
+        try {
+            const parsedValue = JSON.parse(event.newValue ?? 'null');
+            if (isValidPredicate(parsedValue)) {
+                setInternalStoredValue(parsedValue);
+            } else {
+                console.warn(
+                    'An invalid value was set in local storage, ignoring it.',
+                    parsedValue
+                );
+            }
+        } catch (error: unknown) {
+            console.warn('Failed to parse incoming JSON value', error);
+        }
+    }
+
+    useEffect(() => {
+        // 'storage' to handle events from other tabs, 'local-storage' to handle events from other hooks
+        window.addEventListener('storage', storageChangeListener);
+        window.addEventListener('use-local-storage', storageChangeListener);
+        return () => {
+            window.removeEventListener('storage', storageChangeListener);
+            window.removeEventListener('use-local-storage', storageChangeListener);
+        };
+    });
+
+    return [storedValue, setStoredValue];
+}
+
+export default useLocalStorage;

--- a/ui/apps/platform/src/utils/type.utils.ts
+++ b/ui/apps/platform/src/utils/type.utils.ts
@@ -28,3 +28,13 @@ export type ValueOf<T extends Record<string | number | symbol, unknown>> = T[key
  *
  */
 export type Override<T1, T2> = Omit<T1, keyof T2> & T2;
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonObject = { [key in string]: JsonValue } & {
+    [Key in string]?: JsonValue | undefined;
+};
+export type JsonArray = JsonValue[];
+/**
+ * A type that represents any value that can be serialized to JSON.
+ */
+export type JsonValue = JsonPrimitive | JsonObject | JsonArray;


### PR DESCRIPTION
## Description

Reimplements fixability filters and default filters in Workload CVEs when the appropriate feature flag is on.

e2e tests in a follow up to keep the size of this PR manageable.

## Notable changes

- A new `useLocalStorage` [hook](ui/apps/platform/src/hooks/useLocalStorage.ts) has been added. This hook requires a third parameter of a type predicate to ensure the raw value pulled from localStorage is always runtime consistent with the value we expect it to be. This helps prevent the need use type assertions (`value as MyType`) in the code, and avoids runtime errors when the value in localStorage is invalid.
- The TypeScript type for the stored default filters was changed so that it is defined as a [yup schema _first_, and then the TS type is inferred](https://github.com/stackrox/stackrox/pull/8514/files#diff-d9e5b4ae6ecf8116b0d187cf87e8eb49d63fa34c1fb9c10a096e4fdb3f1962abR28-R39) from that value. This lets us [easily check](https://github.com/stackrox/stackrox/pull/8514/files#diff-d9e5b4ae6ecf8116b0d187cf87e8eb49d63fa34c1fb9c10a096e4fdb3f1962abR43-R50) if the value pulled from localStorage matches the correct type and is used in conjunction with the previous change.
- Added some [global types](https://github.com/stackrox/stackrox/pull/8514/files#diff-048909ca741187de80d5818effb63dd1f291cc4bd339138e5e8f6fddff38cf26R32-R40) to the app that allow us to declare a type as JSON serializable. These are used in the new hook to ensure the data being stored in local storage can be parsed/stringified as JSON via `<Storage extends JsonValue>`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

With the fixability filter on, visit workload CVEs and see that "Critical", "Important", and "Fixable" are set as default filters.
![image](https://github.com/stackrox/stackrox/assets/1292638/b965862a-8a71-4054-be01-00f93a220631)
![image](https://github.com/stackrox/stackrox/assets/1292638/897c41d4-051d-48c5-b396-c15dd52f550b)

Additional local filters can be applied alongside the default filters:
![image](https://github.com/stackrox/stackrox/assets/1292638/7d80b945-6a3e-47b9-9cb6-7e2d1028fff4)

Changing the default filters will apply the change to the page.
- Removed default filters will be removed
- Added default filters will be added
- Local filters that are not part of the original default filters will be persisted
![image](https://github.com/stackrox/stackrox/assets/1292638/e8bc85d0-3ac2-4604-a3e6-382423ac76c0)
![image](https://github.com/stackrox/stackrox/assets/1292638/1a373522-725c-42be-90c6-2badee18163a)

Default filters can be manually removed from the toolbar, and will remain gone as long as the user remains on the page:
![image](https://github.com/stackrox/stackrox/assets/1292638/98e5efd6-c656-49b2-9ebe-72e7af745fa7)
![image](https://github.com/stackrox/stackrox/assets/1292638/3531bf59-d2a4-4e33-9a9e-edcfb339815f)

Refreshing the page with local filters applied will _not_ re-apply the default filters.
![image](https://github.com/stackrox/stackrox/assets/1292638/efe9335a-929e-447f-9428-a56716f19153)
![image](https://github.com/stackrox/stackrox/assets/1292638/c9c058fe-908d-4020-8b62-7bee1bac287d)
-> refresh
![image](https://github.com/stackrox/stackrox/assets/1292638/00929ca4-4142-49c6-a913-fbb1ef037a8d)

Navigating away and visiting the Workload CVE page via the navigation _will_ apply the default filters. (Filters will only be applied on page load if no other filters are applied.)
![image](https://github.com/stackrox/stackrox/assets/1292638/c85cc209-b9d4-483f-b80f-f86eb96462fd)

Manually corrupting localStorage and reloading the page correctly returns the default values:
![image](https://github.com/stackrox/stackrox/assets/1292638/5c051ddf-9bd9-4b9a-8a24-00c2bab45cfa)
![image](https://github.com/stackrox/stackrox/assets/1292638/ecd11ad7-9a87-41dc-9598-5793f13c95f5)
