### PR TITLE
ROX-20732: Matcher can use a remote Indexer

### DIFF
--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -179,7 +179,7 @@ func createBackends(ctx context.Context, cfg *config.Config) (*Backends, error) 
 	}
 	if cfg.Matcher.Enable {
 		zlog.Info(ctx).Msg("matcher is enabled")
-		if cfg.Matcher.RemoteIndexer {
+		if cfg.Matcher.RemoteIndexerEnabled {
 			// Create a remote indexer only if the matcher was configured to use one.
 			zlog.Info(ctx).Msg("remote indexer is enabled")
 			b.RemoteIndexer, err = indexer.NewRemoteIndexer(ctx, cfg.Matcher.IndexerAddr)

--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -207,9 +207,9 @@ func getServices(b *Backends) []grpc.APIService {
 		// Set the index report getter to the remote indexer if available, otherwise the
 		// local indexer. A nil getter is ok, see implementation.
 		var getter indexer.ReportGetter
-		getter = b.Indexer
-		if b.RemoteIndexer != nil {
-			getter = b.RemoteIndexer
+		getter = b.RemoteIndexer
+		if getter != nil {
+			getter = b.Indexer
 		}
 		srvs = append(srvs, services.NewMatcherService(b.Matcher, getter))
 	}

--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -30,13 +30,15 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Backends holds the potential engines the scanner
-// may use depending on the mode in which it is running.
+// Backends holds the backend engines the scanner may use depending on the
+// configuration and mode in which it is running.
 type Backends struct {
-	// Indexer is the indexing engine.
+	// Indexer is the indexing backend.
 	Indexer indexer.Indexer
-	// Matcher is the vulnerability matching engine.
+	// Matcher is the vulnerability matching backend.
 	Matcher matcher.Matcher
+	// RemoteIndexer is the indexing backend located in a remote scanner instance.
+	RemoteIndexer indexer.RemoteIndexer
 }
 
 func main() {
@@ -156,21 +158,13 @@ func createGRPCService(backends *Backends, cfg *config.Config) (grpc.API, error)
 		},
 	})
 
-	// Create and register API services.
-	var srvs []grpc.APIService
-	if backends.Indexer != nil {
-		srvs = append(srvs, services.NewIndexerService(backends.Indexer))
-	}
-	if backends.Matcher != nil {
-		// nil indexer is ok, see implementation.
-		srvs = append(srvs, services.NewMatcherService(backends.Matcher, backends.Indexer))
-	}
-	grpcSrv.Register(srvs...)
+	// Register API services.
+	grpcSrv.Register(getServices(backends)...)
 
 	return grpcSrv, nil
 }
 
-// createAPIServices creates all backends.
+// createBackends creates the scanner backends.
 func createBackends(ctx context.Context, cfg *config.Config) (*Backends, error) {
 	var b Backends
 	var err error
@@ -185,6 +179,14 @@ func createBackends(ctx context.Context, cfg *config.Config) (*Backends, error) 
 	}
 	if cfg.Matcher.Enable {
 		zlog.Info(ctx).Msg("matcher is enabled")
+		if cfg.Matcher.RemoteIndexer {
+			// Create a remote indexer only if the matcher was configured to use one.
+			zlog.Info(ctx).Msg("remote indexer is enabled")
+			b.RemoteIndexer, err = indexer.NewRemoteIndexer(ctx, cfg.Matcher.IndexerAddr)
+			if err != nil {
+				return nil, fmt.Errorf("matcher: remote indexer: %w", err)
+			}
+		}
 		b.Matcher, err = matcher.NewMatcher(ctx, cfg.Matcher)
 		if err != nil {
 			return nil, fmt.Errorf("matcher: %w", err)
@@ -195,18 +197,43 @@ func createBackends(ctx context.Context, cfg *config.Config) (*Backends, error) 
 	return &b, nil
 }
 
+// getServices returns the list of the API services based on the backends provided.
+func getServices(b *Backends) []grpc.APIService {
+	var srvs []grpc.APIService
+	if b.Indexer != nil {
+		srvs = append(srvs, services.NewIndexerService(b.Indexer))
+	}
+	if b.Matcher != nil {
+		// Set the index report getter to the remote indexer if available, otherwise the
+		// local indexer. A nil getter is ok, see implementation.
+		var getter indexer.ReportGetter
+		getter = b.Indexer
+		if b.RemoteIndexer != nil {
+			getter = b.RemoteIndexer
+		}
+		srvs = append(srvs, services.NewMatcherService(b.Matcher, getter))
+	}
+	return srvs
+}
+
 // Close closes all the backends used by the scanner.
 func (b *Backends) Close(ctx context.Context) {
-	if b.Matcher != nil {
-		err := b.Matcher.Close(ctx)
-		if err != nil {
-			zlog.Error(ctx).Err(err).Msg("closing matcher")
-		}
+	type Closeable interface {
+		Close(context.Context) error
 	}
-	if b.Indexer != nil {
-		err := b.Indexer.Close(ctx)
-		if err != nil {
-			zlog.Error(ctx).Err(err).Msg("closing indexer")
+	for _, backend := range []struct {
+		name     string
+		instance Closeable
+	}{
+		{"matcher", b.Matcher},
+		{"indexer", b.Indexer},
+		{"remote indexer", b.RemoteIndexer},
+	} {
+		if backend.instance != nil {
+			err := backend.instance.Close(ctx)
+			if err != nil {
+				zlog.Error(ctx).Err(err).Msgf("closing %s", backend.name)
+			}
 		}
 	}
 }

--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -208,7 +208,7 @@ func getServices(b *Backends) []grpc.APIService {
 		// local indexer. A nil getter is ok, see implementation.
 		var getter indexer.ReportGetter
 		getter = b.RemoteIndexer
-		if getter != nil {
+		if getter == nil {
 			getter = b.Indexer
 		}
 		srvs = append(srvs, services.NewMatcherService(b.Matcher, getter))

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -54,7 +55,6 @@ type Config struct {
 }
 
 func (c *Config) validate() error {
-
 	if err := c.MTLS.validate(); err != nil {
 		return fmt.Errorf("mtls: %w", err)
 	}
@@ -99,6 +99,12 @@ type MatcherConfig struct {
 	Database Database `yaml:"database"`
 	// Enable if false disables the Matcher service and vulnerability updater.
 	Enable bool `yaml:"enable"`
+	// IndexerAddr forces the matcher to retrieve index reports from a remote indexer
+	// instance at the specified address, instead of the local indexer (when the
+	// indexer is enabled).
+	IndexerAddr string `yaml:"indexer_addr"`
+	// RemoteIndexer internal and generated flag, true when the remote indexer is enabled.
+	RemoteIndexer bool
 }
 
 func (c *MatcherConfig) validate() error {
@@ -107,6 +113,13 @@ func (c *MatcherConfig) validate() error {
 	}
 	if err := c.Database.validate(); err != nil {
 		return fmt.Errorf("database: %w", err)
+	}
+	c.RemoteIndexer = c.IndexerAddr != ""
+	if c.RemoteIndexer {
+		_, _, err := net.SplitHostPort(c.IndexerAddr)
+		if err != nil {
+			return fmt.Errorf("indexer_addr: failed to parse address: %v", err)
+		}
 	}
 	return nil
 }

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -103,8 +103,8 @@ type MatcherConfig struct {
 	// instance at the specified address, instead of the local indexer (when the
 	// indexer is enabled).
 	IndexerAddr string `yaml:"indexer_addr"`
-	// RemoteIndexer internal and generated flag, true when the remote indexer is enabled.
-	RemoteIndexer bool
+	// RemoteIndexerEnabled internal and generated flag, true when the remote indexer is enabled.
+	RemoteIndexerEnabled bool
 }
 
 func (c *MatcherConfig) validate() error {
@@ -114,8 +114,8 @@ func (c *MatcherConfig) validate() error {
 	if err := c.Database.validate(); err != nil {
 		return fmt.Errorf("database: %w", err)
 	}
-	c.RemoteIndexer = c.IndexerAddr != ""
-	if c.RemoteIndexer {
+	c.RemoteIndexerEnabled = c.IndexerAddr != ""
+	if c.RemoteIndexerEnabled {
 		_, _, err := net.SplitHostPort(c.IndexerAddr)
 		if err != nil {
 			return fmt.Errorf("indexer_addr: failed to parse address: %w", err)

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -118,7 +118,7 @@ func (c *MatcherConfig) validate() error {
 	if c.RemoteIndexer {
 		_, _, err := net.SplitHostPort(c.IndexerAddr)
 		if err != nil {
-			return fmt.Errorf("indexer_addr: failed to parse address: %v", err)
+			return fmt.Errorf("indexer_addr: failed to parse address: %w", err)
 		}
 	}
 	return nil

--- a/scanner/config/config_test.go
+++ b/scanner/config/config_test.go
@@ -123,6 +123,27 @@ func Test_MatcherConfig_validate(t *testing.T) {
 		err := c.validate()
 		assert.Error(t, err)
 	})
+	t.Run("when invalid indexer addr then error ", func(t *testing.T) {
+		for _, addr := range []string{"foo bar", "foo:bar", "80:80"} {
+			c := MatcherConfig{Enable: true, IndexerAddr: addr}
+			err := c.validate()
+			assert.Error(t, err)
+		}
+	})
+	t.Run("when valid addr then remote addr is set", func(t *testing.T) {
+		for _, addr := range []string{":8443", "localhost:443", "127.0.0.1:80"} {
+			c := MatcherConfig{Enable: true, IndexerAddr: addr, Database: Database{ConnString: "host=foobar"}}
+			err := c.validate()
+			assert.NoError(t, err)
+			assert.True(t, c.RemoteIndexer)
+		}
+	})
+	t.Run("when addr is empty then remote addr is not set", func(t *testing.T) {
+		c := MatcherConfig{Enable: true, IndexerAddr: "", Database: Database{ConnString: "host=foobar"}}
+		err := c.validate()
+		assert.NoError(t, err)
+		assert.False(t, c.RemoteIndexer)
+	})
 }
 
 func Test_Database_validate(t *testing.T) {

--- a/scanner/config/config_test.go
+++ b/scanner/config/config_test.go
@@ -135,14 +135,14 @@ func Test_MatcherConfig_validate(t *testing.T) {
 			c := MatcherConfig{Enable: true, IndexerAddr: addr, Database: Database{ConnString: "host=foobar"}}
 			err := c.validate()
 			assert.NoError(t, err)
-			assert.True(t, c.RemoteIndexer)
+			assert.True(t, c.RemoteIndexerEnabled)
 		}
 	})
 	t.Run("when addr is empty then remote addr is not set", func(t *testing.T) {
 		c := MatcherConfig{Enable: true, IndexerAddr: "", Database: Database{ConnString: "host=foobar"}}
 		err := c.validate()
 		assert.NoError(t, err)
-		assert.False(t, c.RemoteIndexer)
+		assert.False(t, c.RemoteIndexerEnabled)
 	})
 }
 

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -32,12 +32,6 @@ type ReportGetter interface {
 	GetIndexReport(context.Context, string) (*claircore.IndexReport, bool, error)
 }
 
-// RemoteIndexer represents the interface offered by remote indexers.
-type RemoteIndexer interface {
-	ReportGetter
-	Close(context.Context) error
-}
-
 // Indexer represents an image indexer.
 //
 //go:generate mockgen-wrapper

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"context"
+	"crypto/sha512"
 	"errors"
 	"fmt"
 	"net/http"
@@ -26,12 +27,23 @@ import (
 	"github.com/stackrox/rox/scanner/internal/version"
 )
 
+// ReportGetter can get index reports from an Indexer.
+type ReportGetter interface {
+	GetIndexReport(context.Context, string) (*claircore.IndexReport, bool, error)
+}
+
+// RemoteIndexer represents the interface offered by remote indexers.
+type RemoteIndexer interface {
+	ReportGetter
+	Close(context.Context) error
+}
+
 // Indexer represents an image indexer.
 //
 //go:generate mockgen-wrapper
 type Indexer interface {
-	IndexContainerImage(context.Context, claircore.Digest, string, ...Option) (*claircore.IndexReport, error)
-	GetIndexReport(ctx context.Context, manifestDigest claircore.Digest) (*claircore.IndexReport, bool, error)
+	ReportGetter
+	IndexContainerImage(context.Context, string, string, ...Option) (*claircore.IndexReport, error)
 	Close(context.Context) error
 }
 
@@ -100,11 +112,15 @@ func (i *localIndexer) Close(ctx context.Context) error {
 // the layer's URI and headers.
 func (i *localIndexer) IndexContainerImage(
 	ctx context.Context,
-	manifestDigest claircore.Digest,
+	hashID string,
 	imageURL string,
 	opts ...Option,
 ) (*claircore.IndexReport, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "scanner/backend/indexer")
+	manifestDigest, err := createManifestDigest(hashID)
+	if err != nil {
+		return nil, err
+	}
 	o := makeOptions(opts...)
 	imgRef, err := parseContainerImageURL(imageURL)
 	if err != nil {
@@ -130,7 +146,7 @@ func (i *localIndexer) IndexContainerImage(
 		if err != nil {
 			return nil, fmt.Errorf("getting layer digests: %w", err)
 		}
-		// TODO Check for non-retriable errors (permission denied, etc.) to report properly.
+		// TODO Check for non-retryable errors (permission denied, etc.) to report properly.
 		layerReq, err := getLayerRequest(httpClient, imgRef, layerDigest)
 		if err != nil {
 			return nil, fmt.Errorf("getting layer request URL and headers (digest: %q): %w",
@@ -203,15 +219,29 @@ func getLayerRequest(httpClient *http.Client, imgRef name.Reference, layerDigest
 	return res.Request, nil
 }
 
-// GetIndexReport retrieves an IndexReport for a particular manifest hash, if it exists.
-func (i *localIndexer) GetIndexReport(ctx context.Context, manifestDigest claircore.Digest) (*claircore.IndexReport, bool, error) {
+// GetIndexReport retrieves an IndexReport for the given hash ID, if it exists.
+func (i *localIndexer) GetIndexReport(ctx context.Context, hashID string) (*claircore.IndexReport, bool, error) {
+	manifestDigest, err := createManifestDigest(hashID)
+	if err != nil {
+		return nil, false, err
+	}
 	return i.libIndex.IndexReport(ctx, manifestDigest)
+}
+
+// createManifestDigest creates a unique claircore.Digest from a Scanner's manifest hash ID.
+func createManifestDigest(hashID string) (claircore.Digest, error) {
+	hashIDSum := sha512.Sum512([]byte(hashID))
+	d, err := claircore.NewDigest(claircore.SHA512, hashIDSum[:])
+	if err != nil {
+		return claircore.Digest{}, fmt.Errorf("creating manifest digest: %w", err)
+	}
+	return d, nil
 }
 
 // getContainerImageLayers fetches the image's manifest from the registry to get
 // a list of layers.
 func getContainerImageLayers(ctx context.Context, ref name.Reference, o options) ([]v1.Layer, error) {
-	// TODO Check for non-retriable errors (permission denied, etc.) to report properly.
+	// TODO Check for non-retryable errors (permission denied, etc.) to report properly.
 	desc, err := remote.Get(ref, remote.WithContext(ctx), remote.WithAuth(o.auth), remote.WithPlatform(o.platform))
 	if err != nil {
 		return nil, err
@@ -227,7 +257,7 @@ func getContainerImageLayers(ctx context.Context, ref name.Reference, o options)
 	return layers, nil
 }
 
-// parseContainerImageURL returns a image reference from an image URL.
+// parseContainerImageURL returns an image reference from an image URL.
 func parseContainerImageURL(imageURL string) (name.Reference, error) {
 	// We expect input was sanitized, so all errors here are considered internal errors.
 	if imageURL == "" {

--- a/scanner/indexer/mocks/indexer.go
+++ b/scanner/indexer/mocks/indexer.go
@@ -55,9 +55,9 @@ func (mr *MockIndexerMockRecorder) Close(arg0 any) *gomock.Call {
 }
 
 // GetIndexReport mocks base method.
-func (m *MockIndexer) GetIndexReport(ctx context.Context, manifestDigest claircore.Digest) (*claircore.IndexReport, bool, error) {
+func (m *MockIndexer) GetIndexReport(arg0 context.Context, arg1 string) (*claircore.IndexReport, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIndexReport", ctx, manifestDigest)
+	ret := m.ctrl.Call(m, "GetIndexReport", arg0, arg1)
 	ret0, _ := ret[0].(*claircore.IndexReport)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -65,13 +65,13 @@ func (m *MockIndexer) GetIndexReport(ctx context.Context, manifestDigest clairco
 }
 
 // GetIndexReport indicates an expected call of GetIndexReport.
-func (mr *MockIndexerMockRecorder) GetIndexReport(ctx, manifestDigest any) *gomock.Call {
+func (mr *MockIndexerMockRecorder) GetIndexReport(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIndexReport", reflect.TypeOf((*MockIndexer)(nil).GetIndexReport), ctx, manifestDigest)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIndexReport", reflect.TypeOf((*MockIndexer)(nil).GetIndexReport), arg0, arg1)
 }
 
 // IndexContainerImage mocks base method.
-func (m *MockIndexer) IndexContainerImage(arg0 context.Context, arg1 claircore.Digest, arg2 string, arg3 ...indexer.Option) (*claircore.IndexReport, error) {
+func (m *MockIndexer) IndexContainerImage(arg0 context.Context, arg1, arg2 string, arg3 ...indexer.Option) (*claircore.IndexReport, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {

--- a/scanner/indexer/mocks/indexer.go
+++ b/scanner/indexer/mocks/indexer.go
@@ -17,6 +17,45 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
+// MockReportGetter is a mock of ReportGetter interface.
+type MockReportGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockReportGetterMockRecorder
+}
+
+// MockReportGetterMockRecorder is the mock recorder for MockReportGetter.
+type MockReportGetterMockRecorder struct {
+	mock *MockReportGetter
+}
+
+// NewMockReportGetter creates a new mock instance.
+func NewMockReportGetter(ctrl *gomock.Controller) *MockReportGetter {
+	mock := &MockReportGetter{ctrl: ctrl}
+	mock.recorder = &MockReportGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockReportGetter) EXPECT() *MockReportGetterMockRecorder {
+	return m.recorder
+}
+
+// GetIndexReport mocks base method.
+func (m *MockReportGetter) GetIndexReport(arg0 context.Context, arg1 string) (*claircore.IndexReport, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIndexReport", arg0, arg1)
+	ret0, _ := ret[0].(*claircore.IndexReport)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetIndexReport indicates an expected call of GetIndexReport.
+func (mr *MockReportGetterMockRecorder) GetIndexReport(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIndexReport", reflect.TypeOf((*MockReportGetter)(nil).GetIndexReport), arg0, arg1)
+}
+
 // MockIndexer is a mock of Indexer interface.
 type MockIndexer struct {
 	ctrl     *gomock.Controller

--- a/scanner/indexer/remote.go
+++ b/scanner/indexer/remote.go
@@ -42,11 +42,11 @@ func NewRemoteIndexer(ctx context.Context, address string) (*remoteIndexer, erro
 }
 
 // Close closes the remote indexer.
-func (r *remoteIndexer) Close(ctx context.Context) error {
+func (r *remoteIndexer) Close(_ context.Context) error {
 	return r.conn.Close()
 }
 
-// GetIndexReport call the remote service to retrieve an IndexReport for the given hash ID.
+// GetIndexReport calls the remote service to retrieve an IndexReport for the given hash ID.
 func (r *remoteIndexer) GetIndexReport(ctx context.Context, hashID string) (*claircore.IndexReport, bool, error) {
 	resp, err := r.indexer.GetIndexReport(ctx, &v4.GetIndexReportRequest{HashId: hashID})
 	if err != nil {

--- a/scanner/indexer/remote.go
+++ b/scanner/indexer/remote.go
@@ -14,6 +14,12 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// RemoteIndexer represents the interface offered by remote indexers.
+type RemoteIndexer interface {
+	ReportGetter
+	Close(context.Context) error
+}
+
 // remoteIndexer is the Indexer implementation that connects to a remote indexer
 // using gRPC.
 type remoteIndexer struct {

--- a/scanner/indexer/remote.go
+++ b/scanner/indexer/remote.go
@@ -1,0 +1,66 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/quay/claircore"
+	"github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stackrox/rox/pkg/clientconn"
+	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stackrox/rox/scanner/mappers"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// remoteIndexer is the Indexer implementation that connects to a remote indexer
+// using gRPC.
+type remoteIndexer struct {
+	conn    *grpc.ClientConn
+	indexer v4.IndexerClient
+}
+
+// NewRemoteIndexer connect to the gRPC address and creates a new remote indexer.
+func NewRemoteIndexer(ctx context.Context, address string) (*remoteIndexer, error) {
+	connOpt := clientconn.Options{
+		TLS: clientconn.TLSConfigOptions{
+			GRPCOnly:           true,
+			InsecureSkipVerify: true,
+		},
+	}
+	// TODO: [ROX-19050] Set the Scanner V4 TLS validation and the correct subject
+	//       when certificates are ready.
+	conn, err := clientconn.GRPCConnection(ctx, mtls.ScannerSubject, address, connOpt)
+	if err != nil {
+		return nil, err
+	}
+	return &remoteIndexer{
+		conn:    conn,
+		indexer: v4.NewIndexerClient(conn),
+	}, nil
+}
+
+// Close closes the remote indexer.
+func (r *remoteIndexer) Close(ctx context.Context) error {
+	return r.conn.Close()
+}
+
+// GetIndexReport call the remote service to retrieve an IndexReport for the given hash ID.
+func (r *remoteIndexer) GetIndexReport(ctx context.Context, hashID string) (*claircore.IndexReport, bool, error) {
+	resp, err := r.indexer.GetIndexReport(ctx, &v4.GetIndexReportRequest{HashId: hashID})
+	if err != nil {
+		if e, ok := status.FromError(err); ok && e.Code() == codes.NotFound {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	if !resp.GetSuccess() {
+		return nil, true, fmt.Errorf("report failed: state %s: %s", resp.GetState(), resp.GetErr())
+	}
+	ir, err := mappers.ToClairCoreIndexReport(resp.GetContents())
+	if err != nil {
+		return nil, true, err
+	}
+	return ir, true, nil
+}

--- a/scanner/indexer/remote.go
+++ b/scanner/indexer/remote.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/quay/claircore"
-	"github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/scanner/mappers"

--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -1,4 +1,4 @@
-package converters
+package mappers
 
 import (
 	"context"

--- a/scanner/mappers/mappers_test.go
+++ b/scanner/mappers/mappers_test.go
@@ -1,4 +1,4 @@
-package converters
+package mappers
 
 import (
 	"context"

--- a/scanner/services/indexer_test.go
+++ b/scanner/services/indexer_test.go
@@ -52,15 +52,15 @@ func createRequest(id, url, username string) *v4.CreateIndexReportRequest {
 	}
 }
 
-func (s *indexerServiceTestSuite) setupMock(optCount int, report *claircore.IndexReport, err error) {
+func (s *indexerServiceTestSuite) setupMock(hashID string, optCount int, report *claircore.IndexReport, err error) {
 	s.indexerMock.
 		EXPECT().
-		IndexContainerImage(gomock.Any(), gomock.Any(), gomock.Eq(imageURL), gomock.Len(optCount)).
+		IndexContainerImage(gomock.Any(), gomock.Eq(hashID), gomock.Eq(imageURL), gomock.Len(optCount)).
 		Return(report, err)
 }
 
 func (s *indexerServiceTestSuite) Test_CreateIndexReport_whenUsername_thenAuthEnabled() {
-	s.setupMock(1, &claircore.IndexReport{}, nil)
+	s.setupMock(hashID, 1, &claircore.IndexReport{}, nil)
 	req := createRequest(hashID, imageURL, "sample username")
 	r, err := s.service.CreateIndexReport(s.ctx, req)
 	s.NoError(err)
@@ -68,7 +68,7 @@ func (s *indexerServiceTestSuite) Test_CreateIndexReport_whenUsername_thenAuthEn
 }
 
 func (s *indexerServiceTestSuite) Test_CreateIndexReport_whenNoUsername_thenAuthDisabled() {
-	s.setupMock(0, &claircore.IndexReport{}, nil)
+	s.setupMock(hashID, 0, &claircore.IndexReport{}, nil)
 	req := createRequest(hashID, imageURL, "")
 	r, err := s.service.CreateIndexReport(s.ctx, req)
 	s.NoError(err)
@@ -76,7 +76,7 @@ func (s *indexerServiceTestSuite) Test_CreateIndexReport_whenNoUsername_thenAuth
 }
 
 func (s *indexerServiceTestSuite) Test_CreateIndexReport_whenIndexerError_thenInternalError() {
-	s.setupMock(0, nil, errors.New(`indexer said "ouch"`))
+	s.setupMock(hashID, 0, nil, errors.New(`indexer said "ouch"`))
 	req := createRequest(hashID, imageURL, "")
 	r, err := s.service.CreateIndexReport(s.ctx, req)
 	s.ErrorContains(err, "ouch")
@@ -196,13 +196,11 @@ func (s *indexerServiceTestSuite) Test_CreateIndexReport_InvalidInput() {
 
 func (s *indexerServiceTestSuite) Test_GetIndexReport() {
 	req := &v4.GetIndexReportRequest{HashId: hashID}
-	manifestDigest, err := createManifestDigest(hashID)
-	s.NoError(err)
 
 	// When get index report returns an error.
 	s.indexerMock.
 		EXPECT().
-		GetIndexReport(gomock.Any(), gomock.Eq(manifestDigest)).
+		GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
 		Return(nil, false, errors.New("ouch"))
 	r, err := s.service.GetIndexReport(s.ctx, req)
 	s.ErrorContains(err, "ouch")
@@ -211,7 +209,7 @@ func (s *indexerServiceTestSuite) Test_GetIndexReport() {
 	// When get index report returns not found.
 	s.indexerMock.
 		EXPECT().
-		GetIndexReport(gomock.Any(), gomock.Eq(manifestDigest)).
+		GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
 		Return(nil, false, nil)
 	r, err = s.service.GetIndexReport(s.ctx, req)
 	s.ErrorContains(err, "not found")
@@ -220,7 +218,7 @@ func (s *indexerServiceTestSuite) Test_GetIndexReport() {
 	// When get index report returns an index report.
 	s.indexerMock.
 		EXPECT().
-		GetIndexReport(gomock.Any(), gomock.Eq(manifestDigest)).
+		GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
 		Return(&claircore.IndexReport{State: "sample state"}, true, nil)
 	r, err = s.service.GetIndexReport(s.ctx, req)
 	s.NoError(err)

--- a/scanner/services/matcher_test.go
+++ b/scanner/services/matcher_test.go
@@ -64,14 +64,11 @@ func (s *matcherServiceTestSuite) Test_matcherService_GetVulnerabilities_empty_c
 		V:    []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 	}
 
-	manifestDigest, err := createManifestDigest("/v4/containerimage/foobar")
-	s.NoError(err)
-
 	s.Run("when empty content is enable and empty contents then retrieve index report", func() {
 		ir := &claircore.IndexReport{}
 		s.indexerMock.
 			EXPECT().
-			GetIndexReport(gomock.Any(), gomock.Eq(manifestDigest)).
+			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
 			Return(ir, true, nil)
 		s.matcherMock.
 			EXPECT().


### PR DESCRIPTION
## Description

Approve this PR to:

- Move service/converters to mappers.

- Add RemoteIndexer.

- Move manifest digest creation to indexer.

- Add config flag to enable remote indexer.

These changes will allow the Matcher to use a remote Indexer to retrieve Index Reports when the vulnerability report request does not contain contents, only index report hash id.
 
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Setup Scanner to run locally in different modes.

`matcher-config.yaml`:

```
http_listen_addr: 127.0.0.1:9444
grpc_listen_addr: 127.0.0.1:8444
indexer:
  enable: false
  database:
    conn_string: "host=/var/run/postgresql"
    password_file: ""
  get_layer_timeout: 1m
matcher:
  enable: true
  database:
    conn_string: "host=/var/run/postgresql"
    password_file: ""
  indexer_addr: :8443
mtls:
  certs_dir: certs/scanner-v4
log_level: info
```

`indexer-config.yaml`:

```
http_listen_addr: 127.0.0.1:9443
grpc_listen_addr: 127.0.0.1:8443
indexer:
  enable: true
  database:
    conn_string: "host=/var/run/postgresql"
    password_file: ""
  get_layer_timeout: 1m
matcher:
  enable: false
  database:
    conn_string: "host=/var/run/postgresql"
    password_file: ""
mtls:
  certs_dir: certs/scanner-v4
log_level: info
```

Run both:

```
⮩  ./bin/scanner -conf indexer-config.yaml 
{"level":"info","host":"descending","component":"main","version":"4.3.x-123-g21285ee594-dirty","time":"2023-11-09T21:30:43-08:00","message":"starting scanner"}
{"level":"info","host":"descending","component":"main","certs_prefix":"certs/scanner-v4","time":"2023-11-09T21:30:43-08:00","message":"identity certificates filename prefix changed"}
pkg/metrics: 2023/11/09 21:30:43.862314 server.go:142: Warn: Secure metrics server is disabled
pkg/metrics: 2023/11/09 21:30:43.862374 server.go:142: Warn: Secure metrics server is disabled
pkg/metrics: 2023/11/09 21:30:43.862416 server.go:142: Warn: Secure metrics server is disabled
{"level":"info","host":"descending","component":"main","time":"2023-11-09T21:30:43-08:00","message":"indexer is enabled"}
{"level":"info","host":"descending","component":"libindex/New","time":"2023-11-09T21:30:43-08:00","message":"registered configured scanners"}
{"level":"info","host":"descending","component":"indexer.NewLayerScanner","time":"2023-11-09T21:30:43-08:00","message":"NewLayerScanner: constructing a new layer-scanner"}
...
```

And:

```
⮩  ROX_METRICS_PORT=:9091 ./bin/scanner -conf matcher-config.yaml  
{"level":"info","host":"descending","component":"main","version":"4.3.x-123-g21285ee594-dirty","time":"2023-11-09T21:31:28-08:00","message":"starting scanner"}
{"level":"info","host":"descending","component":"main","certs_prefix":"certs/scanner-v4","time":"2023-11-09T21:31:28-08:00","message":"identity certificates filename prefix changed"}
pkg/metrics: 2023/11/09 21:31:28.884583 server.go:142: Warn: Secure metrics server is disabled
pkg/metrics: 2023/11/09 21:31:28.884634 server.go:142: Warn: Secure metrics server is disabled
pkg/metrics: 2023/11/09 21:31:28.884665 server.go:142: Warn: Secure metrics server is disabled
{"level":"info","host":"descending","component":"main","time":"2023-11-09T21:31:28-08:00","message":"indexer is disabled"}
{"level":"info","host":"descending","component":"main","time":"2023-11-09T21:31:28-08:00","message":"matcher is enabled"}
{"level":"info","host":"descending","component":"main","time":"2023-11-09T21:31:28-08:00","message":"remote indexer is enabled"}
```

Use `scannerctl` to test:

```
⮩  make certs
...
⮩  make build
...
⮩  ./bin/scannerctl --matcher-address :8444 --insecure-skip-tls-verify scan https://docker.io/library/ubuntu:16.04
2023/11/09 21:22:09 image digest: sha256:a3785f78ab8547ae2710c89e627783cfa7ee7824d3468cae6835c9f4eae23ff7
{
  "hash_id": "/v4/containerimage/sha256:a3785f78ab8547ae2710c89e627783cfa7ee7824d3468cae6835c9f4eae23ff7",
  "vulnerabilities": {
    "1192691": {
      "id": "1192691",
      "name": "CVE-2010-3192 on Ubuntu 16.04 LTS (xenial) - negligible.",
```

Send `SIGTERM` to the Indexer process (press "Control-C" in Linux). Then run `scannerctl` one more time:

```
⮩ ./bin/scannerctl --matcher-address :8444 --insecure-skip-tls-verify scan https://docker.io/library/ubuntu:16.04
2023/11/09 21:27:34 image digest: sha256:a3785f78ab8547ae2710c89e627783cfa7ee7824d3468cae6835c9f4eae23ff7
{"level":"debug","component":"scanner/client","method":"GetOrCreateImageIndex","error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp :8443: connect: connection refused\"","duration":793.438482,"time":"2023-11-09T21:27:34-08:00","message":"retrying gRPC call"}
{"level":"debug","component":"scanner/client","method":"GetOrCreateImageIndex","error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp :8443: connect: connection refused\"","duration":1976.24404,"time":"2023-11-09T21:27:35-08:00","message":"retrying gRPC call"}
{"level":"debug","component":"scanner/client","method":"GetOrCreateImageIndex","error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp :8443: connect: connection refused\"","duration":3680.89325,"time":"2023-11-09T21:27:37-08:00","message":"retrying gRPC call"}
{"level":"debug","component":"scanner/client","method":"GetOrCreateImageIndex","error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp :8443: connect: connection refused\"","duration":6103.658306,"time":"2023-11-09T21:27:41-08:00","message":"retrying gRPC call"}
Error: scanning: get or create index: get index: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :8443: connect: connection refused"
2023/11/09 21:27:47 scanning: get or create index: get index: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :8443: connect: connection refused"
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
