### PR TITLE
ROX-9156: another round of pre-factoring

### DIFF
--- a/image/templates/helm/shared/templates/_image-pull-secrets.tpl
+++ b/image/templates/helm/shared/templates/_image-pull-secrets.tpl
@@ -1,26 +1,34 @@
 {{/*
-  srox.configureImagePullSecretsNames $ $cfgName $imagePullSecrets $secretResourceName $defaultSecretNames $namespace
+  srox.configureImagePullSecrets $ $cfgName $imagePullSecrets $secretResourceName $defaultSecretNames $namespace
 
-  Configures image pull secrets names.
+  Configures image pull secrets.
 
-  This function enriches $imagePullSecrets based on the exposed configuration parameters to contain
-  a list of Kubernetes secret names as field `_names`. The chart templates then use this field
-  to populate imagePullSecrets lists in ServiceAccount objects.
+  Note: This function must be called late in srox.init, as we rely on "srox.configureImage" to collect the
+  set of all referenced images first.
 
-  This list contains the following secrets:
+  This function enriches $imagePullSecrets based on the exposed configuration parameters to contain:
 
-  - Secrets referenced via $imagePullSecrets.useExisting.
-  - Image pull secrets associated with the default service account (unless
-    $imagePullSecrets.useFromDefaultServiceAccount was set to false by the user).
-  - $secretResourceName.
-  - $defaultSecretNames.
+  1. Optionally (i.e. only if $imagePullSecrets contains a username), a `_dockerAuths` field, containing a map
+     from registry URLs to settings that contain login credentials.
+     The map contains registries for all images passed so far to srox.configureImage invocations.
+
+  2. A `_names` field, containing a list of Kubernetes secret names. The chart templates then use this field
+     to populate imagePullSecrets lists in ServiceAccount objects.
+
+     The list contains the following secrets:
+
+     - Secrets referenced via $imagePullSecrets.useExisting.
+     - Image pull secrets associated with the default service account (unless
+       $imagePullSecrets.useFromDefaultServiceAccount was set to false by the user).
+     - $secretResourceName.
+     - $defaultSecretNames.
 
   Additionally, this function fails execution if the list resulting from first three bullet points
   combined is empty.
 
 */}}
 
-{{ define "srox.configureImagePullSecretsNames" }}
+{{ define "srox.configureImagePullSecrets" }}
 {{ $ := index . 0 }}
 {{ $cfgName := index . 1 }}
 {{ $imagePullSecrets := index . 2 }}
@@ -32,6 +40,7 @@
 {{ if not (kindIs "slice" $imagePullSecretNames) }}
   {{ $imagePullSecretNames = regexSplit "\\s*[,;]\\s*" (trim $imagePullSecretNames) -1 }}
 {{ end }}
+
 {{ if $imagePullSecrets.useFromDefaultServiceAccount }}
   {{ $defaultSA := dict }}
   {{ include "srox.safeLookup" (list $ $defaultSA "v1" "ServiceAccount" $namespace "default") }}
@@ -43,44 +52,11 @@
     {{ end }}
   {{ end }}
 {{ end }}
+
 {{ if $imagePullSecrets._username }}
   {{/* When username is present, existence of $secretResourceName will be assured by the templates; add to the list. */}}
   {{ $imagePullSecretNames = append $imagePullSecretNames $secretResourceName }}
-{{ else if $imagePullSecrets._password }}
-  {{ $msg := printf "Username missing in %q. Whenever an image pull password is specified, a username must be specified as well" $cfgName }}
-  {{ include "srox.fail" $msg }}
-{{ end }}
-{{ if and $.Release.IsInstall (not $imagePullSecretNames) (not $imagePullSecrets.allowNone) }}
-  {{ $msg := printf "You have not specified any image pull secrets, and no existing image pull secrets were automatically inferred. If your registry does not need image pull credentials, explicitly set the '%s.allowNone' option to 'true'" $cfgName }}
-  {{ include "srox.fail" $msg }}
-{{ end }}
 
