### PR TITLE
chore(deps): bump github.com/dexidp/dex to v2.37.0

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -52,6 +52,9 @@ updates:
       include: scope
       prefix: chore
     ignore:
+      # Dex versions are not compatible with Go nor dependabot.
+      # See: https://github.com/dexidp/dex/issues/2880
+      - dependency-name: "github.com/dexidp/dex"
       - dependency-name: "github.com/aws/aws-sdk-go"
         update-types: ["version-update:semver-patch"]
       # This version of ClairCore does not build on Darwin.

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.7.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/dave/jennifer v1.7.0
-	github.com/dexidp/dex v2.12.0+incompatible
+	github.com/dexidp/dex v2.13.0+incompatible
 	github.com/docker/distribution v2.8.3+incompatible
 	// If this is updated, be sure to check the version of github.com/opencontainers/runc used.
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.7.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/dave/jennifer v1.7.0
-	github.com/dexidp/dex v2.13.0+incompatible
+	github.com/dexidp/dex v0.0.0-20230630132844-08bb7fb98b16 // v2.37.0
 	github.com/docker/distribution v2.8.3+incompatible
 	// If this is updated, be sure to check the version of github.com/opencontainers/runc used.
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.7.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/dave/jennifer v1.7.0
-	github.com/dexidp/dex v0.0.0-20230320125501-2bb4896d120e
+	github.com/dexidp/dex v2.12.0+incompatible
 	github.com/docker/distribution v2.8.3+incompatible
 	// If this is updated, be sure to check the version of github.com/opencontainers/runc used.
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dexidp/dex v2.12.0+incompatible h1:7hS+bKH1Nzla9jtaud+jMMOg0gqZjoBlAkYxzg9Z4Ts=
-github.com/dexidp/dex v2.12.0+incompatible/go.mod h1:cRGkPWqKhDD1FMCICe2JbYDdVR2xGLa38F6iuH/jNAs=
+github.com/dexidp/dex v2.13.0+incompatible h1:EQPpzCi51omkwBe0KYpRGaV3rk6CVvjcqeMGCe3Q00w=
+github.com/dexidp/dex v2.13.0+incompatible/go.mod h1:cRGkPWqKhDD1FMCICe2JbYDdVR2xGLa38F6iuH/jNAs=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dexidp/dex v0.0.0-20230320125501-2bb4896d120e h1:kCfaMK7fS1occAwOFiDQVK+YNHmIpJWsaSvGr0WqEVs=
-github.com/dexidp/dex v0.0.0-20230320125501-2bb4896d120e/go.mod h1:JUBjDiXIfLHq5uahSzYhoaO1Kics8OjnT/EjGDeCG50=
+github.com/dexidp/dex v2.12.0+incompatible h1:7hS+bKH1Nzla9jtaud+jMMOg0gqZjoBlAkYxzg9Z4Ts=
+github.com/dexidp/dex v2.12.0+incompatible/go.mod h1:cRGkPWqKhDD1FMCICe2JbYDdVR2xGLa38F6iuH/jNAs=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dexidp/dex v2.13.0+incompatible h1:EQPpzCi51omkwBe0KYpRGaV3rk6CVvjcqeMGCe3Q00w=
-github.com/dexidp/dex v2.13.0+incompatible/go.mod h1:cRGkPWqKhDD1FMCICe2JbYDdVR2xGLa38F6iuH/jNAs=
+github.com/dexidp/dex v0.0.0-20230630132844-08bb7fb98b16 h1:aAHfUDU74Xt9qrKV5iAKoSuIyKeUvSQ4oysifq66dAU=
+github.com/dexidp/dex v0.0.0-20230630132844-08bb7fb98b16/go.mod h1:nYrdft4WOC5iwn7daYM7c8pVgWMWR5E1d4jqTkZFjyE=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=

--- a/pkg/auth/authproviders/openshift/internal/dexconnector/openshift.go
+++ b/pkg/auth/authproviders/openshift/internal/dexconnector/openshift.go
@@ -281,11 +281,10 @@ func (c *openshiftConnector) identity(ctx context.Context, s connector.Scopes, t
 	}
 
 	identity = connector.Identity{
-		UserID:            user.UID,
-		Username:          user.Name,
-		PreferredUsername: user.Name,
-		Email:             user.Name,
-		Groups:            user.Groups,
+		UserID:   user.UID,
+		Username: user.Name,
+		Email:    user.Name,
+		Groups:   user.Groups,
 	}
 
 	if s.OfflineAccess {


### PR DESCRIPTION
## Description

Bumps [github.com/dexidp/dex](https://github.com/dexidp/dex) to [v2.37.0](https://github.com/dexidp/dex/releases/tag/v2.37.0).
See:
- https://github.com/dexidp/dex/commit/08bb7fb98b164ab078be17ecda4077b2d21c9bb3
- https://github.com/dexidp/dex/issues/2880
- https://github.com/stackrox/stackrox/security/dependabot/142

As dex does not follow Go versioning conventions we must ignore it in dependabot config and update manually as pseudo version (`v0.0.0-...`) is before all other versions. dex added `go.mod` after `v2.13.0` so this is the last version recognized by dependabot because since `go.mod` was added module should follow convention and add `v2` import path. This could not be currently fixed and we need to wait for `v3`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
