### PR TITLE
ROX-20731: Improve scale tests for listening endpoints

### DIFF
--- a/sensor/kubernetes/fake/flows.go
+++ b/sensor/kubernetes/fake/flows.go
@@ -174,7 +174,17 @@ func getNetworkProcessUniqueKeyFromProcess(process *storage.ProcessSignal) *stor
 }
 
 func getRandomOriginator(containerID string) *storage.NetworkProcessUniqueKey {
-	process := processPool.getRandomProcess(containerID)
+	var process *storage.ProcessSignal
+	var percentMatchedProcess float32 = 0.5
+	p := rand.Float32()
+	if p < percentMatchedProcess {
+		// There is a chance that the process has been filtered out or hasn't gotten to
+		// the central-db for some other reason so this is not a guarantee that the
+		// process is in the central-db
+		process = processPool.getRandomProcess(containerID)
+	} else {
+		process = getGoodProcess(containerID)
+	}
 
 	return getNetworkProcessUniqueKeyFromProcess(process)
 }
@@ -243,8 +253,8 @@ func (w *WorkloadManager) getFakeNetworkConnectionInfo(workload NetworkWorkload)
 		conns = append(conns, conn)
 		if endpointPool.Size < endpointPool.Capacity {
 			endpointPool.add(networkEndpoint)
-			networkEndpoints = append(networkEndpoints, networkEndpoint)
 		}
+		networkEndpoints = append(networkEndpoints, networkEndpoint)
 	}
 
 	for _, endpoint := range endpointPool.EndpointsToBeClosed {


### PR DESCRIPTION
## Description

Currently the number of open listening endpoints added by the fake workload generator in sensor is limited to endpointPool.Capacity, which is set to 10000. The main objective of this PR is to be able to add an arbitrarily large number of open listening endpoints to the central database using  the fake workload generator in sensor.

Another issue is that in production, many listening endpoints do not have an associated process indicator in the central database. However, in the fake data generated by sensor listening endpoints are always associated with process indicators. This PR makes it so that half of the listening endpoints generated by the fake load generator added to the central database are not associated with process indicators.

## Checklist
- [x] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

There are no unit tests for the fake load generator in sensor. There is no CHANEGELOG or documented user facing changes, as there are no changes that impact production. There is no impact to the upgrade steps.

## Testing Performed

### Here I tell how I validated my change

The following script was run to generate fake load

```
#!/usr/bin/env bash
set -eou pipefail

if [[ -z "$tag" ]]; then
	tag="$(make tag)"
fi
echo "tag= $tag"

printf 'yes\n' | /home/jvirtane/go/src/github.com/stackrox/workflow/scripts/runtime/teardown.sh

export USE_MIDSTREAM_IMAGES=false

export API_ENDPOINT=localhost:8000

export STORAGE=pvc # Backing storage
export STORAGE_CLASS=faster # Runs on an SSD type
export STORAGE_SIZE=100 # 100G
export MONITORING_SUPPORT=true # Runs monitoring
export LOAD_BALANCER=lb

./deploy/k8s/central.sh # Launches central

kubectl -n stackrox port-forward deploy/central 8000:8443 > /dev/null 2>&1 &

sleep 20

export ROX_ADMIN_USERNAME=admin

password="$(cat deploy/k8s/central-deploy/password)"

export ROX_ADMIN_PASSWORD="$password"

echo "########### Deploying sensor ###############"
./deploy/k8s/sensor.sh

kubectl -n stackrox set env deploy/sensor MUTEX_WATCHDOG_TIMEOUT_SEC=0
kubectl -n stackrox set env deploy/sensor ROX_FAKE_KUBERNETES_WORKLOAD=long-running

kubectl -n stackrox set env deploy/central MUTEX_WATCHDOG_TIMEOUT_SECS=0

echo "########### Launching workload ###############"
./scale/launch_workload.sh large-plop

```

The contents of `scale/workloads/large-plop.yaml` is

```
deploymentWorkload:
- deploymentType: Deployment
  lifecycleDuration: 72h
  numDeployments: 100
  numLifecycles: 0
  podWorkload:
    containerWorkload:
      numImages: 0
    lifecycleDuration: 72h
    numContainers: 3
    numPods: 2
    processWorkload:
      alertRate: 0.001
      processInterval: 1s
  updateInterval: 10m0s
networkWorkload:
  batchSize: 5000
  flowInterval: 30s
nodeWorkload:
  numNodes: 100
rbacWorkload:
  numBindings: 100
  numRoles: 100
  numServiceAccounts: 100
```

The central database was checked periodically

```
central_active=# select count(*) from listening_endpoints ;
 count 
-------
 19141
(1 row)

central_active=# select count(*) from listening_endpoints ;
 count 
-------
 24140
(1 row)

central_active=# select count(*) from listening_endpoints ;
 count 
-------
 49139
(1 row)
```

This shows that the number of listening endpoints is not limited to 10,000.

#### Short duration

The workload was changed to the following 
```
deploymentWorkload:
- deploymentType: Deployment
  lifecycleDuration: 72h
  numDeployments: 100
  numLifecycles: 0
  podWorkload:
    containerWorkload:
      numImages: 0
    lifecycleDuration: 5m
    numContainers: 3
    numPods: 2
    processWorkload:
      alertRate: 0.001
      processInterval: 1s
  updateInterval: 10m0s
networkWorkload:
  batchSize: 5000
  flowInterval: 30s
nodeWorkload:
  numNodes: 100
rbacWorkload:
  numBindings: 100
  numRoles: 100
  numServiceAccounts: 100
```

Note that the podWorkloadDuration was changed to 5m

The central database was monitored once a minute.

```
central_active=# select count(*) from listening_endpoints ;
 count 
-------
 34976
(1 row)

central_active=# select count(*) from listening_endpoints ;
 count 
-------
 44976
(1 row)

central_active=# select count(*) from listening_endpoints ;
 count 
-------
 54975
(1 row)

central_active=# select count(*) from listening_endpoints ;
 count 
-------
 18675
(1 row)

central_active=# select count(*) from listening_endpoints ;
 count 
-------
 28675
(1 row)

central_active=# select count(*) from listening_endpoints ;
 count 
-------
 38675
(1 row)

central_active=# select count(*) from listening_endpoints ;
 count 
-------
 48675
(1 row)

central_active=# select count(*) from listening_endpoints ;
 count 
-------
 58675
(1 row)

central_active=# select count(*) from listening_endpoints ;
 count 
-------
 21393
(1 row)

```

As pods are deleted the number of listening endpoints goes down.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
