### PR TITLE
ROX-20862: Show updated vs. original request data in request details

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -178,28 +178,19 @@ function ApprovedDeferrals() {
                                     <Requester requester={requester} />
                                 </Td>
                                 <Td>
-                                    <RequestedAction
-                                        exception={exception}
-                                        context="APPROVED_DEFERRALS"
-                                    />
+                                    <RequestedAction exception={exception} context="CURRENT" />
                                 </Td>
                                 <Td>
                                     <RequestCreatedAt createdAt={createdAt} />
                                 </Td>
                                 <Td>
-                                    <RequestExpires
-                                        exception={exception}
-                                        context="APPROVED_DEFERRALS"
-                                    />
+                                    <RequestExpires exception={exception} context="CURRENT" />
                                 </Td>
                                 <Td>
                                     <RequestScope scope={scope} />
                                 </Td>
                                 <Td>
-                                    <RequestedItems
-                                        exception={exception}
-                                        context="APPROVED_DEFERRALS"
-                                    />
+                                    <RequestedItems exception={exception} context="CURRENT" />
                                 </Td>
                             </Tr>
                         );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -170,10 +170,7 @@ function ApprovedFalsePositives() {
                                     <Requester requester={requester} />
                                 </Td>
                                 <Td>
-                                    <RequestedAction
-                                        exception={exception}
-                                        context="APPROVED_FALSE_POSITIVES"
-                                    />
+                                    <RequestedAction exception={exception} context="CURRENT" />
                                 </Td>
                                 <Td>
                                     <RequestCreatedAt createdAt={createdAt} />
@@ -182,10 +179,7 @@ function ApprovedFalsePositives() {
                                     <RequestScope scope={scope} />
                                 </Td>
                                 <Td>
-                                    <RequestedItems
-                                        exception={exception}
-                                        context="APPROVED_FALSE_POSITIVES"
-                                    />
+                                    <RequestedItems exception={exception} context="CURRENT" />
                                 </Td>
                             </Tr>
                         );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -179,28 +179,19 @@ function DeniedRequests() {
                                     <Requester requester={requester} />
                                 </Td>
                                 <Td>
-                                    <RequestedAction
-                                        exception={exception}
-                                        context="DENIED_REQUESTS"
-                                    />
+                                    <RequestedAction exception={exception} context="CURRENT" />
                                 </Td>
                                 <Td>
                                     <RequestCreatedAt createdAt={createdAt} />
                                 </Td>
                                 <Td>
-                                    <RequestExpires
-                                        exception={exception}
-                                        context="DENIED_REQUESTS"
-                                    />
+                                    <RequestExpires exception={exception} context="CURRENT" />
                                 </Td>
                                 <Td>
                                     <RequestScope scope={scope} />
                                 </Td>
                                 <Td>
-                                    <RequestedItems
-                                        exception={exception}
-                                        context="DENIED_REQUESTS"
-                                    />
+                                    <RequestedItems exception={exception} context="CURRENT" />
                                 </Td>
                             </Tr>
                         );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -9,7 +9,6 @@ import {
     PageSection,
     Spinner,
     Tab,
-    TabContent,
     TabTitleText,
     Tabs,
     Title,
@@ -37,7 +36,7 @@ import RequestOverview from './components/RequestOverview';
 import './ExceptionRequestDetailsPage.css';
 import { RequestContext } from './components/ExceptionRequestTableCells';
 
-type RequestDetailsTab = 'REQUESTED_UPDATE' | 'LATEST_APPROVED'
+type RequestDetailsTab = 'REQUESTED_UPDATE' | 'LATEST_APPROVED';
 
 function getSubtitleText(exception: VulnerabilityException) {
     const numCVEs = `${pluralize(exception.cves.length, 'CVE')}`;
@@ -56,13 +55,13 @@ function getSubtitleText(exception: VulnerabilityException) {
 }
 
 export function getCVEsForUpdatedRequest(exception: VulnerabilityException): string[] {
-     if (isDeferralException(exception) && exception.deferralUpdate) {
-         return exception.deferralUpdate.cves;
-     }
-     if (isFalsePositiveException(exception) && exception.falsePositiveUpdate) {
-         return exception.falsePositiveUpdate.cves;
-     }
-     return exception.cves;
+    if (isDeferralException(exception) && exception.deferralUpdate) {
+        return exception.deferralUpdate.cves;
+    }
+    if (isFalsePositiveException(exception) && exception.falsePositiveUpdate) {
+        return exception.falsePositiveUpdate.cves;
+    }
+    return exception.cves;
 }
 
 function ExceptionRequestDetailsPage() {
@@ -116,7 +115,9 @@ function ExceptionRequestDetailsPage() {
     const { status, cves, scope } = vulnerabilityException;
     const isApprovedPendingUpdate = status === 'APPROVED_PENDING_UPDATE';
     const context: RequestContext =
-        selectedTab === 'LATEST_APPROVED' || !isApprovedPendingUpdate ? 'CURRENT' : 'PENDING_UPDATE';
+        selectedTab === 'LATEST_APPROVED' || !isApprovedPendingUpdate
+            ? 'CURRENT'
+            : 'PENDING_UPDATE';
     const relevantCVEs =
         selectedTab === 'LATEST_APPROVED' || !isApprovedPendingUpdate
             ? cves

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -177,28 +177,19 @@ function PendingApprovals() {
                                     <Requester requester={requester} />
                                 </Td>
                                 <Td>
-                                    <RequestedAction
-                                        exception={exception}
-                                        context="PENDING_REQUESTS"
-                                    />
+                                    <RequestedAction exception={exception} context="PENDING_UPDATE" />
                                 </Td>
                                 <Td>
                                     <RequestCreatedAt createdAt={createdAt} />
                                 </Td>
                                 <Td>
-                                    <RequestExpires
-                                        exception={exception}
-                                        context="PENDING_REQUESTS"
-                                    />
+                                    <RequestExpires exception={exception} context="PENDING_UPDATE" />
                                 </Td>
                                 <Td>
                                     <RequestScope scope={scope} />
                                 </Td>
                                 <Td>
-                                    <RequestedItems
-                                        exception={exception}
-                                        context="PENDING_REQUESTS"
-                                    />
+                                    <RequestedItems exception={exception} context="PENDING_UPDATE" />
                                 </Td>
                             </Tr>
                         );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -177,19 +177,28 @@ function PendingApprovals() {
                                     <Requester requester={requester} />
                                 </Td>
                                 <Td>
-                                    <RequestedAction exception={exception} context="PENDING_UPDATE" />
+                                    <RequestedAction
+                                        exception={exception}
+                                        context="PENDING_UPDATE"
+                                    />
                                 </Td>
                                 <Td>
                                     <RequestCreatedAt createdAt={createdAt} />
                                 </Td>
                                 <Td>
-                                    <RequestExpires exception={exception} context="PENDING_UPDATE" />
+                                    <RequestExpires
+                                        exception={exception}
+                                        context="PENDING_UPDATE"
+                                    />
                                 </Td>
                                 <Td>
                                     <RequestScope scope={scope} />
                                 </Td>
                                 <Td>
-                                    <RequestedItems exception={exception} context="PENDING_UPDATE" />
+                                    <RequestedItems
+                                        exception={exception}
+                                        context="PENDING_UPDATE"
+                                    />
                                 </Td>
                             </Tr>
                         );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.test.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.test.tsx
@@ -54,7 +54,7 @@ describe('ExceptionRequestTableCells', () => {
                     },
                 },
             };
-            const context: RequestContext = 'PENDING_REQUESTS';
+            const context: RequestContext = 'PENDING_UPDATE';
 
             const shouldUseUpdatedRequest = getShouldUseUpdatedRequest(
                 vulnerabilityException,
@@ -77,7 +77,7 @@ describe('ExceptionRequestTableCells', () => {
                     },
                 },
             };
-            const context: RequestContext = 'PENDING_REQUESTS';
+            const context: RequestContext = 'PENDING_UPDATE';
 
             const shouldUseUpdatedRequest = getShouldUseUpdatedRequest(
                 vulnerabilityException,
@@ -105,7 +105,7 @@ describe('ExceptionRequestTableCells', () => {
                     },
                 },
             };
-            const context: RequestContext = 'PENDING_REQUESTS';
+            const context: RequestContext = 'PENDING_UPDATE';
 
             const shouldUseUpdatedRequest = getShouldUseUpdatedRequest(
                 vulnerabilityException,
@@ -133,7 +133,7 @@ describe('ExceptionRequestTableCells', () => {
                     },
                 },
             };
-            const context: RequestContext = 'APPROVED_DEFERRALS';
+            const context: RequestContext = 'CURRENT';
 
             const shouldUseUpdatedRequest = getShouldUseUpdatedRequest(
                 vulnerabilityException,
@@ -152,7 +152,7 @@ describe('ExceptionRequestTableCells', () => {
                 status: 'PENDING',
                 falsePositiveRequest: {},
             };
-            const context: RequestContext = 'PENDING_REQUESTS';
+            const context: RequestContext = 'PENDING_UPDATE';
 
             const requestedAction = getRequestedAction(vulnerabilityException, context);
 
@@ -170,7 +170,7 @@ describe('ExceptionRequestTableCells', () => {
                     },
                 },
             };
-            const context: RequestContext = 'PENDING_REQUESTS';
+            const context: RequestContext = 'PENDING_UPDATE';
 
             const requestedAction = getRequestedAction(vulnerabilityException, context);
 
@@ -188,7 +188,7 @@ describe('ExceptionRequestTableCells', () => {
                     },
                 },
             };
-            const context: RequestContext = 'PENDING_REQUESTS';
+            const context: RequestContext = 'PENDING_UPDATE';
 
             const requestedAction = getRequestedAction(vulnerabilityException, context);
 
@@ -207,7 +207,7 @@ describe('ExceptionRequestTableCells', () => {
                     },
                 },
             };
-            const context: RequestContext = 'PENDING_REQUESTS';
+            const context: RequestContext = 'PENDING_UPDATE';
 
             const requestedAction = getRequestedAction(vulnerabilityException, context);
 
@@ -226,7 +226,7 @@ describe('ExceptionRequestTableCells', () => {
                     },
                 },
             };
-            const context: RequestContext = 'PENDING_REQUESTS';
+            const context: RequestContext = 'PENDING_UPDATE';
 
             const requestedAction = getRequestedAction(vulnerabilityException, context);
 
@@ -252,7 +252,7 @@ describe('ExceptionRequestTableCells', () => {
                     },
                 },
             };
-            const context: RequestContext = 'PENDING_REQUESTS';
+            const context: RequestContext = 'PENDING_UPDATE';
 
             const requestedAction = getRequestedAction(vulnerabilityException, context);
 
@@ -278,7 +278,7 @@ describe('ExceptionRequestTableCells', () => {
                     },
                 },
             };
