### PR TITLE
ROX-21188: use grpc storage client

### DIFF
--- a/pkg/cloudproviders/gcp/storage/factory.go
+++ b/pkg/cloudproviders/gcp/storage/factory.go
@@ -2,14 +2,12 @@ package storage
 
 import (
 	"context"
-	"net/http"
 
 	"cloud.google.com/go/storage"
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
-	googleHTTP "google.golang.org/api/transport/http"
+	"google.golang.org/grpc"
 )
 
 // ClientFactory creates a GCP storage client.
@@ -24,13 +22,8 @@ var _ ClientFactory = &clientFactoryImpl{}
 type clientFactoryImpl struct{}
 
 func (s *clientFactoryImpl) NewClient(ctx context.Context, creds *google.Credentials) (*storage.Client, error) {
-	transport, err := googleHTTP.NewTransport(
-		ctx,
-		proxy.RoundTripper(),
+	return storage.NewGRPCClient(ctx,
+		option.WithGRPCDialOption(grpc.WithContextDialer(proxy.AwareDialContext)),
 		option.WithCredentials(creds),
 	)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create transport")
-	}
-	return storage.NewClient(ctx, option.WithHTTPClient(&http.Client{Transport: transport}))
 }

--- a/pkg/cloudproviders/gcp/storage/handler.go
+++ b/pkg/cloudproviders/gcp/storage/handler.go
@@ -59,6 +59,9 @@ func (s *clientHandlerImpl) UpdateClient(ctx context.Context, creds *google.Cred
 	if err != nil {
 		return errors.Wrap(err, "failed to create GCP storage client")
 	}
+	if s.client != nil {
+		s.client.Close()
+	}
 	s.client = client
 	return nil
 }


### PR DESCRIPTION
## Description

I tracked down the API response time observed in ROX-21188 - other than the one caused by the `FindDefaultCredentials` call - to the http client in
```
return storage.NewClient(ctx, option.WithHTTPClient(&http.Client{Transport: transport}))
```

It seems the response time increase occurs when using a combination of the GCS http client with the stackrox proxy round tripper when using OCP 4.11. Using the gRPC client instead seems to solve this problem. Note that the GCS gRPC client is still in tech preview, but most other GCP clients already use gRPC, and our use case is not very complex.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Tested response time of the GCS backup on OCP 4.11.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
