### PR TITLE
ROX-20698: Use real data for approved false positives

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
+    Bullseye,
     PageSection,
     Pagination,
+    Spinner,
     Toolbar,
     ToolbarContent,
     ToolbarGroup,
@@ -21,6 +23,10 @@ import {
 } from 'Containers/Vulnerabilities/components/SearchOptionsDropdown';
 
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
+import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionService';
+import useRestQuery from 'hooks/useRestQuery';
+import useURLSort from 'hooks/useURLSort';
+import NotFoundMessage from 'Components/NotFoundMessage';
 import {
     RequestIDLink,
     RequestedAction,
@@ -30,7 +36,7 @@ import {
     RequestScope,
 } from './components/ExceptionRequestTableCells';
 import FilterAutocompleteSelect from '../components/FilterAutocomplete';
-import { approvedFalsePositives as vulnerabilityExceptions } from './mockUtils';
+import TableErrorComponent from '../WorkloadCves/components/TableErrorComponent';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,
@@ -39,12 +45,67 @@ const searchOptions: SearchOption[] = [
     IMAGE_SEARCH_OPTION,
 ];
 
+const sortFields = ['Request Name', 'Requester User Name', 'Created Time', 'Image Registry Scope'];
+const defaultSortOption = {
+    field: sortFields[0],
+    direction: 'desc',
+} as const;
+
 function ApprovedFalsePositives() {
     const { searchFilter, setSearchFilter } = useURLSearch();
     const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields,
+        defaultSortOption,
+        onSort: () => setPage(1),
+    });
+
+    const vulnerabilityExceptionsFn = useCallback(
+        () =>
+            fetchVulnerabilityExceptions(
+                {
+                    ...searchFilter,
+                    'Request Status': ['APPROVED', 'APPROVED_PENDING_UPDATE'],
+                    'Requested Vulnerability State': 'FALSE_POSITIVE',
+                },
+                sortOption,
+                page - 1,
+                perPage
+            ),
+        [searchFilter, sortOption, page, perPage]
+    );
+    const { data, loading, error } = useRestQuery(vulnerabilityExceptionsFn);
 
     function onFilterChange() {
         setPage(1);
+    }
+
+    if (loading && !data) {
+        return (
+            <Bullseye>
+                <Spinner isSVG />
+            </Bullseye>
+        );
+    }
+
+    if (error) {
+        return (
+            <PageSection variant="light">
+                <TableErrorComponent
+                    error={error}
+                    message="An error occurred. Try refreshing again"
+                />
+            </PageSection>
+        );
+    }
+
+    if (!data) {
+        return (
+            <NotFoundMessage
+                title="404: We couldn't find that page"
+                message="Approved false positive requests could not be found."
+            />
+        );
     }
 
     return (
@@ -58,7 +119,14 @@ function ApprovedFalsePositives() {
                     />
                     <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
                         <Pagination
-                            itemCount={1}
+                            toggleTemplate={({ firstIndex, lastIndex }) => (
+                                <span>
+                                    <b>
+                                        {firstIndex} - {lastIndex}
+                                    </b>{' '}
+                                    of <b>many</b>
+                                </span>
+                            )}
                             page={page}
                             perPage={perPage}
                             onSetPage={(_, newPage) => setPage(newPage)}
@@ -82,16 +150,16 @@ function ApprovedFalsePositives() {
             <TableComposable borders={false}>
                 <Thead noWrap>
                     <Tr>
-                        <Th>Request ID</Th>
-                        <Th>Requester</Th>
+                        <Th sort={getSortParams('Request Name')}>Request name</Th>
+                        <Th sort={getSortParams('Requester User Name')}>Requester</Th>
                         <Th>Requested action</Th>
-                        <Th>Requested</Th>
-                        <Th>Scope</Th>
+                        <Th sort={getSortParams('Created Time')}>Requested</Th>
+                        <Th sort={getSortParams('Image Registry Scope')}>Scope</Th>
                         <Th>Requested items</Th>
                     </Tr>
                 </Thead>
                 <Tbody>
-                    {vulnerabilityExceptions.map((exception) => {
+                    {data.map((exception) => {
                         const { id, name, requester, createdAt, scope } = exception;
                         return (
                             <Tr key={id}>


### PR DESCRIPTION
## Description

This PR uses real data to display the approved false positives data in the Exception Management section. You should be able to filter and sort the same way described in https://github.com/stackrox/stackrox/pull/8577

## Screenshot

<img width="1552" alt="Screenshot 2023-11-10 at 4 02 55 PM" src="https://github.com/stackrox/stackrox/assets/4805485/8f8386d0-898b-40b1-b394-d04b278d09c4">
<img width="1552" alt="Screenshot 2023-11-10 at 4 02 57 PM" src="https://github.com/stackrox/stackrox/assets/4805485/4855590a-93d0-4674-b828-1f08d392595f">



