### PR TITLE
ROX-20783: add secret informer wrapper

### DIFF
--- a/pkg/secretinformer/informer.go
+++ b/pkg/secretinformer/informer.go
@@ -59,6 +59,7 @@ func (c *SecretInformer) Start() error {
 		return errors.Wrap(err, "could not add event handler")
 	}
 	sif.Start(c.stopCh)
+	sif.WaitForCacheSync(c.stopCh)
 
 	return nil
 }

--- a/pkg/secretinformer/informer.go
+++ b/pkg/secretinformer/informer.go
@@ -1,0 +1,85 @@
+package secretinformer
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+)
+
+const resyncTime = 10 * time.Minute
+
+// SecretInformer is a convenience wrapper around a Kubernetes informer for a specific secret.
+type SecretInformer struct {
+	Namespace  string
+	SecretName string
+
+	k8sClient  kubernetes.Interface
+	onAddFn    func(*v1.Secret)
+	onUpdateFn func(*v1.Secret)
+	onDeleteFn func()
+	stopCh     chan struct{}
+}
+
+// NewSecretInformer creates a new secret informer.
+func NewSecretInformer(
+	Namespace string,
+	SecretName string,
+	k8sClient kubernetes.Interface,
+	onAddFn func(*v1.Secret),
+	onUpdateFn func(*v1.Secret),
+	onDeleteFn func(),
+) *SecretInformer {
+	return &SecretInformer{
+		Namespace:  Namespace,
+		SecretName: SecretName,
+		k8sClient:  k8sClient,
+		onAddFn:    onAddFn,
+		onUpdateFn: onUpdateFn,
+		onDeleteFn: onDeleteFn,
+		stopCh:     make(chan struct{}),
+	}
+}
+
+// Start initiates the secret informer loop.
+func (c *SecretInformer) Start() error {
+	nsOption := informers.WithNamespace(c.Namespace)
+	labelOption := informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+		opts.FieldSelector = "metadata.name=" + c.SecretName
+	})
+	sif := informers.NewSharedInformerFactoryWithOptions(c.k8sClient, resyncTime, nsOption, labelOption)
+
+	if _, err := sif.Core().V1().Secrets().Informer().AddEventHandler(c); err != nil {
+		return errors.Wrap(err, "could not add event handler")
+	}
+	sif.Start(c.stopCh)
+
+	return nil
+}
+
+// Stop ends the secret informer loop.
+func (c *SecretInformer) Stop() {
+	close(c.stopCh)
+}
+
+// OnAdd is called when the secret is added.
+func (c *SecretInformer) OnAdd(obj interface{}, _ bool) {
+	if secret, ok := obj.(*v1.Secret); ok {
+		c.onAddFn(secret)
+	}
+}
+
+// OnUpdate is called when the secret is updated.
+func (c *SecretInformer) OnUpdate(_, newObj interface{}) {
+	if secret, ok := newObj.(*v1.Secret); ok {
+		c.onUpdateFn(secret)
+	}
+}
+
+// OnDelete is called when the secret is deleted.
+func (c *SecretInformer) OnDelete(_ interface{}) {
+	c.onDeleteFn()
+}

--- a/pkg/secretinformer/informer.go
+++ b/pkg/secretinformer/informer.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
 const resyncTime = 10 * time.Minute
@@ -23,6 +24,8 @@ type SecretInformer struct {
 	onDeleteFn func()
 	stopCh     chan struct{}
 }
