### PR TITLE
ROX-21014: Make request details tab part of URL

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -172,7 +172,7 @@ function ApprovedDeferrals() {
                         return (
                             <Tr key={id}>
                                 <Td>
-                                    <RequestIDLink id={id} name={name} />
+                                    <RequestIDLink id={id} name={name} context="CURRENT" />
                                 </Td>
                                 <Td>
                                     <Requester requester={requester} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -164,7 +164,7 @@ function ApprovedFalsePositives() {
                         return (
                             <Tr key={id}>
                                 <Td>
-                                    <RequestIDLink id={id} name={name} />
+                                    <RequestIDLink id={id} name={name} context="CURRENT" />
                                 </Td>
                                 <Td>
                                     <Requester requester={requester} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -173,7 +173,7 @@ function DeniedRequests() {
                         return (
                             <Tr key={id}>
                                 <Td>
-                                    <RequestIDLink id={id} name={name} />
+                                    <RequestIDLink id={id} name={name} context="CURRENT" />
                                 </Td>
                                 <Td>
                                     <Requester requester={requester} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import {
     Breadcrumb,
     BreadcrumbItem,
@@ -114,9 +114,7 @@ function ExceptionRequestDetailsPage() {
     const { status, cves, scope } = vulnerabilityException;
     const isApprovedPendingUpdate = status === 'APPROVED_PENDING_UPDATE';
     const relevantCVEs =
-        selectedContext === 'CURRENT'
-            ? cves
-            : getCVEsForUpdatedRequest(vulnerabilityException);
+        selectedContext === 'CURRENT' ? cves : getCVEsForUpdatedRequest(vulnerabilityException);
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -167,11 +167,12 @@ function PendingApprovals() {
                 </Thead>
                 <Tbody>
                     {data.map((exception) => {
-                        const { id, name, requester, createdAt, scope } = exception;
+                        const { id, name, status, requester, createdAt, scope } = exception;
+                        const context = status === 'APPROVED_PENDING_UPDATE' ? 'PENDING_UPDATE' : 'CURRENT';
                         return (
                             <Tr key={id}>
                                 <Td>
-                                    <RequestIDLink id={id} name={name} />
+                                    <RequestIDLink id={id} name={name} context={context} />
                                 </Td>
                                 <Td>
                                     <Requester requester={requester} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -168,7 +168,8 @@ function PendingApprovals() {
                 <Tbody>
                     {data.map((exception) => {
                         const { id, name, status, requester, createdAt, scope } = exception;
-                        const context = status === 'APPROVED_PENDING_UPDATE' ? 'PENDING_UPDATE' : 'CURRENT';
+                        const context =
+                            status === 'APPROVED_PENDING_UPDATE' ? 'PENDING_UPDATE' : 'CURRENT';
                         return (
                             <Tr key={id}>
                                 <Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
@@ -33,7 +33,7 @@ export type RequestIDLinkProps = {
 };
 
 export function RequestIDLink({ id, name, context }: RequestIDLinkProps) {
-    const query = getQueryString({ context })
+    const query = getQueryString({ context });
     return <Link to={`${exceptionManagementPath}/requests/${id}${query}`}>{name}</Link>;
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
@@ -22,16 +22,19 @@ import {
 } from 'services/VulnerabilityExceptionService';
 import { getDate, getDateTime, getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import useModal from 'hooks/useModal';
+import { getQueryString } from 'utils/queryStringUtils';
 
 export type RequestContext = 'CURRENT' | 'PENDING_UPDATE';
 
 export type RequestIDLinkProps = {
     id: VulnerabilityException['id'];
     name: VulnerabilityException['name'];
+    context: RequestContext;
 };
 
-export function RequestIDLink({ id, name }: RequestIDLinkProps) {
-    return <Link to={`${exceptionManagementPath}/requests/${id}`}>{name}</Link>;
+export function RequestIDLink({ id, name, context }: RequestIDLinkProps) {
+    const query = getQueryString({ context })
+    return <Link to={`${exceptionManagementPath}/requests/${id}${query}`}>{name}</Link>;
 }
 
 export type RequesterProps = {


### PR DESCRIPTION
## Description

This PR makes the `Requested update` and `Latest approved` tabs part of the URL. This allows us to go to the correct tab for a request that is approved, but pending an update. We use the query param value of `?context=CURRENT` or `?context=PENDING_UPDATE` to determine which tab to show

Tests will come in a future PR

## Screen recording

https://github.com/stackrox/stackrox/assets/4805485/ff4ca335-ef50-41ac-89e3-cb4e15bb9672

