### PR TITLE
ROX-20886: Add modal for viewing exception request comments

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -12,8 +12,6 @@ import {
     FlexItem,
     PageSection,
     Spinner,
-    Text,
-    TextVariants,
     Title,
     pluralize,
 } from '@patternfly/react-core';
@@ -22,7 +20,6 @@ import { useParams } from 'react-router-dom';
 import { exceptionManagementPath } from 'routePaths';
 import useSet from 'hooks/useSet';
 import useRestQuery from 'hooks/useRestQuery';
-import { getDateTime } from 'utils/dateUtils';
 import { ensureExhaustive } from 'utils/type.utils';
 import {
     VulnerabilityException,
@@ -36,6 +33,8 @@ import {
     RequestedAction,
     RequestCreatedAt,
     RequestScope,
+    RequestComments,
+    RequestComment,
 } from './components/ExceptionRequestTableCells';
 import RequestCVEsTable from './components/RequestCVEsTable';
 import TableErrorComponent from '../WorkloadCves/components/TableErrorComponent';
@@ -169,29 +168,13 @@ function ExceptionRequestDetailsPage() {
                             <DescriptionListGroup>
                                 <DescriptionListTerm>Comments</DescriptionListTerm>
                                 <DescriptionListDescription>
-                                    {vulnerabilityException.comments.length}
+                                    <RequestComments comments={vulnerabilityException.comments} />
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                             <DescriptionListGroup>
                                 <DescriptionListTerm>Latest comment</DescriptionListTerm>
                                 <DescriptionListDescription>
-                                    <Flex direction={{ default: 'column' }}>
-                                        <Flex
-                                            direction={{ default: 'row' }}
-                                            spaceItems={{ default: 'spaceItemsSm' }}
-                                        >
-                                            <Text
-                                                className="pf-u-font-weight-bold"
-                                                component={TextVariants.p}
-                                            >
-                                                {latestComment.user.name}
-                                            </Text>
-                                            <Text component={TextVariants.small}>
-                                                ({getDateTime(latestComment.createdAt)})
-                                            </Text>
-                                        </Flex>
-                                        <FlexItem>{latestComment.message}</FlexItem>
-                                    </Flex>
+                                    <RequestComment comment={latestComment} />
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                         </DescriptionList>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
@@ -1,15 +1,27 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';
+import {
+    Button,
+    Flex,
+    FlexItem,
+    List,
+    ListItem,
+    Modal,
+    Text,
+    TextVariants,
+} from '@patternfly/react-core';
 
 import { exceptionManagementPath } from 'routePaths';
 import {
     ExceptionExpiry,
     VulnerabilityException,
+    VulnerabilityExceptionComment,
     isDeferralException,
     isFalsePositiveException,
 } from 'services/VulnerabilityExceptionService';
-import { getDate, getDistanceStrictAsPhrase } from 'utils/dateUtils';
+import { getDate, getDateTime, getDistanceStrictAsPhrase } from 'utils/dateUtils';
+import useModal from 'hooks/useModal';
 
 export type RequestContext =
     | 'PENDING_REQUESTS'
@@ -154,4 +166,50 @@ export function RequestedItems({ exception, context }: RequestedItemsProps) {
         cvesCount = exception.falsePositiveUpdate.cves.length;
     }
     return <div>{`${cvesCount} ${pluralize('CVE', cvesCount)}`}</div>;
+}
+
+export type RequestCommentProps = {
+    comment: VulnerabilityExceptionComment;
+};
+
+export function RequestComment({ comment }: RequestCommentProps) {
+    return (
+        <Flex direction={{ default: 'column' }}>
+            <Flex direction={{ default: 'row' }} spaceItems={{ default: 'spaceItemsSm' }}>
+                <Text className="pf-u-font-weight-bold" component={TextVariants.p}>
+                    {comment.user.name}
+                </Text>
+                <Text component={TextVariants.small}>({getDateTime(comment.createdAt)})</Text>
+            </Flex>
+            <FlexItem>{comment.message}</FlexItem>
+        </Flex>
+    );
+}
+
+export type RequestCommentsProps = {
+    comments: VulnerabilityExceptionComment[];
+};
+
+export function RequestComments({ comments }: RequestCommentsProps) {
+    const { isModalOpen, openModal, closeModal } = useModal();
+
+    return (
+        <>
+            <Button variant="link" isInline onClick={openModal}>{`${comments.length} ${pluralize(
+                'comment',
+                comments.length
+            )}`}</Button>
+            <Modal variant="small" title="Comments" isOpen={isModalOpen} onClose={closeModal}>
+                <List isPlain isBordered>
+                    {comments.map((comment) => {
+                        return (
+                            <ListItem>
+                                <RequestComment comment={comment} />
+                            </ListItem>
+                        );
+                    })}
+                </List>
+            </Modal>
+        </>
+    );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
@@ -203,7 +203,7 @@ export function RequestComments({ comments }: RequestCommentsProps) {
                 <List isPlain isBordered>
                     {comments.map((comment) => {
                         return (
-                            <ListItem>
+                            <ListItem key={comment.id}>
                                 <RequestComment comment={comment} />
                             </ListItem>
                         );

--- a/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
+++ b/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
@@ -12,7 +12,7 @@ export type VulnerabilityState = 'OBSERVED' | 'DEFERRED' | 'FALSE_POSITIVE';
 
 export type ExceptionStatus = 'PENDING' | 'APPROVED' | 'DENIED' | 'APPROVED_PENDING_UPDATE';
 
-type Comment = {
+export type VulnerabilityExceptionComment = {
     id: string;
     message: string;
     user: SlimUser;
@@ -45,7 +45,7 @@ export type BaseVulnerabilityException = {
     approvers: SlimUser[];
     createdAt: string; // ISO 8601
     lastUpdated: string; // ISO 8601
-    comments: Comment[];
+    comments: VulnerabilityExceptionComment[];
     scope: VulnerabilityExceptionScope;
     cves: string[];
 };


### PR DESCRIPTION
## Description

This PR adds the ability to view comments on the Request Details page. Clicking the comments button/link will open a modal to view comments in a scrollable manner.

## Screenshots

<img width="1552" alt="Screenshot 2023-11-15 at 10 23 07 AM" src="https://github.com/stackrox/stackrox/assets/4805485/1938d5f1-73ff-471b-a0c8-3ae311cb1db0">
<img width="1552" alt="Screenshot 2023-11-15 at 10 23 10 AM" src="https://github.com/stackrox/stackrox/assets/4805485/02c20375-e2ff-48cb-894a-6c02b7c367a2">

