### PR TITLE
fix: linter for log message

### DIFF
--- a/tools/roxvet/analyzers/lognoendwithperiod/analyzer.go
+++ b/tools/roxvet/analyzers/lognoendwithperiod/analyzer.go
@@ -89,7 +89,7 @@ func checkCall(call *ast.CallExpr, pass *analysis.Pass) {
 	}
 
 	switch s[len(s)-1] {
-	case '.', ':', '!', '\n':
+	case '.', '!', '\n':
 		pass.Report(analysis.Diagnostic{
 			Pos:     call.Pos(),
 			Message: fmt.Sprintf("Log message should not end with punctuation or newlines: %q", s),

--- a/tools/roxvet/analyzers/lognoendwithperiod/analyzer.go
+++ b/tools/roxvet/analyzers/lognoendwithperiod/analyzer.go
@@ -91,7 +91,7 @@ func checkCall(call *ast.CallExpr, pass *analysis.Pass) {
 	switch s[len(s)-1] {
 	case '.', '!', '\n':
 		pass.Report(analysis.Diagnostic{
-			Pos:     call.Pos(),
+			Pos:     msg.End() - 1,
 			Message: fmt.Sprintf("Log message should not end with punctuation or newlines: %q", s),
 			SuggestedFixes: []analysis.SuggestedFix{{
 				Message: "Remove trailing punctuation or newline",

--- a/tools/roxvet/analyzers/lognoendwithperiod/analyzer.go
+++ b/tools/roxvet/analyzers/lognoendwithperiod/analyzer.go
@@ -72,6 +72,13 @@ func checkCall(call *ast.CallExpr, pass *analysis.Pass) {
 
 	msg := call.Args[0]
 	val := pass.TypesInfo.Types[msg].Value
+	if val == nil {
+		return
+	}
+	if val.Kind() != constant.String {
+		return
+	}
+
 	s := constant.StringVal(val)
 	if len(s) < 1 {
 		return
@@ -82,7 +89,7 @@ func checkCall(call *ast.CallExpr, pass *analysis.Pass) {
 	}
 
 	switch s[len(s)-1] {
-	case '.', ':', '!', '\n', ' ':
+	case '.', ':', '!', '\n':
 		pass.Report(analysis.Diagnostic{
 			Pos:     call.Pos(),
 			Message: fmt.Sprintf("Log message should not end with punctuation or newlines: %q", s),

--- a/tools/roxvet/analyzers/lognoendwithperiod/analyzer.go
+++ b/tools/roxvet/analyzers/lognoendwithperiod/analyzer.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
-	"honnef.co/go/tools/go/types/typeutil"
+	"golang.org/x/tools/go/types/typeutil"
 )
 
 // Analyzer is the analyzer.

--- a/tools/roxvet/analyzers/lognoendwithperiod/analyzer.go
+++ b/tools/roxvet/analyzers/lognoendwithperiod/analyzer.go
@@ -92,7 +92,7 @@ func checkCall(call *ast.CallExpr, pass *analysis.Pass) {
 	case '.', '!', '\n':
 		pass.Report(analysis.Diagnostic{
 			Pos:     msg.End() - 1,
-			Message: fmt.Sprintf("Log message should not end with punctuation or newlines: %q", s),
+			Message: fmt.Sprintf("Log message should not end with punctuation nor newlines: %q", s),
 			SuggestedFixes: []analysis.SuggestedFix{{
 				Message: "Remove trailing punctuation or newline",
 				TextEdits: []analysis.TextEdit{

--- a/tools/roxvet/analyzers/lognoendwithperiod/analyzer.go
+++ b/tools/roxvet/analyzers/lognoendwithperiod/analyzer.go
@@ -1,0 +1,101 @@
+package lognoendwithperiod
+
+import (
+	"fmt"
+	"go/ast"
+	"go/constant"
+	"go/types"
+	"strings"
+
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/tools/roxvet/common"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+	"honnef.co/go/tools/go/types/typeutil"
+)
+
+// Analyzer is the analyzer.
+var Analyzer = &analysis.Analyzer{
+	Name:     "lognoendwithperiod",
+	Doc:      "check for log messages ending with period",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+var names = set.NewFrozenStringSet(
+	"(github.com/stackrox/rox/pkg/logging.Logger).Debug",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Debugf",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Debugw",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Error",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Errorf",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Errorw",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Fatal",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Fatalf",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Fatalw",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Info",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Infof",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Infow",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Log",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Logf",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Panic",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Panicf",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Panicw",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Warn",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Warnf",
+	"(github.com/stackrox/rox/pkg/logging.Logger).Warnw",
+	"(github.com/stackrox/rox/pkg/logging.Logger).WriteToStderr",
+)
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspectResult := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	nodeFilter := []ast.Node{
+		(*ast.CallExpr)(nil),
+	}
+
+	common.FilteredPreorder(inspectResult, common.Not(common.IsTestFile), nodeFilter, func(n ast.Node) {
+		checkCall(n.(*ast.CallExpr), pass)
+	})
+	return nil, nil
+}
+
+func checkCall(call *ast.CallExpr, pass *analysis.Pass) {
+	fn, ok := typeutil.Callee(pass.TypesInfo, call).(*types.Func)
+	if !ok {
+		return
+	}
+
+	name := fn.FullName()
+	if !names.Contains(name) {
+		return
+	}
+
+	msg := call.Args[0]
+	val := pass.TypesInfo.Types[msg].Value
+	s := constant.StringVal(val)
+	if len(s) < 1 {
+		return
+	}
+
+	if strings.HasSuffix(s, "...") {
+		return
+	}
+
+	switch s[len(s)-1] {
+	case '.', ':', '!', '\n', ' ':
+		pass.Report(analysis.Diagnostic{
+			Pos:     call.Pos(),
+			Message: fmt.Sprintf("Log message should not end with punctuation or newlines: %q", s),
+			SuggestedFixes: []analysis.SuggestedFix{{
+				Message: "Remove trailing punctuation or newline",
+				TextEdits: []analysis.TextEdit{
+					{
+						Pos:     msg.Pos(),
+						End:     msg.End() - 1,
+						NewText: []byte(s[:len(s)-1]),
+					},
+				},
+			}},
+		})
+	}
+}

--- a/tools/roxvet/roxvet.go
+++ b/tools/roxvet/roxvet.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stackrox/rox/tools/roxvet/analyzers/filepathwalk"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/godoccapitalizationmismatch"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/importpackagenames"
+	"github.com/stackrox/rox/tools/roxvet/analyzers/lognoendwithperiod"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/migrationreferencedschema"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/needlessformat"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/protoclone"
@@ -36,5 +37,6 @@ func main() {
 		importpackagenames.Analyzer,
 		structuredlogs.Analyzer,
 		migrationreferencedschema.Analyzer,
+		lognoendwithperiod.Analyzer,
 	)
 }


### PR DESCRIPTION
## Description

Add a check for log messages to prevent them ending with punctuation.
Refs: 
- https://github.com/stackrox/stackrox/pull/8625

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

```
make roxvet
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
