### PR TITLE
chore(deps): Add replacement for unknown go-fuzz-headers1 revision

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -489,3 +489,5 @@ replace (
 exclude k8s.io/client-go v12.0.0+incompatible
 
 exclude github.com/openshift/client-go v3.9.0+incompatible
+
+replace github.com/AdamKorcz/go-fuzz-headers-1 v0.0.0-20230329111138-12e09aba5ebd => github.com/AdamKorcz/go-fuzz-headers-1 v0.0.0-20230919221257-8b5d3ce2d11d

--- a/go.sum
+++ b/go.sum
@@ -52,7 +52,7 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
-github.com/AdamKorcz/go-fuzz-headers-1 v0.0.0-20230329111138-12e09aba5ebd h1:1tbEqR4NyQLgiod7vLXSswHteGetAVZrMGCqrJxLKRs=
+github.com/AdamKorcz/go-fuzz-headers-1 v0.0.0-20230919221257-8b5d3ce2d11d h1:zjqpY4C7H15HjRPEenkS4SAn3Jy2eRRjkjZbGR30TOg=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=


### PR DESCRIPTION
## Description

Bump indirect dependency `go-fuzz-headers1` by replacement.

Problem: With an empty cache or fresh go installation, the referenced version of `go-fuzz-headers1` yields an error
```sh
$ go list -m -json all
go: github.com/AdamKorcz/go-fuzz-headers-1@v0.0.0-20230329111138-12e09aba5ebd: invalid version: unknown revision 12e09aba5ebd

$ go mod why github.com/AdamKorcz/go-fuzz-headers-1
# github.com/AdamKorcz/go-fuzz-headers-1
github.com/stackrox/rox/pkg/signatures
github.com/sigstore/cosign/v2/pkg/cosign
github.com/sigstore/rekor/pkg/types/hashedrekord/v0.0.1
github.com/sigstore/rekor/pkg/types/hashedrekord/v0.0.1.test
github.com/AdamKorcz/go-fuzz-headers-1

```
This PR replaces the reference with latest master, resulting in `go mod` commands working again, including initial installation.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Run `go list -m -json all` on clean go cache / fresh install. Observe error `invalid version`.
Add replacement directive, re-run command, and observe correct functionality and dependency download.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
