### PR TITLE
test(ui): Disable watched images e2e tests

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
@@ -11,7 +11,11 @@ import {
 } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 
-describe('Workload CVE watched images flow', () => {
+// TODO - dv 2023-11-8
+//  These tests are disabled due to usable images with CVEs not being available in the test environment
+//  at the time the tests are executed. This issue is being tracked in ROX-20728 and these tests
+// should be re-enabled or reworked once that issue is resolved.
+describe.skip('Workload CVE watched images flow', () => {
     withAuth();
 
     before(function () {


### PR DESCRIPTION
## Description

Disables the watched image tests pending resolution of https://issues.redhat.com/browse/ROX-20728

These tests cannot be fixed as-is reliably because:

1. The only images that are available during the CI run are under the `gke.gcr.io` registry, which rejects requests on the backend for most images during this flow.
2. Images under `quay.io` are not being scanned, or for some other reason are not showing up on the Workload CVE image list

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local + await CI