### PR TITLE
ROX-20277: gke version compatibility limit test description

### DIFF
--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -32,7 +32,9 @@ shorten_tag() {
     if [[ $long_tag =~ $short_tag_regex ]]; then
         echo "${BASH_REMATCH[1]}"
     else
-        die "Failed to shorten tag ${long_tag} as it did not match the regex: \"${short_tag_regex}\""
+        echo "${long_tag}"
+        >&2 echo "Failed to shorten tag ${long_tag} as it did not match the regex: \"${short_tag_regex}\""
+        exit 1
     fi
 }
 
@@ -78,31 +80,18 @@ compatibility_test() {
     make -C qa-tests-backend compatibility-test || touch FAIL
 
     update_junit_prefix_with_central_and_sensor_version
-    if [ ! "$?" ]; then
-        die "compatibility-test failed to shorten central or sensor tags"
-    fi
 
     short_central_tag="$(shorten_tag "${CENTRAL_CHART_VERSION_OVERRIDE}")"
-    if [ ! "$?" ]; then
-        die "compatibility-test failed to shorten central tag"
-    fi
     short_sensor_tag="$(shorten_tag "${SENSOR_CHART_VERSION_OVERRIDE}")"
-    if [ ! "$?" ]; then
-        die "compatibility-test failed to shorten sensor tag"
-    fi
+
     store_qa_test_results "compatibility-test-central-v${short_central_tag}-sensor-v${short_sensor_tag}"
     [[ ! -f FAIL ]] || die "compatibility-test-central-v${short_central_tag}-sensor-v${short_sensor_tag}"
 }
 
 update_junit_prefix_with_central_and_sensor_version() {
     short_central_tag="$(shorten_tag "${CENTRAL_CHART_VERSION_OVERRIDE}")"
-    if [ ! "$?" ]; then
-        die "update_junit_prefix_with_central_and_sensor_version failed to shorten central tag"
-    fi
     short_sensor_tag="$(shorten_tag "${SENSOR_CHART_VERSION_OVERRIDE}")"
-    if [ ! "$?" ]; then
-        die "update_junit_prefix_with_central_and_sensor_version failed to shorten sensor tag"
-    fi
+    
     result_folder="${ROOT}/qa-tests-backend/build/test-results/testCOMPATIBILITY"
     info "Updating all test in $result_folder to have \"Central-v${short_central_tag}_Sensor-v${short_sensor_tag}_\" prefix"
     for f in "$result_folder"/*.xml; do

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -78,16 +78,16 @@ compatibility_test() {
     make -C qa-tests-backend compatibility-test || touch FAIL
 
     update_junit_prefix_with_central_and_sensor_version
-    if [ "$?" -ne 0 ]; then
+    if [ ! "$?" ]; then
         die "compatibility-test failed to shorten central or sensor tags"
     fi
 
-    short_central_tag="$(shorten_tag ${CENTRAL_CHART_VERSION_OVERRIDE})"
-    if [ "$?" -ne 0 ]; then
+    short_central_tag="$(shorten_tag "${CENTRAL_CHART_VERSION_OVERRIDE}")"
+    if [ ! "$?" ]; then
         die "compatibility-test failed to shorten central tag"
     fi
     short_sensor_tag="$(shorten_tag "${SENSOR_CHART_VERSION_OVERRIDE}")"
-    if [ "$?" -ne 0 ]; then
+    if [ ! "$?" ]; then
         die "compatibility-test failed to shorten sensor tag"
     fi
     store_qa_test_results "compatibility-test-central-v${short_central_tag}-sensor-v${short_sensor_tag}"
@@ -96,11 +96,11 @@ compatibility_test() {
 
 update_junit_prefix_with_central_and_sensor_version() {
     short_central_tag="$(shorten_tag "${CENTRAL_CHART_VERSION_OVERRIDE}")"
-    if [ "$?" -ne 0 ]; then
+    if [ ! "$?" ]; then
         die "update_junit_prefix_with_central_and_sensor_version failed to shorten central tag"
     fi
     short_sensor_tag="$(shorten_tag "${SENSOR_CHART_VERSION_OVERRIDE}")"
-    if [ "$?" -ne 0 ]; then
+    if [ ! "$?" ]; then
         die "update_junit_prefix_with_central_and_sensor_version failed to shorten sensor tag"
     fi
     result_folder="${ROOT}/qa-tests-backend/build/test-results/testCOMPATIBILITY"

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -79,8 +79,16 @@ compatibility_test() {
 
     update_junit_prefix_with_central_and_sensor_version
 
-    short_central_tag=$(shorten_tag "${CENTRAL_CHART_VERSION_OVERRIDE}")
+    short_central_tag="$(shorten_tag ${CENTRAL_CHART_VERSION_OVERRIDE})"
+    exit_code="$?"
+    if [ $exit_code -ne 0 ]; then
+        die "compatibility-test failed to shorten central tag"
+    fi
     short_sensor_tag=$(shorten_tag "${SENSOR_CHART_VERSION_OVERRIDE}")
+    exit_code="$?"
+    if [ $exit_code -ne 0 ]; then
+        die "compatibility-test failed to shorten sensor tag"
+    fi
     store_qa_test_results "compatibility-test-central-v${short_central_tag}-sensor-v${short_sensor_tag}"
     [[ ! -f FAIL ]] || die "compatibility-test-central-v${short_central_tag}-sensor-v${short_sensor_tag}"
 }

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -79,15 +79,15 @@ compatibility_test() {
 
     update_junit_prefix_with_central_and_sensor_version
 
-    short_central_tag=$(shorten_tag ${CENTRAL_CHART_VERSION_OVERRIDE})
-    short_sensor_tag=$(shorten_tag ${SENSOR_CHART_VERSION_OVERRIDE})
+    short_central_tag=$(shorten_tag "${CENTRAL_CHART_VERSION_OVERRIDE}")
+    short_sensor_tag=$(shorten_tag "${SENSOR_CHART_VERSION_OVERRIDE}")
     store_qa_test_results "compatibility-test-central-v${short_central_tag}-sensor-v${short_sensor_tag}"
     [[ ! -f FAIL ]] || die "compatibility-test-central-v${short_central_tag}-sensor-v${short_sensor_tag}"
 }
 
 update_junit_prefix_with_central_and_sensor_version() {
-    short_central_tag=$(shorten_tag ${CENTRAL_CHART_VERSION_OVERRIDE})
-    short_sensor_tag=$(shorten_tag ${SENSOR_CHART_VERSION_OVERRIDE})
+    short_central_tag=$(shorten_tag "${CENTRAL_CHART_VERSION_OVERRIDE}")
+    short_sensor_tag=$(shorten_tag "${SENSOR_CHART_VERSION_OVERRIDE}")
     result_folder="${ROOT}/qa-tests-backend/build/test-results/testCOMPATIBILITY"
     info "Updating all test in $result_folder to have \"Central-v${short_central_tag}_Sensor-v${short_sensor_tag}_\" prefix"
     for f in "$result_folder"/*.xml; do

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -91,7 +91,7 @@ compatibility_test() {
 update_junit_prefix_with_central_and_sensor_version() {
     short_central_tag="$(shorten_tag "${CENTRAL_CHART_VERSION_OVERRIDE}")"
     short_sensor_tag="$(shorten_tag "${SENSOR_CHART_VERSION_OVERRIDE}")"
-    
+
     result_folder="${ROOT}/qa-tests-backend/build/test-results/testCOMPATIBILITY"
     info "Updating all test in $result_folder to have \"Central-v${short_central_tag}_Sensor-v${short_sensor_tag}_\" prefix"
     for f in "$result_folder"/*.xml; do

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -27,7 +27,7 @@ shorten_tag() {
 
     long_tag=$1
 
-    short_tag_regex='[1-9]+\.[1-9]+\.[1-9xX]+'
+    short_tag_regex='([1-9]+\.[1-9]+\.[1-9xX]+)'
 
     if [[ $long_tag =~ $short_tag_regex ]]; then
         echo "${BASH_REMATCH[1]}"

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -27,7 +27,7 @@ shorten_tag() {
 
     long_tag=$1
 
-    short_tag_regex='([1-9]+\.[1-9]+\.[1-9xX]+)'
+    short_tag_regex='([0-9]+\.[0-9]+\.[0-9xX]+)'
 
     if [[ $long_tag =~ $short_tag_regex ]]; then
         echo "${BASH_REMATCH[1]}"

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -25,7 +25,7 @@ shorten_tag() {
         die "Expected a version tag as parameter in shorten_tag: shorten_tag <tag>"
     fi
 
-    long_tag=$1
+    long_tag="$1"
 
     short_tag_regex='([0-9]+\.[0-9]+\.[0-9xX]+)'
 
@@ -78,15 +78,16 @@ compatibility_test() {
     make -C qa-tests-backend compatibility-test || touch FAIL
 
     update_junit_prefix_with_central_and_sensor_version
+    if [ "$?" -ne 0 ]; then
+        die "compatibility-test failed to shorten central or sensor tags"
+    fi
 
     short_central_tag="$(shorten_tag ${CENTRAL_CHART_VERSION_OVERRIDE})"
-    exit_code="$?"
-    if [ $exit_code -ne 0 ]; then
+    if [ "$?" -ne 0 ]; then
         die "compatibility-test failed to shorten central tag"
     fi
-    short_sensor_tag=$(shorten_tag "${SENSOR_CHART_VERSION_OVERRIDE}")
-    exit_code="$?"
-    if [ $exit_code -ne 0 ]; then
+    short_sensor_tag="$(shorten_tag "${SENSOR_CHART_VERSION_OVERRIDE}")"
+    if [ "$?" -ne 0 ]; then
         die "compatibility-test failed to shorten sensor tag"
     fi
     store_qa_test_results "compatibility-test-central-v${short_central_tag}-sensor-v${short_sensor_tag}"
@@ -94,8 +95,14 @@ compatibility_test() {
 }
 
 update_junit_prefix_with_central_and_sensor_version() {
-    short_central_tag=$(shorten_tag "${CENTRAL_CHART_VERSION_OVERRIDE}")
-    short_sensor_tag=$(shorten_tag "${SENSOR_CHART_VERSION_OVERRIDE}")
+    short_central_tag="$(shorten_tag "${CENTRAL_CHART_VERSION_OVERRIDE}")"
+    if [ "$?" -ne 0 ]; then
+        die "update_junit_prefix_with_central_and_sensor_version failed to shorten central tag"
+    fi
+    short_sensor_tag="$(shorten_tag "${SENSOR_CHART_VERSION_OVERRIDE}")"
+    if [ "$?" -ne 0 ]; then
+        die "update_junit_prefix_with_central_and_sensor_version failed to shorten sensor tag"
+    fi
     result_folder="${ROOT}/qa-tests-backend/build/test-results/testCOMPATIBILITY"
     info "Updating all test in $result_folder to have \"Central-v${short_central_tag}_Sensor-v${short_sensor_tag}_\" prefix"
     for f in "$result_folder"/*.xml; do

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 
 shorten_tag() {
     if [[ "$#" -ne 1 ]]; then
-        echo "Expected a version tag as parameter in shorten_tag: shorten_tag <tag>"
+        die "Expected a version tag as parameter in shorten_tag: shorten_tag <tag>"
     fi
 
     long_tag=$1
@@ -32,7 +32,7 @@ shorten_tag() {
     if [[ $long_tag =~ $short_tag_regex ]]; then
         echo "${BASH_REMATCH[1]}"
     else
-        echo "Failed to shorten tag ${long_tag} as it did not match the regex: \"${short_tag_regex}\""
+        die "Failed to shorten tag ${long_tag} as it did not match the regex: \"${short_tag_regex}\""
     fi
 }
 


### PR DESCRIPTION
## Description

Make version strings shorter so test folder names are less verbose and easier to read for users.

The regex works by capturing the first part of an image tag, since image tags can be long or short. Examples:
4.3.x-266-g3e1c64296a --> 4.3.x
400.2.2 --> 400.2.2
74.3.7 --> 74.3.7
It always returns MAJOR.MINOR.PATCH or MAJOR.MINOR.X

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

I manually tested the regex used. The artifacts in the CI runs also show that the test folder names changed as expected:
<img width="573" alt="image" src="https://github.com/stackrox/stackrox/assets/102952141/290fc25d-8b79-4536-94c8-9f3c2049e524">
