### PR TITLE
ROX-20784: Add projected SA volume

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -159,9 +159,11 @@ spec:
           mountPath: /run/secrets/stackrox.io/db-password
         - name: central-external-db-volume
           mountPath: /etc/ext-db
+        {{- if ._rox.env.openshift }}
         - name: central-bound-sa-token
           mountPath: /var/run/secrets/openshift/serviceaccount
           readOnly: true
+        {{- end }}
         {{- if ._rox.central.notifierSecretsEncryption }}
         {{- if ._rox.central.notifierSecretsEncryption.enabled }}
         - name: central-encryption-key
@@ -240,6 +242,7 @@ spec:
         configMap:
           name: central-external-db
           optional: true
+      {{- if ._rox.env.openshift }}
       - name: central-bound-sa-token
         projected:
           defaultMode: 420
@@ -248,6 +251,7 @@ spec:
               path: token
               audience: openshift
               expirationSeconds: 3600
+      {{- end }}
       {{- if ._rox.central.notifierSecretsEncryption }}
       {{- if ._rox.central.notifierSecretsEncryption.enabled }}
       - name: central-encryption-key

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -159,6 +159,9 @@ spec:
           mountPath: /run/secrets/stackrox.io/db-password
         - name: central-external-db-volume
           mountPath: /etc/ext-db
+        - name: central-bound-sa-token
+          mountPath: /var/run/secrets/openshift/serviceaccount
+          readOnly: true
         {{- if ._rox.central.notifierSecretsEncryption }}
         {{- if ._rox.central.notifierSecretsEncryption.enabled }}
         - name: central-encryption-key
@@ -237,6 +240,14 @@ spec:
         configMap:
           name: central-external-db
           optional: true
+      - name: central-bound-sa-token
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              path: token
+              audience: openshift
+              expirationSeconds: 3600
       {{- if ._rox.central.notifierSecretsEncryption }}
       {{- if ._rox.central.notifierSecretsEncryption.enabled }}
       - name: central-encryption-key

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -132,8 +132,10 @@ spec:
           readOnly: true
         - name: cache
           mountPath: /var/cache/stackrox
+        {{- if ._rox.env.openshift }}
         - name: sensor-bound-sa-token
           mountPath: /var/run/secrets/openshift/serviceaccount
+        {{- end }}
         [<- if not .KubectlOutput >]
         - name: helm-cluster-config
           mountPath: /run/secrets/stackrox.io/helm-cluster-config/
@@ -171,14 +173,16 @@ spec:
         emptyDir: {}
       - name: cache
         emptyDir: {}
+      {{- if ._rox.env.openshift }}
       - name: sensor-bound-sa-token
         projected:
           defaultMode: 420
           sources:
           - serviceAccountToken:
-            path: token
-            audience: openshift
-            expirationSeconds: 3600
+              path: token
+              audience: openshift
+              expirationSeconds: 3600
+      {{- end }}
       [<- if not .KubectlOutput >]
       - name: helm-cluster-config
         secret:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -132,6 +132,8 @@ spec:
           readOnly: true
         - name: cache
           mountPath: /var/cache/stackrox
+        - name: sensor-bound-sa-token
+          mountPath: /var/run/secrets/openshift/serviceaccount
         [<- if not .KubectlOutput >]
         - name: helm-cluster-config
           mountPath: /run/secrets/stackrox.io/helm-cluster-config/
@@ -169,6 +171,14 @@ spec:
         emptyDir: {}
       - name: cache
         emptyDir: {}
+      - name: sensor-bound-sa-token
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+            path: token
+            audience: openshift
+            expirationSeconds: 3600
       [<- if not .KubectlOutput >]
       - name: helm-cluster-config
         secret:

--- a/operator/tests/central/basic-central/90-assert-openshift.yaml
+++ b/operator/tests/central/basic-central/90-assert-openshift.yaml
@@ -57,6 +57,9 @@ spec:
            name: central-db-password
          - mountPath: /etc/ext-db
            name: central-external-db-volume
+         - name: central-bound-sa-token
+           mountPath: /var/run/secrets/openshift/serviceaccount
+           readOnly: true
          - name: config-map-1
            mountPath: /run/stackrox.io/declarative-configuration/config-map-1
            readOnly: true
@@ -135,6 +138,14 @@ spec:
           name: central-external-db
           optional: true
         name: central-external-db-volume
+      - name: central-bound-sa-token
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              audience: openshift
+              expirationSeconds: 3600
+              path: token
       - name: stackrox-db
         emptyDir: {}
       - name: config-map-1

--- a/operator/tests/common/central-volumes-assert-openshift.yaml
+++ b/operator/tests/common/central-volumes-assert-openshift.yaml
@@ -57,11 +57,11 @@ spec:
           name: central-db-password
         - mountPath: /etc/ext-db
           name: central-external-db-volume
-        - mountPath: /etc/pki/injected-ca-trust/
-          name: trusted-ca-volume
-          readOnly: true
         - name: central-bound-sa-token
           mountPath: /var/run/secrets/openshift/serviceaccount
+          readOnly: true
+        - mountPath: /etc/pki/injected-ca-trust/
+          name: trusted-ca-volume
           readOnly: true
       volumes:
       - emptyDir: {}

--- a/operator/tests/common/central-volumes-assert-openshift.yaml
+++ b/operator/tests/common/central-volumes-assert-openshift.yaml
@@ -60,6 +60,9 @@ spec:
         - mountPath: /etc/pki/injected-ca-trust/
           name: trusted-ca-volume
           readOnly: true
+        - name: central-bound-sa-token
+          mountPath: /var/run/secrets/openshift/serviceaccount
+          readOnly: true
       volumes:
       - emptyDir: {}
         name: varlog
@@ -123,6 +126,14 @@ spec:
           name: central-external-db
           optional: true
         name: central-external-db-volume
+      - name: central-bound-sa-token
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              audience: openshift
+              expirationSeconds: 3600
+              path: token
       - name: stackrox-db
         emptyDir: {}
       - configMap:


### PR DESCRIPTION
## Description

Add [the projected volume for the service account](https://kubernetes.io/docs/concepts/storage/projected-volumes/) for its usage with the upcoming WIF / STS integration.

The projected volume is required to set a custom audience of `openshift` for parity with the CCO operator's expected audience.

Currently, this is only being done when deployed to OpenShift, for non-OpenShift deployments nothing will be changed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

1. Deploy the latest Helm chart / operator on OS cluster
```bash
./deploy/deploy.sh
```
2. Observe in the rendered YAML for both Central and Sensor the projected volume
```yaml
...
      - name: central-bound-sa-token
        projected:
          defaultMode: 420
          sources:
          - serviceAccountToken:
              audience: openshift
              expirationSeconds: 3600
              path: token
...
      - name: sensor-bound-sa-token
        projected:
          defaultMode: 420
          sources:
          - serviceAccountToken:
              audience: openshift
              expirationSeconds: 3600
              path: token
```
3. Check out the token within the Central / Sensor pod and verify the audience is also changed correctly
```json
{
  "aud": [
    "openshift"
  ],
  "iss": "https://kubernetes.default.svc",
  "kubernetes.io": {
    "namespace": "stackrox",
    "pod": {
      "name": "central-c55c5f657-5dhnx",
      "uid": "3ad95c46-1d6c-4c71-b25a-1fc67c34cf27"
    },
    "serviceaccount": {
      "name": "central",
      "uid": "8f07bbe2-38d3-4338-b517-429e0ba0c624"
    }
  },
  "sub": "system:serviceaccount:stackrox:central"
}
```

Also, additionally verified that OpenShift Auth works correctly and there are no side effects.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
