### PR TITLE
ROX-20699: Using real data for request details page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
     Breadcrumb,
     BreadcrumbItem,
@@ -11,70 +11,84 @@ import {
     Flex,
     FlexItem,
     PageSection,
+    Spinner,
     Text,
     TextVariants,
     Title,
+    pluralize,
 } from '@patternfly/react-core';
-import {
-    ExpandableRowContent,
-    TableComposable,
-    Tbody,
-    Td,
-    Th,
-    Thead,
-    Tr,
-} from '@patternfly/react-table';
-import { SearchIcon } from '@patternfly/react-icons';
-import { useParams, Link } from 'react-router-dom';
-import pluralize from 'pluralize';
+import { useParams } from 'react-router-dom';
 
 import { exceptionManagementPath } from 'routePaths';
 import useSet from 'hooks/useSet';
-import { VulnerabilityException } from 'services/VulnerabilityExceptionService';
+import useRestQuery from 'hooks/useRestQuery';
 import { getDateTime } from 'utils/dateUtils';
 import { ensureExhaustive } from 'utils/type.utils';
-import { vulnerabilityExceptions } from 'Containers/Vulnerabilities/ExceptionManagement/mockUtils';
-import { getEntityPagePath } from 'Containers/Vulnerabilities/WorkloadCves/searchUtils';
-import { VulnerabilitySeverityLabel } from 'Containers/Vulnerabilities/WorkloadCves/types';
+import {
+    VulnerabilityException,
+    fetchVulnerabilityExceptionById,
+} from 'services/VulnerabilityExceptionService';
 
 import NotFoundMessage from 'Components/NotFoundMessage';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import {
     RequestExpires,
     RequestedAction,
     RequestCreatedAt,
     RequestScope,
 } from './components/ExceptionRequestTableCells';
