### PR TITLE
chore(test): Add smoke tests for Compliance 2.0 scan configs

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -239,6 +239,8 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n        value: "'"${ROX_TELEMETRY_STORAGE_KEY_V1:-DISABLED}"'"'
     customize_envVars+=$'\n      - name: ROX_RISK_REPROCESSING_INTERVAL'
     customize_envVars+=$'\n        value: "15s"'
+    customize_envVars+=$'\n      - name: ROX_COMPLIANCE_ENHANCEMENTS'
+    customize_envVars+=$'\n        value: "true"'
 
     CENTRAL_YAML_PATH="tests/e2e/yaml/central-cr.envsubst.yaml"
     # Different yaml for midstream images

--- a/ui/apps/platform/cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
@@ -1,14 +1,56 @@
+import { visitFromLeftNavExpandable } from '../../helpers/nav';
 import { visit } from '../../helpers/visit';
 
 // path
 
 export const basePath = '/main/compliance-enhanced';
+export const statusDashboardPath = `${basePath}/status`;
+export const scanConfigsPath = `${basePath}/scan-configs`;
 
-// visit
+// visit helpers
+export const scanConfigsAlias = 'configurations';
+
+const routeMatcherMapToComplianceEnhancedDashboard = null;
+
+const routeMatcherMapToComplianceEnhancedScanConfigs = {
+    [scanConfigsAlias]: {
+        method: 'GET',
+        url: '/v2/compliance/scan/configurations*',
+    },
+};
+
+export function visitComplianceEnhancedFromLeftNav() {
+    visitFromLeftNavExpandable(
+        'Compliance (2.0)',
+        'Compliance Status',
+        routeMatcherMapToComplianceEnhancedDashboard
+    );
+
+    cy.location('pathname').should('eq', statusDashboardPath);
+}
 
 export function visitComplianceEnhancedDashboard() {
     // TODO: (vjw, 1 Nov 2023) add routes matchers to this function, after API is available for Status
-    visit(`${basePath}/status`);
+    visit(basePath, routeMatcherMapToComplianceEnhancedDashboard);
 
+    cy.location('pathname').should('eq', statusDashboardPath);
     cy.get(`h1:contains("Compliance")`);
+}
+
+export function visitComplianceEnhancedScanConfigsFromLeftNav() {
+    visitFromLeftNavExpandable(
+        'Compliance (2.0)',
+        'Scheduling',
+        routeMatcherMapToComplianceEnhancedScanConfigs
+    );
+
+    cy.location('pathname').should('eq', scanConfigsPath);
+    cy.get(`h1:contains("Scan schedules")`);
+}
+
+export function visitComplianceEnhancedScanConfigs() {
+    // TODO: (vjw, 1 Nov 2023) add routes matchers to this function, after API is available for Status
+    visit(scanConfigsPath, routeMatcherMapToComplianceEnhancedDashboard);
+
+    cy.get(`h1:contains("Scan schedules")`);
 }

--- a/ui/apps/platform/cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/ComplianceEnhanced.helpers.js
@@ -10,47 +10,45 @@ export const scanConfigsPath = `${basePath}/scan-configs`;
 // visit helpers
 export const scanConfigsAlias = 'configurations';
 
-const routeMatcherMapToComplianceEnhancedDashboard = null;
+// TODO: (vjw, 13 Nov 2023) after the API endpoints for the dashboard are published,
+// we will add them to the routeMatcherMap here
+const routeMatcherMapForComplianceDashboard = null;
 
