### PR TITLE
ROX-19357: Add pending exception label to workload cve tables

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -62,7 +62,12 @@ const imageVulnerabilitiesQuery = gql`
     ${imageMetadataContextFragment}
     ${resourceCountByCveSeverityAndStatusFragment}
     ${imageVulnerabilitiesFragment}
-    query getCVEsForImage($id: ID!, $query: String!, $pagination: Pagination!) {
+    query getCVEsForImage(
+        $id: ID!
+        $query: String!
+        $pagination: Pagination!
+        $statusesForExceptionCount: [String!]
+    ) {
         image(id: $id) {
             ...ImageMetadataContext
             imageCVECountBySeverity(query: $query) {
@@ -123,12 +128,17 @@ function ImagePageVulnerabilities({ imageId, imageName }: ImagePageVulnerabiliti
             id: string;
             query: string;
             pagination: PaginationParam;
+            statusesForExceptionCount: string[];
         }
     >(imageVulnerabilitiesQuery, {
         variables: {
             id: imageId,
             query: getVulnStateScopedQueryString(querySearchFilter, currentVulnerabilityState),
             pagination,
+            statusesForExceptionCount:
+                currentVulnerabilityState === 'OBSERVED'
+                    ? ['PENDING']
+                    : ['APPROVED_PENDING_UPDATE'],
         },
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -101,7 +101,11 @@ export const imageCveSummaryQuery = gql`
 export const imageCveAffectedImagesQuery = gql`
     ${imagesForCveFragment}
     # by default, query must include the CVE id
-    query getImagesForCVE($query: String, $pagination: Pagination) {
+    query getImagesForCVE(
+        $query: String
+        $pagination: Pagination
+        $statusesForExceptionCount: [String!]
+    ) {
         images(query: $query, pagination: $pagination) {
             ...ImagesForCVE
         }
@@ -118,6 +122,7 @@ export const imageCveAffectedDeploymentsQuery = gql`
         $moderateImageCountQuery: String
         $importantImageCountQuery: String
         $criticalImageCountQuery: String
+        $statusesForExceptionCount: [String!]
     ) {
         deployments(query: $query, pagination: $pagination) {
             ...DeploymentsForCVE
@@ -431,6 +436,8 @@ function ImageCvePage() {
                                                 images={imageData?.images ?? []}
                                                 getSortParams={getSortParams}
                                                 isFiltered={isFiltered}
+                                                cve={cveId}
+                                                vulnerabilityState={currentVulnerabilityState}
                                             />
                                         )}
                                         {entityTab === 'Deployment' && (
@@ -441,6 +448,8 @@ function ImageCvePage() {
                                                 filteredSeverities={
                                                     searchFilter.Severity as VulnerabilitySeverityLabel[]
                                                 }
+                                                cve={cveId}
+                                                vulnerabilityState={currentVulnerabilityState}
                                             />
                                         )}
                                     </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -55,6 +55,8 @@ function CVEsTableContainer({
                 limit: perPage,
                 sortOption,
             },
+            statusesForExceptionCount:
+                vulnerabilityState === 'OBSERVED' ? ['PENDING'] : ['APPROVED_PENDING_UPDATE'],
         },
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -14,6 +14,7 @@ import { gql } from '@apollo/client';
 
 import useSet from 'hooks/useSet';
 import { UseURLSortResult } from 'hooks/useURLSort';
+import { VulnerabilityState } from 'types/cve.proto';
 import { getEntityPagePath } from '../searchUtils';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
 import EmptyTableResults from '../components/EmptyTableResults';
@@ -66,6 +67,8 @@ export type AffectedDeploymentsTableProps = {
     deployments: DeploymentForCve[];
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
+    cve: string;
+    vulnerabilityState: VulnerabilityState | undefined; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
     filteredSeverities?: VulnerabilitySeverityLabel[];
 };
 
@@ -73,6 +76,8 @@ function AffectedDeploymentsTable({
     deployments,
     getSortParams,
     isFiltered,
+    cve,
+    vulnerabilityState,
     filteredSeverities,
 }: AffectedDeploymentsTableProps) {
     const expandedRowSet = useSet<string>();
@@ -163,6 +168,8 @@ function AffectedDeploymentsTable({
                                 <ExpandableRowContent>
                                     <DeploymentComponentVulnerabilitiesTable
                                         images={imageComponentVulns}
+                                        cve={cve}
+                                        vulnerabilityState={vulnerabilityState}
                                     />
                                 </ExpandableRowContent>
                             </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -38,9 +38,14 @@ import { CveSelectionsProps } from '../components/ExceptionRequestModal/CveSelec
 import CVESelectionTh from '../components/CVESelectionTh';
 import CVESelectionTd from '../components/CVESelectionTd';
 import ExceptionDetailsCell from '../components/ExceptionDetailsCell';
+import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayout';
 
 export const cveListQuery = gql`
-    query getImageCVEList($query: String, $pagination: Pagination) {
+    query getImageCVEList(
+        $query: String
+        $pagination: Pagination
+        $statusesForExceptionCount: [String!]
+    ) {
         imageCVEs(query: $query, pagination: $pagination) {
             cve
             affectedImageCountBySeverity {
@@ -66,6 +71,7 @@ export const cveListQuery = gql`
                 cvss
                 scoreVersion
             }
+            pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
         }
     }
 `;
@@ -93,6 +99,7 @@ type ImageCVE = {
         cvss: number;
         scoreVersion: string;
     }[];
+    pendingExceptionCount: number;
 };
 
 export type CVEsTableProps = {
@@ -176,6 +183,7 @@ function CVEsTable({
                         affectedImageCount,
                         firstDiscoveredInSystem,
                         distroTuples,
+                        pendingExceptionCount,
                     },
                     rowIndex
                 ) => {
@@ -215,7 +223,13 @@ function CVEsTable({
                                     />
                                 )}
                                 <Td dataLabel="CVE">
-                                    <Link to={getEntityPagePath('CVE', cve)}>{cve}</Link>
+                                    <PendingExceptionLabelLayout
+                                        hasPendingException={pendingExceptionCount > 0}
+                                        cve={cve}
+                                        vulnerabilityState={vulnerabilityState}
+                                    >
+                                        <Link to={getEntityPagePath('CVE', cve)}>{cve}</Link>
+                                    </PendingExceptionLabelLayout>
                                 </Td>
                                 <Td dataLabel="Images by severity">
                                     <SeverityCountLabels

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -28,6 +28,7 @@ export const imageComponentVulnerabilitiesFragment = gql`
             vulnerabilityId: id
             severity
             fixedByVersion
+            pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
         }
     }
 `;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -37,6 +37,7 @@ import CVESelectionTh from '../components/CVESelectionTh';
 import CVESelectionTd from '../components/CVESelectionTd';
 import TooltipTh from '../components/TooltipTh';
 import ExceptionDetailsCell from '../components/ExceptionDetailsCell';
+import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayout';
 
 export const imageVulnerabilitiesFragment = gql`
     ${imageComponentVulnerabilitiesFragment}
