### PR TITLE
chore(roxctl): upload-db minor cleanup

### DIFF
--- a/roxctl/scanner/uploaddb/uploaddb.go
+++ b/roxctl/scanner/uploaddb/uploaddb.go
@@ -14,10 +14,10 @@ import (
 )
 
 const (
-	scannerUploadDbAPIPath = "/api/extensions/scannerdefinitions"
+	scannerUploadDBAPIPath = "/api/extensions/scannerdefinitions"
 )
 
-type scannerUploadDbCommand struct {
+type scannerUploadDBCommand struct {
 	// Properties that are bound to cobra flags.
 	filename string
 	timeout  time.Duration
@@ -26,11 +26,11 @@ type scannerUploadDbCommand struct {
 	env environment.Environment
 }
 
-func (cmd *scannerUploadDbCommand) construct(c *cobra.Command) {
+func (cmd *scannerUploadDBCommand) construct(c *cobra.Command) {
 	cmd.timeout = flags.Timeout(c)
 }
 
-func (cmd *scannerUploadDbCommand) uploadDd() error {
+func (cmd *scannerUploadDBCommand) uploadDB() error {
 	file, err := os.Open(cmd.filename)
 	if err != nil {
 		return errors.Wrap(err, "could not open file")
@@ -41,7 +41,7 @@ func (cmd *scannerUploadDbCommand) uploadDd() error {
 	if err != nil {
 		return errors.Wrap(err, "creating HTTP client")
 	}
-	resp, err := client.DoReqAndVerifyStatusCode(scannerUploadDbAPIPath, http.MethodPost, http.StatusOK, file)
+	resp, err := client.DoReqAndVerifyStatusCode(scannerUploadDBAPIPath, http.MethodPost, http.StatusOK, file)
 	if err != nil {
 		return errors.Wrap(err, "could not connect with scanner definitions API")
 	}
@@ -59,20 +59,20 @@ func (cmd *scannerUploadDbCommand) uploadDd() error {
 
 // Command represents the command.
 func Command(cliEnvironment environment.Environment) *cobra.Command {
-	scannerUploadDbCmd := &scannerUploadDbCommand{env: cliEnvironment}
+	scannerUploadDBCmd := &scannerUploadDBCommand{env: cliEnvironment}
 
 	c := &cobra.Command{
 		Use:   "upload-db",
 		Short: "Upload a vulnerability database for the StackRox Scanner.",
 		Args:  cobra.NoArgs,
 		RunE: func(c *cobra.Command, args []string) error {
-			scannerUploadDbCmd.construct(c)
+			scannerUploadDBCmd.construct(c)
 
-			return scannerUploadDbCmd.uploadDd()
+			return scannerUploadDBCmd.uploadDB()
 		},
 	}
 
-	c.Flags().StringVar(&scannerUploadDbCmd.filename, "scanner-db-file", "", "File containing the dumped Scanner definitions DB")
+	c.Flags().StringVar(&scannerUploadDBCmd.filename, "scanner-db-file", "", "File containing the dumped Scanner definitions DB")
 	flags.AddTimeoutWithDefault(c, 10*time.Minute)
 	utils.Must(c.MarkFlagRequired("scanner-db-file"))
 

--- a/roxctl/scanner/uploaddb/uploaddb_test.go
+++ b/roxctl/scanner/uploaddb/uploaddb_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
-	io2 "github.com/stackrox/rox/roxctl/common/io"
+	roxctlio "github.com/stackrox/rox/roxctl/common/io"
 	"github.com/stackrox/rox/roxctl/common/printer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func executeUpdateDbCommand(t *testing.T, serverURL string) (*bytes.Buffer, *bytes.Buffer, error) {
+func executeUpdateDBCommand(t *testing.T, serverURL string) (*bytes.Buffer, *bytes.Buffer, error) {
 	tmpFile, errTempFile := os.CreateTemp("", "*.zip")
 	if errTempFile != nil {
 		return nil, nil, errTempFile
@@ -28,7 +28,7 @@ func executeUpdateDbCommand(t *testing.T, serverURL string) (*bytes.Buffer, *byt
 		return os.Remove(tmpFile.Name())
 	})
 
-	testIO, _, stdOut, stdErr := io2.TestIO()
+	testIO, _, stdOut, stdErr := roxctlio.TestIO()
 	env := environment.NewTestCLIEnvironment(t, testIO, printer.DefaultColorPrinter())
 
 	cmd := Command(env)
@@ -41,7 +41,7 @@ func executeUpdateDbCommand(t *testing.T, serverURL string) (*bytes.Buffer, *byt
 
 	// We are using common.DoHTTPRequestAndCheck200 inside uploadDd(). This
 	// function uses  global variables that are set by command execution.
-	// TODO(ROX-13638): Change uploadDd function to use HTTPClient from Environment.
+	// TODO(ROX-13638): Change uploadDB function to use HTTPClient from Environment.
 	cmdArgs := []string{"--insecure-skip-tls-verify", "--insecure", "--endpoint", serverURL, "--password", "test"}
 	cmdArgs = append(cmdArgs, "--scanner-db-file", tmpFile.Name())
 	cmd.SetArgs(cmdArgs)
@@ -56,9 +56,9 @@ func executeUpdateDbCommand(t *testing.T, serverURL string) (*bytes.Buffer, *byt
 
 func TestScannerUploadDbCommand(t *testing.T) {
 	t.Run("file does not exist", func(t *testing.T) {
-		cmdNoFile := scannerUploadDbCommand{filename: "non-existing-filename"}
+		cmdNoFile := scannerUploadDBCommand{filename: "non-existing-filename"}
 
-		actualErr := cmdNoFile.uploadDd()
+		actualErr := cmdNoFile.uploadDB()
 
 		require.Error(t, actualErr)
 		assert.ErrorIs(t, actualErr, fs.ErrNotExist)
@@ -72,7 +72,7 @@ func TestScannerUploadDbCommand(t *testing.T) {
 		}))
 		defer server.Close()
 
-		_, _, err := executeUpdateDbCommand(t, server.URL)
+		_, _, err := executeUpdateDBCommand(t, server.URL)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), expectedErrorStr)
@@ -84,7 +84,7 @@ func TestScannerUploadDbCommand(t *testing.T) {
 		}))
 		defer server.Close()
 
-		stdOut, stdErr, err := executeUpdateDbCommand(t, server.URL)
+		stdOut, stdErr, err := executeUpdateDBCommand(t, server.URL)
 
 		require.Error(t, err)
 		require.NotNil(t, stdOut)
@@ -101,7 +101,7 @@ func TestScannerUploadDbCommand(t *testing.T) {
 		}))
 		defer server.Close()
 
-		stdOut, stdErr, err := executeUpdateDbCommand(t, server.URL)
+		stdOut, stdErr, err := executeUpdateDBCommand(t, server.URL)
 
 		require.NoError(t, err)
 		assert.Empty(t, stdErr.String())


### PR DESCRIPTION
## Description

Reformats Db to DB and renames `uploadDd` to `uploadDB`

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

If it builds, it builds

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
