### PR TITLE
ROX-21235: backup certs when using external database

### DIFF
--- a/central/certs/export/backup.go
+++ b/central/certs/export/backup.go
@@ -1,0 +1,35 @@
+package export
+
+import (
+	"archive/zip"
+	"context"
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/globaldb/v2backuprestore/backup/generators"
+	"github.com/stackrox/rox/central/globaldb/v2backuprestore/backup/generators/cas"
+	"github.com/stackrox/rox/central/systeminfo/listener"
+	"github.com/stackrox/rox/pkg/backup"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+// BackupCerts backs up the certs and writes a ZIP archive to the given writer.
+func BackupCerts(ctx context.Context, backupListener listener.BackupListener, out io.Writer) error {
+	zipWriter := zip.NewWriter(out)
+	defer utils.IgnoreError(zipWriter.Close)
+
+	listen := func(err error) error {
+		if err == nil {
+			backupListener.OnBackupSuccess(ctx)
+			return nil
+		}
+		backupListener.OnBackupFail(ctx)
+		return err
+	}
+
+	if err := generators.PutPathMapInZip(cas.NewCertsBackup(), backup.KeysBaseFolder).WriteTo(ctx, zipWriter); err != nil {
+		return listen(errors.Wrap(err, "backing up certificates"))
+	}
+
+	return listen(zipWriter.Close())
+}

--- a/central/certs/handlers/http_handler.go
+++ b/central/certs/handlers/http_handler.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/stackrox/rox/central/certs/export"
+	"github.com/stackrox/rox/central/systeminfo/listener"
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+const (
+	certFileFormat = "cert_backup_2006_01_02_15_04_05.zip"
+)
+
+var (
+	log = logging.LoggerForModule()
+)
+
+// BackupCerts is a handler that writes a consistent view of the certs to the HTTP response.
+func BackupCerts(backupListener listener.BackupListener) http.Handler {
+	return dumpCerts(backupListener)
+}
+
+func logAndWriteErrorMsg(w http.ResponseWriter, code int, t string, args ...interface{}) {
+	errMsg := fmt.Sprintf(t, args...)
+	log.Error(errMsg)
+	http.Error(w, errMsg, code)
+}
+
+func dumpCerts(backupListener listener.BackupListener) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		log.Info("Starting cert backup ...")
+		filename := time.Now().Format(certFileFormat)
+
+		w.Header().Set("Content-Type", "application/zip")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+
+		if err := export.BackupCerts(req.Context(), backupListener, w); err != nil {
+			logAndWriteErrorMsg(w, http.StatusInternalServerError, "could not create cert backup: %v", err)
+			return
+		}
+		log.Info("Cert backup completed")
+	}
+}

--- a/central/main.go
+++ b/central/main.go
@@ -370,7 +370,6 @@ func servicesToRegister() []pkgGRPC.APIService {
 		authService.Singleton(),
 		authProviderSvc.New(authProviderRegistry.Singleton(), groupDataStore.Singleton()),
 		backupRestoreService.Singleton(),
-		backupService.Singleton(),
 		centralHealthService.Singleton(),
 		certgen.ServiceSingleton(),
 		clusterInitService.Singleton(),
@@ -428,6 +427,11 @@ func servicesToRegister() []pkgGRPC.APIService {
 		collectionService.Singleton(),
 		policyCategoryService.Singleton(),
 		processListeningOnPorts.Singleton(),
+	}
+
+	// The scheduled backup service is not applicable when using an external database
+	if !env.ManagedCentral.BooleanSetting() && !pgconfig.IsExternalDatabase() {
+		servicesToRegister = append(servicesToRegister, backupService.Singleton())
 	}
 
 	if features.VulnReportingEnhancements.Enabled() {

--- a/central/main.go
+++ b/central/main.go
@@ -28,6 +28,7 @@ import (
 	authProviderTelemetry "github.com/stackrox/rox/central/authprovider/telemetry"
 	centralHealthService "github.com/stackrox/rox/central/centralhealth/service"
 	"github.com/stackrox/rox/central/certgen"
+	certHandler "github.com/stackrox/rox/central/certs/handlers"
 	"github.com/stackrox/rox/central/cli"
 	"github.com/stackrox/rox/central/cloudproviders/gcp"
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
@@ -802,6 +803,12 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 			Route:         "/api/administration/usage/secured-units/csv",
 			Authorizer:    user.With(permissions.View(resources.Administration)),
 			ServerHandler: administrationUsageCSV.CSVHandler(administrationUsageDataStore.Singleton()),
+			Compression:   true,
+		},
+		{
+			Route:         "/api/extensions/certs/backup",
+			Authorizer:    user.With(permissions.View(resources.Administration)),
+			ServerHandler: certHandler.BackupCerts(listener.Singleton()),
 			Compression:   true,
 		},
 	}

--- a/roxctl/central/backup/backup.go
+++ b/roxctl/central/backup/backup.go
@@ -46,13 +46,16 @@ You can use it to restore central service and the database.`,
 If the provided path is a file path, the backup will be written to the file, overwriting it if it already exists. (The directory MUST exist.)
 If the provided path is a directory, the backup will be saved in that directory with the server-provided filename.
 If this argument is omitted, the backup will be saved in the current working directory with the server-provided filename.`)
+	c.Flags().BoolVar(&centralBackupCmd.certsOnly, "certsOnly", false, `only backs up the certs.
+If using an external database this will be how a backup bundle with certs is generated.`)
 	flags.AddTimeoutWithDefault(c, 1*time.Hour)
 	return c
 }
 
 type centralBackupCommand struct {
 	// Properties that are bound to cobra flags.
-	output string
+	output    string
+	certsOnly bool
 
 	// Properties that are injected or constructed.
 	env environment.Environment
@@ -113,7 +116,9 @@ func (cmd *centralBackupCommand) backup(timeout time.Duration, full bool) error 
 	deadline := time.Now().Add(timeout)
 
 	var endpoint string
-	if full {
+	if cmd.certsOnly {
+		endpoint = "/api/extensions/certs/backup"
+	} else if full {
 		endpoint = "/api/extensions/backup"
 	} else {
 		endpoint = "/db/backup"


### PR DESCRIPTION
## Description

The certs are only pulled in a database backup bundle.  When using an external database we do not support pulling a database backup through the product.  So we need to provide a means to backup the certs outside of pulling a database backup.  This change introduces an endpoint that will only backup the certs and adds a roxctl flag to exercise that endpoint.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
~- [ ] Determined and documented upgrade steps~
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Updated the backup test to exercise the new endpoint and ensure that it only returned the certs.  Also spun up a cluster and exercised the various backup endpoints.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
