### PR TITLE
ROX-9716: move signatureIntegrationIDPrefix to common location

### DIFF
--- a/central/signatureintegration/datastore/validate.go
+++ b/central/signatureintegration/datastore/validate.go
@@ -11,26 +11,17 @@ import (
 	"github.com/stackrox/rox/pkg/uuid"
 )
 
-// signatureIntegrationIDPrefix should be prepended to every human-hostile ID of a
-// signature integration for readability, e.g.,
-//
-//	"io.stackrox.signatureintegration.94ac7bfe-f9b2-402e-b4f2-bfda480e1a13".
-//
-// TODO(ROX-9716): refactor to reference the same constant here and in
-// pkg/booleanpolicy/value_regex.go
-const signatureIntegrationIDPrefix = "io.stackrox.signatureintegration."
-
 // GenerateSignatureIntegrationID returns a random valid signature integration ID.
 func GenerateSignatureIntegrationID() string {
-	return signatureIntegrationIDPrefix + uuid.NewV4().String()
+	return signatures.SignatureIntegrationIDPrefix + uuid.NewV4().String()
 }
 
 // ValidateSignatureIntegration checks that signature integration is valid.
 func ValidateSignatureIntegration(integration *storage.SignatureIntegration) error {
 	var multiErr error
 
-	if !strings.HasPrefix(integration.GetId(), signatureIntegrationIDPrefix) {
-		err := errors.Errorf("id field must be in '%s*' format", signatureIntegrationIDPrefix)
+	if !strings.HasPrefix(integration.GetId(), signatures.SignatureIntegrationIDPrefix) {
+		err := errors.Errorf("id field must be in '%s*' format", signatures.SignatureIntegrationIDPrefix)
 		multiErr = multierror.Append(multiErr, err)
 	}
 	if integration.GetName() == "" {

--- a/pkg/booleanpolicy/value_regex.go
+++ b/pkg/booleanpolicy/value_regex.go
@@ -3,6 +3,8 @@ package booleanpolicy
 import (
 	"fmt"
 	"regexp"
+
+	"github.com/stackrox/rox/pkg/signatures"
 )
 
 const (
@@ -33,9 +35,7 @@ var (
 	auditEventResourceValueRegex             = createRegex(`(?i:SECRETS|CONFIGMAPS|CLUSTER_ROLES|CLUSTER_ROLE_BINDINGS|NETWORK_POLICIES|SECURITY_CONTEXT_CONSTRAINTS|EGRESS_FIREWALLS)`)
 	kubernetesNameRegex                      = createRegex(`(?i:[a-z0-9])(?i:[-:a-z0-9]*[a-z0-9])?`)
 	ipAddressValueRegex                      = createRegex(fmt.Sprintf(`(%s)|(%s)`, ipv4Regex, ipv6Regex))
-	// TODO(ROX-9716): refactor to reference the same constant here and in
-	// central/signatureintegration/datastore/validate.go
-	signatureIntegrationIDValueRegex = createRegex("io\\.stackrox\\.signatureintegration\\.[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+	signatureIntegrationIDValueRegex         = createRegex(regexp.QuoteMeta(signatures.SignatureIntegrationIDPrefix) + "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
 )
 
 func createRegex(s string) *regexp.Regexp {

--- a/pkg/signatures/types.go
+++ b/pkg/signatures/types.go
@@ -1,0 +1,7 @@
+package signatures
+
+// SignatureIntegrationIDPrefix should be prepended to every human-hostile ID of a
+// signature integration for readability, e.g.,
+//
+//	"io.stackrox.signatureintegration.94ac7bfe-f9b2-402e-b4f2-bfda480e1a13".
+const SignatureIntegrationIDPrefix = "io.stackrox.signatureintegration."

--- a/pkg/signatures/types_test.go
+++ b/pkg/signatures/types_test.go
@@ -1,0 +1,13 @@
+package signatures
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuoteMetaSignatureIntegrationIDPrefix(t *testing.T) {
+	test := regexp.QuoteMeta(SignatureIntegrationIDPrefix)
+	assert.Equal(t, `io\.stackrox\.signatureintegration\.`, test)
+}


### PR DESCRIPTION
## Description

These changes move `signatureIntegrationIDPrefix` to a common location to reuse between `central/signatureintegration/datastore/validate.go` `pkg/booleanpolicy/value_regex.go`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

See added unit test.
