### PR TITLE
fix(ui): Remove reliance on second page of CVEs in deferral test

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -179,15 +179,11 @@ export function selectMultipleCvesForException(exceptionType) {
     // Select the first CVE on the first page and the first CVE on the second page
     // to test multi-deferral flows
     return cy
-        .get(selectors.firstTableRow)
+        .get(selectors.nthTableRow(1))
         .then(($row) => {
             cveNames.push($row.find('td[data-label="CVE"]').text());
             cy.wrap($row).find(selectors.tableRowSelectCheckbox).click();
-            cy.get(selectors.paginationNext).click();
-            // Wait for the table to finish updating
-            cy.get(selectors.isUpdatingTable).should('not.exist');
-
-            return cy.get(selectors.firstTableRow);
+            return cy.get(selectors.nthTableRow(2));
         })
         .then(($nextRow) => {
             cveNames.push($nextRow.find('td[data-label="CVE"]').text());
@@ -195,8 +191,6 @@ export function selectMultipleCvesForException(exceptionType) {
 
             cy.get(selectors.bulkActionMenuToggle).click();
             cy.get(selectors.menuOption(menuOption)).click();
-        })
-        .then(() => {
             cy.get('button:contains("CVE selections")').click();
             // TODO - Update this code when modal form is completed
             cveNames.forEach((name) => {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -41,6 +41,8 @@ export const selectors = {
 
     // Data table selectors
     isUpdatingTable: '*[aria-busy="true"] table',
+    nthTableRow: (n) =>
+        `.workload-cves-table-container > table > tbody:nth-of-type(${n}) > tr:nth-of-type(1)`,
     firstTableRow: 'table tbody:nth-of-type(1) tr:nth-of-type(1)',
     tableRowSelectCheckbox: 'td input[type="checkbox"][aria-label^="Select row"]',
     tableRowSelectAllCheckbox: 'thead input[type="checkbox"][aria-label^="Select all rows"]',


### PR DESCRIPTION
## Description

Fixes more test casualties of the issue discovered last week.

https://issues.redhat.com/browse/ROX-20773
https://issues.redhat.com/browse/ROX-20774

In this case, these tests were relying on multiple pages of CVE data to test the multi-deferral workflows. Instead, now they just select multiple CVEs from the first page.

This changes the minimum number of required CVEs from 21 -> 2.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI