### PR TITLE
ROX-20339: Fix TLSChallenge timeout

### DIFF
--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -61,6 +61,9 @@ class TLSChallengeTest extends BaseSpecification {
         orchestrator.restartPodByLabelWithExecKill("stackrox", [app: "central"])
         orchestrator.waitForPodsReady("stackrox", [app: "central"], 1, 50, 3)
 
+        // Ensure Central API is reachable.
+        withRetry(30, 2) { Services.getMetadataClient().getMetadata() }
+
         // Restart sensor to reset the gRPC connection to central.
         // Scale to 0 and back to 1 so that the check for sensor healthiness is based on the restarted sensor pod.
         orchestrator.scaleDeployment("stackrox", "sensor", 0)


### PR DESCRIPTION
## Description

We've seen timeouts / io.Exceptions within the test cleanup when assessing whether we currently run on OpenShift 3.11.

The main issue is that the Central deployment gets restarted, and we only verify whether the pods are ready. This doesn't necessarily mean that the API server is started and served already, which may take some time.

Added another step of waiting for the metadata service results before attempting to bounce Sensor to ensure the Central API is reachable and avoid any exceptions / timeouts.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
