### PR TITLE
ROX-19849: Add scanner pod restart pattern for slow db init 

### DIFF
--- a/scripts/ci/logcheck/restart-ok-patterns.json
+++ b/scripts/ci/logcheck/restart-ok-patterns.json
@@ -18,6 +18,12 @@
         "logline": "Failed to connect to sensor.stackrox.* port 443: No route to host"
     },
     {
+        "comment": "scanner restart due to slow postgres db start",
+        "job": "^(ocp|openshift)",
+        "logfile": "scanner-previous",
+        "logline": "Failed to open database despite multiple retries"
+    },
+    {
         "comment": "sensor is up before central in scale-tests",
         "job": "scale-tests",
         "logfile": "sensor-previous",

--- a/scripts/ci/logcheck/restart-ok-patterns.json
+++ b/scripts/ci/logcheck/restart-ok-patterns.json
@@ -19,7 +19,7 @@
     },
     {
         "comment": "scanner restart due to slow postgres db start",
-        "job": "^(ocp|openshift)",
+        "job": "^(ocp|openshift|ibmcloudz)",
         "logfile": "scanner-previous",
         "logline": "Failed to open database despite multiple retries"
     },

--- a/scripts/ci/logcheck/restart-ok-patterns.json
+++ b/scripts/ci/logcheck/restart-ok-patterns.json
@@ -19,7 +19,7 @@
     },
     {
         "comment": "scanner restart due to slow postgres db start",
-        "job": "^(ocp|openshift|ibmcloudz)",
+        "job": "^(ibmcloudz)",
         "logfile": "scanner-previous",
         "logline": "Failed to open database despite multiple retries"
     },


### PR DESCRIPTION
## Description

Adds restarted due to slow postgres startup, for pod restart CI check.
CI pod restart fails on some s390x ci runs, with scanner pod error
```{"Event":"Failed to open database.","Level":"error","Location":"database.go:81","Time":"2023-11-16 20:07:20.304992","error":"pgsql: could not open database: dial tcp 172.30.252.85:5432: connect: connection refused"}
{"Attempt":18,"Event":"Retrying connection to DB","Level":"warning","Location":"database.go:83","Time":"2023-11-16 20:07:20.305061"}
```
CI run is passing otherwise

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed
Relying on CI
### Here I tell how I validated my change
Relying on CI

