### PR TITLE
fix(leak): Remove pod was not working if the pod has owners

### DIFF
--- a/sensor/common/clusterentities/metrics/metrics.go
+++ b/sensor/common/clusterentities/metrics/metrics.go
@@ -1,0 +1,24 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/pkg/metrics"
+)
+
+var (
+	containersStored = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "num_containers_in_entity_store",
+		Help:      "A gauge to track the number of containers in the entity store",
+	})
+)
+
+// UpdateNumberContainersInEntityStored update number of containers stored
+func UpdateNumberContainersInEntityStored(num int) {
+	containersStored.Set(float64(num))
+}
+
+func init() {
+	prometheus.MustRegister(containersStored)
+}

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/sensor/common/clusterentities/metrics"
 )
 
 // ContainerMetadata is the container metadata that is stored per instance
@@ -112,6 +113,10 @@ func (ed *EntityData) AddContainerID(containerID string, container ContainerMeta
 	ed.containerIDs[containerID] = container
 }
 
+func (e *Store) updateMetrics() {
+	metrics.UpdateNumberContainersInEntityStored(len(e.containerIDMap))
+}
+
 // Cleanup deletes all entries from store
 func (e *Store) Cleanup() {
 	e.mutex.Lock()
@@ -124,6 +129,7 @@ func (e *Store) Cleanup() {
 func (e *Store) Apply(updates map[string]*EntityData, incremental bool) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
+	defer e.updateMetrics()
 	e.applyNoLock(updates, incremental)
 }
 

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -121,6 +121,7 @@ func (e *Store) updateMetrics() {
 func (e *Store) Cleanup() {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
+	defer e.updateMetrics()
 	e.initMaps()
 }
 

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -59,7 +59,7 @@ func (d *deploymentDispatcherImpl) ProcessEvent(obj, oldObj interface{}, action 
 	}
 
 	if action == central.ResourceAction_REMOVE_RESOURCE {
-		d.handler.hierarchy.Remove(string(metaObj.GetUID()))
+		defer d.handler.hierarchy.Remove(string(metaObj.GetUID()))
 		return d.handler.processWithType(obj, oldObj, action, d.deploymentType)
 	}
 	d.handler.hierarchy.Add(metaObj)

--- a/sensor/kubernetes/listener/resources/metrics/metrics.go
+++ b/sensor/kubernetes/listener/resources/metrics/metrics.go
@@ -1,0 +1,27 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/pkg/metrics"
+)
+
+var (
+	podsStored = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "num_pods_in_store",
+		Help:      "A gauge to track the number of pods in the store",
+	},
+		[]string{
+			"k8sNamespace",
+		})
+)
+
+// UpdateNumberPodsInStored update number of pods stored
+func UpdateNumberPodsInStored(ns string, num int) {
+	podsStored.With(prometheus.Labels{"k8sNamespace": ns}).Set(float64(num))
+}
+
+func init() {
+	prometheus.MustRegister(podsStored)
+}


### PR DESCRIPTION
## Description

The hierarchy was getting removed before processing the event in the deployment dispatcher. This led to a memory leak in the `PodStore` and the `EntityStore` if a deployment was scaled down (or a pod crashes, gets reschedule, etc).

The following is an example of how to reproduce this leak (the metrics in the first commit of this PR are needed):

- Deploy ACS
- Apply the following yaml:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  labels:
    app: nginx
spec:
  replicas: 10
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
```
- Observe the pods running:
```bash
NAME                               READY   STATUS    RESTARTS   AGE
nginx-deployment-cbdccf466-95p77   1/1     Running   0          29s
nginx-deployment-cbdccf466-h292s   1/1     Running   0          28s
nginx-deployment-cbdccf466-hc9tg   1/1     Running   0          28s
nginx-deployment-cbdccf466-hl4lp   1/1     Running   0          28s
nginx-deployment-cbdccf466-jpnhf   1/1     Running   0          28s
nginx-deployment-cbdccf466-pdnv9   1/1     Running   0          28s
nginx-deployment-cbdccf466-vj5lt   1/1     Running   0          28s
nginx-deployment-cbdccf466-zbgkw   1/1     Running   0          28s
nginx-deployment-cbdccf466-zcthv   1/1     Running   0          28s
nginx-deployment-cbdccf466-zkpjg   1/1     Running   0          28s
```
- Check the metrics and observe Sensor has 10 pods in the namespace were the deployment was applied (there might be more if there are other deployments in that namespace).
- Check the metrics and observe Sensor has 71 containers in the entity store (depending on the workloads of your cluster this number might vary).
![Screenshot 2023-12-01 at 15 58 21](https://github.com/stackrox/stackrox/assets/2685670/71e6083c-576d-42cd-b077-4c7804b09ef6)

- Delete some pods from that deployment (e.g. 100).
- Observe the number of pods in the metrics has increased when it should've stayed the same.

![Screenshot 2023-12-01 at 16 04 10](https://github.com/stackrox/stackrox/assets/2685670/689a6c96-4f35-417f-bae6-0f10f1311a37)

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (created PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merged into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- [x] After the change, the example above should show a constant number of pods and containers in the metrics.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