-// @TODO: Move these files up to a common directory and move the types used in these files as well
-import SeverityCountLabels from '../WorkloadCves/components/SeverityCountLabels';
-import CvssTd from '../WorkloadCves/components/CvssTd';
-import DateDistanceTd from '../WorkloadCves/components/DatePhraseTd';
+import RequestCVEsTable from './components/RequestCVEsTable';
+import TableErrorComponent from '../WorkloadCves/components/TableErrorComponent';
 
 import './ExceptionRequestDetailsPage.css';
 
 function getSubtitleText(exception: VulnerabilityException) {
-    switch (exception.exceptionStatus) {
+    const numCVEs = `${pluralize(exception.cves.length, 'CVE')}`;
+    switch (exception.status) {
         case 'PENDING':
-            return 'Pending';
+            return `Pending (${numCVEs})`;
         case 'DENIED':
-            return `Denied (${exception.cves.length} CVEs)`;
+            return `Denied (${numCVEs})`;
         case 'APPROVED':
-            return `Approved (${exception.cves.length} CVEs)`;
+            return `Approved (${numCVEs})`;
         case 'APPROVED_PENDING_UPDATE':
-            return `Approved pending update (${exception.cves.length} CVEs)`;
+            return `Approved pending update (${numCVEs})`;
         default:
-            return ensureExhaustive(exception.exceptionStatus);
+            return ensureExhaustive(exception.status);
     }
 }
 
 function ExceptionRequestDetailsPage() {
-    const { requestId } = useParams();
     const expandedRowSet = useSet<string>();
-
-    const vulnerabilityException = vulnerabilityExceptions.find(
-        (exception) => exception.id === requestId
+    const { requestId } = useParams();
+    const vulnerabilityExceptionByIdFn = useCallback(
+        () => fetchVulnerabilityExceptionById(requestId),
+        [requestId]
     );
+    const {
+        data: vulnerabilityException,
+        loading,
+        error,
+    } = useRestQuery(vulnerabilityExceptionByIdFn);
+
+    if (loading && !vulnerabilityException) {
+        return (
+            <Bullseye>
+                <Spinner isSVG />
+            </Bullseye>
+        );
+    }
+
+    if (error) {
+        return (
+            <PageSection variant="light">
+                <TableErrorComponent
+                    error={error}
+                    message="An error occurred. Try refreshing again"
+                />
+            </PageSection>
+        );
+    }
 
     if (!vulnerabilityException) {
         return (
@@ -90,7 +104,7 @@ function ExceptionRequestDetailsPage() {
         vulnerabilityException.comments[vulnerabilityException.comments.length - 1];
 
     // @TODO: Will need to figure out a good way to distinguish the original request cves from the updated one
-    const { cves } = vulnerabilityException;
+    const { cves, scope } = vulnerabilityException;
 
     return (
         <>
@@ -185,125 +199,8 @@ function ExceptionRequestDetailsPage() {
                 </PageSection>
             </PageSection>
             <PageSection>
-                <PageSection variant="light">
-                    <Flex direction={{ default: 'column' }}>
-                        <Title headingLevel="h2">{cves.length} results found</Title>
-                        <TableComposable variant="compact">
-                            <Thead noWrap>
-                                <Tr>
-                                    <Td />
-                                    <Th>CVE</Th>
-                                    <Th>Images by severity</Th>
-                                    <Th>CVSS</Th>
-                                    <Th>Affected images</Th>
-                                    <Th>First discovered</Th>
-                                </Tr>
-                            </Thead>
-                            {cves.length === 0 && (
-                                <Tbody>
-                                    <Tr>
-                                        <Td colSpan={6}>
-                                            <Bullseye>
-                                                <EmptyStateTemplate
-                                                    title="No results found"
-                                                    headingLevel="h2"
-                                                    icon={SearchIcon}
-                                                />
-                                            </Bullseye>
-                                        </Td>
-                                    </Tr>
-                                </Tbody>
-                            )}
-                            {cves.length !== 0 &&
-                                cves.map((cve, rowIndex) => {
-                                    const isExpanded = expandedRowSet.has(cve);
-
-                                    // @TODO: Use real data later
-                                    const criticalCount = 4;
-                                    const importantCount = 3;
-                                    const moderateCount = 4;
-                                    const lowCount = 0;
-                                    const filteredSeverities: VulnerabilitySeverityLabel[] = [
-                                        'Critical',
-                                        'Important',
-                                        'Moderate',
-                                        'Low',
-                                    ];
-                                    const scoreVersions = ['V3'];
-                                    const affectedImageCount = 5;
-                                    const firstDiscoveredInSystem = '2023-11-06T15:40:06.988717Z';
-
-                                    return (
-                                        <Tbody key={cve}>
-                                            <Tr>
-                                                <Td
-                                                    expand={{
-                                                        rowIndex,
-                                                        isExpanded,
-                                                        onToggle: () => expandedRowSet.toggle(cve),
-                                                    }}
-                                                />
-                                                <Td>
-                                                    <Link to={getEntityPagePath('CVE', cve)}>
-                                                        {cve}
-                                                    </Link>
-                                                </Td>
-                                                <Td>
-                                                    <SeverityCountLabels
-                                                        criticalCount={criticalCount}
-                                                        importantCount={importantCount}
-                                                        moderateCount={moderateCount}
-                                                        lowCount={lowCount}
-                                                        filteredSeverities={filteredSeverities}
-                                                    />
-                                                </Td>
-                                                <Td>
-                                                    <CvssTd
-                                                        cvss={10}
-                                                        scoreVersion={
-                                                            scoreVersions.length > 0
-                                                                ? scoreVersions.join('/')
-                                                                : undefined
-                                                        }
-                                                    />
-                                                </Td>
-                                                <Td>{`${affectedImageCount} ${pluralize(
-                                                    'image',
-                                                    affectedImageCount
-                                                )}`}</Td>
-                                                <Td>
-                                                    <DateDistanceTd
-                                                        date={firstDiscoveredInSystem}
-                                                    />
-                                                </Td>
-                                            </Tr>
-                                            <Tr isExpanded={isExpanded}>
-                                                <Td />
-                                                <Td colSpan={5}>
-                                                    <ExpandableRowContent>
-                                                        <Text>
-                                                            Contrary to popular belief, Lorem Ipsum
-                                                            is not simply random text. It has roots
-                                                            in a piece of classical Latin literature
-                                                            from 45 BC, making it over 2000 years
-                                                            old. Richard McClintock, a Latin
-                                                            professor at Hampden-Sydney College in
-                                                            Virginia, looked up one of the more
-                                                            obscure Latin words, consectetur, from a
-                                                            Lorem Ipsum passage, and going through
-                                                            the cites of the word in classical
-                                                            literature, discovered the undoubtable
-                                                            source.
-                                                        </Text>
-                                                    </ExpandableRowContent>
-                                                </Td>
-                                            </Tr>
-                                        </Tbody>
-                                    );
-                                })}
-                        </TableComposable>
-                    </Flex>
-                </PageSection>
+                {/* @TODO: Consider reusability with the Workload CVEs CVE table */}
+                <RequestCVEsTable cves={cves} scope={scope} expandedRowSet={expandedRowSet} />
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.test.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.test.tsx
@@ -11,12 +11,13 @@ import {
 const baseException: BaseVulnerabilityException = {
     id: '4837bb34-5357-4b78-ad2b-188fc0b33e78',
     name: '4837bb34-5357-4b78-ad2b-188fc0b33e78',
-    exceptionStatus: 'APPROVED_PENDING_UPDATE',
+    status: 'APPROVED_PENDING_UPDATE',
     expired: false,
     requester: {
         id: 'sso:4df1b98c-24ed-4073-a9ad-356aec6bb62d:admin',
         name: 'admin',
     },
+    approvers: [],
     createdAt: '2023-10-01T19:16:49.155480945Z',
     lastUpdated: '2023-10-01T19:16:49.155480945Z',
     comments: [
@@ -46,7 +47,7 @@ describe('ExceptionRequestTableCells', () => {
             const vulnerabilityException: VulnerabilityException = {
                 ...baseException,
                 targetState: 'DEFERRED',
-                exceptionStatus: 'PENDING',
+                status: 'PENDING',
                 deferralRequest: {
                     expiry: {
                         expiryType: 'ALL_CVE_FIXABLE',
@@ -69,7 +70,7 @@ describe('ExceptionRequestTableCells', () => {
             const vulnerabilityException: VulnerabilityException = {
                 ...baseException,
                 targetState: 'DEFERRED',
-                exceptionStatus: 'APPROVED',
+                status: 'APPROVED',
                 deferralRequest: {
                     expiry: {
                         expiryType: 'ALL_CVE_FIXABLE',
@@ -90,7 +91,7 @@ describe('ExceptionRequestTableCells', () => {
             const vulnerabilityException: VulnerabilityException = {
                 ...baseException,
                 targetState: 'DEFERRED',
-                exceptionStatus: 'APPROVED_PENDING_UPDATE',
+                status: 'APPROVED_PENDING_UPDATE',
                 deferralRequest: {
                     expiry: {
                         expiryType: 'ALL_CVE_FIXABLE',
@@ -118,7 +119,7 @@ describe('ExceptionRequestTableCells', () => {
             const vulnerabilityException: VulnerabilityException = {
                 ...baseException,
                 targetState: 'DEFERRED',
-                exceptionStatus: 'APPROVED_PENDING_UPDATE',
+                status: 'APPROVED_PENDING_UPDATE',
                 deferralRequest: {
                     expiry: {
                         expiryType: 'ALL_CVE_FIXABLE',
@@ -148,7 +149,7 @@ describe('ExceptionRequestTableCells', () => {
             const vulnerabilityException: VulnerabilityException = {
                 ...baseException,
                 targetState: 'FALSE_POSITIVE',
-                exceptionStatus: 'PENDING',
+                status: 'PENDING',
                 falsePositiveRequest: {},
             };
             const context: RequestContext = 'PENDING_REQUESTS';
@@ -162,7 +163,7 @@ describe('ExceptionRequestTableCells', () => {
             const vulnerabilityException: VulnerabilityException = {
                 ...baseException,
                 targetState: 'DEFERRED',
-                exceptionStatus: 'PENDING',
+                status: 'PENDING',
                 deferralRequest: {
                     expiry: {
                         expiryType: 'ALL_CVE_FIXABLE',
@@ -180,7 +181,7 @@ describe('ExceptionRequestTableCells', () => {
             const vulnerabilityException: VulnerabilityException = {
                 ...baseException,
                 targetState: 'DEFERRED',
-                exceptionStatus: 'PENDING',
+                status: 'PENDING',
                 deferralRequest: {
                     expiry: {
                         expiryType: 'ANY_CVE_FIXABLE',
@@ -198,7 +199,7 @@ describe('ExceptionRequestTableCells', () => {
             const vulnerabilityException: VulnerabilityException = {
                 ...baseException,
                 targetState: 'DEFERRED',
-                exceptionStatus: 'PENDING',
+                status: 'PENDING',
                 deferralRequest: {
                     expiry: {
                         expiryType: 'TIME',
@@ -217,7 +218,7 @@ describe('ExceptionRequestTableCells', () => {
             const vulnerabilityException: VulnerabilityException = {
                 ...baseException,
                 targetState: 'DEFERRED',
-                exceptionStatus: 'PENDING',
+                status: 'PENDING',
                 deferralRequest: {
                     expiry: {
                         expiryType: 'TIME',
@@ -236,7 +237,7 @@ describe('ExceptionRequestTableCells', () => {
             const vulnerabilityException: VulnerabilityException = {
                 ...baseException,
                 targetState: 'DEFERRED',
-                exceptionStatus: 'APPROVED_PENDING_UPDATE',
+                status: 'APPROVED_PENDING_UPDATE',
                 deferralRequest: {
                     expiry: {
                         expiryType: 'TIME',
@@ -262,7 +263,7 @@ describe('ExceptionRequestTableCells', () => {
             const vulnerabilityException: VulnerabilityException = {
                 ...baseException,
                 targetState: 'DEFERRED',
-                exceptionStatus: 'APPROVED_PENDING_UPDATE',
+                status: 'APPROVED_PENDING_UPDATE',
                 deferralRequest: {
                     expiry: {
                         expiryType: 'TIME',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
@@ -42,7 +42,7 @@ export function getShouldUseUpdatedRequest(
     exception: VulnerabilityException,
     context: RequestContext
 ): boolean {
-    switch (exception.exceptionStatus) {
+    switch (exception.status) {
         case 'APPROVED_PENDING_UPDATE':
             if (context === 'PENDING_REQUESTS') {
                 if (isDeferralException(exception) && exception.deferralUpdate) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -1,0 +1,253 @@
+import React from 'react';
+import { Bullseye, Flex, PageSection, Spinner, Text, Title } from '@patternfly/react-core';
+import {
+    ExpandableRowContent,
+    TableComposable,
+    Tbody,
+    Td,
+    Th,
+    Thead,
+    Tr,
+} from '@patternfly/react-table';
+import { SearchIcon } from '@patternfly/react-icons';
+import { useQuery } from '@apollo/client';
+import { Link } from 'react-router-dom';
+import pluralize from 'pluralize';
+import omitBy from 'lodash/omitBy';
+
+import { getEntityPagePath } from 'Containers/Vulnerabilities/WorkloadCves/searchUtils';
+import { VulnerabilitySeverityLabel } from 'Containers/Vulnerabilities/WorkloadCves/types';
+import {
+    CVEListQueryResult,
+    cveListQuery,
+} from 'Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable';
+import { SetResult } from 'hooks/useSet';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSort from 'hooks/useURLSort';
+import {
+    CVEsDefaultSort,
+    aggregateByCVSS,
+    aggregateByCreatedTime,
+    aggregateByImageSha,
+    defaultCVESortFields,
+    getScoreVersionsForTopCVSS,
+    sortCveDistroList,
+} from 'Containers/Vulnerabilities/WorkloadCves/sortUtils';
+import { VulnerabilityExceptionScope } from 'services/VulnerabilityExceptionService';
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+// @TODO: Move these files up to a common directory and move the types used in these files as well
+import TableErrorComponent from 'Containers/Vulnerabilities/WorkloadCves/components/TableErrorComponent';
+import SeverityCountLabels from '../../WorkloadCves/components/SeverityCountLabels';
+import CvssTd from '../../WorkloadCves/components/CvssTd';
+import DateDistanceTd from '../../WorkloadCves/components/DatePhraseTd';
+
+type RequestCVEsTableProps = {
+    cves: string[];
+    scope: VulnerabilityExceptionScope;
+    expandedRowSet: SetResult<string>;
+};
+
+function getImageScope(scope: VulnerabilityExceptionScope): string {
+    if (
+        scope.imageScope.registry === '.*' &&
+        scope.imageScope.remote === '.*' &&
+        scope.imageScope.tag === '.*'
+    ) {
+        return '';
+    }
+    if (scope.imageScope.tag === '.*') {
+        return `${scope.imageScope.registry}/${scope.imageScope.remote}`;
+    }
+    return `${scope.imageScope.registry}/${scope.imageScope.remote}:${scope.imageScope.tag}`;
+}
+
+function RequestCVEsTable({ cves, scope, expandedRowSet }: RequestCVEsTableProps) {
+    const { page, perPage, setPage } = useURLPagination(20);
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields: defaultCVESortFields,
+        defaultSortOption: CVEsDefaultSort,
+        onSort: () => setPage(1),
+    });
+
+    const queryObject = {
+        CVE: cves.join(','),
+        Image: getImageScope(scope),
+    };
+
+    const query = getRequestQueryStringForSearchFilter(queryObject);
+
+    const { error, loading, data } = useQuery<CVEListQueryResult>(cveListQuery, {
+        variables: {
+            query,
+            pagination: {
+                offset: (page - 1) * perPage,
+                limit: perPage,
+                sortOption,
+            },
+        },
+    });
+
+    if (loading && !data) {
+        return (
+            <Bullseye>
+                <Spinner isSVG />
+            </Bullseye>
+        );
+    }
+
+    if (error) {
+        return (
+            <PageSection variant="light">
+                <TableErrorComponent
+                    error={error}
+                    message="An error occurred. Try refreshing again"
+                />
+            </PageSection>
+        );
+    }
+
+    return (
+        <PageSection variant="light">
+            <Flex direction={{ default: 'column' }}>
+                <Title headingLevel="h2">{data?.imageCVEs.length || 0} results found</Title>
+                <TableComposable variant="compact">
+                    <Thead noWrap>
+                        <Tr>
+                            <Td />
+                            <Th sort={getSortParams('CVE')}>CVE</Th>
+                            <Th>Images by severity</Th>
+                            <Th sort={getSortParams('CVSS', aggregateByCVSS)}>CVSS</Th>
+                            <Th sort={getSortParams('Image sha', aggregateByImageSha)}>
+                                Affected images
+                            </Th>
+                            <Th sort={getSortParams('CVE Created Time', aggregateByCreatedTime)}>
+                                First discovered
+                            </Th>
+                        </Tr>
+                    </Thead>
+                    {data?.imageCVEs.length === 0 && (
+                        <Tbody>
+                            <Tr>
+                                <Td colSpan={6}>
+                                    <Bullseye>
+                                        <EmptyStateTemplate
+                                            title="No results found"
+                                            headingLevel="h2"
+                                            icon={SearchIcon}
+                                        />
+                                    </Bullseye>
+                                </Td>
+                            </Tr>
+                        </Tbody>
+                    )}
+                    {data?.imageCVEs.length !== 0 &&
+                        data?.imageCVEs.map(
+                            (
+                                {
+                                    cve,
+                                    affectedImageCountBySeverity,
+                                    topCVSS,
+                                    affectedImageCount,
+                                    firstDiscoveredInSystem,
+                                    distroTuples,
+                                },
+                                rowIndex
+                            ) => {
+                                const isExpanded = expandedRowSet.has(cve);
+
+                                const criticalCount = affectedImageCountBySeverity.critical.total;
+                                const importantCount = affectedImageCountBySeverity.important.total;
+                                const moderateCount = affectedImageCountBySeverity.moderate.total;
+                                const lowCount = affectedImageCountBySeverity.low.total;
+                                const filteredSeverities: VulnerabilitySeverityLabel[] = [
+                                    'Critical',
+                                    'Important',
+                                    'Moderate',
+                                    'Low',
+                                ];
+                                const prioritizedDistros = sortCveDistroList(distroTuples);
+                                const scoreVersions = getScoreVersionsForTopCVSS(
+                                    topCVSS,
+                                    distroTuples
+                                );
+                                const summary =
+                                    prioritizedDistros.length > 0
+                                        ? prioritizedDistros[0].summary
+                                        : '';
+
+                                const cveURLQueryOptions = {
+                                    s: {
+                                        IMAGE: queryObject.Image,
+                                    },
+                                    vulnerabilityState: 'DEFERRED',
+                                };
+                                // @TODO: This needs to be tested more thoroughly. Once the deferred tab shows the correct data, we should add a test for this
+                                const cveURL = getEntityPagePath(
+                                    'CVE',
+                                    cve,
+                                    omitBy(cveURLQueryOptions, (value) => value === '')
+                                );
+
+                                return (
+                                    <Tbody key={cve}>
+                                        <Tr>
+                                            <Td
+                                                expand={{
+                                                    rowIndex,
+                                                    isExpanded,
+                                                    onToggle: () => expandedRowSet.toggle(cve),
+                                                }}
+                                            />
+                                            <Td>
+                                                <Link to={cveURL}>{cve}</Link>
+                                            </Td>
+                                            <Td>
+                                                <SeverityCountLabels
+                                                    criticalCount={criticalCount}
+                                                    importantCount={importantCount}
+                                                    moderateCount={moderateCount}
+                                                    lowCount={lowCount}
+                                                    filteredSeverities={filteredSeverities}
+                                                />
+                                            </Td>
+                                            <Td>
+                                                <CvssTd
+                                                    cvss={topCVSS}
+                                                    scoreVersion={
+                                                        scoreVersions.length > 0
+                                                            ? scoreVersions.join('/')
+                                                            : undefined
+                                                    }
+                                                />
+                                            </Td>
+                                            <Td>{`${affectedImageCount} ${pluralize(
+                                                'image',
+                                                affectedImageCount
+                                            )}`}</Td>
+                                            <Td>
+                                                <DateDistanceTd date={firstDiscoveredInSystem} />
+                                            </Td>
+                                        </Tr>
+                                        <Tr isExpanded={isExpanded}>
+                                            <Td />
+                                            <Td colSpan={5}>
+                                                <ExpandableRowContent>
+                                                    {prioritizedDistros.length > 0 && (
+                                                        <Text>{summary}</Text>
+                                                    )}
+                                                </ExpandableRowContent>
+                                            </Td>
+                                        </Tr>
+                                    </Tbody>
+                                );
+                            }
+                        )}
+                </TableComposable>
+            </Flex>
+        </PageSection>
+    );
+}
+
+export default RequestCVEsTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/mockUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/mockUtils.ts
@@ -2,15 +2,16 @@ import { VulnerabilityException } from 'services/VulnerabilityExceptionService';
 
 export const vulnerabilityExceptions: VulnerabilityException[] = [
     {
-        id: '4837bb34-5357-4b78-ad2b-188fc0b33e78',
-        name: '4837bb34-5357-4b78-ad2b-188fc0b33e78',
+        id: 'ecf6b94a-d857-4e69-b50f-cda1cdf002ef',
+        name: 'ecf6b94a-d857-4e69-b50f-cda1cdf002ef',
         targetState: 'DEFERRED',
-        exceptionStatus: 'APPROVED_PENDING_UPDATE',
+        status: 'APPROVED_PENDING_UPDATE',
         expired: false,
         requester: {
             id: 'sso:4df1b98c-24ed-4073-a9ad-356aec6bb62d:admin',
             name: 'admin',
         },
+        approvers: [],
         createdAt: '2023-10-01T19:16:49.155480945Z',
         lastUpdated: '2023-10-01T19:16:49.155480945Z',
         comments: [
@@ -43,18 +44,19 @@ export const vulnerabilityExceptions: VulnerabilityException[] = [
                 expiresOn: '2023-10-31T19:16:49.155480945Z',
             },
         },
-        cves: ['CVE-2018-20839', 'CVE-2018-20840'],
+        cves: ['CVE-2018-20839', 'RHSA-2023:5997'],
     },
     {
         id: '5837bb34-5357-4b78-ad2b-188fc0b33e78',
         name: '5837bb34-5357-4b78-ad2b-188fc0b33e78',
         targetState: 'FALSE_POSITIVE',
-        exceptionStatus: 'APPROVED_PENDING_UPDATE',
+        status: 'APPROVED_PENDING_UPDATE',
         expired: false,
         requester: {
             id: 'sso:4df1b98c-24ed-4073-a9ad-356aec6bb62d:admin',
             name: 'admin',
         },
+        approvers: [],
         createdAt: '2023-10-01T19:16:49.155480945Z',
         lastUpdated: '2023-10-01T19:16:49.155480945Z',
         comments: [
@@ -85,12 +87,13 @@ export const vulnerabilityExceptions: VulnerabilityException[] = [
         id: '6837bb34-5357-4b78-ad2b-188fc0b33e78',
         name: '6837bb34-5357-4b78-ad2b-188fc0b33e78',
         targetState: 'DEFERRED',
-        exceptionStatus: 'DENIED',
+        status: 'DENIED',
         expired: false,
         requester: {
             id: 'sso:4df1b98c-24ed-4073-a9ad-356aec6bb62d:admin',
             name: 'admin',
         },
+        approvers: [],
         createdAt: '2023-10-01T19:16:49.155480945Z',
         lastUpdated: '2023-10-01T19:16:49.155480945Z',
         comments: [
@@ -122,12 +125,13 @@ export const vulnerabilityExceptions: VulnerabilityException[] = [
         id: '7837bb34-5357-4b78-ad2b-188fc0b33e78',
         name: '7837bb34-5357-4b78-ad2b-188fc0b33e78',
         targetState: 'FALSE_POSITIVE',
-        exceptionStatus: 'DENIED',
+        status: 'DENIED',
         expired: false,
         requester: {
             id: 'sso:4df1b98c-24ed-4073-a9ad-356aec6bb62d:admin',
             name: 'admin',
         },
+        approvers: [],
         createdAt: '2023-10-01T19:16:49.155480945Z',
         lastUpdated: '2023-10-01T19:16:49.155480945Z',
         comments: [
@@ -154,25 +158,21 @@ export const vulnerabilityExceptions: VulnerabilityException[] = [
 ];
 
 export const pendingRequests = vulnerabilityExceptions.filter(
-    (exception) =>
-        exception.exceptionStatus === 'PENDING' ||
-        exception.exceptionStatus === 'APPROVED_PENDING_UPDATE'
+    (exception) => exception.status === 'PENDING' || exception.status === 'APPROVED_PENDING_UPDATE'
 );
 
 export const approvedDeferrals = vulnerabilityExceptions.filter(
     (exception) =>
         exception.targetState === 'DEFERRED' &&
-        (exception.exceptionStatus === 'APPROVED' ||
-            exception.exceptionStatus === 'APPROVED_PENDING_UPDATE')
+        (exception.status === 'APPROVED' || exception.status === 'APPROVED_PENDING_UPDATE')
 );
 
 export const approvedFalsePositives = vulnerabilityExceptions.filter(
     (exception) =>
         exception.targetState === 'FALSE_POSITIVE' &&
-        (exception.exceptionStatus === 'APPROVED' ||
-            exception.exceptionStatus === 'APPROVED_PENDING_UPDATE')
+        (exception.status === 'APPROVED' || exception.status === 'APPROVED_PENDING_UPDATE')
 );
 
 export const deniedRequests = vulnerabilityExceptions.filter(
-    (exception) => exception.exceptionStatus === 'DENIED'
+    (exception) => exception.status === 'DENIED'
 );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -76,6 +76,10 @@ export const unfilteredImageCountQuery = gql`
     }
 `;
 
+export type CVEListQueryResult = {
+    imageCVEs: ImageCVE[];
+};
+
 type ImageCVE = {
     cve: string;
     affectedImageCountBySeverity: {

--- a/ui/apps/platform/src/hooks/useSet.ts
+++ b/ui/apps/platform/src/hooks/useSet.ts
@@ -1,12 +1,21 @@
 import { useState } from 'react';
 
+export type SetResult<T> = {
+    has: (key: T) => boolean;
+    toggle: (key: T, isOn?: boolean) => void;
+    clear: () => void;
+    size: number;
+    asArray: () => void;
+};
+
 /**
  * Hook that wraps a native `Set` for easier immutable usage as React component state
  *
  * Note that the API is intentionally limited - we should add more `Set` methods as use
  * cases require them.
  */
-export default function useSet<T>(initialSet: Set<T> = new Set()) {
+
+export default function useSet<T>(initialSet: Set<T> = new Set()): SetResult<T> {
     const [itemSet, setItemSet] = useState(initialSet);
 
     function has(key: T): boolean {

--- a/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
+++ b/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
@@ -39,9 +39,10 @@ export type ExceptionExpiry =
 export type BaseVulnerabilityException = {
     id: string;
     name: string;
-    exceptionStatus: ExceptionStatus;
+    status: ExceptionStatus;
     expired: boolean;
     requester: SlimUser;
+    approvers: SlimUser[];
     createdAt: string; // ISO 8601
     lastUpdated: string; // ISO 8601
     comments: Comment[];
@@ -84,10 +85,10 @@ export type VulnerabilityException =
     | VulnerabilityDeferralException
     | VulnerabilityFalsePositiveException;
 
-export function getVulnerabilityExceptionById(id: string): Promise<BaseVulnerabilityException> {
+export function fetchVulnerabilityExceptionById(id: string): Promise<VulnerabilityException> {
     const url = generatePath(`${baseUrl}/:id`, { id });
     return axios
-        .get<{ exception: BaseVulnerabilityException }>(url)
+        .get<{ exception: VulnerabilityException }>(url)
         .then((response) => response.data.exception);
 }
 


### PR DESCRIPTION
## Description

This PR adds real data for the Request Details page.

Note: When you click on the CVE link in the bottom table, it will navigate you to the CVE single page in the Workload CVEs section. I pass the appropriate URL query params, but the data won't show yet. Also, seems like the autocomplete filter doesn't really work well with a string that doesn't include the full registry, remote, and tag 😢. We might need to tweak that component a bit

## Screeshots

<img width="1552" alt="Screenshot 2023-11-08 at 5 55 07 PM" src="https://github.com/stackrox/stackrox/assets/4805485/ea6a8ca7-1e8c-4071-b2aa-f25ac569ae12">


## Screen Recordings

Defer a CVE with a scope that ranges across all images and deployments
https://github.com/stackrox/stackrox/assets/4805485/e57523bd-e5c1-4e52-af9c-24fd97b394ba

Defer a CVE with a scope for one specific image but across all tags
https://github.com/stackrox/stackrox/assets/4805485/d0560232-61a3-49af-bc8f-01acec456a8c

Defer a CVE with a scope for one specific image with one specific tag
https://github.com/stackrox/stackrox/assets/4805485/e7334f38-20f5-4d8f-abaa-3183738d5550

Defer multiple CVEs
https://github.com/stackrox/stackrox/assets/4805485/29c653a7-aa2f-4f5e-b8e0-c43f62815dfb



