### PR TITLE
ROX-20783: add AWS credentials manager

### DIFF
--- a/central/cloudproviders/aws/singleton.go
+++ b/central/cloudproviders/aws/singleton.go
@@ -35,7 +35,6 @@ func Singleton() aws.CredentialsManager {
 			k8sClient,
 			env.Namespace.Setting(),
 			env.AWSCloudCredentialsSecret.Setting(),
-			"mirrored-awsCloudCredentials",
 		)
 	})
 	return manager

--- a/central/cloudproviders/aws/singleton.go
+++ b/central/cloudproviders/aws/singleton.go
@@ -21,13 +21,13 @@ func Singleton() aws.CredentialsManager {
 	once.Do(func() {
 		restCfg, err := k8sutil.GetK8sInClusterConfig()
 		if err != nil {
-			log.Error("Could create AWS credentials manager. Continuing with default credentials chain: ", err)
+			log.Error("Could not create AWS credentials manager. Continuing with default credentials chain: ", err)
 			manager = &aws.DefaultCredentialsManager{}
 			return
 		}
 		k8sClient, err := kubernetes.NewForConfig(restCfg)
 		if err != nil {
-			log.Error("Could create AWS credentials manager. Continuing with default credentials chain: ", err)
+			log.Error("Could not create AWS credentials manager. Continuing with default credentials chain: ", err)
 			manager = &aws.DefaultCredentialsManager{}
 			return
 		}

--- a/central/cloudproviders/aws/singleton.go
+++ b/central/cloudproviders/aws/singleton.go
@@ -1,0 +1,42 @@
+package aws
+
+import (
+	"github.com/stackrox/rox/pkg/cloudproviders/aws"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/k8sutil"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sync"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	once    sync.Once
+	manager aws.CredentialsManager
+
+	log = logging.LoggerForModule()
+)
+
+// Singleton returns an instance of the AWS cloud credentials manager.
+func Singleton() aws.CredentialsManager {
+	once.Do(func() {
+		restCfg, err := k8sutil.GetK8sInClusterConfig()
+		if err != nil {
+			log.Error("Could create AWS credentials manager. Continuing with default credentials chain: ", err)
+			manager = &aws.DefaultCredentialsManager{}
+			return
+		}
+		k8sClient, err := kubernetes.NewForConfig(restCfg)
+		if err != nil {
+			log.Error("Could create AWS credentials manager. Continuing with default credentials chain: ", err)
+			manager = &aws.DefaultCredentialsManager{}
+			return
+		}
+		manager = aws.NewCredentialsManager(
+			k8sClient,
+			env.Namespace.Setting(),
+			env.AWSCloudCredentialsSecret.Setting(),
+			"mirrored-awsCloudCredentials",
+		)
+	})
+	return manager
+}

--- a/central/main.go
+++ b/central/main.go
@@ -29,6 +29,7 @@ import (
 	centralHealthService "github.com/stackrox/rox/central/centralhealth/service"
 	"github.com/stackrox/rox/central/certgen"
 	"github.com/stackrox/rox/central/cli"
+	"github.com/stackrox/rox/central/cloudproviders/aws"
 	"github.com/stackrox/rox/central/cloudproviders/gcp"
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
 	clusterService "github.com/stackrox/rox/central/cluster/service"
@@ -356,6 +357,9 @@ func startServices() {
 
 	if features.CloudCredentials.Enabled() {
 		gcp.Singleton().Start()
+	}
+	if err := aws.Singleton().Start(); err != nil {
+		log.Error("Failed to start AWS cloud credentials manager: ", err)
 	}
 
 	go registerDelayedIntegrations(iiStore.DelayedIntegrations)
@@ -887,6 +891,7 @@ func waitForTerminationSignal() {
 		{centralclient.InstanceConfig().Telemeter(), "telemetry client"},
 		{administrationUsageInjector.Singleton(), "administration usage injector"},
 		{obj: apiTokenExpiration.Singleton(), name: "api token expiration notifier"},
+		{obj: aws.Singleton(), name: "AWS cloud credentials manager"},
 	}
 
 	if features.VulnReportingEnhancements.Enabled() {

--- a/central/main.go
+++ b/central/main.go
@@ -356,10 +356,8 @@ func startServices() {
 	}
 
 	if features.CloudCredentials.Enabled() {
+		aws.Singleton().Start()
 		gcp.Singleton().Start()
-	}
-	if err := aws.Singleton().Start(); err != nil {
-		log.Error("Failed to start AWS cloud credentials manager: ", err)
 	}
 
 	go registerDelayedIntegrations(iiStore.DelayedIntegrations)
@@ -891,7 +889,6 @@ func waitForTerminationSignal() {
 		{centralclient.InstanceConfig().Telemeter(), "telemetry client"},
 		{administrationUsageInjector.Singleton(), "administration usage injector"},
 		{obj: apiTokenExpiration.Singleton(), name: "api token expiration notifier"},
-		{obj: aws.Singleton(), name: "AWS cloud credentials manager"},
 	}
 
 	if features.VulnReportingEnhancements.Enabled() {
@@ -905,6 +902,7 @@ func waitForTerminationSignal() {
 	}
 
 	if features.CloudCredentials.Enabled() {
+		stoppables = append(stoppables, stoppableWithName{aws.Singleton(), "AWS cloud credentials manager"})
 		stoppables = append(stoppables, stoppableWithName{gcp.Singleton(), "GCP cloud credentials manager"})
 	}
 

--- a/image/templates/helm/stackrox-central/templates/01-central-03-cloud-credentials-rbac.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-03-cloud-credentials-rbac.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames: ["gcp-cloud-credentials"]
+    resourceNames: ["aws-cloud-credentials", "gcp-cloud-credentials"]
     verbs: ["get", "list", "watch"]
 ---
 kind: RoleBinding

--- a/pkg/cloudproviders/aws/cred_manager.go
+++ b/pkg/cloudproviders/aws/cred_manager.go
@@ -7,7 +7,7 @@ import (
 
 // CredentialsManager manages AWS credentials based on the environment.
 type CredentialsManager interface {
-	Start() error
+	Start()
 	Stop()
 	NewSession(cfgs ...*aws.Config) (*session.Session, error)
 }
@@ -18,7 +18,7 @@ type DefaultCredentialsManager struct{}
 var _ CredentialsManager = &DefaultCredentialsManager{}
 
 // Start is a dummy function to fulfil the interface.
-func (c *DefaultCredentialsManager) Start() error { return nil }
+func (c *DefaultCredentialsManager) Start() {}
 
 // Stop is a dummy function to fulfil the interface.
 func (c *DefaultCredentialsManager) Stop() {}

--- a/pkg/cloudproviders/aws/cred_manager.go
+++ b/pkg/cloudproviders/aws/cred_manager.go
@@ -1,0 +1,31 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+// CredentialsManager manages AWS credentials based on the environment.
+type CredentialsManager interface {
+	Start() error
+	Stop()
+	NewSession(cfgs ...*aws.Config) (*session.Session, error)
+}
+
+// DefaultCredentialsManager always returns the default AWS credential chain.
+type DefaultCredentialsManager struct{}
+
+var _ CredentialsManager = &DefaultCredentialsManager{}
+
+// Start is a dummy function to fulfil the interface.
+func (c *DefaultCredentialsManager) Start() error { return nil }
+
+// Stop is a dummy function to fulfil the interface.
+func (c *DefaultCredentialsManager) Stop() {}
+
+// NewSession creates a new AWS session based on the default AWS credential chain.
+func (c *DefaultCredentialsManager) NewSession(cfgs ...*aws.Config) (*session.Session, error) {
+	opts := session.Options{}
+	opts.Config.MergeIn(cfgs...)
+	return session.NewSessionWithOptions(opts)
+}

--- a/pkg/cloudproviders/aws/cred_manager_impl.go
+++ b/pkg/cloudproviders/aws/cred_manager_impl.go
@@ -76,7 +76,7 @@ func (c *awsCredentialsManagerImpl) updateSecret(secret *v1.Secret) {
 		filename, err := mirrorToLocalFile(stsConfig, c.secretName)
 		if err != nil {
 			log.Errorf(
-				"Failed to mirror AWS cloud credential file for %q for %s/%s: ",
+				"Failed to mirror AWS cloud credential file for %q for %s/%s: %s",
 				c.mirroredFilename,
 				c.namespace,
 				c.secretName,
@@ -98,7 +98,7 @@ func (c *awsCredentialsManagerImpl) deleteSecret() {
 	c.stsConfig = []byte{}
 	if err := os.Remove(c.mirroredFilename); err != nil && !os.IsNotExist(err) {
 		log.Errorf(
-			"Could not remove mirrored credentials file %q for %s/%s: ",
+			"Could not remove mirrored credentials file %q for %s/%s: %s",
 			c.mirroredFilename,
 			c.namespace,
 			c.secretName,

--- a/pkg/cloudproviders/aws/cred_manager_impl.go
+++ b/pkg/cloudproviders/aws/cred_manager_impl.go
@@ -83,7 +83,7 @@ func (c *awsCredentialsManagerImpl) Stop() {
 // NewSession returns an AWS session based on the environment.
 //
 // The following sources are considered:
-//  1. Cloud credentials secret (stackrox/awsCloudCredentials) containing the STS configuration
+//  1. Cloud credentials secret (stackrox/aws-cloud-credentials) containing the STS configuration
 //     for pod IAM roles. Ignored if the secret does not exist.
 //  2. The default AWS credentials chain based on the pod's environment and metadata.
 func (c *awsCredentialsManagerImpl) NewSession(cfgs ...*aws.Config) (*session.Session, error) {

--- a/pkg/cloudproviders/aws/cred_manager_impl.go
+++ b/pkg/cloudproviders/aws/cred_manager_impl.go
@@ -18,6 +18,8 @@ const (
 )
 
 type awsCredentialsManagerImpl struct {
+	namespace        string
+	secretName       string
 	informer         *secretinformer.SecretInformer
 	secretFound      bool
 	mirroredFileName string
@@ -33,7 +35,11 @@ func NewCredentialsManager(
 	secretName string,
 	mirroredFileName string,
 ) *awsCredentialsManagerImpl {
-	mgr := &awsCredentialsManagerImpl{mirroredFileName: mirroredFileName}
+	mgr := &awsCredentialsManagerImpl{
+		namespace:        namespace,
+		secretName:       secretName,
+		mirroredFileName: mirroredFileName,
+	}
 	mgr.informer = secretinformer.NewSecretInformer(
 		namespace,
 		secretName,
@@ -55,7 +61,7 @@ func (c *awsCredentialsManagerImpl) updateSecret(secret *v1.Secret) {
 			return
 		}
 		c.secretFound = true
-		log.Infof("Updated AWS cloud credentials based on %s/%s", c.informer.Namespace, c.informer.SecretName)
+		log.Infof("Updated AWS cloud credentials based on %s/%s", c.namespace, c.secretName)
 	}
 }
 
@@ -66,7 +72,7 @@ func (c *awsCredentialsManagerImpl) deleteSecret() {
 	if err := os.Remove(c.mirroredFileName); err != nil {
 		log.Errorf("Could not remove mirrored credentials file %q", c.mirroredFileName)
 	}
-	log.Infof("Deleted AWS cloud credentials based on %s/%s", c.informer.Namespace, c.informer.SecretName)
+	log.Infof("Deleted AWS cloud credentials based on %s/%s", c.namespace, c.secretName)
 }
 
 func (c *awsCredentialsManagerImpl) Start() error {

--- a/pkg/cloudproviders/aws/cred_manager_impl.go
+++ b/pkg/cloudproviders/aws/cred_manager_impl.go
@@ -1,0 +1,114 @@
+package aws
+
+import (
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/secretinformer"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/utils"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	cloudCredentialsKey = "credentials"
+)
+
+type awsCredentialsManagerImpl struct {
+	informer         *secretinformer.SecretInformer
+	secretFound      bool
+	mirroredFileName string
+	mutex            sync.RWMutex
+}
+
+var _ CredentialsManager = &awsCredentialsManagerImpl{}
+
+// NewCredentialsManager creates a new AWS credential manager.
+func NewCredentialsManager(
+	k8sClient kubernetes.Interface,
+	namespace string,
+	secretName string,
+	mirroredFileName string,
+) *awsCredentialsManagerImpl {
+	mgr := &awsCredentialsManagerImpl{mirroredFileName: mirroredFileName}
+	mgr.informer = secretinformer.NewSecretInformer(
+		namespace,
+		secretName,
+		k8sClient,
+		mgr.updateSecret,
+		mgr.updateSecret,
+		mgr.deleteSecret,
+	)
+	return mgr
+}
+
+func (c *awsCredentialsManagerImpl) updateSecret(secret *v1.Secret) {
+	if stsConfig, ok := secret.Data[cloudCredentialsKey]; ok {
+		c.mutex.Lock()
+		defer c.mutex.Unlock()
+		if err := mirrorToLocalFile([]byte(stsConfig), c.mirroredFileName); err != nil {
+			log.Errorf("Failed to mirror AWS cloud credential file for %q", c.mirroredFileName)
+			c.secretFound = false
+			return
+		}
+		c.secretFound = true
+		log.Infof("Updated AWS cloud credentials based on %s/%s", c.informer.Namespace, c.informer.SecretName)
+	}
+}
+
+func (c *awsCredentialsManagerImpl) deleteSecret() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.secretFound = false
+	if err := os.Remove(c.mirroredFileName); err != nil {
+		log.Errorf("Could not remove mirrored credentials file %q", c.mirroredFileName)
+	}
+	log.Infof("Deleted AWS cloud credentials based on %s/%s", c.informer.Namespace, c.informer.SecretName)
+}
+
+func (c *awsCredentialsManagerImpl) Start() error {
+	return c.informer.Start()
+}
+
+func (c *awsCredentialsManagerImpl) Stop() {
+	c.informer.Stop()
+	if err := os.Remove(c.mirroredFileName); err != nil {
+		log.Errorf("Could not remove mirrored credentials file %q", c.mirroredFileName)
+	}
+}
+
+// NewSession returns an AWS session based on the environment.
+//
+// The following sources are considered:
+//  1. Cloud credentials secret (stackrox/awsCloudCredentials) containing the STS configuration
+//     for pod IAM roles. Ignored if the secret does not exist.
+//  2. The default AWS credentials chain based on the pod's environment and metadata.
+func (c *awsCredentialsManagerImpl) NewSession(cfgs ...*aws.Config) (*session.Session, error) {
+	opts := session.Options{}
+	opts.Config.MergeIn(cfgs...)
+
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	if c.secretFound {
+		opts.SharedConfigState = session.SharedConfigEnable
+		opts.SharedConfigFiles = []string{c.mirroredFileName}
+	}
+
+	return session.NewSessionWithOptions(opts)
+}
+
+func mirrorToLocalFile(data []byte, filename string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create AWS cloud credentials file %q", filename)
+	}
+	defer utils.IgnoreError(file.Close)
+
+	if _, err := file.Write(data); err != nil {
+		return errors.Wrapf(err, "failed to write AWS cloud credentials to %q", filename)
+	}
+	return nil
+}

--- a/pkg/cloudproviders/aws/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/aws/cred_manager_impl_test.go
@@ -1,0 +1,142 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	fakeSTSConfig = `
+    [default]
+    sts_regional_endpoints = regional
+    role_name: fake-role
+    web_identity_token_file: /var/run/secrets/openshift/serviceaccount/token`
+
+	namespace  = "stackrox"
+	secretName = "awsCloudCredentials"
+)
+
+func TestCredentialManager(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		setupFn         func(k8sClient *fake.Clientset) error
+		fileExists      bool
+		expectedContent string
+	}{
+		"secret added": {
+			setupFn: func(k8sClient *fake.Clientset) error {
+				_, err := k8sClient.CoreV1().Secrets(namespace).Create(
+					context.Background(),
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: secretName},
+						Data: map[string][]byte{
+							cloudCredentialsKey: []byte(fakeSTSConfig),
+						},
+					},
+					metav1.CreateOptions{},
+				)
+				return err
+			},
+			fileExists:      true,
+			expectedContent: fakeSTSConfig,
+		},
+		"secret updated": {
+			setupFn: func(k8sClient *fake.Clientset) error {
+				_, err := k8sClient.CoreV1().Secrets(namespace).Create(
+					context.Background(),
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: secretName},
+						Data: map[string][]byte{
+							cloudCredentialsKey: []byte("xxx"),
+						},
+					},
+					metav1.CreateOptions{},
+				)
+				if err != nil {
+					return err
+				}
+				// Allow the state to propagate.
+				time.Sleep(10 * time.Millisecond)
+
+				_, err = k8sClient.CoreV1().Secrets(namespace).Update(
+					context.Background(),
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: secretName},
+						Data: map[string][]byte{
+							cloudCredentialsKey: []byte(fakeSTSConfig),
+						},
+					},
+					metav1.UpdateOptions{},
+				)
+				return err
+			},
+			fileExists:      true,
+			expectedContent: fakeSTSConfig,
+		},
+		"secret deleted": {
+			setupFn: func(k8sClient *fake.Clientset) error {
+				_, err := k8sClient.CoreV1().Secrets(namespace).Create(
+					context.Background(),
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: secretName},
+						Data: map[string][]byte{
+							cloudCredentialsKey: []byte(fakeSTSConfig),
+						},
+					},
+					metav1.CreateOptions{},
+				)
+				if err != nil {
+					return err
+				}
+				// Allow the state to propagate.
+				time.Sleep(10 * time.Millisecond)
+
+				return k8sClient.CoreV1().Secrets(namespace).Delete(
+					context.Background(),
+					secretName,
+					metav1.DeleteOptions{},
+				)
+			},
+			fileExists: false,
+		},
+	}
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			k8sClient := fake.NewSimpleClientset()
+			// Randomize file name to make sure test runs don't interfere with each other.
+			fileName := fmt.Sprintf("%s-%d", secretName, rand.Int())
+			manager := NewCredentialsManager(k8sClient, namespace, secretName, fileName)
+			err := manager.Start()
+			require.NoError(t, err)
+			defer manager.Stop()
+
+			err = c.setupFn(k8sClient)
+			require.NoError(t, err)
+
+			// Assert that the secret data has been updated.
+			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+				manager.mutex.RLock()
+				defer manager.mutex.RUnlock()
+				assert.Equal(t, c.fileExists, manager.secretFound)
+				if c.fileExists {
+					stsConfig, err := os.ReadFile(manager.mirroredFileName)
+					assert.NoError(t, err)
+					assert.Equal(t, []byte(c.expectedContent), stsConfig)
+				}
+			}, 5*time.Second, 100*time.Millisecond)
+		})
+	}
+}

--- a/pkg/cloudproviders/aws/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/aws/cred_manager_impl_test.go
@@ -109,6 +109,9 @@ func TestCredentialManager(t *testing.T) {
 			},
 			fileExists: false,
 		},
