### PR TITLE
chore(scanner): various image nits

### DIFF
--- a/scanner/e2etests/helmchart/templates/scanner-deployment.yaml
+++ b/scanner/e2etests/helmchart/templates/scanner-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         image: "{{ ( printf "%s/%s:%s" .Values.image.repository .Values.app.scanner.name .Values.image.tag ) }}"
         imagePullPolicy: IfNotPresent
         command:
-          - /entrypoint.sh
+          - entrypoint.sh
         args:
           - -conf
           - /etc/stackrox.d/scanner/config.yaml

--- a/scanner/image/db/Dockerfile
+++ b/scanner/image/db/Dockerfile
@@ -23,8 +23,7 @@ ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/" \
 ENV LANG=en_US.utf8
 
 COPY signatures/RPM-GPG-KEY-PGDG-13 /
-COPY scripts/docker-entrypoint.sh /usr/local/bin/
-COPY scripts/init-entrypoint.sh /usr/local/bin/
+COPY scripts/docker-entrypoint.sh scripts/init-entrypoint.sh /usr/local/bin/
 COPY --from=postgres_rpms /rpms/postgres.rpm /rpms/postgres-libs.rpm /rpms/postgres-server.rpm /rpms/postgres-contrib.rpm /tmp/
 
 RUN microdnf upgrade --nobest && \
@@ -45,8 +44,6 @@ RUN microdnf upgrade --nobest && \
     rpm -e --nodeps $(rpm -qa shadow-utils curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
-    chown postgres:postgres /usr/local/bin/docker-entrypoint.sh && \
-    chmod +x /usr/local/bin/docker-entrypoint.sh && \
     mkdir /docker-entrypoint-initdb.d
 
 STOPSIGNAL SIGINT

--- a/scanner/image/scanner/Dockerfile
+++ b/scanner/image/scanner/Dockerfile
@@ -12,8 +12,11 @@ LABEL name="scanner" \
 
 SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 
-COPY scripts/ /
-COPY bin/scanner /
+COPY scripts/entrypoint.sh \
+     scripts/import-additional-cas \
+     scripts/restore-all-dir-contents \
+     scripts/save-dir-contents /usr/local/bin/
+COPY bin/scanner /usr/local/bin/
 COPY THIRD_PARTY_NOTICES/ /THIRD_PARTY_NOTICES/
 
 RUN microdnf upgrade --nobest && \
@@ -26,10 +29,9 @@ RUN microdnf upgrade --nobest && \
     # by the script `save-dir-contents` during the image build. The directory
     # contents are then restored by the script `restore-all-dir-contents`
     # during the container start.
-    chown -R 65534:65534 /etc/pki /etc/ssl && /save-dir-contents /etc/pki/ca-trust /etc/ssl && \
-    chmod +rx /scanner
+    chown -R 65534:65534 /etc/pki /etc/ssl && save-dir-contents /etc/pki/ca-trust /etc/ssl
 
 # This is equivalent to nobody:nobody.
 USER 65534:65534
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["entrypoint.sh"]

--- a/scanner/image/scanner/scripts/entrypoint.sh
+++ b/scanner/image/scanner/scripts/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-/restore-all-dir-contents
-/import-additional-cas
+restore-all-dir-contents
+import-additional-cas
 
-exec /scanner "$@"
+exec scanner "$@"


### PR DESCRIPTION
## Description

Scanner image:

* Explicitly copy the scripts we want to prevent unintentional bloat. For example, the `.gitignore` file was copied into the Scanner image, previously
* Put the scripts into `/usr/local/bin` instead of root, as it's the standard location for local binaries in Linux
    * Note: Scanner v4 DB already put scripts here
* Remove `chmod +rx /scanner`, as it already has these permissions

Scanner DB image:

* Keep `the owner of /usr/local/bin/docker-entrypoint.sh` as root to prevent potential attackers using the `postgres` user from messing with the file
* Remove `chmod +x /usr/local/bin/docker-entrypoint.sh` since it's already executable
* Move scripts copies into a single layer

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Build the image and run it. You'll find it builds and runs properly (not file permission errors nor unknown file paths).

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
