### PR TITLE
ROX-20804: Defer rendering of vuln exception config form

### DIFF
--- a/ui/apps/platform/src/Containers/ExceptionConfiguration/ExceptionConfigurationPage.tsx
+++ b/ui/apps/platform/src/Containers/ExceptionConfiguration/ExceptionConfigurationPage.tsx
@@ -1,14 +1,22 @@
 import React from 'react';
-import { PageSection, Tab, Tabs, Title } from '@patternfly/react-core';
+import { Bullseye, PageSection, Spinner, Tab, Tabs, Title } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import PageTitle from 'Components/PageTitle';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import useURLStringUnion from 'hooks/useURLStringUnion';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { useVulnerabilitiesExceptionConfig } from './useVulnerabilitiesExceptionConfig';
 import VulnerabilitiesConfiguration from './VulnerabilitiesConfiguration';
 
 const exceptionConfigurationCategories = ['Vulnerabilities'] as const;
 
 function ExceptionConfigurationPage() {
     const [category, setCategory] = useURLStringUnion('category', exceptionConfigurationCategories);
+
+    const vulnerabilitiesConfigRequest = useVulnerabilitiesExceptionConfig();
+    const { config, isConfigLoading, isUpdateInProgress, configLoadError, updateConfig } =
+        vulnerabilitiesConfigRequest;
 
     return (
         <>
@@ -24,7 +32,30 @@ function ExceptionConfigurationPage() {
                     mountOnEnter
                 >
                     <Tab eventKey="Vulnerabilities" title="Vulnerabilities">
-                        <VulnerabilitiesConfiguration />
+                        {isConfigLoading && !config && (
+                            <Bullseye>
+                                <Spinner aria-label="Loading current vulnerability exception configuration" />
+                            </Bullseye>
+                        )}
+                        {configLoadError && (
+                            <Bullseye>
+                                <EmptyStateTemplate
+                                    title="Error loading vulnerability exception configuration"
+                                    headingLevel="h2"
+                                    icon={ExclamationCircleIcon}
+                                    iconClassName="pf-u-danger-color-100"
+                                >
+                                    {getAxiosErrorMessage(configLoadError)}
+                                </EmptyStateTemplate>
+                            </Bullseye>
+                        )}
+                        {config && (
+                            <VulnerabilitiesConfiguration
+                                config={config}
+                                isUpdateInProgress={isUpdateInProgress}
+                                updateConfig={updateConfig}
+                            />
+                        )}
                     </Tab>
                 </Tabs>
             </PageSection>

--- a/ui/apps/platform/src/Containers/ExceptionConfiguration/VulnerabilitiesConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/ExceptionConfiguration/VulnerabilitiesConfiguration.tsx
@@ -4,7 +4,6 @@ import {
     Alert,
     AlertActionCloseButton,
     AlertGroup,
-    Bullseye,
     Button,
     Divider,
     Flex,
@@ -14,7 +13,6 @@ import {
     Grid,
     GridItem,
     PageSection,
-    Spinner,
     Split,
     SplitItem,
     Switch,
@@ -22,20 +20,18 @@ import {
     TextInput,
     Title,
 } from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import sortBy from 'lodash/sortBy';
 import { FormikHandlers, useFormik } from 'formik';
 import * as yup from 'yup';
 
-import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { VulnerabilitiesExceptionConfig } from 'services/ExceptionConfigService';
 import useToasts, { Toast } from 'hooks/patternfly/useToasts';
 import usePermissions from 'hooks/usePermissions';
 
-import { useVulnerabilitiesExceptionConfig } from './useVulnerabilitiesExceptionConfig';
+import { UseVulnerabilitiesExceptionConfigReturn } from './useVulnerabilitiesExceptionConfig';
 
 type BaseSettingProps = {
     fieldId: string;
@@ -121,25 +117,6 @@ function BooleanSetting({
     );
 }
 
-function getDefaultConfig(): VulnerabilitiesExceptionConfig {
-    return {
-        expiryOptions: {
-            dayOptions: [
-                { numDays: 1, enabled: false },
-                { numDays: 1, enabled: false },
-                { numDays: 1, enabled: false },
-                { numDays: 1, enabled: false },
-            ],
-            fixableCveOptions: {
-                allFixable: false,
-                anyFixable: false,
-            },
-            customDate: false,
-            indefinite: false,
-        },
-    };
-}
-
 const validationSchema = yup.object({
     expiryOptions: yup.object({
         dayOptions: yup
@@ -213,16 +190,22 @@ function ensureMinimumDayOptions(
     };
 }
 
-function VulnerabilitiesConfiguration() {
+export type VulnerabilitiesConfigurationProps = {
+    config: VulnerabilitiesExceptionConfig;
+    updateConfig: UseVulnerabilitiesExceptionConfigReturn['updateConfig'];
+    isUpdateInProgress: boolean;
+};
+
+function VulnerabilitiesConfiguration({
+    config,
+    updateConfig,
+    isUpdateInProgress,
+}: VulnerabilitiesConfigurationProps) {
     const { toasts, addToast, removeToast } = useToasts();
 
-    const { config, isConfigLoading, isUpdateInProgress, configLoadError, updateConfig } =
-        useVulnerabilitiesExceptionConfig();
-
-    const exceptionConfig = ensureMinimumDayOptions(config ?? getDefaultConfig());
+    const exceptionConfig = ensureMinimumDayOptions(config);
 
     const { values, handleChange, errors, submitForm } = useFormik({
-        enableReinitialize: true,
         // Ensure that there are at least 4 day options in case this array was set to zero via the API
         initialValues: exceptionConfig,
         validationSchema,
@@ -273,77 +256,58 @@ function VulnerabilitiesConfiguration() {
             <Divider component="div" />
             <PageSection variant="light" component="div">
                 <Title headingLevel="h2">Configure exception times</Title>
-                {isConfigLoading && (
-                    <Bullseye>
-                        <Spinner aria-label="Loading current vulnerability exception configuration" />
-                    </Bullseye>
-                )}
-                {configLoadError && (
-                    <Bullseye>
-                        <EmptyStateTemplate
-                            title="Error loading vulnerability exception configuration"
-                            headingLevel="h2"
-                            icon={ExclamationCircleIcon}
-                            iconClassName="pf-u-danger-color-100"
-                        >
-                            {getAxiosErrorMessage(configLoadError)}
-                        </EmptyStateTemplate>
-                    </Bullseye>
-                )}
-                {!isConfigLoading && !configLoadError && (
-                    <Form className="pf-u-py-lg">
-                        <Grid hasGutter>
-                            {dayOptions.map(({ numDays, enabled }, index) => {
-                                const fieldIdPrefix = `expiryOptions.dayOptions[${index}]`;
-                                const fieldError = get(errors, `${fieldIdPrefix}.numDays`);
-                                const validated = fieldError ? 'error' : 'default';
-                                return (
-                                    <NumericSetting
-                                        // Note, if we ever support removing or reordering day options, we'll need to
-                                        // use a non-index key here.
-                                        // eslint-disable-next-line react/no-array-index-key
-                                        key={index}
-                                        fieldId={fieldIdPrefix}
-                                        value={numDays}
-                                        isSettingEnabled={enabled}
-                                        isDisabled={!hasWriteAccessForPage}
-                                        handleChange={handleChange}
-                                        validated={validated}
-                                        helperTextInvalid={fieldError}
-                                    />
-                                );
-                            })}
-                            <BooleanSetting
-                                fieldId="expiryOptions.indefinite"
-                                label="Indefinitely"
-                                isSettingEnabled={indefinite}
-                                isDisabled={!hasWriteAccessForPage}
-                                handleChange={handleChange}
-                            />
-                            <BooleanSetting
-                                fieldId="expiryOptions.fixableCveOptions.allFixable"
-                                label="Expires when all CVEs fixable"
-                                isSettingEnabled={fixableCveOptions.allFixable}
-                                isDisabled={!hasWriteAccessForPage}
-                                handleChange={handleChange}
-                            />
-                            <BooleanSetting
-                                fieldId="expiryOptions.fixableCveOptions.anyFixable"
-                                label="Expires when any CVE fixable"
-                                isSettingEnabled={fixableCveOptions.anyFixable}
-                                isDisabled={!hasWriteAccessForPage}
-                                handleChange={handleChange}
-                            />
-                            <BooleanSetting
-                                fieldId="expiryOptions.customDate"
-                                label="Allow custom date"
-                                isSettingEnabled={customDate}
-                                isDisabled={!hasWriteAccessForPage}
-                                handleChange={handleChange}
-                            />
-                        </Grid>
-                    </Form>
-                )}
+                <Form className="pf-u-py-lg">
+                    <Grid hasGutter>
+                        {dayOptions.map(({ numDays, enabled }, index) => {
+                            const fieldIdPrefix = `expiryOptions.dayOptions[${index}]`;
+                            const fieldError = get(errors, `${fieldIdPrefix}.numDays`);
+                            const validated = fieldError ? 'error' : 'default';
+                            return (
+                                <NumericSetting
+                                    // Note, if we ever support removing or reordering day options, we'll need to
+                                    // use a non-index key here.
+                                    // eslint-disable-next-line react/no-array-index-key
+                                    key={index}
+                                    fieldId={fieldIdPrefix}
+                                    value={numDays}
+                                    isSettingEnabled={enabled}
+                                    isDisabled={!hasWriteAccessForPage}
+                                    handleChange={handleChange}
+                                    validated={validated}
+                                    helperTextInvalid={fieldError}
+                                />
+                            );
+                        })}
+                        <BooleanSetting
+                            fieldId="expiryOptions.indefinite"
+                            label="Indefinitely"
+                            isSettingEnabled={indefinite}
+                            isDisabled={!hasWriteAccessForPage}
+                            handleChange={handleChange}
+                        />
+                        <BooleanSetting
+                            fieldId="expiryOptions.fixableCveOptions.allFixable"
+                            label="Expires when all CVEs fixable"
+                            isSettingEnabled={fixableCveOptions.allFixable}
+                            isDisabled={!hasWriteAccessForPage}
+                            handleChange={handleChange}
+                        />
+                        <BooleanSetting
+                            fieldId="expiryOptions.fixableCveOptions.anyFixable"
+                            label="Expires when any CVE fixable"
+                            isSettingEnabled={fixableCveOptions.anyFixable}
+                            isDisabled={!hasWriteAccessForPage}
+                            handleChange={handleChange}
+                        />
+                        <BooleanSetting
+                            fieldId="expiryOptions.customDate"
+                            label="Allow custom date"
+                            isSettingEnabled={customDate}
+                            isDisabled={!hasWriteAccessForPage}
+                            handleChange={handleChange}
+                        />
+                    </Grid>
+                </Form>
             </PageSection>
             <AlertGroup isToast isLiveRegion>
                 {toasts.map(({ key, variant, title, children }: Toast) => (


### PR DESCRIPTION
## Description

This defers rendering of the vulnerability exception config form until after the request has successfully returned the current configuration from the server.

This serves two purposes:
1. Fixes race conditions in tests
2. Prevents rendering the form with invalid placeholder data. The form now will only render with the correct, current data.

Easier to review with "Hide whitespace" on.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local Cypress run + awaiting CI
