### PR TITLE
ROX-20876: Adjust returned errors from tlsutils

### DIFF
--- a/pkg/tlsutils/dial_context.go
+++ b/pkg/tlsutils/dial_context.go
@@ -3,6 +3,13 @@ package tlsutils
 import (
 	"context"
 	"crypto/tls"
+	"errors"
+
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+var (
+	log = logging.LoggerForModule()
 )
 
 // DialContext attempts to establishes a TLS-enabled connection in a context-aware manner.
@@ -12,7 +19,9 @@ func DialContext(ctx context.Context, network, addr string, tlsConfig *tls.Confi
 	}
 	conn, err := dialer.DialContext(ctx, network, addr)
 	if err != nil {
-		return nil, err
+		log.Debug("tls dial failed", logging.Err(err))
+
+		return nil, errors.New("unable to establish a TLS-enabled connection")
 	}
 	return conn.(*tls.Conn), nil
 }

--- a/pkg/tlsutils/dial_context_test.go
+++ b/pkg/tlsutils/dial_context_test.go
@@ -1,0 +1,35 @@
+package tlsutils
+
+import (
+	"context"
+	"crypto/tls"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestDialContextError(t *testing.T) {
+	tests := map[string]string{
+		"connection refused": "127.0.0.1:10001",
+		"no port":            "127.0.0.1",
+		"bad address":        "127.0.0.1:10001/32",
+	}
+
+	for name, dialAddr := range tests {
+		t.Run(name, func(t *testing.T) {
+			observedZapCore, observedLogs := observer.New(zap.DebugLevel)
+			log = &logging.LoggerImpl{
+				InnerLogger: zap.New(observedZapCore).Sugar(),
+			}
+
+			_, err := DialContext(context.Background(), "tcp", dialAddr, &tls.Config{})
+
+			assert.NotContains(t, err.Error(), "127.0.0.1")
+			assert.NotContains(t, err.Error(), "10001")
+			assert.Equal(t, 1, observedLogs.Len())
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR adds functionality to `tlsutils` that will return a custom error message instead of an error returned by the library. An error produced by the library could contain information we do not want to propagate to UI (API caller).

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

1. Added unit test
2. Tested API call:
Example response:
```
"message": "failed to determine scanner cert expiry error: failed to contact scanner at https://scanner.stackrox.svc:8080: unable to establish a TLS-enabled connection",
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
