### PR TITLE
ROX-16830: Fix policy criteria buttons being cut off

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldInput.tsx
@@ -131,6 +131,7 @@ function PolicyCriteriaFieldInput({
                         isDisabled={readOnly}
                         selections={value.value}
                         placeholderText={descriptor.placeholder || 'Select an option'}
+                        menuAppendTo={() => document.body}
                     >
                         {descriptor?.options?.map((option) => (
                             <SelectOption
@@ -161,6 +162,7 @@ function PolicyCriteriaFieldInput({
                         onClear={handleChangeSelectedValue([])}
                         placeholderText={descriptor.placeholder || 'Select one or more options'}
                         variant={SelectVariant.typeaheadMulti}
+                        menuAppendTo={() => document.body}
                     >
                         {descriptor.options?.map((option) => (
                             <SelectOption

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldSubInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldSubInput.tsx
@@ -72,6 +72,7 @@ function PolicyCriteriaFieldSubInput({
                         isDisabled={readOnly}
                         selections={value}
                         placeholderText={subComponent.placeholder || 'Select an option'}
+                        menuAppendTo={() => document.body}
                     >
                         {subComponent.options?.map((option) => (
                             <SelectOption

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.css
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.css
@@ -3,6 +3,10 @@
     overflow-x: scroll;
 }
 
+#policy-sections .pf-c-toggle-group .pf-c-toggle-group__button {
+    white-space: initial;
+}
+
 #policy-sections-container {
     overflow: auto;
 }


### PR DESCRIPTION
## Description

Heavy is the hand that wields the CSS. (or something like that)

This adds a very specific CSS rule to make the option buttons wrap when the option names are long.

It also fixes some select menus for policy criteria options getting cut off, which I noticed while testing every policy field to make sure my new CSS rule didn't break anything. (My first attempt at rule had broken something.)


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

Before
<img width="1544" alt="Screenshot 2023-12-05 at 4 04 10 PM" src="https://github.com/stackrox/stackrox/assets/715729/e1d8d5de-0295-4ae9-b8bf-e5476d021048">

After
<img width="1544" alt="Screenshot 2023-12-05 at 4 06 31 PM" src="https://github.com/stackrox/stackrox/assets/715729/474d78a3-826a-4ef3-84f6-75ae9a36d6c3">

Other buttons in field inputs are not affected (example, the button labelled "Select" here)
<img width="1544" alt="Screenshot 2023-12-05 at 4 31 50 PM" src="https://github.com/stackrox/stackrox/assets/715729/38bd9e7c-3bab-48d2-898d-559552809594">


Correct select options menus that are no longer being cut off
<img width="1544" alt="Screenshot 2023-12-05 at 4 36 59 PM" src="https://github.com/stackrox/stackrox/assets/715729/5ce08255-958e-4b32-b4e5-73eb6fef3724">
<img width="1490" alt="Screenshot 2023-12-05 at 6 39 06 PM" src="https://github.com/stackrox/stackrox/assets/715729/f9c455e5-0595-486e-a749-741a3a609596">
<img width="1490" alt="Screenshot 2023-12-05 at 6 27 49 PM" src="https://github.com/stackrox/stackrox/assets/715729/07c18a86-689f-49e2-93a6-2c9bed156d4d">



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
