### PR TITLE
ROX-20878: Fallback reconcile if gRPC ResourceExhausted

### DIFF
--- a/central/sensor/service/connection/manager.go
+++ b/central/sensor/service/connection/manager.go
@@ -12,7 +12,7 @@ import (
 
 // Preferences determines preferences for the connection learned from sensor.
 type Preferences struct {
-	// SendDeduperState is set to true by default and can be switched off by Central a Sensor sends a ResourcesSynced event
+	// SendDeduperState is set to true by default and can be switched off by Central if a Sensor sends a ResourcesSynced event
 	// with too many resources which could lead to a resourcesExhausted error in the gRPC connection. If this is set
 	// to false, the connected sensor will fall back to the classic reconciliation (i.e. no deduper state is transmitted).
 	SendDeduperState bool

--- a/central/sensor/service/connection/manager.go
+++ b/central/sensor/service/connection/manager.go
@@ -10,6 +10,14 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 )
 
+// Preferences determines preferences for the connection learned from sensor.
+type Preferences struct {
+	// AvoidLargeSyncPayloads can be set by Central when it learns that one Sensor could send a ResourcesSynced event
+	// with too many resources which could lead to a resourcesExhausted error in the gRPC connection. If this is set
+	// to true, the connected sensor will fall back to the classic reconciliation (i.e. no deduper state is transmitted).
+	AvoidLargeSyncPayloads bool
+}
+
 // Manager is responsible for managing all active connections from sensors.
 //
 //go:generate mockgen-wrapper
@@ -33,6 +41,7 @@ type Manager interface {
 	PreparePoliciesAndBroadcast(policies []*storage.Policy)
 	BroadcastMessage(msg *central.MsgToSensor)
 	SendMessage(clusterID string, msg *central.MsgToSensor) error
+	GetConnectionPreference(clusterID string) Preferences
 
 	// Upgrade-related methods.
 	TriggerUpgrade(ctx context.Context, clusterID string) error

--- a/central/sensor/service/connection/manager.go
+++ b/central/sensor/service/connection/manager.go
@@ -12,10 +12,10 @@ import (
 
 // Preferences determines preferences for the connection learned from sensor.
 type Preferences struct {
-	// AvoidLargeSyncPayloads can be set by Central when it learns that one Sensor could send a ResourcesSynced event
+	// SendDeduperState is set to true by default and can be switched off by Central a Sensor sends a ResourcesSynced event
 	// with too many resources which could lead to a resourcesExhausted error in the gRPC connection. If this is set
-	// to true, the connected sensor will fall back to the classic reconciliation (i.e. no deduper state is transmitted).
-	AvoidLargeSyncPayloads bool
+	// to false, the connected sensor will fall back to the classic reconciliation (i.e. no deduper state is transmitted).
+	SendDeduperState bool
 }
 
 // Manager is responsible for managing all active connections from sensors.

--- a/central/sensor/service/connection/manager_impl.go
+++ b/central/sensor/service/connection/manager_impl.go
@@ -317,7 +317,7 @@ func (m *manager) handleConnectionError(clusterID string, err error) {
 			log.Warnf("gRPC connection received a payload too large to be processed: %s", err)
 			log.Warnf("Increase ROX_GRPC_MAX_MESSAGE_SIZE to allow larger payloads. Central will temporarily disable client reconciliation to avoid receiving large payloads from Sensor.")
 			pref := m.GetConnectionPreference(clusterID)
-			pref.AvoidLargeSyncPayloads = true
+			pref.SendDeduperState = false
 			m.connectionPreference.Store(clusterID, pref)
 		}
 	}
@@ -329,7 +329,10 @@ func (m *manager) GetConnectionPreference(clusterID string) Preferences {
 	var p Preferences
 	pref, exists := m.connectionPreference.Load(clusterID)
 	if !exists {
-		p = Preferences{}
+		p = Preferences{
+			SendDeduperState: true,
+		}
+		m.connectionPreference.Store(clusterID, p)
 	} else {
 		var ok bool
 		p, ok = (pref).(Preferences)

--- a/central/sensor/service/connection/manager_impl.go
+++ b/central/sensor/service/connection/manager_impl.go
@@ -327,18 +327,14 @@ func (m *manager) handleConnectionError(clusterID string, err error) {
 // GetConnectionPreference returns the connection preference for cluster ID.
 func (m *manager) GetConnectionPreference(clusterID string) Preferences {
 	var p Preferences
-	pref, exists := m.connectionPreference.Load(clusterID)
-	if !exists {
+	var ok bool
+	if pref, exists := m.connectionPreference.Load(clusterID); !exists {
 		p = Preferences{
 			SendDeduperState: true,
 		}
 		m.connectionPreference.Store(clusterID, p)
-	} else {
-		var ok bool
-		p, ok = (pref).(Preferences)
-		if !ok {
-			log.Warnf("Incorrect entry in Connection preferences map for cluster ID: %s", clusterID)
-		}
+	} else if p, ok = (pref).(Preferences); !ok {
+		log.Warnf("Incorrect entry in Connection preferences map for cluster ID: %s", clusterID)
 	}
 	return p
 }

--- a/central/sensor/service/connection/manager_impl.go
+++ b/central/sensor/service/connection/manager_impl.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -56,6 +58,9 @@ type connectionAndUpgradeController struct {
 type manager struct {
 	connectionsByClusterID      map[string]connectionAndUpgradeController
 	connectionsByClusterIDMutex sync.RWMutex
+
+	// connectionPreference stores preferences based on sensor connections
+	connectionPreference sync.Map
 
 	clusters                   common.ClusterManager
 	networkEntities            common.NetworkEntityManager
@@ -289,7 +294,7 @@ func (m *manager) HandleConnection(ctx context.Context, sensorHello *central.Sen
 	}
 
 	err = conn.Run(ctx, server, conn.capabilities)
-	log.Warnf("Connection to server in cluster %s terminated: %v", clusterID, err)
+	m.handleConnectionError(clusterID, err)
 
 	// Address the scenario in which the sensor loses its connection during
 	// the initial synchronization process.
@@ -304,6 +309,35 @@ func (m *manager) HandleConnection(ctx context.Context, sensorHello *central.Sen
 	})
 
 	return err
+}
+
+func (m *manager) handleConnectionError(clusterID string, err error) {
+	if e, ok := status.FromError(err); ok {
+		if e.Code() == codes.ResourceExhausted {
+			log.Warnf("gRPC connection received a payload too large to be processed: %s", err)
+			log.Warnf("Increase ROX_GRPC_MAX_MESSAGE_SIZE to allow larger payloads. Central will temporarily disable client reconciliation to avoid receiving large payloads from Sensor.")
+			pref := m.GetConnectionPreference(clusterID)
+			pref.AvoidLargeSyncPayloads = true
+			m.connectionPreference.Store(clusterID, pref)
+		}
+	}
+	log.Warnf("Connection to server in cluster %s terminated: %v", clusterID, err)
+}
+
+// GetConnectionPreference returns the connection preference for cluster ID.
+func (m *manager) GetConnectionPreference(clusterID string) Preferences {
+	var p Preferences
+	pref, exists := m.connectionPreference.Load(clusterID)
+	if !exists {
+		p = Preferences{}
+	} else {
+		var ok bool
+		p, ok = (pref).(Preferences)
+		if !ok {
+			log.Warnf("Incorrect entry in Connection preferences map for cluster ID: %s", clusterID)
+		}
+	}
+	return p
 }
 
 func (m *manager) getOrCreateUpgradeCtrl(clusterID string) (upgradecontroller.UpgradeController, error) {

--- a/central/sensor/service/connection/manager_test.go
+++ b/central/sensor/service/connection/manager_test.go
@@ -12,16 +12,16 @@ import (
 func Test_AvoidLargePayloads(t *testing.T) {
 	wrappedErr := errors.Wrap(status.Error(codes.ResourceExhausted, "gRPC exhausted"), "recv error")
 	errToPreferenece := map[error]bool{
-		wrappedErr: true,
-		status.Error(codes.ResourceExhausted, "gRPC exhausted"): true,
-		status.Error(codes.Canceled, "gRPC canceled"):           false,
-		status.Error(codes.Internal, "gRPC internal"):           false,
-		nil:                      false,
-		errors.New("custom err"): false,
+		wrappedErr: false,
+		status.Error(codes.ResourceExhausted, "gRPC exhausted"): false,
+		status.Error(codes.Canceled, "gRPC canceled"):           true,
+		status.Error(codes.Internal, "gRPC internal"):           true,
+		nil:                      true,
+		errors.New("custom err"): true,
 	}
 	for err, pref := range errToPreferenece {
 		m := manager{}
 		m.handleConnectionError("1234", err)
-		assert.Equal(t, pref, m.GetConnectionPreference("1234").AvoidLargeSyncPayloads)
+		assert.Equal(t, pref, m.GetConnectionPreference("1234").SendDeduperState)
 	}
 }

--- a/central/sensor/service/connection/manager_test.go
+++ b/central/sensor/service/connection/manager_test.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func Test_AvoidLargePayloads(t *testing.T) {
+func Test_GetConnectionPreference(t *testing.T) {
 	wrappedErr := errors.Wrap(status.Error(codes.ResourceExhausted, "gRPC exhausted"), "recv error")
 	errToPreferenece := map[error]bool{
 		wrappedErr: false,
@@ -20,8 +20,21 @@ func Test_AvoidLargePayloads(t *testing.T) {
 		errors.New("custom err"): true,
 	}
 	for err, pref := range errToPreferenece {
-		m := manager{}
-		m.handleConnectionError("1234", err)
-		assert.Equal(t, pref, m.GetConnectionPreference("1234").SendDeduperState)
+		var testName string
+		if err == nil {
+			testName = "nil"
+		} else {
+			testName = err.Error()
+		}
+		t.Run(testName, func(t *testing.T) {
+			m := manager{}
+			m.handleConnectionError("1234", err)
+			assert.Equal(t, pref, m.GetConnectionPreference("1234").SendDeduperState)
+		})
 	}
+}
+
+func Test_GetConnectionPreference_DefaultsToTrue(t *testing.T) {
+	m := manager{}
+	assert.Equal(t, true, m.GetConnectionPreference("1234").SendDeduperState)
 }

--- a/central/sensor/service/connection/manager_test.go
+++ b/central/sensor/service/connection/manager_test.go
@@ -1,0 +1,27 @@
+package connection
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func Test_AvoidLargePayloads(t *testing.T) {
+	wrappedErr := errors.Wrap(status.Error(codes.ResourceExhausted, "gRPC exhausted"), "recv error")
+	errToPreferenece := map[error]bool{
+		wrappedErr: true,
+		status.Error(codes.ResourceExhausted, "gRPC exhausted"): true,
+		status.Error(codes.Canceled, "gRPC canceled"):           false,
+		status.Error(codes.Internal, "gRPC internal"):           false,
+		nil:                      false,
+		errors.New("custom err"): false,
+	}
+	for err, pref := range errToPreferenece {
+		m := manager{}
+		m.handleConnectionError("1234", err)
+		assert.Equal(t, pref, m.GetConnectionPreference("1234").AvoidLargeSyncPayloads)
+	}
+}

--- a/central/sensor/service/connection/mocks/manager.go
+++ b/central/sensor/service/connection/mocks/manager.go
@@ -96,6 +96,20 @@ func (mr *MockManagerMockRecorder) GetConnection(clusterID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnection", reflect.TypeOf((*MockManager)(nil).GetConnection), clusterID)
 }
 
+// GetConnectionPreference mocks base method.
+func (m *MockManager) GetConnectionPreference(clusterID string) connection.Preferences {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConnectionPreference", clusterID)
+	ret0, _ := ret[0].(connection.Preferences)
+	return ret0
+}
+
+// GetConnectionPreference indicates an expected call of GetConnectionPreference.
+func (mr *MockManagerMockRecorder) GetConnectionPreference(clusterID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectionPreference", reflect.TypeOf((*MockManager)(nil).GetConnectionPreference), clusterID)
+}
+
 // HandleConnection mocks base method.
 func (m *MockManager) HandleConnection(ctx context.Context, sensorHello *central.SensorHello, cluster *storage.Cluster, eventPipeline pipeline.ClusterPipeline, server central.SensorService_CommunicateServer) error {
 	m.ctrl.T.Helper()

--- a/central/sensor/service/service_impl.go
+++ b/central/sensor/service/service_impl.go
@@ -109,14 +109,15 @@ func (s *serviceImpl) Communicate(server central.SensorService_CommunicateServer
 			capabilities = append(capabilities, centralsensor.SensorReconciliationOnReconnect)
 		}
 
+		preferences := s.manager.GetConnectionPreference(cluster.GetId())
+
 		// Let's be polite and respond with a greeting from our side.
 		centralHello := &central.CentralHello{
-			ClusterId:      cluster.GetId(),
-			ManagedCentral: env.ManagedCentral.BooleanSetting(),
-			CentralId:      installInfo.GetId(),
-			Capabilities:   capabilities,
-			// TODO(ROX-20878): send deduper state conditionally on errors receiving unchanged IDs.
-			SendDeduperState: true,
+			ClusterId:        cluster.GetId(),
+			ManagedCentral:   env.ManagedCentral.BooleanSetting(),
+			CentralId:        installInfo.GetId(),
+			Capabilities:     capabilities,
+			SendDeduperState: preferences.SendDeduperState,
 		}
 
 		if err := safe.RunE(func() error {


### PR DESCRIPTION
## Description

Follow-up from #8430. 

It fixes a possible issue if the cluster is too large and the number of unchangedIDs is too large to be transmitted on initial ResourcesSynced message. 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [ ] CI (with compatibility tests)
- [x] Manual test 

In order to test this locally, I've changed my sensor to inject 260k entries to check that central properly falls back to the old reconciliation.

```
--- a/sensor/common/deduper/deduper.go
+++ b/sensor/common/deduper/deduper.go
@@ -113,6 +114,10 @@ func (d *deduper) Send(msg *central.MsgFromSensor) error {
        resourcesSynced := event.GetSynced()
        if d.appendUnchangedIDs && resourcesSynced != nil {
                d.synced = true
+               for i := 0; i < 260_000; i++ {
+                       d.unchangedIDs.Add(fmt.Sprintf("Deployment:%s", uuid.NewV4()))
+               }
                log.Infof("Adding %d events as unchanged to sync event", len(d.unchangedIDs))
                resourcesSynced.UnchangedIds = d.unchangedIDs.AsSlice()
                metrics.IncrementTotalResourcesSyncSent(len(d.unchangedIDs))
```

1. Initial connection fails, can be seen in Central logs as:
```
sensor/service/connection: 2023/11/20 18:33:40.471422 manager_impl.go:317: Warn: gRPC connection received a payload too large to be processed: recv error: rpc error: code = ResourceExhausted desc = grpc: received message after decompression larger than max (12752991 vs. 12582912)
sensor/service/connection: 2023/11/20 18:33:40.471530 manager_impl.go:318: Warn: Increase ROX_GRPC_MAX_MESSAGE_SIZE to allow larger payloads. Central will temporarily disable client reconciliation to avoid receiving large payloads from Sensor
```
2. On second connection, sensor receives `sendDeduperState=false` from Central
```
common/sensor: 2023/11/20 19:33:50.692105 central_communication_impl.go:252: Info: Sensor client reconciliation state=false (centralCapability=true, centralHello.SendDeduperState=false)
```
3. Second connection attempt is successful, from central logs:
```
sensor/service/connection: 2023/11/20 18:33:51.133689 sensorevents.go:98: Info: Receiving reconciliation event
sensor/service/pipeline/all: 2023/11/20 18:33:51.133792 pipeline.go:55: Info: Received Synced message from Sensor. Determining if there is any reconciliation to be done
sensor/service/pipeline/reconciliation: 2023/11/20 18:33:51.136797 perform.go:24: Info: Deleting 2 pods as a part of reconciliation
sensor/service/pipeline/reconciliation: 2023/11/20 18:33:51.151083 reconciliation.go:153: Info: Reconciliation done. Number of objects deleted by type: map[*central.SensorEvent_Binding:0 *central.SensorEvent_ComplianceOperatorProfile:0 *central.SensorEvent_ComplianceOperatorResult:0 *central.SensorEvent_ComplianceOperatorRule:0 *central.SensorEvent_ComplianceOperatorScan:0 *central.SensorEvent_ComplianceOperatorScanSettingBinding:0 *central.SensorEvent_Deployment:0 *central.SensorEvent_Namespace:0 *central.SensorEvent_NetworkPolicy:0 *central.SensorEvent_Node:0 *central.SensorEvent_Pod:2 *central.SensorEvent_Role:0 *central.SensorEvent_Secret:0 *central.SensorEvent_ServiceAccount:0]
cve/fetcher: 2023/11/20 18:34:58.142411 manager_impl.go:70: Info: Start orchestrator-level vulnerability reconciliation
```

#### Max size for unchanged IDs:

Based on the tests above, the upper limit for number of entries in the `unchangedIDs` slice is ~250k. 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
