### PR TITLE
fix: use sort from stdlib instead of exp

### DIFF
--- a/central/reports/scheduler/v2/reportgenerator/email_formatter.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter.go
@@ -2,15 +2,16 @@ package reportgenerator
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"text/template"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/branding"
+	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/templates"
 	"github.com/stackrox/rox/pkg/timestamp"
-	"golang.org/x/exp/slices"
 )
 
 const (
@@ -103,8 +104,8 @@ func formatReportConfigDetails(snapshot *storage.ReportSnapshot, numDeployedImag
 	// Severities
 	// create a copy because severities will be sorted in descending order (critical, important, moderate, low)
 	severities := append([]storage.VulnerabilitySeverity{}, reportFilters.GetSeverities()...)
-	slices.SortFunc(severities, func(s1, s2 storage.VulnerabilitySeverity) bool {
-		return s1 > s2
+	sort.Slice(severities, func(i, j int) bool {
+		return severities[i] > severities[j]
 	})
 	formatSingleDetail(&writer, "CVE severity", severities...)
 
@@ -118,7 +119,8 @@ func formatReportConfigDetails(snapshot *storage.ReportSnapshot, numDeployedImag
 	// Image types
 	// create a copy because image types will be sorted in ascending order (deployed, watched)
 	imageTypes := append([]storage.VulnerabilityReportFilters_ImageType{}, reportFilters.GetImageTypes()...)
-	slices.Sort(imageTypes)
+	sliceutils.NaturalSort(imageTypes)
+
 	formatSingleDetail(&writer, "Image type", imageTypes...)
 
 	// CVEs discovered since


### PR DESCRIPTION
## Description

We don't need external dep for sorting as we have our own natural sort. We cannot remove exp dependency as we use `Ordered` constraint from it.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
