### PR TITLE
chore(scanner): Add size of Node Inventory Components as metric

### DIFF
--- a/pkg/nodes/enricher/enricher_impl.go
+++ b/pkg/nodes/enricher/enricher_impl.go
@@ -110,6 +110,7 @@ func (e *enricherImpl) enrichNodeWithScanner(node *storage.Node, nodeInventory *
 	scan, err := scanner.GetNodeInventoryScan(node, nodeInventory)
 
 	e.metrics.SetScanDurationTime(scanStartTime, scanner.Name(), err)
+	e.metrics.SetNodeInventoryNumberComponents(len(nodeInventory.GetComponents().GetRhelComponents()), node.GetClusterName())
 	if err != nil {
 		return errors.Wrapf(err, "Error scanning '%s:%s' with scanner %q", node.GetClusterName(), node.GetName(), scanner.Name())
 	}

--- a/pkg/nodes/enricher/enricher_impl.go
+++ b/pkg/nodes/enricher/enricher_impl.go
@@ -110,7 +110,7 @@ func (e *enricherImpl) enrichNodeWithScanner(node *storage.Node, nodeInventory *
 	scan, err := scanner.GetNodeInventoryScan(node, nodeInventory)
 
 	e.metrics.SetScanDurationTime(scanStartTime, scanner.Name(), err)
-	e.metrics.SetNodeInventoryNumberComponents(len(nodeInventory.GetComponents().GetRhelComponents()), node.GetClusterName())
+	e.metrics.SetNodeInventoryNumberComponents(len(nodeInventory.GetComponents().GetRhelComponents()), node.GetClusterName(), node.GetName())
 	if err != nil {
 		return errors.Wrapf(err, "Error scanning '%s:%s' with scanner %q", node.GetClusterName(), node.GetName(), scanner.Name())
 	}

--- a/pkg/nodes/enricher/metrics.go
+++ b/pkg/nodes/enricher/metrics.go
@@ -11,7 +11,7 @@ import (
 // This interface encapsulates the metrics this package needs.
 type metrics interface {
 	SetScanDurationTime(start time.Time, scanner string, err error)
-	SetNodeInventoryNumberComponents(count int, clusterName string)
+	SetNodeInventoryNumberComponents(count int, clusterName string, nodeName string)
 }
 
 type metricsImpl struct {
@@ -27,8 +27,8 @@ func (m *metricsImpl) SetScanDurationTime(start time.Time, scanner string, err e
 	m.scanTimeDuration.With(prometheus.Labels{"Scanner": scanner, "Error": fmt.Sprintf("%t", err != nil)}).Observe(startTimeToMS(start))
 }
 
-func (m *metricsImpl) SetNodeInventoryNumberComponents(count int, clusterName string) {
-	m.nodeInventoryComponentSize.WithLabelValues(clusterName).Set(float64(count))
+func (m *metricsImpl) SetNodeInventoryNumberComponents(count int, clusterName string, nodeName string) {
+	m.nodeInventoryComponentSize.WithLabelValues(clusterName, nodeName).Set(float64(count))
 }
 
 func newMetrics(subsystem pkgMetrics.Subsystem) metrics {
@@ -45,7 +45,7 @@ func newMetrics(subsystem pkgMetrics.Subsystem) metrics {
 			Subsystem: subsystem.String(),
 			Name:      "node_scan_num_components",
 			Help:      "Number of discovered components per Node",
-		}, []string{"ClusterName"}),
+		}, []string{"ClusterName", "NodeName"}),
 	}
 
 	pkgMetrics.EmplaceCollector(

--- a/pkg/nodes/enricher/metrics.go
+++ b/pkg/nodes/enricher/metrics.go
@@ -28,7 +28,6 @@ func (m *metricsImpl) SetScanDurationTime(start time.Time, scanner string, err e
 }
 
 func (m *metricsImpl) SetNodeInventoryNumberComponents(count int, clusterName string, nodeName string) {
-	fmt.Printf("Generating prom metric node_scan_num_components with count %v for node %v/%v\n", count, clusterName, nodeName)
 	m.nodeInventoryComponentSize.WithLabelValues(clusterName, nodeName).Set(float64(count))
 }
 

--- a/pkg/nodes/enricher/metrics.go
+++ b/pkg/nodes/enricher/metrics.go
@@ -11,10 +11,12 @@ import (
 // This interface encapsulates the metrics this package needs.
 type metrics interface {
 	SetScanDurationTime(start time.Time, scanner string, err error)
+	SetNodeInventoryNumberComponents(count int, clusterName string)
 }
 
 type metricsImpl struct {
-	scanTimeDuration *prometheus.HistogramVec
+	scanTimeDuration           *prometheus.HistogramVec
+	nodeInventoryComponentSize *prometheus.GaugeVec
 }
 
 func startTimeToMS(t time.Time) float64 {
@@ -23,6 +25,10 @@ func startTimeToMS(t time.Time) float64 {
 
 func (m *metricsImpl) SetScanDurationTime(start time.Time, scanner string, err error) {
 	m.scanTimeDuration.With(prometheus.Labels{"Scanner": scanner, "Error": fmt.Sprintf("%t", err != nil)}).Observe(startTimeToMS(start))
+}
+
+func (m *metricsImpl) SetNodeInventoryNumberComponents(count int, clusterName string) {
+	m.nodeInventoryComponentSize.WithLabelValues(clusterName).Set(float64(count))
 }
 
 func newMetrics(subsystem pkgMetrics.Subsystem) metrics {
@@ -34,10 +40,17 @@ func newMetrics(subsystem pkgMetrics.Subsystem) metrics {
 			Help:      "Amount of time it's taken to scan a node in ms",
 			Buckets:   prometheus.ExponentialBuckets(4, 2, 16),
 		}, []string{"Scanner", "Error"}),
+		nodeInventoryComponentSize: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: pkgMetrics.PrometheusNamespace,
+			Subsystem: subsystem.String(),
+			Name:      "node_scan_num_components",
+			Help:      "Number of discovered components per Node",
+		}, []string{"ClusterName"}),
 	}
 
 	pkgMetrics.EmplaceCollector(
 		m.scanTimeDuration,
+		m.nodeInventoryComponentSize,
 	)
 
 	return m

--- a/pkg/nodes/enricher/metrics.go
+++ b/pkg/nodes/enricher/metrics.go
@@ -28,6 +28,7 @@ func (m *metricsImpl) SetScanDurationTime(start time.Time, scanner string, err e
 }
 
 func (m *metricsImpl) SetNodeInventoryNumberComponents(count int, clusterName string, nodeName string) {
+	fmt.Printf("Generating prom metric node_scan_num_components with count %v for node %v/%v\n", count, clusterName, nodeName)
 	m.nodeInventoryComponentSize.WithLabelValues(clusterName, nodeName).Set(float64(count))
 }
 


### PR DESCRIPTION
## Description

This PR adds a Prometheus metric to central to track the number of received Node Scan components per node and node scan.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
Created an OpenShift 4 cluster, deployed via `deploy.sh` and port-forwarded port 9090 from the monitoring pod to localhost.
I then waited for the first Node Scans to arrive, to check the metric `rox_central_node_scan_num_components` (see [screenshot in this comment](https://github.com/stackrox/stackrox/pull/8686#issuecomment-1819186844))

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
