### PR TITLE
ROX-20318: Move operator lower bound OCP version 4.10 -> 4.11

### DIFF
--- a/operator/bundle.Dockerfile
+++ b/operator/bundle.Dockerfile
@@ -17,7 +17,7 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 # Labels for operator certification https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory
 # Note: vX means "X or later": https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions
-LABEL com.redhat.openshift.versions="v4.10"
+LABEL com.redhat.openshift.versions="v4.11"
 LABEL com.redhat.delivery.operator.bundle=true
 
 # Use post-processed files (instead of the original ones).

--- a/operator/bundle.Dockerfile.extra
+++ b/operator/bundle.Dockerfile.extra
@@ -1,6 +1,6 @@
 # Labels for operator certification https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory
 # Note: vX means "X or later": https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions
-LABEL com.redhat.openshift.versions="v4.10"
+LABEL com.redhat.openshift.versions="v4.11"
 LABEL com.redhat.delivery.operator.bundle=true
 
 # Use post-processed files (instead of the original ones).


### PR DESCRIPTION
## Description

This change is because OCP 4.10 reached EoL and we don't get new operator versions published downstream for it.
Here's info https://docs.engineering.redhat.com/display/SP/Shipping+Operators+to+EOL+OCP+versions

Downstream change as part of the same ticket ROX-20318: https://gitlab.cee.redhat.com/stackrox/rhacs-midstream/-/merge_requests/2182

E2E tests were already adjusted for 4.11 instead of 4.10 in https://issues.redhat.com/browse/ROX-20167.

## Checklist
- [x] Investigated and inspected CI test results

None of these are needed:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

I won't do any manual testing for this change, rather will run OSCI operator tests for higher and lower OCP bounds.

I will not specifically validate that the new value works as expected because the change should be self-evident and I use benefit of relying that this attribute should work as expected.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
