### PR TITLE
ROX-21183: Spew error instead of crashing if notifiers are not secured

### DIFF
--- a/central/notifier/processor/singleton.go
+++ b/central/notifier/processor/singleton.go
@@ -51,7 +51,7 @@ func initialize() {
 		var err error
 		cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 		if err != nil {
-			utils.CrashOnError(err)
+			utils.Should(errors.Wrapf(err, "Error reading encryption key, notifiers will be unable to send notifications"))
 		}
 	}
 
@@ -66,7 +66,8 @@ func initialize() {
 		encCredsModified, err := notifierUtils.SecureNotifier(protoNotifier, cryptoKey)
 		if err != nil {
 			// Don't send out error from crypto lib
-			utils.CrashOnError(fmt.Errorf("Error securing notifier %s", protoNotifier.GetId()))
+			utils.Should(fmt.Errorf("Error securing notifier %s, notifications to this notifier will fail", protoNotifier.GetId()))
+			continue
 		}
 		if encCredsModified {
 			_, err = datastore.Singleton().UpsertNotifier(ctx, protoNotifier)

--- a/central/notifier/processor/singleton.go
+++ b/central/notifier/processor/singleton.go
@@ -51,7 +51,7 @@ func initialize() {
 		var err error
 		cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 		if err != nil {
-			utils.Should(errors.Wrapf(err, "Error reading encryption key, notifiers will be unable to send notifications"))
+			utils.Should(errors.Wrap(err, "Error reading encryption key, notifiers will be unable to send notifications"))
 		}
 	}
 

--- a/central/notifiers/awssh/notifier.go
+++ b/central/notifiers/awssh/notifier.go
@@ -78,7 +78,7 @@ func init() {
 		if env.EncNotifierCreds.BooleanSetting() {
 			cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 			if err != nil {
-				utils.Should(errors.Wrapf(err, "Error reading encryption key, notifier will be unable to send notifications"))
+				utils.Should(errors.Wrap(err, "Error reading encryption key, notifier will be unable to send notifications"))
 			}
 		}
 		configuration.cryptoKey = cryptoKey

--- a/central/notifiers/awssh/notifier.go
+++ b/central/notifiers/awssh/notifier.go
@@ -78,7 +78,7 @@ func init() {
 		if env.EncNotifierCreds.BooleanSetting() {
 			cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 			if err != nil {
-				utils.CrashOnError(err)
+				utils.Should(errors.Wrapf(err, "Error reading encryption key, notifier will be unable to send notifications"))
 			}
 		}
 		configuration.cryptoKey = cryptoKey

--- a/central/notifiers/cscc/cscc.go
+++ b/central/notifiers/cscc/cscc.go
@@ -44,7 +44,7 @@ func init() {
 	if env.EncNotifierCreds.BooleanSetting() {
 		cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 		if err != nil {
-			utils.CrashOnError(err)
+			utils.Should(errors.Wrapf(err, "Error reading encryption key, notifier will be unable to send notifications"))
 		}
 	}
 

--- a/central/notifiers/cscc/cscc.go
+++ b/central/notifiers/cscc/cscc.go
@@ -44,7 +44,7 @@ func init() {
 	if env.EncNotifierCreds.BooleanSetting() {
 		cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 		if err != nil {
-			utils.Should(errors.Wrapf(err, "Error reading encryption key, notifier will be unable to send notifications"))
+			utils.Should(errors.Wrap(err, "Error reading encryption key, notifier will be unable to send notifications"))
 		}
 	}
 

--- a/central/notifiers/email/email.go
+++ b/central/notifiers/email/email.go
@@ -581,7 +581,7 @@ func init() {
 	if env.EncNotifierCreds.BooleanSetting() {
 		cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 		if err != nil {
-			utils.Should(errors.Wrapf(err, "Error reading encryption key, notifier will be unable to send notifications"))
+			utils.Should(errors.Wrap(err, "Error reading encryption key, notifier will be unable to send notifications"))
 		}
 	}
 	notifiers.Add(notifiers.EmailType, func(notifier *storage.Notifier) (notifiers.Notifier, error) {

--- a/central/notifiers/email/email.go
+++ b/central/notifiers/email/email.go
@@ -581,7 +581,7 @@ func init() {
 	if env.EncNotifierCreds.BooleanSetting() {
 		cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 		if err != nil {
-			utils.CrashOnError(err)
+			utils.Should(errors.Wrapf(err, "Error reading encryption key, notifier will be unable to send notifications"))
 		}
 	}
 	notifiers.Add(notifiers.EmailType, func(notifier *storage.Notifier) (notifiers.Notifier, error) {

--- a/central/notifiers/generic/generic.go
+++ b/central/notifiers/generic/generic.go
@@ -278,7 +278,7 @@ func init() {
 	if env.EncNotifierCreds.BooleanSetting() {
 		cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 		if err != nil {
-			utils.Should(errors.Wrapf(err, "Error reading encryption key, notifier will be unable to send notifications"))
+			utils.Should(errors.Wrap(err, "Error reading encryption key, notifier will be unable to send notifications"))
 		}
 	}
 	notifiers.Add(notifiers.GenericType, func(notifier *storage.Notifier) (notifiers.Notifier, error) {

--- a/central/notifiers/generic/generic.go
+++ b/central/notifiers/generic/generic.go
@@ -278,7 +278,7 @@ func init() {
 	if env.EncNotifierCreds.BooleanSetting() {
 		cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 		if err != nil {
-			utils.CrashOnError(err)
+			utils.Should(errors.Wrapf(err, "Error reading encryption key, notifier will be unable to send notifications"))
 		}
 	}
 	notifiers.Add(notifiers.GenericType, func(notifier *storage.Notifier) (notifiers.Notifier, error) {

--- a/central/notifiers/jira/jira.go
+++ b/central/notifiers/jira/jira.go
@@ -478,7 +478,7 @@ func init() {
 	if env.EncNotifierCreds.BooleanSetting() {
 		cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 		if err != nil {
-			utils.Should(errors.Wrapf(err, "Error reading encryption key, notifier will be unable to send notifications"))
+			utils.Should(errors.Wrap(err, "Error reading encryption key, notifier will be unable to send notifications"))
 		}
 	}
 	notifiers.Add(notifiers.JiraType, func(notifier *storage.Notifier) (notifiers.Notifier, error) {

--- a/central/notifiers/jira/jira.go
+++ b/central/notifiers/jira/jira.go
@@ -478,7 +478,7 @@ func init() {
 	if env.EncNotifierCreds.BooleanSetting() {
 		cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 		if err != nil {
-			utils.CrashOnError(err)
+			utils.Should(errors.Wrapf(err, "Error reading encryption key, notifier will be unable to send notifications"))
 		}
 	}
 	notifiers.Add(notifiers.JiraType, func(notifier *storage.Notifier) (notifiers.Notifier, error) {

--- a/central/notifiers/pagerduty/pagerduty.go
+++ b/central/notifiers/pagerduty/pagerduty.go
@@ -221,7 +221,7 @@ func init() {
 	if env.EncNotifierCreds.BooleanSetting() {
 		cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 		if err != nil {
-			utils.Should(errors.Wrapf(err, "Error reading encryption key, notifier will be unable to send notifications"))
+			utils.Should(errors.Wrap(err, "Error reading encryption key, notifier will be unable to send notifications"))
 		}
 	}
 

--- a/central/notifiers/pagerduty/pagerduty.go
+++ b/central/notifiers/pagerduty/pagerduty.go
@@ -221,7 +221,7 @@ func init() {
 	if env.EncNotifierCreds.BooleanSetting() {
 		cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 		if err != nil {
-			utils.CrashOnError(err)
+			utils.Should(errors.Wrapf(err, "Error reading encryption key, notifier will be unable to send notifications"))
 		}
 	}
 

--- a/central/notifiers/splunk/splunk.go
+++ b/central/notifiers/splunk/splunk.go
@@ -220,7 +220,7 @@ func init() {
 	if env.EncNotifierCreds.BooleanSetting() {
 		cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 		if err != nil {
-			utils.Should(errors.Wrapf(err, "Error reading encryption key, notifier will be unable to send notifications"))
+			utils.Should(errors.Wrap(err, "Error reading encryption key, notifier will be unable to send notifications"))
 		}
 	}
 	notifiers.Add(notifiers.SplunkType, func(notifier *storage.Notifier) (notifiers.Notifier, error) {

--- a/central/notifiers/splunk/splunk.go
+++ b/central/notifiers/splunk/splunk.go
@@ -220,7 +220,7 @@ func init() {
 	if env.EncNotifierCreds.BooleanSetting() {
 		cryptoKey, err = notifierUtils.GetNotifierSecretEncryptionKey()
 		if err != nil {
-			utils.CrashOnError(err)
+			utils.Should(errors.Wrapf(err, "Error reading encryption key, notifier will be unable to send notifications"))
 		}
 	}
 	notifiers.Add(notifiers.SplunkType, func(notifier *storage.Notifier) (notifiers.Notifier, error) {


### PR DESCRIPTION
## Description
Fix to spew out error instead of crashing if notifiers cannot be secured

## Checklist
- [x] Investigated and inspected CI test results

If any of these don't apply, please comment below.

## Testing Performed
Eyeball only