### PR TITLE
refactor(postgres): adjust generated store tests for cached stores

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store_test.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ActiveComponentsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE active_components CASCADE")
 	s.T().Log("active_components", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/administration/events/datastore/internal/store/postgres/store_test.go
+++ b/central/administration/events/datastore/internal/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *AdministrationEventsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE administration_events CASCADE")
 	s.T().Log("administration_events", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/administration/usage/store/postgres/store_test.go
+++ b/central/administration/usage/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *SecuredUnitsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE secured_units CASCADE")
 	s.T().Log("secured_units", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/alert/datastore/internal/store/postgres/store_test.go
+++ b/central/alert/datastore/internal/store/postgres/store_test.go
@@ -294,7 +294,7 @@ func (s *AlertsStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/alert/datastore/internal/store/postgres/store_test.go
+++ b/central/alert/datastore/internal/store/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *AlertsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE alerts CASCADE")
 	s.T().Log("alerts", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/alert/datastore/internal/store/postgres/store_test.go
+++ b/central/alert/datastore/internal/store/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *AlertsStoreSuite) getTestData(access storage.Access) (*storage.Alert, *storage.Alert, map[string]testCase) {
+func (s *AlertsStoreSuite) getTestData(access ...storage.Access) (*storage.Alert, *storage.Alert, map[string]testCase) {
 	objA := &storage.Alert{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *AlertsStoreSuite) getTestData(access storage.Access) (*storage.Alert, *
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *AlertsStoreSuite) getTestData(access storage.Access) (*storage.Alert, *
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys(objA.GetNamespace()),
@@ -191,7 +191,7 @@ func (s *AlertsStoreSuite) getTestData(access storage.Access) (*storage.Alert, *
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 				)),
@@ -204,7 +204,7 @@ func (s *AlertsStoreSuite) getTestData(access storage.Access) (*storage.Alert, *
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -217,7 +217,7 @@ func (s *AlertsStoreSuite) getTestData(access storage.Access) (*storage.Alert, *
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -339,7 +339,7 @@ func (s *AlertsStoreSuite) TestSACGet() {
 }
 
 func (s *AlertsStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -366,7 +366,7 @@ func (s *AlertsStoreSuite) TestSACDelete() {
 }
 
 func (s *AlertsStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/apitoken/datastore/internal/store/postgres/store_test.go
+++ b/central/apitoken/datastore/internal/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *APITokensStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE api_tokens CASCADE")
 	s.T().Log("api_tokens", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/auth/store/postgres/store_test.go
+++ b/central/auth/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *AuthMachineToMachineConfigsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE auth_machine_to_machine_configs CASCADE")
 	s.T().Log("auth_machine_to_machine_configs", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/authprovider/datastore/internal/store/postgres/store_test.go
+++ b/central/authprovider/datastore/internal/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *AuthProvidersStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE auth_providers CASCADE")
 	s.T().Log("auth_providers", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/blob/datastore/store/postgres/store_test.go
+++ b/central/blob/datastore/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *BlobsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE blobs CASCADE")
 	s.T().Log("blobs", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/cluster/store/cluster/postgres/store_test.go
+++ b/central/cluster/store/cluster/postgres/store_test.go
@@ -293,7 +293,7 @@ func (s *ClustersStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/cluster/store/cluster/postgres/store_test.go
+++ b/central/cluster/store/cluster/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *ClustersStoreSuite) getTestData(access storage.Access) (*storage.Cluster, *storage.Cluster, map[string]testCase) {
+func (s *ClustersStoreSuite) getTestData(access ...storage.Access) (*storage.Cluster, *storage.Cluster, map[string]testCase) {
 	objA := &storage.Cluster{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *ClustersStoreSuite) getTestData(access storage.Access) (*storage.Cluste
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *ClustersStoreSuite) getTestData(access storage.Access) (*storage.Cluste
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetId()),
 				)),
@@ -190,7 +190,7 @@ func (s *ClustersStoreSuite) getTestData(access storage.Access) (*storage.Cluste
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetId()),
 				)),
@@ -203,7 +203,7 @@ func (s *ClustersStoreSuite) getTestData(access storage.Access) (*storage.Cluste
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -216,7 +216,7 @@ func (s *ClustersStoreSuite) getTestData(access storage.Access) (*storage.Cluste
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -338,7 +338,7 @@ func (s *ClustersStoreSuite) TestSACGet() {
 }
 
 func (s *ClustersStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -365,7 +365,7 @@ func (s *ClustersStoreSuite) TestSACDelete() {
 }
 
 func (s *ClustersStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/cluster/store/cluster/postgres/store_test.go
+++ b/central/cluster/store/cluster/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *ClustersStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE clusters CASCADE")
 	s.T().Log("clusters", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/cluster/store/clusterhealth/postgres/store_test.go
+++ b/central/cluster/store/clusterhealth/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ClusterHealthStatusesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE cluster_health_statuses CASCADE")
 	s.T().Log("cluster_health_statuses", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/clustercveedge/datastore/store/postgres/store_test.go
+++ b/central/clustercveedge/datastore/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ClusterCveEdgesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE cluster_cve_edges CASCADE")
 	s.T().Log("cluster_cve_edges", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/clusterinit/store/postgres/store_test.go
+++ b/central/clusterinit/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ClusterInitBundlesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE cluster_init_bundles CASCADE")
 	s.T().Log("cluster_init_bundles", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/compliance/datastore/internal/store/postgres/compliance_config/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/compliance_config/store_test.go
@@ -35,6 +35,7 @@ func (s *ComplianceConfigsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_configs CASCADE")
 	s.T().Log("compliance_configs", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/compliance/datastore/internal/store/postgres/domain/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store_test.go
@@ -35,6 +35,7 @@ func (s *ComplianceDomainsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_domains CASCADE")
 	s.T().Log("compliance_domains", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *ComplianceRunMetadataStoreSuite) getTestData(access storage.Access) (*storage.ComplianceRunMetadata, *storage.ComplianceRunMetadata, map[string]testCase) {
+func (s *ComplianceRunMetadataStoreSuite) getTestData(access ...storage.Access) (*storage.ComplianceRunMetadata, *storage.ComplianceRunMetadata, map[string]testCase) {
 	objA := &storage.ComplianceRunMetadata{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *ComplianceRunMetadataStoreSuite) getTestData(access storage.Access) (*s
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *ComplianceRunMetadataStoreSuite) getTestData(access storage.Access) (*s
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 				)),
@@ -190,7 +190,7 @@ func (s *ComplianceRunMetadataStoreSuite) getTestData(access storage.Access) (*s
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 				)),
@@ -203,7 +203,7 @@ func (s *ComplianceRunMetadataStoreSuite) getTestData(access storage.Access) (*s
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -216,7 +216,7 @@ func (s *ComplianceRunMetadataStoreSuite) getTestData(access storage.Access) (*s
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -338,7 +338,7 @@ func (s *ComplianceRunMetadataStoreSuite) TestSACGet() {
 }
 
 func (s *ComplianceRunMetadataStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -365,7 +365,7 @@ func (s *ComplianceRunMetadataStoreSuite) TestSACDelete() {
 }
 
 func (s *ComplianceRunMetadataStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
@@ -38,6 +38,7 @@ func (s *ComplianceRunMetadataStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_run_metadata CASCADE")
 	s.T().Log("compliance_run_metadata", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
@@ -293,7 +293,7 @@ func (s *ComplianceRunMetadataStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/compliance/datastore/internal/store/postgres/results/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store_test.go
@@ -38,6 +38,7 @@ func (s *ComplianceRunResultsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_run_results CASCADE")
 	s.T().Log("compliance_run_results", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/compliance/datastore/internal/store/postgres/results/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *ComplianceRunResultsStoreSuite) getTestData(access storage.Access) (*storage.ComplianceRunResults, *storage.ComplianceRunResults, map[string]testCase) {
+func (s *ComplianceRunResultsStoreSuite) getTestData(access ...storage.Access) (*storage.ComplianceRunResults, *storage.ComplianceRunResults, map[string]testCase) {
 	objA := &storage.ComplianceRunResults{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *ComplianceRunResultsStoreSuite) getTestData(access storage.Access) (*st
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *ComplianceRunResultsStoreSuite) getTestData(access storage.Access) (*st
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetRunMetadata().GetClusterId()),
 				)),
@@ -190,7 +190,7 @@ func (s *ComplianceRunResultsStoreSuite) getTestData(access storage.Access) (*st
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetRunMetadata().GetClusterId()),
 				)),
@@ -203,7 +203,7 @@ func (s *ComplianceRunResultsStoreSuite) getTestData(access storage.Access) (*st
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -216,7 +216,7 @@ func (s *ComplianceRunResultsStoreSuite) getTestData(access storage.Access) (*st
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetRunMetadata().GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -338,7 +338,7 @@ func (s *ComplianceRunResultsStoreSuite) TestSACGet() {
 }
 
 func (s *ComplianceRunResultsStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -365,7 +365,7 @@ func (s *ComplianceRunResultsStoreSuite) TestSACDelete() {
 }
 
 func (s *ComplianceRunResultsStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/compliance/datastore/internal/store/postgres/results/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store_test.go
@@ -293,7 +293,7 @@ func (s *ComplianceRunResultsStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/compliance/datastore/internal/store/postgres/strings/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store_test.go
@@ -35,6 +35,7 @@ func (s *ComplianceStringsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_strings CASCADE")
 	s.T().Log("compliance_strings", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/complianceoperator/checkresults/store/postgres/store_test.go
+++ b/central/complianceoperator/checkresults/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ComplianceOperatorCheckResultsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_operator_check_results CASCADE")
 	s.T().Log("compliance_operator_check_results", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/complianceoperator/profiles/store/postgres/store_test.go
+++ b/central/complianceoperator/profiles/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ComplianceOperatorProfilesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_operator_profiles CASCADE")
 	s.T().Log("compliance_operator_profiles", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/complianceoperator/rules/store/postgres/store_test.go
+++ b/central/complianceoperator/rules/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ComplianceOperatorRulesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_operator_rules CASCADE")
 	s.T().Log("compliance_operator_rules", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/complianceoperator/scans/store/postgres/store_test.go
+++ b/central/complianceoperator/scans/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ComplianceOperatorScansStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_operator_scans CASCADE")
 	s.T().Log("compliance_operator_scans", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/complianceoperator/scansettingbinding/store/postgres/store_test.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ComplianceOperatorScanSettingBindingsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_operator_scan_setting_bindings CASCADE")
 	s.T().Log("compliance_operator_scan_setting_bindings", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/complianceoperator/v2/checkresults/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/checkresults/store/postgres/store_test.go
@@ -42,6 +42,7 @@ func (s *ComplianceOperatorCheckResultV2StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_operator_check_result_v2 CASCADE")
 	s.T().Log("compliance_operator_check_result_v2", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/complianceoperator/v2/integration/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/integration/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ComplianceIntegrationsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_integrations CASCADE")
 	s.T().Log("compliance_integrations", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/complianceoperator/v2/profiles/profileclusteredge/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/profiles/profileclusteredge/store/postgres/store_test.go
@@ -42,6 +42,7 @@ func (s *ComplianceOperatorProfileClusterEdgesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_operator_profile_cluster_edges CASCADE")
 	s.T().Log("compliance_operator_profile_cluster_edges", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/complianceoperator/v2/profiles/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/profiles/store/postgres/store_test.go
@@ -42,6 +42,7 @@ func (s *ComplianceOperatorProfileV2StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_operator_profile_v2 CASCADE")
 	s.T().Log("compliance_operator_profile_v2", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/complianceoperator/v2/rules/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/rules/store/postgres/store_test.go
@@ -42,6 +42,7 @@ func (s *ComplianceOperatorRuleV2StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_operator_rule_v2 CASCADE")
 	s.T().Log("compliance_operator_rule_v2", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store_test.go
@@ -42,6 +42,7 @@ func (s *ComplianceOperatorClusterScanConfigStatusesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_operator_cluster_scan_config_statuses CASCADE")
 	s.T().Log("compliance_operator_cluster_scan_config_statuses", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/complianceoperator/v2/scanconfigurations/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/store/postgres/store_test.go
@@ -42,6 +42,7 @@ func (s *ComplianceOperatorScanConfigurationV2StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_operator_scan_configuration_v2 CASCADE")
 	s.T().Log("compliance_operator_scan_configuration_v2", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/complianceoperator/v2/scans/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scans/store/postgres/store_test.go
@@ -42,6 +42,7 @@ func (s *ComplianceOperatorScanV2StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE compliance_operator_scan_v2 CASCADE")
 	s.T().Log("compliance_operator_scan_v2", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/componentcveedge/datastore/store/postgres/store_test.go
+++ b/central/componentcveedge/datastore/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ImageComponentCveEdgesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE image_component_cve_edges CASCADE")
 	s.T().Log("image_component_cve_edges", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/cve/cluster/datastore/store/postgres/store_test.go
+++ b/central/cve/cluster/datastore/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ClusterCvesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE cluster_cves CASCADE")
 	s.T().Log("cluster_cves", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/cve/image/datastore/store/postgres/store_test.go
+++ b/central/cve/image/datastore/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ImageCvesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE image_cves CASCADE")
 	s.T().Log("image_cves", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/cve/node/datastore/store/postgres/store_test.go
+++ b/central/cve/node/datastore/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *NodeCvesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE node_cves CASCADE")
 	s.T().Log("node_cves", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/declarativeconfig/health/datastore/store/postgres/store_test.go
+++ b/central/declarativeconfig/health/datastore/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *DeclarativeConfigHealthsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE declarative_config_healths CASCADE")
 	s.T().Log("declarative_config_healths", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/deployment/store/postgres/store_test.go
+++ b/central/deployment/store/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *DeploymentsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE deployments CASCADE")
 	s.T().Log("deployments", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/deployment/store/postgres/store_test.go
+++ b/central/deployment/store/postgres/store_test.go
@@ -294,7 +294,7 @@ func (s *DeploymentsStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/deployment/store/postgres/store_test.go
+++ b/central/deployment/store/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *DeploymentsStoreSuite) getTestData(access storage.Access) (*storage.Deployment, *storage.Deployment, map[string]testCase) {
+func (s *DeploymentsStoreSuite) getTestData(access ...storage.Access) (*storage.Deployment, *storage.Deployment, map[string]testCase) {
 	objA := &storage.Deployment{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *DeploymentsStoreSuite) getTestData(access storage.Access) (*storage.Dep
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *DeploymentsStoreSuite) getTestData(access storage.Access) (*storage.Dep
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys(objA.GetNamespace()),
@@ -191,7 +191,7 @@ func (s *DeploymentsStoreSuite) getTestData(access storage.Access) (*storage.Dep
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 				)),
@@ -204,7 +204,7 @@ func (s *DeploymentsStoreSuite) getTestData(access storage.Access) (*storage.Dep
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -217,7 +217,7 @@ func (s *DeploymentsStoreSuite) getTestData(access storage.Access) (*storage.Dep
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -339,7 +339,7 @@ func (s *DeploymentsStoreSuite) TestSACGet() {
 }
 
 func (s *DeploymentsStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -366,7 +366,7 @@ func (s *DeploymentsStoreSuite) TestSACDelete() {
 }
 
 func (s *DeploymentsStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/externalbackups/internal/store/postgres/store_test.go
+++ b/central/externalbackups/internal/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ExternalBackupsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE external_backups CASCADE")
 	s.T().Log("external_backups", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/group/datastore/internal/store/postgres/store_test.go
+++ b/central/group/datastore/internal/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *GroupsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE groups CASCADE")
 	s.T().Log("groups", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/hash/datastore/store/postgres/store_test.go
+++ b/central/hash/datastore/store/postgres/store_test.go
@@ -42,6 +42,7 @@ func (s *HashesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE hashes CASCADE")
 	s.T().Log("hashes", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/imagecomponent/datastore/store/postgres/store_test.go
+++ b/central/imagecomponent/datastore/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ImageComponentsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE image_components CASCADE")
 	s.T().Log("image_components", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store_test.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ImageComponentEdgesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE image_component_edges CASCADE")
 	s.T().Log("image_component_edges", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/imagecveedge/datastore/postgres/store_test.go
+++ b/central/imagecveedge/datastore/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ImageCveEdgesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE image_cve_edges CASCADE")
 	s.T().Log("image_cve_edges", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/imageintegration/store/postgres/store_test.go
+++ b/central/imageintegration/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ImageIntegrationsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE image_integrations CASCADE")
 	s.T().Log("image_integrations", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/integrationhealth/store/postgres/store_test.go
+++ b/central/integrationhealth/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *IntegrationHealthsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE integration_healths CASCADE")
 	s.T().Log("integration_healths", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/logimbue/store/postgres/store_test.go
+++ b/central/logimbue/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *LogImbuesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE log_imbues CASCADE")
 	s.T().Log("log_imbues", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/namespace/store/postgres/store_test.go
+++ b/central/namespace/store/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *NamespacesStoreSuite) getTestData(access storage.Access) (*storage.NamespaceMetadata, *storage.NamespaceMetadata, map[string]testCase) {
+func (s *NamespacesStoreSuite) getTestData(access ...storage.Access) (*storage.NamespaceMetadata, *storage.NamespaceMetadata, map[string]testCase) {
 	objA := &storage.NamespaceMetadata{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *NamespacesStoreSuite) getTestData(access storage.Access) (*storage.Name
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *NamespacesStoreSuite) getTestData(access storage.Access) (*storage.Name
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys(objA.GetName()),
@@ -191,7 +191,7 @@ func (s *NamespacesStoreSuite) getTestData(access storage.Access) (*storage.Name
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 				)),
@@ -204,7 +204,7 @@ func (s *NamespacesStoreSuite) getTestData(access storage.Access) (*storage.Name
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -217,7 +217,7 @@ func (s *NamespacesStoreSuite) getTestData(access storage.Access) (*storage.Name
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -339,7 +339,7 @@ func (s *NamespacesStoreSuite) TestSACGet() {
 }
 
 func (s *NamespacesStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -366,7 +366,7 @@ func (s *NamespacesStoreSuite) TestSACDelete() {
 }
 
 func (s *NamespacesStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/namespace/store/postgres/store_test.go
+++ b/central/namespace/store/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *NamespacesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE namespaces CASCADE")
 	s.T().Log("namespaces", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/namespace/store/postgres/store_test.go
+++ b/central/namespace/store/postgres/store_test.go
@@ -294,7 +294,7 @@ func (s *NamespacesStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/networkbaseline/store/postgres/store_test.go
+++ b/central/networkbaseline/store/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *NetworkBaselinesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE network_baselines CASCADE")
 	s.T().Log("network_baselines", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/networkbaseline/store/postgres/store_test.go
+++ b/central/networkbaseline/store/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *NetworkBaselinesStoreSuite) getTestData(access storage.Access) (*storage.NetworkBaseline, *storage.NetworkBaseline, map[string]testCase) {
+func (s *NetworkBaselinesStoreSuite) getTestData(access ...storage.Access) (*storage.NetworkBaseline, *storage.NetworkBaseline, map[string]testCase) {
 	objA := &storage.NetworkBaseline{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *NetworkBaselinesStoreSuite) getTestData(access storage.Access) (*storag
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *NetworkBaselinesStoreSuite) getTestData(access storage.Access) (*storag
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys(objA.GetNamespace()),
@@ -191,7 +191,7 @@ func (s *NetworkBaselinesStoreSuite) getTestData(access storage.Access) (*storag
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 				)),
@@ -204,7 +204,7 @@ func (s *NetworkBaselinesStoreSuite) getTestData(access storage.Access) (*storag
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -217,7 +217,7 @@ func (s *NetworkBaselinesStoreSuite) getTestData(access storage.Access) (*storag
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -339,7 +339,7 @@ func (s *NetworkBaselinesStoreSuite) TestSACGet() {
 }
 
 func (s *NetworkBaselinesStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -366,7 +366,7 @@ func (s *NetworkBaselinesStoreSuite) TestSACDelete() {
 }
 
 func (s *NetworkBaselinesStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/networkbaseline/store/postgres/store_test.go
+++ b/central/networkbaseline/store/postgres/store_test.go
@@ -294,7 +294,7 @@ func (s *NetworkBaselinesStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/networkgraph/config/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *NetworkGraphConfigsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE network_graph_configs CASCADE")
 	s.T().Log("network_graph_configs", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *NetworkEntitiesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE network_entities CASCADE")
 	s.T().Log("network_entities", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/networkpolicies/datastore/internal/store/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *NetworkpoliciesStoreSuite) getTestData(access storage.Access) (*storage.NetworkPolicy, *storage.NetworkPolicy, map[string]testCase) {
+func (s *NetworkpoliciesStoreSuite) getTestData(access ...storage.Access) (*storage.NetworkPolicy, *storage.NetworkPolicy, map[string]testCase) {
 	objA := &storage.NetworkPolicy{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *NetworkpoliciesStoreSuite) getTestData(access storage.Access) (*storage
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *NetworkpoliciesStoreSuite) getTestData(access storage.Access) (*storage
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys(objA.GetNamespace()),
@@ -191,7 +191,7 @@ func (s *NetworkpoliciesStoreSuite) getTestData(access storage.Access) (*storage
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 				)),
@@ -204,7 +204,7 @@ func (s *NetworkpoliciesStoreSuite) getTestData(access storage.Access) (*storage
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -217,7 +217,7 @@ func (s *NetworkpoliciesStoreSuite) getTestData(access storage.Access) (*storage
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -339,7 +339,7 @@ func (s *NetworkpoliciesStoreSuite) TestSACGet() {
 }
 
 func (s *NetworkpoliciesStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -366,7 +366,7 @@ func (s *NetworkpoliciesStoreSuite) TestSACDelete() {
 }
 
 func (s *NetworkpoliciesStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/networkpolicies/datastore/internal/store/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store_test.go
@@ -294,7 +294,7 @@ func (s *NetworkpoliciesStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/networkpolicies/datastore/internal/store/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *NetworkpoliciesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE networkpolicies CASCADE")
 	s.T().Log("networkpolicies", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *NetworkpoliciesundodeploymentsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE networkpoliciesundodeployments CASCADE")
 	s.T().Log("networkpoliciesundodeployments", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *NetworkpolicyapplicationundorecordsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE networkpolicyapplicationundorecords CASCADE")
 	s.T().Log("networkpolicyapplicationundorecords", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/nodecomponent/datastore/store/postgres/store_test.go
+++ b/central/nodecomponent/datastore/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *NodeComponentsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE node_components CASCADE")
 	s.T().Log("node_components", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/nodecomponentcveedge/datastore/store/postgres/store_test.go
+++ b/central/nodecomponentcveedge/datastore/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *NodeComponentsCvesEdgesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE node_components_cves_edges CASCADE")
 	s.T().Log("node_components_cves_edges", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/nodecomponentedge/store/postgres/store_test.go
+++ b/central/nodecomponentedge/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *NodeComponentEdgesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE node_component_edges CASCADE")
 	s.T().Log("node_component_edges", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/notifier/datastore/internal/store/postgres/store_test.go
+++ b/central/notifier/datastore/internal/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *NotifiersStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE notifiers CASCADE")
 	s.T().Log("notifiers", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/pod/store/postgres/store_test.go
+++ b/central/pod/store/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *PodsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE pods CASCADE")
 	s.T().Log("pods", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/pod/store/postgres/store_test.go
+++ b/central/pod/store/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *PodsStoreSuite) getTestData(access storage.Access) (*storage.Pod, *storage.Pod, map[string]testCase) {
+func (s *PodsStoreSuite) getTestData(access ...storage.Access) (*storage.Pod, *storage.Pod, map[string]testCase) {
 	objA := &storage.Pod{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *PodsStoreSuite) getTestData(access storage.Access) (*storage.Pod, *stor
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *PodsStoreSuite) getTestData(access storage.Access) (*storage.Pod, *stor
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys(objA.GetNamespace()),
@@ -191,7 +191,7 @@ func (s *PodsStoreSuite) getTestData(access storage.Access) (*storage.Pod, *stor
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 				)),
@@ -204,7 +204,7 @@ func (s *PodsStoreSuite) getTestData(access storage.Access) (*storage.Pod, *stor
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -217,7 +217,7 @@ func (s *PodsStoreSuite) getTestData(access storage.Access) (*storage.Pod, *stor
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -339,7 +339,7 @@ func (s *PodsStoreSuite) TestSACGet() {
 }
 
 func (s *PodsStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -366,7 +366,7 @@ func (s *PodsStoreSuite) TestSACDelete() {
 }
 
 func (s *PodsStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/pod/store/postgres/store_test.go
+++ b/central/pod/store/postgres/store_test.go
@@ -294,7 +294,7 @@ func (s *PodsStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/policy/store/postgres/store_test.go
+++ b/central/policy/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *PoliciesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE policies CASCADE")
 	s.T().Log("policies", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/policycategory/store/postgres/store_test.go
+++ b/central/policycategory/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *PolicyCategoriesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE policy_categories CASCADE")
 	s.T().Log("policy_categories", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/policycategoryedge/store/postgres/store_test.go
+++ b/central/policycategoryedge/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *PolicyCategoryEdgesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE policy_category_edges CASCADE")
 	s.T().Log("policy_category_edges", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/processbaseline/store/postgres/store_test.go
+++ b/central/processbaseline/store/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *ProcessBaselinesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE process_baselines CASCADE")
 	s.T().Log("process_baselines", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/processbaseline/store/postgres/store_test.go
+++ b/central/processbaseline/store/postgres/store_test.go
@@ -294,7 +294,7 @@ func (s *ProcessBaselinesStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/processbaseline/store/postgres/store_test.go
+++ b/central/processbaseline/store/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *ProcessBaselinesStoreSuite) getTestData(access storage.Access) (*storage.ProcessBaseline, *storage.ProcessBaseline, map[string]testCase) {
+func (s *ProcessBaselinesStoreSuite) getTestData(access ...storage.Access) (*storage.ProcessBaseline, *storage.ProcessBaseline, map[string]testCase) {
 	objA := &storage.ProcessBaseline{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *ProcessBaselinesStoreSuite) getTestData(access storage.Access) (*storag
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *ProcessBaselinesStoreSuite) getTestData(access storage.Access) (*storag
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetKey().GetClusterId()),
 					sac.NamespaceScopeKeys(objA.GetKey().GetNamespace()),
@@ -191,7 +191,7 @@ func (s *ProcessBaselinesStoreSuite) getTestData(access storage.Access) (*storag
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetKey().GetClusterId()),
 				)),
@@ -204,7 +204,7 @@ func (s *ProcessBaselinesStoreSuite) getTestData(access storage.Access) (*storag
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -217,7 +217,7 @@ func (s *ProcessBaselinesStoreSuite) getTestData(access storage.Access) (*storag
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetKey().GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -339,7 +339,7 @@ func (s *ProcessBaselinesStoreSuite) TestSACGet() {
 }
 
 func (s *ProcessBaselinesStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -366,7 +366,7 @@ func (s *ProcessBaselinesStoreSuite) TestSACDelete() {
 }
 
 func (s *ProcessBaselinesStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *ProcessBaselineResultsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE process_baseline_results CASCADE")
 	s.T().Log("process_baseline_results", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *ProcessBaselineResultsStoreSuite) getTestData(access storage.Access) (*storage.ProcessBaselineResults, *storage.ProcessBaselineResults, map[string]testCase) {
+func (s *ProcessBaselineResultsStoreSuite) getTestData(access ...storage.Access) (*storage.ProcessBaselineResults, *storage.ProcessBaselineResults, map[string]testCase) {
 	objA := &storage.ProcessBaselineResults{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *ProcessBaselineResultsStoreSuite) getTestData(access storage.Access) (*
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *ProcessBaselineResultsStoreSuite) getTestData(access storage.Access) (*
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys(objA.GetNamespace()),
@@ -191,7 +191,7 @@ func (s *ProcessBaselineResultsStoreSuite) getTestData(access storage.Access) (*
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 				)),
@@ -204,7 +204,7 @@ func (s *ProcessBaselineResultsStoreSuite) getTestData(access storage.Access) (*
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -217,7 +217,7 @@ func (s *ProcessBaselineResultsStoreSuite) getTestData(access storage.Access) (*
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -339,7 +339,7 @@ func (s *ProcessBaselineResultsStoreSuite) TestSACGet() {
 }
 
 func (s *ProcessBaselineResultsStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -366,7 +366,7 @@ func (s *ProcessBaselineResultsStoreSuite) TestSACDelete() {
 }
 
 func (s *ProcessBaselineResultsStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
@@ -294,7 +294,7 @@ func (s *ProcessBaselineResultsStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/processindicator/store/postgres/store_test.go
+++ b/central/processindicator/store/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *ProcessIndicatorsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE process_indicators CASCADE")
 	s.T().Log("process_indicators", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/processindicator/store/postgres/store_test.go
+++ b/central/processindicator/store/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *ProcessIndicatorsStoreSuite) getTestData(access storage.Access) (*storage.ProcessIndicator, *storage.ProcessIndicator, map[string]testCase) {
+func (s *ProcessIndicatorsStoreSuite) getTestData(access ...storage.Access) (*storage.ProcessIndicator, *storage.ProcessIndicator, map[string]testCase) {
 	objA := &storage.ProcessIndicator{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *ProcessIndicatorsStoreSuite) getTestData(access storage.Access) (*stora
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *ProcessIndicatorsStoreSuite) getTestData(access storage.Access) (*stora
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys(objA.GetNamespace()),
@@ -191,7 +191,7 @@ func (s *ProcessIndicatorsStoreSuite) getTestData(access storage.Access) (*stora
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 				)),
@@ -204,7 +204,7 @@ func (s *ProcessIndicatorsStoreSuite) getTestData(access storage.Access) (*stora
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -217,7 +217,7 @@ func (s *ProcessIndicatorsStoreSuite) getTestData(access storage.Access) (*stora
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -339,7 +339,7 @@ func (s *ProcessIndicatorsStoreSuite) TestSACGet() {
 }
 
 func (s *ProcessIndicatorsStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -366,7 +366,7 @@ func (s *ProcessIndicatorsStoreSuite) TestSACDelete() {
 }
 
 func (s *ProcessIndicatorsStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/processindicator/store/postgres/store_test.go
+++ b/central/processindicator/store/postgres/store_test.go
@@ -294,7 +294,7 @@ func (s *ProcessIndicatorsStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/processlisteningonport/store/postgres/store_test.go
+++ b/central/processlisteningonport/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ListeningEndpointsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE listening_endpoints CASCADE")
 	s.T().Log("listening_endpoints", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/rbac/k8srole/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srole/internal/store/postgres/store_test.go
@@ -294,7 +294,7 @@ func (s *K8sRolesStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/rbac/k8srole/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srole/internal/store/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *K8sRolesStoreSuite) getTestData(access storage.Access) (*storage.K8SRole, *storage.K8SRole, map[string]testCase) {
+func (s *K8sRolesStoreSuite) getTestData(access ...storage.Access) (*storage.K8SRole, *storage.K8SRole, map[string]testCase) {
 	objA := &storage.K8SRole{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *K8sRolesStoreSuite) getTestData(access storage.Access) (*storage.K8SRol
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *K8sRolesStoreSuite) getTestData(access storage.Access) (*storage.K8SRol
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys(objA.GetNamespace()),
@@ -191,7 +191,7 @@ func (s *K8sRolesStoreSuite) getTestData(access storage.Access) (*storage.K8SRol
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 				)),
@@ -204,7 +204,7 @@ func (s *K8sRolesStoreSuite) getTestData(access storage.Access) (*storage.K8SRol
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -217,7 +217,7 @@ func (s *K8sRolesStoreSuite) getTestData(access storage.Access) (*storage.K8SRol
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -339,7 +339,7 @@ func (s *K8sRolesStoreSuite) TestSACGet() {
 }
 
 func (s *K8sRolesStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -366,7 +366,7 @@ func (s *K8sRolesStoreSuite) TestSACDelete() {
 }
 
 func (s *K8sRolesStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/rbac/k8srole/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srole/internal/store/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *K8sRolesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE k8s_roles CASCADE")
 	s.T().Log("k8s_roles", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *RoleBindingsStoreSuite) getTestData(access storage.Access) (*storage.K8SRoleBinding, *storage.K8SRoleBinding, map[string]testCase) {
+func (s *RoleBindingsStoreSuite) getTestData(access ...storage.Access) (*storage.K8SRoleBinding, *storage.K8SRoleBinding, map[string]testCase) {
 	objA := &storage.K8SRoleBinding{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *RoleBindingsStoreSuite) getTestData(access storage.Access) (*storage.K8
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *RoleBindingsStoreSuite) getTestData(access storage.Access) (*storage.K8
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys(objA.GetNamespace()),
@@ -191,7 +191,7 @@ func (s *RoleBindingsStoreSuite) getTestData(access storage.Access) (*storage.K8
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 				)),
@@ -204,7 +204,7 @@ func (s *RoleBindingsStoreSuite) getTestData(access storage.Access) (*storage.K8
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -217,7 +217,7 @@ func (s *RoleBindingsStoreSuite) getTestData(access storage.Access) (*storage.K8
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -339,7 +339,7 @@ func (s *RoleBindingsStoreSuite) TestSACGet() {
 }
 
 func (s *RoleBindingsStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -366,7 +366,7 @@ func (s *RoleBindingsStoreSuite) TestSACDelete() {
 }
 
 func (s *RoleBindingsStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
@@ -294,7 +294,7 @@ func (s *RoleBindingsStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *RoleBindingsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE role_bindings CASCADE")
 	s.T().Log("role_bindings", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/reports/config/store/postgres/store_test.go
+++ b/central/reports/config/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ReportConfigurationsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE report_configurations CASCADE")
 	s.T().Log("report_configurations", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/reports/snapshot/datastore/store/postgres/store_test.go
+++ b/central/reports/snapshot/datastore/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ReportSnapshotsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE report_snapshots CASCADE")
 	s.T().Log("report_snapshots", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/resourcecollection/datastore/store/postgres/store_test.go
+++ b/central/resourcecollection/datastore/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *CollectionsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE collections CASCADE")
 	s.T().Log("collections", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/risk/datastore/internal/store/postgres/store_test.go
+++ b/central/risk/datastore/internal/store/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *RisksStoreSuite) getTestData(access storage.Access) (*storage.Risk, *storage.Risk, map[string]testCase) {
+func (s *RisksStoreSuite) getTestData(access ...storage.Access) (*storage.Risk, *storage.Risk, map[string]testCase) {
 	objA := &storage.Risk{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *RisksStoreSuite) getTestData(access storage.Access) (*storage.Risk, *st
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *RisksStoreSuite) getTestData(access storage.Access) (*storage.Risk, *st
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetSubject().GetClusterId()),
 					sac.NamespaceScopeKeys(objA.GetSubject().GetNamespace()),
@@ -191,7 +191,7 @@ func (s *RisksStoreSuite) getTestData(access storage.Access) (*storage.Risk, *st
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetSubject().GetClusterId()),
 				)),
@@ -204,7 +204,7 @@ func (s *RisksStoreSuite) getTestData(access storage.Access) (*storage.Risk, *st
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -217,7 +217,7 @@ func (s *RisksStoreSuite) getTestData(access storage.Access) (*storage.Risk, *st
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetSubject().GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -339,7 +339,7 @@ func (s *RisksStoreSuite) TestSACGet() {
 }
 
 func (s *RisksStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -366,7 +366,7 @@ func (s *RisksStoreSuite) TestSACDelete() {
 }
 
 func (s *RisksStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/risk/datastore/internal/store/postgres/store_test.go
+++ b/central/risk/datastore/internal/store/postgres/store_test.go
@@ -294,7 +294,7 @@ func (s *RisksStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/risk/datastore/internal/store/postgres/store_test.go
+++ b/central/risk/datastore/internal/store/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *RisksStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE risks CASCADE")
 	s.T().Log("risks", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/role/store/permissionset/postgres/store_test.go
+++ b/central/role/store/permissionset/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *PermissionSetsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE permission_sets CASCADE")
 	s.T().Log("permission_sets", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/role/store/role/postgres/store_test.go
+++ b/central/role/store/role/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *RolesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE roles CASCADE")
 	s.T().Log("roles", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/role/store/simpleaccessscope/postgres/store_test.go
+++ b/central/role/store/simpleaccessscope/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *SimpleAccessScopesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE simple_access_scopes CASCADE")
 	s.T().Log("simple_access_scopes", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/secret/internal/store/postgres/store_test.go
+++ b/central/secret/internal/store/postgres/store_test.go
@@ -294,7 +294,7 @@ func (s *SecretsStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/secret/internal/store/postgres/store_test.go
+++ b/central/secret/internal/store/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *SecretsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE secrets CASCADE")
 	s.T().Log("secrets", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/secret/internal/store/postgres/store_test.go
+++ b/central/secret/internal/store/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *SecretsStoreSuite) getTestData(access storage.Access) (*storage.Secret, *storage.Secret, map[string]testCase) {
+func (s *SecretsStoreSuite) getTestData(access ...storage.Access) (*storage.Secret, *storage.Secret, map[string]testCase) {
 	objA := &storage.Secret{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *SecretsStoreSuite) getTestData(access storage.Access) (*storage.Secret,
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *SecretsStoreSuite) getTestData(access storage.Access) (*storage.Secret,
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys(objA.GetNamespace()),
@@ -191,7 +191,7 @@ func (s *SecretsStoreSuite) getTestData(access storage.Access) (*storage.Secret,
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 				)),
@@ -204,7 +204,7 @@ func (s *SecretsStoreSuite) getTestData(access storage.Access) (*storage.Secret,
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -217,7 +217,7 @@ func (s *SecretsStoreSuite) getTestData(access storage.Access) (*storage.Secret,
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -339,7 +339,7 @@ func (s *SecretsStoreSuite) TestSACGet() {
 }
 
 func (s *SecretsStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -366,7 +366,7 @@ func (s *SecretsStoreSuite) TestSACDelete() {
 }
 
 func (s *SecretsStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/serviceaccount/internal/store/postgres/store_test.go
+++ b/central/serviceaccount/internal/store/postgres/store_test.go
@@ -38,6 +38,7 @@ func (s *ServiceAccountsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE service_accounts CASCADE")
 	s.T().Log("service_accounts", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/serviceaccount/internal/store/postgres/store_test.go
+++ b/central/serviceaccount/internal/store/postgres/store_test.go
@@ -137,7 +137,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *ServiceAccountsStoreSuite) getTestData(access storage.Access) (*storage.ServiceAccount, *storage.ServiceAccount, map[string]testCase) {
+func (s *ServiceAccountsStoreSuite) getTestData(access ...storage.Access) (*storage.ServiceAccount, *storage.ServiceAccount, map[string]testCase) {
 	objA := &storage.ServiceAccount{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -164,7 +164,7 @@ func (s *ServiceAccountsStoreSuite) getTestData(access storage.Access) (*storage
 		withNoAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 				)),
@@ -177,7 +177,7 @@ func (s *ServiceAccountsStoreSuite) getTestData(access storage.Access) (*storage
 		withAccess: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys(objA.GetNamespace()),
@@ -191,7 +191,7 @@ func (s *ServiceAccountsStoreSuite) getTestData(access storage.Access) (*storage
 		withAccessToCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 				)),
@@ -204,7 +204,7 @@ func (s *ServiceAccountsStoreSuite) getTestData(access storage.Access) (*storage
 		withAccessToDifferentCluster: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 				)),
@@ -217,7 +217,7 @@ func (s *ServiceAccountsStoreSuite) getTestData(access storage.Access) (*storage
 		withAccessToDifferentNs: {
 			context: sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(objA.GetClusterId()),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -339,7 +339,7 @@ func (s *ServiceAccountsStoreSuite) TestSACGet() {
 }
 
 func (s *ServiceAccountsStoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -366,7 +366,7 @@ func (s *ServiceAccountsStoreSuite) TestSACDelete() {
 }
 
 func (s *ServiceAccountsStoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/central/serviceaccount/internal/store/postgres/store_test.go
+++ b/central/serviceaccount/internal/store/postgres/store_test.go
@@ -294,7 +294,7 @@ func (s *ServiceAccountsStoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }

--- a/central/serviceidentities/internal/store/postgres/store_test.go
+++ b/central/serviceidentities/internal/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *ServiceIdentitiesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE service_identities CASCADE")
 	s.T().Log("service_identities", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/signatureintegration/store/postgres/store_test.go
+++ b/central/signatureintegration/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *SignatureIntegrationsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE signature_integrations CASCADE")
 	s.T().Log("signature_integrations", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *VulnerabilityRequestsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE vulnerability_requests CASCADE")
 	s.T().Log("vulnerability_requests", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/central/watchedimage/datastore/internal/store/postgres/store_test.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *WatchedImagesStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE watched_images CASCADE")
 	s.T().Log("watched_images", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *TestStructsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_structs CASCADE")
 	s.T().Log("test_structs", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -181,7 +181,7 @@ type testCase struct {
 	expectedWriteError     error
 }
 
-func (s *{{$namePrefix}}StoreSuite) getTestData(access storage.Access) (*{{.Type}}, *{{.Type}}, map[string]testCase) {
+func (s *{{$namePrefix}}StoreSuite) getTestData(access ...storage.Access) (*{{.Type}}, *{{.Type}}, map[string]testCase) {
 	objA := &{{.Type}}{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
@@ -208,7 +208,7 @@ func (s *{{$namePrefix}}StoreSuite) getTestData(access storage.Access) (*{{.Type
 		withNoAccessToCluster: {
 			context:                sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys(uuid.Nil.String()),
 			)),
@@ -221,7 +221,7 @@ func (s *{{$namePrefix}}StoreSuite) getTestData(access storage.Access) (*{{.Type
 		withAccess: {
 			context:                sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys({{ "objA" | .Obj.GetClusterID }}),
 					{{- if .Obj.IsNamespaceScope }}
@@ -237,7 +237,7 @@ func (s *{{$namePrefix}}StoreSuite) getTestData(access storage.Access) (*{{.Type
 		withAccessToCluster: {
 			context:                sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys({{ "objA" | .Obj.GetClusterID }}),
 			)),
@@ -250,7 +250,7 @@ func (s *{{$namePrefix}}StoreSuite) getTestData(access storage.Access) (*{{.Type
 		withAccessToDifferentCluster: {
 			context:                sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys("caaaaaaa-bbbb-4011-0000-111111111111"),
 			)),
@@ -263,7 +263,7 @@ func (s *{{$namePrefix}}StoreSuite) getTestData(access storage.Access) (*{{.Type
 		withAccessToDifferentNs: {
 			context:                sac.WithGlobalAccessScopeChecker(context.Background(),
 				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(access),
+					sac.AccessModeScopeKeys(access...),
 					sac.ResourceScopeKeys(targetResource),
 					sac.ClusterScopeKeys({{ "objA" | .Obj.GetClusterID }}),
 					sac.NamespaceScopeKeys("unknown ns"),
@@ -395,7 +395,7 @@ func (s *{{$namePrefix}}StoreSuite) TestSACGet() {
 }
 
 func (s *{{$namePrefix}}StoreSuite) TestSACDelete() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
@@ -423,7 +423,7 @@ func (s *{{$namePrefix}}StoreSuite) TestSACDelete() {
 
 {{ if eq (len .Schema.PrimaryKeys) 1 }}
 func (s *{{$namePrefix}}StoreSuite) TestSACDeleteMany() {
-	objA, objB, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			s.SetupTest()

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -339,7 +339,6 @@ func (s *{{$namePrefix}}StoreSuite) TestSACWalk() {
 	}
 }
 
-{{ if eq (len .Schema.PrimaryKeys) 1 }}
 func (s *{{$namePrefix}}StoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
@@ -349,11 +348,10 @@ func (s *{{$namePrefix}}StoreSuite) TestSACGetIDs() {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers, err := s.store.GetIDs(testCase.context)
 			assert.NoError(t, err)
-			assert.EqualValues(t, testCase.expectedObjIDs, identifiers)
+			assert.ElementsMatch(t, testCase.expectedObjIDs, identifiers)
 		})
 	}
 }
-{{ end }}
 
 func (s *{{$namePrefix}}StoreSuite) TestSACExists() {
 	objA, _, testCases := s.getTestData(storage.Access_READ_ACCESS)
@@ -421,7 +419,6 @@ func (s *{{$namePrefix}}StoreSuite) TestSACDelete() {
 	}
 }
 
-{{ if eq (len .Schema.PrimaryKeys) 1 }}
 func (s *{{$namePrefix}}StoreSuite) TestSACDeleteMany() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
@@ -471,7 +468,6 @@ func (s *{{$namePrefix}}StoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
-{{ end }}
 
 {{end}}
 {{- end }}

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -54,6 +54,7 @@ func (s *{{$namePrefix}}StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE {{ .Schema.Table }} CASCADE")
 	s.T().Log("{{ .Schema.Table }}", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *TestSingleKeyStructsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_single_key_structs CASCADE")
 	s.T().Log("test_single_key_structs", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
@@ -35,6 +35,7 @@ func (s *TestChild1StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_child1 CASCADE")
 	s.T().Log("test_child1", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store_test.go
@@ -35,6 +35,7 @@ func (s *TestChild1P4StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_child1_p4 CASCADE")
 	s.T().Log("test_child1_p4", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store_test.go
@@ -35,6 +35,7 @@ func (s *TestChild2StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_child2 CASCADE")
 	s.T().Log("test_child2", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store_test.go
@@ -35,6 +35,7 @@ func (s *TestG2GrandChild1StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_g2_grand_child1 CASCADE")
 	s.T().Log("test_g2_grand_child1", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
@@ -35,6 +35,7 @@ func (s *TestG3GrandChild1StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_g3_grand_child1 CASCADE")
 	s.T().Log("test_g3_grand_child1", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
@@ -35,6 +35,7 @@ func (s *TestGGrandChild1StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_g_grand_child1 CASCADE")
 	s.T().Log("test_g_grand_child1", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store_test.go
@@ -35,6 +35,7 @@ func (s *TestGrandChild1StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_grand_child1 CASCADE")
 	s.T().Log("test_grand_child1", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
@@ -35,6 +35,7 @@ func (s *TestGrandparentsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_grandparents CASCADE")
 	s.T().Log("test_grandparents", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store_test.go
@@ -35,6 +35,7 @@ func (s *TestParent1StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_parent1 CASCADE")
 	s.T().Log("test_parent1", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store_test.go
@@ -35,6 +35,7 @@ func (s *TestParent2StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_parent2 CASCADE")
 	s.T().Log("test_parent2", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store_test.go
@@ -35,6 +35,7 @@ func (s *TestParent3StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_parent3 CASCADE")
 	s.T().Log("test_parent3", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store_test.go
@@ -35,6 +35,7 @@ func (s *TestParent4StoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_parent4 CASCADE")
 	s.T().Log("test_parent4", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store_test.go
@@ -35,6 +35,7 @@ func (s *TestShortCircuitsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_short_circuits CASCADE")
 	s.T().Log("test_short_circuits", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store_test.go
@@ -35,6 +35,7 @@ func (s *TestSingleUUIDKeyStructsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
 	tag, err := s.testDB.Exec(ctx, "TRUNCATE test_single_uuid_key_structs CASCADE")
 	s.T().Log("test_single_uuid_key_structs", tag)
+	s.store = New(s.testDB.DB)
 	s.NoError(err)
 }
 


### PR DESCRIPTION
## Description

With the possible introduction of cached stores, it would make sense to re-instantiate the store for each test so the cache is in sync with the DB for the test.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
