### PR TITLE
ROX-21048: Fixed report prunning sql query

### DIFF
--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -94,7 +94,7 @@ const (
 			AND NOT EXISTS
 			(
 				SELECT 1 FROM ` + schema.BlobsTableName + ` blobs
-				WHERE blobs.name not ilike '%%/snapshots.reportid'
+				WHERE blobs.name ilike CONCAT('%%/',snapshots.reportid)
 			)
 			AND (snapshots.reportstatus_completedat < now() AT time zone 'utc' - INTERVAL '%d MINUTES')
 		)`


### PR DESCRIPTION
PR fixes sql query to get report snapshots that in the pruning window. 
## Testing Performed
Manual Testing
1.deploy 4.3 acs
2. create report configs and run scheduled email jobs, on demand email and download.
3. set pruning window to 2 days
4. verify that report snapshots in the pruning window are deleted