### PR TITLE
ROX-20681: Bump CSV install timeout.

### DIFF
--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -152,7 +152,7 @@ function nurse_deployment_until_available() {
   # the _old_ .spec until the deployment controller runs the first reconciliation.
   # We use kuttl because CSV has a Condition type incompatible with `kubectl wait`.
   log "Waiting for the ${version_tag} CSV to finish installing."
-  "${KUTTL}" assert --timeout 300 --namespace "${operator_ns}" /dev/stdin <<-END
+  "${KUTTL}" assert --timeout 600 --namespace "${operator_ns}" /dev/stdin <<-END
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:


### PR DESCRIPTION
## Description

PR #8214 bumped the upgrade step timeout, which helped a lot with failures like ROX-17348 due to recent OLM versions (on OCP 4.14) taking longer to install.

However, inside the upgrade script ran by the upgrade step there is this additional 5m timeout for CSV upgrade, which apparently should have been bumped too. This change doubles it.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
