### PR TITLE
ROX-16831: Fix UI validation for mount propagation policy criterion

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -164,6 +164,7 @@ const memoryResource = (label: string): GroupDescriptor => ({
 
 // TODO Delete after signaturePolicyCriteria type encapsulates its behavior.
 export const imageSigningCriteriaName = 'Image Signature Verified By';
+export const mountPropagationCriteriaName = 'Mount Propagation';
 
 // A form descriptor for every option (key) on the policy criteria form page.
 /*
@@ -763,7 +764,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
-        name: 'Mount Propagation',
+        name: mountPropagationCriteriaName,
         shortName: 'Mount propagation',
         longName: 'Mount propagation is',
         negatedName: 'Mount propagation is not',


### PR DESCRIPTION
## Description

This issue was noticed while testing other aspects of policies.
> If I select Mount Propagation criteria and drag it to the policy section area then I can press Next and continue (but it's an error since I need to have values in there).
>
> However if I select a value from the drop (or even multiple ones), the Next button is disabled.
>
> It's the opposite logic of what should be. Interestingly, if I select a value and then clear it, the Next button is not re-enabled (which is correct).

When the Policies section was migrated to PatternFly, the only front-end validation we were doing to enable the next button was to make sure you had at least one field in each "group" added. When we added the Image Signature field later, we wrote a custom validation function for it, but that seems to have caused the strange behavior noted above.

Rather than back out that custom validation, I added a custom case to handle Mount Propagation.
(I also standardized the parameters passed to the `.text()` Yup function here, to match the way we use it in the rest of the app. I suspect that this was causing inconsistent behavior even with the Image Signature validation before. I also suspect that the Image Signature validation is not really checking it correctly, but I'm treating that as out-of-scope for this PR and leaving the current functionality.)


## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

### Here I tell how I validated my change

I added the Mount Propagation field, and observed the behavior expected.

1. No criteria added yet--Next button is disabled
2. Mount Propagation field added--Next button is still disabled, because no selection has been made yet
3. I selected one or more options--Next button is enabled whatever combination of 1, 2, or all 3 options are selected
4. I cleared all the options--the Next button becomes disabled again

No criteria added yet
<img width="1527" alt="Screenshot 2023-12-05 at 3 13 36 PM" src="https://github.com/stackrox/stackrox/assets/715729/48962961-e1ff-445c-8098-0c1c2b5f42af">

Mount Propagation field added (Next button still disabled)
<img width="1550" alt="Screenshot 2023-12-05 at 3 13 51 PM" src="https://github.com/stackrox/stackrox/assets/715729/74c9b62a-c0aa-4bdb-87e3-d91508c2876a">

I selected one or more options (Next button now enabled)
<img width="1550" alt="Screenshot 2023-12-05 at 3 13 56 PM" src="https://github.com/stackrox/stackrox/assets/715729/a9ab25a7-9c23-4b0a-a58d-1c5770197414">

I cleared all the options (Next button disabled again)
<img width="1550" alt="Screenshot 2023-12-05 at 3 14 04 PM" src="https://github.com/stackrox/stackrox/assets/715729/9411c199-aac6-4b8a-b1b7-83155783453f">



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
