### PR TITLE
ROX-20928: Clear default filters before navigation in e2e test

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.js
@@ -86,6 +86,11 @@ describe('Workload CVE Image Single page', () => {
     it('should correctly apply severity filters', () => {
         visitWorkloadCveOverview();
 
+        // Clear default filters if enabled, to prevent inconsistencies when navigating to the image page
+        if (hasFeatureFlag('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS')) {
+            cy.get(selectors.clearFiltersButton).click();
+        }
+
         selectEntityTab('Image');
 
         // Find any image with at least one CVE


### PR DESCRIPTION
## Description

For this particular test, clears the default filters at the start of the test. This prevent inconsistencies after navigation since default filters do not persist when moving from the overview page to the detail pages.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local Cypress run
Awaiting CI
