### PR TITLE
fix(pods): remove unused datastore functions

### DIFF
--- a/central/pod/datastore/datastore.go
+++ b/central/pod/datastore/datastore.go
@@ -31,8 +31,6 @@ type DataStore interface {
 	UpsertPod(ctx context.Context, pod *storage.Pod) error
 
 	RemovePod(ctx context.Context, id string) error
-
-	GetPodIDs(ctx context.Context) ([]string, error)
 }
 
 // NewPostgresDB creates a pod datastore based on Postgres

--- a/central/pod/datastore/datastore_impl.go
+++ b/central/pod/datastore/datastore_impl.go
@@ -187,10 +187,6 @@ func (ds *datastoreImpl) RemovePod(ctx context.Context, id string) error {
 	return errPlop
 }
 
-func (ds *datastoreImpl) GetPodIDs(ctx context.Context) ([]string, error) {
-	return ds.podStore.GetIDs(ctx)
-}
-
 func (ds *datastoreImpl) WalkAll(ctx context.Context, fn func(pod *storage.Pod) error) error {
 	if ok, err := podsSAC.ReadAllowed(ctx); err != nil {
 		return err

--- a/central/pod/datastore/mocks/datastore.go
+++ b/central/pod/datastore/mocks/datastore.go
@@ -72,21 +72,6 @@ func (mr *MockDataStoreMockRecorder) GetPod(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPod", reflect.TypeOf((*MockDataStore)(nil).GetPod), ctx, id)
 }
 
-// GetPodIDs mocks base method.
-func (m *MockDataStore) GetPodIDs(ctx context.Context) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPodIDs", ctx)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPodIDs indicates an expected call of GetPodIDs.
-func (mr *MockDataStoreMockRecorder) GetPodIDs(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodIDs", reflect.TypeOf((*MockDataStore)(nil).GetPodIDs), ctx)
-}
-
 // RemovePod mocks base method.
 func (m *MockDataStore) RemovePod(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Description

Fix unused `GetPodIDs` function in the pod datastore.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

N/A 
### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
