### PR TITLE
feat(ui): Add hook to invalidate all workload cve queries

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -66,7 +66,7 @@ const summaryQuery = gql`
     }
 `;
 
-const vulnerabilityQuery = gql`
+export const deploymentVulnerabilitiesQuery = gql`
     ${imageMetadataContextFragment}
     ${deploymentWithVulnerabilitiesFragment}
     query getCvesForDeployment(
@@ -150,7 +150,7 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
             pagination: PaginationParam;
             statusesForExceptionCount: string[];
         }
-    >(vulnerabilityQuery, {
+    >(deploymentVulnerabilitiesQuery, {
         variables: {
             id: deploymentId,
             query,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -23,6 +23,7 @@ import PageTitle from 'Components/PageTitle';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import ImagePageVulnerabilities from './ImagePageVulnerabilities';
 import ImagePageResources from './ImagePageResources';
 import { detailsTabValues } from '../types';
@@ -72,6 +73,7 @@ function ImagePage() {
         variables: { id: imageId },
     });
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
+    const { invalidateAll: refetchAll } = useInvalidateVulnerabilityQueries();
 
     const imageData = data && data.image;
     const imageName = imageData?.name
@@ -155,6 +157,7 @@ function ImagePage() {
                                         tag: '',
                                     }
                                 }
+                                refetchAll={refetchAll}
                             />
                         </Tab>
                         <Tab

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -59,7 +59,7 @@ import ExceptionRequestModal, {
 import CompletedExceptionRequestModal from '../components/ExceptionRequestModal/CompletedExceptionRequestModal';
 import useExceptionRequestModal from '../hooks/useExceptionRequestModal';
 
-const imageVulnerabilitiesQuery = gql`
+export const imageVulnerabilitiesQuery = gql`
     ${imageMetadataContextFragment}
     ${resourceCountByCveSeverityAndStatusFragment}
     ${imageVulnerabilitiesFragment}
@@ -92,9 +92,14 @@ export type ImagePageVulnerabilitiesProps = {
         remote: string;
         tag: string;
     };
+    refetchAll: () => void;
 };
 
-function ImagePageVulnerabilities({ imageId, imageName }: ImagePageVulnerabilitiesProps) {
+function ImagePageVulnerabilities({
+    imageId,
+    imageName,
+    refetchAll,
+}: ImagePageVulnerabilitiesProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isUnifiedDeferralsEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL');
 
@@ -299,6 +304,7 @@ function ImagePageVulnerabilities({ imageId, imageName }: ImagePageVulnerabiliti
                     onExceptionRequestSuccess={(exception) => {
                         selectedCves.clear();
                         showModal({ type: 'COMPLETION', exception });
+                        return refetchAll();
                     }}
                     onClose={closeModals}
                 />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -9,6 +9,7 @@ import useURLSearch from 'hooks/useURLSearch';
 import useMap from 'hooks/useMap';
 import { getHasSearchApplied } from 'utils/searchUtils';
 import { VulnerabilityState } from 'types/cve.proto';
+import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import CVEsTable, { cveListQuery, unfilteredImageCountQuery } from '../Tables/CVEsTable';
 import TableErrorComponent from '../components/TableErrorComponent';
 import { EntityCounts } from '../components/EntityTypeToggleGroup';
@@ -65,6 +66,8 @@ function CVEsTableContainer({
 
     const { data: imageCountData } = useQuery(unfilteredImageCountQuery);
 
+    const { invalidateAll: refetchAll } = useInvalidateVulnerabilityQueries();
+
     const selectedCves = useMap<string, ExceptionRequestModalProps['cves'][number]>();
     const {
         exceptionRequestModalOptions,
@@ -89,6 +92,7 @@ function CVEsTableContainer({
                     onExceptionRequestSuccess={(exception) => {
                         selectedCves.clear();
                         showModal({ type: 'COMPLETION', exception });
+                        return refetchAll();
                     }}
                     onClose={closeModals}
                 />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useInvalidateVulnerabilityQueries.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useInvalidateVulnerabilityQueries.ts
@@ -1,0 +1,74 @@
+import { useApolloClient } from '@apollo/client';
+import { DocumentNode, FieldNode, OperationDefinitionNode } from 'graphql';
+import uniq from 'lodash/uniq';
+
+import { imageListQuery } from '../WorkloadCves/Tables/ImagesTable';
+import { cveListQuery } from '../WorkloadCves/Tables/CVEsTable';
+import { deploymentListQuery } from '../WorkloadCves/Tables/DeploymentsTable';
+import { deploymentVulnerabilitiesQuery } from '../WorkloadCves/Deployment/DeploymentPageVulnerabilities';
+import { imageVulnerabilitiesQuery } from '../WorkloadCves/Image/ImagePageVulnerabilities';
+import {
+    imageCveAffectedDeploymentsQuery,
+    imageCveAffectedImagesQuery,
+} from '../WorkloadCves/ImageCve/ImageCvePage';
+
+/**
+ * Extracts the top-level field names from a GraphQL document node. This is used to determine
+ * which query fields to invalidate.
+ *
+ * @param documentNode A GraphQL document node
+ * @returns An array of top-level field names
+ */
+function extractTopLevelFieldNames(documentNode: DocumentNode): string[] {
+    return documentNode.definitions
+        .filter((def): def is OperationDefinitionNode => def.kind === 'OperationDefinition')
+        .filter((def) => def.operation === 'query')
+        .flatMap((def) =>
+            def.selectionSet.selections
+                .filter((sel): sel is FieldNode => sel.kind === 'Field')
+                .map((sel) => sel.name.value)
+        );
+}
+
+const queryFieldNames = uniq(
+    [
+        // Queries for the tables on the Workload CVE list page
+        imageListQuery,
+        cveListQuery,
+        deploymentListQuery,
+        // Queries for the Workload CVE detail page
+        imageCveAffectedDeploymentsQuery,
+        imageCveAffectedImagesQuery,
+        // Query for the Workload CVE image detail page
+        imageVulnerabilitiesQuery,
+        // Query for the Workload CVE deployment detail page
+        deploymentVulnerabilitiesQuery,
+    ].flatMap(extractTopLevelFieldNames)
+);
+
+/**
+ * A hook that returns a function that invalidates all queries related to vulnerabilities in Workload CVEs. Active queries will
+ * be automatically refetched, while inactive queries will refetch when then become observed again. This should
+ * be used any time a mutation is performed that changes the vulnerability state of a CVE. These mutations include:
+ * - Deferring a CVE
+ * - Marking a CVE as false positive
+ * - Approving an exception request
+ * - Updating an exception request
+ * - Deleting an exception request
+ *
+ * @returns {invalidateAll} - function that invalidates all queries related to vulnerabilities in Workload CVEs
+ */
+export default function useInvalidateVulnerabilityQueries() {
+    const apolloClient = useApolloClient();
+
+    function invalidateAll() {
+        queryFieldNames.forEach((fieldName) => {
+            apolloClient.cache.evict({ fieldName });
+        });
+        apolloClient.cache.gc();
+    }
+
+    return {
+        invalidateAll,
+    };
+}


### PR DESCRIPTION
## Description

Adds a hook that instructs the Apollo client to evict the cache of all top level fields related to workload CVEs. _This will only make network calls for queries that are active and depend on these fields._ Inactive queries will only be refetched when their component is rendered again.

This is used to ensure the Workload CVE data cache is up to date with known mutations. In the case of this PR, this occurs when the user submits an exception request in order to correctly render the "Pending exception" labels.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit Workload CVEs and then visit a single CVE page. This will populate the apollo cache with the query result for that CVE. Navigate back to the CVE list and defer this CVE.
- The list view in the background will automatically update with the "Pending exception" label without the need for a full browser refresh.
- Revisit the CVE single page and see that the "Pending exception" label is present without the need for a full browser refresh.
![image](https://github.com/stackrox/stackrox/assets/1292638/f67b3070-d03d-40ac-a491-bc6cceda8a2d)
![image](https://github.com/stackrox/stackrox/assets/1292638/cb216792-e6d5-4377-a281-2e870f62b5b0)
![image](https://github.com/stackrox/stackrox/assets/1292638/cf9ac274-ebf0-4504-bb9a-20a35bf1ff99)
![image](https://github.com/stackrox/stackrox/assets/1292638/8417415b-6b45-4051-9af1-f65e15c467a5)
![image](https://github.com/stackrox/stackrox/assets/1292638/7e2e5f99-e901-4a47-8a43-74e19b569c09)


