### PR TITLE
chore(ui): Fix errors and enable jest-dom recommended lint rules

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -346,7 +346,7 @@ module.exports = [
                 },
             ],
 
-            // ...pluginJestDOM.configs.recommended.rules, // TODO fix errors
+            ...pluginJestDOM.configs.recommended.rules, // TODO fix errors
 
             ...pluginTestingLibrary.configs.react.rules,
 

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -346,7 +346,7 @@ module.exports = [
                 },
             ],
 
-            ...pluginJestDOM.configs.recommended.rules, // TODO fix errors
+            ...pluginJestDOM.configs.recommended.rules,
 
             ...pluginTestingLibrary.configs.react.rules,
 

--- a/ui/apps/platform/src/Components/BinderTabs/Binder.test.tsx
+++ b/ui/apps/platform/src/Components/BinderTabs/Binder.test.tsx
@@ -17,7 +17,7 @@ describe('BinderTabs', () => {
                 </Tab>
             </BinderTabs>
         );
-        expect(screen.getByText('Tab 1 Content')).toBeDefined();
+        expect(screen.getByText('Tab 1 Content')).toBeInTheDocument();
     });
 
     test("selecting a new tab render's the new tab's contents", async () => {
@@ -35,6 +35,6 @@ describe('BinderTabs', () => {
 
         await act(() => user.click(screen.getByText('tab 2')));
 
-        expect(screen.getByText('Tab 2 Content')).toBeDefined();
+        expect(screen.getByText('Tab 2 Content')).toBeInTheDocument();
     });
 });

--- a/ui/apps/platform/src/Components/Pagination/NextPaginationButton/NextPaginationButton.test.js
+++ b/ui/apps/platform/src/Components/Pagination/NextPaginationButton/NextPaginationButton.test.js
@@ -35,7 +35,7 @@ test('can press the next button when on the first page', async () => {
     const button = screen.getByRole('button', options);
 
     // button should not be disabled
-    expect(button).not.toHaveAttribute('disabled');
+    expect(button).toBeEnabled();
 });
 
 test('can not press the next button when on the last page', async () => {
@@ -43,7 +43,7 @@ test('can not press the next button when on the last page', async () => {
     const button = screen.getByRole('button', options);
 
     // button should be disabled
-    expect(button).toHaveAttribute('disabled');
+    expect(button).toBeDisabled();
 });
 
 test('pressing the button increases the page count', async () => {

--- a/ui/apps/platform/src/Components/Pagination/PrevPaginationButton/PrevPaginationButton.test.js
+++ b/ui/apps/platform/src/Components/Pagination/PrevPaginationButton/PrevPaginationButton.test.js
@@ -35,7 +35,7 @@ test('can not press the previous button when on the first page', async () => {
     const button = screen.getByRole('button', options);
 
     // button should be disabled
-    expect(button).toHaveAttribute('disabled');
+    expect(button).toBeDisabled();
 });
 
 test('can press the previous button when on the last page', async () => {
@@ -43,7 +43,7 @@ test('can press the previous button when on the last page', async () => {
     const button = screen.getByRole('button', options);
 
     // button should not be disabled
-    expect(button).not.toHaveAttribute('disabled');
+    expect(button).toBeEnabled();
 });
 
 test('pressing the button decreases the page count', async () => {

--- a/ui/apps/platform/src/Components/Select.test.js
+++ b/ui/apps/platform/src/Components/Select.test.js
@@ -34,7 +34,7 @@ describe('Component:Select', () => {
         const firstOption = screen.getAllByRole('option')[0];
 
         // assert
-        expect(firstOption).toBeDefined();
+        expect(firstOption).toBeInTheDocument();
         expect(getNodeText(firstOption)).toEqual(initialPlaceholder);
     });
 

--- a/ui/apps/platform/src/Components/TimelineGraph/EventsGraph/ClusteredEventMarker/ClusteredEventMarker.test.tsx
+++ b/ui/apps/platform/src/Components/TimelineGraph/EventsGraph/ClusteredEventMarker/ClusteredEventMarker.test.tsx
@@ -35,7 +35,7 @@ test('should show a clustered generic event marker', () => {
             />
         </svg>
     );
-    expect(screen.getByTestId('clustered-generic-event')).not.toBeNull();
+    expect(screen.getByTestId('clustered-generic-event')).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
 });
 
@@ -61,7 +61,7 @@ test('should show a clustered policy violation event marker', () => {
             />
         </svg>
     );
-    expect(screen.getByTestId('clustered-policy-violation-event')).not.toBeNull();
+    expect(screen.getByTestId('clustered-policy-violation-event')).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
 });
 
@@ -91,7 +91,7 @@ test('should show a clustered process activity event marker', () => {
             />
         </svg>
     );
-    expect(screen.getByTestId('clustered-process-activity-event')).not.toBeNull();
+    expect(screen.getByTestId('clustered-process-activity-event')).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
 });
 
@@ -122,7 +122,7 @@ test('should show a clustered process in baseline activity event marker', () => 
             />
         </svg>
     );
-    expect(screen.getByTestId('clustered-process-in-baseline-activity-event')).not.toBeNull();
+    expect(screen.getByTestId('clustered-process-in-baseline-activity-event')).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
 });
 
@@ -148,7 +148,7 @@ test('should show a clustered container restart event marker', () => {
             />
         </svg>
     );
-    expect(screen.getByTestId('clustered-restart-event')).not.toBeNull();
+    expect(screen.getByTestId('clustered-restart-event')).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
 });
 
@@ -175,6 +175,6 @@ test('should show a container termination event marker', () => {
             />
         </svg>
     );
-    expect(screen.getByTestId('clustered-termination-event')).not.toBeNull();
+    expect(screen.getByTestId('clustered-termination-event')).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
 });

--- a/ui/apps/platform/src/Components/TimelineGraph/EventsGraph/EventMarker/EventMarker.test.js
+++ b/ui/apps/platform/src/Components/TimelineGraph/EventsGraph/EventMarker/EventMarker.test.js
@@ -20,7 +20,7 @@ test('should show a policy violation event marker', async () => {
             />
         </svg>
     );
-    expect(screen.getByTestId('policy-violation-event')).not.toBeNull();
+    expect(screen.getByTestId('policy-violation-event')).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
 });
 
