### PR TITLE
ROX-20697: Use real data for approved deferrals

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
+    Bullseye,
     PageSection,
     Pagination,
+    Spinner,
     Toolbar,
     ToolbarContent,
     ToolbarGroup,
@@ -12,6 +14,8 @@ import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-tab
 import useURLPagination from 'hooks/useURLPagination';
 
 import useURLSearch from 'hooks/useURLSearch';
+import useURLSort from 'hooks/useURLSort';
+import useRestQuery from 'hooks/useRestQuery';
 import {
     IMAGE_CVE_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
@@ -19,8 +23,10 @@ import {
     REQUEST_NAME_SEARCH_OPTION,
     SearchOption,
 } from 'Containers/Vulnerabilities/components/SearchOptionsDropdown';
+import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionService';
 
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
+import NotFoundMessage from 'Components/NotFoundMessage';
 import {
     RequestExpires,
     RequestIDLink,
@@ -31,7 +37,7 @@ import {
     RequestScope,
 } from './components/ExceptionRequestTableCells';
 import FilterAutocompleteSelect from '../components/FilterAutocomplete';
-import { approvedDeferrals as vulnerabilityExceptions } from './mockUtils';
+import TableErrorComponent from '../WorkloadCves/components/TableErrorComponent';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,
@@ -40,12 +46,73 @@ const searchOptions: SearchOption[] = [
     IMAGE_SEARCH_OPTION,
 ];
 
+const sortFields = [
+    'Request Name',
+    'Requester User Name',
+    'Created Time',
+    'Request Expiry Time',
+    'Image Registry Scope',
+];
+const defaultSortOption = {
+    field: sortFields[0],
+    direction: 'desc',
+} as const;
+
 function ApprovedDeferrals() {
     const { searchFilter, setSearchFilter } = useURLSearch();
     const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields,
+        defaultSortOption,
+        onSort: () => setPage(1),
+    });
+
+    const vulnerabilityExceptionsFn = useCallback(
+        () =>
+            fetchVulnerabilityExceptions(
+                {
+                    ...searchFilter,
+                    'Request Status': ['APPROVED', 'APPROVED_PENDING_UPDATE'],
+                    'Requested Vulnerability State': 'DEFERRED',
+                },
+                sortOption,
+                page - 1,
+                perPage
+            ),
+        [searchFilter, sortOption, page, perPage]
+    );
+    const { data, loading, error } = useRestQuery(vulnerabilityExceptionsFn);
 
     function onFilterChange() {
         setPage(1);
+    }
+
+    if (loading && !data) {
+        return (
+            <Bullseye>
+                <Spinner isSVG />
+            </Bullseye>
+        );
+    }
+
+    if (error) {
+        return (
+            <PageSection variant="light">
+                <TableErrorComponent
+                    error={error}
+                    message="An error occurred. Try refreshing again"
+                />
+            </PageSection>
+        );
+    }
+
+    if (!data) {
+        return (
+            <NotFoundMessage
+                title="404: We couldn't find that page"
+                message="Pending vulnerability exception requests could not be found."
+            />
+        );
     }
 
     return (
@@ -59,7 +126,14 @@ function ApprovedDeferrals() {
                     />
                     <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
                         <Pagination
-                            itemCount={1}
+                            toggleTemplate={({ firstIndex, lastIndex }) => (
+                                <span>
+                                    <b>
+                                        {firstIndex} - {lastIndex}
+                                    </b>{' '}
+                                    of <b>many</b>
+                                </span>
+                            )}
                             page={page}
                             perPage={perPage}
                             onSetPage={(_, newPage) => setPage(newPage)}
@@ -83,17 +157,17 @@ function ApprovedDeferrals() {
             <TableComposable borders={false}>
                 <Thead noWrap>
                     <Tr>
-                        <Th>Request ID</Th>
-                        <Th>Requester</Th>
+                        <Th sort={getSortParams('Request Name')}>Request name</Th>
+                        <Th sort={getSortParams('Requester User Name')}>Requester</Th>
                         <Th>Requested action</Th>
-                        <Th>Requested</Th>
-                        <Th>Expires</Th>
-                        <Th>Scope</Th>
+                        <Th sort={getSortParams('Created Time')}>Requested</Th>
+                        <Th sort={getSortParams('Request Expiry Time')}>Expires</Th>
+                        <Th sort={getSortParams('Image Registry Scope')}>Scope</Th>
                         <Th>Requested items</Th>
                     </Tr>
                 </Thead>
                 <Tbody>
-                    {vulnerabilityExceptions.map((exception) => {
+                    {data.map((exception) => {
                         const { id, name, requester, createdAt, scope } = exception;
                         return (
                             <Tr key={id}>


### PR DESCRIPTION
## Description

This PR uses real data to display the approved deferrals' data in the Exception Management section. You should be able to filter and sort the same way described in https://github.com/stackrox/stackrox/pull/8577

## Screenshot

<img width="1552" alt="Screenshot 2023-11-10 at 3 56 02 PM" src="https://github.com/stackrox/stackrox/assets/4805485/84b6418c-1cd0-4605-853a-fbb1cf65268d">
<img width="1552" alt="Screenshot 2023-11-10 at 3 56 08 PM" src="https://github.com/stackrox/stackrox/assets/4805485/95972cc2-dbc9-4737-9f3b-8642b7a36723">


