### PR TITLE
ROX-20834: Reset pagination when changing vuln state tabs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -187,7 +187,7 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
                 className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
                 component="div"
             >
-                <VulnerabilityStateTabs isBox />
+                <VulnerabilityStateTabs isBox onChange={() => setPage(1)} />
                 <div className="pf-u-px-sm pf-u-background-color-100">
                     <WorkloadTableToolbar
                         autocompleteSearchContext={{

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -323,7 +323,7 @@ function ImagePageVulnerabilities({
                 className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
                 component="div"
             >
-                <VulnerabilityStateTabs isBox />
+                <VulnerabilityStateTabs isBox onChange={() => setPage(1)} />
                 <div className="pf-u-px-sm pf-u-background-color-100">
                     <WorkloadTableToolbar
                         searchOptions={searchOptions}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -340,7 +340,11 @@ function ImageCvePage() {
             </PageSection>
             <Divider component="div" />
             <PageSection className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1">
-                <VulnerabilityStateTabs titleOverrides={{ observed: 'Workloads' }} isBox />
+                <VulnerabilityStateTabs
+                    titleOverrides={{ observed: 'Workloads' }}
+                    isBox
+                    onChange={() => setPage(1)}
+                />
                 <div className="pf-u-background-color-100">
                     <div className="pf-u-px-sm">
                         <WorkloadTableToolbar

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -193,7 +193,7 @@ function WorkloadCvesOverviewPage() {
                     component="div"
                     className="pf-u-pl-lg pf-u-background-color-100"
                 >
-                    <VulnerabilityStateTabs />
+                    <VulnerabilityStateTabs onChange={() => pagination.setPage(1)} />
                 </PageSection>
                 <PageSection isCenterAligned>
                     <Card>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VulnerabilityStateTabs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VulnerabilityStateTabs.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Tabs, Tab, TabTitleText, TabsProps } from '@patternfly/react-core';
 
-import { vulnerabilityStates } from 'types/cve.proto';
+import { VulnerabilityState, isVulnerabilityState, vulnerabilityStates } from 'types/cve.proto';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 
@@ -12,9 +12,14 @@ export type VulnerabilityStateTabsProps = {
         deferred?: string;
         falsePositive?: string;
     };
+    onChange?: (key: VulnerabilityState) => void;
 };
 
-function VulnerabilityStateTabs({ titleOverrides, isBox = false }: VulnerabilityStateTabsProps) {
+function VulnerabilityStateTabs({
+    titleOverrides,
+    isBox = false,
+    onChange,
+}: VulnerabilityStateTabsProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isUnifiedDeferralsEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL');
     const [vulnerabilityStateKey, setVulnerabilityStateKey] = useURLStringUnion(
@@ -25,7 +30,12 @@ function VulnerabilityStateTabs({ titleOverrides, isBox = false }: Vulnerability
     return isUnifiedDeferralsEnabled ? (
         <Tabs
             activeKey={vulnerabilityStateKey}
-            onSelect={(_e, tab) => setVulnerabilityStateKey(tab)}
+            onSelect={(_e, tab) => {
+                setVulnerabilityStateKey(tab);
+                if (onChange && isVulnerabilityState(tab)) {
+                    onChange(tab);
+                }
+            }}
             component="nav"
             isBox={isBox}
         >


### PR DESCRIPTION
## Description

Resets the current table page when navigating between deferral state tabs. Previously the page would be maintained, leading to incorrect data displays where the table would show no data.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

On the observed tab, cycle a handful of pages forward:
![image](https://github.com/stackrox/stackrox/assets/1292638/a6244076-de0c-4a62-b026-7f333885d9b5)

Move to the "Deferred" tab an ensure you are on the first page of results:
![image](https://github.com/stackrox/stackrox/assets/1292638/be175fd6-e3c2-4b9b-b4fd-2a04a3db4ccc)

Repeat for the Image, ImageCVE, and Deployment detail pages.
