### PR TITLE
ROX-21072: Limit RHTAP PR workflows if branch name contains "rhtap"

### DIFF
--- a/.tekton/central-db-pull-request.yaml
+++ b/.tekton/central-db-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && source_branch.contains("rhtap")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/central-db-pull-request.yaml
+++ b/.tekton/central-db-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
+    # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && source_branch.contains("rhtap")
   creationTimestamp: null
   labels:

--- a/.tekton/roxctl-pull-request.yaml
+++ b/.tekton/roxctl-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
+    # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && source_branch.contains("rhtap")
   creationTimestamp: null
   labels:

--- a/.tekton/roxctl-pull-request.yaml
+++ b/.tekton/roxctl-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-event: '[pull_request]'
-    pipelinesascode.tekton.dev/on-target-branch: '[*]'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && source_branch.contains("rhtap")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs


### PR DESCRIPTION
## Description

Was requested by colleagues in https://redhat-internal.slack.com/archives/C0321S70YK1/p1700742096346419

`contains` function is mentioned here https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions

## Checklist
- [ ] Investigated and inspected CI test results

None of these needed, none will be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Confirmed it works by seeing RHTAP here and not seeing it in https://github.com/stackrox/stackrox/pull/8768.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
