### PR TITLE
ROX-21188: remove http proxy

### DIFF
--- a/pkg/cloudproviders/gcp/storage/factory.go
+++ b/pkg/cloudproviders/gcp/storage/factory.go
@@ -2,14 +2,10 @@ package storage
 
 import (
 	"context"
-	"net/http"
 
 	"cloud.google.com/go/storage"
-	"github.com/pkg/errors"
-	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
-	googleHTTP "google.golang.org/api/transport/http"
 )
 
 // ClientFactory creates a GCP storage client.
@@ -24,13 +20,5 @@ var _ ClientFactory = &clientFactoryImpl{}
 type clientFactoryImpl struct{}
 
 func (s *clientFactoryImpl) NewClient(ctx context.Context, creds *google.Credentials) (*storage.Client, error) {
-	transport, err := googleHTTP.NewTransport(
-		ctx,
-		proxy.RoundTripper(),
-		option.WithCredentials(creds),
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create transport")
-	}
-	return storage.NewClient(ctx, option.WithHTTPClient(&http.Client{Transport: transport}))
+	return storage.NewClient(ctx, option.WithCredentials(creds))
 }


### PR DESCRIPTION
## Description

I tracked down the API response time observed in ROX-21188 - other than the one caused by the `FindDefaultCredentials` call - to the http client in
```
return storage.NewClient(ctx, option.WithHTTPClient(&http.Client{Transport: transport}))
```

It seems the response time increase occurs when using a custom http client on OCP 4.11. The custom http client is used to inject the stackrox proxy configuration. The google SDK presently does not provide a better way to configure a proxy. This PR removes the proxy config until either the problem is better understood and we find a different solution. Also note that proxies configured via the common env vars should still work out of the box.

In the meantime this should unblock CI and prevent the response time jump.


## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Tested creation of GCS backup integrations on OCP 4.11.54.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