+
+var _ cache.ResourceEventHandler = &SecretInformer{}
 
 // NewSecretInformer creates a new secret informer.
 func NewSecretInformer(

--- a/pkg/secretinformer/informer.go
+++ b/pkg/secretinformer/informer.go
@@ -15,8 +15,8 @@ const resyncTime = 10 * time.Minute
 
 // SecretInformer is a convenience wrapper around a Kubernetes informer for a specific secret.
 type SecretInformer struct {
-	Namespace  string
-	SecretName string
+	namespace  string
+	secretName string
 
 	k8sClient  kubernetes.Interface
 	onAddFn    func(*v1.Secret)
@@ -29,16 +29,16 @@ var _ cache.ResourceEventHandler = &SecretInformer{}
 
 // NewSecretInformer creates a new secret informer.
 func NewSecretInformer(
-	Namespace string,
-	SecretName string,
+	namespace string,
+	secretName string,
 	k8sClient kubernetes.Interface,
 	onAddFn func(*v1.Secret),
 	onUpdateFn func(*v1.Secret),
 	onDeleteFn func(),
 ) *SecretInformer {
 	return &SecretInformer{
-		Namespace:  Namespace,
-		SecretName: SecretName,
+		namespace:  namespace,
+		secretName: secretName,
 		k8sClient:  k8sClient,
 		onAddFn:    onAddFn,
 		onUpdateFn: onUpdateFn,
@@ -49,9 +49,9 @@ func NewSecretInformer(
 
 // Start initiates the secret informer loop.
 func (c *SecretInformer) Start() error {
-	nsOption := informers.WithNamespace(c.Namespace)
+	nsOption := informers.WithNamespace(c.namespace)
 	labelOption := informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
-		opts.FieldSelector = "metadata.name=" + c.SecretName
+		opts.FieldSelector = "metadata.name=" + c.secretName
 	})
 	sif := informers.NewSharedInformerFactoryWithOptions(c.k8sClient, resyncTime, nsOption, labelOption)
 

--- a/pkg/secretinformer/informer_test.go
+++ b/pkg/secretinformer/informer_test.go
@@ -1,0 +1,155 @@
+package secretinformer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	namespace  = "stackrox"
+	secretName = "cloudCredentials"
+	secretKey  = "key"
+	secretData = "fake data"
+)
+
+func TestSecretInformer(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		setupFn             func(k8sClient *fake.Clientset) error
+		expectedOnAddCnt    int
+		expectedOnUpdateCnt int
+		expectedOnDeleteCnt int
+		expectedData        string
+	}{
+		"secret added": {
+			setupFn: func(k8sClient *fake.Clientset) error {
+				_, err := k8sClient.CoreV1().Secrets(namespace).Create(
+					context.Background(),
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: secretName},
+						Data: map[string][]byte{
+							secretKey: []byte(secretData),
+						},
+					},
+					metav1.CreateOptions{},
+				)
+				return err
+			},
+			expectedOnAddCnt: 1,
+			expectedData:     secretData,
+		},
+		"secret updated": {
+			setupFn: func(k8sClient *fake.Clientset) error {
+				_, err := k8sClient.CoreV1().Secrets(namespace).Create(
+					context.Background(),
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: secretName},
+						Data: map[string][]byte{
+							secretKey: []byte(secretData),
+						},
+					},
+					metav1.CreateOptions{},
+				)
+				if err != nil {
+					return err
+				}
+				// Allow the state to propagate.
+				time.Sleep(100 * time.Millisecond)
+				_, err = k8sClient.CoreV1().Secrets(namespace).Update(
+					context.Background(),
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: secretName},
+						Data: map[string][]byte{
+							secretKey: []byte(secretData),
+						},
+					},
+					metav1.UpdateOptions{},
+				)
+				return err
+			},
+			expectedOnAddCnt:    1,
+			expectedOnUpdateCnt: 1,
+			expectedData:        secretData,
+		},
+		"secret deleted": {
+			setupFn: func(k8sClient *fake.Clientset) error {
+				_, err := k8sClient.CoreV1().Secrets(namespace).Create(
+					context.Background(),
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: secretName},
+						Data: map[string][]byte{
+							secretKey: []byte(secretData),
+						},
+					},
+					metav1.CreateOptions{},
+				)
+				if err != nil {
+					return err
+				}
+				// Allow the state to propagate.
+				time.Sleep(100 * time.Millisecond)
+				err = k8sClient.CoreV1().Secrets(namespace).Delete(
+					context.Background(), secretName, metav1.DeleteOptions{},
+				)
+				return err
+			},
+			expectedOnAddCnt:    1,
+			expectedOnDeleteCnt: 1,
+			expectedData:        secretData,
+		},
+	}
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			k8sClient := fake.NewSimpleClientset()
+			var onAddCnt, onUpdateCnt, onDeleteCnt int
+			var mutex sync.RWMutex
+			informer := NewSecretInformer(
+				namespace,
+				secretName,
+				k8sClient,
+				func(s *v1.Secret) {
+					mutex.Lock()
+					defer mutex.Unlock()
+					onAddCnt++
+					assert.Equal(t, c.expectedData, string(s.Data[secretKey]))
+				},
+				func(s *v1.Secret) {
+					mutex.Lock()
+					defer mutex.Unlock()
+					onUpdateCnt++
+					assert.Equal(t, c.expectedData, string(s.Data[secretKey]))
+				},
+				func() {
+					mutex.Lock()
+					defer mutex.Unlock()
+					onDeleteCnt++
+				},
+			)
+
+			err := informer.Start()
+			require.NoError(t, err)
+			defer informer.Stop()
+			err = c.setupFn(k8sClient)
+			require.NoError(t, err)
+
+			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+				mutex.RLock()
+				defer mutex.RUnlock()
+				assert.Equal(t, c.expectedOnAddCnt, onAddCnt)
+				assert.Equal(t, c.expectedOnUpdateCnt, onUpdateCnt)
+				assert.Equal(t, c.expectedOnDeleteCnt, onDeleteCnt)
+			}, 5*time.Second, 100*time.Millisecond)
+		})
+	}
+}

--- a/pkg/secretinformer/informer_test.go
+++ b/pkg/secretinformer/informer_test.go
@@ -61,8 +61,6 @@ func TestSecretInformer(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				// Allow the state to propagate.
-				time.Sleep(100 * time.Millisecond)
 				_, err = k8sClient.CoreV1().Secrets(namespace).Update(
 					context.Background(),
 					&v1.Secret{
@@ -94,8 +92,6 @@ func TestSecretInformer(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				// Allow the state to propagate.
-				time.Sleep(100 * time.Millisecond)
 				err = k8sClient.CoreV1().Secrets(namespace).Delete(
 					context.Background(), secretName, metav1.DeleteOptions{},
 				)

--- a/pkg/secretinformer/informer_test.go
+++ b/pkg/secretinformer/informer_test.go
@@ -105,6 +105,11 @@ func TestSecretInformer(t *testing.T) {
 			expectedOnDeleteCnt: 1,
 			expectedData:        secretData,
 		},
+		"no secret": {
+			setupFn: func(k8sClient *fake.Clientset) error {
+				return nil
+			},
+		},
 	}
 
 	for name, c := range cases {


### PR DESCRIPTION
## Description

Add a secret informer wrapper for use in watching the cloud credential secrets `awsCloudCredentials`/`gcpCloudCredentials`/`azureCloudCredentials`. These secrets will contain STS configuration for workload identity federation.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
