### PR TITLE
chore(pg): use pgx driver instead lib/pq

### DIFF
--- a/pkg/postgres/pgtest/postgres.go
+++ b/pkg/postgres/pgtest/postgres.go
@@ -13,10 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 	"k8s.io/utils/env"
-
-	// Ignore blank import warning as this is for test only
-	_ "github.com/lib/pq"
 )
+
+const driverName = "pgx"
 
 // TestPostgres is a Postgres instance used in tests
 type TestPostgres struct {
@@ -42,7 +41,7 @@ func CreateDatabase(t testing.TB, database string) {
 	// Bootstrap the test database by connecting to the default postgres database and running create
 	sourceWithPostgresDatabase := conn.GetConnectionStringWithDatabaseName(t, "postgres")
 
-	db, err := sql.Open("postgres", sourceWithPostgresDatabase)
+	db, err := sql.Open(driverName, sourceWithPostgresDatabase)
 	require.NoError(t, err)
 
 	// Checks to see if DB already exists
@@ -67,7 +66,7 @@ func DropDatabase(t testing.TB, database string) {
 	// Connect to the admin postgres database to drop the test database.
 	if database != "postgres" {
 		sourceWithPostgresDatabase := conn.GetConnectionStringWithDatabaseName(t, "postgres")
-		db, err := sql.Open("postgres", sourceWithPostgresDatabase)
+		db, err := sql.Open(driverName, sourceWithPostgresDatabase)
 		require.NoError(t, err)
 
 		_, _ = db.Exec("DROP DATABASE " + database)


### PR DESCRIPTION
## Description

This PR changes the SQL driver used in tests. Instead of loading lib/pq just for a side effect of loading `postgres` driver we can use `pgx` driver that is already loaded by gorm.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