-{{ $imagePullSecretNames = concat (append $imagePullSecretNames $secretResourceName) $defaultSecretNames | uniq | sortAlpha }}
-{{ $_ := set $imagePullSecrets "_names" $imagePullSecretNames }}
-
-{{ end }}
-
-
-{{/*
-  srox.configureImagePullSecretsCreds $ $imagePullSecrets
-
-  Configures credentials for an image pull Secret.
-
-  Note: This function must be called late in srox.init, as we rely on "srox.configureImage" to collect the
-  set of all referenced images first.
-
-  If username was not set on the passed $imagePullSecrets, this function does nothing.
-
-  Otherwise, it sets a "_dockerAuths" field on the passed $imagePullSecrets to be a
-  map from registry URLs to settings that contain login credentials. The map
-  contains registries for all images passed so far to srox.configureImage invocations.
-*/}}
-
-{{ define "srox.configureImagePullSecretsCreds" }}
-{{ $ := index . 0 }}
-{{ $imagePullSecrets := index . 1 }}
-
-{{ if $imagePullSecrets._username }}
   {{ $dockerAuths := dict }}
   {{ range $image := keys $._rox._state.referencedImages }}
     {{ $registry := splitList "/" $image | first }}
@@ -98,6 +74,18 @@
   {{ end }}
 
   {{ $_ := set $imagePullSecrets "_dockerAuths" $dockerAuths }}
+
+{{ else if $imagePullSecrets._password }}
+  {{ $msg := printf "Username missing in %q. Whenever an image pull password is specified, a username must be specified as well" $cfgName }}
+  {{ include "srox.fail" $msg }}
 {{ end }}
+
+{{ if and $.Release.IsInstall (not $imagePullSecretNames) (not $imagePullSecrets.allowNone) }}
+  {{ $msg := printf "You have not specified any image pull secrets, and no existing image pull secrets were automatically inferred. If your registry does not need image pull credentials, explicitly set the '%s.allowNone' option to 'true'" $cfgName }}
+  {{ include "srox.fail" $msg }}
+{{ end }}
+
+{{ $imagePullSecretNames = concat (append $imagePullSecretNames $secretResourceName) $defaultSecretNames | uniq | sortAlpha }}
+{{ $_ := set $imagePullSecrets "_names" $imagePullSecretNames }}
 
 {{ end }}

--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -179,14 +179,6 @@
 {{/* Add environment information which should not be modifiable by the user. */}}
 {{ $_ := set $env "centralServices" true }}
 
-{{/* Initial image pull secret setup.
-
-     Always assume that there are `stackrox` and `stackrox-scanner` image pull secrets,
-     even if they weren't specified.
-     This is required for updates anyway, so referencing it on first install will minimize a later
-     diff. */}}
-{{ include "srox.configureImagePullSecretsNames" (list $ "imagePullSecrets" $._rox.imagePullSecrets "stackrox" (list "stackrox" "stackrox-scanner") $.Release.Namespace) }}
-
 {{/* Global CA setup */}}
 {{ $caCertSpec := dict "CN" "StackRox Certificate Authority" "ca" true }}
 {{ include "srox.configureCrypto" (list $ "ca" $caCertSpec) }}
@@ -314,10 +306,16 @@
      contain any concrete (leaf) values. */}}
 {{ include "srox.compactDict" (list $._rox._state.generated -1) }}
 