@@ -45,7 +45,7 @@ test('should show a process activity event marker', async () => {
             />
         </svg>
     );
-    expect(screen.getByTestId('process-activity-event')).not.toBeNull();
+    expect(screen.getByTestId('process-activity-event')).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
 });
 
@@ -71,7 +71,7 @@ test('should show a process in baseline activity event marker', async () => {
             />
         </svg>
     );
-    expect(screen.getByTestId('process-in-baseline-activity-event')).not.toBeNull();
+    expect(screen.getByTestId('process-in-baseline-activity-event')).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
 });
 
@@ -92,7 +92,7 @@ test('should show a container restart event marker', async () => {
             />
         </svg>
     );
-    expect(screen.getByTestId('restart-event')).not.toBeNull();
+    expect(screen.getByTestId('restart-event')).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
 });
 
@@ -114,6 +114,6 @@ test('should show a container termination event marker', async () => {
             />
         </svg>
     );
-    expect(screen.getByTestId('termination-event')).not.toBeNull();
+    expect(screen.getByTestId('termination-event')).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
 });

--- a/ui/apps/platform/src/Containers/Dashboard/ScopeBar.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/ScopeBar.test.tsx
@@ -53,7 +53,7 @@ describe('Resource scope bar', () => {
 
         const clusterDropdownToggle = screen.getByLabelText('Select clusters');
         const namespaceDropdownToggle = screen.getByLabelText('Select namespaces');
-        await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
+        await waitFor(() => expect(clusterDropdownToggle).toBeEnabled());
 
         // The default state is all clusters selected, with the ns dropdown disabled
         await act(() => user.click(clusterDropdownToggle));
@@ -67,13 +67,13 @@ describe('Resource scope bar', () => {
 
         const clusterDropdownToggle = screen.getByLabelText('Select clusters');
         const namespaceDropdownToggle = screen.getByLabelText('Select namespaces');
-        await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
+        await waitFor(() => expect(clusterDropdownToggle).toBeEnabled());
 
         // Selecting one or more clusters enables the ns dropdown
         await act(() => user.click(clusterDropdownToggle));
         await act(() => user.click(screen.getByLabelText('production')));
         await act(() => user.click(clusterDropdownToggle));
-        expect(namespaceDropdownToggle).not.toBeDisabled();
+        expect(namespaceDropdownToggle).toBeEnabled();
         expect(clusterDropdownToggle).toHaveTextContent('Clusters1');
 
         // Enable some namespaces and check that the select badge updates
@@ -117,7 +117,7 @@ describe('Resource scope bar', () => {
         // Check that the default state of "select all" results in empty URL search parameters
         const clusterDropdownToggle = screen.getByLabelText('Select clusters');
         const namespaceDropdownToggle = screen.getByLabelText('Select namespaces');
-        await waitFor(() => expect(clusterDropdownToggle).not.toBeDisabled());
+        await waitFor(() => expect(clusterDropdownToggle).toBeEnabled());
         expect(history.location.search).toBe('');
 
         // Select a cluster and verify it has been added to the URL

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/VulnRequestedAction/VulnRequestedAction.test.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/VulnRequestedAction/VulnRequestedAction.test.tsx
@@ -18,7 +18,7 @@ describe('VulnRequestedAction', () => {
                 currentDate={new Date()}
             />
         );
-        expect(screen.getByText('False positive')).toBeDefined();
+        expect(screen.getByText('False positive')).toBeInTheDocument();
     });
 
     it('should show the requested action for an until fixed deferral', () => {
@@ -33,7 +33,7 @@ describe('VulnRequestedAction', () => {
                 currentDate={new Date()}
             />
         );
-        expect(screen.getByText('Deferral (until fixed)')).toBeDefined();
+        expect(screen.getByText('Deferral (until fixed)')).toBeInTheDocument();
     });
 
     it('should show the requested action for a 2 week deferral', () => {
@@ -52,7 +52,7 @@ describe('VulnRequestedAction', () => {
                 currentDate={currentDate}
             />
         );
-        expect(screen.getByText('Deferral (14 days)')).toBeDefined();
+        expect(screen.getByText('Deferral (14 days)')).toBeInTheDocument();
     });
 
     it('should show the requested action for a 30 day deferral', () => {
@@ -71,7 +71,7 @@ describe('VulnRequestedAction', () => {
                 currentDate={currentDate}
             />
         );
-        expect(screen.getByText('Deferral (30 days)')).toBeDefined();
+        expect(screen.getByText('Deferral (30 days)')).toBeInTheDocument();
     });
 
     it('should show the requested action for a 90 day deferral', () => {
@@ -90,7 +90,7 @@ describe('VulnRequestedAction', () => {
                 currentDate={currentDate}
             />
         );
-        expect(screen.getByText('Deferral (90 days)')).toBeDefined();
+        expect(screen.getByText('Deferral (90 days)')).toBeInTheDocument();
     });
 
     // @TODO: Add test for indefinite deferral

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/MyActiveJobStatus.test.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/MyActiveJobStatus.test.tsx
@@ -17,7 +17,7 @@ describe('MyActiveJobStatus', () => {
 
         render(<MyActiveJobStatus reportStatus={reportStatus} />);
 
-        expect(screen.getByText('Preparing')).toBeDefined();
+        expect(screen.getByText('Preparing')).toBeInTheDocument();
     });
 
     test('should show "WAITING" when your active job status is waiting', async () => {
@@ -31,7 +31,7 @@ describe('MyActiveJobStatus', () => {
 
         render(<MyActiveJobStatus reportStatus={reportStatus} />);
 
-        expect(screen.getByText('Waiting')).toBeDefined();
+        expect(screen.getByText('Waiting')).toBeInTheDocument();
     });
 
     test('should show "-" when your active job status is a success', async () => {
@@ -45,7 +45,7 @@ describe('MyActiveJobStatus', () => {
 
         render(<MyActiveJobStatus reportStatus={reportStatus} />);
 
-        expect(screen.getByText('-')).toBeDefined();
+        expect(screen.getByText('-')).toBeInTheDocument();
     });
 
     test('should show "-" when your active job status is a failure', async () => {
@@ -59,6 +59,6 @@ describe('MyActiveJobStatus', () => {
 
         render(<MyActiveJobStatus reportStatus={reportStatus} />);
 
-        expect(screen.getByText('-')).toBeDefined();
+        expect(screen.getByText('-')).toBeInTheDocument();
     });
 });

--- a/ui/apps/platform/src/hooks/useTabs.test.js
+++ b/ui/apps/platform/src/hooks/useTabs.test.js
@@ -39,7 +39,7 @@ describe('useTabs', () => {
 
         expect(tabHeaders[0].isActive).toEqual(true);
         expect(tabHeaders[1].isActive).toEqual(false);
-        expect(screen.getByText('Tab 1 Content')).toBeDefined();
+        expect(screen.getByText('Tab 1 Content')).toBeInTheDocument();
     });
 
     it("should select the second tab and see the second tab's content", async () => {
@@ -58,6 +58,6 @@ describe('useTabs', () => {
 
         expect(tabHeaders[0].isActive).toEqual(false);
         expect(tabHeaders[1].isActive).toEqual(true);
-        expect(screen.getByText('Tab 2 Content')).toBeDefined();
+        expect(screen.getByText('Tab 2 Content')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Description

We disabled some rules to limit the number of changes in #8629

All errors to prefer a different assertion method have automatic fix.

There was one extraneous change from `getAllByRole` to `getByRole` which broke Select.test.js but I undid it to keep only the assertion method change.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited unit tests

## Testing Performed

1. `yarn lint:fix` in ui/apps/platform
2. `yarn test` in ui/apps/platform