### PR TITLE
fix(gha): split go mod and build cache

### DIFF
--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -15,7 +15,15 @@ runs:
       with:
         path: |
           ${{ steps.cache-paths.outputs.GOMODCACHE }}
+        key: go-mod-v1-${{ hashFiles('**/go.sum') }}
+
+    - name: Cache Go Build
+      uses: actions/cache@v3
+      with:
+        path: |
           ${{ steps.cache-paths.outputs.GOCACHE }}
-        key: go-v3-${{ github.job }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          go-v3-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+        key: go-build-v1-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+
+    - name: Download Go modules
+      run: make deps --always-make
+      shell: bash

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -115,6 +115,9 @@ jobs:
 
     - uses: ./.github/actions/job-preamble
 
+    - name: Cache Go dependencies
+      uses: ./.github/actions/cache-go-dependencies
+
     - name: Check Cache golangci-lint
       run: make golangci-lint-cache-status
 

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ clean-proto-generated-srcs:
 .PHONY: generated-srcs
 generated-srcs: go-generated-srcs
 
-deps: $(BASE_DIR)/go.sum tools/linters/go.sum tools/test/go.sum
+deps: $(shell find $(BASE_DIR) -name "go.sum")
 	@echo "+ $@"
 	$(SILENT)touch deps
 
@@ -319,6 +319,7 @@ ifdef CI
 	$(SILENT)git diff --exit-code -- go.mod go.sum || { echo "go.mod/go.sum files were updated after running 'go mod tidy', run this command on your local machine and commit the results." ; exit 1 ; }
 	go mod verify
 endif
+	$(SILENT)go mod download
 	$(SILENT)touch $@
 
 .PHONY: clean-deps


### PR DESCRIPTION
## Description

Currently in go cache we keep both modules and build artifacts. This PR splits this cache into two 
1. GOMODCACHE
2. GOBUILDCACHE

This separation will allow us to keep a single go mod cache for every job (this requires downloading always all modules) but as we usually do it anyway it's not a big problem. Having a single cache key will limit amount of used cache space and increase cache lifespan.

Refs:
- https://github.com/stackrox/stackrox/pull/8494
- https://github.com/stackrox/stackrox/pull/8495

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