-{{/* Setup Image Pull Secrets for Docker Registry.
-     Note: This must happen afterwards, as we rely on "srox.configureImage" to collect the
-     set of all referenced images first. */}}
-{{ include "srox.configureImagePullSecretsCreds" (list $ ._rox.imagePullSecrets) }}
+{{/* Setup Image Pull Secrets.
+
+     Note: This must happen late, as we rely on "srox.configureImage" to collect the
+     set of all referenced images first.
+
+     Always assume that there are `stackrox` and `stackrox-scanner` image pull secrets,
+     even if they weren't specified.
+     This is required for updates anyway, so referencing it on first install will minimize a later
+     diff. */}}
+{{ include "srox.configureImagePullSecrets" (list $ "imagePullSecrets" $._rox.imagePullSecrets "stackrox" (list "stackrox" "stackrox-scanner") $.Release.Namespace) }}
 
 {{/* Final warnings based on state. */}}
 {{ if $._rox._state.customCertGen }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -160,11 +160,10 @@
 {{ if and (eq $._rox.env.openshift 3) $._rox.admissionControl.listenOnEvents }}
   {{ include "srox.fail" "'admissionControl.listenOnEvents' is set to true, but the chart is being deployed in OpenShift 3.x compatibility mode, which does not work with this feature. Set 'env.openshift' to '4' in order to enable OpenShift 4.x features." }}
 {{ end }}
+
 {{/* Initial image pull secret setup. */}}
 {{ include "srox.mergeInto" (list $._rox.mainImagePullSecrets $._rox.imagePullSecrets) }}
-{{ include "srox.configureImagePullSecretsNames" (list $ "mainImagePullSecrets" $._rox.mainImagePullSecrets "secured-cluster-services-main" (list "stackrox") $._rox._namespace) }}
 {{ include "srox.mergeInto" (list $._rox.collectorImagePullSecrets $._rox.imagePullSecrets) }}
-{{ include "srox.configureImagePullSecretsNames" (list $ "collectorImagePullSecrets" $._rox.collectorImagePullSecrets "secured-cluster-services-collector" (list "stackrox" "collector-stackrox") $._rox._namespace) }}
 
 {{/* Additional CAs. */}}
 {{ $additionalCAList := list }}
@@ -245,16 +244,19 @@
   {{ $_ := set $._rox.scanner "slimImage" ._rox.image.scanner }}
   {{ $_ := set $._rox.scanner "slimDBImage" ._rox.image.scannerDb }}
   {{ include "srox.scannerInit" (list $ $._rox.scanner) }}
-  {{ include "srox.configureImagePullSecretsNames" (list $ "imagePullSecrets" $._rox.imagePullSecrets "secured-cluster-services-main" (list "stackrox" "stackrox-scanner") $.Release.Namespace) }}
+
+  {{/* Note: This must happen late, as we rely on "srox.configureImage" to collect the
+       set of all referenced images first. */}}
+  {{ include "srox.configureImagePullSecrets" (list $ "imagePullSecrets" $._rox.imagePullSecrets "secured-cluster-services-main" (list "stackrox" "stackrox-scanner") $.Release.Namespace) }}
 {{ end }}
 [<- end >]
 
-{{/*
-    Post-processing steps.
-   */}}
+{{/* Setup Image Pull Secrets.
 
-{{ include "srox.configureImagePullSecretsCreds" (list $ ._rox.mainImagePullSecrets) }}
-{{ include "srox.configureImagePullSecretsCreds" (list $ ._rox.collectorImagePullSecrets) }}
+     Note: This must happen late, as we rely on "srox.configureImage" to collect the
+     set of all referenced images first. */}}
+{{ include "srox.configureImagePullSecrets" (list $ "mainImagePullSecrets" $._rox.mainImagePullSecrets "secured-cluster-services-main" (list "stackrox") $._rox._namespace) }}
+{{ include "srox.configureImagePullSecrets" (list $ "collectorImagePullSecrets" $._rox.collectorImagePullSecrets "secured-cluster-services-collector" (list "stackrox" "collector-stackrox") $._rox._namespace) }}
 
 {{ end }}
 

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -4,6 +4,20 @@ defs: |
         .secrets["stackrox"].data[".dockerconfigjson"] | @base64d | fromjson | .auths
           | .["https://" + (if ($mainRegistry == "docker.io") then "index.docker.io/v1/" else $mainRegistry end)]
           | .auth | @base64d;
+
+  # Please keep the defs here in sync with the ones in the secured cluster sibling of this test.
+
+  # Separate function, to make error messages helpful.
+  def containsAll(needles):
+      . as $hay | all(needles[]; . as $needle | any($hay[]; . == $needle));
+
+  def saRefersTo(pullSecretNames):
+      [.imagePullSecrets[] | .name] | assertThat(. | containsAll(pullSecretNames));
+
+  # This treats the lists as multisets.
+  def saOnlyRefersTo(pullSecretNames):
+      [.imagePullSecrets[] | .name] | sort | assertThat(. == (pullSecretNames | sort));
+
 values:
   central:
     persistence:
@@ -11,15 +25,9 @@ values:
 
 expect: |
   # Ensure that default service accounts are always referenced in the correct fashion in the non-error case
-
-  assumeThat(.error == null) | .serviceaccounts["central"] | .imagePullSecrets[] | select(.name == "stackrox")
-  assumeThat(.error == null) | .serviceaccounts["central"] | .imagePullSecrets[] | select(.name == "stackrox-scanner")
-
-  assumeThat(.error == null) | .serviceaccounts["central-db"] | .imagePullSecrets[] | select(.name == "stackrox")
-  assumeThat(.error == null) | .serviceaccounts["central-db"] | .imagePullSecrets[] | select(.name == "stackrox-scanner")
-
-  assumeThat(.error == null) | .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "stackrox")
-  assumeThat(.error == null) | .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "stackrox-scanner")
+  assumeThat(.error == null) | .serviceaccounts["central"] | saRefersTo(["stackrox", "stackrox-scanner"])
+  assumeThat(.error == null) | .serviceaccounts["central-db"] | saRefersTo(["stackrox", "stackrox-scanner"])
+  assumeThat(.error == null) | .serviceaccounts["scanner"] | saRefersTo(["stackrox", "stackrox-scanner"])
 
 tests:
 - name: "with no image pull secret creation"
