### PR TITLE
ROX-20898: Remove tech preview for external DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ## [NEXT RELEASE]
 
 ### Added Features
+- Customer-provided PostgreSQL databases are now GA
 
 ### Removed Features
 - ROX-18840: Sunburst widgets in the Compliance section have been removed (deprecation announced in version 4.2 release notes)

--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -228,11 +228,10 @@ type CentralDBSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Administrator Password",order=1
 	PasswordSecret *LocalSecretReference `json:"passwordSecret,omitempty"`
 
-	// NOTE: Connecting to an external database is in Technology Preview.
 	// Specify a connection string that corresponds to an external database. If set, the operator will not manage Central DB.
 	// When using this option, you must explicitly set a password secret; automatically generating a password will not
 	// be supported.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=2,displayName="Connection String (Technology Preview)"
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=2,displayName="Connection String"
 	ConnectionStringOverride *string `json:"connectionString,omitempty"`
 
 	// Configures how Central DB should store its persistent data. You can choose between using a persistent

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -73,12 +73,11 @@ spec:
                         - name
                         type: object
                       connectionString:
-                        description: 'NOTE: Connecting to an external database is
-                          in Technology Preview. Specify a connection string that
-                          corresponds to an external database. If set, the operator
-                          will not manage Central DB. When using this option, you
-                          must explicitly set a password secret; automatically generating
-                          a password will not be supported.'
+                        description: Specify a connection string that corresponds
+                          to an external database. If set, the operator will not manage
+                          Central DB. When using this option, you must explicitly
+                          set a password secret; automatically generating a password
+                          will not be supported.
                         type: string
                       isEnabled:
                         default: Default

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -171,12 +171,11 @@ spec:
           in the "password" item in the "central-db-password" secret.
         displayName: Administrator Password
         path: central.db.passwordSecret
-      - description: 'NOTE: Connecting to an external database is in Technology Preview.
-          Specify a connection string that corresponds to an external database. If
-          set, the operator will not manage Central DB. When using this option, you
-          must explicitly set a password secret; automatically generating a password
-          will not be supported.'
-        displayName: Connection String (Technology Preview)
+      - description: Specify a connection string that corresponds to an external database.
+          If set, the operator will not manage Central DB. When using this option,
+          you must explicitly set a password secret; automatically generating a password
+          will not be supported.
+        displayName: Connection String
         path: central.db.connectionString
       - description: Configures how Central DB should store its persistent data. You
           can choose between using a persistent volume claim (recommended default),

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -73,12 +73,11 @@ spec:
                         - name
                         type: object
                       connectionString:
-                        description: 'NOTE: Connecting to an external database is
-                          in Technology Preview. Specify a connection string that
-                          corresponds to an external database. If set, the operator
-                          will not manage Central DB. When using this option, you
-                          must explicitly set a password secret; automatically generating
-                          a password will not be supported.'
+                        description: Specify a connection string that corresponds
+                          to an external database. If set, the operator will not manage
+                          Central DB. When using this option, you must explicitly
+                          set a password secret; automatically generating a password
+                          will not be supported.
                         type: string
                       isEnabled:
                         default: Default

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -145,12 +145,11 @@ spec:
           effect.
         displayName: Scanner Component
         path: scanner.scannerComponent
-      - description: 'NOTE: Connecting to an external database is in Technology Preview.
-          Specify a connection string that corresponds to an external database. If
-          set, the operator will not manage Central DB. When using this option, you
-          must explicitly set a password secret; automatically generating a password
-          will not be supported.'
-        displayName: Connection String (Technology Preview)
+      - description: Specify a connection string that corresponds to an external database.
+          If set, the operator will not manage Central DB. When using this option,
+          you must explicitly set a password secret; automatically generating a password
+          will not be supported.
+        displayName: Connection String
         path: central.db.connectionString
       - description: The size of the persistent volume when created through the claim.
           If a claim was automatically created, this can be used after the initial


### PR DESCRIPTION
## Description

Removes the annotations for tech preview for external db

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Trivial

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
