### PR TITLE
fix(store): Put DeleteMany into a transaction

### DIFF
--- a/pkg/postgres/context.go
+++ b/pkg/postgres/context.go
@@ -19,3 +19,8 @@ func TxFromContext(ctx context.Context) (*Tx, bool) {
 	}
 	return obj.(*Tx), true
 }
+
+// HasTxInContext returns true if the tx is in the context
+func HasTxInContext(ctx context.Context) bool {
+	return ctx.Value(txContextKey{}) != nil
+}


### PR DESCRIPTION
## Description

DeleteMany currently has strange semantics where it may give you a partial deletion. This moves delete many into a single, all or nothing transaction which is much clearer semantics

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Unit tests test the nesting

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
