### PR TITLE
fix: Prune listening endpoints by deploymentid even if poduid is null

### DIFF
--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -32,7 +32,7 @@ const (
 		(SELECT 1 FROM clusters WHERE nodes.clusterid = clusters.Id)`
 
 	// Explain Analyze indicated that 2 statements for PLOP is faster than one.
-	deleteOrphanedPLOPDeployments = `DELETE FROM listening_endpoints WHERE processindicatorid in (SELECT id from process_indicators pi WHERE NOT EXISTS
+	deleteOrphanedPLOPDeploymentsAndPI = `DELETE FROM listening_endpoints WHERE processindicatorid in (SELECT id from process_indicators pi WHERE NOT EXISTS
 		(SELECT 1 FROM deployments WHERE pi.deploymentid = deployments.Id) AND 
 		(signal_time < now() at time zone 'utc' - INTERVAL '%d MINUTES' OR signal_time is NULL))`
 
@@ -44,7 +44,7 @@ const (
 	// This leads to a possible race condition where a listening endpoint reaches the database before the deployment,
 	// and the pruning job happens to run before the deployment information arrives in the database.
 	// This should be rare, so this should be acceptable. This could be improved by adding a timestamp to the listening endpoints table
-	deleteOrphanedPLOPDeploymentsWithPodUID = `DELETE FROM listening_endpoints WHERE NOT EXISTS
+	deleteOrphanedPLOPDeployments = `DELETE FROM listening_endpoints WHERE NOT EXISTS
 		(SELECT 1 FROM deployments WHERE listening_endpoints.deploymentid = deployments.Id)`
 
 	// Unfortunately if a listening endpoint is marked as being open there is no indication of how old it is.
@@ -180,7 +180,7 @@ func GetOrphanedNodeIDs(ctx context.Context, pool postgres.DB) ([]string, error)
 func PruneOrphanedProcessIndicators(ctx context.Context, pool postgres.DB, orphanWindow time.Duration) {
 	// Delete processes listening on ports orphaned because process indicators are orphaned due to
 	// missing deployments
-	query := fmt.Sprintf(deleteOrphanedPLOPDeployments, int(orphanWindow.Minutes()))
+	query := fmt.Sprintf(deleteOrphanedPLOPDeploymentsAndPI, int(orphanWindow.Minutes()))
 	if _, err := pool.Exec(ctx, query); err != nil {
 		log.Errorf("failed to prune process listening on ports by deployment: %v", err)
 	}
@@ -232,7 +232,7 @@ func PruneOrphanedPLOPs(ctx context.Context, pool postgres.DB, orphanWindow time
 	}
 
 	// Delete processes listening on ports orphaned due to missing deployments
-	if _, err := pool.Exec(ctx, deleteOrphanedPLOPDeploymentsWithPodUID); err != nil {
+	if _, err := pool.Exec(ctx, deleteOrphanedPLOPDeployments); err != nil {
 		log.Errorf("failed to prune process listening on ports by deployment: %v", err)
 	}
 

--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -44,7 +44,7 @@ const (
 	// This leads to a possible race condition where a listening endpoint reaches the database before the deployment,
 	// and the pruning job happens to run before the deployment information arrives in the database.
 	// This should be rare, so this should be acceptable. This could be improved by adding a timestamp to the listening endpoints table
-	deleteOrphanedPLOPDeploymentsWithPodUID = `DELETE FROM listening_endpoints WHERE poduid IS NOT NULL AND NOT EXISTS
+	deleteOrphanedPLOPDeploymentsWithPodUID = `DELETE FROM listening_endpoints WHERE NOT EXISTS
 		(SELECT 1 FROM deployments WHERE listening_endpoints.deploymentid = deployments.Id)`
 
 	// Unfortunately if a listening endpoint is marked as being open there is no indication of how old it is.

--- a/central/postgres/pruning_test.go
+++ b/central/postgres/pruning_test.go
@@ -474,7 +474,7 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedPLOPs() {
 		expectedPlopDeletions []string
 	}{
 		{
-			name: "no deployments nor pods - remove plops with PodUid since there are no pods",
+			name: "no deployments nor pods - remove plops since there are no pods",
 			initialPlops: []*storage.ProcessListeningOnPortStorage{
 				fixtures.GetPlopStorage1(),
 				fixtures.GetPlopStorage2(),
@@ -485,7 +485,7 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedPLOPs() {
 			},
 			deployments:           set.NewFrozenStringSet(),
 			pods:                  set.NewFrozenStringSet(),
-			expectedPlopDeletions: []string{fixtureconsts.PlopUID4, fixtureconsts.PlopUID5, fixtureconsts.PlopUID6},
+			expectedPlopDeletions: []string{fixtureconsts.PlopUID1, fixtureconsts.PlopUID2, fixtureconsts.PlopUID3, fixtureconsts.PlopUID4, fixtureconsts.PlopUID5, fixtureconsts.PlopUID6},
 		},
 		{
 			name: "deployments one missing pod - remove plops with PodUid with no matching pod even though there are deployments",
@@ -502,7 +502,7 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedPLOPs() {
 			expectedPlopDeletions: []string{fixtureconsts.PlopUID6},
 		},
 		{
-			name: "one missing deployments no missing pods - remove plops with PodUid with no matching deployments even though there are matching pods",
+			name: "one missing deployments no missing pods - remove plops with no matching deployments even though there are matching pods",
 			initialPlops: []*storage.ProcessListeningOnPortStorage{
 				fixtures.GetPlopStorage1(),
 				fixtures.GetPlopStorage2(),
@@ -513,7 +513,7 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedPLOPs() {
 			},
 			deployments:           set.NewFrozenStringSet(fixtureconsts.Deployment5, fixtureconsts.Deployment3),
 			pods:                  set.NewFrozenStringSet(fixtureconsts.PodUID1, fixtureconsts.PodUID2, fixtureconsts.PodUID3),
-			expectedPlopDeletions: []string{fixtureconsts.PlopUID4},
+			expectedPlopDeletions: []string{fixtureconsts.PlopUID1, fixtureconsts.PlopUID4},
 		},
 		{
 			name: "no missing deployments or pods but plops are expired - remove all expired plops",

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -1314,7 +1314,7 @@ func (s *PruningTestSuite) TestRemoveOrphanedPLOPs() {
 		expectedDeletions []string
 	}{
 		{
-			name: "Plop is active so it should not be removed",
+			name: "Plop is active but does not have a matching deployment so it should be removed",
 			initialPlops: []*storage.ProcessListeningOnPortStorage{
 				{
 					Id:                 plopID1,
@@ -1332,7 +1332,7 @@ func (s *PruningTestSuite) TestRemoveOrphanedPLOPs() {
 					},
 				},
 			},
-			expectedDeletions: []string{},
+			expectedDeletions: []string{plopID1},
 		},
 		{
 			name: "Plop is closed but not expired so it is not removed",
@@ -1351,8 +1351,10 @@ func (s *PruningTestSuite) TestRemoveOrphanedPLOPs() {
 						ProcessArgs:         "test_arguments1",
 						ProcessExecFilePath: "test_path1",
 					},
+					DeploymentId: fixtureconsts.Deployment1,
 				},
 			},
+			deployments:       set.NewFrozenStringSet(fixtureconsts.Deployment1),
 			expectedDeletions: []string{},
 		},
 		{


### PR DESCRIPTION
## Description

There is a periodic pruning job that deletes listening endpoints that have a deploymentid that does not match any of the ids in the deployments table. However, currently the listening endpoint is only deleted if the PodUid is not null. This was done as a result of a conversation in this PR https://github.com/stackrox/stackrox/pull/8171. It would be better if the check for the existence of a PodUid were removed, so that more stale listening endpoints are removed.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

This is not a large enough change to merit a CHANGELOG entry or user facing documentation. This PR does not impact upgrading. 

## Testing Performed

### Here I tell how I validated my change

Unit tests are sufficient

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
