### PR TITLE
chore(CI): remove unused secrets mount

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -965,9 +965,6 @@ ensure_writable_home_dir() {
 
 openshift_ci_import_creds() {
     shopt -s nullglob
-    for cred in /tmp/secret/**/[A-Z]*; do
-        export "$(basename "$cred")"="$(cat "$cred")"
-    done
     for cred in /tmp/vault/**/[A-Z]*; do
         export "$(basename "$cred")"="$(cat "$cred")"
     done


### PR DESCRIPTION
## Description

`/tmp/secrets` is not used. ref: https://github.com/stackrox/stackrox/pull/2540 & https://github.com/openshift/release/pull/30789

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] add osd-aws