@@ -35,8 +43,7 @@ tests:
       expectError: true
     - name: "should succeed with useExisting"
       expect: |
-        .serviceaccounts[] | [.imagePullSecrets[] | select(.name == "extra-secret1" or .name == "extra-secret2")]
-          | assertThat(length == 2)
+        .serviceaccounts[] | saRefersTo(["extra-secret1", "extra-secret2"])
       tests:
       - name: as JSON list
         set:
@@ -49,7 +56,7 @@ tests:
 - name: "with image pull secret creation"
   expect: |
     .secrets["stackrox"] | assertThat(. != null)
-    .serviceaccounts[] | [.imagePullSecrets[] | select(.name == "stackrox")] | assertThat(length == 1)
+    .serviceaccounts[] | saRefersTo(["stackrox"])
   tests:
   - name: "with username and password specified"
     values:
@@ -74,24 +81,19 @@ tests:
     expect: |
       authForCentral | assertThat(. == "foo:")
 
-- name: "default image pull secrets are referenced in service accounts"
+- name: "with no image pull secret creation, only default image pull secrets are referenced in service accounts"
   set:
     imagePullSecrets.allowNone: true
   expect: |
-    .serviceaccounts["central"] | .imagePullSecrets[] | select(.name == "stackrox")
-    .serviceaccounts["central"] | .imagePullSecrets[] | select(.name == "stackrox-scanner")
-
-    .serviceaccounts["central-db"] | .imagePullSecrets[] | select(.name == "stackrox")
-    .serviceaccounts["central-db"] | .imagePullSecrets[] | select(.name == "stackrox-scanner")
-
-    .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "stackrox")
-    .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "stackrox-scanner")
+    .serviceaccounts["central"] | saOnlyRefersTo(["stackrox", "stackrox-scanner"])
+    .serviceaccounts["central-db"] | saOnlyRefersTo(["stackrox", "stackrox-scanner"])
+    .serviceaccounts["scanner"] | saOnlyRefersTo(["stackrox", "stackrox-scanner"])
 
 - name: "additional image pull secrets are referenced in service accounts"
   values:
     imagePullSecrets:
       useExisting: custom-ips
   expect: |
-    .serviceaccounts["central"] | .imagePullSecrets[] | select(.name == "custom-ips")
-    .serviceaccounts["central-db"] | .imagePullSecrets[] | select(.name == "custom-ips")
-    .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "custom-ips")
+    .serviceaccounts["central"] | saRefersTo(["custom-ips"])
+    .serviceaccounts["central-db"] | saRefersTo(["custom-ips"])
+    .serviceaccounts["scanner"] | saRefersTo(["custom-ips"])

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -90,4 +90,3 @@ tests:
       imagePullSecrets.useExisting: ["extra-secret1", "extra-secret2"]
     expect: |
       .serviceaccounts[] | saRefersTo(["extra-secret1", "extra-secret2"])
-

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -26,7 +26,7 @@ tests:
   expect: |
     .secrets?["stackrox"]? | assertThat(. == null)
   tests:
-  - name: "with allowNone=true"
+  - name: "works with allowNone=true"
     set:
       imagePullSecrets.allowNone: true
   - name: "with default setting of allowNone=false"
@@ -66,7 +66,7 @@ tests:
     - name: "with docker registry"
       set:
         central.image.registry: docker.io/stackrox
-  - name: "with empty password"
+  - name: "with username specified, but empty password"
     values:
       imagePullSecrets:
         username: foo

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -57,15 +57,17 @@ tests:
         set:
           imagePullSecrets.useExisting: "extra-secret1; extra-secret2 "
 
-- name: "with image pull secret creation"
+- name: "with image pull secret creation (username specified)"
+  values:
+    imagePullSecrets:
+      username: foo
   expect: |
     .secrets["stackrox"] | assertThat(. != null)
     .serviceaccounts[] | saRefersTo(["stackrox"])
   tests:
-  - name: "with username and password specified"
+  - name: "with password specified too"
     values:
       imagePullSecrets:
-        username: foo
         password: bar
     expect: |
       authForCentral | assertThat(. == "foo:bar")
@@ -77,19 +79,15 @@ tests:
     - name: "with docker registry"
       set:
         central.image.registry: docker.io/stackrox
-  - name: "with username specified, but empty password"
+  - name: "with empty password"
     values:
       imagePullSecrets:
