### PR TITLE
chore(govulncheck): Allow for exceptions to govulncheck

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -604,18 +604,7 @@ jobs:
 
     - name: Scan
       run: |
-        GOVULNCHECK_BIN="$(make  which-govulncheck --silent)"
-        find bin/linux_amd64 -maxdepth 1 -type f -exec "$GOVULNCHECK_BIN" -mode=binary -json {} \; | tee vulns.json
-        source "scripts/ci/lib.sh"
-        jq '.osv | select(. != null ) | [.id, .summary, .details] | @tsv' -r vulns.json | sort -u | while IFS=$'\t' read -r -a vulns
-        do
-          id="${vulns[0]}"
-          summary="${vulns[1]}"
-          details="${vulns[2]}"
-          echo "$id" "$summary"
-          save_junit_failure "$id" "$summary" "$details"
-        done
-        grep -q finding vulns.json && (exit 1)
+        ./scripts/ci/govulncheck.sh
 
     - name: Publish Test Report
       uses: test-summary/action@v2

--- a/govulncheck-allowlist.json
+++ b/govulncheck-allowlist.json
@@ -5,7 +5,7 @@
     },
     "GO-2023-2186": {
       "reason": "False positive as this path is not exercised in the codebase",
-      "until": "2024-01-05T00:00:00Z",
+      "until": "2024-01-05T00:00:00Z"
     }
   }
 }

--- a/govulncheck-allowlist.json
+++ b/govulncheck-allowlist.json
@@ -1,0 +1,11 @@
+{
+  "exceptions": {
+    "GO-2022-0646": {
+      "reason": "Unused portion of the SDK"
+    },
+    "GO-2023-2186": {
+      "reason": "False positive as this path is not exercised in the codebase",
+      "until": "2024-01-05T00:00:00Z",
+    }
+  }
+}

--- a/govulncheck/main.go
+++ b/govulncheck/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+const (
+	exceptionsFile = "govulncheck-allowlist.json"
+)
+
+// Exception is the metadata around the vuln's exception
+type Exception struct {
+	Reason string     `json:"reason"`
+	Until  *time.Time `json:"until"`
+}
+
+// ExceptionConfig is a wrapper around the vuln exceptions
+type ExceptionConfig struct {
+	Exceptions map[string]*Exception `json:"exceptions"`
+}
+
+func printlnAndExitf(s string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, s+"\n", args...)
+	os.Exit(1)
+}
+
+func readExceptionsFile() *ExceptionConfig {
+	data, err := os.ReadFile(exceptionsFile)
+	if err != nil {
+		printlnAndExitf("unable to read %v: %v", exceptionsFile, err)
+	}
+	var ec ExceptionConfig
+	if err := json.Unmarshal(data, &ec); err != nil {
+		printlnAndExitf("unable to unmarshal %v: %v", exceptionsFile, err)
+		os.Exit(1)
+	}
+	return &ec
+}
+
+// Output is the output of the program
+type Output struct {
+	Data []map[string]interface{} `json:"data"`
+}
+
+func parseData(config *ExceptionConfig, data map[string]interface{}) (map[string]interface{}, bool) {
+	keyMap, exists := data["finding"]
+	if exists {
+		keyMapI := keyMap.(map[string]interface{})
+		return keyMapI, hasException(config, keyMapI["osv"].(string))
+	}
+
+	keyMap, exists = data["osv"]
+	if exists {
+		keyMapI := keyMap.(map[string]interface{})
+		return keyMapI, hasException(config, keyMapI["id"].(string))
+	}
+	return data, false
+}
+
+func hasException(config *ExceptionConfig, id string) bool {
+	if exception, ok := config.Exceptions[id]; ok {
+		// Implies this vuln is excluded forever
+		if exception.Until == nil || exception.Until.After(time.Now()) {
+			return true
+		}
+	}
+	return false
+}
+
+func main() {
+	exceptionConfig := readExceptionsFile()
+
+	file, err := os.Open(os.Args[1])
+	if err != nil {
+		printlnAndExitf("error opening vulns file: %v", err)
+		os.Exit(1)
+	}
+	defer file.Close()
+
+	var output Output
+	decoder := json.NewDecoder(file)
+	for {
+		data := make(map[string]interface{})
+		err := decoder.Decode(&data)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			printlnAndExitf("error reading vulns file: %v", err)
+			os.Exit(1)
+		}
+
+		findingMap, excepted := parseData(exceptionConfig, data)
+		if excepted {
+			continue
+		}
+		output.Data = append(output.Data, findingMap)
+	}
+
+	outputBytes, err := json.MarshalIndent(&output, "", "  ")
+	if err != nil {
+		printlnAndExitf("error marshaling output: %v", err)
+	}
+	fmt.Fprintln(os.Stdout, string(outputBytes))
+}


### PR DESCRIPTION
## Description

Adds the ability to add exceptions to the govulncheck binary

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
