### PR TITLE
fix: do not set central ID as user ID when tracking secured cluster registration

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -17,7 +17,7 @@ const securedClusterClient = "Secured Cluster"
 
 func trackClusterRegistered(ctx context.Context, cluster *storage.Cluster) {
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
-		userID := cfg.ClientID
+		var userID string
 		if id, err := authn.IdentityFromContext(ctx); err == nil {
 			userID = cfg.HashUserAuthID(id)
 		}


### PR DESCRIPTION
## Description

Telemetry framework sets specific properties to the Track event if no user ID is provided. This results in `Platform` property to be `Central Server` on Amplitude, for example.
The code shouldn't had set user ID to client ID (i.e. central ID), otherwise the `Platform` of the central changes to `Central`.


## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
