### PR TITLE
fix(debug): Install missing golang binary to enable debug builds

### DIFF
--- a/image/rhel/download.sh
+++ b/image/rhel/download.sh
@@ -28,7 +28,7 @@ if [[ "$DEBUG_BUILD" == "yes" ]]; then
       GOBIN="${output_dir}/go/bin" go install github.com/go-delve/delve/cmd/dlv@latest
     fi
   else
-    echo "WARNING: Architecture ${goarch} is not spported by delve. Rerun with DEBUG_BUILD=no"
+    echo "WARNING: Architecture ${goarch} is not supported by delve. Debugging won't be available"
   fi
 fi
 


### PR DESCRIPTION
## Description

Trying `DEBUG_BUILD=yes make image SKIP_UI_BUILD=1` results in `download.sh` being unable to execute `go` binary - see [stackrox/stackrox/actions/runs/7115604696/job/19372578854?pr=8932](https://github.com/stackrox/stackrox/actions/runs/7115604696/job/19372578854?pr=8932).

It looks like the go binary is missing. This PR installs it when `DEBUG_BUILD=yes`.

## Checklist
- [x] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

- [x] Locally running `DEBUG_BUILD=yes make image SKIP_UI_BUILD=1`
- [x] On CI with a branch containing `-debug` substring (e.g., this branch)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