-        username: foo
         password: ""
     expect: |
       authForCentral | assertThat(. == "foo:")
+  - name: "useExisting secrets are referenced, if specified"
+    set:
+      imagePullSecrets.useExisting: ["extra-secret1", "extra-secret2"]
+    expect: |
+      .serviceaccounts[] | saRefersTo(["extra-secret1", "extra-secret2"])
 
-- name: "additional image pull secrets are referenced in service accounts"
-  values:
-    imagePullSecrets:
-      useExisting: custom-ips
-  expect: |
-    .serviceaccounts["central"] | saRefersTo(["custom-ips"])
-    .serviceaccounts["central-db"] | saRefersTo(["custom-ips"])
-    .serviceaccounts["scanner"] | saRefersTo(["custom-ips"])

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -34,9 +34,13 @@ tests:
   expect: |
     .secrets?["stackrox"]? | assertThat(. == null)
   tests:
-  - name: "works with allowNone=true"
+  - name: "works with allowNone=true, and only default image pull secrets are referenced in service accounts"
     set:
       imagePullSecrets.allowNone: true
+    expect: |
+      .serviceaccounts["central"] | saOnlyRefersTo(["stackrox", "stackrox-scanner"])
+      .serviceaccounts["central-db"] | saOnlyRefersTo(["stackrox", "stackrox-scanner"])
+      .serviceaccounts["scanner"] | saOnlyRefersTo(["stackrox", "stackrox-scanner"])
   - name: "with default setting of allowNone=false"
     tests:
     - name: "should fail with no extra secrets"
@@ -80,14 +84,6 @@ tests:
         password: ""
     expect: |
       authForCentral | assertThat(. == "foo:")
-
-- name: "with no image pull secret creation, only default image pull secrets are referenced in service accounts"
-  set:
-    imagePullSecrets.allowNone: true
-  expect: |
-    .serviceaccounts["central"] | saOnlyRefersTo(["stackrox", "stackrox-scanner"])
-    .serviceaccounts["central-db"] | saOnlyRefersTo(["stackrox", "stackrox-scanner"])
-    .serviceaccounts["scanner"] | saOnlyRefersTo(["stackrox", "stackrox-scanner"])
 
 - name: "additional image pull secrets are referenced in service accounts"
   values:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -37,7 +37,7 @@ tests:
     .secrets?["secured-cluster-services-main"]? | assertThat(. == null)
     .secrets?["secured-cluster-services-collector"]? | assertThat(. == null)
   tests:
-  - name: "with allowNone=true"
+  - name: "works with allowNone=true"
     set:
       imagePullSecrets.allowNone: true
   - name: "with default setting of allowNone=false"
@@ -58,7 +58,6 @@ tests:
           imagePullSecrets.useExisting: "extra-secret1; extra-secret2 "
 
 - name: "with image pull secret creation"
-
   expect: |
     .secrets["secured-cluster-services-main"] | assertThat(. != null)
     .secrets["secured-cluster-services-collector"] | assertThat(. != null)
@@ -88,7 +87,7 @@ tests:
     - name: "with docker registry"
       set:
         image.registry: docker.io/stackrox
-  - name: "with empty password"
+  - name: "with username specified, but empty password"
     values:
       imagePullSecrets:
         username: foo

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -29,10 +29,8 @@ expect: |
   # Ensure that default/legacy service accounts are always referenced in the correct fashion in the non-error case
 
   assumeThat(.error == null) | .serviceaccounts["collector"] | saRefersTo(["stackrox", "collector-stackrox"])
-
   assumeThat(.error == null) | .serviceaccounts["sensor"] | saRefersTo(["stackrox"])
   assumeThat(.error == null) | .serviceaccounts["sensor"] | saNotRefersTo(["collector-stackrox"])
-
   assumeThat(.error == null) | .serviceaccounts["admission-control"] | saRefersTo(["stackrox"])
   assumeThat(.error == null) | .serviceaccounts["admission-control"] | saNotRefersTo(["collector-stackrox"])
 
@@ -70,17 +68,19 @@ tests:
         set:
           imagePullSecrets.useExisting: "extra-secret1; extra-secret2 "
 
-- name: "with image pull secret creation"
+- name: "with image pull secret creation (username specified)"
+  values:
+    imagePullSecrets:
+      username: foo
   expect: |
     .secrets["secured-cluster-services-main"] | assertThat(. != null)
     .secrets["secured-cluster-services-collector"] | assertThat(. != null)
     .serviceaccounts[] | saRefersTo(["secured-cluster-services-main"])
     .serviceaccounts["collector"] | saRefersTo(["secured-cluster-services-collector"])
   tests:
