### PR TITLE
fix(db): batch upsert in a single call

### DIFF
--- a/central/alert/datastore/internal/store/postgres/bench_test.go
+++ b/central/alert/datastore/internal/store/postgres/bench_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stackrox/rox/pkg/testutils"
 )
 
-func BenchmarkGetMany(b *testing.B) {
+func BenchmarkMany(b *testing.B) {
 	var alerts []*storage.Alert
-	const alertsNum = 3000
+	const alertsNum = 10000
 	for i := 0; i < alertsNum; i++ {
 		alert := &storage.Alert{}
 		err := testutils.FullInit(alert, testutils.UniqueInitializer(), testutils.JSONFieldsFilter)
@@ -38,7 +38,13 @@ func BenchmarkGetMany(b *testing.B) {
 	}
 
 	for n := 1; n < alertsNum; n = n * 2 {
-		b.Run(fmt.Sprintf("%d alerts", n), func(b *testing.B) {
+		b.Run(fmt.Sprintf("upsert %d alerts", n), func(b *testing.B) {
+			err := store.UpsertMany(ctx, alerts[:n])
+			if err != nil {
+				b.Fatal(err)
+			}
+		})
+		b.Run(fmt.Sprintf("get %d alerts", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, _, err := store.GetMany(ctx, idx[:n])
 				if err != nil {


### PR DESCRIPTION
## Description

As documentation says `Close` will collect data of all queries so in our case there is no need to manually loop over all queries inside the batch. 
Another change in this PR is to make a single batch for all objects updated and not a batch per object especially when we have batching in `UpsertMany`.

> `Close` closes the batch operation. All unread results are read and any callback functions registered with `QueuedQuery.Query`, `QueuedQuery.QueryRow`, or `QueuedQuery.Exec` will be called. If a callback function returns an error or the batch encounters an error subsequent callback functions will not be called.

> `Exec` reads the results from the next query in the batch as if the query has been sent with Conn.Exec. Prefer calling `Exec` on the `QueuedQuery`.


Refs:
- https://pkg.go.dev/github.com/jackc/pgx/v5#BatchResults
- https://issues.redhat.com/browse/ROX-17934
- https://github.com/jackc/pgx/issues/1801

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

```bash
# go test -run=. -bench=BenchmarkMany/upsert ./central/alert/datastore/... -count 10 -benchmem
# benchstat -table "PGX"  -confidence 0.030  old.txt new.txt                  
PGX: 
                          │     old.txt     │                 new.txt                  │
                          │     sec/op      │      sec/op       vs base                │
Many/upsert_1_alerts-8      0.0007204n ± 6%   0.0007168n ±  2%        ~ (p=0.684 n=10)
Many/upsert_2_alerts-8       0.001148n ± 0%    0.001179n ± 11%        ~ (p=0.645 n=10)
Many/upsert_4_alerts-8       0.002005n ± 2%    0.001575n ±  6%  -21.43% (p=0.023 n=10)
Many/upsert_8_alerts-8       0.003903n ± 1%    0.002722n ±  3%  -30.27% (p=0.003 n=10)
Many/upsert_16_alerts-8      0.007026n ± 0%    0.003624n ±  4%  -48.42% (p=0.000 n=10)
Many/upsert_32_alerts-8      0.014195n ± 1%    0.007438n ±  3%  -47.60% (p=0.000 n=10)
Many/upsert_64_alerts-8       0.02662n ± 0%     0.01380n ±  1%  -48.14% (p=0.000 n=10)
Many/upsert_128_alerts-8      0.01727n ± 1%     0.01769n ±  1%        ~ (p=0.315 n=10)
Many/upsert_256_alerts-8      0.03279n ± 0%     0.03049n ±  2%        ~ (p=0.436 n=10)
Many/upsert_512_alerts-8      0.06116n ± 3%     0.06387n ±  2%        ~ (p=0.190 n=10)
Many/upsert_1024_alerts-8      0.1237n ± 3%      0.1173n ±  0%        ~ (p=0.542 n=10)
Many/upsert_2048_alerts-8      0.2406n ± 0%      0.2273n ±  2%        ~ (p=0.382 n=10)
Many/upsert_4096_alerts-8      0.7372n ± 8%      0.4580n ±  0%  -37.86% (p=0.002 n=10)
Many/upsert_8192_alerts-8        1.377 ± 5%        1.146 ±  7%        ~ (p=0.165 n=10)
geomean                        0.1043n          0.08226n        -21.11%
```
### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
