### PR TITLE
ROX-20905: Handle multiple yaml files

### DIFF
--- a/central/detection/service/service_impl.go
+++ b/central/detection/service/service_impl.go
@@ -39,6 +39,7 @@ import (
 	resourcesConv "github.com/stackrox/rox/pkg/protoconv/resources"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	pkgUtils "github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/pkg/uuid"
 	"google.golang.org/grpc"
 	coreV1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -234,6 +235,12 @@ func (s *serviceImpl) runDeployTimeDetect(ctx context.Context, enrichmentContext
 	if err != nil {
 		return nil, errox.InvalidArgs.New("could not convert to deployment from resource").CausedBy(err)
 	}
+
+	// Deployment ID is empty because the processed yaml comes from roxctl and therefore doesn't
+	// get a Kubernetes generated ID. This is a temporary ID only required for roxctl to distinguish
+	// between different generated deployments.
+	deployment.Id = uuid.NewV4().String()
+	fmt.Printf("Set deployment ID %s\n", deployment.GetId())
 
 	return s.enrichAndDetect(ctx, enrichmentContext, deployment, policyCategories...)
 }

--- a/central/detection/service/service_impl.go
+++ b/central/detection/service/service_impl.go
@@ -39,7 +39,6 @@ import (
 	resourcesConv "github.com/stackrox/rox/pkg/protoconv/resources"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	pkgUtils "github.com/stackrox/rox/pkg/utils"
-	"github.com/stackrox/rox/pkg/uuid"
 	"google.golang.org/grpc"
 	coreV1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -235,11 +234,6 @@ func (s *serviceImpl) runDeployTimeDetect(ctx context.Context, enrichmentContext
 	if err != nil {
 		return nil, errox.InvalidArgs.New("could not convert to deployment from resource").CausedBy(err)
 	}
-
-	// Deployment ID is empty because the processed yaml comes from roxctl and therefore doesn't
-	// get a Kubernetes generated ID. This is a temporary ID only required for roxctl to distinguish
-	// between different generated deployments.
-	deployment.Id = uuid.NewV4().String()
 
 	return s.enrichAndDetect(ctx, enrichmentContext, deployment, policyCategories...)
 }

--- a/central/detection/service/service_impl.go
+++ b/central/detection/service/service_impl.go
@@ -240,7 +240,6 @@ func (s *serviceImpl) runDeployTimeDetect(ctx context.Context, enrichmentContext
 	// get a Kubernetes generated ID. This is a temporary ID only required for roxctl to distinguish
 	// between different generated deployments.
 	deployment.Id = uuid.NewV4().String()
-	fmt.Printf("Set deployment ID %s\n", deployment.GetId())
 
 	return s.enrichAndDetect(ctx, enrichmentContext, deployment, policyCategories...)
 }

--- a/roxctl/deployment/check/check.go
+++ b/roxctl/deployment/check/check.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/stackrox/rox/pkg/printers"
 	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stackrox/rox/pkg/utils"
-	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
@@ -212,7 +212,7 @@ func (d *deploymentCheckCommand) checkDeployment() error {
 				return errors.Wrapf(err, "could not read deployment file: %q", file)
 			}
 			if len(deploymentFileContents) > 0 {
-				deploymentFileContents = append(deploymentFileContents, "---\n"...)
+				deploymentFileContents = append(deploymentFileContents, "\n---\n"...)
 			}
 			deploymentFileContents = append(deploymentFileContents, fileContents...)
 		}
@@ -251,17 +251,13 @@ func (d *deploymentCheckCommand) getAlertsAndIgnoredObjectRefs(deploymentYaml st
 		alerts = append(alerts, r.GetAlerts()...)
 	}
 
-	// Deployment ID is empty because the processed yaml comes from roxctl and therefore doesn't
-	// get a  Kubernetes generated ID. This is a temporary ID only required for roxctl to distinguish
-	// between different generated deployments.
-	for _, alert := range alerts {
+	for i, alert := range alerts {
 		switch entity := alert.Entity.(type) {
 		case *storage.Alert_Deployment_:
-			if entity.Deployment.GetId() == "" {
-				entity.Deployment.Id = uuid.NewV4().String()
-			}
+			fmt.Printf("Alert %d has ID: %s\n", i, entity.Deployment.GetId())
 		}
 	}
+
 	return alerts, response.GetIgnoredObjectRefs(), nil
 }
 

--- a/roxctl/deployment/check/check.go
+++ b/roxctl/deployment/check/check.go
@@ -109,7 +109,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	// Add all printer related flags
 	objectPrinterFactory.AddFlags(c)
 
-	c.Flags().StringArrayVar(&deploymentCheckCmd.file, "file", nil, "yaml file to send to Central to evaluate policies against")
+	c.Flags().StringArrayVar(&deploymentCheckCmd.files, "file", nil, "yaml files to send to Central to evaluate policies against")
 	c.Flags().BoolVar(&deploymentCheckCmd.json, "json", false, "output policy results as json.")
 	c.Flags().IntVarP(&deploymentCheckCmd.retryDelay, "retry-delay", "d", 3, "set time to wait between retries in seconds")
 	c.Flags().IntVarP(&deploymentCheckCmd.retryCount, "retries", "r", 3, "Number of retries before exiting as error")
@@ -128,7 +128,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	// We need a string parameter with the filenames for the sarif printer factory
 	// If a report is based on a single yaml file it will work as previously, if multiple
 	// they will be concatenated as csv
-	deploymentCheckCmd.joinedFiles = strings.Join(deploymentCheckCmd.file[:], ",")
+	deploymentCheckCmd.joinedFiles = strings.Join(deploymentCheckCmd.files[:], ",")
 
 	return c
 }
