### PR TITLE
chore(scanner): remove go version check

### DIFF
--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -51,7 +51,7 @@ all: images
 ###############################################################
 
 OSSLS_BIN := $(GOBIN)/ossls
-$(OSSLS_BIN): | build-go-check-ver
+$(OSSLS_BIN):
 	@echo "+ $@"
 	$(SILENT)cd tools/ && go install github.com/stackrox/ossls
 
@@ -87,7 +87,7 @@ $(build-t): $(build-deps-t)
 	@echo "+ $@"
 	$(build-cmd) -o $@ ./cmd/$(@F)
 
-$(build-deps-t): ../go.mod | build-go-check-ver
+$(build-deps-t): ../go.mod
 	@echo "+ $@"
 	$(SILENT)go mod tidy
 ifdef CI
@@ -98,15 +98,6 @@ ifdef CI
 endif
 	$(SILENT)go mod verify
 	$(SILENT)touch $@
-
-.PHONY: build-go-check-ver
-build-go-check-ver:
-ifdef CI
-	@echo "+ $@"
-ifneq ($(GO_VERSION),$(EXPECTED_GO_VERSION))
-	$(error 'Go version "$(GO_VERSION)" does not match the expected "$(EXPECTED_GO_VERSION)" version.')
-endif
-endif
 
 ############
 ## Images ##

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -5,7 +5,6 @@ The container image scanner.  Built with [ClairCore](https://github.com/quay/cla
 ## Development
 
 It is recommended to use the [EXPECTED_GO_VERSION](../EXPECTED_GO_VERSION), but this is not enforced for development.
-It is, however, enforced in CI.
 
 ### Running locally
 


### PR DESCRIPTION
## Description

Downstream images may be built with newer Go versions. Because of this, the `build-go-check-ver` check for the `$(build-deps-t)` is removed. After removing from that target, there isn't much of a reason to keep it around anymore, so I'm just going to remove it, completely.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
