### PR TITLE
ROX-20787: Add STS to AWS SH notifier

### DIFF
--- a/central/notifiers/awssh/notifier.go
+++ b/central/notifiers/awssh/notifier.go
@@ -4,6 +4,7 @@ package awssh
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -22,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/cryptoutils/cryptocodec"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/set"
@@ -216,7 +218,7 @@ func newNotifier(configuration configuration) (*notifier, error) {
 			"",
 		))
 	}
-
+	awsConfig = awsConfig.WithHTTPClient(&http.Client{Transport: proxy.RoundTripper()})
 	awss, err := session.NewSession(awsConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create AWS session")

--- a/central/notifiers/awssh/notifier_test.go
+++ b/central/notifiers/awssh/notifier_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mocks/github.com/aws/aws-sdk-go/service/securityhub/securityhubiface/mocks"
 	"github.com/stackrox/rox/pkg/stringutils"
-	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -333,12 +332,7 @@ func configFromEnv() (*storage.AWSSecurityHub, error) {
 func TestNotifierCreationFromEnvAndTest(t *testing.T) {
 	config, err := configFromEnv()
 	if err != nil {
-		if testutils.IsRunningInCI() {
-			// TODO(tvoss): Fail with an error once we have credentials for CI runs.
-			t.Skip("failed to load config from env", err)
-		} else {
-			t.Skip("failed to load config from env", err)
-		}
+		t.Skip("failed to load config from env", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
## Description

Add STS support to the AWS SH notifier and correctly set up the client during creation.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

1. Create a sample AWS SH notifier with STS enabled
```json
{
    "id": "",
    "name": "sts-security-hub",
    "type": "awsSecurityHub",
    "uiEndpoint": "https://<central-endpoint>",
    "awsSecurityHub": {
        "region": "us-east-1",
        "credentials": {
            "stsEnabled": true
        },
        "accountId": "<account-id>"
    }
}
```
2. Ensure that the test functionality works as expected (i.e. go to `Integrations -> AWS SH -> Click Edit -> Click Test`)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
