### PR TITLE
ROX-20612, ROX-20608: graphQL for exception count

### DIFF
--- a/central/graphql/resolvers/vulnerability_requests.go
+++ b/central/graphql/resolvers/vulnerability_requests.go
@@ -7,15 +7,19 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/graphql/resolvers/inputtypes"
+	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
 	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/common"
 	vulnReqUtils "github.com/stackrox/rox/central/vulnerabilityrequest/utils"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/paginated"
+	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
@@ -528,4 +532,68 @@ func (dr *DeferralRequestResolver) ExpiresOn(_ context.Context) (*graphql.Time, 
 // ExpiresWhenFixed returns true if the deferral request expires when vulnerability is fixable.
 func (dr *DeferralRequestResolver) ExpiresWhenFixed(_ context.Context) bool {
 	return dr.data.GetExpiry().GetExpiresWhenFixed()
+}
+
+type exceptionQueryFilters struct {
+	cves          []string
+	requestStates []string
+}
+
+// unExpiredExceptionQuery returns a query to retrieve unexpired vulnerability exceptions. If an image scope is found
+// in `ctx`, then the query for exceptions covering the specified image is returned.
+// Filters`cves` and `requestStates` are optional.
+func unExpiredExceptionQuery(ctx context.Context, filters exceptionQueryFilters) (*v1.Query, error) {
+	qb := search.NewQueryBuilder().AddBools(search.ExpiredRequest, false)
+
+	if len(filters.cves) > 0 {
+		qb.AddExactMatches(search.CVE, filters.cves...)
+	}
+	if len(filters.requestStates) > 0 {
+		qb.AddExactMatches(search.RequestStatus, filters.requestStates...)
+	}
+
+	var imageID string
+	scope, hasScope := scoped.GetScopeAtLevel(ctx, v1.SearchCategory_IMAGES)
+	if hasScope {
+		imageID = scope.ID
+	}
+	// Return query with scope part.
+	if imageID == "" {
+		return qb.ProtoQuery(), nil
+	}
+
+	imageLoader, err := loaders.GetImageLoader(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting image loader")
+	}
+	img, err := imageLoader.FromID(sac.WithAllAccess(context.Background()), imageID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "fetching image with id %s", imageID)
+	}
+	imageName := img.GetName()
+
+	specificTag := search.NewQueryBuilder().
+		AddExactMatches(search.ImageRegistryScope, imageName.GetRegistry()).
+		AddExactMatches(search.ImageRemoteScope, imageName.GetRemote())
+
+	if imageName.GetTag() == "" {
+		specificTag.AddExactMatches(search.ImageTagScope, "")
+	} else {
+		specificTag.AddExactMatches(search.ImageTagScope, imageName.GetTag())
+	}
+
+	// Add clauses to search global exception, all tags exception, and specific image exception that cover the concerned image.
+	scopeQ := search.DisjunctionQuery(
+		search.NewQueryBuilder().
+			AddExactMatches(search.ImageRegistryScope, common.MatchAll).
+			AddExactMatches(search.ImageRemoteScope, common.MatchAll).
+			AddExactMatches(search.ImageTagScope, common.MatchAll).ProtoQuery(),
+		search.NewQueryBuilder().
+			AddExactMatches(search.ImageRegistryScope, imageName.GetRegistry()).
+			AddExactMatches(search.ImageRemoteScope, imageName.GetRemote()).
+			AddExactMatches(search.ImageTagScope, common.MatchAll).ProtoQuery(),
+		specificTag.ProtoQuery(),
+	)
+
+	return search.ConjunctionQuery(qb.ProtoQuery(), scopeQ), nil
 }


### PR DESCRIPTION
## Description

This PR adds graphql vulnerability sub-resolver for getting an exception count. The sub-resolver does not accept a free-form query but instead, a direct filter `requestStatus: PENDING, APPROVED...`. Upon an authorization error on the sub-field, the Go zero-value is returned for the returned type (This is something we should be doing to all APIs).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Unit Test

<img width="1519" alt="image" src="https://github.com/stackrox/stackrox/assets/9895898/e0a252b6-3339-4092-801e-5489554258cd">

<img width="1519" alt="image" src="https://github.com/stackrox/stackrox/assets/9895898/a89830b8-26bc-4623-9f0d-20422879fb4a">

<img width="1519" alt="image" src="https://github.com/stackrox/stackrox/assets/9895898/96d64fd7-39f2-41fa-9d36-6fa0cc341ca6">


