### PR TITLE
ROX-20786: use GCP STS client in GCS backup integration

### DIFF
--- a/central/externalbackups/plugins/gcs/gcs.go
+++ b/central/externalbackups/plugins/gcs/gcs.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stackrox/rox/central/externalbackups/plugins"
 	"github.com/stackrox/rox/central/externalbackups/plugins/types"
 	"github.com/stackrox/rox/generated/storage"
-	roxStorage "github.com/stackrox/rox/pkg/cloudproviders/gcp/storage"
+	gcpStorage "github.com/stackrox/rox/pkg/cloudproviders/gcp/storage"
 	"github.com/stackrox/rox/pkg/cloudproviders/gcp/storage/utils"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/logging"
@@ -35,7 +35,7 @@ var log = logging.LoggerForModule()
 
 type gcs struct {
 	integration   *storage.ExternalBackup
-	clientHandler roxStorage.ClientHandler
+	clientHandler gcpStorage.ClientHandler
 
 	backupsToKeep int
 	bucket        string

--- a/central/externalbackups/plugins/gcs/gcs.go
+++ b/central/externalbackups/plugins/gcs/gcs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"path"
 	"sort"
 	"strings"
@@ -11,14 +12,18 @@ import (
 
 	googleStorage "cloud.google.com/go/storage"
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/cloudproviders/gcp"
 	"github.com/stackrox/rox/central/externalbackups/plugins"
 	"github.com/stackrox/rox/central/externalbackups/plugins/types"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/logging"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+	googleHTTP "google.golang.org/api/transport/http"
 )
 
 const (
@@ -29,13 +34,11 @@ const (
 	timeFormat   = "2006-01-02-15-04-05"
 )
 
-var (
-	log = logging.LoggerForModule()
-)
+var log = logging.LoggerForModule()
 
 type gcs struct {
-	integration  *storage.ExternalBackup
-	bucketHandle *googleStorage.BucketHandle
+	integration *storage.ExternalBackup
+	client      *googleStorage.Client
 
 	backupsToKeep int
 	bucket        string
@@ -56,13 +59,6 @@ func validate(conf *storage.GCSConfig) error {
 	return errorList.ToError()
 }
 
-func getClient(conf *storage.GCSConfig) (*googleStorage.Client, error) {
-	if conf.GetUseWorkloadId() {
-		return googleStorage.NewClient(context.Background())
-	}
-	return googleStorage.NewClient(context.Background(), option.WithCredentialsJSON([]byte(conf.GetServiceAccount())))
-}
-
 func newGCS(integration *storage.ExternalBackup) (*gcs, error) {
 	conf := integration.GetGcs()
 	if conf == nil {
@@ -72,24 +68,61 @@ func newGCS(integration *storage.ExternalBackup) (*gcs, error) {
 		return nil, err
 	}
 
-	client, err := getClient(conf)
+	client, err := createClient(conf)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create GCS client")
 	}
 	return &gcs{
 		integration:   integration,
-		bucketHandle:  client.Bucket(conf.GetBucket()),
+		client:        client,
 		bucket:        conf.GetBucket(),
 		backupsToKeep: int(integration.GetBackupsToKeep()),
 		objectPrefix:  conf.GetObjectPrefix(),
 	}, nil
 }
 
-func (s *gcs) send(duration time.Duration, objectPath string, reader io.Reader) error {
+func gcsClientWithTransport(ctx context.Context, opts ...option.ClientOption) (*googleStorage.Client, error) {
+	transport, err := googleHTTP.NewTransport(
+		ctx,
+		proxy.RoundTripper(),
+		opts...,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create transport")
+	}
+	return googleStorage.NewClient(
+		ctx,
+		option.WithHTTPClient(&http.Client{Transport: transport}),
+	)
+}
+
+func createClient(conf *storage.GCSConfig) (*googleStorage.Client, error) {
+	if !conf.GetUseWorkloadId() {
+		return gcsClientWithTransport(
+			context.Background(),
+			option.WithCredentialsJSON([]byte(conf.GetServiceAccount())),
+			option.WithScopes("https://www.googleapis.com/auth/cloud-platform"),
+		)
+	}
+	if features.CloudCredentials.Enabled() {
+		return nil, nil
+	}
+	return gcsClientWithTransport(context.Background())
+}
+
+func (s *gcs) getClient() (*googleStorage.Client, func()) {
+	if s.integration.GetGcs().GetUseWorkloadId() && features.CloudCredentials.Enabled() {
+		return gcp.Singleton().StorageClient()
+	}
+	return s.client, func() {}
+}
+
+func (s *gcs) send(client *googleStorage.Client, duration time.Duration, objectPath string, reader io.Reader) error {
 	ctx, cancel := context.WithTimeout(context.Background(), duration)
 	defer cancel()
 
-	wc := s.bucketHandle.Object(objectPath).NewWriter(ctx)
+	bucketHandle := client.Bucket(s.bucket)
+	wc := bucketHandle.Object(objectPath).NewWriter(ctx)
 	if _, err := io.Copy(wc, reader); err != nil {
 		if err := wc.Close(); err != nil {
 			log.Errorf("closing GCS writer: %v", err)
@@ -102,21 +135,23 @@ func (s *gcs) send(duration time.Duration, objectPath string, reader io.Reader) 
 	return nil
 }
 
-func (s *gcs) delete(objectPath string) error {
+func (s *gcs) delete(client *googleStorage.Client, objectPath string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	err := s.bucketHandle.Object(objectPath).Delete(ctx)
+	bucketHandle := client.Bucket(s.bucket)
+	err := bucketHandle.Object(objectPath).Delete(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "deleting object: %s", objectPath)
 	}
 	return nil
 }
 
-func (s *gcs) pruneBackupsIfNecessary() {
+func (s *gcs) pruneBackupsIfNecessary(client *googleStorage.Client) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	objectIterator := s.bucketHandle.Objects(ctx, &googleStorage.Query{
+	bucketHandle := client.Bucket(s.bucket)
+	objectIterator := bucketHandle.Objects(ctx, &googleStorage.Query{
 		Prefix: s.objectPrefix,
 	})
 
@@ -149,7 +184,7 @@ func (s *gcs) pruneBackupsIfNecessary() {
 	numBackupsToRemove := len(currentBackups) - s.backupsToKeep
 	for _, attrToRemove := range currentBackups[:numBackupsToRemove] {
 		log.Infof("Pruning old backup %s", attrToRemove.Name)
-		if err := s.delete(attrToRemove.Name); err != nil {
+		if err := s.delete(client, attrToRemove.Name); err != nil {
 			log.Errorf("deleting element %s: %v", attrToRemove.Name, err)
 			return
 		}
@@ -165,6 +200,12 @@ func formattedTime() string {
 }
 
 func (s *gcs) Backup(reader io.ReadCloser) error {
+	client, done := s.getClient()
+	defer done()
+	if client == nil {
+		return errors.New("failed to get GCS client")
+	}
+
 	defer func() {
 		if err := reader.Close(); err != nil {
 			log.Errorf("Error closing reader: %v", err)
@@ -175,22 +216,28 @@ func (s *gcs) Backup(reader io.ReadCloser) error {
 	formattedKey := s.prefixKey(key)
 
 	log.Infof("Starting GCS Backup for file %v", formattedKey)
-	if err := s.send(backupMaxTimeout, formattedKey, reader); err != nil {
+	if err := s.send(client, backupMaxTimeout, formattedKey, reader); err != nil {
 		return s.createError(fmt.Sprintf("error creating backup in bucket %q with key %q", s.bucket, formattedKey), err)
 	}
 	log.Info("Successfully backed up to GCS")
-	go s.pruneBackupsIfNecessary()
+	go s.pruneBackupsIfNecessary(client)
 	return nil
 }
 
 func (s *gcs) Test() error {
+	client, done := s.getClient()
+	defer done()
+	if client == nil {
+		return errors.New("failed to get GCS client")
+	}
+
 	formattedKey := s.prefixKey(fmt.Sprintf("%s-test-%s", backupPrefix, formattedTime()))
 	reader := strings.NewReader("This is a test of the StackRox integration with this bucket")
-	if err := s.send(timeout, formattedKey, reader); err != nil {
+	if err := s.send(client, timeout, formattedKey, reader); err != nil {
 		return s.createError(fmt.Sprintf("error creating test object %q in bucket %q", formattedKey, s.bucket), err)
 	}
 
-	if err := s.delete(formattedKey); err != nil {
+	if err := s.delete(client, formattedKey); err != nil {
 		return s.createError("deleting test object", err)
 	}
 	return nil

--- a/central/externalbackups/plugins/gcs/gcs.go
+++ b/central/externalbackups/plugins/gcs/gcs.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+	googleStoragev1 "google.golang.org/api/storage/v1"
 	googleHTTP "google.golang.org/api/transport/http"
 )
 
@@ -101,7 +102,7 @@ func createClient(conf *storage.GCSConfig) (*googleStorage.Client, error) {
 		return gcsClientWithTransport(
 			context.Background(),
 			option.WithCredentialsJSON([]byte(conf.GetServiceAccount())),
-			option.WithScopes("https://www.googleapis.com/auth/cloud-platform"),
+			option.WithScopes(googleStoragev1.CloudPlatformScope),
 		)
 	}
 	if features.CloudCredentials.Enabled() {


### PR DESCRIPTION
## Description

Use the STS client manager in GCS backup integrations. If the feature flag is disabled we revert to the previous client based on default credentials. However, we now add the proxy transport by default.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

* CI
* manual e2e test w/ both WIF config and static service account credentials.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
