### PR TITLE
fix: report vulns to jira on push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -624,6 +624,7 @@ jobs:
 
     - name: Report junit failures in jira
       uses: ./.github/actions/junit2jira
+      if: always()
       with:
         jira-token: ${{ secrets.JIRA_TOKEN }}
         directory: 'junit-reports'


### PR DESCRIPTION
## Description

We need to run junit2jira especially when previous step was failing. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
