### PR TITLE
ROX-21185: Disable apollo cache for deployment page query

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -128,6 +128,7 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
         },
         { id: string; query: string; statusesForExceptionCount: string[] }
     >(summaryQuery, {
+        fetchPolicy: 'no-cache',
         variables: {
             id: deploymentId,
             query,
@@ -158,6 +159,7 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
             statusesForExceptionCount: string[];
         }
     >(deploymentVulnerabilitiesQuery, {
+        fetchPolicy: 'no-cache',
         variables: {
             id: deploymentId,
             query,


### PR DESCRIPTION
## Description

Disables the cache for the CVE list query on the Workload CVE deployments page. Preventing Apollo from caching this data removes the bug where data is duplicated across every row in the table.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a deployment detail page in Workload CVEs. Severity, status, and affected component should not be the same for every row in the table.

Before:
![image](https://github.com/stackrox/stackrox/assets/1292638/c402c1c0-9ae2-41a5-b574-c5220407da2d)

After:
![image](https://github.com/stackrox/stackrox/assets/1292638/a0a152c0-ee19-4e61-b1f0-7a034ebc4d4c)

