### PR TITLE
fix: configure telemetry in helm output

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -82,6 +82,9 @@ spec:
         - name: ROX_TELEMETRY_STORAGE_KEY_V1
           value: {{ ._rox.central.telemetry.storage.key | quote }}
         {{- end }}
+        {{- else }}
+        - name: ROX_TELEMETRY_STORAGE_KEY_V1
+          value: "DISABLED"
         {{- end }}
         - name: ROX_OFFLINE_MODE
           value: {{ ._rox.env.offlineMode | quote }}

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -74,6 +74,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         {{- if ne (._rox.central.telemetry.enabled | toString) "false" }}
+        {{- /* If telemetry.enabled is true or null, configure the endpoint and
+               the key, if provided. */}}
         {{- if ._rox.central.telemetry.storage.endpoint }}
         - name: ROX_TELEMETRY_ENDPOINT
           value: {{ ._rox.central.telemetry.storage.endpoint | quote }}
@@ -82,7 +84,10 @@ spec:
         - name: ROX_TELEMETRY_STORAGE_KEY_V1
           value: {{ ._rox.central.telemetry.storage.key | quote }}
         {{- end }}
+        {{- /* Otherwise... */}}
         {{- else }}
+        {{- /* ... if telemetry.enabled is false, configure the key to disable
+               telemetry collection */}}
         - name: ROX_TELEMETRY_STORAGE_KEY_V1
           value: "DISABLED"
         {{- end }}

--- a/operator/tests/central/basic-central/81-assert-non-openshift.yaml
+++ b/operator/tests/central/basic-central/81-assert-non-openshift.yaml
@@ -30,6 +30,8 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: ROX_TELEMETRY_STORAGE_KEY_V1
+              value: DISABLED
             - name: ROX_OFFLINE_MODE
               value: "false"
             - name: ROX_INSTALL_METHOD

--- a/operator/tests/central/basic-central/81-assert-openshift.yaml
+++ b/operator/tests/central/basic-central/81-assert-openshift.yaml
@@ -30,6 +30,8 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: ROX_TELEMETRY_STORAGE_KEY_V1
+              value: DISABLED
             - name: ROX_OFFLINE_MODE
               value: "false"
             - name: ROX_ENABLE_OPENSHIFT_AUTH

--- a/pkg/helm/charts/meta.go
+++ b/pkg/helm/charts/meta.go
@@ -86,6 +86,7 @@ func GetMetaValuesForFlavor(imageFlavor defaults.ImageFlavor) *MetaValues {
 		Operator:                 false,
 		ReleaseBuild:             buildinfo.ReleaseBuild,
 		FeatureFlags:             getFeatureFlags(),
+		TelemetryEnabled:         true,
 
 		AutoSensePodSecurityPolicies: true,
 	}

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/telemetry.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/telemetry.test.yaml
@@ -10,20 +10,20 @@ values:
       none: true
 
 tests:
-  - name: Central telemetry should not be enabled by default
+  - name: Central telemetry should not have a configured key by default
     expect: |
       envVars(.deployments.central; "central") | assertThat(has("ROX_TELEMETRY_STORAGE_KEY_V1") == false)
 
-  - name: Central telemetry should be enabled when enabled
+  - name: Central telemetry should be configured when enabled
     set:
       central.telemetry.enabled: true
       central.telemetry.storage.key: "key"
     expect: |
       envVars(.deployments.central; "central")["ROX_TELEMETRY_STORAGE_KEY_V1"] | assertThat(. == "key")
 
-  - name: Central monitoring should be disabled when not enabled
+  - name: Central telemetry should not have a key when not enabled
     set:
       central.telemetry.enabled: false
       central.telemetry.storage.key: "key"
     expect: |
-      envVars(.deployments.central; "central") | assertThat(has("ROX_TELEMETRY_STORAGE_KEY_V1") == false)
+      envVars(.deployments.central; "central")["ROX_TELEMETRY_STORAGE_KEY_V1"] | assertThat(. == "DISABLED")

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/telemetry.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/telemetry.test.yaml
@@ -21,7 +21,7 @@ tests:
     expect: |
       envVars(.deployments.central; "central")["ROX_TELEMETRY_STORAGE_KEY_V1"] | assertThat(. == "key")
 
