### PR TITLE
chore(CI): Add python dev tooling for openshift-ci

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
   openshift-ci-lint:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.61-8-g0aa20f230a
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.62
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
   openshift-ci-lint:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.61
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.61-8-g0aa20f230a
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,13 +1,19 @@
-name: Lint GitHub Actions workflows
+name: Lint
 on:
   push:
+    tags:
+    - '*'
     branches:
-      - master
-      - main
+    - master
+    - release-*
   pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
 
 jobs:
-  actionlint:
+  github-actions-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,9 +24,26 @@ jobs:
       - name: Check workflow files
         run: ${{ steps.get_actionlint.outputs.executable }} -color
         shell: bash
-  shellcheck:
+
+  github-actions-shellcheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Check scripts with shellcheck
         run: shellcheck -P SCRIPTDIR -x ./.github/workflows/scripts/*.sh
+
+  openshift-ci-lint:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.61
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ./.github/actions/job-preamble
+
+      - name: Pylint
+        run: make -C .openshift-ci lint

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -74,7 +74,7 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.61
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.61-8-g0aa20f230a
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -74,7 +74,7 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.61-8-g0aa20f230a
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.62
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.openshift-ci/.gitignore
+++ b/.openshift-ci/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 *.pyc
+.dev-venv

--- a/.openshift-ci/.pylintrc
+++ b/.openshift-ci/.pylintrc
@@ -323,13 +323,13 @@ ignore-comments=yes
 ignore-docstrings=yes
 
 # Imports are removed from the similarity computation
-ignore-imports=no
+ignore-imports=yes
 
 # Signatures are removed from the similarity computation
 ignore-signatures=no
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=8
 
 
 [SPELLING]

--- a/.openshift-ci/.pylintrc
+++ b/.openshift-ci/.pylintrc
@@ -278,7 +278,8 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=90
+# Note: Must be kept in sync with --max-line-length for pycodestyle in Makefile
+max-line-length=120
 
 # Maximum number of lines in a module.
 max-module-lines=1000

--- a/.openshift-ci/.pylintrc
+++ b/.openshift-ci/.pylintrc
@@ -278,7 +278,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=90
 
 # Maximum number of lines in a module.
 max-module-lines=1000

--- a/.openshift-ci/.pylintrc
+++ b/.openshift-ci/.pylintrc
@@ -78,7 +78,8 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=raw-checker-failed,
+disable=bad-continuation,
+        raw-checker-failed,
         bad-inline-option,
         locally-disabled,
         file-ignored,

--- a/.openshift-ci/Makefile
+++ b/.openshift-ci/Makefile
@@ -32,4 +32,4 @@ fix-style: $(VENV)/bin/activate
 
 .PHONY: lint
 lint: $(VENV)/bin/activate
-	$(PYLINT) --rcfile .pylintrc --ignore=$(VENV) *.py **/*.py
+	$(PYLINT) --rcfile .pylintrc --ignore=$(VENV) *.py **/*.py ../scripts/ci/jobs/*.py

--- a/.openshift-ci/Makefile
+++ b/.openshift-ci/Makefile
@@ -25,7 +25,8 @@ endif
 
 .PHONY: style
 style: $(VENV)/bin/activate
-	$(PYCODESTYLE) --max-line-length=90 --exclude=$(VENV) $(PY_SRCS)
+	@# (--max-line-length must be kept in sync with max-line-length in .pylintrc)
+	$(PYCODESTYLE) --max-line-length=120 --exclude=$(VENV) $(PY_SRCS)
 
 .PHONY: fix-style
 fix-style: $(VENV)/bin/activate

--- a/.openshift-ci/Makefile
+++ b/.openshift-ci/Makefile
@@ -1,3 +1,4 @@
+PY_SRCS := *.py **/*.py ../scripts/ci/jobs/*.py
 VENV := .dev-venv
 
 ifdef CI
@@ -24,12 +25,12 @@ endif
 
 .PHONY: style
 style: $(VENV)/bin/activate
-	$(PYCODESTYLE) --max-line-length=120 --exclude=$(VENV) .
+	$(PYCODESTYLE) --max-line-length=90 --exclude=$(VENV) $(PY_SRCS)
 
 .PHONY: fix-style
 fix-style: $(VENV)/bin/activate
-	$(AUTOPEP8) --in-place --exclude=$(VENV) *.py **/*.py
+	$(AUTOPEP8) --in-place --exclude=$(VENV) $(PY_SRCS)
 
 .PHONY: lint
 lint: $(VENV)/bin/activate