-  - name: "with username and password specified"
+  - name: "with password specified too"
     values:
       imagePullSecrets:
-        username: foo
         password: bar
     expect: |
       authForMain | assertThat(. == "foo:bar")
@@ -99,20 +99,15 @@ tests:
     - name: "with docker registry"
       set:
         image.registry: docker.io/stackrox
-  - name: "with username specified, but empty password"
+  - name: "with empty password"
     values:
       imagePullSecrets:
-        username: foo
         password: ""
     expect: |
       authForMain | assertThat(. == "foo:")
       authForCollector | assertThat(. == "foo:")
-
-- name: "additional image pull secret are referenced in service accounts"
-  values:
-    imagePullSecrets:
-      useExisting: custom-ips
-  expect: |
-    .serviceaccounts["collector"] | saRefersTo(["custom-ips"])
-    .serviceaccounts["sensor"] | saRefersTo(["custom-ips"])
-    .serviceaccounts["admission-control"] | saRefersTo(["custom-ips"])
+  - name: "useExisting secrets are referenced, if specified"
+    set:
+      imagePullSecrets.useExisting: ["extra-secret1", "extra-secret2"]
+    expect: |
+      .serviceaccounts[] | saRefersTo(["extra-secret1", "extra-secret2"])

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -39,9 +39,9 @@ expect: |
   assumeThat(.error == null) | .serviceaccounts["collector"]
     | saRefersTo(["secured-cluster-services-main", "secured-cluster-services-collector"])
   assumeThat(.error == null) | .serviceaccounts["sensor"] | saRefersTo(["secured-cluster-services-main"])
-  assumeThat(.error == null) | .serviceaccounts["sensor"] | saNotRefersTo(["secured-cluster-services-collector"])
+  assumeThat(.error == null) | .serviceaccounts["sensor"] | saNotRefersTo(["secured-cluster-services-collector", "collector-stackrox"])
   assumeThat(.error == null) | .serviceaccounts["admission-control"] | saRefersTo(["secured-cluster-services-main"])
-  assumeThat(.error == null) | .serviceaccounts["admission-control"] | saNotRefersTo(["secured-cluster-services-collector"])
+  assumeThat(.error == null) | .serviceaccounts["admission-control"] | saNotRefersTo(["secured-cluster-services-collector", "collector-stackrox"])
 
 tests:
 - name: "with no image pull secret creation"

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -108,19 +108,6 @@ tests:
       authForMain | assertThat(. == "foo:")
       authForCollector | assertThat(. == "foo:")
 
-- name: "default image pull secret are referenced in service accounts"
-  values:
-    imagePullSecrets:
-      allowNone: true
-  expect: |
-    .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "stackrox")
-    .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "collector-stackrox")
-
-    .serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "stackrox")
-    [.serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "collector-stackrox")] | assertThat(length == 0)
-    .serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "stackrox")
-    [.serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "collector-stackrox")] | assertThat(length == 0)
-
 - name: "additional image pull secret are referenced in service accounts"
   values:
     imagePullSecrets:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -11,25 +11,39 @@ defs: |
           | .["https://" + (if ($mainRegistry == "docker.io") then "index.docker.io/v1/" else $mainRegistry end)]
           | .auth | @base64d;
 
+  # Please keep the defs here in sync with the ones in the central sibling of this test.
+
+  # Separate functions, to make error messages helpful.
+  def containsAll(needles):
+      . as $hay | all(needles[]; . as $needle | any($hay[]; . == $needle));
+  def containsNone(needles):
+      . as $hay | all(needles[]; . as $needle | all($hay[]; . != $needle));
+
+  def saRefersTo(pullSecretNames):
+      [.imagePullSecrets[] | .name] | assertThat(. | containsAll(pullSecretNames));
+
+  def saNotRefersTo(pullSecretNames):
+      [.imagePullSecrets[] | .name] | assertThat(. | containsNone(pullSecretNames));
+
 expect: |
   # Ensure that default/legacy service accounts are always referenced in the correct fashion in the non-error case
 
-  assumeThat(.error == null) | .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "stackrox")
-  assumeThat(.error == null) | .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "collector-stackrox")
+  assumeThat(.error == null) | .serviceaccounts["collector"] | saRefersTo(["stackrox", "collector-stackrox"])
 
