### PR TITLE
ROX-14176: fix protoc download retry, add quotes

### DIFF
--- a/make/github.mk
+++ b/make/github.mk
@@ -4,18 +4,18 @@
 # For usage instructions, see uses of this macro elsewhere, since there is no
 # single standard for architecture naming.
 GET_GITHUB_RELEASE_FN = get_github_release() { \
-	[ -x $${1} ] || { \
+	[[ -x $${1} ]] || { \
 		set -euo pipefail ;\
 		echo "+ $${1}" ;\
 		mkdir -p bin ;\
 		attempts=5 ;\
 		for i in $$(seq $$attempts); do \
-			curl --silent --show-error --fail --location --output $${1} $${2} && break ;\
-			[ $$i -eq $$attempts ] && exit 1; \
+			curl --silent --show-error --fail --location --output "$${1}" "$${2}" && break ;\
+			[[ $$i -eq $$attempts ]] && exit 1; \
 			echo "Retrying after $$((i*i)) seconds..."; \
-			sleep $$((i*i)); \
+			sleep "$$((i*i))"; \
 		done ;\
-		[[ "$$(uname -s)" != "Darwin" ]] || xattr -c $${1} ;\
-		chmod +x $${1} ;\
+		[[ $$(uname -s) != Darwin ]] || xattr -c "$${1}" ;\
+		chmod +x "$${1}" ;\
 	} \
 }

--- a/make/github.mk
+++ b/make/github.mk
@@ -12,8 +12,8 @@ GET_GITHUB_RELEASE_FN = get_github_release() { \
 		for i in $$(seq $$attempts); do \
 			curl --silent --show-error --fail --location --output $${1} $${2} && break ;\
 			[ $$i -eq $$attempts ] && exit 1; \
-			echo "Retrying after $$(i*i) seconds..."; \
-			sleep $$(i*i); \
+			echo "Retrying after $$((i*i)) seconds..."; \
+			sleep $$((i*i)); \
 		done ;\
 		[[ "$$(uname -s)" != "Darwin" ]] || xattr -c $${1} ;\
 		chmod +x $${1} ;\


### PR DESCRIPTION
## Description

The `$$(i*i)` never worked:

```
curl: (22) The requested URL returned error: ... 
environment: i*i: command not found
Retrying after  seconds...
environment: i*i: command not found
sleep: missing operand
Try 'sleep --help' for more information.
make: *** [make/protogen.mk:81: /home/mowsiany/go/src/github.com/stackrox/stackrox/.proto/.downloads/protoc-22.0-linux-x86_64.zip] Error 1
```

This changes to use double parens, which are the way to do arithmetic in bash.

While at it, it also made quoting consistent (present when necessary, i.e. not within `[[ ]]` which does not perform word splitting).


## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

First, applied this change to [make/github.mk](make/github.mk):

```
--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -76,9 +76,10 @@ PROTOC_FILE := $(PROTOC_DOWNLOADS_DIR)/$(PROTOC_ZIP)
 
 include $(BASE_PATH)/make/github.mk
 
+badger: $(PROTOC_FILE)
 $(PROTOC_FILE): $(PROTOC_DOWNLOADS_DIR)
        @$(GET_GITHUB_RELEASE_FN); \
-       get_github_release "$@" "https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/$(PROTOC_ZIP)"
+       get_github_release "$@" "https://github.com/protocolbuffers/protobuf/releases/downloadx/v$(PROTOC_VERSION)/$(PROTOC_ZIP)"
 
 .PRECIOUS: $(PROTOC_FILE)
 
```

Then ran `make badger` and received error message like at the top. Then applied this change and ran `make badger` again. This time the output and delays were as expected:

```
[mowsiany@mowsiany stackrox]$ make badger
+ /home/mowsiany/go/src/github.com/stackrox/stackrox/.proto/.downloads/protoc-22.0-linux-x86_64.zip
curl: (22) The requested URL returned error: 404 
Retrying after 1 seconds...
curl: (22) The requested URL returned error: 404 
Retrying after 4 seconds...
curl: (22) The requested URL returned error: 404 
Retrying after 9 seconds...
curl: (22) The requested URL returned error: 404 
Retrying after 16 seconds...
curl: (22) The requested URL returned error: 404 
make: *** [make/protogen.mk:81: /home/mowsiany/go/src/github.com/stackrox/stackrox/.proto/.downloads/protoc-22.0-linux-x86_64.zip] Error 1
[mowsiany@mowsiany stackrox]$ 
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
