### PR TITLE
ROX-20934: Change the scope value for global to be more human readable

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
@@ -142,9 +142,12 @@ export type RequestScopeProps = {
 };
 
 export function RequestScope({ scope }: RequestScopeProps) {
-    return (
-        <div>{`${scope.imageScope.registry}/${scope.imageScope.remote}:${scope.imageScope.tag}`}</div>
-    );
+    const { registry, remote, tag } = scope.imageScope;
+    const text =
+        registry === '.*' && remote === '.*' && tag === '.*'
+            ? '.*'
+            : `${registry}/${remote}:${tag}`;
+    return <div>{text}</div>;
 }
 
 export type RequestedItemsProps = {


### PR DESCRIPTION
## Description

This PR changes the value for the global scope shown in the `Scope` column to be more human-readable (well at least as much as it is right now). So instead of `.*/.*:.*` it'll be just `.*`

## Screenshot

<img width="1440" alt="Screenshot 2023-11-28 at 11 16 22 AM" src="https://github.com/stackrox/stackrox/assets/4805485/7cfeb130-5f98-4f61-acd2-3639ed75743d">
