### PR TITLE
fix(perf): Add new network graph utilities to lower memory usage

### DIFF
--- a/central/compliance/checks/common/checks.go
+++ b/central/compliance/checks/common/checks.go
@@ -245,8 +245,8 @@ func deploymentHasNetworkPolicies(ctx framework.ComplianceContext, deployment *s
 		framework.SkipNow(ctx, "Kubernetes system deployments are exempt from this requirement")
 	}
 
-	hasIngress := deploymentHasSpecifiedNetworkPolicy(ctx, storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE, deploymentIDToNetworkPolicies, deployment)
-	hasEgress := deploymentHasSpecifiedNetworkPolicy(ctx, storage.NetworkPolicyType_EGRESS_NETWORK_POLICY_TYPE, deploymentIDToNetworkPolicies, deployment)
+	hasIngress := deploymentHasSpecifiedNetworkPolicy(storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE, deploymentIDToNetworkPolicies, deployment)
+	hasEgress := deploymentHasSpecifiedNetworkPolicy(storage.NetworkPolicyType_EGRESS_NETWORK_POLICY_TYPE, deploymentIDToNetworkPolicies, deployment)
 	usesHostNamespace := deployment.GetHostNetwork()
 
 	if hasIngress && hasEgress && !usesHostNamespace {
@@ -272,7 +272,7 @@ func deploymentHasIngressNetworkPolicies(ctx framework.ComplianceContext, deploy
 		return
 	}
 
-	hasIngress := deploymentHasSpecifiedNetworkPolicy(ctx, storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE, deploymentIDToNetworkPolicies, deployment)
+	hasIngress := deploymentHasSpecifiedNetworkPolicy(storage.NetworkPolicyType_INGRESS_NETWORK_POLICY_TYPE, deploymentIDToNetworkPolicies, deployment)
 	usesHostNamespace := deployment.GetHostNetwork()
 
 	if usesHostNamespace {
@@ -298,7 +298,7 @@ func deploymentHasEgressNetworkPolicies(ctx framework.ComplianceContext, deploym
 		return
 	}
 
-	hasIngress := deploymentHasSpecifiedNetworkPolicy(ctx, storage.NetworkPolicyType_EGRESS_NETWORK_POLICY_TYPE, deploymentIDToNodes, deployment)
+	hasIngress := deploymentHasSpecifiedNetworkPolicy(storage.NetworkPolicyType_EGRESS_NETWORK_POLICY_TYPE, deploymentIDToNodes, deployment)
 	usesHostNamespace := deployment.GetHostNetwork()
 
 	if usesHostNamespace {
@@ -316,7 +316,7 @@ func deploymentHasEgressNetworkPolicies(ctx framework.ComplianceContext, deploym
 	}
 }
 
-func deploymentHasSpecifiedNetworkPolicy(ctx framework.ComplianceContext, policyType storage.NetworkPolicyType, deploymentsToNetworkPolicies map[string][]*storage.NetworkPolicy, deployment *storage.Deployment) bool {
+func deploymentHasSpecifiedNetworkPolicy(policyType storage.NetworkPolicyType, deploymentsToNetworkPolicies map[string][]*storage.NetworkPolicy, deployment *storage.Deployment) bool {
 	netPols, ok := deploymentsToNetworkPolicies[deployment.GetId()]
 	if !ok {
 		return false

--- a/central/compliance/checks/common/checks.go
+++ b/central/compliance/checks/common/checks.go
@@ -210,33 +210,34 @@ This control checks that all deployments have ingress and egress network policie
 // has ingress and egress network policies and does not use host network namespace.
 // Use this with DeploymentKind control checks.
 func CheckNetworkPoliciesByDeployment(ctx framework.ComplianceContext) {
-	// Map deployments to nodes.
-	networkGraph := ctx.Data().DeploymentsToNetworkPolicies()
+	// Map deployments to NetworkPolicies
+	deploymentsToNetworkPolicies := ctx.Data().DeploymentsToNetworkPolicies()
 
 	// Use the deployment node map to validate each deployment.
 	framework.ForEachDeployment(ctx, func(ctx framework.ComplianceContext, deployment *storage.Deployment) {
-		deploymentHasNetworkPolicies(ctx, deployment, networkGraph)
+		deploymentHasNetworkPolicies(ctx, deployment, deploymentsToNetworkPolicies)
 	})
 }
 
 // ClusterHasIngressNetworkPolicies ensures the cluster has ingress network policies and does
 // not use host network namespace.
 func ClusterHasIngressNetworkPolicies(ctx framework.ComplianceContext) {
-	networkGraph := ctx.Data().DeploymentsToNetworkPolicies()
+	// Map deployments to nodes.
+	deploymentsToNetworkPolicies := ctx.Data().DeploymentsToNetworkPolicies()
 	// Use the deployment node map to validate each deployment.
 	framework.ForEachDeployment(ctx, func(ctx framework.ComplianceContext, deployment *storage.Deployment) {
-		deploymentHasIngressNetworkPolicies(ctx, deployment, networkGraph)
+		deploymentHasIngressNetworkPolicies(ctx, deployment, deploymentsToNetworkPolicies)
 	})
 }
 
 // ClusterHasEgressNetworkPolicies ensures the cluster has egress network policies and does
 // not use host network namespace.
 func ClusterHasEgressNetworkPolicies(ctx framework.ComplianceContext) {
-	networkGraph := ctx.Data().DeploymentsToNetworkPolicies()
+	deploymentsToNetworkPolicies := ctx.Data().DeploymentsToNetworkPolicies()
 
 	// Use the deployment node map to validate each deployment.
 	framework.ForEachDeployment(ctx, func(ctx framework.ComplianceContext, deployment *storage.Deployment) {
-		deploymentHasEgressNetworkPolicies(ctx, deployment, networkGraph)
+		deploymentHasEgressNetworkPolicies(ctx, deployment, deploymentsToNetworkPolicies)
 	})
 }
 

--- a/central/compliance/checks/nist800-190/check442/check_test.go
+++ b/central/compliance/checks/nist800-190/check442/check_test.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/stackrox/rox/central/compliance/framework"
 	"github.com/stackrox/rox/central/compliance/framework/mocks"
-	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
@@ -49,18 +47,13 @@ func (s *suiteImpl) TestHostNetwork() {
 
 	testPolicies := s.networkPolicies()
 
-	testNetworkGraph := &v1.NetworkGraph{
-		Nodes: []*v1.NetworkNode{
-			{
-				Entity:    networkgraph.EntityForDeployment(testDeployments[0].GetId()).ToProto(),
-				PolicyIds: []string{testPolicies[0].GetId(), testPolicies[1].GetId()},
-			},
-		},
+	testDeploymentsToNetworkPolicies := map[string][]*storage.NetworkPolicy{
+		testDeployments[0].GetId(): {testPolicies[0], testPolicies[1]},
 	}
 
 	data := mocks.NewMockComplianceDataRepository(s.mockCtrl)
 	data.EXPECT().NetworkPolicies().AnyTimes().Return(toMap(testPolicies))
-	data.EXPECT().NetworkGraph().AnyTimes().Return(testNetworkGraph)
+	data.EXPECT().DeploymentsToNetworkPolicies().AnyTimes().Return(testDeploymentsToNetworkPolicies)
 
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
@@ -97,18 +90,13 @@ func (s *suiteImpl) TestMissingIngress() {
 
 	testPolicies := s.networkPolicies()
 
-	testNetworkGraph := &v1.NetworkGraph{
-		Nodes: []*v1.NetworkNode{
-			{
-				Entity:    networkgraph.EntityForDeployment(testDeployments[0].GetId()).ToProto(),
-				PolicyIds: []string{testPolicies[1].GetId()}, // Only egress
-			},
-		},
+	testDeploymentsToNetworkPolicies := map[string][]*storage.NetworkPolicy{
+		testDeployments[0].GetId(): {testPolicies[1]},
 	}
 
 	data := mocks.NewMockComplianceDataRepository(s.mockCtrl)
 	data.EXPECT().NetworkPolicies().AnyTimes().Return(toMap(testPolicies))
-	data.EXPECT().NetworkGraph().AnyTimes().Return(testNetworkGraph)
+	data.EXPECT().DeploymentsToNetworkPolicies().AnyTimes().Return(testDeploymentsToNetworkPolicies)
 
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
@@ -145,18 +133,13 @@ func (s *suiteImpl) TestMissingEgress() {
 
 	testPolicies := s.networkPolicies()
 
-	testNetworkGraph := &v1.NetworkGraph{
-		Nodes: []*v1.NetworkNode{
-			{
-				Entity:    networkgraph.EntityForDeployment(testDeployments[0].GetId()).ToProto(),
-				PolicyIds: []string{testPolicies[0].GetId()}, // Only ingress
-			},
-		},
+	testDeploymentsToNetworkPolicies := map[string][]*storage.NetworkPolicy{
+		testDeployments[0].GetId(): {testPolicies[0]},
 	}
 
 	data := mocks.NewMockComplianceDataRepository(s.mockCtrl)
 	data.EXPECT().NetworkPolicies().AnyTimes().Return(toMap(testPolicies))
-	data.EXPECT().NetworkGraph().AnyTimes().Return(testNetworkGraph)
+	data.EXPECT().DeploymentsToNetworkPolicies().AnyTimes().Return(testDeploymentsToNetworkPolicies)
 
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
@@ -192,11 +175,11 @@ func (s *suiteImpl) TestSkipKubeSystem() {
 
 	testNodes := s.nodes()
 	testPolicies := s.networkPolicies()
-	testNetworkGraph := &v1.NetworkGraph{}
+	testDeploymentsToNetworkPolicies := map[string][]*storage.NetworkPolicy{}
 
 	data := mocks.NewMockComplianceDataRepository(s.mockCtrl)
 	data.EXPECT().NetworkPolicies().AnyTimes().Return(toMap(testPolicies))
-	data.EXPECT().NetworkGraph().AnyTimes().Return(testNetworkGraph)
+	data.EXPECT().DeploymentsToNetworkPolicies().AnyTimes().Return(testDeploymentsToNetworkPolicies)
 
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
@@ -238,22 +221,14 @@ func (s *suiteImpl) TestPass() {
 
 	testPolicies := s.networkPolicies()
 
-	testNetworkGraph := &v1.NetworkGraph{
-		Nodes: []*v1.NetworkNode{
-			{
-				Entity:    networkgraph.EntityForDeployment(testDeployments[0].GetId()).ToProto(),
-				PolicyIds: []string{testPolicies[0].GetId(), testPolicies[1].GetId()},
-			},
-			{
-				Entity:    networkgraph.EntityForDeployment(testDeployments[1].GetId()).ToProto(),
-				PolicyIds: []string{testPolicies[0].GetId(), testPolicies[1].GetId()},
-			},
-		},
+	testDeploymentsToNetworkPolicies := map[string][]*storage.NetworkPolicy{
+		testDeployments[0].GetId(): {testPolicies[0], testPolicies[1]},
+		testDeployments[1].GetId(): {testPolicies[0], testPolicies[1]},
 	}
 
 	data := mocks.NewMockComplianceDataRepository(s.mockCtrl)
 	data.EXPECT().NetworkPolicies().AnyTimes().Return(toMap(testPolicies))
-	data.EXPECT().NetworkGraph().AnyTimes().Return(testNetworkGraph)
+	data.EXPECT().DeploymentsToNetworkPolicies().AnyTimes().Return(testDeploymentsToNetworkPolicies)
 
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)

--- a/central/compliance/checks/pcidss32/check134/check_test.go
+++ b/central/compliance/checks/pcidss32/check134/check_test.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/stackrox/rox/central/compliance/framework"
 	"github.com/stackrox/rox/central/compliance/framework/mocks"
-	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
@@ -34,12 +32,12 @@ func (s *suiteImpl) TearDownSuite() {
 }
 
 type testCase struct {
-	cluster         *storage.Cluster
-	nodes           []*storage.Node
-	deployments     []*storage.Deployment
-	networkPolicies []*storage.NetworkPolicy
-	networkGraph    *v1.NetworkGraph
-	expectedStatus  framework.Status
+	cluster                      *storage.Cluster
+	nodes                        []*storage.Node
+	deployments                  []*storage.Deployment
+	networkPolicies              []*storage.NetworkPolicy
+	deploymentsToNetworkPolicies map[string][]*storage.NetworkPolicy
+	expectedStatus               framework.Status
 }
 
 func (s *suiteImpl) TestHostNetwork() {
@@ -58,13 +56,8 @@ func (s *suiteImpl) TestHostNetwork() {
 	}
 
 	// ingress and egress networkpolicies enabled
-	tc.networkGraph = &v1.NetworkGraph{
-		Nodes: []*v1.NetworkNode{
-			{
-				Entity:    networkgraph.EntityForDeployment(tc.deployments[0].GetId()).ToProto(),
-				PolicyIds: []string{tc.networkPolicies[0].GetId(), tc.networkPolicies[1].GetId()},
-			},
-		},
+	tc.deploymentsToNetworkPolicies = map[string][]*storage.NetworkPolicy{
+		tc.deployments[0].GetId(): {tc.networkPolicies[0], tc.networkPolicies[1]},
 	}
 
 	tc.expectedStatus = framework.FailStatus
@@ -85,13 +78,8 @@ func (s *suiteImpl) TestEgress() {
 	}
 
 	// only egress networkpolicies enabled
-	tc.networkGraph = &v1.NetworkGraph{
-		Nodes: []*v1.NetworkNode{
-			{
-				Entity:    networkgraph.EntityForDeployment(tc.deployments[0].GetId()).ToProto(),
-				PolicyIds: []string{tc.networkPolicies[1].GetId()},
-			},
-		},
+	tc.deploymentsToNetworkPolicies = map[string][]*storage.NetworkPolicy{
+		tc.deployments[0].GetId(): {tc.networkPolicies[1]},
 	}
 
 	tc.expectedStatus = framework.PassStatus
@@ -112,13 +100,8 @@ func (s *suiteImpl) TestIngress() {
 	}
 
 	// only ingress networkpolicies enabled
-	tc.networkGraph = &v1.NetworkGraph{
-		Nodes: []*v1.NetworkNode{
-			{
-				Entity:    networkgraph.EntityForDeployment(tc.deployments[0].GetId()).ToProto(),
-				PolicyIds: []string{tc.networkPolicies[0].GetId()},
-			},
-		},
+	tc.deploymentsToNetworkPolicies = map[string][]*storage.NetworkPolicy{
+		tc.deployments[0].GetId(): {tc.networkPolicies[0]},
 	}
 
 	tc.expectedStatus = framework.FailStatus
@@ -140,12 +123,8 @@ func (s *suiteImpl) TestKubeSystem() {
 		},
 	}
 
-	tc.networkGraph = &v1.NetworkGraph{
-		Nodes: []*v1.NetworkNode{
-			{
-				Entity: networkgraph.EntityForDeployment(tc.deployments[0].GetId()).ToProto(),
-			},
-		},
+	tc.deploymentsToNetworkPolicies = map[string][]*storage.NetworkPolicy{
+		tc.deployments[0].GetId(): {},
 	}
 
 	tc.expectedStatus = framework.SkipStatus
@@ -168,17 +147,9 @@ func (s *suiteImpl) TestPass() {
 		},
 	}
 
-	tc.networkGraph = &v1.NetworkGraph{
-		Nodes: []*v1.NetworkNode{
-			{
-				Entity:    networkgraph.EntityForDeployment(tc.deployments[0].GetId()).ToProto(),
-				PolicyIds: []string{tc.networkPolicies[0].GetId(), tc.networkPolicies[1].GetId()},
-			},
-			{
-				Entity:    networkgraph.EntityForDeployment(tc.deployments[1].GetId()).ToProto(),
-				PolicyIds: []string{tc.networkPolicies[0].GetId(), tc.networkPolicies[1].GetId()},
-			},
-		},
+	tc.deploymentsToNetworkPolicies = map[string][]*storage.NetworkPolicy{
+		tc.deployments[0].GetId(): {tc.networkPolicies[0], tc.networkPolicies[1]},
+		tc.deployments[1].GetId(): {tc.networkPolicies[0], tc.networkPolicies[1]},
 	}
 
 	tc.expectedStatus = framework.PassStatus
@@ -199,7 +170,7 @@ func (s *suiteImpl) checkTestCase(tc *testCase) {
 
 	data := mocks.NewMockComplianceDataRepository(s.mockCtrl)
 	data.EXPECT().NetworkPolicies().AnyTimes().Return(toMap(tc.networkPolicies))
-	data.EXPECT().NetworkGraph().AnyTimes().Return(tc.networkGraph)
+	data.EXPECT().DeploymentsToNetworkPolicies().AnyTimes().Return(tc.deploymentsToNetworkPolicies)
 
 	check := s.verifyCheckRegistered()
 	run, err := framework.NewComplianceRun(check)

--- a/central/compliance/data/repository.go
+++ b/central/compliance/data/repository.go
@@ -203,7 +203,6 @@ func policyCategories(policies []*storage.Policy) map[string]set.StringSet {
 }
 
 func (r *repository) init(ctx context.Context, domain framework.ComplianceDomain, scrapeResults map[string]*compliance.ComplianceReturn, f *factory) error {
-	log.Infof("Init'ing repo")
 	r.cluster = domain.Cluster().Cluster()
 	r.nodes = nodesByID(framework.Nodes(domain))
 

--- a/central/compliance/data/repository.go
+++ b/central/compliance/data/repository.go
@@ -31,23 +31,23 @@ type repository struct {
 	nodes       map[string]*storage.Node
 	deployments map[string]*storage.Deployment
 
-	unresolvedAlerts      []*storage.ListAlert
-	networkPolicies       map[string]*storage.NetworkPolicy
-	networkGraph          *v1.NetworkGraph
-	policies              map[string]*storage.Policy
-	images                []*storage.ListImage
-	imageIntegrations     []*storage.ImageIntegration
-	registries            []framework.ImageMatcher
-	scanners              []framework.ImageMatcher
-	sshProcessIndicators  []*storage.ProcessIndicator
-	hasProcessIndicators  bool
-	networkFlows          []*storage.NetworkFlow
-	notifiers             []*storage.Notifier
-	roles                 []*storage.K8SRole
-	bindings              []*storage.K8SRoleBinding
-	cisDockerRunCheck     bool
-	cisKubernetesRunCheck bool
-	categoryToPolicies    map[string]set.StringSet // maps categories to policy set
+	unresolvedAlerts             []*storage.ListAlert
+	networkPolicies              map[string]*storage.NetworkPolicy
+	deploymentsToNetworkPolicies map[string][]*storage.NetworkPolicy
+	policies                     map[string]*storage.Policy
+	images                       []*storage.ListImage
+	imageIntegrations            []*storage.ImageIntegration
+	registries                   []framework.ImageMatcher
+	scanners                     []framework.ImageMatcher
+	sshProcessIndicators         []*storage.ProcessIndicator
+	hasProcessIndicators         bool
+	networkFlows                 []*storage.NetworkFlow
+	notifiers                    []*storage.Notifier
+	roles                        []*storage.K8SRole
+	bindings                     []*storage.K8SRoleBinding
+	cisDockerRunCheck            bool
+	cisKubernetesRunCheck        bool
+	categoryToPolicies           map[string]set.StringSet // maps categories to policy set
 
 	complianceOperatorResults map[string][]*storage.ComplianceOperatorCheckResult
 
@@ -72,8 +72,8 @@ func (r *repository) NetworkPolicies() map[string]*storage.NetworkPolicy {
 	return r.networkPolicies
 }
 
-func (r *repository) NetworkGraph() *v1.NetworkGraph {
-	return r.networkGraph
+func (r *repository) DeploymentsToNetworkPolicies() map[string][]*storage.NetworkPolicy {
+	return r.deploymentsToNetworkPolicies
 }
 
 func (r *repository) Policies() map[string]*storage.Policy {
@@ -203,6 +203,7 @@ func policyCategories(policies []*storage.Policy) map[string]set.StringSet {
 }
 
 func (r *repository) init(ctx context.Context, domain framework.ComplianceDomain, scrapeResults map[string]*compliance.ComplianceReturn, f *factory) error {
+	log.Infof("Init'ing repo")
 	r.cluster = domain.Cluster().Cluster()
 	r.nodes = nodesByID(framework.Nodes(domain))
 
@@ -228,7 +229,7 @@ func (r *repository) init(ctx context.Context, domain framework.ComplianceDomain
 		networkTree = f.netTreeMgr.CreateNetworkTree(ctx, clusterID)
 	}
 
-	r.networkGraph = f.networkGraphEvaluator.GetGraph(clusterID, nil, deployments, networkTree, networkPolicies, false)
+	r.deploymentsToNetworkPolicies = f.networkGraphEvaluator.GetApplyingPoliciesPerDeployment(deployments, networkTree, networkPolicies)
 
 	policies, err := f.policyStore.GetAllPolicies(ctx)
 	if err != nil {

--- a/central/compliance/framework/data.go
+++ b/central/compliance/framework/data.go
@@ -1,7 +1,6 @@
 package framework
 
 import (
-	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/compliance"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
@@ -26,7 +25,7 @@ type ComplianceDataRepository interface {
 
 	UnresolvedAlerts() []*storage.ListAlert
 	NetworkPolicies() map[string]*storage.NetworkPolicy
-	NetworkGraph() *v1.NetworkGraph
+	DeploymentsToNetworkPolicies() map[string][]*storage.NetworkPolicy
 	// Policies returns all policies, keyed by their name.
 	Policies() map[string]*storage.Policy
 	Images() []*storage.ListImage

--- a/central/compliance/framework/mocks/data.go
+++ b/central/compliance/framework/mocks/data.go
@@ -12,7 +12,6 @@ import (
 	reflect "reflect"
 
 	framework "github.com/stackrox/rox/central/compliance/framework"
-	v1 "github.com/stackrox/rox/generated/api/v1"
 	compliance "github.com/stackrox/rox/generated/internalapi/compliance"
 	storage "github.com/stackrox/rox/generated/storage"
 	set "github.com/stackrox/rox/pkg/set"
@@ -135,6 +134,20 @@ func (mr *MockComplianceDataRepositoryMockRecorder) Deployments() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deployments", reflect.TypeOf((*MockComplianceDataRepository)(nil).Deployments))
 }
 
+// DeploymentsToNetworkPolicies mocks base method.
+func (m *MockComplianceDataRepository) DeploymentsToNetworkPolicies() map[string][]*storage.NetworkPolicy {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeploymentsToNetworkPolicies")
+	ret0, _ := ret[0].(map[string][]*storage.NetworkPolicy)
+	return ret0
+}
+
+// DeploymentsToNetworkPolicies indicates an expected call of DeploymentsToNetworkPolicies.
+func (mr *MockComplianceDataRepositoryMockRecorder) DeploymentsToNetworkPolicies() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeploymentsToNetworkPolicies", reflect.TypeOf((*MockComplianceDataRepository)(nil).DeploymentsToNetworkPolicies))
+}
+
 // HasProcessIndicators mocks base method.
 func (m *MockComplianceDataRepository) HasProcessIndicators() bool {
 	m.ctrl.T.Helper()
@@ -231,20 +244,6 @@ func (m *MockComplianceDataRepository) NetworkFlows() []*storage.NetworkFlow {
 func (mr *MockComplianceDataRepositoryMockRecorder) NetworkFlows() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkFlows", reflect.TypeOf((*MockComplianceDataRepository)(nil).NetworkFlows))
-}
-
-// NetworkGraph mocks base method.
-func (m *MockComplianceDataRepository) NetworkGraph() *v1.NetworkGraph {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NetworkGraph")
-	ret0, _ := ret[0].(*v1.NetworkGraph)
-	return ret0
-}
-
-// NetworkGraph indicates an expected call of NetworkGraph.
-func (mr *MockComplianceDataRepositoryMockRecorder) NetworkGraph() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkGraph", reflect.TypeOf((*MockComplianceDataRepository)(nil).NetworkGraph))
 }
 
 // NetworkPolicies mocks base method.

--- a/central/networkpolicies/graph/evaluator.go
+++ b/central/networkpolicies/graph/evaluator.go
@@ -31,6 +31,7 @@ type Evaluator interface {
 	// GetGraph returns the network policy graph. If `queryDeploymentIDs` is nil, it is assumed that all deployments are queried/relevant.
 	GetGraph(clusterID string, queryDeploymentIDs set.StringSet, clusterDeployments []*storage.Deployment, networkTree tree.ReadOnlyNetworkTree, networkPolicies []*storage.NetworkPolicy, includePorts bool) *v1.NetworkGraph
 	GetAppliedPolicies(deployments []*storage.Deployment, networkTree tree.ReadOnlyNetworkTree, networkPolicies []*storage.NetworkPolicy) []*storage.NetworkPolicy
+	GetApplyingPoliciesPerDeployment(deployments []*storage.Deployment, networkTree tree.ReadOnlyNetworkTree, networkPolicies []*storage.NetworkPolicy) map[string][]*storage.NetworkPolicy
 	IncrementEpoch(clusterID string)
 	Epoch(clusterID string) uint32
 }
@@ -88,6 +89,11 @@ func (g *evaluatorImpl) GetGraph(clusterID string, queryDeploymentIDs set.String
 		Epoch: g.Epoch(clusterID),
 		Nodes: nodes,
 	}
+}
+
+// GetApplyingPoliciesPerDeployment creates a map of deployment IDs to the applying network policies
+func (g *evaluatorImpl) GetApplyingPoliciesPerDeployment(deployments []*storage.Deployment, networkTree tree.ReadOnlyNetworkTree, networkPolicies []*storage.NetworkPolicy) map[string][]*storage.NetworkPolicy {
+	return newGraphBuilder(nil, deployments, networkTree, g.getNamespacesByID()).GetApplyingPoliciesPerDeployment(networkPolicies)
 }
 
 // GetAppliedPolicies creates a filtered list of policies from the input network policies, composed of only the policies

--- a/central/networkpolicies/graph/evaluator_test.go
+++ b/central/networkpolicies/graph/evaluator_test.go
@@ -2330,3 +2330,43 @@ func TestEvaluateClustersWithPorts(t *testing.T) {
 		})
 	}
 }
+
+func TestGetApplyingPoliciesPerDeployment(t *testing.T) {
+	evaluator := newMockGraphEvaluator()
+
+	deployments := []*storage.Deployment{
+		{
+			Id:          "a",
+			Namespace:   "default",
+			NamespaceId: "default",
+			PodLabels:   deploymentLabels("app", "a"),
+		},
+		{
+			Id:          "b",
+			Namespace:   "default",
+			NamespaceId: "default",
+			PodLabels:   deploymentLabels("app", "b"),
+		},
+		{
+			Id:          "c",
+			Namespace:   "default",
+			NamespaceId: "default",
+			PodLabels:   deploymentLabels("app", "c"),
+		},
+	}
+
+	networkPolicies := []*storage.NetworkPolicy{
+		getExamplePolicy("a-ingress-tcp-8080"),
+		getExamplePolicy("b-egress-a-tcp-ports-and-dns"),
+		getExamplePolicy("c-egress-a-tcp-8443-and-udp"),
+	}
+
+	expectedResults := map[string][]*storage.NetworkPolicy{
+		"a": {networkPolicies[0]},
+		"b": {networkPolicies[1]},
+		"c": {networkPolicies[2]},
+	}
+
+	resultMap := evaluator.GetApplyingPoliciesPerDeployment(deployments, nil, networkPolicies)
+	assert.Equal(t, expectedResults, resultMap)
+}

--- a/central/networkpolicies/graph/graph_builder.go
+++ b/central/networkpolicies/graph/graph_builder.go
@@ -321,6 +321,18 @@ func (b *graphBuilder) AddEdgesForNetworkPolicies(netPols []*storage.NetworkPoli
 	b.forEachNetworkPolicy(netPols, b.addEdgesForNetworkPolicy)
 }
 
+func (b *graphBuilder) GetApplyingPoliciesPerDeployment(allNetPols []*storage.NetworkPolicy) map[string][]*storage.NetworkPolicy {
+	deploymentsToNetPols := make(map[string][]*storage.NetworkPolicy)
+	b.forEachNetworkPolicy(allNetPols, func(netPol *storage.NetworkPolicy, _ *storage.NamespaceMetadata, matchedDeployments []*node) {
+		for _, node := range matchedDeployments {
+			if id := node.deployment.GetId(); id != "" {
+				deploymentsToNetPols[id] = append(deploymentsToNetPols[id], netPol)
+			}
+		}
+	})
+	return deploymentsToNetPols
+}
+
 func (b *graphBuilder) GetApplyingPolicies(allNetPols []*storage.NetworkPolicy) []*storage.NetworkPolicy {
 	var applyingPolicies []*storage.NetworkPolicy
 	b.forEachNetworkPolicy(allNetPols, func(netPol *storage.NetworkPolicy, _ *storage.NamespaceMetadata, matchedDeployments []*node) {

--- a/central/networkpolicies/graph/mocks/evaluator.go
+++ b/central/networkpolicies/graph/mocks/evaluator.go
@@ -70,6 +70,20 @@ func (mr *MockEvaluatorMockRecorder) GetAppliedPolicies(deployments, networkTree
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppliedPolicies", reflect.TypeOf((*MockEvaluator)(nil).GetAppliedPolicies), deployments, networkTree, networkPolicies)
 }
 
+// GetApplyingPoliciesPerDeployment mocks base method.
+func (m *MockEvaluator) GetApplyingPoliciesPerDeployment(deployments []*storage.Deployment, networkTree tree.ReadOnlyNetworkTree, networkPolicies []*storage.NetworkPolicy) map[string][]*storage.NetworkPolicy {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplyingPoliciesPerDeployment", deployments, networkTree, networkPolicies)
+	ret0, _ := ret[0].(map[string][]*storage.NetworkPolicy)
+	return ret0
+}
+
+// GetApplyingPoliciesPerDeployment indicates an expected call of GetApplyingPoliciesPerDeployment.
+func (mr *MockEvaluatorMockRecorder) GetApplyingPoliciesPerDeployment(deployments, networkTree, networkPolicies any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplyingPoliciesPerDeployment", reflect.TypeOf((*MockEvaluator)(nil).GetApplyingPoliciesPerDeployment), deployments, networkTree, networkPolicies)
+}
+
 // GetGraph mocks base method.
 func (m *MockEvaluator) GetGraph(clusterID string, queryDeploymentIDs set.StringSet, clusterDeployments []*storage.Deployment, networkTree tree.ReadOnlyNetworkTree, networkPolicies []*storage.NetworkPolicy, includePorts bool) *v1.NetworkGraph {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Description

GetGraph can be very expensive when network policies are fairly wide in creating the edges. We only care about which network policies match which deployments

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Will check compliance before and after and write a unit test

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
