### PR TITLE
Added vuln report filter to report snapshot

### DIFF
--- a/migrator/migrations/m_192_to_m_193_report_config_migrations/migration_impl.go
+++ b/migrator/migrations/m_192_to_m_193_report_config_migrations/migration_impl.go
@@ -87,6 +87,9 @@ func createReportSnapshot(v1Config *storage.ReportConfiguration, v2Config *stora
 				ReportRequestType: storage.ReportStatus_SCHEDULED,
 				CompletedAt:       v1Config.LastSuccessfulRunTime,
 			},
+			Filter: &storage.ReportSnapshot_VulnReportFilters{
+				VulnReportFilters: v2Config.GetVulnReportFilters().Clone(),
+			},
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR fixes ROX-21029.  In this pr vuln report filters of v1 config  are added to report snapshots created. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed
Manual Testing:
1. Create a v1 report config in 4.2.
2. Schedule email report and wait for email to be sent 
3. Upgrade and verify user can click on migrated config 