-  assumeThat(.error == null) | .serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "stackrox")
-  assumeThat(.error == null) | [.serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "collector-stackrox")] | assertThat(length == 0)
-  assumeThat(.error == null) | .serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "stackrox")
-  assumeThat(.error == null) | [.serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "collector-stackrox")] | assertThat(length == 0)
+  assumeThat(.error == null) | .serviceaccounts["sensor"] | saRefersTo(["stackrox"])
+  assumeThat(.error == null) | .serviceaccounts["sensor"] | saNotRefersTo(["collector-stackrox"])
+
+  assumeThat(.error == null) | .serviceaccounts["admission-control"] | saRefersTo(["stackrox"])
+  assumeThat(.error == null) | .serviceaccounts["admission-control"] | saNotRefersTo(["collector-stackrox"])
 
   # Ensure that newly created secrets are always referenced in the correct fashion in the non-error case.
-  assumeThat(.error == null) | .serviceaccounts["collector"] | [.imagePullSecrets[] |
-    select(.name == "secured-cluster-services-main" or .name == "secured-cluster-services-collector")] |
-    assertThat(length == 2)
-  assumeThat(.error == null) | .serviceaccounts["sensor"] | .imagePullSecrets[] |
-    select(.name == "secured-cluster-services-main")
-  assumeThat(.error == null) | .serviceaccounts["admission-control"] | .imagePullSecrets[] |
-    select(.name == "secured-cluster-services-main")
+
+  assumeThat(.error == null) | .serviceaccounts["collector"]
+    | saRefersTo(["secured-cluster-services-main", "secured-cluster-services-collector"])
+  assumeThat(.error == null) | .serviceaccounts["sensor"] | saRefersTo(["secured-cluster-services-main"])
+  assumeThat(.error == null) | .serviceaccounts["sensor"] | saNotRefersTo(["secured-cluster-services-collector"])
+  assumeThat(.error == null) | .serviceaccounts["admission-control"] | saRefersTo(["secured-cluster-services-main"])
+  assumeThat(.error == null) | .serviceaccounts["admission-control"] | saNotRefersTo(["secured-cluster-services-collector"])
 
 tests:
 - name: "with no image pull secret creation"
@@ -46,8 +60,7 @@ tests:
       expectError: true
     - name: "should succeed with useExisting"
       expect: |
-        .serviceaccounts[] | [.imagePullSecrets[] | select(.name == "extra-secret1" or .name == "extra-secret2")]
-          | assertThat(length == 2)
+        .serviceaccounts[] | saRefersTo(["extra-secret1", "extra-secret2"])
       tests:
       - name: as JSON list
         set:
@@ -61,9 +74,8 @@ tests:
   expect: |
     .secrets["secured-cluster-services-main"] | assertThat(. != null)
     .secrets["secured-cluster-services-collector"] | assertThat(. != null)
-    .serviceaccounts[] | [.imagePullSecrets[] | select(.name == "secured-cluster-services-main")] | assertThat(length == 1)
-    .serviceaccounts.collector | [.imagePullSecrets[] | select(.name == "secured-cluster-services-collector")]
-      | assertThat(length == 1)
+    .serviceaccounts[] | saRefersTo(["secured-cluster-services-main"])
+    .serviceaccounts["collector"] | saRefersTo(["secured-cluster-services-collector"])
   tests:
   - name: "with username and password specified"
     values:
@@ -114,6 +126,6 @@ tests:
     imagePullSecrets:
       useExisting: custom-ips
   expect: |
-    .serviceaccounts["collector"] | .imagePullSecrets[] | select(.name == "custom-ips")
-    .serviceaccounts["sensor"] | .imagePullSecrets[] | select(.name == "custom-ips")
-    .serviceaccounts["admission-control"] | .imagePullSecrets[] | select(.name == "custom-ips")
+    .serviceaccounts["collector"] | saRefersTo(["custom-ips"])
+    .serviceaccounts["sensor"] | saRefersTo(["custom-ips"])
+    .serviceaccounts["admission-control"] | saRefersTo(["custom-ips"])

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -11,20 +11,6 @@ defs: |
           | .["https://" + (if ($mainRegistry == "docker.io") then "index.docker.io/v1/" else $mainRegistry end)]
           | .auth | @base64d;
 
