### PR TITLE
fix: sensor install method fallback to `manifest`

### DIFF
--- a/sensor/common/installmethod/install.go
+++ b/sensor/common/installmethod/install.go
@@ -24,11 +24,11 @@ func Set(value storage.ManagerType) {
 	defer mutex.Unlock()
 
 	switch value {
-	case storage.ManagerType_MANAGER_TYPE_MANUAL:
-		installMethod = "manifest"
 	case storage.ManagerType_MANAGER_TYPE_HELM_CHART:
 		installMethod = "helm"
 	case storage.ManagerType_MANAGER_TYPE_KUBERNETES_OPERATOR:
 		installMethod = "operator"
+	default:
+		installMethod = "manifest"
 	}
 }


### PR DESCRIPTION
## Description

Default sensor install method to `manifest`. The install method is used for our Telemeter metrics, where sensors installed via a downloaded yaml manifest bundle currently show up w/ an empty install method. The reason is that such manifest installs may result in `ManagerType_MANAGER_TYPE_UNKOWN`.