### PR TITLE
chore(perf): Ignore tekton last applied hash annotation

### DIFF
--- a/pkg/kubernetes/annotations.go
+++ b/pkg/kubernetes/annotations.go
@@ -17,6 +17,7 @@ var (
 		"k8s.ovn.org/pod-networks",
 		"k8s.v1.cni.cncf.io/network-status",
 		"k8s.v1.cni.cncf.io/networks-status",
+		"operator.tekton.dev/last-applied-hash",
 	)
 )
 


### PR DESCRIPTION
## Description

Small thing noticed when using tekton is that it will append the hash into an annotation. This forces the storage of the object even if there isn't a change in our representation of it

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Trivial

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
