### PR TITLE
fix(perf): Reduce memory usage for compliance runs

### DIFF
--- a/central/compliance/data/factory.go
+++ b/central/compliance/data/factory.go
@@ -20,13 +20,12 @@ import (
 	processIndicatorStore "github.com/stackrox/rox/central/processindicator/datastore"
 	k8sRoleDataStore "github.com/stackrox/rox/central/rbac/k8srole/datastore"
 	k8sBindingDataStore "github.com/stackrox/rox/central/rbac/k8srolebinding/datastore"
-	"github.com/stackrox/rox/generated/internalapi/compliance"
 	"github.com/stackrox/rox/pkg/images/integration"
 )
 
 // RepositoryFactory allows creating `ComplianceDataRepository`s to be used in compliance runs.
 type RepositoryFactory interface {
-	CreateDataRepository(ctx context.Context, domain framework.ComplianceDomain, scrapeResults map[string]*compliance.ComplianceReturn) (framework.ComplianceDataRepository, error)
+	CreateDataRepository(ctx context.Context, domain framework.ComplianceDomain) (framework.ComplianceDataRepository, error)
 }
 
 type factory struct {
@@ -70,9 +69,9 @@ func NewDefaultFactory() RepositoryFactory {
 	}
 }
 
-func (f *factory) CreateDataRepository(ctx context.Context, domain framework.ComplianceDomain, scrapeResults map[string]*compliance.ComplianceReturn) (framework.ComplianceDataRepository, error) {
+func (f *factory) CreateDataRepository(ctx context.Context, domain framework.ComplianceDomain) (framework.ComplianceDataRepository, error) {
 	log.Info("---- CreateDataRepository ----")
-	return newRepository(ctx, domain, scrapeResults, f)
+	return newRepository(ctx, domain, f)
 }
 
 //go:generate mockgen-wrapper

--- a/central/compliance/data/factory.go
+++ b/central/compliance/data/factory.go
@@ -70,7 +70,6 @@ func NewDefaultFactory() RepositoryFactory {
 }
 
 func (f *factory) CreateDataRepository(ctx context.Context, domain framework.ComplianceDomain) (framework.ComplianceDataRepository, error) {
-	log.Info("---- CreateDataRepository ----")
 	return newRepository(ctx, domain, f)
 }
 

--- a/central/compliance/data/factory.go
+++ b/central/compliance/data/factory.go
@@ -71,6 +71,7 @@ func NewDefaultFactory() RepositoryFactory {
 }
 
 func (f *factory) CreateDataRepository(ctx context.Context, domain framework.ComplianceDomain, scrapeResults map[string]*compliance.ComplianceReturn) (framework.ComplianceDataRepository, error) {
+	log.Info("---- CreateDataRepository ----")
 	return newRepository(ctx, domain, scrapeResults, f)
 }
 

--- a/central/compliance/data/mocks/factory.go
+++ b/central/compliance/data/mocks/factory.go
@@ -13,7 +13,6 @@ import (
 	reflect "reflect"
 
 	framework "github.com/stackrox/rox/central/compliance/framework"
-	compliance "github.com/stackrox/rox/generated/internalapi/compliance"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,16 +40,16 @@ func (m *MockRepositoryFactory) EXPECT() *MockRepositoryFactoryMockRecorder {
 }
 
 // CreateDataRepository mocks base method.
-func (m *MockRepositoryFactory) CreateDataRepository(ctx context.Context, domain framework.ComplianceDomain, scrapeResults map[string]*compliance.ComplianceReturn) (framework.ComplianceDataRepository, error) {
+func (m *MockRepositoryFactory) CreateDataRepository(ctx context.Context, domain framework.ComplianceDomain) (framework.ComplianceDataRepository, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateDataRepository", ctx, domain, scrapeResults)
+	ret := m.ctrl.Call(m, "CreateDataRepository", ctx, domain)
 	ret0, _ := ret[0].(framework.ComplianceDataRepository)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateDataRepository indicates an expected call of CreateDataRepository.
-func (mr *MockRepositoryFactoryMockRecorder) CreateDataRepository(ctx, domain, scrapeResults any) *gomock.Call {
+func (mr *MockRepositoryFactoryMockRecorder) CreateDataRepository(ctx, domain any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDataRepository", reflect.TypeOf((*MockRepositoryFactory)(nil).CreateDataRepository), ctx, domain, scrapeResults)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDataRepository", reflect.TypeOf((*MockRepositoryFactory)(nil).CreateDataRepository), ctx, domain)
 }

--- a/central/compliance/data/repository.go
+++ b/central/compliance/data/repository.go
@@ -144,9 +144,9 @@ func (r *repository) ComplianceOperatorResults() map[string][]*storage.Complianc
 	return r.complianceOperatorResults
 }
 
-func newRepository(ctx context.Context, domain framework.ComplianceDomain, scrapeResults map[string]*compliance.ComplianceReturn, factory *factory) (*repository, error) {
+func newRepository(ctx context.Context, domain framework.ComplianceDomain, factory *factory) (*repository, error) {
 	r := &repository{}
-	if err := r.init(ctx, domain, scrapeResults, factory); err != nil {
+	if err := r.init(ctx, domain, factory); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -202,7 +202,7 @@ func policyCategories(policies []*storage.Policy) map[string]set.StringSet {
 	return result
 }
 
-func (r *repository) init(ctx context.Context, domain framework.ComplianceDomain, scrapeResults map[string]*compliance.ComplianceReturn, f *factory) error {
+func (r *repository) init(ctx context.Context, domain framework.ComplianceDomain, f *factory) error {
 	r.cluster = domain.Cluster().Cluster()
 	r.nodes = nodesByID(framework.Nodes(domain))
 
@@ -329,16 +329,6 @@ func (r *repository) init(ctx context.Context, domain framework.ComplianceDomain
 		return err
 	}
 
-	// Flatten the files so we can do direct lookups on the nested values
-	for _, n := range scrapeResults {
-		totalNodeFiles := data.FlattenFileMap(n.GetFiles())
-		n.Files = totalNodeFiles
-	}
-
-	r.hostScrape = scrapeResults
-
-	r.nodeResults = getNodeResults(scrapeResults)
-
 	cisKubernetesStandardID, err := f.standardsRepo.GetCISKubernetesStandardID()
 	if err != nil {
 		return err
@@ -350,6 +340,18 @@ func (r *repository) init(ctx context.Context, domain framework.ComplianceDomain
 	}
 
 	return nil
+}
+
+func (r *repository) AddHostScrapedData(scrapeResults map[string]*compliance.ComplianceReturn) {
+	// Flatten the files so we can do direct lookups on the nested values
+	for _, n := range scrapeResults {
+		totalNodeFiles := data.FlattenFileMap(n.GetFiles())
+		n.Files = totalNodeFiles
+	}
+
+	r.hostScrape = scrapeResults
+
+	r.nodeResults = getNodeResults(scrapeResults)
 }
 
 func getNodeResults(scrapeResults map[string]*compliance.ComplianceReturn) map[string]map[string]*compliance.ComplianceStandardResult {

--- a/central/compliance/framework/data.go
+++ b/central/compliance/framework/data.go
@@ -46,4 +46,6 @@ type ComplianceDataRepository interface {
 	// Per-host data
 	HostScraped(node *storage.Node) *compliance.ComplianceReturn
 	NodeResults() map[string]map[string]*compliance.ComplianceStandardResult
+
+	AddHostScrapedData(scrapeResults map[string]*compliance.ComplianceReturn)
 }

--- a/central/compliance/framework/mocks/data.go
+++ b/central/compliance/framework/mocks/data.go
@@ -78,6 +78,18 @@ func (m *MockComplianceDataRepository) EXPECT() *MockComplianceDataRepositoryMoc
 	return m.recorder
 }
 
+// AddHostScrapedData mocks base method.
+func (m *MockComplianceDataRepository) AddHostScrapedData(scrapeResults map[string]*compliance.ComplianceReturn) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddHostScrapedData", scrapeResults)
+}
+
+// AddHostScrapedData indicates an expected call of AddHostScrapedData.
+func (mr *MockComplianceDataRepositoryMockRecorder) AddHostScrapedData(scrapeResults any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddHostScrapedData", reflect.TypeOf((*MockComplianceDataRepository)(nil).AddHostScrapedData), scrapeResults)
+}
+
 // CISKubernetesTriggered mocks base method.
 func (m *MockComplianceDataRepository) CISKubernetesTriggered() bool {
 	m.ctrl.T.Helper()

--- a/central/compliance/manager/data_promise.go
+++ b/central/compliance/manager/data_promise.go
@@ -71,7 +71,10 @@ func (p *scrapePromise) finish(ctx context.Context, scrapeResult map[string]*com
 	}
 
 	log.Info("CreateDataRepository finish")
-	p.result, err = p.dataRepoFactory.CreateDataRepository(ctx, p.domain, scrapeResult)
+	p.result, err = p.dataRepoFactory.CreateDataRepository(ctx, p.domain)
+	if err == nil {
+		p.result.AddHostScrapedData(scrapeResult)
+	}
 	p.finishedSig.SignalWithError(err)
 }
 

--- a/central/compliance/manager/data_promise.go
+++ b/central/compliance/manager/data_promise.go
@@ -22,7 +22,7 @@ type fixedDataPromise struct {
 }
 
 func newFixedDataPromise(ctx context.Context, dataRepoFactory data.RepositoryFactory, domain framework.ComplianceDomain) dataPromise {
-	dataRepo, err := dataRepoFactory.CreateDataRepository(ctx, domain, nil)
+	dataRepo, err := dataRepoFactory.CreateDataRepository(ctx, domain)
 
 	return &fixedDataPromise{
 		dataRepo: dataRepo,

--- a/central/compliance/manager/data_promise.go
+++ b/central/compliance/manager/data_promise.go
@@ -70,6 +70,7 @@ func (p *scrapePromise) finish(ctx context.Context, scrapeResult map[string]*com
 		log.Warnf("Did not collect scrape data for %+v", missingNodes)
 	}
 
+	log.Info("CreateDataRepository finish")
 	p.result, err = p.dataRepoFactory.CreateDataRepository(ctx, p.domain, scrapeResult)
 	p.finishedSig.SignalWithError(err)
 }

--- a/central/compliance/manager/manager_impl.go
+++ b/central/compliance/manager/manager_impl.go
@@ -350,11 +350,13 @@ func (m *manager) createAndLaunchRuns(ctx context.Context, clusterStandardPairs 
 					for _, standard := range standardImpls {
 						standardIDs = append(standardIDs, standard.ID)
 					}
+					log.Info("scrapBasedPromise")
 					scrapeBasedPromise = createAndRunScrape(elevatedCtx, m.scrapeFactory, m.dataRepoFactory, domain, scrapeTimeout, standardIDs)
 				}
 				dataPromise = scrapeBasedPromise
 			} else {
 				if scrapeLessPromise == nil {
+					log.Info("newFixedDataPromise")
 					scrapeLessPromise = newFixedDataPromise(elevatedCtx, m.dataRepoFactory, domain)
 				}
 				dataPromise = scrapeLessPromise

--- a/central/compliance/manager/manager_impl.go
+++ b/central/compliance/manager/manager_impl.go
@@ -368,13 +368,11 @@ func (m *manager) createAndLaunchRuns(ctx context.Context, clusterStandardPairs 
 					for _, standard := range standardImpls {
 						standardIDs = append(standardIDs, standard.ID)
 					}
-					log.Info("scrapBasedPromise")
 					scrapeBasedPromise = createAndRunScrape(elevatedCtx, m.scrapeFactory, perClusterDataRepoOnce, domain, scrapeTimeout, standardIDs)
 				}
 				dataPromise = scrapeBasedPromise
 			} else {
 				if scrapeLessPromise == nil {
-					log.Info("newFixedDataPromise")
 					scrapeLessPromise = newFixedDataPromise(elevatedCtx, perClusterDataRepoOnce, domain)
 				}
 				dataPromise = scrapeLessPromise


### PR DESCRIPTION
## Description

There are two sets of data promises in the current compliance code, but they are deduped on if they have been instantiated. Once the compliance operator was added, both data promise paths are hit. The one that pulls the data right away and starts running and the other that waits until a scrape comes back. This results in _most_ of the same data going into the data repo twice costing twice the memory. This change dedupes the common data in those promises by wrapping it with a once.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Ran compliance on openshift with the compliance operator prior to this change and logged that the data repo was instantiated twice. Now with logs it is instantiated once.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
