### PR TITLE
test(ui): Clear all filters before performing deferral tests

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/cveListExceptionFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/cveListExceptionFlow.test.js
@@ -20,7 +20,8 @@ describe('Workload CVE List deferral and false positive flows', () => {
     before(function () {
         if (
             !hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES') ||
-            !hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL')
+            !hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL') ||
+            !hasFeatureFlag('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS')
         ) {
             this.skip();
         }
@@ -29,7 +30,8 @@ describe('Workload CVE List deferral and false positive flows', () => {
     beforeEach(() => {
         if (
             hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES') &&
-            hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL')
+            hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL') &&
+            hasFeatureFlag('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS')
         ) {
             cancelAllCveExceptions();
         }
@@ -38,7 +40,8 @@ describe('Workload CVE List deferral and false positive flows', () => {
     after(() => {
         if (
             hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES') &&
-            hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL')
+            hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL') &&
+            hasFeatureFlag('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS')
         ) {
             cancelAllCveExceptions();
         }
@@ -87,6 +90,7 @@ describe('Workload CVE List deferral and false positive flows', () => {
 
     it('should defer a single CVE', () => {
         visitWorkloadCveOverview();
+        cy.get(selectors.clearFiltersButton).click(); // Note: This is a workaround to prevent a lack of CVE data from causing the test to fail in CI
 
         selectSingleCveForException('DEFERRAL').then((cveName) => {
             verifySelectedCvesInModal([cveName]);
@@ -105,6 +109,7 @@ describe('Workload CVE List deferral and false positive flows', () => {
 
     it('should defer multiple selected CVEs', () => {
         visitWorkloadCveOverview();
+        cy.get(selectors.clearFiltersButton).click(); // Note: This is a workaround to prevent a lack of CVE data from causing the test to fail in CI
 
         selectMultipleCvesForException('DEFERRAL').then((cveNames) => {
             verifySelectedCvesInModal(cveNames);
@@ -121,6 +126,7 @@ describe('Workload CVE List deferral and false positive flows', () => {
 
     it('should mark a single CVE false positive', () => {
         visitWorkloadCveOverview();
+        cy.get(selectors.clearFiltersButton).click(); // Note: This is a workaround to prevent a lack of CVE data from causing the test to fail in CI
 
         selectSingleCveForException('FALSE_POSITIVE').then((cveName) => {
             verifySelectedCvesInModal([cveName]);
@@ -135,6 +141,7 @@ describe('Workload CVE List deferral and false positive flows', () => {
 
     it('should mark multiple selected CVEs as false positive', () => {
         visitWorkloadCveOverview();
+        cy.get(selectors.clearFiltersButton).click(); // Note: This is a workaround to prevent a lack of CVE data from causing the test to fail in CI
 
         selectMultipleCvesForException('FALSE_POSITIVE').then((cveNames) => {
             verifySelectedCvesInModal(cveNames);

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
@@ -35,9 +35,6 @@ describe('Workload CVE overview page tests', () => {
             'aria-pressed',
             'true'
         );
-
-        // Check the no filters exist in the chips
-        cy.get(selectors.filterChipGroup).should('not.exist');
     });
 
     it('should correctly handle applied filters across entity tabs', function () {


### PR DESCRIPTION
## Description

The combination of the following recent changes have made the amount of CVE data available in CI unpredictable:
1. https://issues.redhat.com/browse/ROX-20728 resulting in fewer overall images scanned at runtime
2. https://issues.redhat.com/browse/ROX-17494 resulting in unfixable, low severity, and moderate severity CVEs being filtered from the table
3. The fact that CVEs disappear from the CI when an update fixes the vulnerability (disproportionately affecting the inverse of 2 above - Critical/Important and Fixable CVEs)

This attempts to mitigate at least 2 and 3 by clearing all applied filters at the beginning of the tests. A [new ticket](https://issues.redhat.com/browse/ROX-20910) was created to revisit the overall test strategy here with a focus on reliability.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local Cypress run, CI
