### PR TITLE
ROX-17934: split reports for suspicious logs

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -586,7 +586,8 @@ check_for_errors_in_stackrox_logs() {
         local check_out=""
         # shellcheck disable=SC2086
         if ! check_out="$(scripts/ci/logcheck/check.sh $filtered)"; then
-            save_junit_failure "SuspiciousLog" "Suspicious entries in log file(s)" "$check_out"
+            local last_log="${check_out##*.log:}"
+            save_junit_failure "SuspiciousLog" "${last_log##*: }" "$check_out"
             die "ERROR: Found at least one suspicious log file entry."
         else
             save_junit_success "SuspiciousLog" "Suspicious entries in log file(s)"


### PR DESCRIPTION
## Description

In [ROX-17934](https://issues.redhat.com/browse/ROX-17934) we have all types of errors found across different CI runs. This make no sense. This PR introduces heuristic to create a jira unit based on last found line. We take the part after last `.log[` and from that we extract last segment after splitting by `:` (a common go error delimiter). After merging this PR we should have more fine grained issues.

Refs:
- https://github.com/stackrox/stackrox/pull/8378

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI and I've run command for different outputs I found in original jira issue.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
