### PR TITLE
chore(notifiers): Add telemetry for notifiers

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -102,6 +102,7 @@ import (
 	networkFlowService "github.com/stackrox/rox/central/networkgraph/service"
 	networkPolicyService "github.com/stackrox/rox/central/networkpolicies/service"
 	nodeService "github.com/stackrox/rox/central/node/service"
+	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/notifier/processor"
 	notifierService "github.com/stackrox/rox/central/notifier/service"
 	_ "github.com/stackrox/rox/central/notifiers/all" // These imports are required to register things from the respective packages.
@@ -599,6 +600,7 @@ func startGRPCServer() {
 				gs.AddGatherer(roleDataStore.Gather)
 				gs.AddGatherer(clusterDataStore.Gather)
 				gs.AddGatherer(declarativeconfig.ManagerSingleton().Gather())
+				gs.AddGatherer(notifierDS.Gather)
 			}
 		}
 	}

--- a/central/notifier/datastore/telemetry.go
+++ b/central/notifier/datastore/telemetry.go
@@ -49,13 +49,31 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 		pkgNotifiers.TeamsType:          0,
 	}
 
+	cloudCredentialsEnabledNotifiersCount := map[string]int{
+		"WIF enabled": 0,
+		"STS enabled": 0,
+	}
+
 	for _, notifier := range notifiers {
 		notifierTypesCount[notifier.GetType()]++
+
+		if notifier.GetType() == pkgNotifiers.AWSSecurityHubType && notifier.GetAwsSecurityHub().GetCredentials().GetStsEnabled() {
+			cloudCredentialsEnabledNotifiersCount["STS enabled"]++
+		}
+
+		if notifier.GetType() == pkgNotifiers.CSCCType && notifier.GetCscc().GetWifEnabled() {
+			cloudCredentialsEnabledNotifiersCount["WIF enabled"]++
+		}
 	}
 
 	for notifierType, count := range notifierTypesCount {
 		props[fmt.Sprintf("Total %s Notifiers",
 			cases.Title(language.English, cases.Compact).String(notifierType))] = count
+	}
+
+	for cloudCredentialsType, count := range cloudCredentialsEnabledNotifiersCount {
+		props[fmt.Sprintf("Total %s Notifiers",
+			cases.Title(language.English, cases.Compact).String(cloudCredentialsType))] = count
 	}
 
 	return props, nil

--- a/central/notifier/datastore/telemetry.go
+++ b/central/notifier/datastore/telemetry.go
@@ -1,0 +1,62 @@
+package datastore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	pkgNotifiers "github.com/stackrox/rox/pkg/notifiers"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// Gather notifier types.
+// Current properties we gather:
+// "Total Notifiers"
+// "Total <notifier type> Notifiers"
+var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
+	ctx = sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Integration)))
+	props := make(map[string]any)
+
+	notifiers, err := Singleton().GetNotifiers(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get notifiers")
+	}
+
+	// Can safely ignore the error here since we already fetched notifiers.
+	_ = phonehome.AddTotal(ctx, props, "Notifiers", func(_ context.Context) (int, error) {
+		return len(notifiers), nil
+	})
+
+	notifierTypesCount := map[string]int{
+		pkgNotifiers.AWSSecurityHubType: 0,
+		pkgNotifiers.CSCCType:           0,
+		pkgNotifiers.EmailType:          0,
+		pkgNotifiers.GenericType:        0,
+		pkgNotifiers.JiraType:           0,
+		pkgNotifiers.PagerDutyType:      0,
+		pkgNotifiers.SlackType:          0,
+		pkgNotifiers.SplunkType:         0,
+		pkgNotifiers.SumoLogicType:      0,
+		pkgNotifiers.SyslogType:         0,
+		pkgNotifiers.TeamsType:          0,
+	}
+
+	for _, notifier := range notifiers {
+		notifierTypesCount[notifier.GetType()]++
+	}
+
+	for notifierType, count := range notifierTypesCount {
+		props[fmt.Sprintf("Total %s Notifiers",
+			cases.Title(language.English, cases.Compact).String(notifierType))] = count
+	}
+
+	return props, nil
+}

--- a/central/notifier/datastore/telemetry.go
+++ b/central/notifier/datastore/telemetry.go
@@ -50,19 +50,19 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 	}
 
 	cloudCredentialsEnabledNotifiersCount := map[string]int{
-		"WIF enabled": 0,
-		"STS enabled": 0,
+		pkgNotifiers.AWSSecurityHubType: 0,
+		pkgNotifiers.CSCCType:           0,
 	}
 
 	for _, notifier := range notifiers {
 		notifierTypesCount[notifier.GetType()]++
 
 		if notifier.GetType() == pkgNotifiers.AWSSecurityHubType && notifier.GetAwsSecurityHub().GetCredentials().GetStsEnabled() {
-			cloudCredentialsEnabledNotifiersCount["STS enabled"]++
+			cloudCredentialsEnabledNotifiersCount[pkgNotifiers.AWSSecurityHubType]++
 		}
 
 		if notifier.GetType() == pkgNotifiers.CSCCType && notifier.GetCscc().GetWifEnabled() {
-			cloudCredentialsEnabledNotifiersCount["WIF enabled"]++
+			cloudCredentialsEnabledNotifiersCount[pkgNotifiers.CSCCType]++
 		}
 	}
 
@@ -72,7 +72,7 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 	}
 
 	for cloudCredentialsType, count := range cloudCredentialsEnabledNotifiersCount {
-		props[fmt.Sprintf("Total %s Notifiers",
+		props[fmt.Sprintf("Total STS enabled %s Notifiers",
 			cases.Title(language.English, cases.Compact).String(cloudCredentialsType))] = count
 	}
 


### PR DESCRIPTION
## Description

Add telemetry for collecting the total number of notifiers, the different types of notifiers, and WIF / STS enabled notifiers.

This is within the scope of the feature of cloud credentials support (i.e. adding WIF / STS support to certain integrations).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

N/A

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