@@ -136,7 +136,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 type deploymentCheckCommand struct {
 	// properties bound to cobra flags
 	joinedFiles        string
-	file               []string
+	files              []string
 	json               bool
 	retryDelay         int
 	retryCount         int
@@ -171,7 +171,7 @@ func (d *deploymentCheckCommand) Construct(_ []string, cmd *cobra.Command, f *pr
 
 func (d *deploymentCheckCommand) Validate() error {
 	var errors errorhelpers.ErrorList
-	for _, file := range d.file {
+	for _, file := range d.files {
 		if _, err := os.Open(file); err != nil {
 			errors.AddError(err)
 		}
@@ -202,7 +202,7 @@ func (d *deploymentCheckCommand) Check() error {
 
 func (d *deploymentCheckCommand) checkDeployment() error {
 	var deploymentFileContents []byte
-	for _, file := range d.file {
+	for _, file := range d.files {
 		fileContents, err := os.ReadFile(file)
 		if err != nil {
 			return errors.Wrapf(err, "could not read deployment file: %q", file)

--- a/roxctl/deployment/check/check.go
+++ b/roxctl/deployment/check/check.go
@@ -172,14 +172,14 @@ func (d *deploymentCheckCommand) Construct(_ []string, cmd *cobra.Command, f *pr
 }
 
 func (d *deploymentCheckCommand) Validate() error {
-	var errors errorhelpers.ErrorList
+	var fileErrs errorhelpers.ErrorList
 	for _, file := range d.files {
 		if _, err := os.Open(file); err != nil {
-			errors.AddError(err)
+			fileErrs.AddError(err)
 		}
 	}
-	if !errors.Empty() {
-		return common.ErrInvalidCommandOption.CausedBy(errors.ErrorStrings())
+	if !fileErrs.Empty() {
+		return common.ErrInvalidCommandOption.CausedBy(fileErrs.ErrorStrings())
 	}
 
 	return nil
@@ -214,7 +214,7 @@ func (d *deploymentCheckCommand) checkDeployment() error {
 		}
 		deploymentFileContents = append(deploymentFileContents, fileContents...)
 	}
-	log.Info("roxctl deployment check is handling file input of size %s", len(deploymentFileContents))
+	d.env.Logger().InfofLn("roxctl deployment check is handling file input of size %d", len(deploymentFileContents))
 
 	alerts, ignoredObjRefs, err := d.getAlertsAndIgnoredObjectRefs(string(deploymentFileContents))
 	if err != nil {

--- a/roxctl/deployment/check/check.go
+++ b/roxctl/deployment/check/check.go
@@ -116,7 +116,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c.Flags().StringSliceVarP(&deploymentCheckCmd.policyCategories, "categories", "c", nil, "optional comma separated list of policy categories to run.  Defaults to all policy categories.")
 	c.Flags().BoolVar(&deploymentCheckCmd.printAllViolations, "print-all-violations", false, "whether to print all violations per alert or truncate violations for readability")
 	c.Flags().BoolVar(&deploymentCheckCmd.force, "force", false, "bypass Central's cache for images and force a new pull from the Scanner")
-	//utils.Must(c.MarkFlagRequired("file"))
+	c.MarkFlagsOneRequired("file", "files")
 	c.Flags().StringVar(&deploymentCheckCmd.cluster, "cluster", "", "cluster name or ID to use as context for evaluation")
 
 	// mark legacy output format specific flags as deprecated

--- a/roxctl/deployment/check/check.go
+++ b/roxctl/deployment/check/check.go
@@ -109,7 +109,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	// Add all printer related flags
 	objectPrinterFactory.AddFlags(c)
 
-	c.Flags().StringArrayVar(&deploymentCheckCmd.files, "file", nil, "yaml files to send to Central to evaluate policies against")
+	c.Flags().StringArrayVarP(&deploymentCheckCmd.files, "file", "f", nil, "yaml files to send to Central to evaluate policies against")
 	c.Flags().BoolVar(&deploymentCheckCmd.json, "json", false, "output policy results as json.")
 	c.Flags().IntVarP(&deploymentCheckCmd.retryDelay, "retry-delay", "d", 3, "set time to wait between retries in seconds")
 	c.Flags().IntVarP(&deploymentCheckCmd.retryCount, "retries", "r", 3, "Number of retries before exiting as error")

--- a/roxctl/deployment/check/check.go
+++ b/roxctl/deployment/check/check.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/gjson"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/printers"
 	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stackrox/rox/pkg/utils"
@@ -38,7 +37,6 @@ const (
 )
 
 var (
-	log = logging.CreateLogger(logging.CurrentModule(), 0)
 	// Default headers to use when printing tabular output
 	defaultDeploymentCheckHeaders = []string{
 		"POLICY", "SEVERITY", "BREAKS DEPLOY", "DEPLOYMENT", "DESCRIPTION", "VIOLATION", "REMEDIATION",
@@ -86,7 +84,7 @@ var (
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	deploymentCheckCmd := &deploymentCheckCommand{env: cliEnvironment}
 
-	// TODO(ROX-21443): Pass deploymentCheckCmd.files to the Sarif printer CTor once they can handle multiple entities
+	// TODO(ROX-21443): Pass deploymentCheckCmd.files to the Sarif printer once it can handle multiple entities
 	objectPrinterFactory, err := printer.NewObjectPrinterFactory("table", append(supportedObjectPrinters,
 		printer.NewSarifPrinterFactory(printers.SarifPolicyReport, sarifJSONPathExpressions, &deploymentCheckCmd.firstFile))...)
 	// this error should never occur, it would only occur if default values are invalid

--- a/roxctl/deployment/check/check.go
+++ b/roxctl/deployment/check/check.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/gjson"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/printers"
 	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stackrox/rox/pkg/utils"
@@ -37,6 +38,7 @@ const (
 )
 
 var (
+	log = logging.CreateLogger(logging.CurrentModule(), 0)
 	// Default headers to use when printing tabular output
 	defaultDeploymentCheckHeaders = []string{
 		"POLICY", "SEVERITY", "BREAKS DEPLOY", "DEPLOYMENT", "DESCRIPTION", "VIOLATION", "REMEDIATION",
@@ -128,7 +130,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	// We need a string parameter with the filenames for the sarif printer factory
 	// If a report is based on a single yaml file it will work as previously, if multiple
 	// they will be concatenated as csv
-	deploymentCheckCmd.joinedFiles = strings.Join(deploymentCheckCmd.files[:], ",")
+	deploymentCheckCmd.joinedFiles = strings.Join(deploymentCheckCmd.files, ",")
 
 	return c
 }
@@ -212,6 +214,7 @@ func (d *deploymentCheckCommand) checkDeployment() error {
 		}
 		deploymentFileContents = append(deploymentFileContents, fileContents...)
 	}
+	log.Info("roxctl deployment check is handling file input of size %s", len(deploymentFileContents))
 
 	alerts, ignoredObjRefs, err := d.getAlertsAndIgnoredObjectRefs(string(deploymentFileContents))
 	if err != nil {

--- a/roxctl/deployment/check/check_test.go
+++ b/roxctl/deployment/check/check_test.go
@@ -281,6 +281,39 @@ func (d *deployCheckTestSuite) SetupTest() {
 	}
 }
 
+func (d *deployCheckTestSuite) TestNormalizeYaml() {
+	cases := map[string]struct {
+		inputYaml              string
+		expectedNormalizedYaml string
+	}{
+		"Should trim leading and trailing whitespace": {
+			inputYaml:              " \n   \t\t \n \nYAMLCONTENT\n \t\t \n \n\t\n\t  ",
+			expectedNormalizedYaml: "YAMLCONTENT\n",
+		},
+		"Should add missing newline at EOF": {
+			inputYaml:              "YAMLCONTENT",
+			expectedNormalizedYaml: "YAMLCONTENT\n",
+		},
+		"Should remove \"---\\n\" prefix": {
+			inputYaml:              "---\nYAMLCONTENT\n",
+			expectedNormalizedYaml: "YAMLCONTENT\n",
+		},
+		"Should remove \"---\" postfix": {
+			inputYaml:              "YAMLCONTENT\n---",
+			expectedNormalizedYaml: "YAMLCONTENT\n",
+		},
+		"Should not remove \"---\" prefix or postfix not separated from yaml content by \\n": {
+			inputYaml:              "---YAMLCONTENT---\n",
+			expectedNormalizedYaml: "---YAMLCONTENT---\n",
+		},
+	}
+	for name, c := range cases {
+		d.Run(name, func() {
+			d.Assert().Equal(c.expectedNormalizedYaml, normalizeYaml(c.inputYaml))
+		})
+	}
+}
+
 func (d *deployCheckTestSuite) TestMultipleFiles() {
 	deployCheckCmd := d.defaultDeploymentCheckCommand
 	deployCheckCmd.files = []string{"testdata/deployment.yaml", "testdata/deployment2.yaml"}

--- a/roxctl/deployment/check/check_test.go
+++ b/roxctl/deployment/check/check_test.go
@@ -284,28 +284,22 @@ func (d *deployCheckTestSuite) SetupTest() {
 }
 
 func (d *deployCheckTestSuite) TestMultipleFiles() {
-	d.defaultDeploymentCheckCommand = deploymentCheckCommand{
-		files:              []string{"testdata/deployment.yaml", "testdata/deployment2.yaml"},
-		retryDelay:         3,
-		retryCount:         3,
-		timeout:            1 * time.Minute,
-		printAllViolations: true,
-	}
+	deployCheckCmd := d.defaultDeploymentCheckCommand
+	deployCheckCmd.files = []string{"testdata/deployment.yaml", "testdata/deployment2.yaml"}
 
 	conn, closeF, server := d.createGRPCMockDetectionService(testDeploymentAlertsWithoutFailure, []string{""})
 	defer closeF()
-	deployCheckCmd := d.defaultDeploymentCheckCommand
 	deployCheckCmd.env, _, _ = d.createMockEnvironmentWithConn(conn)
 
 	tablePrinter, err := printer.NewTabularPrinterFactory(defaultDeploymentCheckHeaders,
 		defaultDeploymentCheckJSONPathExpression).CreatePrinter("table")
-	d.Assert().NoError(err)
+	d.Require().NoError(err)
 	deployCheckCmd.printer = tablePrinter
 	err = deployCheckCmd.Check()
-	d.Assert().NoError(err)
+	d.Require().NoError(err)
 	var expectedBinary []byte
 	expectedBinary, err = os.ReadFile("testdata/testMultipleFilesExpectedYaml.yaml")
-	d.Assert().NoError(err)
+	d.Require().NoError(err)
 	expectedString := fmt.Sprintf("yaml:%s ", strconv.Quote(string(expectedBinary)))
 	d.Assert().Equal(expectedString, server.request.String())
 }

--- a/roxctl/deployment/check/check_test.go
+++ b/roxctl/deployment/check/check_test.go
@@ -327,8 +327,7 @@ func (d *deployCheckTestSuite) TestMultipleFiles() {
 	d.Require().NoError(err)
 	deployCheckCmd.printer = tablePrinter
 	d.Require().NoError(deployCheckCmd.Check())
-	var expectedBinary []byte
-	expectedBinary, err = os.ReadFile("testdata/testMultipleFilesExpectedYaml.yaml")
+	expectedBinary, err := os.ReadFile("testdata/testMultipleFilesExpectedYaml.yaml")
 	d.Require().NoError(err)
 	expectedString := string(expectedBinary)
 	d.Assert().Equal(expectedString, server.request.GetYaml())
@@ -396,15 +395,15 @@ func (d *deployCheckTestSuite) TestConstruct() {
 
 func (d *deployCheckTestSuite) TestValidate() {
 	cases := map[string]struct {
-		file       []string
+		files      []string
 		shouldFail bool
 		error      error
 	}{
 		"should not fail with default file name": {
-			file: d.defaultDeploymentCheckCommand.files,
+			files: d.defaultDeploymentCheckCommand.files,
 		},
 		"should fail with non existing file name": {
-			file:       []string{"invalidfile"},
+			files:      []string{"invalidfile"},
 			shouldFail: true,
 			error:      errox.InvalidArgs,
 		},
@@ -413,7 +412,7 @@ func (d *deployCheckTestSuite) TestValidate() {
 	for name, c := range cases {
 		d.Run(name, func() {
 			deployCheckCmd := d.defaultDeploymentCheckCommand
-			deployCheckCmd.files = c.file
+			deployCheckCmd.files = c.files
 
 			err := deployCheckCmd.Validate()
 			if c.shouldFail {

--- a/roxctl/deployment/check/check_test.go
+++ b/roxctl/deployment/check/check_test.go
@@ -318,7 +318,7 @@ func (d *deployCheckTestSuite) TestMultipleFiles() {
 	deployCheckCmd := d.defaultDeploymentCheckCommand
 	deployCheckCmd.files = []string{"testdata/deployment.yaml", "testdata/deployment2.yaml"}
 
-	conn, closeF, server := d.createGRPCMockDetectionService(testDeploymentAlertsWithoutFailure, []string{""})
+	conn, closeF, server := d.createGRPCMockDetectionService(testDeploymentAlertsWithoutFailure, nil)
 	defer closeF()
 	deployCheckCmd.env, _, _ = d.createMockEnvironmentWithConn(conn)
 

--- a/roxctl/deployment/check/check_test.go
+++ b/roxctl/deployment/check/check_test.go
@@ -376,7 +376,7 @@ func (d *deployCheckTestSuite) TestValidate() {
 		shouldFail bool
 		error      error
 	}{
-		"should not fail with default files name": {
+		"should not fail with default file name": {
 			file: d.defaultDeploymentCheckCommand.files,
 		},
 		"should fail with non existing file name": {

--- a/roxctl/deployment/check/check_test.go
+++ b/roxctl/deployment/check/check_test.go
@@ -275,7 +275,7 @@ func (d *deployCheckTestSuite) createMockEnvironmentWithConn(conn *grpc.ClientCo
 
 func (d *deployCheckTestSuite) SetupTest() {
 	d.defaultDeploymentCheckCommand = deploymentCheckCommand{
-		file:               []string{"testdata/deployment.yaml"},
+		files:              []string{"testdata/deployment.yaml"},
 		retryDelay:         3,
 		retryCount:         3,
 		timeout:            1 * time.Minute,
@@ -285,7 +285,7 @@ func (d *deployCheckTestSuite) SetupTest() {
 
 func (d *deployCheckTestSuite) TestMultipleFiles() {
 	d.defaultDeploymentCheckCommand = deploymentCheckCommand{
-		file:               []string{"testdata/deployment.yaml", "testdata/deployment2.yaml"},
+		files:              []string{"testdata/deployment.yaml", "testdata/deployment2.yaml"},
 		retryDelay:         3,
 		retryCount:         3,
 		timeout:            1 * time.Minute,
@@ -376,8 +376,8 @@ func (d *deployCheckTestSuite) TestValidate() {
 		shouldFail bool
 		error      error
 	}{
-		"should not fail with default file name": {
-			file: d.defaultDeploymentCheckCommand.file,
+		"should not fail with default files name": {
+			file: d.defaultDeploymentCheckCommand.files,
 		},
 		"should fail with non existing file name": {
 			file:       []string{"invalidfile"},
@@ -389,7 +389,7 @@ func (d *deployCheckTestSuite) TestValidate() {
 	for name, c := range cases {
 		d.Run(name, func() {
 			deployCheckCmd := d.defaultDeploymentCheckCommand
-			deployCheckCmd.file = c.file
+			deployCheckCmd.files = c.file
 
 			err := deployCheckCmd.Validate()
 			if c.shouldFail {

--- a/roxctl/deployment/check/check_test.go
+++ b/roxctl/deployment/check/check_test.go
@@ -247,10 +247,10 @@ func (d *deployCheckTestSuite) createGRPCMockDetectionService(alerts []*storage.
 	buffer := 1024 * 1024
 	listener := bufconn.Listen(buffer)
 
-	mockDetectionServiceServer1 := mockDetectionServiceServer{alerts: alerts, ignoredObjRefs: ignoredObjRefs}
+	mockDetectionService := mockDetectionServiceServer{alerts: alerts, ignoredObjRefs: ignoredObjRefs}
 	server := grpc.NewServer()
 	v1.RegisterDetectionServiceServer(server,
-		&mockDetectionServiceServer1)
+		&mockDetectionService)
 
 	go func() {
 		utils.IgnoreError(func() error { return server.Serve(listener) })
@@ -266,7 +266,7 @@ func (d *deployCheckTestSuite) createGRPCMockDetectionService(alerts []*storage.
 		server.Stop()
 	}
 
-	return conn, closeFunction, &mockDetectionServiceServer1
+	return conn, closeFunction, &mockDetectionService
 }
 
 func (d *deployCheckTestSuite) createMockEnvironmentWithConn(conn *grpc.ClientConn) (environment.Environment, *bytes.Buffer, *bytes.Buffer) {

--- a/roxctl/deployment/check/check_test.go
+++ b/roxctl/deployment/check/check_test.go
@@ -3,12 +3,10 @@ package check
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net"
 	"os"
 	"path"
 	"runtime"
-	"strconv"
 	"testing"
 	"time"
 
@@ -295,13 +293,12 @@ func (d *deployCheckTestSuite) TestMultipleFiles() {
 		defaultDeploymentCheckJSONPathExpression).CreatePrinter("table")
 	d.Require().NoError(err)
 	deployCheckCmd.printer = tablePrinter
-	err = deployCheckCmd.Check()
-	d.Require().NoError(err)
+	d.Require().NoError(deployCheckCmd.Check())
 	var expectedBinary []byte
 	expectedBinary, err = os.ReadFile("testdata/testMultipleFilesExpectedYaml.yaml")
 	d.Require().NoError(err)
-	expectedString := fmt.Sprintf("yaml:%s ", strconv.Quote(string(expectedBinary)))
-	d.Assert().Equal(expectedString, server.request.String())
+	expectedString := string(expectedBinary)
+	d.Assert().Equal(expectedString, server.request.GetYaml())
 }
 
 func (d *deployCheckTestSuite) TestConstruct() {

--- a/roxctl/deployment/check/check_test.go
+++ b/roxctl/deployment/check/check_test.go
@@ -275,7 +275,7 @@ func (d *deployCheckTestSuite) createMockEnvironmentWithConn(conn *grpc.ClientCo
 
 func (d *deployCheckTestSuite) SetupTest() {
 	d.defaultDeploymentCheckCommand = deploymentCheckCommand{
-		file:               "testdata/deployment.yaml",
+		file:               []string{"testdata/deployment.yaml"},
 		retryDelay:         3,
 		retryCount:         3,
 		timeout:            1 * time.Minute,
@@ -285,7 +285,7 @@ func (d *deployCheckTestSuite) SetupTest() {
 
 func (d *deployCheckTestSuite) TestMultipleFiles() {
 	d.defaultDeploymentCheckCommand = deploymentCheckCommand{
-		files:              []string{"testdata/deployment.yaml", "testdata/deployment2.yaml"},
+		file:               []string{"testdata/deployment.yaml", "testdata/deployment2.yaml"},
 		retryDelay:         3,
 		retryCount:         3,
 		timeout:            1 * time.Minute,
@@ -372,7 +372,7 @@ func (d *deployCheckTestSuite) TestConstruct() {
 
 func (d *deployCheckTestSuite) TestValidate() {
 	cases := map[string]struct {
-		file       string
+		file       []string
 		shouldFail bool
 		error      error
 	}{
@@ -380,7 +380,7 @@ func (d *deployCheckTestSuite) TestValidate() {
 			file: d.defaultDeploymentCheckCommand.file,
 		},
 		"should fail with non existing file name": {
-			file:       "invalidfile",
+			file:       []string{"invalidfile"},
 			shouldFail: true,
 			error:      errox.InvalidArgs,
 		},

--- a/roxctl/deployment/check/testdata/deployment2.yaml
+++ b/roxctl/deployment/check/testdata/deployment2.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: wordpress2
+  labels:
+    app: wordpress
+spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: frontend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: frontend
+    spec:
+      containers:
+      - image: wordpress:latest
+        name: wordpress
+        env:
+        - name: WORDPRESS_DB_HOST
+          value: wordpress-mysql
+        - name: WORDPRESS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        ports:
+        - containerPort: 22
+          name: wordpress
+        volumeMounts:
+        - name: wordpress-persistent-storage
+          mountPath: /var/www/html
+      volumes:
+      - name: wordpress-persistent-storage
+        persistentVolumeClaim:
+          claimName: wp-pv-claim

--- a/roxctl/deployment/check/testdata/testMultipleFilesExpectedYaml.yaml
+++ b/roxctl/deployment/check/testdata/testMultipleFilesExpectedYaml.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: wordpress
+  labels:
+    app: wordpress
+spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: frontend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: frontend
+    spec:
+      containers:
+      - image: wordpress:latest
+        name: wordpress
+        env:
+        - name: WORDPRESS_DB_HOST
+          value: wordpress-mysql
+        - name: WORDPRESS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        ports:
+        - containerPort: 22
+          name: wordpress
+        volumeMounts:
+        - name: wordpress-persistent-storage
+          mountPath: /var/www/html
+      volumes:
+      - name: wordpress-persistent-storage
+        persistentVolumeClaim:
+          claimName: wp-pv-claim
+
+---
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: wordpress2
+  labels:
+    app: wordpress
+spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: frontend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: frontend
+    spec:
+      containers:
+      - image: wordpress:latest
+        name: wordpress
+        env:
+        - name: WORDPRESS_DB_HOST
+          value: wordpress-mysql
+        - name: WORDPRESS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        ports:
+        - containerPort: 22
+          name: wordpress
+        volumeMounts:
+        - name: wordpress-persistent-storage
+          mountPath: /var/www/html
+      volumes:
+      - name: wordpress-persistent-storage
+        persistentVolumeClaim:
+          claimName: wp-pv-claim

--- a/roxctl/deployment/check/testdata/testMultipleFilesExpectedYaml.yaml
+++ b/roxctl/deployment/check/testdata/testMultipleFilesExpectedYaml.yaml
@@ -38,7 +38,6 @@ spec:
       - name: wordpress-persistent-storage
         persistentVolumeClaim:
           claimName: wp-pv-claim
-
 ---
 apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
 kind: Deployment


### PR DESCRIPTION
## Description

Take multiple yaml files as input to roxctl deployment check --file instead of only a single one.
In order not to break legacy support I decided to add an additional --files flag with this behavior. Let me know in the comments if it would make more sense to also remove the old --file flag, OR to make the --file flag work in the way the --files flag works now.

On a sidenote I also moved the assignment of random IDs for deployments parsed from yaml from the previous PR https://github.com/stackrox/stackrox/pull/8763 to a different spot where I think it makes more sense.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

I manually tested roxctl deployment check --files with multiple input files and some print statements and it looks to be behaving as expected to me.
