### PR TITLE
chore(deps): Revert bump actions/labeler from 4 to 5

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ github.token }}"
         sync-labels: ""


### PR DESCRIPTION
Reverts stackrox/stackrox#8929 as it's failing with 
```
Error: TypeError: Input does not meet YAML 1.2 "Core Schema" specification: sync-labels
Support boolean input list: `true | True | TRUE | false | False | FALSE`
Error: Input does not meet YAML 1.2 "Core Schema" specification: sync-labels
Support boolean input list: `true | True | TRUE | false | False | FALSE`
```