### PR TITLE
ROX-20693: Move common key functions to pkg

### DIFF
--- a/central/hash/manager/deduper_test.go
+++ b/central/hash/manager/deduper_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	eventPkg "github.com/stackrox/rox/pkg/sensor/event"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -272,8 +273,8 @@ func TestReconciliation(t *testing.T) {
 	deduper.MarkSuccessful(d2)
 	deduper.ProcessSync()
 	assert.Len(t, deduper.successfullyProcessed, 2)
-	assert.Contains(t, deduper.successfullyProcessed, getKey(d1))
-	assert.Contains(t, deduper.successfullyProcessed, getKey(d2))
+	assert.Contains(t, deduper.successfullyProcessed, eventPkg.GetKeyFromMessage(d1))
+	assert.Contains(t, deduper.successfullyProcessed, eventPkg.GetKeyFromMessage(d2))
 
 	// Values in successfully processed that should be removed
 	deduper.ShouldProcess(d3)
@@ -286,8 +287,8 @@ func TestReconciliation(t *testing.T) {
 	deduper.MarkSuccessful(d5)
 	deduper.ProcessSync()
 	assert.Len(t, deduper.successfullyProcessed, 2)
-	assert.Contains(t, deduper.successfullyProcessed, getKey(d4))
-	assert.Contains(t, deduper.successfullyProcessed, getKey(d5))
+	assert.Contains(t, deduper.successfullyProcessed, eventPkg.GetKeyFromMessage(d4))
+	assert.Contains(t, deduper.successfullyProcessed, eventPkg.GetKeyFromMessage(d5))
 
 	// Should clear out successfully processed
 	deduper.StartSync()
@@ -303,7 +304,7 @@ func TestReconciliation(t *testing.T) {
 	deduper.ShouldProcess(d1)
 	deduper.ProcessSync()
 	assert.Len(t, deduper.successfullyProcessed, 1)
-	assert.Contains(t, deduper.successfullyProcessed, getKey(d1))
+	assert.Contains(t, deduper.successfullyProcessed, eventPkg.GetKeyFromMessage(d1))
 
 	deduper.StartSync()
 	deduper.ProcessSync()

--- a/pkg/deduperkey/key.go
+++ b/pkg/deduperkey/key.go
@@ -48,7 +48,7 @@ type Key struct {
 // String returns the string version of the key
 func (k *Key) String() string {
 	typ := stringutils.GetAfter(k.ResourceType.String(), "_")
-	return fmt.Sprintf("%s:%s", typ, k.ID)
+	return eventPkg.FormatKey(typ, k.ID)
 }
 
 // ParseKeySlice returns a list of Key objects from a list a string formatted keys. An error returned means that some

--- a/pkg/deduperkey/key_test.go
+++ b/pkg/deduperkey/key_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	eventPkg "github.com/stackrox/rox/pkg/sensor/event"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -17,26 +18,26 @@ const (
 
 var (
 	stateWithAll = map[string]uint64{
-		fmt.Sprintf("%s:%s", "NetworkPolicy", fixtureconsts.NetworkPolicy1):   stubHash,
-		fmt.Sprintf("%s:%s", "Deployment", fixtureconsts.Deployment1):         stubHash,
-		fmt.Sprintf("%s:%s", "Pod", fixtureconsts.PodUID1):                    stubHash,
-		fmt.Sprintf("%s:%s", "Namespace", fixtureconsts.Namespace1):           stubHash,
-		fmt.Sprintf("%s:%s", "Secret", fixtureconsts.ServiceAccount1):         stubHash,
-		fmt.Sprintf("%s:%s", "Node", fixtureconsts.Node1):                     stubHash,
-		fmt.Sprintf("%s:%s", "ServiceAccount", fixtureconsts.ServiceAccount1): stubHash,
-		fmt.Sprintf("%s:%s", "Role", fixtureconsts.Role1):                     stubHash,
-		fmt.Sprintf("%s:%s", "Binding", fixtureconsts.RoleBinding1):           stubHash,
-		fmt.Sprintf("%s:%s", "NodeInventory", stubID):                         stubHash,
-		fmt.Sprintf("%s:%s", "ProcessIndicator", stubID):                      stubHash,
-		fmt.Sprintf("%s:%s", "ProviderMetadata", stubID):                      stubHash,
-		fmt.Sprintf("%s:%s", "OrchestratorMetadata", stubID):                  stubHash,
-		fmt.Sprintf("%s:%s", "ImageIntegration", stubID):                      stubHash,
-		fmt.Sprintf("%s:%s", "ComplianceOperatorResult", stubID):              stubHash,
-		fmt.Sprintf("%s:%s", "ComplianceOperatorProfile", stubID):             stubHash,
-		fmt.Sprintf("%s:%s", "ComplianceOperatorRule", stubID):                stubHash,
-		fmt.Sprintf("%s:%s", "ComplianceOperatorScanSettingBinding", stubID):  stubHash,
-		fmt.Sprintf("%s:%s", "ComplianceOperatorScan", stubID):                stubHash,
-		fmt.Sprintf("%s:%s", "AlertResults", stubID):                          stubHash,
+		eventPkg.FormatKey("NetworkPolicy", fixtureconsts.NetworkPolicy1):   stubHash,
+		eventPkg.FormatKey("Deployment", fixtureconsts.Deployment1):         stubHash,
+		eventPkg.FormatKey("Pod", fixtureconsts.PodUID1):                    stubHash,
+		eventPkg.FormatKey("Namespace", fixtureconsts.Namespace1):           stubHash,
+		eventPkg.FormatKey("Secret", fixtureconsts.ServiceAccount1):         stubHash,
+		eventPkg.FormatKey("Node", fixtureconsts.Node1):                     stubHash,
+		eventPkg.FormatKey("ServiceAccount", fixtureconsts.ServiceAccount1): stubHash,
+		eventPkg.FormatKey("Role", fixtureconsts.Role1):                     stubHash,
+		eventPkg.FormatKey("Binding", fixtureconsts.RoleBinding1):           stubHash,
+		eventPkg.FormatKey("NodeInventory", stubID):                         stubHash,
+		eventPkg.FormatKey("ProcessIndicator", stubID):                      stubHash,
+		eventPkg.FormatKey("ProviderMetadata", stubID):                      stubHash,
+		eventPkg.FormatKey("OrchestratorMetadata", stubID):                  stubHash,
+		eventPkg.FormatKey("ImageIntegration", stubID):                      stubHash,
+		eventPkg.FormatKey("ComplianceOperatorResult", stubID):              stubHash,
+		eventPkg.FormatKey("ComplianceOperatorProfile", stubID):             stubHash,
+		eventPkg.FormatKey("ComplianceOperatorRule", stubID):                stubHash,
+		eventPkg.FormatKey("ComplianceOperatorScanSettingBinding", stubID):  stubHash,
+		eventPkg.FormatKey("ComplianceOperatorScan", stubID):                stubHash,
+		eventPkg.FormatKey("AlertResults", stubID):                          stubHash,
 	}
 	expectedStateWithAll = map[Key]uint64{
 		withKey(&central.SensorEvent_NetworkPolicy{}, fixtureconsts.NetworkPolicy1):   stubHash,
@@ -86,7 +87,7 @@ func (s *deduperKeySuite) Test_CopyState() {
 		},
 		"With malformed entry": {
 			inputState: map[string]uint64{
-				fmt.Sprintf("%s:%s", "Deployment", fixtureconsts.Deployment1):           stubHash,
+				eventPkg.FormatKey("Deployment", fixtureconsts.Deployment1):             stubHash,
 				fmt.Sprintf("%s_malformed_%s", "Deployment", fixtureconsts.Deployment1): stubHash,
 			},
 			expectedState: map[Key]uint64{
@@ -95,8 +96,8 @@ func (s *deduperKeySuite) Test_CopyState() {
 		},
 		"With invalid type entry": {
 			inputState: map[string]uint64{
-				fmt.Sprintf("%s:%s", "Deployment", fixtureconsts.Deployment1):  stubHash,
-				fmt.Sprintf("%s:%s", "InvalidType", fixtureconsts.Deployment1): stubHash,
+				eventPkg.FormatKey("Deployment", fixtureconsts.Deployment1):  stubHash,
+				eventPkg.FormatKey("InvalidType", fixtureconsts.Deployment1): stubHash,
 			},
 			expectedState: map[Key]uint64{
 				withKey(&central.SensorEvent_Deployment{}, fixtureconsts.Deployment1): stubHash,

--- a/pkg/sensor/event/event.go
+++ b/pkg/sensor/event/event.go
@@ -1,6 +1,9 @@
 package event
 
 import (
+	"fmt"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/reflectutils"
 	"github.com/stackrox/rox/pkg/stringutils"
 )
@@ -8,4 +11,20 @@ import (
 // GetEventTypeWithoutPrefix trims the *central.SensorEvent_ from the event type
 func GetEventTypeWithoutPrefix(i interface{}) string {
 	return stringutils.GetAfter(reflectutils.Type(i), "_")
+}
+
+// ParseIDFromKey returns the uuid portion of a key formatted with FormatKey.
+func ParseIDFromKey(key string) string {
+	return stringutils.GetAfter(key, ":")
+}
+
+// FormatKey formats a sensor event unique key formatted as <TYPE>:<UUID>
+func FormatKey(typ, id string) string {
+	return fmt.Sprintf("%s:%s", typ, id)
+}
+
+// GetKeyFromMessage generates an unique key from event resource type and event ID.
+func GetKeyFromMessage(msg *central.MsgFromSensor) string {
+	event := msg.GetEvent()
+	return FormatKey(GetEventTypeWithoutPrefix(event.GetResource()), event.GetId())
 }


### PR DESCRIPTION
## Description

This PR introduces generic functions to manage parsing of key-like strings in `/pkg`. 

This is related to the PR comment: https://github.com/stackrox/stackrox/pull/8430#pullrequestreview-1717551083

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

New tests can be skipped for this change since it's a minimal refactor. The current test suite will check for regressions.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
