### PR TITLE
fix(default): Add ECR public registry as default config

### DIFF
--- a/central/imageintegration/store/defaults.go
+++ b/central/imageintegration/store/defaults.go
@@ -89,6 +89,17 @@ var DefaultImageIntegrations = []*storage.ImageIntegration{
 		},
 	},
 	{
+		Id:         "5febb194-a21d-4109-9fad-6880dd632adc",
+		Name:       "Public Amazon ECR",
+		Type:       "docker",
+		Categories: []storage.ImageIntegrationCategory{storage.ImageIntegrationCategory_REGISTRY},
+		IntegrationConfig: &storage.ImageIntegration_Docker{
+			Docker: &storage.DockerConfig{
+				Endpoint: "public.ecr.aws",
+			},
+		},
+	},
+	{
 		Id:         "54107745-5717-49c1-9073-a2b72f7a3b49",
 		Name:       "registry.access.redhat.com",
 		Type:       "rhel",


### PR DESCRIPTION
## Description

Same as other defaults, support the public registry

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

scanned public.ecr.aws/aws-observability/aws-for-fluent-bit:latest

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
