### PR TITLE
build(scanner): allow cgo enablement

### DIFF
--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -27,9 +27,10 @@ ifeq ($(shell uname -s),Darwin)
 	HOST_OS := darwin
 endif
 
+CGO_ENABLED := 0
 GOOS := $(HOST_OS)
 
-GO_BUILD_FLAGS = CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH}
+GO_BUILD_FLAGS = CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH}
 GO_BUILD_CMD   = $(GO_BUILD_FLAGS) go build \
                    -trimpath \
                    -ldflags="-X github.com/stackrox/rox/scanner/internal/version.Version=$(TAG)"


### PR DESCRIPTION
## Description

Now you can create Scanner with CGO enabled. For example:

```
$ make CGO_ENABLED=1 image/scanner/bin/scanner
+ bin/scanner
CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-X github.com/stackrox/rox/scanner/internal/version.Version=4.3.x-253-g4280dc16e2" -o bin/scanner ./cmd/scanner
```

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Run `make CGO_ENABLED=1 image/scanner/bin/scanner`. It may not compile on macOS, but that's ok. It's meant for the downstream images.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
