### PR TITLE
ROX-20575: Add source column to embedded vuln tables

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -80,6 +80,7 @@ function DeploymentComponentVulnerabilitiesTable({
                     <Th sort={getSortParams('Component')}>Component</Th>
                     <Th>Version</Th>
                     <Th>CVE fixed in</Th>
+                    <Th>Source</Th>
                     <Th>Location</Th>
                 </Tr>
             </Thead>
@@ -133,12 +134,13 @@ function DeploymentComponentVulnerabilitiesTable({
                             <Td modifier="nowrap">
                                 <FixedByVersionTd fixedByVersion={fixedByVersion} />
                             </Td>
+                            <Td>{source}</Td>
                             <Td>
                                 <ComponentLocationTd location={location} source={source} />
                             </Td>
                         </Tr>
                         <Tr>
-                            <Td colSpan={7} className="pf-u-pt-0">
+                            <Td colSpan={8} className="pf-u-pt-0">
                                 <DockerfileLayerTd layer={layer} />
                             </Td>
                         </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -65,6 +65,7 @@ function ImageComponentVulnerabilitiesTable({
                     <Th sort={getSortParams('Component')}>Component</Th>
                     <Th>Version</Th>
                     <Th>CVE Fixed in</Th>
+                    <Th>Source</Th>
                     <Th>Location</Th>
                 </Tr>
             </Thead>
@@ -93,12 +94,13 @@ function ImageComponentVulnerabilitiesTable({
                             <Td modifier="nowrap">
                                 <FixedByVersionTd fixedByVersion={fixedByVersion} />
                             </Td>
+                            <Td>{source}</Td>
                             <Td>
                                 <ComponentLocationTd location={location} source={source} />
                             </Td>
                         </Tr>
                         <Tr>
-                            <Td colSpan={4} className="pf-u-pt-0">
+                            <Td colSpan={5} className="pf-u-pt-0">
                                 <DockerfileLayerTd layer={layer} />
                             </Td>
                         </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocationTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocationTd.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex, Tooltip } from '@patternfly/react-core';
+import { Flex, Tooltip, Truncate } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 
 import { SourceType } from '../Tables/table.utils';
@@ -12,7 +12,7 @@ export type ComponentLocationTdProps = {
 function ComponentLocationTd({ location, source }: ComponentLocationTdProps) {
     return (
         <Flex spaceItems={{ default: 'spaceItemsXs' }} alignItems={{ default: 'alignItemsCenter' }}>
-            <span>{location || 'N/A'}</span>
+            <Truncate content={location || 'N/A'} position="middle" />
             {source === 'OS' && (
                 <Tooltip content="Location is unavailable for operating system packages">
                     <InfoCircleIcon color="var(--pf-global--info-color--100)" />


### PR DESCRIPTION
## Description

Adds component source to Workload CVE tables. The "Location" field was also wrapped in `<Truncate>` to prevent forcing the parent table off screen.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tables with an image context:
![image](https://github.com/stackrox/stackrox/assets/1292638/a0dccd32-9f26-40eb-b506-adadae3bb180)

Tables without an image context:
![image](https://github.com/stackrox/stackrox/assets/1292638/dcc4eb18-11b6-47f9-b6ae-7c0f71fa743a)

Location tooltip:
![image](https://github.com/stackrox/stackrox/assets/1292638/685e3e4c-7125-41ef-9776-02dc2f8d2ecb)
