### PR TITLE
chore(deps): revert claircore to 1.5.19 again...

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/prometheus/client_model v0.5.0
 	github.com/prometheus/common v0.45.0
-	github.com/quay/claircore v1.5.20
+	github.com/quay/claircore v1.5.19
 	github.com/quay/zlog v1.1.7
 	github.com/rs/zerolog v1.31.0
 	github.com/russellhaering/gosaml2 v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1182,8 +1182,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quasilyte/go-ruleguard v0.2.0/go.mod h1:2RT/tf0Ce0UDj5y243iWKosQogJd8+1G3Rs2fxmlYnw=
 github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95/go.mod h1:rlzQ04UMyJXu/aOvhd8qT+hvDrFpiwqp8MRXDY9szc0=
-github.com/quay/claircore v1.5.20 h1:pR4lKRgdznk9wBqTXHSmYJPdYAPMRQTtSMzi6P3Vg9s=
-github.com/quay/claircore v1.5.20/go.mod h1:vz6VeOwzk2QLWGWAWrzjmPlUPkL9WwdeV3myHOwGwvA=
+github.com/quay/claircore v1.5.19 h1:nQ6Lg0yodxXPRbBj2yOHt0irit/79aKqaa37qSe3ak8=
+github.com/quay/claircore v1.5.19/go.mod h1:PrexKaa8EamLaA/dnOebPH8pWT31mg+AoXHlVDU4kn0=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=
 github.com/quay/claircore/toolkit v1.1.1 h1:9GFy14ffOkIOpl0fbR+bHr4i19VEwms1pXw8S8up0e4=
 github.com/quay/claircore/toolkit v1.1.1/go.mod h1:ZZHA/b/qpfUcNHFJeYVA0bOp7aL4r3CTFhlBV/ezoFI=


### PR DESCRIPTION
## Description

Dependabot is a menace and needs to be stopped.

Reverts https://github.com/stackrox/stackrox/pull/8618 because it will not build on Darwin. Already had to revert this before https://github.com/stackrox/stackrox/pull/8512.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
