### PR TITLE
ROX-20521: Add frontend filter for policy criteria modal

### DIFF
--- a/ui/apps/platform/cypress/integration/policies/policyWizardStep3-dnd.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policyWizardStep3-dnd.test.js
@@ -1,6 +1,7 @@
 import { selectors } from '../../constants/PoliciesPage';
 import * as api from '../../constants/apiEndpoints';
 import withAuth from '../../helpers/basicAuth';
+import DndSimulatorDataTransfer from '../../helpers/dndSimulatorDataTransfer';
 import {
     visitPolicies,
     doPolicyRowAction,
@@ -10,44 +11,51 @@ import {
 } from '../../helpers/policies';
 import { closeModalByButton } from '../../helpers/modal';
 import { hasFeatureFlag } from '../../helpers/features';
+import { getInputByLabel } from '../../helpers/formHelpers';
 
-// open Policy Fields modal, select given field, and add it to the section card
-function addPolicyField(fieldName) {
-    cy.get('.policy-section-card button:contains("Add policy field")').click();
+const dataTransfer = new DndSimulatorDataTransfer();
 
-    // Note: we only use the first word of the field name to filter, because the PatternFly 4
-    // TreeView search field has a bug where it doesn't accept spaces
-    const firstWordOfFieldName = fieldName.split(' ')[0];
-    cy.log(firstWordOfFieldName);
-    cy.get('.pf-c-tree-view__search input[name="search-input"]').type(firstWordOfFieldName);
-
-    cy.get(
-        `.pf-c-tree-view__list-item .pf-c-tree-view__list-item .pf-c-tree-view__node-title:contains(${fieldName})`
-    ).click();
-
-    cy.get('.pf-c-tree-view__list-item .pf-c-tree-view__list-item .pf-c-tree-view__node').should(
-        'have.class',
-        'pf-m-current'
-    );
-
-    closeModalByButton('Add policy field');
+function dragFieldIntoSection(fieldSelector) {
+    cy.get(fieldSelector)
+        .trigger('mousedown', {
+            which: 1,
+        })
+        .trigger('dragstart', {
+            dataTransfer,
+        })
+        .trigger('drag');
+    cy.get(selectors.step3.policySection.dropTarget)
+        .trigger('dragover', {
+            dataTransfer,
+        })
+        .trigger('drop', {
+            dataTransfer,
+        })
+        .trigger('dragend', {
+            dataTransfer,
+        })
+        .trigger('mouseup', {
+            which: 1,
+        });
 }
 
-// open Policy Fields modal and ensure a given field is not available
-function assertPolicyFieldNotAvailable(fieldName) {
-    cy.get('.policy-section-card button:contains("Add policy field")').click();
+function addPolicyFieldCard(index) {
+    cy.get(selectors.step3.policyCriteria.key)
+        .eq(index)
+        .trigger('mousedown', { which: 1 })
+        .trigger('dragstart', { dataTransfer })
+        .trigger('drag');
+    cy.get(selectors.step3.policySection.dropTarget)
+        .trigger('dragover', { dataTransfer })
+        .trigger('drop', { dataTransfer })
+        .trigger('dragend', { dataTransfer })
+        .trigger('mouseup', { which: 1 });
+}
 
-    // Note: we only use the first word of the field name to filter, because the PatternFly 4
-    // TreeView search field has a bug where it doesn't accept spaces
-    const firstWordOfFieldName = fieldName.split(' ')[0];
-    cy.log(firstWordOfFieldName);
-    cy.get('.pf-c-tree-view__search input[name="search-input"]').type(firstWordOfFieldName);
-
+function clickPolicyKeyGroup(categoryName) {
     cy.get(
-        `.pf-c-tree-view__list-item .pf-c-tree-view__list-item .pf-c-tree-view__node-title:contains(${fieldName})`
-    ).should('not.exist');
-
-    closeModalByButton('Cancel');
+        `${selectors.step3.policyCriteria.keyGroup}:contains(${categoryName}) .pf-c-expandable-section__toggle`
+    ).click();
 }
 
 function goToPoliciesAndCloneToStep3() {
@@ -69,7 +77,7 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
     withAuth();
 
     before(function () {
-        if (!hasFeatureFlag('ROX_POLICY_CRITERIA_MODAL')) {
+        if (hasFeatureFlag('ROX_POLICY_CRITERIA_MODAL')) {
             this.skip();
         }
     });
@@ -84,45 +92,18 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
         cy.get(selectors.step3.policySection.addBtn).should('not.exist');
     });
 
-    it('should have a modal with nested policy field keys', () => {
+    it('should have nested policy field keys', () => {
         goToPoliciesAndCloneToStep3();
 
-        // open policy fields modal
-        cy.get('.policy-section-card button:contains("Add policy field")').click();
-        cy.get('.pf-c-modal-box__title-text:contains("Add policy criteria field")');
-
-        // check that all Deploy-time categories are available
-        // after filtering for Lifecycle was added, the number of groups for a Deploy-only policy is 7
-        const GROUPS_AVAILABLE_FOR_DEPLOY_POLICY = [
-            'Image registry',
-            'Image contents',
-            'Container configuration',
-            'Deployment metadata',
-            'Storage',
-            'Networking',
-            'Kubernetes access',
-        ];
-        cy.get('.pf-c-tree-view__list-item').each((element, index) => {
-            element.get(
-                `.pf-c-tree-view__node-title:contains(${GROUPS_AVAILABLE_FOR_DEPLOY_POLICY[index]})`
-            );
+        cy.get(selectors.step3.policyCriteria.keyGroup).should((values) => {
+            // before we began filtering what policy criteria were available,
+            // there were 9 groups of criteria to count
+            // after filtering for Lifecycle was added, the number of groups for a Deploy-only policy is 7
+            const GROUPS_AVAILABLE_FOR_DEPLOY_POLICY = 7;
+            expect(values).to.have.length(GROUPS_AVAILABLE_FOR_DEPLOY_POLICY);
         });
 
-        // now, check the criteria in a category
-        const FIELDS_AVAILABLE_FOR_DEPLOY_POLICY = [
-            'Image registry',
-            'Image name',
-            'Image tag',
-            'Image signature',
-        ];
-        cy.get('.pf-c-tree-view__list-item:first').click();
-        cy.get('.pf-c-tree-view__list-item .pf-c-tree-view__list-item').each((element, index) => {
-            element.get(
-                `.pf-c-tree-view__node-title:contains(${FIELDS_AVAILABLE_FOR_DEPLOY_POLICY[index]})`
-            );
-        });
-
-        closeModalByButton('Cancel');
+        cy.get(`${selectors.step3.policyCriteria.key}:first`).scrollIntoView().should('be.visible');
     });
 
     describe('Policy section', () => {
@@ -161,7 +142,7 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
 
             // add policy field card
             cy.get(selectors.step3.policyCriteria.groupCards).then((cards) => {
-                addPolicyField('Image registry', 0);
+                addPolicyFieldCard(0);
                 cy.get(selectors.step3.policyCriteria.groupCards).then((newCards) => {
                     expect(newCards).to.have.length(cards.length + 1);
                 });
@@ -180,9 +161,9 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
             goToPoliciesAndCloneToStep3();
 
             cy.get(selectors.step3.policyCriteria.groupCards).then((cards) => {
-                addPolicyField('Image registry');
-                addPolicyField('Image name');
-                addPolicyField('Image tag');
+                addPolicyFieldCard(0);
+                addPolicyFieldCard(1);
+                addPolicyFieldCard(2);
                 cy.get(selectors.step3.policyCriteria.groupCards).then((newCards) => {
                     expect(newCards).to.have.length(cards.length + 3);
                 });
@@ -193,8 +174,8 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
             goToPoliciesAndCloneToStep3();
 
             cy.get(selectors.step3.policyCriteria.groupCards).then((cards) => {
-                addPolicyField('Image name');
-                assertPolicyFieldNotAvailable('Image name');
+                addPolicyFieldCard(0);
+                addPolicyFieldCard(0);
                 cy.get(selectors.step3.policyCriteria.groupCards).then((newCards) => {
                     expect(newCards).to.have.length(cards.length + 1);
                 });
@@ -209,7 +190,9 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                 clearPolicyCriteriaCards();
 
                 // add field values for Image Registry
-                addPolicyField('Image name');
+                dragFieldIntoSection(
+                    `${selectors.step3.policyCriteria.key}:contains('Image registry')`
+                );
                 cy.get(selectors.step3.policyCriteria.value.deleteBtn).should('not.exist');
                 cy.get(selectors.step3.policyCriteria.value.addBtn).first().click();
                 cy.get(selectors.step3.policyCriteria.value.textInput).then((inputs) => {
@@ -226,13 +209,39 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                     cy.get(selectors.step3.policyCriteria.value.deleteBtn).should('not.exist');
                     cy.get(selectors.step3.policyCriteria.booleanOperator).should('not.exist');
                 });
+
+                // TODO: (vjw, 2023-10-30) currently, this feature flag is only _adding_ another way to add policy criteria fields
+                //       after adding fields has been thoroughly tested, this flag will indicate _whether_ to test the old way or the new way
+                if (hasFeatureFlag('ROX_POLICY_CRITERIA_MODAL')) {
+                    cy.get('.policy-section-card button:contains("Add policy field")').click();
+                    cy.get('.pf-c-modal-box__title-text:contains("Add policy criteria field")');
+
+                    // ensure closing modal with no actions
+                    closeModalByButton('Cancel');
+
+                    // now, add a field with modal
+                    cy.get('.policy-section-card button:contains("Add policy field")').click();
+                    cy.get(
+                        'button.pf-c-tree-view__node:contains("Container configuration")'
+                    ).click();
+                    cy.get('button.pf-c-tree-view__node:contains("Environment variable")')
+                        .click()
+                        .should('have.class', 'pf-m-current');
+                    cy.get('.pf-c-modal-box__footer button:contains("Add policy field")').click();
+
+                    getInputByLabel('Key').clear().type('dev');
+                    getInputByLabel('Value').clear().type('true');
+                }
             });
 
             it('should not add multiple field values for the same field if not applicable', () => {
                 goToPoliciesAndCloneToStep3();
                 clearPolicyCriteriaCards();
 
-                addPolicyField('Mounted volume writability');
+                clickPolicyKeyGroup('Storage');
+                dragFieldIntoSection(
+                    `${selectors.step3.policyCriteria.key}:contains('Mounted volume writability')`
+                );
                 cy.get(selectors.step3.policyCriteria.value.radioGroup).should('exist');
                 cy.get(selectors.step3.policyCriteria.value.addBtn).should('not.exist');
             });
@@ -243,7 +252,9 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                 goToPoliciesAndCloneToStep3();
                 clearPolicyCriteriaCards();
 
-                addPolicyField('Image registry');
+                dragFieldIntoSection(
+                    `${selectors.step3.policyCriteria.key}:contains('Image registry')`
+                );
                 cy.get(selectors.step3.policyCriteria.value.negateCheckbox).should(
                     'not.be.checked'
                 );
@@ -256,7 +267,10 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                 goToPoliciesAndCloneToStep3();
                 clearPolicyCriteriaCards();
 
-                addPolicyField('Mounted volume writability');
+                clickPolicyKeyGroup('Storage');
+                dragFieldIntoSection(
+                    `${selectors.step3.policyCriteria.key}:contains('Mounted volume writability')`
+                );
                 cy.get(selectors.step3.policyCriteria.value.negateCheckbox).should('not.exist');
             });
         });
@@ -266,7 +280,9 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                 goToPoliciesAndCloneToStep3();
                 clearPolicyCriteriaCards();
 
-                addPolicyField('Image registry');
+                dragFieldIntoSection(
+                    `${selectors.step3.policyCriteria.key}:contains('Image registry')`
+                );
                 cy.get(selectors.step3.policyCriteria.value.addBtn).first().click();
                 cy.get(selectors.step3.policyCriteria.booleanOperator).should('not.be.disabled');
                 cy.get(selectors.step3.policyCriteria.booleanOperator).contains('or');
@@ -278,7 +294,8 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                 goToPoliciesAndCloneToStep3();
                 clearPolicyCriteriaCards();
 
-                addPolicyField('Image age');
+                clickPolicyKeyGroup('Image contents');
+                dragFieldIntoSection(`${selectors.step3.policyCriteria.key}:contains('Image age')`);
                 cy.get(selectors.step3.policyCriteria.value.addBtn).first().click();
                 cy.get(selectors.step3.policyCriteria.booleanOperator).should('be.disabled');
                 cy.get(selectors.step3.policyCriteria.booleanOperator).contains('or');
@@ -290,7 +307,10 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                 goToPoliciesAndCloneToStep3();
                 clearPolicyCriteriaCards();
 
-                addPolicyField('Image scan status');
+                clickPolicyKeyGroup('Image contents');
+                dragFieldIntoSection(
+                    `${selectors.step3.policyCriteria.key}:contains('Image scan status')`
+                );
                 cy.get(selectors.step3.policyCriteria.value.radioGroup).should('exist');
                 cy.get(
                     `${selectors.step3.policyCriteria.value.radioGroupItem}:contains('Scanned') button`
@@ -313,7 +333,10 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                 goToPoliciesAndCloneToStep3();
                 clearPolicyCriteriaCards();
 
-                addPolicyField('Seccomp profile type');
+                clickPolicyKeyGroup('Container configuration');
+                dragFieldIntoSection(
+                    `${selectors.step3.policyCriteria.key}:contains('Seccomp profile type')`
+                );
                 cy.get(selectors.step3.policyCriteria.value.radioGroupString).should('exist');
                 cy.get(
                     `${selectors.step3.policyCriteria.value.radioGroupStringItem} button.pf-m-selected`
@@ -333,7 +356,9 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                 goToPoliciesAndCloneToStep3();
                 clearPolicyCriteriaCards();
 
-                addPolicyField('Image registry');
+                dragFieldIntoSection(
+                    `${selectors.step3.policyCriteria.key}:contains('Image registry')`
+                );
                 cy.get(selectors.step3.policyCriteria.value.textInput).should('have.value', '');
                 cy.get(selectors.step3.policyCriteria.value.textInput).type('test');
                 cy.get(selectors.step3.policyCriteria.value.textInput).should('have.value', 'test');
@@ -343,7 +368,10 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                 goToPoliciesAndCloneToStep3();
                 clearPolicyCriteriaCards();
 
-                addPolicyField('Drop capabilities');
+                clickPolicyKeyGroup('Container configuration');
+                dragFieldIntoSection(
+                    `${selectors.step3.policyCriteria.key}:contains('Drop capabilities')`
+                );
                 cy.get(selectors.step3.policyCriteria.value.select).should('have.value', '');
                 cy.get(selectors.step3.policyCriteria.value.select).click();
                 cy.get(selectors.step3.policyCriteria.value.selectOption)
@@ -358,7 +386,10 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                 goToPoliciesAndCloneToStep3();
                 clearPolicyCriteriaCards();
 
-                addPolicyField('Mount propagation');
+                clickPolicyKeyGroup('Storage');
+                dragFieldIntoSection(
+                    `${selectors.step3.policyCriteria.key}:contains('Mount propagation')`
+                );
                 cy.get(selectors.step3.policyCriteria.value.multiselect).should('have.value', '');
                 cy.get(selectors.step3.policyCriteria.value.multiselect).click();
                 cy.get(selectors.step3.policyCriteria.value.multiselectOption)
@@ -375,7 +406,8 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                 goToPoliciesAndCloneToStep3();
                 clearPolicyCriteriaCards();
 
-                addPolicyField('CVSS');
+                clickPolicyKeyGroup('Image contents');
+                dragFieldIntoSection(`${selectors.step3.policyCriteria.key}:contains('CVSS')`);
                 cy.get(selectors.step3.policyCriteria.value.select).should('have.value', '');
                 cy.get(selectors.step3.policyCriteria.value.numberInput).should('have.value', '');
                 cy.get(selectors.step3.policyCriteria.value.select).click();
@@ -398,7 +430,9 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
 
                 goToPoliciesAndCloneToStep3();
                 clearPolicyCriteriaCards();
-                addPolicyField('Image signature');
+                dragFieldIntoSection(
+                    `${selectors.step3.policyCriteria.key}:contains('Image signature')`
+                );
                 cy.wait('@getSignatureIntegrations');
             });
 

--- a/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
@@ -11,6 +11,9 @@ import {
 import { closeModalByButton } from '../../helpers/modal';
 import { hasFeatureFlag } from '../../helpers/features';
 
+const TREE_VIEW_SEARCH_INPUT = '.pf-c-tree-view__search input[name="search-input"]';
+const TREE_VIEW_FIRST_LEVEL_CHILD = '.pf-c-tree-view__list-item .pf-c-tree-view__list-item';
+
 // open Policy Fields modal, select given field, and add it to the section card
 function addPolicyField(fieldName) {
     cy.get('.policy-section-card button:contains("Add policy field")').click();
@@ -19,13 +22,13 @@ function addPolicyField(fieldName) {
     // TreeView search field has a bug where it doesn't accept spaces
     const firstWordOfFieldName = fieldName.split(' ')[0];
     cy.log(firstWordOfFieldName);
-    cy.get('.pf-c-tree-view__search input[name="search-input"]').type(firstWordOfFieldName);
+    cy.get(TREE_VIEW_SEARCH_INPUT).type(firstWordOfFieldName);
 
     cy.get(
-        `.pf-c-tree-view__list-item .pf-c-tree-view__list-item .pf-c-tree-view__node-title:contains(${fieldName})`
+        `${TREE_VIEW_FIRST_LEVEL_CHILD} .pf-c-tree-view__node-title:contains(${fieldName})`
     ).click();
 
-    cy.get('.pf-c-tree-view__list-item .pf-c-tree-view__list-item .pf-c-tree-view__node').should(
+    cy.get(`${TREE_VIEW_FIRST_LEVEL_CHILD} .pf-c-tree-view__node`).should(
         'have.class',
         'pf-m-current'
     );
@@ -41,10 +44,10 @@ function assertPolicyFieldNotAvailable(fieldName) {
     // TreeView search field has a bug where it doesn't accept spaces
     const firstWordOfFieldName = fieldName.split(' ')[0];
     cy.log(firstWordOfFieldName);
-    cy.get('.pf-c-tree-view__search input[name="search-input"]').type(firstWordOfFieldName);
+    cy.get(TREE_VIEW_SEARCH_INPUT).type(firstWordOfFieldName);
 
     cy.get(
-        `.pf-c-tree-view__list-item .pf-c-tree-view__list-item .pf-c-tree-view__node-title:contains(${fieldName})`
+        `${TREE_VIEW_FIRST_LEVEL_CHILD} .pf-c-tree-view__node-title:contains(${fieldName})`
     ).should('not.exist');
 
     closeModalByButton('Cancel');
@@ -116,7 +119,7 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
             'Image signature',
         ];
         cy.get('.pf-c-tree-view__list-item:first').click();
-        cy.get('.pf-c-tree-view__list-item .pf-c-tree-view__list-item').each((element, index) => {
+        cy.get(TREE_VIEW_FIRST_LEVEL_CHILD).each((element, index) => {
             element.get(
                 `.pf-c-tree-view__node-title:contains(${FIELDS_AVAILABLE_FOR_DEPLOY_POLICY[index]})`
             );

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
@@ -23,6 +23,8 @@ function PolicyCriteriaForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
     const { criteriaLocked } = values;
     const { isFeatureFlagEnabled } = useFeatureFlags();
 
+    const showPolicyCriteriaModal = isFeatureFlagEnabled('ROX_POLICY_CRITERIA_MODAL');
+
     function addNewPolicySection() {
         if (values.policySections.length < MAX_POLICY_SECTIONS) {
             const newPolicySection = {
@@ -87,6 +89,7 @@ function PolicyCriteriaForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
     }
 
     return (
+        // TODO: (vjw, 15-Nov-2023) remove the DndProvider after the PolicyCriteriaModal flag has been made unflagged
         <DndProvider backend={HTML5Backend}>
             <Flex fullWidth={{ default: 'fullWidth' }} className="pf-u-h-100">
                 <Flex
@@ -121,9 +124,11 @@ function PolicyCriteriaForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                     </Flex>
                 </Flex>
                 <Divider component="div" isVertical />
-                <Flex className="pf-u-h-100 pf-u-pt-lg" id="policy-criteria-keys-container">
-                    <PolicyCriteriaKeys keys={filteredDescriptors} />
-                </Flex>
+                {!showPolicyCriteriaModal && (
+                    <Flex className="pf-u-h-100 pf-u-pt-lg" id="policy-criteria-keys-container">
+                        <PolicyCriteriaKeys keys={filteredDescriptors} />
+                    </Flex>
+                )}
             </Flex>
         </DndProvider>
     );

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaModal.tsx
@@ -101,6 +101,7 @@ function PolicyCriteriaModal({
 
     useEffect(() => {
         setFilteredItems(treeDataItems);
+        setIsFiltered(false);
     }, [treeDataItems]);
 
     function onSearch(evt) {
@@ -111,7 +112,7 @@ function PolicyCriteriaModal({
         } else {
             const filtered = treeDataItems.map((item) => {
                 const filteredItem = { ...item };
-                if (item.children && item.children.length && item.children.length > 0) {
+                if (item.children && item.children.length > 0) {
                     const filteredChildren = item.children.filter((child) => {
                         const name = typeof child.name === 'string' ? child.name : '';
                         const title = typeof child.title === 'string' ? child.title : '';
@@ -158,7 +159,7 @@ function PolicyCriteriaModal({
                         onSearch={onSearch}
                         id="input-search"
                         name="search-input"
-                        aria-label="Search input example"
+                        aria-label="Filter policy criteria"
                     />
                 </ToolbarItem>
             </ToolbarContent>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
@@ -155,6 +155,7 @@ function PolicySection({ sectionIndex, descriptors, readOnly = false }: PolicySe
             {showPolicyCriteriaModal && (
                 <PolicyCriteriaModal
                     descriptors={descriptors}
+                    existingGroups={policyGroups}
                     isModalOpen={isModalOpen}
                     onClose={closeModal}
                     addPolicyFieldCardHandler={addPolicyFieldCardHandler}

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
@@ -128,7 +128,7 @@ function PolicySection({ sectionIndex, descriptors, readOnly = false }: PolicySe
                             )
                         );
                     })}
-                    {!readOnly && (
+                    {!showPolicyCriteriaModal && !readOnly && (
                         <PolicySectionDropTarget
                             sectionIndex={sectionIndex}
                             descriptors={descriptors}


### PR DESCRIPTION
## Description

This is the final step in implementing the new Policy Field modal to replace the drag-and-drop style of add policy fields to a Policy.

1. Adds the filter text input to the TreeView, which does front-end filtering on the list of available criteria as the user types in the input. (Note: as discussed in the UX-UI meeting, the TreeView's filter bar appears immediate above the tree, with the Expand All button above the whole TreeView component)
2. Disables the modal's primary button until a field has been selected.
3. Filters fields that have already been used in a policy section out of the list in the modal. (This need was revealed when porting one of the e2e tests to check that a field can't be added twice--and I chose it as the simplest solution, because disabling TreeView items is not a PatternFly option.)
4. Makes the display of Policy Field Modal vs. Drag sidebar/Drag target an either-or choice, based on the state of the feature flag. (I had left the drag method on during early development to help test feature partity.)
5. Split the e2e test file into two (2) files: the policyWizardStep3-dnd.test.js is now the test the drag functionality with the feature flag off, and the policyWizardStep3.test.js was updated to test only the modal when the feature flag is on. (This will make removing all code related to drag-and-drop easier later.)

## Checklist
- [x] Investigated and inspected CI test results (ui-e2e-tests failures are random known flakes)
- [x] Unit test and regression tests added


## Testing Performed

Besides manual testing of the filter feature, I enabled each e2e test, one at a time, to find all the breakages, and then updated the ones that were necessary to update. This also revealed some edge cases that I fixed.

Here is a demo of the feature, with filter bar working.

https://github.com/stackrox/stackrox/assets/715729/5e5dc7af-afd2-42f0-b7b6-10796e4d7947



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