+		"no secret": {
+			setupFn: func(k8sClient *fake.Clientset) error { return nil },
+		},
 	}
 
 	for name, c := range cases {
@@ -118,12 +121,11 @@ func TestCredentialManager(t *testing.T) {
 			k8sClient := fake.NewSimpleClientset()
 			// Randomize file name to make sure test runs don't interfere with each other.
 			fileName := fmt.Sprintf("%s-%d", secretName, rand.Int())
-			manager := NewCredentialsManager(k8sClient, namespace, secretName, fileName)
-			err := manager.Start()
-			require.NoError(t, err)
+			manager := newAWSCredentialsManagerImpl(k8sClient, namespace, secretName, fileName)
+			manager.Start()
 			defer manager.Stop()
 
-			err = c.setupFn(k8sClient)
+			err := c.setupFn(k8sClient)
 			require.NoError(t, err)
 
 			// Assert that the secret data has been updated.

--- a/pkg/cloudproviders/aws/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/aws/cred_manager_impl_test.go
@@ -21,7 +21,7 @@ const (
     web_identity_token_file: /var/run/secrets/openshift/serviceaccount/token`
 
 	namespace  = "stackrox"
-	secretName = "aws-cloud-credentials"
+	secretName = "aws-cloud-credentials" // #nosec G101
 )
 
 func TestCredentialManager(t *testing.T) {

--- a/pkg/cloudproviders/aws/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/aws/cred_manager_impl_test.go
@@ -23,7 +23,7 @@ const (
     web_identity_token_file: /var/run/secrets/openshift/serviceaccount/token`
 
 	namespace  = "stackrox"
-	secretName = "awsCloudCredentials"
+	secretName = "aws-cloud-credentials"
 )
 
 func TestCredentialManager(t *testing.T) {

--- a/pkg/cloudproviders/aws/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/aws/cred_manager_impl_test.go
@@ -132,7 +132,7 @@ func TestCredentialManager(t *testing.T) {
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 				manager.mutex.RLock()
 				defer manager.mutex.RUnlock()
-				assert.Equal(t, c.fileExists, manager.secretFound)
+				assert.Equal(t, c.fileExists, len(manager.stsConfig) > 0)
 				if c.fileExists {
 					stsConfig, err := os.ReadFile(manager.mirroredFileName)
 					assert.NoError(t, err)

--- a/pkg/cloudproviders/aws/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/aws/cred_manager_impl_test.go
@@ -2,8 +2,6 @@ package aws
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -119,9 +117,7 @@ func TestCredentialManager(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()
-			// Randomize file name to make sure test runs don't interfere with each other.
-			fileName := fmt.Sprintf("%s-%d", secretName, rand.Int())
-			manager := newAWSCredentialsManagerImpl(k8sClient, namespace, secretName, fileName)
+			manager := newAWSCredentialsManagerImpl(k8sClient, namespace, secretName)
 			manager.Start()
 			defer manager.Stop()
 
@@ -134,7 +130,7 @@ func TestCredentialManager(t *testing.T) {
 				defer manager.mutex.RUnlock()
 				assert.Equal(t, c.fileExists, len(manager.stsConfig) > 0)
 				if c.fileExists {
-					stsConfig, err := os.ReadFile(manager.mirroredFileName)
+					stsConfig, err := os.ReadFile(manager.mirroredFilename)
 					assert.NoError(t, err)
 					assert.Equal(t, []byte(c.expectedContent), stsConfig)
 				}

--- a/pkg/env/cloudproviders.go
+++ b/pkg/env/cloudproviders.go
@@ -1,4 +1,7 @@
 package env
 
+// AWSCloudCredentialsSecret is the variable that specifies the name of the AWS cloud credentials secret.
+var AWSCloudCredentialsSecret = RegisterSetting("ROX_AWS_CLOUD_CREDENTIALS_SECRET", WithDefault("awsCloudCredentials"))
+
 // GCPCloudCredentialsSecret is the variable that specifies the name of the GCP cloud credentials secret.
 var GCPCloudCredentialsSecret = RegisterSetting("ROX_GCP_CLOUD_CREDENTIALS_SECRET", WithDefault("gcp-cloud-credentials"))

--- a/pkg/env/cloudproviders.go
+++ b/pkg/env/cloudproviders.go
@@ -1,7 +1,7 @@
 package env
 
 // AWSCloudCredentialsSecret is the variable that specifies the name of the AWS cloud credentials secret.
-var AWSCloudCredentialsSecret = RegisterSetting("ROX_AWS_CLOUD_CREDENTIALS_SECRET", WithDefault("awsCloudCredentials"))
+var AWSCloudCredentialsSecret = RegisterSetting("ROX_AWS_CLOUD_CREDENTIALS_SECRET", WithDefault("aws-cloud-credentials"))
 
 // GCPCloudCredentialsSecret is the variable that specifies the name of the GCP cloud credentials secret.
 var GCPCloudCredentialsSecret = RegisterSetting("ROX_GCP_CLOUD_CREDENTIALS_SECRET", WithDefault("gcp-cloud-credentials"))


### PR DESCRIPTION
## Description

Add an AWS credentials manager that watches a secret in the stackrox namespace (`stackrox/awsCloudCredentials`) for STS configuration to use in STS IAM role integrations. If the secret does not exist, the default AWS credential chain is returned. The secret must be provided by users when they intend to use workload identities on EKS/EC2 clusters.

The AWS SDK expects the configuration as a local file, which is why the content of the secret is mirrored to the local file system.

Example STS config:

```
    [default]
    sts_regional_endpoints = regional
    role_name: fake-role
    web_identity_token_file: /var/run/secrets/openshift/serviceaccount/token`
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
