### PR TITLE
ROX-20574: Add component filters to workload cves

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -27,6 +27,8 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import NotFoundMessage from 'Components/NotFoundMessage';
 import {
+    COMPONENT_SEARCH_OPTION,
+    COMPONENT_SOURCE_SEARCH_OPTION,
     IMAGE_CVE_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
     SearchOption,
@@ -84,7 +86,12 @@ export const deploymentVulnerabilitiesQuery = gql`
 
 const defaultSortFields = ['CVE'];
 
-const searchOptions: SearchOption[] = [IMAGE_CVE_SEARCH_OPTION, IMAGE_SEARCH_OPTION];
+const searchOptions: SearchOption[] = [
+    IMAGE_CVE_SEARCH_OPTION,
+    IMAGE_SEARCH_OPTION,
+    COMPONENT_SEARCH_OPTION,
+    COMPONENT_SOURCE_SEARCH_OPTION,
+];
 
 export type DeploymentPageVulnerabilitiesProps = {
     deploymentId: string;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -29,6 +29,8 @@ import useFeatureFlags from 'hooks/useFeatureFlags';
 import useMap from 'hooks/useMap';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 import {
+    COMPONENT_SEARCH_OPTION,
+    COMPONENT_SOURCE_SEARCH_OPTION,
     IMAGE_CVE_SEARCH_OPTION,
     SearchOption,
 } from 'Containers/Vulnerabilities/components/SearchOptionsDropdown';
@@ -83,7 +85,11 @@ export const imageVulnerabilitiesQuery = gql`
 
 const defaultSortFields = ['CVE', 'CVSS', 'Severity'];
 
-const searchOptions: SearchOption[] = [IMAGE_CVE_SEARCH_OPTION];
+const searchOptions: SearchOption[] = [
+    IMAGE_CVE_SEARCH_OPTION,
+    COMPONENT_SEARCH_OPTION,
+    COMPONENT_SOURCE_SEARCH_OPTION,
+];
 
 export type ImagePageVulnerabilitiesProps = {
     imageId: string;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -32,6 +32,8 @@ import { Pagination as PaginationParam } from 'services/types';
 import { VulnerabilitySeverity } from 'types/cve.proto';
 import {
     CLUSTER_SEARCH_OPTION,
+    COMPONENT_SEARCH_OPTION,
+    COMPONENT_SOURCE_SEARCH_OPTION,
     DEPLOYMENT_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
     NAMESPACE_SEARCH_OPTION,
@@ -163,6 +165,8 @@ const searchOptions: SearchOption[] = [
     DEPLOYMENT_SEARCH_OPTION,
     NAMESPACE_SEARCH_OPTION,
     CLUSTER_SEARCH_OPTION,
+    COMPONENT_SEARCH_OPTION,
+    COMPONENT_SOURCE_SEARCH_OPTION,
 ];
 
 function ImageCvePage() {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/TableEntityToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/TableEntityToolbar.tsx
@@ -5,6 +5,8 @@ import { SortOption } from 'types/table';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import {
     CLUSTER_SEARCH_OPTION,
+    COMPONENT_SEARCH_OPTION,
+    COMPONENT_SOURCE_SEARCH_OPTION,
     DEPLOYMENT_SEARCH_OPTION,
     IMAGE_CVE_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
@@ -32,6 +34,8 @@ const searchOptions: SearchOption[] = [
     DEPLOYMENT_SEARCH_OPTION,
     NAMESPACE_SEARCH_OPTION,
     CLUSTER_SEARCH_OPTION,
+    COMPONENT_SEARCH_OPTION,
+    COMPONENT_SOURCE_SEARCH_OPTION,
 ];
 
 function TableEntityToolbar({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
@@ -105,6 +105,14 @@ function WorkloadTableToolbar({
             searchFilterName: 'CLUSTER',
         },
         {
+            displayName: 'Component',
+            searchFilterName: 'COMPONENT',
+        },
+        {
+            displayName: 'Component Source',
+            searchFilterName: 'COMPONENT SOURCE',
+        },
+        {
             displayName: 'Severity',
             searchFilterName: 'Severity',
             render: (filter: string) => (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
@@ -88,7 +88,15 @@ export function parseQuerySearchFilter(rawSearchFilter: SearchFilter): QuerySear
     const cleanSearchFilter: QuerySearchFilter = {};
 
     // SearchFilter values that can be directly translated over to the backend equivalent
-    const unprocessedSearchKeys = ['CVE', 'IMAGE', 'DEPLOYMENT', 'NAMESPACE', 'CLUSTER'] as const;
+    const unprocessedSearchKeys = [
+        'CVE',
+        'IMAGE',
+        'DEPLOYMENT',
+        'NAMESPACE',
+        'CLUSTER',
+        'COMPONENT',
+        'COMPONENT SOURCE',
+    ] as const;
     unprocessedSearchKeys.forEach((key) => {
         cleanSearchFilter[key] = searchValueAsArray(rawSearchFilter[key]);
     });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SearchOptionsDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SearchOptionsDropdown.tsx
@@ -39,6 +39,18 @@ export const CLUSTER_SEARCH_OPTION: SearchOption = {
     category: 'CLUSTERS',
 };
 
+export const COMPONENT_SEARCH_OPTION: SearchOption = {
+    label: 'Component',
+    value: 'COMPONENT',
+    category: 'IMAGE_COMPONENTS',
+};
+
+export const COMPONENT_SOURCE_SEARCH_OPTION: SearchOption = {
+    label: 'Component Source',
+    value: 'COMPONENT SOURCE',
+    category: 'IMAGE_VULNERABILITIES',
+};
+
 export const REQUEST_NAME_SEARCH_OPTION: SearchOption = {
     label: 'Request name',
     value: 'Request Name',


### PR DESCRIPTION
## Description

Adds the ability to filter all Workload CVE tables by "Component" and "Component Source".

Follow up: refactoring of workload cve filters to enforce a single source of truth

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Filter by component:
![image](https://github.com/stackrox/stackrox/assets/1292638/934fc7a2-c8b2-4852-b1ac-38a511e065c7)
![image](https://github.com/stackrox/stackrox/assets/1292638/2c3e4629-7259-4dbd-9c40-5ffa7e76a7e6)

Filter by component source:
![image](https://github.com/stackrox/stackrox/assets/1292638/3a1b6331-bf66-4fc0-90f8-1791e0ebd751)
![image](https://github.com/stackrox/stackrox/assets/1292638/bd9f8dfe-413e-44dd-a71b-074af27ed135)

On the image single page:
![image](https://github.com/stackrox/stackrox/assets/1292638/b51029aa-bb0e-4202-bb4b-a56abc4c3a1e)
![image](https://github.com/stackrox/stackrox/assets/1292638/92214340-a418-4470-9443-71f072237486)
![image](https://github.com/stackrox/stackrox/assets/1292638/a08fcbef-a52d-4b28-87cf-10b0b13f86d6)

Repeat filtering on the CVE and Deployment single pages
