### PR TITLE
ROX-21225: fix(ci): Allow Collector logs for errors due to offline mode

### DIFF
--- a/scripts/ci/logcheck/allowlist-patterns
+++ b/scripts/ci/logcheck/allowlist-patterns
@@ -30,3 +30,5 @@ Error: error enriching image
 # Network flakiness can lead to this error occurring in Sensor k8s libraries. All tests pass and it is not
 # an indication of a Sensor issue
 request.go:1116] Unexpected error when reading response body: context deadline exceeded
+# Collector downloading a probe while Sensor is Offline (http.StatusServiceUnavailable -- ROX-19018)
+Unexpected HTTP request failure (HTTP 503)


### PR DESCRIPTION
## Description

Collector logs probe download errors with the HTTP return code, and 503 makes it suspicious during CI.

This particular error code was added in https://github.com/stackrox/stackrox/pull/7377 to distinguish between probe nonexistence and unavailability.

When this statement is present but the test succeeds, it means that this is only transient. If the probe is really unavailable, the test will fail.

## Checklist
- [ ] Investigated and inspected CI test results
