### PR TITLE
fix(initbundle): cache init bundle meta calls

### DIFF
--- a/central/clusterinit/backend/backend.go
+++ b/central/clusterinit/backend/backend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/central/clusterinit/store"
 	"github.com/stackrox/rox/central/clusters"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/cache/storebased"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 )
 
@@ -44,5 +45,6 @@ func newBackend(store store.Store, certProvider certificate.Provider) Backend {
 	return &backendImpl{
 		store:        store,
 		certProvider: certProvider,
+		cache:        storebased.NewCache[*storage.InitBundleMeta](store.Get),
 	}
 }

--- a/pkg/cache/storebased/store.go
+++ b/pkg/cache/storebased/store.go
@@ -1,0 +1,54 @@
+package storebased
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/pkg/maputil"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+// GetObjectFunction is the datastore function which retrieves a specific object.
+type GetObjectFunction[T any] func(ctx context.Context, id string) (T, error)
+
+// NewCache returns a cache which is expected to be backed by a store (i.e. the GetObjectFunction is a call to the
+// database).
+// As underlying in-memory structure a maputil.FastRMap is used, hence it is only recommended to use this cache
+// in case of heavy read but sparse write operations.
+func NewCache[T any](refreshFn GetObjectFunction[T]) *Cache[T] {
+	return &Cache[T]{
+		cachedObjects: maputil.NewFastRMap[string, T](),
+		getObjectFn:   refreshFn,
+	}
+}
+
+// Cache represents a cache which is backed by a store.
+type Cache[T any] struct {
+	mutex         sync.Mutex
+	cachedObjects *maputil.FastRMap[string, T]
+	getObjectFn   GetObjectFunction[T]
+}
+
+// GetObject retrieves the given object either from cache or from the specified datastore function.
+func (s *Cache[T]) GetObject(ctx context.Context, id string) (T, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	obj, exists := s.cachedObjects.Get(id)
+	if exists {
+		return obj, nil
+	}
+
+	obj, err := s.getObjectFn(ctx, id)
+	if err != nil {
+		return *new(T), err
+	}
+
+	s.cachedObjects.Set(id, obj)
+	return obj, nil
+}
+
+// InvalidateCache invalidates specific objects in the cache.
+func (s *Cache[T]) InvalidateCache(ids ...string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.cachedObjects.DeleteMany(ids...)
+}

--- a/pkg/cache/storebased/store_test.go
+++ b/pkg/cache/storebased/store_test.go
@@ -1,0 +1,61 @@
+package storebased
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetObject(t *testing.T) {
+	var callCount int
+	fn := func(ctx context.Context, id string) (*storage.ServiceAccount, error) {
+		m := map[string]*storage.ServiceAccount{
+			"1": {Name: "1"},
+			"2": {Name: "2"},
+			"3": {Name: "3"},
+		}
+		callCount++
+		return m[id], nil
+	}
+
+	cache := NewCache(fn)
+
+	obj, err := cache.GetObject(context.Background(), "1")
+	assert.NoError(t, err)
+	assert.Equal(t, &storage.ServiceAccount{Name: "1"}, obj)
+	assert.Equal(t, 1, callCount)
+
+	obj2, err := cache.GetObject(context.Background(), "2")
+	assert.NoError(t, err)
+	assert.Equal(t, &storage.ServiceAccount{Name: "2"}, obj2)
+	assert.Equal(t, 2, callCount)
+
+	assert.Equal(t, cache.cachedObjects.GetMap(), map[string]*storage.ServiceAccount{"1": obj, "2": obj2})
+
+	obj, err = cache.GetObject(context.Background(), "1")
+	assert.NoError(t, err)
+	assert.Equal(t, &storage.ServiceAccount{Name: "1"}, obj)
+	assert.Equal(t, 2, callCount)
+
+	obj2, err = cache.GetObject(context.Background(), "2")
+	assert.NoError(t, err)
+	assert.Equal(t, &storage.ServiceAccount{Name: "2"}, obj2)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestInvalidateCache(t *testing.T) {
+	cache := NewCache[*storage.ServiceAccount](nil)
+
+	cache.cachedObjects.SetMany(map[string]*storage.ServiceAccount{
+		"1": {Name: "1"},
+		"2": {Name: "2"},
+		"3": {Name: "3"},
+		"4": {Name: "4"},
+	})
+
+	cache.InvalidateCache("1", "2", "3")
+
+	assert.Equal(t, cache.cachedObjects.GetMap(), map[string]*storage.ServiceAccount{"4": {Name: "4"}})
+}


### PR DESCRIPTION
## Description

Introduce caching for the init bundle backend (i.e. datastore) since we've seen it impact performance due to its usage in the gRPC identity extractor.

The datastore itself is low volume with little changes, hence the cache implementation using a `maputil.FastRMap`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see added unit tests.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
