### PR TITLE
chore(scanner): copy postgres configs from new location

### DIFF
--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -342,7 +342,7 @@ clean-e2e:
 
 # DB configuration files.
 #
-$(e2e-files-d)/db-%.conf: image/db/%.conf
+$(e2e-files-d)/db-%.conf: ../image/templates/helm/shared/config-templates/scanner-v4-db/%.conf.default
 	$(SILENT)mkdir -p $(@D)
 	$(SILENT)cp $^ $@
 


### PR DESCRIPTION
## Description

#8445 moved the location of the postgres config files to conform to current StackRox deployment conventions. Moving these files means we cannot run `make -C scanner e2e-deploy` anymore, though, so this PR updates this `make` target to copy the files from the new location.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

`make -C scanner e2e-deploy`. You'll find the files are copied over correctly.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