@@ -47,6 +48,7 @@ export const imageVulnerabilitiesFragment = gql`
         cvss
         scoreVersion
         discoveredAtImage
+        pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
         imageComponents(query: $query) {
             ...ImageComponentVulnerabilities
         }
@@ -60,6 +62,7 @@ export type ImageVulnerability = {
     cvss: number;
     scoreVersion: string;
     discoveredAtImage: string | null;
+    pendingExceptionCount: number;
     imageComponents: ImageComponentVulnerability[];
 };
 
@@ -130,6 +133,7 @@ function ImageVulnerabilitiesTable({
                         scoreVersion,
                         imageComponents,
                         discoveredAtImage,
+                        pendingExceptionCount,
                     },
                     rowIndex
                 ) => {
@@ -155,7 +159,13 @@ function ImageVulnerabilitiesTable({
                                     />
                                 )}
                                 <Td dataLabel="CVE">
-                                    <Link to={getEntityPagePath('CVE', cve)}>{cve}</Link>
+                                    <PendingExceptionLabelLayout
+                                        hasPendingException={pendingExceptionCount > 0}
+                                        cve={cve}
+                                        vulnerabilityState={vulnerabilityState}
+                                    >
+                                        <Link to={getEntityPagePath('CVE', cve)}>{cve}</Link>
+                                    </PendingExceptionLabelLayout>
                                 </Td>
                                 <Td modifier="nowrap" dataLabel="CVE severity">
                                     {isVulnerabilitySeverity(severity) && (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -63,6 +63,7 @@ export type ComponentVulnerabilityBase = {
         vulnerabilityId: string;
         severity: string;
         fixedByVersion: string;
+        pendingExceptionCount: number;
     }[];
 };
 
@@ -79,6 +80,7 @@ export type DeploymentComponentVulnerability = Omit<
         scoreVersion: string;
         fixedByVersion: string;
         discoveredAtImage: string | null;
+        pendingExceptionCount: number;
     }[];
 };
 
@@ -103,6 +105,7 @@ export type TableDataRow = {
         instruction: string;
         value: string;
     } | null;
+    pendingExceptionCount: number;
 };
 
 /**
@@ -178,6 +181,7 @@ function extractCommonComponentFields(
             ? vulnerability.severity
             : 'UNKNOWN_VULNERABILITY_SEVERITY';
     const fixedByVersion = vulnerability?.fixedByVersion ?? 'N/A';
+    const pendingExceptionCount = vulnerability?.pendingExceptionCount ?? 0;
 
     return {
         name,
@@ -189,6 +193,7 @@ function extractCommonComponentFields(
         vulnerabilityId,
         severity,
         fixedByVersion,
+        pendingExceptionCount,
     };
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/PendingExceptionLabelLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/PendingExceptionLabelLayout.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Flex, FlexItem, Label } from '@patternfly/react-core';
+import { OutlinedClockIcon } from '@patternfly/react-icons';
+
+import { VulnerabilityState } from 'types/cve.proto';
+import { exceptionManagementPath } from 'routePaths';
+import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
+
+export type PendingExceptionLabelLayoutProps = {
+    children: React.ReactNode;
+    hasPendingException: boolean;
+    cve: string;
+    vulnerabilityState: VulnerabilityState | undefined; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
+};
+
+/**
+ * ‘Pending exception’ label layout for use in tables. Conditionally renders a label
+ * with a link to the exception request page if the vulnerability has a pending exception.
+ *
+ * @param children - The table cell contents to render before the label
+ * @param hasPendingException - Whether the vulnerability has a pending exception
+ * @param cve - The CVE ID of the vulnerability
+ * @param vulnerabilityState - The vulnerability state
+ */
+function PendingExceptionLabelLayout({
+    children,
+    hasPendingException,
+    cve,
+    vulnerabilityState,
+}: PendingExceptionLabelLayoutProps) {
+    const query = getUrlQueryStringForSearchFilter({ cve });
+    const url = `${exceptionManagementPath}/exceptions?${query}`;
+    return (
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXs' }}>
+            {children}
+            {hasPendingException && vulnerabilityState && (
+                <FlexItem>
+                    <Link to={url}>
+                        <Label
+                            color="blue"
+                            isCompact
+                            icon={<OutlinedClockIcon />}
+                            variant="outline"
+                        >
+                            {vulnerabilityState === 'OBSERVED'
+                                ? 'Pending exception'
+                                : 'Pending update'}
+                        </Label>
+                    </Link>
+                </FlexItem>
+            )}
+        </Flex>
+    );
+}
+
+export default PendingExceptionLabelLayout;


### PR DESCRIPTION
## Description

Adds a "Pending exception" label to CVEs, Images, and Deployment under "Observed" tabs when the entity has an open exception request that has not yet been approved.

Adds a "Pending update" label to CVEs, Images, and Deployments under "Deferred" (and theoretically "False Positive") tabs when the entity has an approved exception request with a new pending update.

Note: False positive requests currently cannot be updated, but if that is changed the labels will show up under that tab as well.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Defer a CVE via the Workload CVE Image page, only for a single image.

Visit the Workload CVE list page, the CVE shows up with a Pending label on the list page, the relevant image page, deployment page, and for affected images/deployments on that CVE's single page:
![image](https://github.com/stackrox/stackrox/assets/1292638/2737311a-a666-4d61-a54e-b2809250a756)
![image](https://github.com/stackrox/stackrox/assets/1292638/e82e46a7-ee8c-4008-ac05-346c7d96747e)
![image](https://github.com/stackrox/stackrox/assets/1292638/d0eb3eb6-2630-4948-9428-3a830b6389bd)
![image](https://github.com/stackrox/stackrox/assets/1292638/2ba98c29-13bd-47e8-bfa3-db698cfb2a67)
![image](https://github.com/stackrox/stackrox/assets/1292638/d246e189-6860-4b02-a3c3-fc3478789c3a)


Approve the exception request, then make an update request via VM 1.0 Risk Acceptance. The CVE will now show up with a Pending label on the Deferral tab of the previous pages:
![image](https://github.com/stackrox/stackrox/assets/1292638/e8338f28-8fc8-4696-b26c-b7c645baae2b)
![image](https://github.com/stackrox/stackrox/assets/1292638/951916e4-cae4-4d1f-ae7e-c33e8e846f05)
![image](https://github.com/stackrox/stackrox/assets/1292638/11e22e0b-0013-4ec0-a142-9768f8af6789)
![image](https://github.com/stackrox/stackrox/assets/1292638/cec6019f-af71-4a72-a8bc-75f9b80907fa)
![image](https://github.com/stackrox/stackrox/assets/1292638/a3f8693d-0e0d-4b3f-8535-a6aacc376c56)


