### PR TITLE
chore: Decrease RHTAP workspace size for `roxctl` builds

### DIFF
--- a/.tekton/roxctl-pull-request.yaml
+++ b/.tekton/roxctl-pull-request.yaml
@@ -51,7 +51,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 10Gi
+            storage: 3Gi
       status: { }
   - name: git-auth
     secret:

--- a/.tekton/roxctl-pull-request.yaml
+++ b/.tekton/roxctl-pull-request.yaml
@@ -232,6 +232,21 @@ spec:
       - name: source
         workspace: workspace
 
+    - name: check-workspace-size
+      runAfter:
+      - prefetch-dependencies
+      workspaces:
+      - name: source
+        workspace: workspace
+      taskSpec:
+        steps:
+        - name: check-space
+          image: registry.access.redhat.com/ubi8/ubi
+          script: |
+            df -h
+            du -hs /workspace/source
+            du -hs /workspace/source/*
+
     - name: build-container
       params:
       - name: IMAGE

--- a/.tekton/roxctl-pull-request.yaml
+++ b/.tekton/roxctl-pull-request.yaml
@@ -232,21 +232,6 @@ spec:
       - name: source
         workspace: workspace
 
-    - name: check-workspace-size
-      runAfter:
-      - prefetch-dependencies
-      workspaces:
-      - name: source
-        workspace: workspace
-      taskSpec:
-        steps:
-        - name: check-space
-          image: registry.access.redhat.com/ubi8/ubi
-          script: |
-            df -h
-            du -hs /workspace/source
-            du -hs /workspace/source/*
-
     - name: build-container
       params:
       - name: IMAGE

--- a/.tekton/roxctl-push.yaml
+++ b/.tekton/roxctl-push.yaml
@@ -51,7 +51,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 10Gi
+            storage: 3Gi
       status: { }
   - name: git-auth
     secret:


### PR DESCRIPTION
## Description

This is to fix failing builds due to insufficient persistent volume quota when multiple build requests run in parallel.
See https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1699473999600919

## Checklist
- [x] Investigated and inspected CI test results

None of these are needed and will not be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

Verified needed volume size by injecting a Task that prints free and used space.
The passing build is the confirmation that the setting gives sufficient storage size.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
