### PR TITLE
ROX-20713: Add log with connection details (External Entities in NWG)

### DIFF
--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/gogo/protobuf/types"
@@ -476,7 +477,7 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 			if conn.incoming {
 				log.Warnf("Incoming connection to container %s/%s from %q. "+
 					"Marking it as 'External Entities' in the network graph.",
-					container.Namespace, container.ContainerName, conn.remote.IPAndPort.String())
+					container.Namespace, container.ContainerName, conn.remote.IPAndPort.String()+":"+strconv.Itoa(int(port)))
 			} else {
 				log.Warnf("Outgoing connection from container %s/%s to %q. "+
 					"Marking it as 'External Entities' in the network graph.",

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -475,11 +475,11 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 				},
 			}
 			if conn.incoming {
-				log.Warnf("Incoming connection to container %s/%s from %q. "+
+				log.Debugf("Incoming connection to container %s/%s from %q. "+
 					"Marking it as 'External Entities' in the network graph.",
 					container.Namespace, container.ContainerName, conn.remote.IPAndPort.String()+":"+strconv.Itoa(int(port)))
 			} else {
-				log.Warnf("Outgoing connection from container %s/%s to %q. "+
+				log.Debugf("Outgoing connection from container %s/%s to %q. "+
 					"Marking it as 'External Entities' in the network graph.",
 					container.Namespace, container.ContainerName, conn.remote.IPAndPort.String())
 			}

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -466,12 +466,21 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 		}
 
 		if extSrc == nil {
-			// Fake a lookup result.
+			// Fake a lookup result. This shows "External Entities" in the network graph
 			lookupResults = []clusterentities.LookupResult{
 				{
 					Entity:         networkgraph.InternetEntity(),
 					ContainerPorts: []uint16{port},
 				},
+			}
+			if conn.incoming {
+				log.Warnf("Incoming connection to container %s/%s from %q. "+
+					"Marking it as 'External Entities' in the network graph.",
+					container.Namespace, container.ContainerName, conn.remote.IPAndPort.String())
+			} else {
+				log.Warnf("Outgoing connection from container %s/%s to %q. "+
+					"Marking it as 'External Entities' in the network graph.",
+					container.Namespace, container.ContainerName, conn.remote.IPAndPort.String())
 			}
 		} else {
 			lookupResults = []clusterentities.LookupResult{

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -475,11 +475,11 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 				},
 			}
 			if conn.incoming {
-				log.Debugf("Incoming connection to container %s/%s from %q. "+
+				log.Debugf("Incoming connection to container %s/%s from %s:%s. "+
 					"Marking it as 'External Entities' in the network graph.",
-					container.Namespace, container.ContainerName, conn.remote.IPAndPort.String()+":"+strconv.Itoa(int(port)))
+					container.Namespace, container.ContainerName, conn.remote.IPAndPort.String(), strconv.Itoa(int(port)))
 			} else {
-				log.Debugf("Outgoing connection from container %s/%s to %q. "+
+				log.Debugf("Outgoing connection from container %s/%s to %s. "+
 					"Marking it as 'External Entities' in the network graph.",
 					container.Namespace, container.ContainerName, conn.remote.IPAndPort.String())
 			}


### PR DESCRIPTION
## Description

Currently, if customers see an edge connecting a container with External Entities on the network graph, then they have no  information about this connection.

With this PR, we are adding a log line to Sensor with information about all external connections that are unknown. It means that we show source and destination of the connection (namespace + container name on one side, and IP address and port on the other side) for all cases when "External Entities" would appear on the graph.

Note that we will not show this log line, if the source/destination is external but belongs to the known CIDR ranges. In that case, we will show the name associated with the CIDR range on the graph and no log entry will be produced.

## Checklist
- [x] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

- I have deployed a cluster and triggered an edge to "External Entities" (stackrox has such edges by default)
- Opened Sensor logs and visually confirmed that the log line appears.

```
(...) Warn: Outgoing connection from container stackrox/central to "169.254.169.254:80". Marking it as 'External Entities' in the network graph.
(...) Warn: Outgoing connection from container stackrox/central to "255.255.255.255:443". Marking it as 'External Entities' in the network graph.
(...) Warn: Incoming connection to container stackrox/central from "10.74.41.227:8443". Marking it as 'External Entities' in the network graph.
```

![Screenshot 2023-11-10 at 12 27 36](https://github.com/stackrox/stackrox/assets/114479/27a7ff02-31c7-4579-ba35-0441170fea5d)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
