### PR TITLE
ROX-19053: Wrap up first Scanner V4 Deployment test executing in CI

### DIFF
--- a/scripts/ci/jobs/gke_scanner_v4_tests.py
+++ b/scripts/ci/jobs/gke_scanner_v4_tests.py
@@ -13,6 +13,7 @@ from post_tests import PostClusterTest, FinalPost
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 os.environ["OUTPUT_FORMAT"] = "helm"
 os.environ["ROX_SCANNER_V4_ENABLED"] = "true"
+os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 
 ClusterTestRunner(
     cluster=GKECluster("scanner-v4-test", machine_type="e2-standard-8"),

--- a/scripts/ci/jobs/gke_scanner_v4_tests.py
+++ b/scripts/ci/jobs/gke_scanner_v4_tests.py
@@ -13,7 +13,9 @@ from post_tests import PostClusterTest, FinalPost
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 os.environ["OUTPUT_FORMAT"] = "helm"
 os.environ["ROX_SCANNER_V4_ENABLED"] = "true"
+os.environ["STORE_METRICS"] = "true"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_BASELINE_GENERATION_DURATION"] = "5m"
 
 ClusterTestRunner(
     cluster=GKECluster("scanner-v4-test", machine_type="e2-standard-8"),

--- a/scripts/ci/logcheck/restart-ok-patterns.json
+++ b/scripts/ci/logcheck/restart-ok-patterns.json
@@ -46,5 +46,17 @@
         "job": "upgrade",
         "logfile": "sensor-previous",
         "logline": "checking central status failed after"
+    },
+    {
+        "comment": "Scanner V4 Indexer restart due to Scanner V4 DB not being ready",
+        "job": ".*",
+        "logfile": "indexer-previous",
+        "logline": "connecting to postgres for indexer: failed to create ConnPool: failed to connect to"
+    },
+    {
+        "comment": "Scanner V4 Matcher restart due to Scanner V4 DB not being ready",
+        "job": ".*",
+        "logfile": "matcher-previous",
+        "logline": "connecting to postgres for matcher: failed to create ConnPool: failed to connect to"
     }
 ]

--- a/tests/e2e/run-scanner-v4.sh
+++ b/tests/e2e/run-scanner-v4.sh
@@ -29,20 +29,9 @@ scannerV4_test() {
     remove_existing_stackrox_resources
     setup_default_TLS_certs
 
-    deploy_stackrox_in_scannerV4_mode
+    deploy_stackrox
 
     run_scannerV4_test
-}
-
-deploy_stackrox_in_scannerV4_mode() {
-    "$ROOT/deploy/k8s/deploy.sh"
-
-    DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}" \
-    export_central_basic_auth_creds
-
-    wait_for_api
-
-    touch "${STATE_DEPLOYED}"
 }
 
 run_scannerV4_test() {


### PR DESCRIPTION
## Description

We have recently merged a change containing the first step towards Scanner V4 tests running in CI.
After the required changes to support this the test were merged to the `openshift/release` repo we were able to actually execute the test and fix the remaining issues currently preventing this test from passing. This PR contains the required changes for allowing this test to pass.

Follow-up PRs are planned for adding test cases to the new Scanner V4 test.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~ (n/a)
- [ ] ~~Evaluated and added CHANGELOG entry if required~~ (n/a)
- [ ] ~~Determined and documented upgrade steps~~ (n/a)
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~ (no user facing changes)

## Testing Performed

This just fixes a new CI test.