-const routeMatcherMapToComplianceEnhancedScanConfigs = {
+const routeMatcherMapForComplianceScanConfigs = {
     [scanConfigsAlias]: {
         method: 'GET',
         url: '/v2/compliance/scan/configurations*',
     },
 };
 
-export function visitComplianceEnhancedFromLeftNav() {
+export function visitComplianceEnhancedFromLeftNav(staticResponseMap) {
     visitFromLeftNavExpandable(
         'Compliance (2.0)',
         'Compliance Status',
-        routeMatcherMapToComplianceEnhancedDashboard
+        routeMatcherMapForComplianceDashboard,
+        staticResponseMap
     );
-
-    cy.location('pathname').should('eq', statusDashboardPath);
 }
 
-export function visitComplianceEnhancedDashboard() {
+export function visitComplianceEnhancedDashboard(staticResponseMap) {
     // TODO: (vjw, 1 Nov 2023) add routes matchers to this function, after API is available for Status
-    visit(basePath, routeMatcherMapToComplianceEnhancedDashboard);
-
-    cy.location('pathname').should('eq', statusDashboardPath);
+    visit(basePath, routeMatcherMapForComplianceDashboard, staticResponseMap);
     cy.get(`h1:contains("Compliance")`);
 }
 
-export function visitComplianceEnhancedScanConfigsFromLeftNav() {
+export function visitComplianceEnhancedScanConfigsFromLeftNav(staticResponseMap) {
     visitFromLeftNavExpandable(
         'Compliance (2.0)',
         'Scheduling',
-        routeMatcherMapToComplianceEnhancedScanConfigs
+        routeMatcherMapForComplianceScanConfigs,
+        staticResponseMap
     );
 
-    cy.location('pathname').should('eq', scanConfigsPath);
     cy.get(`h1:contains("Scan schedules")`);
 }
 
-export function visitComplianceEnhancedScanConfigs() {
-    // TODO: (vjw, 1 Nov 2023) add routes matchers to this function, after API is available for Status
-    visit(scanConfigsPath, routeMatcherMapToComplianceEnhancedDashboard);
+export function visitComplianceEnhancedScanConfigs(staticResponseMap) {
+    visit(scanConfigsPath, routeMatcherMapForComplianceScanConfigs, staticResponseMap);
 
     cy.get(`h1:contains("Scan schedules")`);
 }

--- a/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedDashboard.test.js
@@ -2,7 +2,11 @@ import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
 import { getRegExpForTitleWithBranding } from '../../helpers/title';
 
-import { visitComplianceEnhancedDashboard } from './ComplianceEnhanced.helpers';
+import {
+    visitComplianceEnhancedDashboard,
+    visitComplianceEnhancedFromLeftNav,
+    visitComplianceEnhancedScanConfigsFromLeftNav,
+} from './ComplianceEnhanced.helpers';
 
 describe('Compliance Dashboard', () => {
     withAuth();
@@ -13,7 +17,13 @@ describe('Compliance Dashboard', () => {
         }
     });
 
-    it('should have title', () => {
+    it('should visit using the left nav', () => {
+        visitComplianceEnhancedFromLeftNav();
+
+        cy.title().should('match', getRegExpForTitleWithBranding('Compliance Status Dashboard'));
+    });
+
+    it('should have expected elements on the status page', () => {
         visitComplianceEnhancedDashboard();
 
         cy.title().should('match', getRegExpForTitleWithBranding('Compliance Status Dashboard'));
@@ -26,5 +36,33 @@ describe('Compliance Dashboard', () => {
         cy.get('th[scope="col"]:contains("Profiles")');
         cy.get('th[scope="col"]:contains("Failing Controls")');
         cy.get('th[scope="col"]:contains("Last Scanned")');
+    });
+
+    it('should visit scan configurations scheduling from the left nav', () => {
+        visitComplianceEnhancedScanConfigsFromLeftNav();
+
+        cy.title().should('match', getRegExpForTitleWithBranding('Scan Schedules'));
+    });
+
+    it('should have expected elements on the scans page', () => {
+        visitComplianceEnhancedScanConfigsFromLeftNav();
+
+        cy.title().should('match', getRegExpForTitleWithBranding('Scan Schedules'));
+
+        cy.get('th[scope="col"]:contains("Name")');
+        cy.get('th[scope="col"]:contains("Schedule")');
+        cy.get('th[scope="col"]:contains("Last run")');
+        cy.get('th[scope="col"]:contains("Clusters")');
+        cy.get('th[scope="col"]:contains("Profiles")');
+
+        cy.get('h2:contains("No scan schedules")');
+
+        cy.get('.pf-c-toolbar__content a:contains("Create scan schedule")').click();
+        cy.location('search').should('eq', '?action=create');
+
+        cy.go('back');
+
+        cy.get('.pf-c-empty-state__content a:contains("Create scan schedule")').click();
+        cy.location('search').should('eq', '?action=create');
     });
 });

--- a/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedDashboard.test.js
@@ -6,6 +6,8 @@ import {
     visitComplianceEnhancedDashboard,
     visitComplianceEnhancedFromLeftNav,
     visitComplianceEnhancedScanConfigsFromLeftNav,
+    statusDashboardPath,
+    scanConfigsPath,
 } from './ComplianceEnhanced.helpers';
 
 describe('Compliance Dashboard', () => {
@@ -20,11 +22,15 @@ describe('Compliance Dashboard', () => {
     it('should visit using the left nav', () => {
         visitComplianceEnhancedFromLeftNav();
 
+        cy.location('pathname').should('eq', statusDashboardPath);
+
         cy.title().should('match', getRegExpForTitleWithBranding('Compliance Status Dashboard'));
     });
 
     it('should have expected elements on the status page', () => {
         visitComplianceEnhancedDashboard();
+
+        cy.location('pathname').should('eq', statusDashboardPath);
 
         cy.title().should('match', getRegExpForTitleWithBranding('Compliance Status Dashboard'));
 
@@ -41,13 +47,14 @@ describe('Compliance Dashboard', () => {
     it('should visit scan configurations scheduling from the left nav', () => {
         visitComplianceEnhancedScanConfigsFromLeftNav();
 
-        cy.title().should('match', getRegExpForTitleWithBranding('Scan Schedules'));
+        cy.location('pathname').should('eq', scanConfigsPath);
+        cy.title().should('match', getRegExpForTitleWithBranding('Compliance Scan Schedules'));
     });
 
     it('should have expected elements on the scans page', () => {
         visitComplianceEnhancedScanConfigsFromLeftNav();
 
-        cy.title().should('match', getRegExpForTitleWithBranding('Scan Schedules'));
+        cy.title().should('match', getRegExpForTitleWithBranding('Compliance Scan Schedules'));
 
         cy.get('th[scope="col"]:contains("Name")');
         cy.get('th[scope="col"]:contains("Schedule")');

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ScanConfigs/ScanConfigPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ScanConfigs/ScanConfigPage.tsx
@@ -3,7 +3,6 @@ import { Bullseye, Spinner, Button } from '@patternfly/react-core';
 
 import { complianceEnhancedScanConfigsBasePath } from 'routePaths';
 import NotFoundMessage from 'Components/NotFoundMessage';
-import PageTitle from 'Components/PageTitle';
 import {
     getScanConfig,
     ComplianceScanConfigurationStatus,
@@ -91,7 +90,6 @@ function ScanConfigPage({
 
     return (
         <>
-            <PageTitle title="ScanConfig Management - ScanConfig" />
             {isLoading ? (
                 <Bullseye>
                     <Spinner isSVG />

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ScanConfigs/ScanConfigsHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ScanConfigs/ScanConfigsHeader.tsx
@@ -18,7 +18,7 @@ type ScanConfigsHeaderProps = {
 function ScanConfigsHeader({ description, actions }: ScanConfigsHeaderProps) {
     return (
         <>
-            <PageTitle title="Scan Schedules" />
+            <PageTitle title="Compliance Scan Schedules" />
             <PageSection variant="light">
                 <Title headingLevel="h1">Scan schedules</Title>
             </PageSection>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ScanConfigs/Table/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ScanConfigs/Table/ScanConfigsTablePage.tsx
@@ -227,7 +227,7 @@ function ScanConfigsTablePage({
                             <Tr>
                                 <Th sort={getSortParams('Name')}>Name</Th>
                                 <Th>Schedule</Th>
-                                <Th sort={getSortParams('Last Run')}>Last Run</Th>
+                                <Th sort={getSortParams('Last Run')}>Last run</Th>
                                 <Th>Clusters</Th>
                                 <Th>Profiles</Th>
                                 <Td />


### PR DESCRIPTION
## Description

Expand the original base test for Compliance 2.0 to:

1. visit dashboard (aka Status page) from left nav
2. visit dashboard (aka Status page) by direct navigation and check existing page elements
3. visit scan configs (aka Scheduling page) from left nav
4. visit scan configs (aka Scheduling page)  by direct navigation and check existing page elements, and start creation process

Note: I'm also adding the env var to turn on the feature flag in OCP CI environments, because this feature really only works on OCP

## Checklist
- [x] Investigated and inspected CI test results (all ui-e2e-test failures are different known flakes)
- [x] Unit test and regression tests added

## Testing Performed

### Here I tell how I validated my change

Ran tests locally
<img width="2098" alt="Screenshot 2023-11-09 at 4 17 57 PM" src="https://github.com/stackrox/stackrox/assets/715729/71be6e0f-5299-4241-a21d-d3dd91ddefa4">


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
