### PR TITLE
chore(ui): Refactor VM 2.0 search options for single source of truth

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -16,13 +16,6 @@ import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
 import useRestQuery from 'hooks/useRestQuery';
-import {
-    IMAGE_CVE_SEARCH_OPTION,
-    IMAGE_SEARCH_OPTION,
-    REQUESTER_SEARCH_OPTION,
-    REQUEST_NAME_SEARCH_OPTION,
-    SearchOption,
-} from 'Containers/Vulnerabilities/components/SearchOptionsDropdown';
 import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionService';
 
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
@@ -38,6 +31,13 @@ import {
 } from './components/ExceptionRequestTableCells';
 import FilterAutocompleteSelect from '../components/FilterAutocomplete';
 import TableErrorComponent from '../WorkloadCves/components/TableErrorComponent';
+import {
+    SearchOption,
+    REQUEST_NAME_SEARCH_OPTION,
+    IMAGE_CVE_SEARCH_OPTION,
+    REQUESTER_SEARCH_OPTION,
+    IMAGE_SEARCH_OPTION,
+} from '../searchOptions';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -14,13 +14,6 @@ import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-tab
 import useURLPagination from 'hooks/useURLPagination';
 
 import useURLSearch from 'hooks/useURLSearch';
-import {
-    IMAGE_CVE_SEARCH_OPTION,
-    IMAGE_SEARCH_OPTION,
-    REQUESTER_SEARCH_OPTION,
-    REQUEST_NAME_SEARCH_OPTION,
-    SearchOption,
-} from 'Containers/Vulnerabilities/components/SearchOptionsDropdown';
 
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionService';
@@ -37,6 +30,13 @@ import {
 } from './components/ExceptionRequestTableCells';
 import FilterAutocompleteSelect from '../components/FilterAutocomplete';
 import TableErrorComponent from '../WorkloadCves/components/TableErrorComponent';
+import {
+    SearchOption,
+    REQUEST_NAME_SEARCH_OPTION,
+    IMAGE_CVE_SEARCH_OPTION,
+    REQUESTER_SEARCH_OPTION,
+    IMAGE_SEARCH_OPTION,
+} from '../searchOptions';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -16,13 +16,6 @@ import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useRestQuery from 'hooks/useRestQuery';
 import useURLSort from 'hooks/useURLSort';
-import {
-    IMAGE_CVE_SEARCH_OPTION,
-    IMAGE_SEARCH_OPTION,
-    REQUESTER_SEARCH_OPTION,
-    REQUEST_NAME_SEARCH_OPTION,
-    SearchOption,
-} from 'Containers/Vulnerabilities/components/SearchOptionsDropdown';
 import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionService';
 
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
@@ -38,6 +31,13 @@ import {
 } from './components/ExceptionRequestTableCells';
 import FilterAutocompleteSelect from '../components/FilterAutocomplete';
 import TableErrorComponent from '../WorkloadCves/components/TableErrorComponent';
+import {
+    SearchOption,
+    REQUEST_NAME_SEARCH_OPTION,
+    IMAGE_CVE_SEARCH_OPTION,
+    REQUESTER_SEARCH_OPTION,
+    IMAGE_SEARCH_OPTION,
+} from '../searchOptions';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -16,13 +16,6 @@ import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useRestQuery from 'hooks/useRestQuery';
 import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionService';
-import {
-    IMAGE_CVE_SEARCH_OPTION,
-    IMAGE_SEARCH_OPTION,
-    REQUESTER_SEARCH_OPTION,
-    REQUEST_NAME_SEARCH_OPTION,
-    SearchOption,
-} from 'Containers/Vulnerabilities/components/SearchOptionsDropdown';
 
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import useURLSort from 'hooks/useURLSort';
@@ -38,6 +31,13 @@ import {
 } from './components/ExceptionRequestTableCells';
 import FilterAutocompleteSelect from '../components/FilterAutocomplete';
 import TableErrorComponent from '../WorkloadCves/components/TableErrorComponent';
