### PR TITLE
chore(ui): Limit node globals for lint of product files

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -152,7 +152,7 @@ module.exports = [
             ...parserAndOptions,
             globals: {
                 ...browserGlobals,
-                ...nodeGlobals, // TODO limit to minimum used like process.env.WHATEVER
+                process: false, // for JavaScript files which have process.env.NODE_ENV and so on
             },
         },
 

--- a/ui/apps/platform/src/services/AuthService/AccessTokenManager.test.js
+++ b/ui/apps/platform/src/services/AuthService/AccessTokenManager.test.js
@@ -1,3 +1,4 @@
+/* global global */
 import AccessTokenManager from './AccessTokenManager';
 
 describe('AccessTokenManager', () => {


### PR DESCRIPTION
## Description

Deferred until now to limit number of changes in #8629

* TypeScript apparently understands `process.env.NODE_ENV` and so on.
* With `checkJs` for JavaScript files, `globals` does need to specify `process` property.
    By the way, `false` means read-only.
* Because unknown `global` was unique to a specific unit test, specify it with amusing looking `/* global global */` configuration comment.
    https://eslint.org/docs/latest/use/configure/language-options#using-configuration-comments-1

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui/apps/platform