### PR TITLE
fix(test): Fix RBAC test by making it order agnostic

### DIFF
--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -183,13 +183,18 @@ class K8sRbacTest extends BaseSpecification {
                 role.annotations.remove("kubectl.kubernetes.io/last-applied-configuration")
                 assert role.annotations == stackroxRole.annotationsMap
                 for (int i = 0; i < role.rules.size(); i++) {
+                    def found = false
                     K8sPolicyRule oRule = role.rules[i]
-                    Rbac.PolicyRule sRule = stackroxRole.rulesList[i]
-                    assert oRule.verbs == sRule.verbsList
-                    assert oRule.apiGroups == sRule.apiGroupsList
-                    assert oRule.resources == sRule.resourcesList
-                    assert oRule.nonResourceUrls == sRule.nonResourceUrlsList
-                    assert oRule.resourceNames == sRule.resourceNamesList
+                    for (int j = 0; j < stackroxRole.rulesList.size(); j++) {
+                        Rbac.PolicyRule sRule = stackroxRole.rulesList[i]
+                        if (oRule.verbs != sRule.verbsList) { continue }
+                        if (oRule.apiGroups != sRule.apiGroupsList) { continue }
+                        if (oRule.resources != sRule.resourcesList) { continue }
+                        if (oRule.nonResourceUrls != sRule.nonResourceUrlsList) { continue }
+                        if (oRule.resourceNames != sRule.resourceNamesList) { continue }
+                        found = true
+                    }
+                    assert found
                 }
                 assert RbacService.getRole(stackroxRole.id) == stackroxRole
             }


### PR DESCRIPTION
## Description

Sensor does not trigger changes on simple rule reordering, but the cluster version operator reorders the rules (investigation pending) so do a naive comparison check for the test

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI test

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