+import {
+    SearchOption,
+    REQUEST_NAME_SEARCH_OPTION,
+    IMAGE_CVE_SEARCH_OPTION,
+    REQUESTER_SEARCH_OPTION,
+    IMAGE_SEARCH_OPTION,
+} from '../searchOptions';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -27,12 +27,12 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import NotFoundMessage from 'Components/NotFoundMessage';
 import {
+    SearchOption,
     COMPONENT_SEARCH_OPTION,
     COMPONENT_SOURCE_SEARCH_OPTION,
     IMAGE_CVE_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
-    SearchOption,
-} from 'Containers/Vulnerabilities/components/SearchOptionsDropdown';
+} from 'Containers/Vulnerabilities/searchOptions';
 import { DynamicTableLabel } from '../components/DynamicIcon';
 import WorkloadTableToolbar from '../components/WorkloadTableToolbar';
 import TableErrorComponent from '../components/TableErrorComponent';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -29,11 +29,11 @@ import useFeatureFlags from 'hooks/useFeatureFlags';
 import useMap from 'hooks/useMap';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 import {
+    SearchOption,
+    IMAGE_CVE_SEARCH_OPTION,
     COMPONENT_SEARCH_OPTION,
     COMPONENT_SOURCE_SEARCH_OPTION,
-    IMAGE_CVE_SEARCH_OPTION,
-    SearchOption,
-} from 'Containers/Vulnerabilities/components/SearchOptionsDropdown';
+} from 'Containers/Vulnerabilities/searchOptions';
 import WorkloadTableToolbar from '../components/WorkloadTableToolbar';
 import CvesByStatusSummaryCard, {
     ResourceCountByCveSeverityAndStatus,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -31,14 +31,14 @@ import { Pagination as PaginationParam } from 'services/types';
 
 import { VulnerabilitySeverity } from 'types/cve.proto';
 import {
+    SearchOption,
+    IMAGE_SEARCH_OPTION,
+    DEPLOYMENT_SEARCH_OPTION,
+    NAMESPACE_SEARCH_OPTION,
     CLUSTER_SEARCH_OPTION,
     COMPONENT_SEARCH_OPTION,
     COMPONENT_SOURCE_SEARCH_OPTION,
-    DEPLOYMENT_SEARCH_OPTION,
-    IMAGE_SEARCH_OPTION,
-    NAMESPACE_SEARCH_OPTION,
-    SearchOption,
-} from 'Containers/Vulnerabilities/components/SearchOptionsDropdown';
+} from 'Containers/Vulnerabilities/searchOptions';
 import {
     getHiddenSeverities,
     getOverviewCvesPath,
@@ -239,7 +239,7 @@ function ImageCvePage() {
     function getDeploymentSearchQuery(severity?: VulnerabilitySeverity) {
         const filters = { ...querySearchFilter, CVE: [cveId] };
         if (severity) {
-            filters.Severity = [severity];
+            filters.SEVERITY = [severity];
         }
         return getVulnStateScopedQueryString(filters, currentVulnerabilityState);
     }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -54,18 +54,18 @@ function mergeDefaultAndLocalFilters(
 ): SearchFilter {
     const filter = cloneDeep(searchFilter);
 
-    let Severity = filter.Severity ?? [];
-    let Fixable = filter.Fixable ?? [];
+    let SEVERITY = filter.SEVERITY ?? [];
+    let FIXABLE = filter.FIXABLE ?? [];
 
     // Remove existing applied filters that are no longer in the default filters, then
     // add the new default filters.
-    Severity = difference(Severity, oldDefaults.Severity, newDefaults.Severity);
-    Severity = Severity.concat(newDefaults.Severity);
+    SEVERITY = difference(SEVERITY, oldDefaults.SEVERITY, newDefaults.SEVERITY);
+    SEVERITY = SEVERITY.concat(newDefaults.SEVERITY);
 
-    Fixable = difference(Fixable, oldDefaults.Fixable, newDefaults.Fixable);
-    Fixable = Fixable.concat(newDefaults.Fixable);
+    FIXABLE = difference(FIXABLE, oldDefaults.FIXABLE, newDefaults.FIXABLE);
+    FIXABLE = FIXABLE.concat(newDefaults.FIXABLE);
 
-    return { ...filter, Severity, Fixable };
+    return { ...filter, SEVERITY, FIXABLE };
 }
 
 function WorkloadCvesOverviewPage() {
@@ -96,8 +96,8 @@ function WorkloadCvesOverviewPage() {
     const defaultStorage: VulnMgmtLocalStorage = {
         preferences: {
             defaultFilters: {
-                Severity: isFixabilityFiltersEnabled ? ['Critical', 'Important'] : [],
-                Fixable: isFixabilityFiltersEnabled ? ['Fixable'] : [],
+                SEVERITY: isFixabilityFiltersEnabled ? ['Critical', 'Important'] : [],
+                FIXABLE: isFixabilityFiltersEnabled ? ['Fixable'] : [],
             },
         },
     } as const;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CVESeverityDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CVESeverityDropdown.tsx
@@ -5,7 +5,7 @@ import { SearchFilter } from 'types/search';
 
 type CVESeverityDropdownProps = {
     searchFilter: SearchFilter;
-    onSelect: (filterType, e, selection) => void;
+    onSelect: (filterType: 'SEVERITY', checked: boolean, selection: string) => void;
 };
 
 function CVESeverityDropdown({ searchFilter, onSelect }: CVESeverityDropdownProps) {
@@ -15,18 +15,16 @@ function CVESeverityDropdown({ searchFilter, onSelect }: CVESeverityDropdownProp
         setCveSeverityIsOpen(isOpen);
     }
 
-    function onCveSeveritySelect(e, selection) {
-        onSelect('Severity', e, selection);
-    }
-
     return (
         <Select
             variant="checkbox"
             aria-label="CVE severity filter menu items"
             toggleAriaLabel="CVE severity filter menu toggle"
             onToggle={onCveSeverityToggle}
-            onSelect={onCveSeveritySelect}
-            selections={searchFilter.Severity}
+            onSelect={(e, selection) => {
+                onSelect('SEVERITY', (e.target as HTMLInputElement).checked, selection as string);
+            }}
+            selections={searchFilter.SEVERITY}
             isOpen={cveSeverityIsOpen}
             placeholderText="CVE severity"
             className="cve-severity-select"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CVEStatusDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CVEStatusDropdown.tsx
@@ -5,7 +5,7 @@ import { SearchFilter } from 'types/search';
 
 type CVEStatusDropdownProps = {
     searchFilter: SearchFilter;
-    onSelect: (filterType, e, selection) => void;
+    onSelect: (filterType: 'FIXABLE', checked: boolean, selection: string) => void;
 };
 
 function CVEStatusDropdown({ searchFilter, onSelect }: CVEStatusDropdownProps) {
@@ -14,9 +14,6 @@ function CVEStatusDropdown({ searchFilter, onSelect }: CVEStatusDropdownProps) {
     function onCveStatusToggle(isOpen: boolean) {
         setCveStatusIsOpen(isOpen);
     }
-    function onCveStatusSelect(e, selection) {
-        onSelect('Fixable', e, selection);
-    }
 
     return (
         <Select
@@ -24,8 +21,10 @@ function CVEStatusDropdown({ searchFilter, onSelect }: CVEStatusDropdownProps) {
             aria-label="CVE status filter menu items"
             toggleAriaLabel="CVE status filter menu toggle"
             onToggle={onCveStatusToggle}
-            onSelect={onCveStatusSelect}
-            selections={searchFilter.Fixable}
+            onSelect={(e, selection) => {
+                onSelect('FIXABLE', (e.target as HTMLInputElement).checked, selection as string);
+            }}
+            selections={searchFilter.FIXABLE}
             isOpen={cveStatusIsOpen}
             placeholderText="CVE status"
         >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
@@ -13,7 +13,7 @@ type DefaultFilterModalProps = {
 
 function DefaultFilterModal({ defaultFilters, setLocalStorage }: DefaultFilterModalProps) {
     const [isOpen, setIsOpen] = useState(false);
-    const totalFilters = defaultFilters.Severity.length + defaultFilters.Fixable.length;
+    const totalFilters = defaultFilters.SEVERITY.length + defaultFilters.FIXABLE.length;
 
     const formik = useFormik({
         initialValues: cloneDeep(defaultFilters),
@@ -24,8 +24,8 @@ function DefaultFilterModal({ defaultFilters, setLocalStorage }: DefaultFilterMo
     });
 
     const { submitForm, values, setFieldValue, setValues } = formik;
-    const severityValues = values.Severity;
-    const fixableValues = values.Fixable;
+    const severityValues = values.SEVERITY;
+    const fixableValues = values.FIXABLE;
 
     function handleModalToggle() {
         if (isOpen) {
@@ -41,7 +41,7 @@ function DefaultFilterModal({ defaultFilters, setLocalStorage }: DefaultFilterMo
         } else {
             newSeverityValues = newSeverityValues.filter((val) => val !== severity);
         }
-        setFieldValue('Severity', newSeverityValues).catch(() => {});
+        setFieldValue('SEVERITY', newSeverityValues).catch(() => {});
     }
 
     function handleFixableChange(fixable: FixableStatus, isChecked: boolean) {
@@ -51,7 +51,7 @@ function DefaultFilterModal({ defaultFilters, setLocalStorage }: DefaultFilterMo
         } else {
             newFixableValues = newFixableValues.filter((val) => val !== fixable);
         }
-        setFieldValue('Fixable', newFixableValues).catch(() => {});
+        setFieldValue('FIXABLE', newFixableValues).catch(() => {});
     }
 
     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/TableEntityToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/TableEntityToolbar.tsx
@@ -12,7 +12,7 @@ import {
     IMAGE_SEARCH_OPTION,
     NAMESPACE_SEARCH_OPTION,
     SearchOption,
-} from 'Containers/Vulnerabilities/components/SearchOptionsDropdown';
+} from 'Containers/Vulnerabilities/searchOptions';
 import WorkloadTableToolbar from './WorkloadTableToolbar';
 import { DynamicTableLabel } from './DynamicIcon';
 import EntityTypeToggleGroup, { EntityCounts } from './EntityTypeToggleGroup';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
@@ -5,9 +5,9 @@ import { Toolbar, ToolbarGroup, ToolbarContent, Flex } from '@patternfly/react-c
 import useURLSearch from 'hooks/useURLSearch';
 import { SearchFilter } from 'types/search';
 import { Globe } from 'react-feather';
-import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
-import { SearchOption } from 'Containers/Vulnerabilities/components/SearchOptionsDropdown';
+import SearchFilterChips, { SearchFilterChipsProps } from 'Components/PatternFly/SearchFilterChips';
 import useFeatureFlags from 'hooks/useFeatureFlags';
+import { SearchOption, SearchOptionValue } from 'Containers/Vulnerabilities/searchOptions';
 import { DefaultFilters } from '../types';
 import FilterAutocomplete, {
     FilterAutocompleteSelectProps,
@@ -35,11 +35,10 @@ function FilterChip({ isGlobal, name }: FilterChipProps) {
 }
 
 const emptyDefaultFilters = {
-    Severity: [],
-    Fixable: [],
+    SEVERITY: [],
+    FIXABLE: [],
 };
 
-type FilterType = 'Severity' | 'Fixable';
 type WorkloadTableToolbarProps = {
     defaultFilters?: DefaultFilters;
     searchOptions: SearchOption[];
@@ -63,8 +62,11 @@ function WorkloadTableToolbar({
         onFilterChange(newFilter);
     }
 
-    function onSelect(type: FilterType, e, selection) {
-        const { checked } = e.target as HTMLInputElement;
+    function onSelect(
+        type: Extract<SearchOptionValue, 'SEVERITY' | 'FIXABLE'>,
+        checked: boolean,
+        selection: string
+    ) {
         const selectedSearchFilter = searchFilter[type] as string[];
         if (searchFilter[type]) {
             onChangeSearchFilter({
@@ -83,7 +85,9 @@ function WorkloadTableToolbar({
         }
     }
 
-    const filterChipGroupDescriptors = [
+    const filterChipGroupDescriptors: (SearchFilterChipsProps['filterChipGroupDescriptors'][number] & {
+        searchFilterName: SearchOptionValue;
+    })[] = [
         {
             displayName: 'Deployment',
             searchFilterName: 'DEPLOYMENT',
@@ -114,10 +118,10 @@ function WorkloadTableToolbar({
         },
         {
             displayName: 'Severity',
-            searchFilterName: 'Severity',
+            searchFilterName: 'SEVERITY',
             render: (filter: string) => (
                 <FilterChip
-                    isGlobal={defaultFilters.Severity?.some((severity) => severity === filter)}
+                    isGlobal={defaultFilters.SEVERITY?.some((severity) => severity === filter)}
                     name={filter}
                 />
             ),
@@ -127,10 +131,10 @@ function WorkloadTableToolbar({
     if (isFixabilityFiltersEnabled) {
         filterChipGroupDescriptors.push({
             displayName: 'Fixable',
-            searchFilterName: 'Fixable',
+            searchFilterName: 'FIXABLE',
             render: (filter: string) => (
                 <FilterChip
-                    isGlobal={defaultFilters.Fixable?.some((fixability) => fixability === filter)}
+                    isGlobal={defaultFilters.FIXABLE?.some((fixability) => fixability === filter)}
                     name={filter}
                 />
             ),

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
@@ -16,8 +16,8 @@ export function isFixableStatus(value: unknown): value is FixableStatus {
 // `QuerySearchFilter` is a restricted subset of the `SearchFilter` obtained from the URL that only
 // supports search keys that are valid in the Workload CVE section of the app
 export type QuerySearchFilter = Partial<{
-    Severity: VulnerabilitySeverity[];
-    Fixable: ('true' | 'false')[];
+    SEVERITY: VulnerabilitySeverity[];
+    FIXABLE: ('true' | 'false')[];
     CVE: string[];
     IMAGE: string[];
     DEPLOYMENT: string[];
@@ -28,10 +28,10 @@ export type QuerySearchFilter = Partial<{
 const vulnMgmtLocalStorageSchema = yup.object({
     preferences: yup.object({
         defaultFilters: yup.object({
-            Severity: yup
+            SEVERITY: yup
                 .array(yup.string().required().oneOf(vulnerabilitySeverityLabels))
                 .required(),
-            Fixable: yup.array(yup.string().required().oneOf(fixableStatuses)).required(),
+            FIXABLE: yup.array(yup.string().required().oneOf(fixableStatuses)).required(),
         }),
     }),
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterAutocomplete.tsx
@@ -5,9 +5,10 @@ import { useQuery } from '@apollo/client';
 import { SearchFilter } from 'types/search';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import SEARCH_AUTOCOMPLETE_QUERY from 'queries/searchAutocomplete';
-import SearchOptionsDropdown, { SearchOption } from './SearchOptionsDropdown';
+import SearchOptionsDropdown from './SearchOptionsDropdown';
 
 import './FilterAutocomplete.css';
+import { SearchOption } from '../searchOptions';
 
 function getOptions(data: string[] | undefined): React.ReactElement[] | undefined {
     return data?.map((value) => <SelectOption key={value} value={value} />);
@@ -107,7 +108,11 @@ function FilterAutocompleteSelect({
                 searchOption={searchOption}
             >
                 {searchOptions.map(({ label, value }) => {
-                    return <SelectOption value={value}>{label}</SelectOption>;
+                    return (
+                        <SelectOption key={label} value={value}>
+                            {label}
+                        </SelectOption>
+                    );
                 })}
             </SearchOptionsDropdown>
             <Select

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterAutocomplete.tsx
@@ -6,9 +6,9 @@ import { SearchFilter } from 'types/search';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import SEARCH_AUTOCOMPLETE_QUERY from 'queries/searchAutocomplete';
 import SearchOptionsDropdown from './SearchOptionsDropdown';
+import { SearchOption } from '../searchOptions';
 
 import './FilterAutocomplete.css';
-import { SearchOption } from '../searchOptions';
 
 function getOptions(data: string[] | undefined): React.ReactElement[] | undefined {
     return data?.map((value) => <SelectOption key={value} value={value} />);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SearchOptionsDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SearchOptionsDropdown.tsx
@@ -1,67 +1,8 @@
-// @TODO: Replace the usage of FilterResourceDropdown with this
-
 import React, { ReactElement } from 'react';
 import { Select, SelectOption } from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import { SearchCategory } from 'services/SearchService';
-
-export type SearchOption = { label: string; value: string; category: SearchCategory };
-
-// @TODO: If list gets too long, consider putting it in it's own file
-export const IMAGE_CVE_SEARCH_OPTION: SearchOption = {
-    label: 'CVE',
-    value: 'CVE',
-    category: 'IMAGE_VULNERABILITIES',
-};
-
-export const IMAGE_SEARCH_OPTION: SearchOption = {
-    label: 'Image',
-    value: 'IMAGE',
-    category: 'IMAGES',
-};
-
-export const DEPLOYMENT_SEARCH_OPTION: SearchOption = {
-    label: 'Deployment',
-    value: 'DEPLOYMENT',
-    category: 'DEPLOYMENTS',
-};
-
-export const NAMESPACE_SEARCH_OPTION: SearchOption = {
-    label: 'Namespace',
-    value: 'NAMESPACE',
-    category: 'NAMESPACES',
-};
-
-export const CLUSTER_SEARCH_OPTION: SearchOption = {
-    label: 'Cluster',
-    value: 'CLUSTER',
-    category: 'CLUSTERS',
-};
-
-export const COMPONENT_SEARCH_OPTION: SearchOption = {
-    label: 'Component',
-    value: 'COMPONENT',
-    category: 'IMAGE_COMPONENTS',
-};
-
-export const COMPONENT_SOURCE_SEARCH_OPTION: SearchOption = {
-    label: 'Component Source',
-    value: 'COMPONENT SOURCE',
-    category: 'IMAGE_VULNERABILITIES',
-};
-
-export const REQUEST_NAME_SEARCH_OPTION: SearchOption = {
-    label: 'Request name',
-    value: 'Request Name',
-    category: 'VULN_REQUEST', // This might need to change
-};
-
-export const REQUESTER_SEARCH_OPTION: SearchOption = {
-    label: 'Requester',
-    value: 'Requester User Name',
-    category: 'VULN_REQUEST', // This might need to change
-};
+import { SearchOption } from '../searchOptions';
 
 export type SearchOptionsDropdownProps = {
     setSearchOption: (selection) => void;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchOptions.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchOptions.ts
@@ -64,7 +64,7 @@ export const COMPONENT_SEARCH_OPTION = {
 } as const;
 
 export const COMPONENT_SOURCE_SEARCH_OPTION = {
-    label: 'Component Source',
+    label: 'Component source',
     value: 'COMPONENT SOURCE',
     category: 'IMAGE_VULNERABILITIES',
 } as const;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchOptions.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchOptions.ts
@@ -1,0 +1,82 @@
+import { SearchCategory } from 'services/SearchService';
+
+export type SearchOptionValue =
+    | 'SEVERITY'
+    | 'FIXABLE'
+    | 'CVE'
+    | 'IMAGE'
+    | 'DEPLOYMENT'
+    | 'NAMESPACE'
+    | 'CLUSTER'
+    | 'COMPONENT'
+    | 'COMPONENT SOURCE'
+    | 'Request Name'
+    | 'Requester User Name';
+
+export type SearchOption = { label: string; value: SearchOptionValue; category: SearchCategory };
+
+export const SEVERITY_SEARCH_OPTION = {
+    label: 'Severity',
+    value: 'SEVERITY',
+    category: 'IMAGE_VULNERABILITIES',
+} as const;
+
+export const FIXABLE_SEARCH_OPTION = {
+    label: 'Fixable',
+    value: 'FIXABLE',
+    category: 'IMAGE_VULNERABILITIES',
+} as const;
+
+export const IMAGE_CVE_SEARCH_OPTION = {
+    label: 'CVE',
+    value: 'CVE',
+    category: 'IMAGE_VULNERABILITIES',
+} as const;
+
+export const IMAGE_SEARCH_OPTION = {
+    label: 'Image',
+    value: 'IMAGE',
+    category: 'IMAGES',
+} as const;
+
+export const DEPLOYMENT_SEARCH_OPTION = {
+    label: 'Deployment',
+    value: 'DEPLOYMENT',
+    category: 'DEPLOYMENTS',
+} as const;
+
+export const NAMESPACE_SEARCH_OPTION = {
+    label: 'Namespace',
+    value: 'NAMESPACE',
+    category: 'NAMESPACES',
+} as const;
+
+export const CLUSTER_SEARCH_OPTION = {
+    label: 'Cluster',
+    value: 'CLUSTER',
+    category: 'CLUSTERS',
+} as const;
+
+export const COMPONENT_SEARCH_OPTION = {
+    label: 'Component',
+    value: 'COMPONENT',
+    category: 'IMAGE_COMPONENTS',
+} as const;
+
+export const COMPONENT_SOURCE_SEARCH_OPTION = {
+    label: 'Component Source',
+    value: 'COMPONENT SOURCE',
+    category: 'IMAGE_VULNERABILITIES',
+} as const;
+
+export const REQUEST_NAME_SEARCH_OPTION = {
+    label: 'Request name',
+    value: 'Request Name',
+    category: 'VULN_REQUEST', // This might need to change
+} as const;
+
+export const REQUESTER_SEARCH_OPTION = {
+    label: 'Requester',
+    value: 'Requester User Name',
+    category: 'VULN_REQUEST', // This might need to change
+} as const;


### PR DESCRIPTION
## Description

Implements [this TODO](https://github.com/stackrox/stackrox/pull/8721/files#diff-48d45bd63292341708a815735bc19c0a64cf72c76de6934038e2208eeded2b44L11), and uses the new options to provide a single source of truth throughout workload CVE sections. Also makes some minor changes to standardize on ALL_CAPS for existing Workload CVE filters.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing of all search filters on the list page, image detail page, cve detail page, and deployment detail page.

Additional testing via existing Cypress tests.