### PR TITLE
ROX-20556: Add flow for approving a vulnerability request

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -94,9 +94,9 @@ function ExceptionRequestDetailsPage() {
         setSelectedContext(value);
     }
 
-    function onApprovalSuccess(exception: VulnerabilityException) {
+    function onApprovalSuccess() {
         refetch();
-        setSuccessMessage(`Vulnerability request ${exception.name} was successfully approved`);
+        setSuccessMessage(`The vulnerability request was successfully approved`);
     }
 
     if (loading && !vulnerabilityException) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -1,5 +1,8 @@
-import React, { useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
+    Alert,
+    AlertActionCloseButton,
+    AlertVariant,
     Breadcrumb,
     BreadcrumbItem,
     Bullseye,
@@ -19,6 +22,8 @@ import { useParams } from 'react-router-dom';
 import { exceptionManagementPath } from 'routePaths';
 import useSet from 'hooks/useSet';
 import useRestQuery from 'hooks/useRestQuery';
+import usePermissions from 'hooks/usePermissions';
+import useURLStringUnion from 'hooks/useURLStringUnion';
 import { ensureExhaustive } from 'utils/type.utils';
 import {
     VulnerabilityException,
@@ -32,7 +37,8 @@ import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import RequestCVEsTable from './components/RequestCVEsTable';
 import TableErrorComponent from '../WorkloadCves/components/TableErrorComponent';
 import RequestOverview from './components/RequestOverview';
-import useURLStringUnion from 'hooks/useURLStringUnion';
+import { RequestContext } from './components/ExceptionRequestTableCells';
+import RequestApprovalButtonModal from './components/RequestApprovalButtonModal';
 
 import './ExceptionRequestDetailsPage.css';
 
@@ -65,9 +71,13 @@ export function getCVEsForUpdatedRequest(exception: VulnerabilityException): str
 }
 
 function ExceptionRequestDetailsPage() {
+    const { requestId } = useParams();
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForApproving = hasReadWriteAccess('VulnerabilityManagementApprovals');
+
     const [selectedContext, setSelectedContext] = useURLStringUnion('context', contextValues);
     const expandedRowSet = useSet<string>();
-    const { requestId } = useParams();
+    const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
     const vulnerabilityExceptionByIdFn = useCallback(
         () => fetchVulnerabilityExceptionById(requestId),
@@ -77,10 +87,16 @@ function ExceptionRequestDetailsPage() {
         data: vulnerabilityException,
         loading,
         error,
+        refetch,
     } = useRestQuery(vulnerabilityExceptionByIdFn);
 
     function handleTabClick(event, value) {
         setSelectedContext(value);
+    }
+
+    function onApprovalSuccess(exception: VulnerabilityException) {
+        refetch();
+        setSuccessMessage(`Vulnerability request ${exception.name} was successfully approved`);
     }
 
     if (loading && !vulnerabilityException) {
@@ -112,12 +128,25 @@ function ExceptionRequestDetailsPage() {
     }
 
     const { status, cves, scope } = vulnerabilityException;
+
     const isApprovedPendingUpdate = status === 'APPROVED_PENDING_UPDATE';
+    const showApprovalButton =
+        hasWriteAccessForApproving &&
+        (status === 'PENDING' || status === 'APPROVED_PENDING_UPDATE');
+
     const relevantCVEs =
         selectedContext === 'CURRENT' ? cves : getCVEsForUpdatedRequest(vulnerabilityException);
 
     return (
         <>
+            {successMessage && (
+                <Alert
+                    variant={AlertVariant.success}
+                    isInline
+                    title={successMessage}
+                    actionClose={<AlertActionCloseButton onClose={() => setSuccessMessage(null)} />}
+                />
+            )}
             <PageSection variant="light" className="pf-u-py-md">
                 <Breadcrumb>
                     <BreadcrumbItemLink to={exceptionManagementPath}>
@@ -128,9 +157,17 @@ function ExceptionRequestDetailsPage() {
             </PageSection>
             <Divider component="div" />
             <PageSection variant="light">
-                <Flex direction={{ default: 'column' }}>
-                    <Title headingLevel="h1">Request {vulnerabilityException.name}</Title>
-                    <FlexItem>{getSubtitleText(vulnerabilityException)}</FlexItem>
+                <Flex>
+                    <Flex direction={{ default: 'column' }} flex={{ default: 'flex_1' }}>
+                        <Title headingLevel="h1">Request {vulnerabilityException.name}</Title>
+                        <FlexItem>{getSubtitleText(vulnerabilityException)}</FlexItem>
+                    </Flex>
+                    {showApprovalButton && (
+                        <RequestApprovalButtonModal
+                            exception={vulnerabilityException}
+                            onSuccess={onApprovalSuccess}
+                        />
+                    )}
                 </Flex>
             </PageSection>
             <PageSection className="pf-u-p-0">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -37,7 +37,6 @@ import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import RequestCVEsTable from './components/RequestCVEsTable';
 import TableErrorComponent from '../WorkloadCves/components/TableErrorComponent';
 import RequestOverview from './components/RequestOverview';
-import { RequestContext } from './components/ExceptionRequestTableCells';
 import RequestApprovalButtonModal from './components/RequestApprovalButtonModal';
 
 import './ExceptionRequestDetailsPage.css';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestApprovalButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestApprovalButtonModal.tsx
@@ -1,5 +1,13 @@
 import React, { useState } from 'react';
-import { Alert, AlertVariant, Button, Form, Modal, TextArea, pluralize } from '@patternfly/react-core';
+import {
+    Alert,
+    AlertVariant,
+    Button,
+    Form,
+    Modal,
+    TextArea,
+    pluralize,
+} from '@patternfly/react-core';
 import * as yup from 'yup';
 import { useFormik } from 'formik';
 import isEqual from 'lodash/isEqual';
@@ -30,7 +38,7 @@ function RequestApprovalButtonModal({ exception, onSuccess }: RequestApprovalBut
     const approveRequestMutation = useRestMutation(approveVulnerabilityException);
 
     const { isModalOpen, openModal, closeModal } = useModal();
-    const [errorMessage, setErrorMessage] = useState<string | null>(null); 
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
     const formik = useFormik({
         initialValues,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestApprovalButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestApprovalButtonModal.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import { Alert, AlertVariant, Button, Form, Modal, TextArea, pluralize } from '@patternfly/react-core';
+import * as yup from 'yup';
+import { useFormik } from 'formik';
+import isEqual from 'lodash/isEqual';
+
+import useModal from 'hooks/useModal';
+import {
+    VulnerabilityException,
+    approveVulnerabilityException,
+} from 'services/VulnerabilityExceptionService';
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+import useRestMutation from 'hooks/useRestMutation';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+type RequestApprovalButtonModalProps = {
+    exception: VulnerabilityException;
+    onSuccess: (vulnerabilityException: VulnerabilityException) => void;
+};
+
+const initialValues = {
+    rationale: '',
+};
+
+const validationSchema = yup.object().shape({
+    rationale: yup.string().required('Approval rationale is required'),
+});
+
+function RequestApprovalButtonModal({ exception, onSuccess }: RequestApprovalButtonModalProps) {
+    const approveRequestMutation = useRestMutation(approveVulnerabilityException);
+
+    const { isModalOpen, openModal, closeModal } = useModal();
+    const [errorMessage, setErrorMessage] = useState<string | null>(null); 
+
+    const formik = useFormik({
+        initialValues,
+        validationSchema,
+        onSubmit: (values, helpers) => {
+            const payload = {
+                id: exception.id,
+                comment: values.rationale,
+            };
+            approveRequestMutation.mutate(payload, {
+                onSuccess: (exception) => {
+                    onSuccess(exception);
+                    onClose();
+                },
+                onError: (error) => {
+                    setErrorMessage(getAxiosErrorMessage(error));
+                    helpers.setSubmitting(false);
+                },
+            });
+        },
+    });
+
+    function onClose() {
+        formik.resetForm();
+        closeModal();
+    }
+
+    const modalTitle = `Approve ${
+        exception.targetState === 'DEFERRED' ? 'deferral' : 'false positive'
+    } for ${pluralize(exception.cves.length, 'CVE')}`;
+
+    const isFormModified = !isEqual(formik.values, formik.initialValues);
+    const hasErrors = Object.keys(formik.errors).length > 0;
+    const isDisabled = !isFormModified || hasErrors;
+
+    return (
+        <>
+            <Button variant="primary" onClick={openModal}>
+                Approve request
+            </Button>
+            <Modal
+                variant="small"
+                title={modalTitle}
+                isOpen={isModalOpen}
+                onClose={onClose}
+                actions={[
+                    <Button
+                        key="approve"
+                        variant="primary"
+                        isLoading={formik.isSubmitting}
+                        isDisabled={isDisabled}
+                        onClick={() => formik.handleSubmit()}
+                    >
+                        Approve
+                    </Button>,
+                    <Button key="cancel" variant="link" onClick={onClose}>
+                        Cancel
+                    </Button>,
+                ]}
+            >
+                {errorMessage && (
+                    <Alert
+                        isInline
+                        variant={AlertVariant.danger}
+                        title={errorMessage}
+                    />
+                )}
+                <Form>
+                    <FormLabelGroup
+                        isRequired
+                        label="Approval rationale"
+                        fieldId="rationale"
+                        errors={formik.errors}
+                    >
+                        <TextArea
+                            type="text"
+                            id="rationale"
+                            value={formik.values.rationale}
+                            onChange={(_, event) => formik.handleChange(event)}
+                            onBlur={formik.handleBlur}
+                        />
+                    </FormLabelGroup>
+                </Form>
+            </Modal>
+        </>
+    );
+}
+
+export default RequestApprovalButtonModal;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestApprovalButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestApprovalButtonModal.tsx
@@ -64,7 +64,7 @@ function RequestApprovalButtonModal({ exception, onSuccess }: RequestApprovalBut
 
     const isFormModified = !isEqual(formik.values, formik.initialValues);
     const hasErrors = Object.keys(formik.errors).length > 0;
-    const isDisabled = !isFormModified || hasErrors;
+    const isSubmitDisabled = !isFormModified || hasErrors || formik.isSubmitting;
 
     return (
         <>
@@ -81,7 +81,7 @@ function RequestApprovalButtonModal({ exception, onSuccess }: RequestApprovalBut
                         key="approve"
                         variant="primary"
                         isLoading={formik.isSubmitting}
-                        isDisabled={isDisabled}
+                        isDisabled={isSubmitDisabled}
                         onClick={() => formik.handleSubmit()}
                     >
                         Approve
@@ -90,13 +90,10 @@ function RequestApprovalButtonModal({ exception, onSuccess }: RequestApprovalBut
                         Cancel
                     </Button>,
                 ]}
+                showClose={false}
             >
                 {errorMessage && (
-                    <Alert
-                        isInline
-                        variant={AlertVariant.danger}
-                        title={errorMessage}
-                    />
+                    <Alert isInline variant={AlertVariant.danger} title={errorMessage} />
                 )}
                 <Form>
                     <FormLabelGroup

--- a/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
+++ b/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
@@ -137,3 +137,20 @@ export function createFalsePositiveVulnerabilityException(
         .post<{ exception: VulnerabilityFalsePositiveException }>(url, payload)
         .then((response) => response.data.exception);
 }
+
+export type ApproveVulnerabilityExceptionRequest = {
+    id: string;
+    comment: string;
+};
+
+export function approveVulnerabilityException(
+    payload: ApproveVulnerabilityExceptionRequest
+): Promise<VulnerabilityDeferralException> {
+    const { id, comment } = payload;
+    const url = `${baseUrl}/${id}/approve`;
+    return axios
+        .post<{ exception: VulnerabilityDeferralException }>(url, {
+            comment,
+        })
+        .then((response) => response.data.exception);
+}


### PR DESCRIPTION
## Description

This PR adds the ability to approve requests. The approve button will show up on the Request Details page on the following conditions:
1. The user has read/write access for `VulnerabilityManagementApprovals`
2. The request is either in the `PENDING` or `APPROVED_PENDING_UPDATE` status

## Screenshots

The approve button shows up in the top right section
<img width="1440" alt="Screenshot 2023-11-22 at 11 38 03 AM" src="https://github.com/stackrox/stackrox/assets/4805485/40f552c9-f118-4885-b812-304f0f7f9de2">

Clicking on the button will show a modal. The modal will display one form field for inputting an approval rationale. The form has validation. The button will be disabled initially and when no value is inputted for the approval rationale.
<img width="1438" alt="Screenshot 2023-11-22 at 11 38 11 AM" src="https://github.com/stackrox/stackrox/assets/4805485/0fdfef66-e33c-41a7-82f0-b4442d576652">

If the request was approved, you'll see a success banner at the top of the page showing it was approved. The data on the page will be updated as well.
<img width="1440" alt="Screenshot 2023-11-22 at 11 38 47 AM" src="https://github.com/stackrox/stackrox/assets/4805485/c60ac2f5-4401-4af3-844f-6bee338039e4">


