### PR TITLE
ROX-20766: Do not assert operand health in upgrade step 20

### DIFF
--- a/operator/tests/common/upgrade-assert.envsubst.yaml
+++ b/operator/tests/common/upgrade-assert.envsubst.yaml
@@ -16,13 +16,6 @@ status:
     type: ReleaseFailed
   productVersion: ${PRODUCT_VERSION}
 ---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: central
-status:
-  availableReplicas: 1
----
 apiVersion: platform.stackrox.io/v1alpha1
 kind: SecuredCluster
 metadata:
@@ -41,19 +34,5 @@ status:
   - status: "False"
     type: ReleaseFailed
   productVersion: ${PRODUCT_VERSION}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: sensor
-status:
-  availableReplicas: 1
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: admission-control
-status:
-  availableReplicas: 3
 # Note: when adding/removing entries in this file, see the comment about timeout near the place
 # where `kuttl assert` is invoked on this file.

--- a/operator/tests/upgrade/upgrade/20-assert.yaml
+++ b/operator/tests/upgrade/upgrade/20-assert.yaml
@@ -10,18 +10,9 @@ commands:
     # Note: apparently $PWD is NOT set to directory of this file for TestAssert but it is for TestStep
     env - PATH=$PATH PRODUCT_VERSION=$NEW_PRODUCT_VERSION envsubst < tests/common/upgrade-assert.envsubst.yaml > $assert_file
     # Note: As of kuttl 0.11.0 the timeout value actually means "the number of attempts".
-    # With 5 objects in the assert file, each attempt typically takes ~18 seconds (including the 1s sleep between attempts),
+    # With 2 objects in the assert file, each attempt typically takes ~8 seconds (including the 1s sleep between attempts),
     # although it can occasionally take significantly longer, see https://github.com/kudobuilder/kuttl/issues/321
-    # So we specify a timeout value of 16, aiming for under 5 minutes.
-    ${KUTTL:-kubectl-kuttl} assert --namespace $NAMESPACE --timeout 16 $assert_file
+    # So we specify a timeout value of 37, aiming for under 5 minutes.
+    ${KUTTL:-kubectl-kuttl} assert --namespace $NAMESPACE --timeout 37 $assert_file
     rm $assert_file
-collectors:
-- type: pod
-  selector: app=central
-  tail: -1
-- type: pod
-  selector: app=sensor
-  tail: -1
-- type: pod
-  selector: app=admission-control
-  tail: -1
+# The operand health is asserted by the subsequent step.


### PR DESCRIPTION
## Description

This step timed out by less than a second due to quay slowness.

By only focusing on the status of CRs, and leaving assertion of operand health to subsequent step 30, we:
- reduce the scope of this step to just the operator reconciliation, greatly increasing its probability of success within the timeout
- increase the quality of the operand health checks, since step 30 has more checks and more collectors

One can think of this as continuation of the changes in https://github.com/stackrox/stackrox/pull/8431

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI should be sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
