### PR TITLE
fix(lint): enable linting for integration tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ run:
   skip-dirs:
   - pkg/complianceoperator/api
   build-tags:
+  - integration
   - sql_integration
   modules-download-mode: readonly
 

--- a/central/notifiers/email/email_integration_test.go
+++ b/central/notifiers/email/email_integration_test.go
@@ -20,7 +20,7 @@ import (
 const (
 	server   = "smtp.mailgun.org"
 	user     = "postmaster@sandboxd6576ea8be3c477989eba2c14735d2e6.mailgun.org"
-	password = "ec221fbe09156dfef5bd48afb71d277c"
+	password = "ec221fbe09156dfef5bd48afb71d277c" //#nosec G101
 
 	recipientTestEnv = "EMAIL_RECIPIENT"
 )

--- a/central/notifiers/splunk/splunk_test.go
+++ b/central/notifiers/splunk/splunk_test.go
@@ -15,9 +15,6 @@ import (
 )
 
 const (
-	endpoint = "https://localhost:8088/services/collector/event"
-	token    = "292A25D6-FF99-448C-BD90-7029FBD537BC"
-
 	tokenEnv    = "SPLUNK_TOKEN"
 	endpointEnv = "SPLUNK_ENDPOINT"
 )

--- a/pkg/registries/ibm/ibm_integration_test.go
+++ b/pkg/registries/ibm/ibm_integration_test.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	testImage = "us.icr.io/sr-testing/nginx:1.10"
-	apiToken  = "Z_t3ZI1AcDB_513s91kHw_RXpGVcY-GFUQLLx-UwZqzB"
+	apiToken  = "Z_t3ZI1AcDB_513s91kHw_RXpGVcY-GFUQLLx-UwZqzB" //#nosec G101
 )
 
 func TestIBM(t *testing.T) {

--- a/pkg/registries/quay/quay_integration_test.go
+++ b/pkg/registries/quay/quay_integration_test.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// This is a robot token that can only pull from quay.io/integration/nginx
-	testOauthToken = "0j9dhT9jCNFpsVAzwLavnyeEy2HWnrfTQnbJgQF8"
+	testOauthToken = "0j9dhT9jCNFpsVAzwLavnyeEy2HWnrfTQnbJgQF8" //#nosec G101
 )
 
 func TestQuay(t *testing.T) {

--- a/pkg/scanners/quay/quay_integration_test.go
+++ b/pkg/scanners/quay/quay_integration_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	testOauthToken = "0j9dhT9jCNFpsVAzwLavnyeEy2HWnrfTQnbJgQF8"
+	testOauthToken = "0j9dhT9jCNFpsVAzwLavnyeEy2HWnrfTQnbJgQF8" //#nosec G101
 )
 
 func TestQuayIntegrationSuite(t *testing.T) {


### PR DESCRIPTION
## Description

Integration tests are guarded by `integration` tags. To lint them we need to add `integration` tag to linter.
There are some suspicious lines that looks like a real tokens/passwords that should be injected.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