-  # Please keep the defs here in sync with the ones in the central sibling of this test.
-
-  # Separate functions, to make error messages helpful.
-  def containsAll(needles):
-      . as $hay | all(needles[]; . as $needle | any($hay[]; . == $needle));
-  def containsNone(needles):
-      . as $hay | all(needles[]; . as $needle | all($hay[]; . != $needle));
-
-  def saRefersTo(pullSecretNames):
-      [.imagePullSecrets[] | .name] | assertThat(. | containsAll(pullSecretNames));
-
-  def saNotRefersTo(pullSecretNames):
-      [.imagePullSecrets[] | .name] | assertThat(. | containsNone(pullSecretNames));
-
 expect: |
   # Ensure that default/legacy service accounts are always referenced in the correct fashion in the non-error case
 

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-slim.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-slim.test.yaml
@@ -73,17 +73,15 @@ tests:
     scanner.disable: false
     scanner.mode: "slim"
   expect: |
-    assumeThat(.error == null) | .serviceaccounts["scanner"] | assertThat(. != null)
-    assumeThat(.error == null) | .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "secured-cluster-services-main")
-    assumeThat(.error == null) | .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "stackrox")
-    assumeThat(.error == null) | .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "stackrox-scanner")
+    assumeThat(.error == null) | .serviceaccounts["scanner"] | saRefersTo(["secured-cluster-services-main", "stackrox", "stackrox-scanner"])
+    assumeThat(.error == null) | .serviceaccounts["scanner"] | saNotRefersTo(["secured-cluster-services-collector", "collector-stackrox"])
   tests:
   - name: "when authenticating in image registry with user and password"
     set:
       imagePullSecrets.username: "imagePullUser"
       imagePullSecrets.password: "imagePullPassword"
     expect: |
-      .serviceaccounts["scanner"] | .imagePullSecrets | assertThat(length == 3)
+      .serviceaccounts["scanner"] | saOnlyRefersTo(["secured-cluster-services-main", "stackrox", "stackrox-scanner"])
       .secrets["secured-cluster-services-main"] | assertThat(. != null)
   - name: "when username/password are not provided, no secret is created"
     expect: .secrets["secured-cluster-services-main"] | assertThat(. == null)
@@ -95,14 +93,13 @@ tests:
     - name: "when allowNone is true"
       set:
         imagePullSecrets.allowNone: true
-      expect: .serviceaccounts["scanner"] | .imagePullSecrets | assertThat(length == 3)
+      expect: .serviceaccounts["scanner"] | saOnlyRefersTo(["secured-cluster-services-main", "stackrox", "stackrox-scanner"])
     - name: "when using existing secrets"
       set:
         imagePullSecrets.useExisting: "existing-secret1; existing-secret2"
       expect: |
-        .serviceaccounts["scanner"] | .imagePullSecrets | assertThat(length == 5)
-        .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "existing-secret1")
-        .serviceaccounts["scanner"] | .imagePullSecrets[] | select(.name == "existing-secret2")
+        .serviceaccounts["scanner"] | saOnlyRefersTo([
+          "secured-cluster-services-main", "stackrox", "stackrox-scanner", "existing-secret1", "existing-secret2"])
 
 - name: "sensor only connects to local scanner when it is enabled"
   set:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/suite.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/suite.yaml
@@ -39,6 +39,24 @@ defs: |
       | select(.containerPort == 9090 and .name == "monitoring")]
         | (length == 1);
 
+  # Please keep the defs here in sync with the ones in the central image-pull-secrets test.
+
+  # Separate functions, to make error messages helpful.
+  def containsAll(needles):
+      . as $hay | all(needles[]; . as $needle | any($hay[]; . == $needle));
+  def containsNone(needles):
+      . as $hay | all(needles[]; . as $needle | all($hay[]; . != $needle));
+
+  def saRefersTo(pullSecretNames):
+      [.imagePullSecrets[] | .name] | assertThat(. | containsAll(pullSecretNames));
+
+  def saNotRefersTo(pullSecretNames):
+      [.imagePullSecrets[] | .name] | assertThat(. | containsNone(pullSecretNames));
+
+  # This treats the lists as multisets.
+  def saOnlyRefersTo(pullSecretNames):
+      [.imagePullSecrets[] | .name] | sort | assertThat(. == (pullSecretNames | sort));
+
 server:
   visibleSchemas:
   - kubernetes-1.20.2


### PR DESCRIPTION
## Description

No change in functionality.

The goal of this PR is to:
- reduce the implicit coupling between the `srox.configureImagePullSecrets*` functions by merging them
- simplify and reduce the number of test cases for pull image secret related features

This further paves the road to the fix for ROX-9156, which will necessarily introduce another dimension in this space: the existence vs non-existence of certain `Secret` resources.

Similar to #8804 I recommend looking at individual commits, as their messages explain the rationale behind each change.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
