### PR TITLE
chore(ui): Fix errors and turn on no-explicit-any lint rule

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -309,7 +309,6 @@ module.exports = [
             '@typescript-eslint/no-unsafe-member-access': 'off',
 
             // Turn off new rules until after we fix errors in follow-up contributions.
-            '@typescript-eslint/no-explicit-any': 'off', // fix 7 errors
             '@typescript-eslint/no-floating-promises': 'off', // fix 7 errors
             '@typescript-eslint/no-misused-promises': 'off', // more than 100 errors
             '@typescript-eslint/no-unsafe-argument': 'off', // more than 300 errors

--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
@@ -12,6 +12,7 @@ import { SEARCH_OPTIONS_QUERY } from 'queries/search';
 import usePermissions from 'hooks/usePermissions';
 import useURLSearch from 'hooks/useURLSearch';
 import { clustersDelegatedScanningPath } from 'routePaths';
+import { Cluster } from 'services/ClustersService';
 import parseURL from 'utils/URLParser';
 
 import ClustersTablePanel from './ClustersTablePanel';
@@ -32,8 +33,8 @@ function ClustersPage(): ReactElement {
 
     // Handle changes to the currently selected deployment.
     const setSelectedClusterId = useCallback(
-        (newCluster: string) => {
-            const newClusterId = newCluster || '';
+        (newCluster: string | Cluster) => {
+            const newClusterId = typeof newCluster === 'string' ? newCluster : newCluster?.id ?? '';
             const newWorkflowState = newClusterId
                 ? workflowState.pushRelatedEntity(entityTypes.CLUSTER, newClusterId)
                 : workflowState.pop();

--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
@@ -32,8 +32,8 @@ function ClustersPage(): ReactElement {
 
     // Handle changes to the currently selected deployment.
     const setSelectedClusterId = useCallback(
-        (newCluster: any) => {
-            const newClusterId = newCluster?.id || newCluster || '';
+        (newCluster: string) => {
+            const newClusterId = newCluster || '';
             const newWorkflowState = newClusterId
                 ? workflowState.pushRelatedEntity(entityTypes.CLUSTER, newClusterId)
                 : workflowState.pop();

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategoryChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategoryChart.tsx
@@ -197,7 +197,9 @@ function ViolationsByPolicyCategoryChart({
                 data={data}
                 labelComponent={<ChartTooltip constrainToVisibleArea />}
                 events={[
-                    navigateOnClickEvent(history, (targetProps) => {
+                    // TS2339: Property 'xName' does not exist on type '{}'.
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    navigateOnClickEvent(history, (targetProps: any) => {
                         const category = targetProps?.datum?.xName;
                         return linkForViolationsCategory(
                             category,

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -138,7 +138,7 @@ const TopologyComponent = ({
     }, [controller]);
 
     const panNodeIntoView = useCallback(
-        (node) => {
+        (node: CustomNodeModel) => {
             const selectedNodeElement = controller.getNodeById(node.id);
             if (selectedNodeElement) {
                 // the offset is to make sure the label also makes it inside the viewport

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -138,7 +138,7 @@ const TopologyComponent = ({
     }, [controller]);
 
     const panNodeIntoView = useCallback(
-        (node: any) => {
+        (node) => {
             const selectedNodeElement = controller.getNodeById(node.id);
             if (selectedNodeElement) {
                 // the offset is to make sure the label also makes it inside the viewport

--- a/ui/apps/platform/src/Containers/Policies/Modal/DuplicatePolicyForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/DuplicatePolicyForm.tsx
@@ -17,7 +17,8 @@ function DuplicatePolicyForm({
     // this creates a partially applied function to update the radio button value,
     //   and then notified the parent
     const changeRadio = useCallback(
-        (handler: any, name: any, value: any) => () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (handler: any, name: string, value: string) => () => {
             handler(name)(value);
             updateResolution(name, value);
         },
@@ -27,7 +28,8 @@ function DuplicatePolicyForm({
     // this creates a partially applied function to update a text value,
     //   and then notified the parent
     const changeText = useCallback(
-        (handler: any, name: any) => (value) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (handler: any, name: string) => (value: string) => {
             handler(name)(value);
             updateResolution(name, value);
         },

--- a/ui/apps/platform/src/Containers/Policies/PolicyPage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PolicyPage.tsx
@@ -8,7 +8,7 @@ import { policiesBasePath } from 'routePaths';
 import NotFoundMessage from 'Components/NotFoundMessage';
 import PageTitle from 'Components/PageTitle';
 import { getPolicy, updatePolicyDisabledState } from 'services/PoliciesService';
-import { ClientPolicy } from 'types/policy.proto';
+import { ClientPolicy, Policy } from 'types/policy.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { ExtendedPageAction } from 'utils/queryStringUtils';
 
@@ -38,7 +38,7 @@ type WizardPolicyState = {
 
 const wizardPolicyState = createStructuredSelector<
     WizardPolicyState,
-    { wizardPolicy: ClientPolicy }
+    { wizardPolicy: ClientPolicy } // TODO is this ClientPolicy or Policy?
 >({
     wizardPolicy: selectors.getWizardPolicy,
 });
@@ -56,9 +56,12 @@ function PolicyPage({
 }: PolicyPageProps): ReactElement {
     const { wizardPolicy } = useSelector(wizardPolicyState);
 
+    // If wizardPolicy: ClientPolicy is correct above, then getClientWizardPolicy is unneeded below.
+    // TS2352: Conversion of type 'ClientPolicy' to type 'Policy' may be a mistake because neither type sufficiently overlaps with the other.
+    // If this was intentional, convert the expression to 'unknown' first.
     const [policy, setPolicy] = useState<ClientPolicy>(
         pageAction === 'generate' && wizardPolicy
-            ? getClientWizardPolicy(wizardPolicy)
+            ? getClientWizardPolicy(wizardPolicy as unknown as Policy)
             : initialPolicy
     );
     const [policyError, setPolicyError] = useState<ReactElement | null>(null);
@@ -122,7 +125,7 @@ function PolicyPage({
                     <PolicyDetail
                         handleUpdateDisabledState={handleUpdateDisabledState}
                         hasWriteAccessForPolicy={hasWriteAccessForPolicy}
-                        policy={policy}
+                        policy={policy as unknown as Policy}
                     />
                 ))
             )}

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
@@ -14,15 +14,18 @@ import isEqual from 'lodash/isEqual';
 import pluralize from 'pluralize';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
-import useTableSelection from 'hooks/useTableSelection';
 import TableCellValue from 'Components/TableCellValue/TableCellValue';
+import { IntegrationTableColumnDescriptor } from 'Containers/Integrations/utils/tableColumnDescriptor';
+import useTableSelection from 'hooks/useTableSelection';
+import { ClientPolicyValue } from 'types/policy.proto';
+import { SignatureIntegration } from 'types/signatureIntegration.proto';
 
 type TableModalProps = {
-    setValue: (value: unknown) => void;
-    value: any;
+    setValue: (value: ClientPolicyValue) => void;
+    value: ClientPolicyValue;
     readOnly?: boolean;
     rows: { id: string; link: string }[];
-    columns: any;
+    columns: IntegrationTableColumnDescriptor<SignatureIntegration>[];
     typeText: string;
 };
 
@@ -37,7 +40,8 @@ function TableModal({
     const [isModalOpen, setIsModalOpen] = useState(false);
 
     const isPreSelected = useCallback(
-        (row: any) => (value.arrayValue ? (value.arrayValue.includes(row.id) as boolean) : false),
+        (row: { id: string }) =>
+            Array.isArray(value.arrayValue) ? value.arrayValue.includes(row.id) : false,
         [value]
     );
 
@@ -60,8 +64,8 @@ function TableModal({
                 data-testid="table-modal-text-input"
                 isDisabled
                 value={
-                    value.arrayValue?.length > 0
-                        ? `Selected ${value.arrayValue?.length as string} ${pluralize(
+                    Array.isArray(value.arrayValue) && value.arrayValue.length !== 0
+                        ? `Selected ${value.arrayValue.length} ${pluralize(
                               typeText,
                               value.arrayValue?.length
                           )}`

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -381,7 +381,9 @@ function preFormatNestedPolicyFields(policy: Policy): ClientPolicy {
         return policy as unknown as ClientPolicy;
     }
 
-    const clientPolicy = cloneDeep(policy) as ClientPolicy;
+    // TS2352: Conversion of type 'Policy' to type 'ClientPolicy' may be a mistake because neither type sufficiently overlaps with the other.
+    // If this was intentional, convert the expression to 'unknown' first.
+    const clientPolicy = cloneDeep(policy) as unknown as ClientPolicy;
     clientPolicy.serverPolicySections = policy.policySections;
     // itreating through each value in a policy group in a policy section to parse value string
     policy.policySections.forEach((policySection, sectionIdx) => {

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -420,10 +420,14 @@ export function formatValueStr(valueObj: ValueObj, fieldName: string): string {
 
 function postFormatNestedPolicyFields(policy: ClientPolicy): Policy {
     if (!policy.policySections) {
-        return policy;
+        // TS2352: Conversion of type 'ClientPolicy' to type 'Policy' may be a mistake because neither type sufficiently overlaps with the other.
+        // If this was intentional, convert the expression to 'unknown' first.
+        return policy as unknown as Policy;
     }
 
-    const serverPolicy = cloneDeep(policy) as Policy;
+    // TS2352: Conversion of type 'ClientPolicy' to type 'Policy' may be a mistake because neither type sufficiently overlaps with the other.
+    // If this was intentional, convert the expression to 'unknown' first.
+    const serverPolicy = cloneDeep(policy) as unknown as Policy;
     if (policy.criteriaLocked) {
         serverPolicy.policySections = policy.serverPolicySections;
     } else {
@@ -456,7 +460,9 @@ function postFormatNestedPolicyFields(policy: ClientPolicy): Policy {
  */
 function preFormatExclusionField(policy: Policy): ClientPolicy {
     const { exclusions } = policy;
-    const clientPolicy = { ...policy } as ClientPolicy;
+    // TS2352: Conversion of type 'Policy' to type 'ClientPolicy' may be a mistake because neither type sufficiently overlaps with the other.
+    // If this was intentional, convert the expression to 'unknown' first.
+    const clientPolicy = { ...policy } as unknown as ClientPolicy;
 
     clientPolicy.excludedImageNames = [];
 
@@ -476,7 +482,9 @@ function preFormatExclusionField(policy: Policy): ClientPolicy {
  * Merge client-wizard excludedDeploymentScopes and excludedImageNames properties into server exclusions property.
  */
 export function postFormatExclusionField(policy: ClientPolicy): Policy {
-    const serverPolicy = { ...policy } as Policy;
+    // TS2352: Conversion of type 'ClientPolicy' to type 'Policy' may be a mistake because neither type sufficiently overlaps with the other.
+    // If this was intentional, convert the expression to 'unknown' first.
+    const serverPolicy = { ...policy } as unknown as Policy;
     serverPolicy.exclusions = [];
 
     const { excludedDeploymentScopes } = policy;
@@ -500,10 +508,14 @@ export function postFormatExclusionField(policy: ClientPolicy): Policy {
 
 export function preFormatImageSigningPolicyGroup(policy: Policy): ClientPolicy {
     if (!policy.policySections) {
-        return policy as ClientPolicy;
+        // TS2352: Conversion of type 'Policy' to type 'ClientPolicy' may be a mistake because neither type sufficiently overlaps with the other.
+        // If this was intentional, convert the expression to 'unknown' first.
+        return policy as unknown as ClientPolicy;
     }
 
-    const clientPolicy = cloneDeep(policy) as ClientPolicy;
+    // TS2352: Conversion of type 'Policy' to type 'ClientPolicy' may be a mistake because neither type sufficiently overlaps with the other.
+    // If this was intentional, convert the expression to 'unknown' first.
+    const clientPolicy = cloneDeep(policy) as unknown as ClientPolicy;
     policy.policySections.forEach((policySection, sectionIdx) => {
         const { policyGroups } = policySection;
         policyGroups.forEach((policyGroup, groupIdx) => {

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -376,7 +376,9 @@ export function parseValueStr(value, fieldName): ValueObj {
 
 function preFormatNestedPolicyFields(policy: Policy): ClientPolicy {
     if (!policy.policySections) {
-        return policy as ClientPolicy;
+        // TS2352: Conversion of type 'Policy' to type 'ClientPolicy' may be a mistake because neither type sufficiently overlaps with the other.
+        // If this was intentional, convert the expression to 'unknown' first.
+        return policy as unknown as ClientPolicy;
     }
 
     const clientPolicy = cloneDeep(policy) as ClientPolicy;

--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
@@ -18,6 +18,7 @@ import useIsRouteEnabled from 'hooks/useIsRouteEnabled';
 import usePermissions from 'hooks/usePermissions';
 import { fetchAlert } from 'services/AlertsService';
 import { Alert, isDeploymentAlert, isResourceAlert } from 'types/alert.proto';
+import { Policy } from 'types/policy.proto';
 
 import DeploymentTabWithReadAccessForDeployment from './Deployment/DeploymentTabWithReadAccessForDeployment';
 import DeploymentTabWithoutReadAccessForDeployment from './Deployment/DeploymentTabWithoutReadAccessForDeployment';
@@ -135,7 +136,9 @@ function ViolationDetailsPage(): ReactElement {
                                     Policy overview
                                 </Title>
                                 <Divider component="div" className="pf-u-pb-md" />
-                                <PolicyDetailContent policy={getClientWizardPolicy(policy)} />
+                                <PolicyDetailContent
+                                    policy={getClientWizardPolicy(policy) as unknown as Policy}
+                                />
                             </PageSection>
                         </Tab>
                     )}

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/Form/NotifierSelection.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/Form/NotifierSelection.tsx
@@ -20,10 +20,10 @@ import EmailNotifierFormModal from './EmailNotifierFormModal';
 type NotifierSelectionProps = {
     notifierId: string;
     mailingLists: string[];
-    setFieldValue: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
-    handleBlur: (e: React.FocusEvent<any, Element>) => void;
-    errors: FormikErrors<any>;
-    touched: FormikTouched<any>;
+    setFieldValue: (field: string, value: unknown, shouldValidate?: boolean | undefined) => void;
+    handleBlur: (e: React.FocusEvent<unknown, Element>) => void;
+    errors: FormikErrors<unknown>;
+    touched: FormikTouched<unknown>;
     allowCreate: boolean;
 };
 

--- a/ui/apps/platform/src/hooks/useWidgetConfig.ts
+++ b/ui/apps/platform/src/hooks/useWidgetConfig.ts
@@ -99,7 +99,7 @@ function useWidgetConfig<ConfigT extends WidgetConfig, ActionT = Partial<ConfigT
     });
 
     const configUpdateFn = useCallback(
-        (config: any) => {
+        (config: ActionT) => {
             const nextValue = reducer
                 ? reducer(widgetRouteConfig, config)
                 : { ...widgetRouteConfig, ...config };

--- a/ui/apps/platform/src/utils/chartUtils.ts
+++ b/ui/apps/platform/src/utils/chartUtils.ts
@@ -1,5 +1,10 @@
 import { History } from 'react-router-dom';
-import { getTheme, ChartThemeColor, ChartBarProps } from '@patternfly/react-charts';
+import {
+    ChartBarProps,
+    ChartLabelProps,
+    ChartThemeColor,
+    getTheme,
+} from '@patternfly/react-charts';
 import merge from 'lodash/merge';
 
 import { policySeverityColorMap } from 'constants/severityColors';
@@ -55,7 +60,7 @@ type ChartEventHandler = ValueOf<ChartEventProp['eventHandlers']>;
 export function navigateOnClickEvent(
     history: History,
     /** A function that generates the link to navigate to when the entity is clicked */
-    linkWith: (props: any) => string,
+    linkWith: (props: ChartLabelProps) => string,
     /** An array of Victory onClick event handlers that will be called before navigation is initiated */
     defaultOnClicks: ChartEventHandler[] = []
 ): ChartEventProp {


### PR DESCRIPTION
## Description

We disabled some rules to limit the number of changes in #8629

1. To expedite turning on this rule, I added disable comments where I am not sure about types:
    * `handler` argument in `DuplicatePolicyForm`
    * `targetProps?.datum?.xName` in ViolationsByPolicyCategoryChart
2. TypeScript errors related to `ClientPolicy` and `Policy` were confusing.
    Although I think some of the type declarations are incorrect, I added `as unknown` idiom which we can find in the future to sort it out.
    * `yarn build` displays only the first error.
    * `yarn start` displays some errors in its overlay.
    * Visual Studio Code displays errors only for open files. The delayed cause and effect between errors felt like dominos falling in slow motion.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui
3. `yarn start` in ui