### PR TITLE
fix: use nil if no time provided in image

### DIFF
--- a/pkg/protoconv/time.go
+++ b/pkg/protoconv/time.go
@@ -37,14 +37,6 @@ func ConvertTimestampToTimeOrDefault(gogo *gogoTimestamp.Timestamp, defaultVal t
 	return t
 }
 
-// ConvertTimeToTimestampOrNow converts golang time to proto timestamp.
-func ConvertTimeToTimestampOrNow(goTime *time.Time) *gogoTimestamp.Timestamp {
-	if goTime == nil {
-		return gogoTimestamp.TimestampNow()
-	}
-	return ConvertTimeToTimestamp(*goTime)
-}
-
 // ConvertTimeToTimestamp converts golang time to proto timestamp.
 func ConvertTimeToTimestamp(goTime time.Time) *gogoTimestamp.Timestamp {
 	t, err := gogoTimestamp.TimestampProto(goTime)


### PR DESCRIPTION
## Description

This PR changes the logic of defaulting timestamp to now to `nil` if there is no value. Requested at https://github.com/stackrox/stackrox/pull/8866#discussion_r1414348425


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
