### PR TITLE
ROX-20789: Fix pod hierarchy test flake

### DIFF
--- a/sensor/tests/resource/pod/pod_test.go
+++ b/sensor/tests/resource/pod/pod_test.go
@@ -157,7 +157,12 @@ func (s *PodHierarchySuite) Test_DeleteDeployment() {
 			return nil
 		}, "deployment should be deleted", time.Minute)
 		testC.LastViolationStateByIDWithTimeout(t, id, func(alertResults *central.AlertResults) error {
-			if alertResults.GetAlerts() != nil {
+			if alertResults.GetAlerts() != nil && len(alertResults.GetAlerts()) > 0 {
+				var alertNames []string
+				for _, a := range alertResults.GetAlerts() {
+					alertNames = append(alertNames, a.GetPolicy().GetName())
+				}
+				t.Logf("AlertResults are not empty: %v", alertNames)
 				return errors.New("AlertResults should be empty")
 			}
 			return nil


### PR DESCRIPTION
## Description

This time the flake is in `DeleteDeployment` test.

IIUC the `nil` check is not sufficient if the alerts were resolved as opposed to never triggered. So if alert results aren't `nil`, they should have 0 elements in the slice. 

If this doesn't solve the issue, I've added additional logs for the next time this fails. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [ ] `PodHierarchy_DeleteDeployment` passes

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
