### PR TITLE
ROX-19053: Install central and secured-cluster in separate namespaces

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -95,7 +95,8 @@ function local_dev {
 # Checks if central already exists in this cluster.
 # If yes, the user is asked if they want to continue. If they answer no, then the script is terminated.
 function prompt_if_central_exists() {
-    if "${ORCH_CMD}" -n stackrox get deployment central 2>&1; then
+    local namespace=${1:-stackrox}
+    if "${ORCH_CMD}" -n "$namespace" get deployment central 2>&1; then
         yes_no_prompt "Detected there is already a central running on this cluster. Are you sure you want to proceed with this deploy?" || { echo >&2 "Exiting as requested"; exit 1; }
     fi
 }
@@ -121,11 +122,12 @@ function yes_no_prompt() {
 
 function launch_central {
     local k8s_dir="$1"
+    local namespace=${2:-stackrox}
     local common_dir="${k8s_dir}/../common"
 
     verify_orch
     if [[ -z "$CI" ]]; then
-        prompt_if_central_exists
+        prompt_if_central_exists "$namespace"
     fi
 
     echo "Generating central config..."
@@ -514,8 +516,8 @@ function launch_central {
 
 function launch_sensor {
     local k8s_dir="$1"
+    local namespace=${2:-stackrox}
     local common_dir="${k8s_dir}/../common"
-
     local extra_config=()
     local extra_json_config=''
     local extra_helm_config=()

--- a/deploy/common/monitoring.sh
+++ b/deploy/common/monitoring.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-kubectl -n stackrox patch svc/sensor -p '{"spec":{"ports":[{"name":"monitoring","port":9090,"protocol":"TCP","targetPort":9090}]}}'
-kubectl -n stackrox patch svc/central -p '{"spec":{"ports":[{"name":"monitoring","port":9090,"protocol":"TCP","targetPort":9090}]}}'
-kubectl -n stackrox patch daemonset/collector --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/1/ports", "value":[{"containerPort":9091,"name":"cmonitor","protocol":"TCP"}]}]'
+central_namespace=${CENTRAL_NAMESPACE:-stackrox}
+sensor_namespace=${SENSOR_NAMESPACE:-stackrox}
+
+kubectl -n "$sensor_namespace" patch svc/sensor -p '{"spec":{"ports":[{"name":"monitoring","port":9090,"protocol":"TCP","targetPort":9090}]}}'
+kubectl -n "$central_namespace" patch svc/central -p '{"spec":{"ports":[{"name":"monitoring","port":9090,"protocol":"TCP","targetPort":9090}]}}'
+kubectl -n "$sensor_namespace" patch daemonset/collector --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/1/ports", "value":[{"containerPort":9091,"name":"cmonitor","protocol":"TCP"}]}]'
 
 # Modify network policies to allow ingress
 kubectl apply -f - <<EOF
@@ -11,8 +14,8 @@ kind: NetworkPolicy
 metadata:
   labels:
     app.kubernetes.io/name: stackrox
-  name: allow-monitoring
-  namespace: stackrox
+  name: allow-monitoring-central
+  namespace: "$central_namespace"
 spec:
   ingress:
   - ports:
@@ -30,7 +33,7 @@ metadata:
   labels:
     app.kubernetes.io/name: stackrox
   name: allow-compliance-monitoring
-  namespace: stackrox
+  namespace: "$sensor_namespace"
 spec:
   ingress:
   - ports:

--- a/deploy/k8s/central.sh
+++ b/deploy/k8s/central.sh
@@ -2,6 +2,7 @@
 # shellcheck disable=SC1091
 set -e
 
+NAMESPACE=${1:-stackrox}
 K8S_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 COMMON_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../common && pwd)"
 
@@ -14,4 +15,4 @@ source "$COMMON_DIR"/k8sbased.sh
 # shellcheck source=./env.sh
 source "$K8S_DIR"/env.sh
 
-launch_central "$K8S_DIR"
+launch_central "$K8S_DIR" "$NAMESPACE"

--- a/deploy/k8s/sensor.sh
+++ b/deploy/k8s/sensor.sh
@@ -2,6 +2,7 @@
 # shellcheck disable=SC1091
 set -e
 
+NAMESPACE=${1:-stackrox}
 K8S_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 COMMON_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../common && pwd)"
 
@@ -28,4 +29,4 @@ if [[ -z "$ROX_ADMIN_PASSWORD" && -f "${K8S_DIR}/central-deploy/password" ]]; th
 	export ROX_ADMIN_PASSWORD
 fi
 
-launch_sensor "$K8S_DIR"
+launch_sensor "$K8S_DIR" "$NAMESPACE"

--- a/deploy/openshift/central.sh
+++ b/deploy/openshift/central.sh
@@ -2,6 +2,7 @@
 # shellcheck disable=SC1091
 set -e
 
+NAMESPACE=${1:-stackrox}
 K8S_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 COMMON_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../common && pwd)"
 
@@ -14,4 +15,4 @@ source "$COMMON_DIR"/k8sbased.sh
 # shellcheck source=./env.sh
 source "$K8S_DIR"/env.sh
 
-launch_central "$K8S_DIR"
+launch_central "$K8S_DIR" "$NAMESPACE"

--- a/scale/dev/launch_sensor.sh
+++ b/scale/dev/launch_sensor.sh
@@ -18,7 +18,7 @@ if [ ! -f "$file" ]; then
     exit 1
 fi
 
-SENSOR_HELM_DEPLOY=false CLUSTER="${namespace}" NAMESPACE_OVERRIDE="${namespace}" "$DIR/../../deploy/k8s/sensor.sh"
+SENSOR_HELM_DEPLOY=false CLUSTER="${namespace}" "$DIR/../../deploy/k8s/sensor.sh" "$namespace"
 
 # This is purposefully kept as stackrox because this is where central should be run
 if ! kubectl -n stackrox get pvc/central-db > /dev/null; then

--- a/scripts/ci/sensor-wait.sh
+++ b/scripts/ci/sensor-wait.sh
@@ -9,11 +9,14 @@ set -eu
 #   sensor-wait.sh
 #
 # Example:
-# $ ./scripts/ci/sensor-wait.sh
+# $ ./scripts/ci/sensor-wait.sh <optional namespace>
 #
 
 sensor_wait() {
-    echo "Waiting for sensor to start"
+    local namespace=${1:-stackrox}
+
+    echo "Waiting for sensor to start in namespace $namespace"
+
     start_time="$(date '+%s')"
     while true; do
       sensor_json="$(kubectl -n stackrox get deploy/sensor -o json)"

--- a/tests/e2e/sensor.sh
+++ b/tests/e2e/sensor.sh
@@ -31,6 +31,7 @@ test_sensor() {
 
     test_preamble
     setup_deployment_env false false
+    # shellcheck disable=SC2119
     remove_existing_stackrox_resources
 
     rm -f FAIL


### PR DESCRIPTION
## Description

According to https://issues.redhat.com/browse/ROX-19053 test scenarios are desired which use different clusters for central-services and secured-cluster-services, because this is the standard way of installing ACS. Since our CI setup currently does not support multi-cluster tests, this is an attempt to at least get close to this setup by installing central-services and secured-cluster-services into different namespaces, thereby establishing a certain level of isolation between them.

This is WIP.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes

## Testing Performed

Depending solely on existing tests.

