### PR TITLE
chore(ui): Fix errors and enable typescript eslint rules (part 1)

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -271,14 +271,10 @@ module.exports = [
             '@typescript-eslint/no-unsafe-member-access': 'off',
 
             // Turn off new rules until after we fix errors in follow-up contributions.
-            '@typescript-eslint/no-duplicate-type-constituents': 'off', // fix 1 error
             '@typescript-eslint/no-explicit-any': 'off', // fix 7 errors
             '@typescript-eslint/no-floating-promises': 'off', // fix 7 errors
             '@typescript-eslint/no-misused-promises': 'off', // more than 100 errors
-            '@typescript-eslint/no-redundant-type-constituents': 'off', // fix 3 errors
             '@typescript-eslint/no-unsafe-argument': 'off', // more than 300 errors
-            '@typescript-eslint/no-unsafe-return': 'off', // fix 1 error
-            // '@typescript-eslint/no-unused-vars': 'off', // fix 4 errors
             '@typescript-eslint/require-await': 'off', // about 20 errors
 
             '@typescript-eslint/array-type': 'error',

--- a/ui/apps/platform/src/Components/PageTitle.tsx
+++ b/ui/apps/platform/src/Components/PageTitle.tsx
@@ -4,7 +4,7 @@ import { Helmet } from 'react-helmet';
 import { getProductBranding } from 'constants/productBranding';
 
 type PageTitleProps = {
-    title: string | null;
+    title: string | null | undefined;
 };
 
 const PageTitle = ({ title }: PageTitleProps): ReactElement => {

--- a/ui/apps/platform/src/Components/workflow/TableCountLinks/TableCountLinks.tsx
+++ b/ui/apps/platform/src/Components/workflow/TableCountLinks/TableCountLinks.tsx
@@ -19,8 +19,7 @@ type TableCountLinksProps = {
 };
 
 function TableCountLinks({ row, textOnly }: TableCountLinksProps): ReactElement {
-    const fixableVulnType: (typeof entityTypes)[keyof typeof entityTypes] | '' | null | undefined =
-        useContext(fixableVulnTypeContext);
+    const fixableVulnType: string | null | undefined = useContext(fixableVulnTypeContext);
     const workflowState = useContext(workflowStateContext);
     const entityType = workflowState.getCurrentEntityType();
     const entityContext = workflowState.getEntityContext() as Record<ResourceType, string>;

--- a/ui/apps/platform/src/Containers/AppPageTitle.tsx
+++ b/ui/apps/platform/src/Containers/AppPageTitle.tsx
@@ -22,10 +22,9 @@ const getTitleFromWorkflowState = (workflowState): string => {
     return useCase;
 };
 
-const getPageTitleText = (location: Location): string | null => {
+const getPageTitleText = (location: Location): string | null | undefined => {
     if (basePathToLabelMap[location.pathname]) {
-        const topPageLabel = basePathToLabelMap[location.pathname];
-        return topPageLabel.toString();
+        return basePathToLabelMap[location.pathname];
     }
     const workflowState = parseURL(location);
     const useCase = workflowState.getUseCase();

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/types.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/types.ts
@@ -4,7 +4,8 @@ type Protocols = 'L4_PROTOCOL_TCP' | 'L4_PROTOCOL_UDP';
 
 type Ports = string; // number format
 
-export type FilterValue = Directionality | Protocols | Ports;
+// string because of Ports, which overrides string enumerations
+export type FilterValue = string; // Directionality | Protocols | Ports
 
 export type AdvancedFlowsFilterType = {
     directionality: Directionality[];

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -368,7 +368,7 @@ export function isRouteEnabled(
  * New Framwork-related route paths
  */
 
-export const urlEntityListTypes = {
+export const urlEntityListTypes: Record<string, string> = {
     [resourceTypes.NAMESPACE]: 'namespaces',
     [resourceTypes.CLUSTER]: 'clusters',
     [resourceTypes.NODE]: 'nodes',
@@ -389,7 +389,7 @@ export const urlEntityListTypes = {
     [rbacConfigTypes.ROLE]: 'roles',
 };
 
-export const urlEntityTypes = {
+export const urlEntityTypes: Record<string, string> = {
     [resourceTypes.NAMESPACE]: 'namespace',
     [resourceTypes.CLUSTER]: 'cluster',
     [resourceTypes.NODE]: 'node',
@@ -411,21 +411,21 @@ export const urlEntityTypes = {
     [rbacConfigTypes.ROLE]: 'role',
 };
 
-const vulnManagementPathToLabelMap = {
+const vulnManagementPathToLabelMap: Record<string, string> = {
     [vulnManagementPath]: 'Dashboard',
     // TODO: add mapping for Deferrals
     [vulnManagementReportsPath]: 'Reporting',
     [vulnManagementRiskAcceptancePath]: 'Risk Acceptance',
 };
 
-const vulnerabilitiesPathToLabelMap = {
+const vulnerabilitiesPathToLabelMap: Record<string, string> = {
     [vulnerabilitiesBasePath]: 'Vulnerabilities',
     [vulnerabilitiesWorkloadCvesPath]: 'Workload CVEs',
     [vulnerabilityReportsPath]: 'Vulnerability Reporting',
     [exceptionManagementPath]: 'Exception Management',
 };
 
-export const basePathToLabelMap = {
+export const basePathToLabelMap: Record<string, string> = {
     [dashboardPath]: 'Dashboard',
     [networkBasePath]: 'Network Graph',
     [listeningEndpointsBasePath]: 'Listening Endpoints',

--- a/ui/apps/platform/src/types/risk.proto.ts
+++ b/ui/apps/platform/src/types/risk.proto.ts
@@ -30,7 +30,6 @@ export type RiskSubjectType =
     | 'CLUSTER'
     | 'NODE'
     | 'NODE_COMPONENT'
-    | 'IMAGE_COMPONENT'
     | 'IMAGE'
     | 'IMAGE_COMPONENT'
     | 'SERVICEACCOUNT';

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -247,7 +247,7 @@ export function searchValueAsArray(searchValue: ValueOf<SearchFilter>): string[]
  * @param {string} item
  * @returns {string}
  */
-export function convertToExactMatch(item): string | unknown {
+export function convertToExactMatch(item): unknown {
     if (typeof item !== 'string') {
         return item;
     }


### PR DESCRIPTION
## Description

We disabled some rules to limit the number of changes in #8629

1. no-duplicate-type-constituents
    * Delete duplicate `'IMAGE_COMPONENT'` from string enumeration.
2. no-redundant-type-constituents
    * TableCountLinks: `""` is overriden by string in this union type
        Simplify because `(typeof entityTypes)[keyof typeof entityTypes]` means `string`
    * AdvancedFlowsFilter/types.ts
        * "ingress" | "egress" is overridden by string in this union type
        * "L4_PROTOCOL_TCP" | "L4_PROTOCOL_UDP" is overridden by string in this union type
    * searchUtils.ts: `unknown` overrides all other types in this union type
        Simplify
3. no-unsafe-return
    * Add `Record<string, string>` to objects in routePaths.ts file.
    * Delete `.toString()` in AppPageTitle.tsx file.
    * Add `| undefined` in AppPageTitle.tsx and PageTitle files.
4. no-unused-vars
    * Already fixed but forgot to remove comment.

### Residue

1. Save for later to limit the number of changes in each batch.
    * no-explicit-any now has about 16 errors.
    * no-floating-promises has about 7 errors.
    * require-await has about 20 errors.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui/apps/platform