### PR TITLE
ROX-20927: Scope Invite Users modal to Access write permission

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -47,6 +47,7 @@ import ErrorBoundary from 'Components/PatternFly/ErrorBoundary/ErrorBoundary';
 import { HasReadAccess } from 'hooks/usePermissions';
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import useAnalytics from 'hooks/useAnalytics';
+import usePermissions from 'hooks/usePermissions';
 
 import asyncComponent from './AsyncComponent';
 import InviteUsersModal from './InviteUsers/InviteUsersModal';
@@ -219,6 +220,8 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     useEffect(() => {
         analyticsPageVisit('Page Viewed', '', { path: location.pathname });
     }, [location, analyticsPageVisit]);
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForInviting = hasReadWriteAccess('Access');
 
     const { isDarkMode } = useTheme();
 
@@ -244,7 +247,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                         })}
                     <Route component={NotFoundPage} />
                 </Switch>
-                <InviteUsersModal />
+                {hasWriteAccessForInviting && <InviteUsersModal />}
             </ErrorBoundary>
         </div>
     );


### PR DESCRIPTION
## Description

Prevent InviteUsersModal from rendering and causing GET request to various Auth-related endpoints, if user does not have appropriate permissions to act on inviting.

Discovered gap when customer who had user Role without even read access to ACCESS got stuck in a logout/login redirect loop.

## Checklist
- [x] Investigated and inspected CI test results (ui-e2e-tests failures are known flakes in only one flavor of test run)


## Testing Performed

### Here I tell how I validated my change

tbd

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