-	$(PYLINT) --rcfile .pylintrc --ignore=$(VENV) *.py **/*.py ../scripts/ci/jobs/*.py
+	$(PYLINT) --rcfile .pylintrc --ignore=$(VENV) $(PY_SRCS)

--- a/.openshift-ci/Makefile
+++ b/.openshift-ci/Makefile
@@ -1,0 +1,35 @@
+VENV := .dev-venv
+
+ifdef CI
+	PYCODESTYLE=pycodestyle
+	AUTOPEP8=autopep8
+	PYLINT=pylint
+else
+	PYCODESTYLE=$(VENV)/bin/pycodestyle
+	AUTOPEP8=$(VENV)/bin/autopep8
+	PYLINT=$(VENV)/bin/pylint
+endif
+
+.PHONY: all
+all: style lint
+
+$(VENV)/bin/activate: dev-requirements.txt
+ifdef CI
+	$(PYCODESTYLE) --version
+	$(PYLINT) --version
+else
+	python3 -m venv $(VENV)
+	$(VENV)/bin/pip3 --quiet --require-virtualenv --no-input --disable-pip-version-check install -r dev-requirements.txt
+endif
+
+.PHONY: style
+style: $(VENV)/bin/activate
+	$(PYCODESTYLE) --max-line-length=120 --exclude=$(VENV) .
+
+.PHONY: fix-style
+fix-style: $(VENV)/bin/activate
+	$(AUTOPEP8) --in-place --exclude=$(VENV) *.py **/*.py
+
+.PHONY: lint
+lint: $(VENV)/bin/activate
+	$(PYLINT) --rcfile .pylintrc --ignore=$(VENV) *.py **/*.py

--- a/.openshift-ci/README.md
+++ b/.openshift-ci/README.md
@@ -1,18 +1,30 @@
-This folder supports OpenShift CI from https://github.com/openshift/release/tree/master/ci-operator/config/stackrox/stackrox
+This folder supports OpenShift CI for this repo [config](https://github.com/openshift/release/tree/master/ci-operator/config/stackrox/stackrox).
 
-- [dispatch.sh](dispatch.sh) is the entrypoint for tests and builds (binary_build_commands, test_binary_build_commands).
-- [build/](build) is for openshift/release image support.
-- *.py provides some semantics useful to e2e and system tests e.g.:
-  - create a cluster
-  - run test
-  - gather and examine state
-  - teardown
+stackrox/stackrox jobs in openshift/release typically execute the following steps:
 
-## Workflow aliases for test/format/lint
+- [begin.sh](begin.sh)
+- An automation-flavors create() depending on cluster type. [optional: e.g. with GKE create() is handled in dispatch.sh]
+- [dispatch.sh](dispatch.sh) is the entrypoint for tests. Depending on the job, this will run one of the scripts in [scripts/ci/jobs](../scripts/ci/jobs/).
+- An automation-flavors destroy() depending on cluster type.
+- [end.sh](end.sh)
+
+The `*.py` in this folder provides some semantics useful to e2e and system tests e.g.:
+
+- create a cluster
+- run test
+- gather and examine state
+- teardown
+
+## Python Style & Lint
+
+Python code is expected to be PEP8 and checked with
+[pycodestyle](https://pypi.org/project/pycodestyle/). Linting is via
+[pylint](https://pypi.org/project/pylint/).
+
+For dev workflow there are make targets:
 
 ```
-alias osci='cdrox; cd .openshift-ci'
-alias osci-format='osci; ack -f --python | entr black .'
-alias osci-lint='osci; ack -f --python | entr pylint --rcfile .pylintrc *.py tests'
-alias osci-test='osci; ack -f --python --shell | entr python -m unittest discover'
+make style
+make fix-style
+make lint
 ```

--- a/.openshift-ci/base_qa_e2e_test.py
+++ b/.openshift-ci/base_qa_e2e_test.py
@@ -4,7 +4,12 @@
 Run QA e2e tests against a given cluster.
 """
 from pre_tests import PreSystemTests
-from ci_tests import QaE2eTestPart1, QaE2eTestPart2, QaE2eDBBackupRestoreTest, CustomSetTest
+from ci_tests import (
+    QaE2eTestPart1,
+    QaE2eTestPart2,
+    QaE2eDBBackupRestoreTest,
+    CustomSetTest,
+)
 from post_tests import PostClusterTest, CheckStackroxLogs, FinalPost
 from runners import ClusterTestSetsRunner
 
@@ -45,6 +50,7 @@ def make_qa_e2e_test_runner(cluster):
             store_qa_tests_data=True,
         ),
     )
+
 
 def make_qa_e2e_test_runner_custom(cluster):
     return ClusterTestSetsRunner(

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -23,7 +23,9 @@ class BaseTest:
                     raise RuntimeError(f"Test failed: exit {exitstatus}")
             except subprocess.TimeoutExpired as err:
                 # Kill child processes as we cannot rely on bash scripts to handle signals and stop tests
-                subprocess.run(["/usr/bin/pkill", "-P", str(cmd.pid)], check=True, timeout=5)
+                subprocess.run(
+                    ["/usr/bin/pkill", "-P", str(cmd.pid)], check=True, timeout=5
+                )
                 # Then kill the test command
                 popen_graceful_kill(cmd)
                 raise err
@@ -45,16 +47,25 @@ class UpgradeTest(BaseTest):
 
         def set_dirs_after_start():
             # let post test know where logs are
-            self.test_outputs = [UpgradeTest.TEST_SENSOR_OUTPUT_DIR, UpgradeTest.TEST_OUTPUT_DIR]
+            self.test_outputs = [
+                UpgradeTest.TEST_SENSOR_OUTPUT_DIR,
+                UpgradeTest.TEST_OUTPUT_DIR,
+            ]
 
         self.run_with_graceful_kill(
-            ["tests/upgrade/postgres_sensor_run.sh", UpgradeTest.TEST_SENSOR_OUTPUT_DIR],
+            [
+                "tests/upgrade/postgres_sensor_run.sh",
+                UpgradeTest.TEST_SENSOR_OUTPUT_DIR,
+            ],
             UpgradeTest.TEST_TIMEOUT,
             post_start_hook=set_dirs_after_start,
         )
 
         self.run_with_graceful_kill(
-            ["tests/upgrade/legacy_to_postgres_run.sh", UpgradeTest.TEST_LEGACY_OUTPUT_DIR],
+            [
+                "tests/upgrade/legacy_to_postgres_run.sh",
+                UpgradeTest.TEST_LEGACY_OUTPUT_DIR,
+            ],
             UpgradeTest.TEST_TIMEOUT,
             post_start_hook=set_dirs_after_start,
         )
@@ -74,11 +85,18 @@ class OperatorE2eTest(BaseTest):
     def __init__(self, *args, **kwargs):
         super(OperatorE2eTest, self).__init__(*args, **kwargs)
         self._operator_cluster_type = kwargs.get(
-            "operator_cluster_type", OperatorE2eTest.OPERATOR_CLUSTER_TYPE_OPENSHIFT4)
+            "operator_cluster_type", OperatorE2eTest.OPERATOR_CLUSTER_TYPE_OPENSHIFT4
+        )
 
     def run(self):
-        if self._operator_cluster_type != OperatorE2eTest.OPERATOR_CLUSTER_TYPE_OPENSHIFT4:
-            print("Running on cluster type %s, installing OLM" % self._operator_cluster_type)
+        if (
+            self._operator_cluster_type
+            != OperatorE2eTest.OPERATOR_CLUSTER_TYPE_OPENSHIFT4
+        ):
+            print(
+                "Running on cluster type %s, installing OLM"
+                % self._operator_cluster_type
+            )
             self.run_with_graceful_kill(
                 ["make", "-C", "operator", "olm-install"],
                 OperatorE2eTest.TEST_TIMEOUT_SEC,
@@ -120,7 +138,8 @@ class QaE2eTestCompatibility(BaseTest):
         print("Executing qa-tests-compatibility tests")
 
         self.run_with_graceful_kill(
-            ["qa-tests-backend/scripts/run-compatibility.sh"], QaE2eTestCompatibility.TEST_TIMEOUT
+            ["qa-tests-backend/scripts/run-compatibility.sh"],
+            QaE2eTestCompatibility.TEST_TIMEOUT,
         )
 
 
@@ -215,7 +234,6 @@ class SensorIntegrationOCP(SensorIntegration):
         print("Skipping the Sensor Integration Tests for OCP")
 
 
-
 class ScaleTest(BaseTest):
     TEST_TIMEOUT = 90 * 60
     PPROF_ZIP_OUTPUT = "/tmp/scale-test/pprof.zip"
@@ -232,6 +250,7 @@ class ScaleTest(BaseTest):
             ScaleTest.TEST_TIMEOUT,
             post_start_hook=set_dirs_after_start,
         )
+
 
 class CustomSetTest(BaseTest):
     TEST_TIMEOUT = 240 * 60

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -10,7 +10,7 @@ from common import popen_graceful_kill
 
 
 class BaseTest:
-    def __init__(self, *args, **kwargs):
+    def __init__(self):
         self.test_outputs = []
 
     def run_with_graceful_kill(self, args, timeout, post_start_hook=None):
@@ -22,7 +22,8 @@ class BaseTest:
                 if exitstatus != 0:
                     raise RuntimeError(f"Test failed: exit {exitstatus}")
             except subprocess.TimeoutExpired as err:
-                # Kill child processes as we cannot rely on bash scripts to handle signals and stop tests
+                # Kill child processes as we cannot rely on bash scripts to
+                # handle signals and stop tests
                 subprocess.run(
                     ["/usr/bin/pkill", "-P", str(cmd.pid)], check=True, timeout=5
                 )
@@ -82,11 +83,9 @@ class OperatorE2eTest(BaseTest):
     TEST_TIMEOUT_SEC = 60 * 60 * 2
     OPERATOR_CLUSTER_TYPE_OPENSHIFT4 = "openshift4"
 
-    def __init__(self, *args, **kwargs):
-        super(OperatorE2eTest, self).__init__(*args, **kwargs)
-        self._operator_cluster_type = kwargs.get(
-            "operator_cluster_type", OperatorE2eTest.OPERATOR_CLUSTER_TYPE_OPENSHIFT4
-        )
+    def __init__(self, operator_cluster_type=OPERATOR_CLUSTER_TYPE_OPENSHIFT4):
+        super().__init__()
+        self._operator_cluster_type = operator_cluster_type
 
     def run(self):
         if (
@@ -94,8 +93,7 @@ class OperatorE2eTest(BaseTest):
             != OperatorE2eTest.OPERATOR_CLUSTER_TYPE_OPENSHIFT4
         ):
             print(
-                "Running on cluster type %s, installing OLM"
-                % self._operator_cluster_type
+                f"Running on cluster type {self._operator_cluster_type}, installing OLM"
             )
             self.run_with_graceful_kill(
                 ["make", "-C", "operator", "olm-install"],

--- a/.openshift-ci/clusters.py
+++ b/.openshift-ci/clusters.py
@@ -58,7 +58,8 @@ class GKECluster:
             try:
                 exitstatus = cmd.wait(GKECluster.PROVISION_TIMEOUT)
                 if exitstatus != 0:
-                    raise RuntimeError(f"Cluster provision failed: exit {exitstatus}")
+                    raise RuntimeError(
+                        f"Cluster provision failed: exit {exitstatus}")
             except subprocess.TimeoutExpired as err:
                 popen_graceful_kill(cmd)
                 raise err

--- a/.openshift-ci/common.py
+++ b/.openshift-ci/common.py
@@ -6,10 +6,11 @@ def popen_graceful_kill(cmd):
     cmd.terminate()
     try:
         cmd.wait(5)
-        print(f"Terminated")
+        print("Terminated")
     except subprocess.TimeoutExpired as err:
+        print(f"Exception raised waiting after SIGTERM to {cmd.args}, {err}")
         # SIGKILL if necessary
         print(f"Sending SIGKILL to {cmd.args}")
         cmd.kill()
         cmd.wait(5)
-        print(f"Terminated")
+        print("Terminated")

--- a/.openshift-ci/compatibility_test.py
+++ b/.openshift-ci/compatibility_test.py
@@ -9,6 +9,7 @@ from ci_tests import QaE2eTestCompatibility
 from post_tests import PostClusterTest, CheckStackroxLogs, FinalPost
 from runners import ClusterTestSetsRunner
 
+
 def make_compatibility_test_runner(cluster):
     return ClusterTestSetsRunner(
         cluster=cluster,
@@ -18,8 +19,8 @@ def make_compatibility_test_runner(cluster):
                 "pre_test": PreSystemTests(),
                 "test": QaE2eTestCompatibility(),
                 "post_test": PostClusterTest(
-                   check_stackrox_logs=True,
-                   artifact_destination_prefix="compatibility",
+                    check_stackrox_logs=True,
+                    artifact_destination_prefix="compatibility",
                 ),
             },
         ],

--- a/.openshift-ci/compatibility_test.py
+++ b/.openshift-ci/compatibility_test.py
@@ -6,7 +6,7 @@ Run compatibility tests against a given cluster.
 
 from pre_tests import PreSystemTests
 from ci_tests import QaE2eTestCompatibility
-from post_tests import PostClusterTest, CheckStackroxLogs, FinalPost
+from post_tests import PostClusterTest, FinalPost
 from runners import ClusterTestSetsRunner
 
 

--- a/.openshift-ci/dev-requirements.txt
+++ b/.openshift-ci/dev-requirements.txt
@@ -1,3 +1,4 @@
+# These versions match those in stackrox-test-0.3.62
 pycodestyle==2.10.0
 autopep8
 pylint==2.13.9

--- a/.openshift-ci/dev-requirements.txt
+++ b/.openshift-ci/dev-requirements.txt
@@ -1,6 +1,6 @@
 # These versions should match those used in the current CI test image (stackrox-test-0.3.62).
 # See .github/workflows/{lint,style}.yaml for that.
-# And the stackrox/rox-ci-image repo for the original source and pinned versions. 
+# And the stackrox/rox-ci-image repo for the original source and pinned versions.
 pycodestyle==2.10.0
 autopep8
 pylint==2.13.9

--- a/.openshift-ci/dev-requirements.txt
+++ b/.openshift-ci/dev-requirements.txt
@@ -1,3 +1,3 @@
 pycodestyle==2.10.0
-autopep8==2.0.4
-pylint==3.0.2
+autopep8
+pylint==2.13.9

--- a/.openshift-ci/dev-requirements.txt
+++ b/.openshift-ci/dev-requirements.txt
@@ -1,4 +1,6 @@
-# These versions match those in stackrox-test-0.3.62
+# These versions should match those used in the current CI test image.
+# See .github/workflows/{lint,style}.yaml for that.
+# And the stackrox/rox-ci-image repo for the original source and pinned versions. 
 pycodestyle==2.10.0
 autopep8
 pylint==2.13.9

--- a/.openshift-ci/dev-requirements.txt
+++ b/.openshift-ci/dev-requirements.txt
@@ -1,4 +1,4 @@
-# These versions should match those used in the current CI test image.
+# These versions should match those used in the current CI test image (stackrox-test-0.3.62).
 # See .github/workflows/{lint,style}.yaml for that.
 # And the stackrox/rox-ci-image repo for the original source and pinned versions. 
 pycodestyle==2.10.0

--- a/.openshift-ci/dev-requirements.txt
+++ b/.openshift-ci/dev-requirements.txt
@@ -1,0 +1,3 @@
+pycodestyle==2.10.0
+autopep8==2.0.4
+pylint==3.0.2

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -21,8 +21,8 @@ repo_root = this_script_dir.parent
 
 HELM_REPO_NAME = "temp-stackrox-oss-repo-should-not-see-me"
 
-add_repo_cmd = f"""helm repo add {HELM_REPO_NAME}
- https://raw.githubusercontent.com/stackrox/helm-charts/main/opensource"""
+add_repo_cmd = f"""helm repo add {HELM_REPO_NAME} \
+https://raw.githubusercontent.com/stackrox/helm-charts/main/opensource"""
 UPDATE_REPO_CMD = "helm repo update"
 search_cmd = f"helm search repo {HELM_REPO_NAME} --versions --output json"
 remove_repo_cmd = f"helm repo remove {HELM_REPO_NAME}"

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 
 """
-Looks up N previous releases and outputs a Helm chart version for the most recent patch for each found release.
+Looks up N previous releases and outputs a Helm chart version for the most
+recent patch for each found release.
 """
+
+# pylint: disable=logging-fstring-interpolation
 
 import json
 import logging
@@ -16,12 +19,13 @@ from collections import namedtuple
 this_script_dir = pathlib.Path(__file__).parent
 repo_root = this_script_dir.parent
 
-helm_repo_name = "temp-stackrox-oss-repo-should-not-see-me"
+HELM_REPO_NAME = "temp-stackrox-oss-repo-should-not-see-me"
 
-add_repo_cmd = f"helm repo add {helm_repo_name} https://raw.githubusercontent.com/stackrox/helm-charts/main/opensource"
-update_repo_cmd = "helm repo update"
-search_cmd = f"helm search repo {helm_repo_name} --versions --output json"
-remove_repo_cmd = f"helm repo remove {helm_repo_name}"
+add_repo_cmd = f"""helm repo add {HELM_REPO_NAME}
+ https://raw.githubusercontent.com/stackrox/helm-charts/main/opensource"""
+UPDATE_REPO_CMD = "helm repo update"
+search_cmd = f"helm search repo {HELM_REPO_NAME} --versions --output json"
+remove_repo_cmd = f"helm repo remove {HELM_REPO_NAME}"
 
 Version = namedtuple("Version", ["major", "minor", "patch"])
 
@@ -29,35 +33,38 @@ Version = namedtuple("Version", ["major", "minor", "patch"])
 Release = namedtuple("Release", ["major", "minor"])
 
 # Default value of N, the number of previous releases to look up.
-# The current release cadence is 9 weeks (sometimes extended but not reduced), i.e. 9*7=63 days.
+# The current release cadence is 9 weeks (sometimes extended but not reduced),
+# i.e. 9*7=63 days.
 # The current support period is 6 months, i.e. at most 184 days.
-# Therefore, at most 3 releases will be in support at any given moment of time with the current cadence and support
-# period.
-num_releases_default = 3
+# Therefore, at most 3 releases will be in support at any given moment of time
+# with the current cadence and support period.
+NUM_RELEASES_DEFAULT = 3
 
-# For support exceptions we may need to get the latest patch for a specific release that is not within the
-# last N versions. In that case get_latest_helm_chart_version_for_specific_release will provide the latest
+# For support exceptions we may need to get the latest patch for a specific
+# release that is not within the last N versions. In that case
+# get_latest_helm_chart_version_for_specific_release will provide the latest
 # patch of the input release.
 sample_support_exception = Release(major=3, minor=74)
 
 
 def main(argv):
     logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
-    n = int(argv[1]) if len(argv) > 1 else num_releases_default
+    num_releases = int(argv[1]) if len(argv) > 1 else NUM_RELEASES_DEFAULT
     helm_versions = get_latest_helm_chart_versions(
-        "stackrox-secured-cluster-services", n
+        "stackrox-secured-cluster-services", num_releases
     )
-    logging.info(f"Helm chart versions for the latest {n} releases:")
+    logging.info(f"Helm chart versions for the latest {num_releases} releases:")
     print("\n".join(helm_versions))
     helm_version_specific = get_latest_helm_chart_version_for_specific_release(
         "stackrox-secured-cluster-services", sample_support_exception
     )
     logging.info(
-        f"Latest chart version for the {sample_support_exception} releases is {helm_version_specific}"
+        f"Latest chart version for the {sample_support_exception} "
+        f"releases is {helm_version_specific}"
     )
 
 
-def get_latest_helm_chart_versions(chart_name, num_releases=num_releases_default):
+def get_latest_helm_chart_versions(chart_name, num_releases=NUM_RELEASES_DEFAULT):
     add_helm_repo()
     try:
         update_helm_repo()
@@ -132,7 +139,7 @@ def parse_version(version_str):
 
 
 def filter_charts_by_name(charts, chart_name):
-    return [c for c in charts if c["name"] == f"{helm_repo_name}/{chart_name}"]
+    return [c for c in charts if c["name"] == f"{HELM_REPO_NAME}/{chart_name}"]
 
 
 def get_latest_chart_for_each_release(charts):
@@ -175,7 +182,7 @@ def add_helm_repo():
 
 def update_helm_repo():
     logging.info("Updating temp helm repository...")
-    run_command(update_repo_cmd)
+    run_command(UPDATE_REPO_CMD)
 
 
 def remove_helm_repo():
@@ -191,6 +198,7 @@ def run_command(command, log_stdout=True):
         stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        check=False
     )
 
     stdout = format_command_output(

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -53,7 +53,8 @@ def main(argv):
     helm_versions = get_latest_helm_chart_versions(
         "stackrox-secured-cluster-services", num_releases
     )
-    logging.info(f"Helm chart versions for the latest {num_releases} releases:")
+    logging.info(
+        f"Helm chart versions for the latest {num_releases} releases:")
     print("\n".join(helm_versions))
     helm_version_specific = get_latest_helm_chart_version_for_specific_release(
         "stackrox-secured-cluster-services", sample_support_exception

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -40,14 +40,21 @@ num_releases_default = 3
 # patch of the input release.
 sample_support_exception = Release(major=3, minor=74)
 
+
 def main(argv):
     logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
     n = int(argv[1]) if len(argv) > 1 else num_releases_default
-    helm_versions = get_latest_helm_chart_versions("stackrox-secured-cluster-services", n)
+    helm_versions = get_latest_helm_chart_versions(
+        "stackrox-secured-cluster-services", n
+    )
     logging.info(f"Helm chart versions for the latest {n} releases:")
     print("\n".join(helm_versions))
-    helm_version_specific = get_latest_helm_chart_version_for_specific_release("stackrox-secured-cluster-services", sample_support_exception)
-    logging.info(f"Latest chart version for the {sample_support_exception} releases is {helm_version_specific}")
+    helm_version_specific = get_latest_helm_chart_version_for_specific_release(
+        "stackrox-secured-cluster-services", sample_support_exception
+    )
+    logging.info(
+        f"Latest chart version for the {sample_support_exception} releases is {helm_version_specific}"
+    )
 
 
 def get_latest_helm_chart_versions(chart_name, num_releases=num_releases_default):
@@ -73,10 +80,14 @@ def __get_latest_helm_chart_versions(chart_name, num_releases):
     logging.info(f"Discovered total {len(charts)} charts")
 
     filtered_charts = filter_charts_by_name(charts, chart_name)
-    logging.info(f"Found {len(filtered_charts)} charts with the given name {chart_name}")
+    logging.info(
+        f"Found {len(filtered_charts)} charts with the given name {chart_name}"
+    )
 
-    latest_charts = get_latest_chart_for_each_release(filtered_charts)[:num_releases]
-    logging.debug(f"Identified these charts as {num_releases} latest: {latest_charts}")
+    latest_charts = get_latest_chart_for_each_release(filtered_charts)[
+        :num_releases]
+    logging.debug(
+        f"Identified these charts as {num_releases} latest: {latest_charts}")
 
     return [c["version"] for c in latest_charts]
 
@@ -86,10 +97,13 @@ def __get_latest_helm_chart_version_for_specific_release(chart_name, release):
     logging.info(f"Discovered total {len(charts)} charts")
 
     filtered_charts = filter_charts_by_name(charts, chart_name)
-    print(f"Found {len(filtered_charts)} charts with the given name {chart_name}")
+    print(
+        f"Found {len(filtered_charts)} charts with the given name {chart_name}")
 
-    latest_chart = get_latest_chart_for_specific_release(filtered_charts, release)
-    logging.debug(f"Identified {latest_chart} as latest version of release {release}")
+    latest_chart = get_latest_chart_for_specific_release(
+        filtered_charts, release)
+    logging.debug(
+        f"Identified {latest_chart} as latest version of release {release}")
 
     return latest_chart["version"]
 
@@ -98,7 +112,9 @@ def read_charts():
     json_str = run_command(search_cmd, log_stdout=False)
     charts_from_json = json.loads(json_str)
 
-    release_charts = [c for c in charts_from_json if is_release_version(c["app_version"])]
+    release_charts = [
+        c for c in charts_from_json if is_release_version(c["app_version"])
+    ]
 
     for entry in release_charts:
         entry["parsed_app_version"] = parse_version(entry["app_version"])
@@ -120,7 +136,8 @@ def filter_charts_by_name(charts, chart_name):
 
 
 def get_latest_chart_for_each_release(charts):
-    sorted_charts = sorted(charts, key=lambda x: x["parsed_app_version"], reverse=True)
+    sorted_charts = sorted(
+        charts, key=lambda x: x["parsed_app_version"], reverse=True)
 
     result = []
     release = None
@@ -135,14 +152,16 @@ def get_latest_chart_for_each_release(charts):
 
 
 def get_latest_chart_for_specific_release(charts, release):
-    sorted_charts = sorted(charts, key=lambda x: x["parsed_app_version"], reverse=True)
+    sorted_charts = sorted(
+        charts, key=lambda x: x["parsed_app_version"], reverse=True)
 
     for chart in sorted_charts:
         chart_release = version_to_release(chart["parsed_app_version"])
         if chart_release == release:
             return chart
 
-    raise RuntimeError(f"Could not find chart for requested release version {release}")
+    raise RuntimeError(
+        f"Could not find chart for requested release version {release}")
 
 
 def version_to_release(version):
@@ -165,12 +184,21 @@ def remove_helm_repo():
 
 
 def run_command(command, log_stdout=True):
-    result = subprocess.run(command, shell=True, encoding='utf-8',
-                            stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result = subprocess.run(
+        command,
+        shell=True,
+        encoding="utf-8",
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
 
-    stdout = format_command_output("Stdout", result.stdout) if log_stdout else ""
+    stdout = format_command_output(
+        "Stdout", result.stdout) if log_stdout else ""
     stderr = format_command_output("Stderr", result.stderr)
-    logging.debug(f"Got exit code {result.returncode} for command: {command}{stdout}{stderr}")
+    logging.debug(
+        f"Got exit code {result.returncode} for command: {command}{stdout}{stderr}"
+    )
 
     result.check_returncode()
 

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -91,7 +91,8 @@ class StoreArtifacts(RunWithBestEffortMixin):
             if self.artifact_destination_prefix:
                 args.append(
                     os.path.join(
-                        self.artifact_destination_prefix, os.path.basename(source)
+                        self.artifact_destination_prefix, os.path.basename(
+                            source)
                     )
                 )
             self.run_with_best_effort(
@@ -245,7 +246,8 @@ class PostClusterTest(StoreArtifacts):
 
     def check_stackrox_logs(self):
         self.run_with_best_effort(
-            ["tests/e2e/lib.sh", "check_stackrox_logs", PostTestsConstants.K8S_LOG_DIR],
+            ["tests/e2e/lib.sh", "check_stackrox_logs",
+                PostTestsConstants.K8S_LOG_DIR],
             timeout=PostTestsConstants.CHECK_TIMEOUT,
         )
 
@@ -332,7 +334,8 @@ class FinalPost(StoreArtifacts):
                 PostTestsConstants.QA_GRADLE_RESULTS
             )
             # Spock test specification logs.
-            self.dirs_to_store_to_osci_artifacts.append(PostTestsConstants.QA_SPEC_LOGS)
+            self.dirs_to_store_to_osci_artifacts.append(
+                PostTestsConstants.QA_SPEC_LOGS)
         self._handle_e2e_progress_failures = handle_e2e_progress_failures
 
     def run(self, test_outputs=None):

--- a/.openshift-ci/runners.py
+++ b/.openshift-ci/runners.py
@@ -126,7 +126,8 @@ class ClusterTestSetsRunner:
         print(marker)
 
     def set_provisioned_state(self):
-        subprocess.check_call("tests/e2e/lib.sh set_provisioned_state", shell=True)
+        subprocess.check_call(
+            "tests/e2e/lib.sh set_provisioned_state", shell=True)
 
 
 # pylint: disable=too-many-arguments

--- a/.openshift-ci/tests/test_clusters.py
+++ b/.openshift-ci/tests/test_clusters.py
@@ -20,10 +20,12 @@ class TestGKECluster(unittest.TestCase):
         GKECluster.PROVISION_TIMEOUT = 0.1
         GKECluster.WAIT_TIMEOUT = 0.1
         GKECluster.TEARDOWN_TIMEOUT = 0.1
-        GKECluster.PROVISION_PATH = os.path.join(_dirname, "fixtures", "null.sh")
+        GKECluster.PROVISION_PATH = os.path.join(
+            _dirname, "fixtures", "null.sh")
         GKECluster.WAIT_PATH = os.path.join(_dirname, "fixtures", "null.sh")
         GKECluster.REFRESH_PATH = os.path.join(_dirname, "fixtures", "null.sh")
-        GKECluster.TEARDOWN_PATH = os.path.join(_dirname, "fixtures", "null.sh")
+        GKECluster.TEARDOWN_PATH = os.path.join(
+            _dirname, "fixtures", "null.sh")
 
     def test_pass(self):
         GKECluster("test").provision().teardown()
@@ -38,7 +40,8 @@ class TestGKECluster(unittest.TestCase):
         return os.path.join(_dirname, "fixtures", "timeout.sh")
 
     def prepare_for_timeout_termination(self, tmp_dir):
-        os.environ["TEST_TERM_PIDFILE"] = os.path.join(tmp_dir, "TEST_TERM_PIDFILE")
+        os.environ["TEST_TERM_PIDFILE"] = os.path.join(
+            tmp_dir, "TEST_TERM_PIDFILE")
         return os.environ["TEST_TERM_PIDFILE"]
 
     def prepare_for_timeout_kill(self, tmp_dir):

--- a/.openshift-ci/tests/test_runners.py
+++ b/.openshift-ci/tests/test_runners.py
@@ -76,7 +76,8 @@ class TestClusterTestRunner(unittest.TestCase):
         post_test = Mock()
         test.run.side_effect = Exception("oops")
         with self.assertRaisesRegex(Exception, "oops"):
-            ClusterTestRunner(cluster=cluster, test=test, post_test=post_test).run()
+            ClusterTestRunner(cluster=cluster, test=test,
+                              post_test=post_test).run()
         test.run.assert_called_once()  # skips test
         post_test.run.assert_called_once()  # still post tests
         cluster.teardown.assert_called_once()  # still tearsdown
@@ -87,7 +88,8 @@ class TestClusterTestRunner(unittest.TestCase):
         post_test = Mock()
         post_test.run.side_effect = Exception("oops")
         with self.assertRaisesRegex(Exception, "oops"):
-            ClusterTestRunner(cluster=cluster, test=test, post_test=post_test).run()
+            ClusterTestRunner(cluster=cluster, test=test,
+                              post_test=post_test).run()
         cluster.teardown.assert_called_once()  # still tearsdown
 
     def test_run_and_post_test_failure(self):
@@ -97,7 +99,8 @@ class TestClusterTestRunner(unittest.TestCase):
         test.run.side_effect = Exception("run oops")
         post_test.run.side_effect = Exception("post test oops")
         with self.assertRaisesRegex(Exception, "run oops"):  # the run error is #1
-            ClusterTestRunner(cluster=cluster, test=test, post_test=post_test).run()
+            ClusterTestRunner(cluster=cluster, test=test,
+                              post_test=post_test).run()
         cluster.teardown.assert_called_once()  # still tearsdown
 
     def test_run_and_post_test_and_teardown_failure(self):
@@ -108,7 +111,8 @@ class TestClusterTestRunner(unittest.TestCase):
         post_test.run.side_effect = Exception("post test oops")
         cluster.teardown.side_effect = Exception("teardown oops")
         with self.assertRaisesRegex(Exception, "run oops"):  # the run error is #1
-            ClusterTestRunner(cluster=cluster, test=test, post_test=post_test).run()
+            ClusterTestRunner(cluster=cluster, test=test,
+                              post_test=post_test).run()
 
     def test_post_test_and_teardown_failure(self):
         cluster = Mock()
@@ -119,7 +123,8 @@ class TestClusterTestRunner(unittest.TestCase):
         with self.assertRaisesRegex(
             Exception, "post test oops"
         ):  # the post_test error is #1
-            ClusterTestRunner(cluster=cluster, test=test, post_test=post_test).run()
+            ClusterTestRunner(cluster=cluster, test=test,
+                              post_test=post_test).run()
 
     def test_provision_and_teardown_failure(self):
         cluster = Mock()
@@ -130,7 +135,8 @@ class TestClusterTestRunner(unittest.TestCase):
         with self.assertRaisesRegex(
             Exception, "provision oops"
         ):  # the provision error is #1
-            ClusterTestRunner(cluster=cluster, test=test, post_test=post_test).run()
+            ClusterTestRunner(cluster=cluster, test=test,
+                              post_test=post_test).run()
 
     def test_pre_test_and_teardown_failure(self):
         cluster = Mock()
@@ -205,7 +211,8 @@ class TestClusterTestSetsRunner(unittest.TestCase):
         test1.run.side_effect = Exception("test1 oops")
         test2 = Mock()
         with self.assertRaisesRegex(Exception, "test1 oops"):
-            ClusterTestSetsRunner(sets=[{"test": test1}, {"test": test2}]).run()
+            ClusterTestSetsRunner(
+                sets=[{"test": test1}, {"test": test2}]).run()
         test2.run.assert_called_once()
 
     def test_first_failure_is_reported(self):
@@ -214,7 +221,8 @@ class TestClusterTestSetsRunner(unittest.TestCase):
         test2 = Mock()
         test2.run.side_effect = Exception("test2 oops")
         with self.assertRaisesRegex(Exception, "test1 oops"):
-            ClusterTestSetsRunner(sets=[{"test": test1}, {"test": test2}]).run()
+            ClusterTestSetsRunner(
+                sets=[{"test": test1}, {"test": test2}]).run()
 
     def test_can_always_run(self):
         test1 = Mock()

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,17 @@ $(call go-tool, GOVULNCHECK_BIN, golang.org/x/vuln/cmd/govulncheck, tools/linter
 style: golangci-lint style-slim
 
 .PHONY: style-slim
-style-slim: roxvet blanks newlines check-service-protos no-large-files storage-protos-compatible ui-lint qa-tests-style shell-style
+style-slim: \
+	blanks \
+	check-service-protos \
+	newlines \
+	no-large-files \
+	openshift-ci-style \
+	qa-tests-style \
+	roxvet \
+	shell-style \
+	storage-protos-compatible \
+	ui-lint
 
 GOLANGCILINT_FLAGS := --verbose --print-resources-usage
 
@@ -177,6 +187,11 @@ qa-tests-style:
 ui-lint:
 	@echo "+ $@"
 	make -C ui lint
+
+.PHONY: openshift-ci-style
+openshift-ci-style:
+	@echo "+ $@"
+	make -C .openshift-ci/ style
 
 .PHONY: shell-style
 shell-style:

--- a/scripts/ci/jobs/gke_upgrade_tests.py
+++ b/scripts/ci/jobs/gke_upgrade_tests.py
@@ -3,7 +3,6 @@
 """
 Run the upgrade test in a GKE cluster
 """
-import os
 from runners import ClusterTestRunner
 from clusters import GKECluster
 from pre_tests import PreSystemTests

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -27,7 +27,8 @@ logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 
-central_chart_versions = get_latest_helm_chart_versions("stackrox-central-services", 2)
+central_chart_versions = get_latest_helm_chart_versions(
+    "stackrox-central-services", 2)
 sensor_chart_versions = get_latest_helm_chart_versions(
     "stackrox-secured-cluster-services", 3
 )
@@ -43,17 +44,20 @@ if len(central_chart_versions) == 0:
 if len(sensor_chart_versions) == 0:
     raise RuntimeError("Could not find sensor chart versions.")
 
-ChartVersions = namedtuple("Chart_versions", ["central_version", "sensor_version"])
+ChartVersions = namedtuple(
+    "Chart_versions", ["central_version", "sensor_version"])
 
 # Latest central vs sensor versions in sensor_chart_versions
 test_tuples = [
-    ChartVersions(central_version=latest_tag, sensor_version=sensor_chart_version)
+    ChartVersions(central_version=latest_tag,
+                  sensor_version=sensor_chart_version)
     for sensor_chart_version in sensor_chart_versions
 ]
 # Latest sensor vs central versions in central_chart_versions
 test_tuples.extend(
     [
-        ChartVersions(central_version=central_chart_version, sensor_version=latest_tag)
+        ChartVersions(central_version=central_chart_version,
+                      sensor_version=latest_tag)
         for central_chart_version in central_chart_versions
     ]
 )
@@ -75,7 +79,8 @@ test_tuples.extend(
     if support_exception not in test_tuples
 )
 
-gkecluster = GKECluster("compat-test", machine_type="e2-standard-8", num_nodes=2)
+gkecluster = GKECluster(
+    "compat-test", machine_type="e2-standard-8", num_nodes=2)
 
 failing_tuples = []
 for test_tuple in test_tuples:

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -8,11 +8,15 @@ import os
 import subprocess
 import sys
 
-from clusters import GKECluster
 from collections import namedtuple
-from compatibility_test import make_compatibility_test_runner
-from get_latest_helm_chart_versions import get_latest_helm_chart_versions, get_latest_helm_chart_version_for_specific_release
 from pathlib import Path
+
+from clusters import GKECluster
+from compatibility_test import make_compatibility_test_runner
+from get_latest_helm_chart_versions import (
+    get_latest_helm_chart_versions,
+    get_latest_helm_chart_version_for_specific_release,
+)
 
 Release = namedtuple("Release", ["major", "minor"])
 
@@ -24,40 +28,84 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 
 central_chart_versions = get_latest_helm_chart_versions("stackrox-central-services", 2)
-sensor_chart_versions = get_latest_helm_chart_versions("stackrox-secured-cluster-services", 3)
+sensor_chart_versions = get_latest_helm_chart_versions(
+    "stackrox-secured-cluster-services", 3
+)
 makefile_path = Path(__file__).parent.parent.parent.parent
-latest_tag = subprocess.check_output(["make", "tag", "-C", makefile_path, "--quiet", "--no-print-director"], shell=False, encoding='utf-8').strip()
+latest_tag = subprocess.check_output(
+    ["make", "tag", "-C", makefile_path, "--quiet", "--no-print-director"],
+    shell=False,
+    encoding="utf-8",
+).strip()
 
 if len(central_chart_versions) == 0:
     raise RuntimeError("Could not find central chart versions.")
 if len(sensor_chart_versions) == 0:
     raise RuntimeError("Could not find sensor chart versions.")
 
-Chart_versions = namedtuple("Chart_versions", ["central_version", "sensor_version"])
+ChartVersions = namedtuple("Chart_versions", ["central_version", "sensor_version"])
 
 # Latest central vs sensor versions in sensor_chart_versions
-test_tuples = [Chart_versions(central_version=latest_tag, sensor_version=sensor_chart_version) for sensor_chart_version in sensor_chart_versions]
+test_tuples = [
+    ChartVersions(central_version=latest_tag, sensor_version=sensor_chart_version)
+    for sensor_chart_version in sensor_chart_versions
+]
 # Latest sensor vs central versions in central_chart_versions
-test_tuples.extend([Chart_versions(central_version=central_chart_version, sensor_version=latest_tag) for central_chart_version in central_chart_versions])
+test_tuples.extend(
+    [
+        ChartVersions(central_version=central_chart_version, sensor_version=latest_tag)
+        for central_chart_version in central_chart_versions
+    ]
+)
 
-# Support exception for latest central and sensor 3.74 as per https://issues.redhat.com/browse/ROX-18223
-support_exceptions = [Chart_versions(central_version=latest_tag, sensor_version=get_latest_helm_chart_version_for_specific_release("stackrox-secured-cluster-services", Release(major=3, minor=74)))]
+# Support exception for latest central and sensor 3.74 as per
+# https://issues.redhat.com/browse/ROX-18223
+support_exceptions = [
+    ChartVersions(
+        central_version=latest_tag,
+        sensor_version=get_latest_helm_chart_version_for_specific_release(
+            "stackrox-secured-cluster-services", Release(major=3, minor=74)
+        ),
+    )
+]
 
-test_tuples.extend(support_exception for support_exception in support_exceptions if support_exception not in test_tuples)
+test_tuples.extend(
+    support_exception
+    for support_exception in support_exceptions
+    if support_exception not in test_tuples
+)
 
 gkecluster = GKECluster("compat-test", machine_type="e2-standard-8", num_nodes=2)
 
 failing_tuples = []
-for tuple in test_tuples:
-    os.environ["CENTRAL_CHART_VERSION_OVERRIDE"] = tuple.central_version
-    os.environ["SENSOR_CHART_VERSION_OVERRIDE"] = tuple.sensor_version
+for test_tuple in test_tuples:
+    os.environ["CENTRAL_CHART_VERSION_OVERRIDE"] = test_tuple.central_version
+    os.environ["SENSOR_CHART_VERSION_OVERRIDE"] = test_tuple.sensor_version
     try:
         make_compatibility_test_runner(cluster=gkecluster).run()
     except Exception as e:
-        print(f"Exception \"{str(e)}\" raised in compatibility test for central version {tuple.central_version} and sensor version {tuple.sensor_version}",
-            file=sys.stderr)
-        failing_tuples.append(tuple)
+        print(
+            f'Exception "{str(e)}" raised in compatibility test for '
+            f'central version {test_tuple.central_version} and '
+            f'sensor version {test_tuple.sensor_version}',
+            file=sys.stderr,
+        )
+        failing_tuples.append(test_tuple)
 
 if len(failing_tuples) > 0:
-    failing_string = ', '.join([("(Central v" + str(failing_tuple.central_version) + ", Sensor v" + str(failing_tuple.sensor_version) + ")") for failing_tuple in failing_tuples])
-    raise RuntimeError("Compatibility tests failed for versions " + failing_string + ".")
+    # pylint: disable=invalid-name
+    failing_string = ", ".join(
+        [
+            (
+                "(Central v"
+                + str(failing_tuple.central_version)
+                + ", Sensor v"
+                + str(failing_tuple.sensor_version)
+                + ")"
+            )
+            for failing_tuple in failing_tuples
+        ]
+    )
+    raise RuntimeError(
+        "Compatibility tests failed for versions " + failing_string + "."
+    )

--- a/scripts/ci/jobs/ibmcloudz_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ibmcloudz_qa_e2e_tests.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S python3 -u
 
 """
-Run qa-tests-backend in a IBM CLOUD Z Openshift cluster provided via automation-flavors/ibmcloudz.
+Run qa-tests-backend in a IBM CLOUD Z Openshift cluster provided via
+automation-flavors/ibmcloudz.
 """
 import os
 from base_qa_e2e_test import make_qa_e2e_test_runner_custom

--- a/scripts/ci/jobs/ocp_sensor_integration_tests.py
+++ b/scripts/ci/jobs/ocp_sensor_integration_tests.py
@@ -19,6 +19,7 @@ os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 ClusterTestRunner(
     cluster=AutomationFlavorsCluster(),
     pre_test=PreSystemTests(run_poll_for_system_test_images=False),
-    # TODO(ROX-17875): Run the regular SensorIntegration() here after the tests are tuned to work on OCP
+    # TODO(ROX-17875): Run the regular SensorIntegration() here after the tests
+    # are tuned to work on OCP
     test=SensorIntegrationOCP(),
 ).run()

--- a/scripts/ci/jobs/powervs_qa_e2e_tests.py
+++ b/scripts/ci/jobs/powervs_qa_e2e_tests.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S python3 -u
 
 """
-Run qa-tests-backend in a IBM CLOUD POWERVS Openshift cluster provided via automation-flavors/powervs.
+Run qa-tests-backend in a IBM CLOUD POWERVS Openshift cluster provided via
+automation-flavors/powervs.
 """
 import os
 from base_qa_e2e_test import make_qa_e2e_test_runner_custom


### PR DESCRIPTION
## Description

When we migrated to openshift-ci with the .openshift-ci Python layer we described tooling for style and lint but did not enforce it resulting in some understandable drift. This PR rectifies that with style (PEP8/pycodestyle) and lint (pylint) checks. And fixes existing style and lint issues.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed
- [x] Test affected job: gke_version_compat