### PR TITLE
fix: Configure Matcher to pull IR from Indexer

### DIFF
--- a/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
@@ -22,5 +22,5 @@ matcher:
       {{ if not (kindIs "invalid" ._rox.scannerV4.db.source.maxConns) -}} pool_max_conns={{._rox.scannerV4.db.source.maxConns}} {{- end }}
       client_encoding=UTF8
     password_file: /run/secrets/stackrox.io/secrets/password
-  indexer_addr: scanner-v4-indexer.{{ .Release.Namespace }}.svc.cluster.local:8443
+  indexer_addr: scanner-v4-indexer.{{ .Release.Namespace }}.svc:8443
 log_level: info

--- a/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
@@ -22,5 +22,5 @@ matcher:
       {{ if not (kindIs "invalid" ._rox.scannerV4.db.source.maxConns) -}} pool_max_conns={{._rox.scannerV4.db.source.maxConns}} {{- end }}
       client_encoding=UTF8
     password_file: /run/secrets/stackrox.io/secrets/password
-  indexer: scanner-v4-indexer.{{ .Release.Namespace }}.svc.cluster.local:8443
+  indexer_addr: scanner-v4-indexer.{{ .Release.Namespace }}.svc.cluster.local:8443
 log_level: info

--- a/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
@@ -22,4 +22,5 @@ matcher:
       {{ if not (kindIs "invalid" ._rox.scannerV4.db.source.maxConns) -}} pool_max_conns={{._rox.scannerV4.db.source.maxConns}} {{- end }}
       client_encoding=UTF8
     password_file: /run/secrets/stackrox.io/secrets/password
+  indexer: scanner-v4-indexer.{{ .Release.Namespace }}.svc.cluster.local:8443
 log_level: info

--- a/image/templates/helm/shared/templates/02-scanner-v4-05-indexer-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-05-indexer-network-policy.yaml
@@ -24,6 +24,13 @@ spec:
   - from:
     - podSelector:
         matchLabels:
+          app: scanner-v4-matcher
+    ports:
+    - port: 8443
+      protocol: TCP
+  - from:
+    - podSelector:
+        matchLabels:
           app: sensor
     ports:
     - port: 8443


### PR DESCRIPTION
## Description

1. Add the configuration to the Matcher to access IR from the Indexer.
2. Update the network policies to allow these calls.

Calls to Match vulnerabilities in Central will now accept the Index Report content in the API but instead pull the Index Report directly from the Indexer.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

```
bin/linux_amd64/roxctl helm output central-services \
    --image-defaults=development_build \
    --debug \
    --debug-path image \
    --remove \
    --output-dir /home/jvdm/stackrox-infra/minikube/rox-deploy/charts/central-services
```

Then, I verified the helm chart was configured as expected. I did not deploy this, yet.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
