### PR TITLE
ROX-19385: Add flow for cancelling request

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -148,9 +148,7 @@ function ExceptionRequestDetailsPage() {
     const showApproveDenyButtons =
         hasWriteAccessForApproving &&
         (status === 'PENDING' || status === 'APPROVED_PENDING_UPDATE');
-    const showCancelButton =
-        currentUser.userId === requester.id &&
-        (status === 'PENDING' || status === 'APPROVED_PENDING_UPDATE');
+    const showCancelButton = currentUser.userId === requester.id;
 
     const relevantCVEs =
         selectedContext === 'CURRENT' ? cves : getCVEsForUpdatedRequest(vulnerabilityException);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -73,6 +73,7 @@ function PendingApprovals() {
                 {
                     ...searchFilter,
                     'Request Status': ['PENDING', 'APPROVED_PENDING_UPDATE'],
+                    'Expired Request': 'false',
                 },
                 sortOption,
                 page - 1,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCancelButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCancelButtonModal.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import { Alert, AlertVariant, Button, Flex, Modal, Spinner, Text } from '@patternfly/react-core';
+
+import {
+    VulnerabilityException,
+    cancelVulnerabilityException,
+} from 'services/VulnerabilityExceptionService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import useModal from 'hooks/useModal';
+import useRestMutation from 'hooks/useRestMutation';
+import useAffectedImagesCount from '../hooks/useAffectedImagesCount';
+
+type RequestCancelButtonModalProps = {
+    exception: VulnerabilityException;
+    onSuccess: (vulnerabilityException: VulnerabilityException) => void;
+};
+
+function RequestCancelButtonModal({ exception, onSuccess }: RequestCancelButtonModalProps) {
+    const cancelRequestMutation = useRestMutation(cancelVulnerabilityException);
+    const { isAffectedImagesCountLoading, affectedImagesCount } = useAffectedImagesCount(exception);
+
+    const { isModalOpen, openModal, closeModal } = useModal();
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    function cancelRequest() {
+        const payload = {
+            id: exception.id,
+        };
+        cancelRequestMutation.mutate(payload, {
+            onSuccess: (exception) => {
+                onSuccess(exception);
+                closeModal();
+            },
+            onError: (error) => {
+                setErrorMessage(getAxiosErrorMessage(error));
+            },
+        });
+    }
+
+    const isCancelRequestDisabled = isAffectedImagesCountLoading || cancelRequestMutation.isLoading;
+
+    return (
+        <>
+            <Button variant="secondary" onClick={openModal}>
+                Cancel request
+            </Button>
+            <Modal
+                variant="small"
+                title="Cancel request"
+                isOpen={isModalOpen}
+                onClose={closeModal}
+                actions={[
+                    <Button
+                        key="approve"
+                        variant="primary"
+                        isLoading={cancelRequestMutation.isLoading}
+                        isDisabled={isCancelRequestDisabled}
+                        onClick={cancelRequest}
+                    >
+                        Cancel request
+                    </Button>,
+                    <Button key="cancel" variant="link" onClick={closeModal}>
+                        Cancel
+                    </Button>,
+                ]}
+                showClose={false}
+            >
+                <Flex className="pf-u-py-md">
+                    {errorMessage && (
+                        <Alert isInline variant={AlertVariant.danger} title={errorMessage} />
+                    )}
+                    <Alert
+                        variant="warning"
+                        isInline
+                        title="Cancelling the request will return the CVEs to the 'Observed' status."
+                    >
+                        <Text>CVE count: {exception.cves.length}</Text>
+                        <Text>
+                            Affected images:{' '}
+                            {isAffectedImagesCountLoading ? (
+                                <Spinner
+                                    isSVG
+                                    size="md"
+                                    aria-label="Loading affected images count"
+                                />
+                            ) : (
+                                affectedImagesCount
+                            )}
+                        </Text>
+                    </Alert>
+                </Flex>
+            </Modal>
+        </>
+    );
+}
+
+export default RequestCancelButtonModal;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestDenialButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestDenialButtonModal.tsx
@@ -106,7 +106,8 @@ function RequestDenialButtonModal({ exception, onSuccess }: RequestDenialButtonM
                         <Alert isInline variant={AlertVariant.danger} title={errorMessage} />
                     )}
                     <Alert
-                        variant="info"
+                        variant="warning"
+                        isInline
                         title="Denying the request will return the CVEs to the 'Observed' status."
                     >
                         <Text>CVE count: {exception.cves.length}</Text>

--- a/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
+++ b/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
@@ -145,11 +145,11 @@ export type ApproveVulnerabilityExceptionRequest = {
 
 export function approveVulnerabilityException(
     payload: ApproveVulnerabilityExceptionRequest
-): Promise<VulnerabilityDeferralException> {
+): Promise<VulnerabilityException> {
     const { id, comment } = payload;
     const url = `${baseUrl}/${id}/approve`;
     return axios
-        .post<{ exception: VulnerabilityDeferralException }>(url, {
+        .post<{ exception: VulnerabilityException }>(url, {
             comment,
         })
         .then((response) => response.data.exception);
@@ -162,12 +162,26 @@ export type DenyVulnerabilityExceptionRequest = {
 
 export function denyVulnerabilityException(
     payload: DenyVulnerabilityExceptionRequest
-): Promise<VulnerabilityDeferralException> {
+): Promise<VulnerabilityException> {
     const { id, comment } = payload;
     const url = `${baseUrl}/${id}/deny`;
     return axios
-        .post<{ exception: VulnerabilityDeferralException }>(url, {
+        .post<{ exception: VulnerabilityException }>(url, {
             comment,
         })
+        .then((response) => response.data.exception);
+}
+
+export type CancelVulnerabilityExceptionRequest = {
+    id: string;
+};
+
+export function cancelVulnerabilityException(
+    payload: CancelVulnerabilityExceptionRequest
+): Promise<VulnerabilityException> {
+    const { id } = payload;
+    const url = `${baseUrl}/${id}/cancel`;
+    return axios
+        .post<{ exception: VulnerabilityException }>(url)
         .then((response) => response.data.exception);
 }


### PR DESCRIPTION
## Description

This PR adds the ability to cancel requests. The cancel button will show up on the Request Details page on the following conditions:
1. The user is the requester
2. The request is either in the `PENDING` or `APPROVED_PENDING_UPDATE` status

## Screenshots

The cancel button shows up in the top right section
<img width="1440" alt="Screenshot 2023-12-04 at 9 48 45 AM" src="https://github.com/stackrox/stackrox/assets/4805485/df4bd638-cb17-4775-94be-14c60d0879e2">

Clicking on the button will show a modal. The modal will display an alert that gives a little warning and shows how many CVEs are in the request and how many Images it will affect.
<img width="1437" alt="Screenshot 2023-12-04 at 9 48 54 AM" src="https://github.com/stackrox/stackrox/assets/4805485/3e3a6155-01a3-46ac-b9b1-904452ce0549">

If the request was canceled, you'll be navigated back to the pending requests table. NOTE: This may change depending on UX decision here https://redhat-internal.slack.com/archives/C03JMGWJYMD/p1701372644906699.
<img width="1440" alt="Screenshot 2023-12-04 at 9 50 08 AM" src="https://github.com/stackrox/stackrox/assets/4805485/548b701d-4c52-4c01-8982-7ebe8e50f19a">


