### PR TITLE
chore(ui): Fix errors and enable react display-name lint rule

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -208,7 +208,6 @@ module.exports = [
             ...pluginReact.configs.recommended.rules,
 
             // Turn off new rules until after we fix errors in follow-up contributions.
-            // 'react/display-name': 'off', // TODO delete after eslint-disable in ReactSelect and URLSearchInputWithAutocomplete
             'react/jsx-key': 'off', // more that 30 errors
 
             'react/forbid-prop-types': [

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -208,7 +208,7 @@ module.exports = [
             ...pluginReact.configs.recommended.rules,
 
             // Turn off new rules until after we fix errors in follow-up contributions.
-            'react/display-name': 'off', // TODO delete after eslint-disable in ReactSelect and URLSearchInputWithAutocomplete
+            // 'react/display-name': 'off', // TODO delete after eslint-disable in ReactSelect and URLSearchInputWithAutocomplete
             'react/jsx-key': 'off', // more that 30 errors
 
             'react/forbid-prop-types': [

--- a/ui/apps/platform/src/Components/ReactSelect/ReactSelect.js
+++ b/ui/apps/platform/src/Components/ReactSelect/ReactSelect.js
@@ -60,7 +60,7 @@ export const defaultSelectStyles = {
  *   3. value property expects only option value (not the whole option object with label and value)
  */
 function withAdjustedBehavior(SelectComponent) {
-    return class extends Component {
+    return class ReactSelectComponent extends Component {
         static propTypes = {
             /* Note: getOptionValue isn't fully supported by react-select Creatable component, it's recommended to use { label, value } options */
             getOptionValue: PropTypes.func,

--- a/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
+++ b/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
@@ -18,15 +18,18 @@ const categoryOptionClass = `bg-primary-200 text-primary-700 ${borderClass}`;
 const valueOptionClass = `bg-base-200 text-base-600 ${borderClass}`;
 
 // Render readonly input with placeholder instead of span to prevent insufficient color contrast.
-export const placeholderCreator = (placeholderText) => () => (
-    <span className="flex h-full items-center pointer-events-none">
-        <input
-            className="bg-base-100 text-base-600 absolute pf-u-w-100"
-            placeholder={placeholderText}
-            readOnly
-        />
-    </span>
-);
+export const placeholderCreator = (placeholderText) =>
+    function Placeholder() {
+        return (
+            <span className="flex h-full items-center pointer-events-none">
+                <input
+                    className="bg-base-100 text-base-600 absolute pf-u-w-100"
+                    placeholder={placeholderText}
+                    readOnly
+                />
+            </span>
+        );
+    };
 
 const isCategoryChip = (value) => value.endsWith(':');
 


### PR DESCRIPTION
## Description

We disabled some rules to limit the number of changes in #8629

1. react/display-name
    * ReactSelect: provide name of class.
    * URLSearchInputWithAutocomplete: replace arrow function with named function.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui/apps/platform