### PR TITLE
fix(scannerv4): Increase default scanner v4 DB PVC size

### DIFF
--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -229,5 +229,5 @@ dbPVCDefaults:
 [<- if .FeatureFlags.ROX_SCANNER_V4 >]
 scannerV4DBPVCDefaults:
   claimName: "scanner-v4-db"
-  size: "10Gi"
+  size: "50Gi"
 [<- end >]


### PR DESCRIPTION
## Description

Through light usage the Scanner V4 PVC was filling up, this PR increases the PV size from `10 GiB` to `50 GiB`

```
2023-11-30 18:00:01.598 UTC [23] FATAL:  the database system is starting up
2023-11-30 18:00:08.156 UTC [16] PANIC:  could not write to file "pg_wal/xlogtemp.16": No space left on device
```

```
sh-4.4$ df -h
Filesystem      Size  Used Avail Use% Mounted on
overlay         128G   17G  112G  13% /
tmpfs            64M     0   64M   0% /dev
tmpfs           6.3G   64M  6.3G   1% /etc/hostname
tmpfs           250M     0  250M   0% /dev/shm
/dev/sda4       128G   17G  112G  13% /etc/hosts
/dev/sdb        9.8G  9.8G  9.9M 100% /var/lib/postgresql/data
tmpfs           4.0G   12K  4.0G   1% /run/secrets/stackrox.io/certs
tmpfs           4.0G   20K  4.0G   1% /run/secrets/kubernetes.io/serviceaccount
tmpfs            16G     0   16G   0% /proc/acpi
tmpfs            16G     0   16G   0% /proc/scsi
tmpfs            16G     0   16G   0% /sys/firmware
```

## Checklist
- [ ] ~Investigated and inspected CI test results~
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Tested in an infra cluster, running: 

```
$ make cli_darwin-arm64

$ ./bin/darwin_arm64/roxctl helm output central-services --image-defaults=development_build --debug-path=./image --debug --remove

$ helm upgrade --install -n stackrox stackrox-central-services --create-namespace  ./stackrox-central-services-chart         -f "$vals"

...

$ k get pvc scanner-v4-db
NAME            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
scanner-v4-db   Bound    pvc-5a8ed2a6-68b9-4262-98b8-6c1f60b38de4   50Gi       RWO            standard-csi   28m
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
