### PR TITLE
ROX-20848: Maintain vuln state across Workload CVE links

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -187,6 +187,11 @@ function RequestCVEsTable({ cves, scope, expandedRowSet }: RequestCVEsTableProps
                                 const cveURL = getEntityPagePath(
                                     'CVE',
                                     cve,
+                                    // TODO: (dv 2023-11-15)
+                                    //      We need to pass the appropriate request state here in order to link to the correct tab
+                                    //      This will change depending on what type of request we are looking at as well as
+                                    //      the state of the request
+                                    'OBSERVED',
                                     omitBy(cveURLQueryOptions, (value) => value === '')
                                 );
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
@@ -7,6 +7,7 @@ import { UseURLSortResult } from 'hooks/useURLSort';
 import DateDistanceTd from '../components/DatePhraseTd';
 import EmptyTableResults from '../components/EmptyTableResults';
 import { getEntityPagePath } from '../searchUtils';
+import useVulnerabilityState from '../hooks/useVulnerabilityState';
 
 export type DeploymentResources = {
     deploymentCount: number;
@@ -38,6 +39,7 @@ export type DeploymentResourceTableProps = {
 };
 
 function DeploymentResourceTable({ data, getSortParams }: DeploymentResourceTableProps) {
+    const vulnerabilityState = useVulnerabilityState();
     return (
         <TableComposable borders={false} variant="compact">
             <Thead noWrap>
@@ -59,7 +61,9 @@ function DeploymentResourceTable({ data, getSortParams }: DeploymentResourceTabl
                     >
                         <Tr>
                             <Td>
-                                <Link to={getEntityPagePath('Deployment', id)}>{name}</Link>
+                                <Link to={getEntityPagePath('Deployment', id, vulnerabilityState)}>
+                                    {name}
+                                </Link>
                             </Td>
                             <Td>{clusterName}</Td>
                             <Td>{namespace}</Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -138,7 +138,9 @@ function AffectedDeploymentsTable({
                                     direction={{ default: 'column' }}
                                     spaceItems={{ default: 'spaceItemsNone' }}
                                 >
-                                    <Link to={getEntityPagePath('Deployment', id)}>
+                                    <Link
+                                        to={getEntityPagePath('Deployment', id, vulnerabilityState)}
+                                    >
                                         <Truncate position="middle" content={name} />
                                     </Link>
                                 </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -232,7 +232,11 @@ function CVEsTable({
                                         cve={cve}
                                         vulnerabilityState={vulnerabilityState}
                                     >
-                                        <Link to={getEntityPagePath('CVE', cve)}>{cve}</Link>
+                                        <Link
+                                            to={getEntityPagePath('CVE', cve, vulnerabilityState)}
+                                        >
+                                            {cve}
+                                        </Link>
                                     </PendingExceptionLabelLayout>
                                 </Td>
                                 <Td dataLabel="Images by severity">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -198,7 +198,9 @@ function DeploymentVulnerabilitiesTable({
                                     cve={cve}
                                     vulnerabilityState={vulnerabilityState}
                                 >
-                                    <Link to={getEntityPagePath('CVE', cve)}>{cve}</Link>
+                                    <Link to={getEntityPagePath('CVE', cve, vulnerabilityState)}>
+                                        {cve}
+                                    </Link>
                                 </PendingExceptionLabelLayout>
                             </Td>
                             <Td modifier="nowrap" dataLabel="Severity">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -13,6 +13,7 @@ import EmptyTableResults from '../components/EmptyTableResults';
 import DateDistanceTd from '../components/DatePhraseTd';
 import TooltipTh from '../components/TooltipTh';
 import { VulnerabilitySeverityLabel } from '../types';
+import useVulnerabilityState from '../hooks/useVulnerabilityState';
 
 export const deploymentListQuery = gql`
     query getDeploymentList($query: String, $pagination: Pagination) {
@@ -69,6 +70,7 @@ function DeploymentsTable({
     isFiltered,
     filteredSeverities,
 }: DeploymentsTableProps) {
+    const vulnerabilityState = useVulnerabilityState();
     return (
         <TableComposable borders={false} variant="compact">
             <Thead noWrap>
@@ -112,7 +114,9 @@ function DeploymentsTable({
                         >
                             <Tr>
                                 <Td>
-                                    <Link to={getEntityPagePath('Deployment', id)}>
+                                    <Link
+                                        to={getEntityPagePath('Deployment', id, vulnerabilityState)}
+                                    >
                                         <Truncate position="middle" content={name} />
                                     </Link>
                                 </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -164,7 +164,11 @@ function ImageVulnerabilitiesTable({
                                         cve={cve}
                                         vulnerabilityState={vulnerabilityState}
                                     >
-                                        <Link to={getEntityPagePath('CVE', cve)}>{cve}</Link>
+                                        <Link
+                                            to={getEntityPagePath('CVE', cve, vulnerabilityState)}
+                                        >
+                                            {cve}
+                                        </Link>
                                     </PendingExceptionLabelLayout>
                                 </Td>
                                 <Td modifier="nowrap" dataLabel="CVE severity">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameTd.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { Flex, Truncate } from '@patternfly/react-core';
 
 import { getEntityPagePath } from '../searchUtils';
+import useVulnerabilityState from '../hooks/useVulnerabilityState';
 
 export type ImageNameTdProps = {
     name: {
@@ -15,9 +16,10 @@ export type ImageNameTdProps = {
 };
 
 function ImageNameTd({ name, id, children }: ImageNameTdProps) {
+    const vulnerabilityState = useVulnerabilityState();
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsNone' }}>
-            <Link to={getEntityPagePath('Image', id)}>
+            <Link to={getEntityPagePath('Image', id, vulnerabilityState)}>
                 <Truncate position="middle" content={`${name.remote}:${name.tag}`} />
             </Link>{' '}
             <span className="pf-u-color-200 pf-u-font-size-sm">in {name.registry}</span>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
@@ -45,9 +45,10 @@ export function getOverviewCvesPath(workloadCvesSearch: WorkloadCvesSearch): str
 export function getEntityPagePath(
     workloadCveEntity: EntityTab,
     id: string,
+    vulnerabilityState: VulnerabilityState | undefined, // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
     queryOptions?: qs.ParsedQs
 ): string {
-    const queryString = getQueryString(queryOptions);
+    const queryString = getQueryString({ ...queryOptions, vulnerabilityState });
     switch (workloadCveEntity) {
         case 'CVE':
             return `${vulnerabilitiesWorkloadCvesPath}/cves/${id}${queryString}`;


### PR DESCRIPTION
## Description

Links throughout the Workload CVE section will keep the user on the same vulnerability state tab (Observed, Deferred, False Positive).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Create and approve false positive and deferral requests.

Visit the deferred tab on the over view list page. Test that links for CVEs, Images, and Deployments keep you on the Deferred tab across pages:
![image](https://github.com/stackrox/stackrox/assets/1292638/513747d5-e389-4962-9a1a-28022e64097d)
![image](https://github.com/stackrox/stackrox/assets/1292638/35c86bb1-ae9b-4c29-9d3f-91d3c33bfcf4)
![image](https://github.com/stackrox/stackrox/assets/1292638/9722ecd4-1c85-41a8-89a0-7fca2c2b0440)
![image](https://github.com/stackrox/stackrox/assets/1292638/047e119b-55ac-4882-864c-03d2f9281ff1)

Check the outgoing links from the CVE single page:
![image](https://github.com/stackrox/stackrox/assets/1292638/c363c137-a09e-496d-88cc-f722e63a74f2)
![image](https://github.com/stackrox/stackrox/assets/1292638/d584d741-9200-4b35-af63-5b03df704f24)
![image](https://github.com/stackrox/stackrox/assets/1292638/b01c280c-f827-4895-98d6-aa3a08e4d143)
![image](https://github.com/stackrox/stackrox/assets/1292638/11445ec3-6353-44ae-8919-08015c553b4c)

Repeat for outgoing links from the Image and Deployment single pages.

Repeat all of the above for the Observed and False Positive tabs.
