### PR TITLE
fix(ui): Fix infinite rerender in vm reporting

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -71,6 +71,8 @@ const sortOptions = {
     defaultSortOption: { field: reportNameSearchKey, direction: 'asc' } as const,
 };
 
+const emptyReportArray = [];
+
 function VulnReportsPage() {
     const history = useHistory();
 
@@ -129,7 +131,7 @@ function VulnReportsPage() {
         onSelectAll,
         onClearAll: onClearAllSelected,
         getSelectedIds,
-    } = useTableSelection(reportConfigurations || []);
+    } = useTableSelection(reportConfigurations || emptyReportArray);
 
     const {
         openDeleteModal,


### PR DESCRIPTION
## Description

Found this while navigating with the console open. The VM reporting list page will rerender infinitely until the report list returns from the API call, or indefinitely if there is a network error on the initial request.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

With the console open, verify that the "Maximum update depth exceeded." error is not displayed when visiting VM reporting.