-  - name: Central telemetry should have a DISABLED key when not enabled
+  - name: Central telemetry should have DISABLED key when not enabled
     set:
       central.telemetry.enabled: false
       central.telemetry.storage.key: "key"

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/telemetry.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/telemetry.test.yaml
@@ -21,7 +21,7 @@ tests:
     expect: |
       envVars(.deployments.central; "central")["ROX_TELEMETRY_STORAGE_KEY_V1"] | assertThat(. == "key")
 
-  - name: Central telemetry should not have a key when not enabled
+  - name: Central telemetry should have a DISABLED key when not enabled
     set:
       central.telemetry.enabled: false
       central.telemetry.storage.key: "key"

--- a/roxctl/helm/output/output.go
+++ b/roxctl/helm/output/output.go
@@ -111,16 +111,6 @@ func (cfg *helmOutputCommand) outputHelmChart() error {
 		return errors.Wrap(err, "unable to get chart meta values")
 	}
 
-	if (version.IsReleaseVersion() || pkgEnv.TelemetryStorageKey.Setting() != "") &&
-		pkgEnv.TelemetryStorageKey.Setting() != phonehome.DisabledKey {
-		chartMetaValues.TelemetryEnabled = true
-		chartMetaValues.TelemetryKey = pkgEnv.TelemetryStorageKey.Setting()
-		chartMetaValues.TelemetryEndpoint = pkgEnv.TelemetryEndpoint.Setting()
-	} else {
-		chartMetaValues.TelemetryEnabled = false
-		chartMetaValues.TelemetryKey = phonehome.DisabledKey
-	}
-
 	// load image with templates
 	templateImage := image.GetDefaultImage()
 	if flags.IsDebug() {
@@ -159,7 +149,19 @@ func (cfg *helmOutputCommand) getChartMetaValues(release bool) (*charts.MetaValu
 	if err != nil {
 		return nil, errox.InvalidArgs.Newf("'--%s': %v", flags.ImageDefaultsFlagName, err)
 	}
-	return charts.GetMetaValuesForFlavor(imageFlavor), nil
+
+	values := charts.GetMetaValuesForFlavor(imageFlavor)
+
+	if (version.IsReleaseVersion() || pkgEnv.TelemetryStorageKey.Setting() != "") &&
+		pkgEnv.TelemetryStorageKey.Setting() != phonehome.DisabledKey {
+		values.TelemetryEnabled = true
+		values.TelemetryKey = pkgEnv.TelemetryStorageKey.Setting()
+		values.TelemetryEndpoint = pkgEnv.TelemetryEndpoint.Setting()
+	} else {
+		values.TelemetryEnabled = false
+		values.TelemetryKey = phonehome.DisabledKey
+	}
+	return values, nil
 }
 
 func handleRhacsWarnings(rhacs, _ bool, logger logger.Logger) {

--- a/roxctl/helm/output/output.go
+++ b/roxctl/helm/output/output.go
@@ -111,13 +111,14 @@ func (cfg *helmOutputCommand) outputHelmChart() error {
 		return errors.Wrap(err, "unable to get chart meta values")
 	}
 
-	if version.IsReleaseVersion() || pkgEnv.TelemetryStorageKey.Setting() != "" {
+	if (version.IsReleaseVersion() || pkgEnv.TelemetryStorageKey.Setting() != "") &&
+		pkgEnv.TelemetryStorageKey.Setting() != phonehome.DisabledKey {
 		chartMetaValues.TelemetryEnabled = true
 		chartMetaValues.TelemetryKey = pkgEnv.TelemetryStorageKey.Setting()
 		chartMetaValues.TelemetryEndpoint = pkgEnv.TelemetryEndpoint.Setting()
 	} else {
-		chartMetaValues.TelemetryKey = phonehome.DisabledKey
 		chartMetaValues.TelemetryEnabled = false
+		chartMetaValues.TelemetryKey = phonehome.DisabledKey
 	}
 
 	// load image with templates


### PR DESCRIPTION
## Description

* Set telemetry key to `DISABLED`, if `central.telemetry.enabled==false`;
* Configure telemetry in `roxctl helm` output.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

`roxctl central generate k8s pvc`, running release version of `roxctl` generates this in `helm/values-public.yaml`:
```yaml
central:
  telemetry:
    enabled: true
    storage:
      endpoint: 
      key: 
```
and provided `--enabled-telemtry=false`:
```yaml
central:
  telemetry:
    enabled: false
    storage:
      endpoint: 
      key: DISABLED
```
the rendered helm chart in this case has this variable in the central deployment:
```yaml
        - name: ROX_TELEMETRY_STORAGE_KEY_V1
          value: "DISABLED"
```
### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