-            const context: RequestContext = 'APPROVED_DEFERRALS';
+            const context: RequestContext = 'CURRENT';
 
             const requestedAction = getRequestedAction(vulnerabilityException, context);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
@@ -172,9 +172,7 @@ export function RequestComment({ comment }: RequestCommentProps) {
     return (
         <Flex direction={{ default: 'column' }}>
             <Flex direction={{ default: 'row' }} spaceItems={{ default: 'spaceItemsSm' }}>
-                <Text className="pf-u-font-weight-bold">
-                    {comment.user.name}
-                </Text>
+                <Text className="pf-u-font-weight-bold">{comment.user.name}</Text>
                 <Text component={TextVariants.small}>({getDateTime(comment.createdAt)})</Text>
             </Flex>
             <FlexItem>{comment.message}</FlexItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
@@ -23,11 +23,7 @@ import {
 import { getDate, getDateTime, getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import useModal from 'hooks/useModal';
 
-export type RequestContext =
-    | 'PENDING_REQUESTS'
-    | 'APPROVED_DEFERRALS'
-    | 'APPROVED_FALSE_POSITIVES'
-    | 'DENIED_REQUESTS';
+export type RequestContext = 'CURRENT' | 'PENDING_UPDATE';
 
 export type RequestIDLinkProps = {
     id: VulnerabilityException['id'];
@@ -56,7 +52,7 @@ export function getShouldUseUpdatedRequest(
 ): boolean {
     switch (exception.status) {
         case 'APPROVED_PENDING_UPDATE':
-            if (context === 'PENDING_REQUESTS') {
+            if (context === 'PENDING_UPDATE') {
                 if (isDeferralException(exception) && exception.deferralUpdate) {
                     return true;
                 }
@@ -176,7 +172,7 @@ export function RequestComment({ comment }: RequestCommentProps) {
     return (
         <Flex direction={{ default: 'column' }}>
             <Flex direction={{ default: 'row' }} spaceItems={{ default: 'spaceItemsSm' }}>
-                <Text className="pf-u-font-weight-bold" component={TextVariants.p}>
+                <Text className="pf-u-font-weight-bold">
                     {comment.user.name}
                 </Text>
                 <Text component={TextVariants.small}>({getDateTime(comment.createdAt)})</Text>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestOverview.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestOverview.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import {
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Flex,
+    PageSection,
+    Title,
+} from '@patternfly/react-core';
+import { VulnerabilityException } from 'services/VulnerabilityExceptionService';
+import {
+    RequestComment,
+    RequestComments,
+    RequestContext,
+    RequestCreatedAt,
+    RequestExpires,
+    RequestScope,
+    RequestedAction,
+} from './ExceptionRequestTableCells';
+
+export type RequestOverviewProps = {
+    exception: VulnerabilityException;
+    context: RequestContext
+};
+
+function RequestOverview({ exception, context }: RequestOverviewProps) {
+    // There will always be at least 1 comment
+    const latestComment = exception.comments.at(-1);
+
+    return (
+        <PageSection variant="light">
+            <Flex direction={{ default: 'column' }}>
+                <Title headingLevel="h2">Overview</Title>
+                <DescriptionList className="vulnerability-exception-request-overview">
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Requestor</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {exception.requester?.name || '-'}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Requested action</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            <RequestedAction exception={exception} context={context} />
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Requested</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            <RequestCreatedAt createdAt={exception.createdAt} />
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Expires</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            <RequestExpires exception={exception} context={context} />
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Scope</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            <RequestScope scope={exception.scope} />
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Comments</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            <RequestComments comments={exception.comments} />
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    {latestComment && (
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Latest comment</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                <RequestComment comment={latestComment} />
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                    )}
+                </DescriptionList>
+            </Flex>
+        </PageSection>
+    );
+}
+
+export default RequestOverview;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestOverview.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestOverview.tsx
@@ -21,7 +21,7 @@ import {
 
 export type RequestOverviewProps = {
     exception: VulnerabilityException;
-    context: RequestContext
+    context: RequestContext;
 };
 
 function RequestOverview({ exception, context }: RequestOverviewProps) {


### PR DESCRIPTION
## Description

This PR shows a slightly different view for request details when the exception status is `APPROVED_PENDING_UPDATE`. Because this is a mixed state, we want to be able to show the request data as it was approved and the request data that is pending approval

## Screenshot

<img width="1547" alt="Screenshot 2023-11-17 at 4 25 06 PM" src="https://github.com/stackrox/stackrox/assets/4805485/3a61ae06-5927-4883-81fe-08041fe22a36">
<img width="1547" alt="Screenshot 2023-11-17 at 4 25 08 PM" src="https://github.com/stackrox/stackrox/assets/4805485/732057cf-4dfa-4cc8-b584-66a7adc66ab9">

