### PR TITLE
ROX-19540: Central Implement a workflow to delete scan config 

### DIFF
--- a/central/complianceoperator/v2/compliancemanager/manager.go
+++ b/central/complianceoperator/v2/compliancemanager/manager.go
@@ -28,6 +28,5 @@ type Manager interface {
 	// ProcessRescanRequest processes a request to rerun an existing compliance scan configuration.
 	ProcessRescanRequest(ctx context.Context, rescanRequest interface{}) error
 	// DeleteScan processes a request to delete an existing compliance scan configuration.
-	// TODO(ROX-19540)
-	DeleteScan(ctx context.Context, deleteScanRequest interface{}) error
+	DeleteScan(ctx context.Context, scanID string) error
 }

--- a/central/complianceoperator/v2/compliancemanager/manager_impl.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl.go
@@ -244,11 +244,37 @@ func (m *managerImpl) ProcessRescanRequest(_ context.Context, _ interface{}) err
 }
 
 // DeleteScan processes a request to delete an existing compliance scan configuration.
-// TODO(ROX-19540)
-func (m *managerImpl) DeleteScan(_ context.Context, _ interface{}) error {
-	// TODO:
-	// 1. Validate config exists in database
-	// 2. Lock config so it cannot be edited/updated
-	// 3. Push request to Sensor
-	panic("implement me")
+func (m *managerImpl) DeleteScan(ctx context.Context, scanID string) error {
+	// Remove the scan configuration from the database
+	scanConfigName, clustersDeleted, err := m.scanSettingDS.DeleteScanConfiguration(ctx, scanID)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to delete scan configuration ID %q.", scanID)
+	}
+
+	if scanConfigName == "" {
+		return errors.Errorf("Unable to find scan configuration name for ID %q.", scanID)
+	}
+
+	// send delete request to sensor
+	for _, clusterID := range clustersDeleted {
+		// id for the request message to sensor
+		sensorRequestID := uuid.NewV4().String()
+		sensorMessage := &central.MsgToSensor{
+			Msg: &central.MsgToSensor_ComplianceRequest{
+				ComplianceRequest: &central.ComplianceRequest{
+					Request: &central.ComplianceRequest_DeleteScanConfig{
+						DeleteScanConfig: &central.DeleteComplianceScanConfigRequest{
+							Id:   sensorRequestID,
+							Name: scanConfigName,
+						},
+					},
+				},
+			},
+		}
+		err := m.sensorConnMgr.SendMessage(clusterID, sensorMessage)
+		if err != nil {
+			log.Errorf("unable to remove scan config %q from cluster %q: %v", scanConfigName, clusterID, err)
+		}
+	}
+	return nil
 }

--- a/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
@@ -230,8 +230,8 @@ func (suite *complianceManagerTestSuite) TestDeleteScanConfiguration() {
 			desc: "Successful delection of scan configuration",
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().DeleteScanConfiguration(gomock.Any(), mockScanID).Return(mockScanName,
-					[]string{fixtureconsts.Cluster1}, nil).Times(1)
-				suite.connectionMgr.EXPECT().SendMessage(fixtureconsts.Cluster1, gomock.Any()).Return(nil).Times(1)
+					nil).Times(1)
+				suite.connectionMgr.EXPECT().BroadcastMessage(gomock.Any()).Times(1)
 			},
 			isErrorTest: false,
 		},
@@ -239,37 +239,19 @@ func (suite *complianceManagerTestSuite) TestDeleteScanConfiguration() {
 			desc: "Error from delection of scan configuration",
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().DeleteScanConfiguration(gomock.Any(), mockScanID).Return(mockScanName,
-					[]string{fixtureconsts.Cluster1}, errors.New("Unable to delete scan configuration")).Times(1)
+					errors.New("Unable to delete scan configuration")).Times(1)
 			},
 			isErrorTest: true,
 			expectedErr: errors.New("Unable to delete scan configuration"),
 		},
 		{
-			desc: "Empty cluster list",
-			setMocks: func() {
-				suite.scanConfigDS.EXPECT().DeleteScanConfiguration(gomock.Any(), mockScanID).Return(mockScanName,
-					[]string{}, nil).Times(1)
-			},
-			isErrorTest: false,
-		},
-		{
 			desc: "Empty scan configuration name",
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().DeleteScanConfiguration(gomock.Any(), mockScanID).Return("",
-					[]string{fixtureconsts.Cluster1}, nil).Times(1)
+					nil).Times(1)
 			},
 			isErrorTest: true,
 			expectedErr: errors.Errorf("Unable to find scan configuration name for ID %q", mockScanID),
-		},
-		{
-			// we should not return error if we are unable to send message to sensor
-			desc: "Error from sensor",
-			setMocks: func() {
-				suite.scanConfigDS.EXPECT().DeleteScanConfiguration(gomock.Any(), mockScanID).Return(mockScanName,
-					[]string{fixtureconsts.Cluster1}, nil).Times(1)
-				suite.connectionMgr.EXPECT().SendMessage(fixtureconsts.Cluster1, gomock.Any()).Return(errors.New("Unable to process sensor message")).Times(1)
-			},
-			isErrorTest: false,
 		},
 	}
 	for _, tc := range cases {

--- a/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	mockScanName = "mockScan"
+	mockScanID   = "mockScanID"
 )
 
 type pipelineTestCase struct {
@@ -223,8 +224,71 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 	}
 }
 
+func (suite *complianceManagerTestSuite) TestDeleteScanConfiguration() {
+	cases := []processScanConfigTestCase{
+		{
+			desc: "Successful delection of scan configuration",
+			setMocks: func() {
+				suite.scanConfigDS.EXPECT().DeleteScanConfiguration(gomock.Any(), mockScanID).Return(mockScanName,
+					[]string{fixtureconsts.Cluster1}, nil).Times(1)
+				suite.connectionMgr.EXPECT().SendMessage(fixtureconsts.Cluster1, gomock.Any()).Return(nil).Times(1)
+			},
+			isErrorTest: false,
+		},
+		{
+			desc: "Error from delection of scan configuration",
+			setMocks: func() {
+				suite.scanConfigDS.EXPECT().DeleteScanConfiguration(gomock.Any(), mockScanID).Return(mockScanName,
+					[]string{fixtureconsts.Cluster1}, errors.New("Unable to delete scan configuration")).Times(1)
+			},
+			isErrorTest: true,
+			expectedErr: errors.New("Unable to delete scan configuration"),
+		},
+		{
+			desc: "Empty cluster list",
+			setMocks: func() {
+				suite.scanConfigDS.EXPECT().DeleteScanConfiguration(gomock.Any(), mockScanID).Return(mockScanName,
+					[]string{}, nil).Times(1)
+			},
+			isErrorTest: false,
+		},
+		{
+			desc: "Empty scan configuration name",
+			setMocks: func() {
+				suite.scanConfigDS.EXPECT().DeleteScanConfiguration(gomock.Any(), mockScanID).Return("",
+					[]string{fixtureconsts.Cluster1}, nil).Times(1)
+			},
+			isErrorTest: true,
+			expectedErr: errors.Errorf("Unable to find scan configuration name for ID %q", mockScanID),
+		},
+		{
+			// we should not return error if we are unable to send message to sensor
+			desc: "Error from sensor",
+			setMocks: func() {
+				suite.scanConfigDS.EXPECT().DeleteScanConfiguration(gomock.Any(), mockScanID).Return(mockScanName,
+					[]string{fixtureconsts.Cluster1}, nil).Times(1)
+				suite.connectionMgr.EXPECT().SendMessage(fixtureconsts.Cluster1, gomock.Any()).Return(errors.New("Unable to process sensor message")).Times(1)
+			},
+			isErrorTest: false,
+		},
+	}
+	for _, tc := range cases {
+		suite.T().Run(tc.desc, func(t *testing.T) {
+			tc.setMocks()
+
+			err := suite.manager.DeleteScan(suite.hasWriteCtx, getTestRec().Id)
+			if tc.isErrorTest {
+				suite.Require().NotNil(err)
+			} else {
+				suite.Require().NoError(err)
+			}
+		})
+	}
+}
+
 func getTestRec() *storage.ComplianceOperatorScanConfigurationV2 {
 	return &storage.ComplianceOperatorScanConfigurationV2{
+		Id:                     mockScanID,
 		ScanName:               mockScanName,
 		AutoApplyRemediations:  false,
 		AutoUpdateRemediations: false,

--- a/central/complianceoperator/v2/compliancemanager/mocks/manager.go
+++ b/central/complianceoperator/v2/compliancemanager/mocks/manager.go
@@ -40,17 +40,17 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // DeleteScan mocks base method.
-func (m *MockManager) DeleteScan(ctx context.Context, deleteScanRequest any) error {
+func (m *MockManager) DeleteScan(ctx context.Context, scanID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteScan", ctx, deleteScanRequest)
+	ret := m.ctrl.Call(m, "DeleteScan", ctx, scanID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteScan indicates an expected call of DeleteScan.
-func (mr *MockManagerMockRecorder) DeleteScan(ctx, deleteScanRequest any) *gomock.Call {
+func (mr *MockManagerMockRecorder) DeleteScan(ctx, scanID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteScan", reflect.TypeOf((*MockManager)(nil).DeleteScan), ctx, deleteScanRequest)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteScan", reflect.TypeOf((*MockManager)(nil).DeleteScan), ctx, scanID)
 }
 
 // HandleScanRequestResponse mocks base method.

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore.go
@@ -32,7 +32,7 @@ type DataStore interface {
 	UpsertScanConfiguration(ctx context.Context, scanConfig *storage.ComplianceOperatorScanConfigurationV2) error
 
 	// DeleteScanConfiguration deletes the scan configuration specified by id
-	DeleteScanConfiguration(ctx context.Context, id string) error
+	DeleteScanConfiguration(ctx context.Context, id string) (string, []string, error)
 
 	// UpdateClusterStatus updates the scan configuration with the cluster status
 	UpdateClusterStatus(ctx context.Context, scanID string, clusterID string, clusterStatus string) error

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore.go
@@ -32,7 +32,7 @@ type DataStore interface {
 	UpsertScanConfiguration(ctx context.Context, scanConfig *storage.ComplianceOperatorScanConfigurationV2) error
 
 	// DeleteScanConfiguration deletes the scan configuration specified by id
-	DeleteScanConfiguration(ctx context.Context, id string) (string, []string, error)
+	DeleteScanConfiguration(ctx context.Context, id string) (string, error)
 
 	// UpdateClusterStatus updates the scan configuration with the cluster status
 	UpdateClusterStatus(ctx context.Context, scanID string, clusterID string, clusterStatus string) error

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -87,17 +87,51 @@ func (ds *datastoreImpl) UpsertScanConfiguration(ctx context.Context, scanConfig
 }
 
 // DeleteScanConfiguration deletes the scan configuration specified by id
-func (ds *datastoreImpl) DeleteScanConfiguration(ctx context.Context, id string) error {
+func (ds *datastoreImpl) DeleteScanConfiguration(ctx context.Context, id string) (string, []string, error) {
 	if ok, err := scanConfigurationsSAC.WriteAllowed(ctx); err != nil {
-		return err
+		return "", nil, err
 	} else if !ok {
-		return sac.ErrResourceAccessDenied
+		return "", nil, sac.ErrResourceAccessDenied
 	}
 
 	ds.keyedMutex.Lock(id)
 	defer ds.keyedMutex.Unlock(id)
 
-	return ds.storage.Delete(ctx, id)
+	// first check if the scan configuration exists
+	scanConfig, found, err := ds.GetScanConfiguration(ctx, id)
+	if err != nil {
+		return "", nil, errors.Wrapf(err, "Unable to find scan configuration id %q", id)
+	}
+	if !found {
+		return "", nil, errors.Wrapf(err, "Scan configuration id %q not found", id)
+	}
+	scanConfigName := scanConfig.GetScanName()
+
+	// get scan status for the scan configuration
+	scanStatuses, err := ds.GetScanConfigClusterStatus(ctx, id)
+	if err != nil {
+		return "", nil, errors.Wrapf(err, "Unable to find scan status for scan configuration id %q", id)
+	}
+
+	clustersDeleted := []string{}
+	// retrieve the clusters using this scan configuration
+	for _, scanStatus := range scanStatuses {
+		clustersDeleted = append(clustersDeleted, scanStatus.ClusterId)
+	}
+
+	// remove scan data from scan status table first
+	err = ds.statusStorage.DeleteByQuery(ctx, search.NewQueryBuilder().
+		AddExactMatches(search.ComplianceOperatorScanConfig, id).ProtoQuery())
+	if err != nil {
+		return "", nil, errors.Wrapf(err, "Unable to delete scan status for scan configuration id %q", id)
+	}
+
+	err = ds.storage.Delete(ctx, id)
+	if err != nil {
+		return "", nil, errors.Wrapf(err, "Unable to delete scan configuration id %q", id)
+	}
+
+	return scanConfigName, clustersDeleted, nil
 }
 
 // UpdateClusterStatus updates the scan configuration with the cluster status

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -103,7 +103,7 @@ func (ds *datastoreImpl) DeleteScanConfiguration(ctx context.Context, id string)
 		return "", errors.Wrapf(err, "Unable to find scan configuration id %q", id)
 	}
 	if !found {
-		return "", errors.Wrapf(err, "Scan configuration id %q not found", id)
+		return "", errors.Errorf("Scan configuration id %q not found", id)
 	}
 	scanConfigName := scanConfig.GetScanName()
 

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
@@ -213,8 +213,20 @@ func (s *complianceScanConfigDataStoreTestSuite) TestDeleteScanConfiguration() {
 	s.Require().True(found)
 	s.Require().Equal(scanConfig, foundConfig)
 
+	// Add a record so we have something to find
+	s.Require().NoError(s.storage.Upsert(s.hasWriteCtx, scanConfig))
+
+	// Add Scan config status
+	s.Require().NoError(s.dataStore.UpdateClusterStatus(s.hasWriteCtx, configID, fixtureconsts.Cluster1, "testing status"))
+
+	clusterStatuses, err := s.dataStore.GetScanConfigClusterStatus(s.hasReadCtx, configID)
+	s.Require().NoError(err)
+	s.Require().Equal(1, len(clusterStatuses))
 	// Now delete it
-	s.Require().NoError(s.dataStore.DeleteScanConfiguration(s.hasWriteCtx, configID))
+	scanConfigName, clusterDeleted, err := s.dataStore.DeleteScanConfiguration(s.hasWriteCtx, configID)
+	s.Require().NoError(err)
+	s.Require().Equal(mockScanName, scanConfigName)
+	s.Require().Equal(1, len(clusterDeleted))
 
 	// Verify it no longer exists
 	foundConfig, found, err = s.dataStore.GetScanConfiguration(s.hasReadCtx, configID)
@@ -222,9 +234,16 @@ func (s *complianceScanConfigDataStoreTestSuite) TestDeleteScanConfiguration() {
 	s.Require().False(found)
 	s.Require().Nil(foundConfig)
 
-	// Delete a non-existing one
-	err = s.dataStore.DeleteScanConfiguration(s.hasWriteCtx, uuid.NewV4().String())
+	// cluster status should also be deleted
+	clusterStatuses, err = s.dataStore.GetScanConfigClusterStatus(s.hasReadCtx, configID)
 	s.Require().NoError(err)
+	s.Require().Equal(0, len(clusterStatuses))
+
+	// Delete a non-existing one
+	scanConfigName, clusterDeleted, err = s.dataStore.DeleteScanConfiguration(s.hasWriteCtx, uuid.NewV4().String())
+	s.Require().Error(err)
+	s.Require().Equal("", scanConfigName)
+	s.Require().Equal(0, len(clusterDeleted))
 }
 
 func (s *complianceScanConfigDataStoreTestSuite) TestClusterStatus() {

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
@@ -223,10 +223,9 @@ func (s *complianceScanConfigDataStoreTestSuite) TestDeleteScanConfiguration() {
 	s.Require().NoError(err)
 	s.Require().Equal(1, len(clusterStatuses))
 	// Now delete it
-	scanConfigName, clusterDeleted, err := s.dataStore.DeleteScanConfiguration(s.hasWriteCtx, configID)
+	scanConfigName, err := s.dataStore.DeleteScanConfiguration(s.hasWriteCtx, configID)
 	s.Require().NoError(err)
 	s.Require().Equal(mockScanName, scanConfigName)
-	s.Require().Equal(1, len(clusterDeleted))
 
 	// Verify it no longer exists
 	foundConfig, found, err = s.dataStore.GetScanConfiguration(s.hasReadCtx, configID)
@@ -240,10 +239,9 @@ func (s *complianceScanConfigDataStoreTestSuite) TestDeleteScanConfiguration() {
 	s.Require().Equal(0, len(clusterStatuses))
 
 	// Delete a non-existing one
-	scanConfigName, clusterDeleted, err = s.dataStore.DeleteScanConfiguration(s.hasWriteCtx, uuid.NewV4().String())
+	scanConfigName, err = s.dataStore.DeleteScanConfiguration(s.hasWriteCtx, uuid.NewV4().String())
 	s.Require().Error(err)
 	s.Require().Equal("", scanConfigName)
-	s.Require().Equal(0, len(clusterDeleted))
 }
 
 func (s *complianceScanConfigDataStoreTestSuite) TestClusterStatus() {

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
@@ -239,9 +239,9 @@ func (s *complianceScanConfigDataStoreTestSuite) TestDeleteScanConfiguration() {
 	s.Require().Equal(0, len(clusterStatuses))
 
 	// Delete a non-existing one
-	scanConfigName, err = s.dataStore.DeleteScanConfiguration(s.hasWriteCtx, uuid.NewV4().String())
-	s.Require().Error(err)
+	scanConfigName, err = s.dataStore.DeleteScanConfiguration(s.hasWriteCtx, configID)
 	s.Require().Equal("", scanConfigName)
+	s.Require().Error(err)
 }
 
 func (s *complianceScanConfigDataStoreTestSuite) TestClusterStatus() {

--- a/central/complianceoperator/v2/scanconfigurations/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/mocks/datastore.go
@@ -56,11 +56,13 @@ func (mr *MockDataStoreMockRecorder) CountScanConfigurations(ctx, q any) *gomock
 }
 
 // DeleteScanConfiguration mocks base method.
-func (m *MockDataStore) DeleteScanConfiguration(ctx context.Context, id string) error {
+func (m *MockDataStore) DeleteScanConfiguration(ctx context.Context, id string) (string, []string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteScanConfiguration", ctx, id)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].([]string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // DeleteScanConfiguration indicates an expected call of DeleteScanConfiguration.

--- a/central/complianceoperator/v2/scanconfigurations/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/mocks/datastore.go
@@ -56,13 +56,12 @@ func (mr *MockDataStoreMockRecorder) CountScanConfigurations(ctx, q any) *gomock
 }
 
 // DeleteScanConfiguration mocks base method.
-func (m *MockDataStore) DeleteScanConfiguration(ctx context.Context, id string) (string, []string, error) {
+func (m *MockDataStore) DeleteScanConfiguration(ctx context.Context, id string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteScanConfiguration", ctx, id)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].([]string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // DeleteScanConfiguration indicates an expected call of DeleteScanConfiguration.

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -90,6 +90,19 @@ func (s *serviceImpl) CreateComplianceScanConfiguration(ctx context.Context, req
 	return convertStorageScanConfigToV2(ctx, scanConfig, s.complianceScanSettingsDS)
 }
 
+func (s *serviceImpl) DeleteComplianceScanConfiguration(ctx context.Context, req *v2.ResourceByID) (*v2.Empty, error) {
+	if req.GetId() == "" {
+		return nil, errors.Wrap(errox.InvalidArgs, "Scan configuration ID is required for deletion")
+	}
+
+	err := s.manager.DeleteScan(ctx, req.GetId())
+	if err != nil {
+		return nil, errors.Wrapf(errox.InvalidArgs, "Unable to delete scan config: %v", err)
+	}
+
+	return &v2.Empty{}, nil
+}
+
 func (s *serviceImpl) ListComplianceScanConfigurations(ctx context.Context, query *v2.RawQuery) (*v2.ListComplianceScanConfigurationsResponse, error) {
 	// Fill in Query.
 	parsedQuery, err := search.ParseQuery(query.GetQuery(), search.MatchAllIfEmpty())

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -280,6 +280,8 @@ func (c *sensorConnection) processComplianceResponse(ctx context.Context, msg *c
 	switch m := msg.Response.(type) {
 	case *central.ComplianceResponse_ApplyComplianceScanConfigResponse_:
 		return c.complianceOperatorMgr.HandleScanRequestResponse(ctx, m.ApplyComplianceScanConfigResponse.GetId(), c.clusterID, m.ApplyComplianceScanConfigResponse.GetError())
+	case *central.ComplianceResponse_DeleteComplianceScanConfigResponse_:
+		log.Infof("received delete compliance scan config error response %v for cluster %v", m.DeleteComplianceScanConfigResponse.GetError(), c.clusterID)
 	default:
 		log.Infof("Unimplemented compliance response  %T", m)
 	}


### PR DESCRIPTION
## Description

This PR adds Compliance Scan Config deletion to central.
The central will check if a scan config exist in the datastore and we will remove the scan config from the datastore if they do and send the delete message to all cluster. 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit-tests and Deployed and tested on a cluster

### Here I tell how I validated my change

* Added Unit test DeleteComplianceScanConfiguration in central service
* Added Unit test DeleteScanConfiguration in central manager
* Added mock test for datastore for deleting scan
* Deployed and tested deleting scan on a real cluster

```
[vincent@node stackrox]$ roxcurl /v2/compliance/scan/configurations
{"configurations":[{"id":"c70743cf-05b5-43ff-a7c6-5a43472c3cc4","scanName":"testscan","scanConfig":{"oneTimeScan":false,"profiles":["rhcos4-high"],"scanSchedule":{"intervalType":"DAILY","hour":0,"minute":0}},"clusterStatus":[],"createdTime":"2023-12-07T18:55:22.588916392Z","lastUpdatedTime":"2023-12-07T18:55:22.588922454Z","modifiedBy":{"id":"admin","name":"admin"}},{"id":"52b6eedb-7bd8-4d3a-ae61-73483edfebde","scanName":"v2-testscan","scanConfig":{"oneTimeScan":false,"profiles":["rhcos4-high"],"scanSchedule":{"intervalType":"DAILY","hour":0,"minute":0}},"clusterStatus":[{"clusterId":"7e1af9bf-3006-4533-af2b-1e47e1b27036","errors":[""],"clusterName":"remote"}],"createdTime":"2023-12-07T18:56:27.555716449Z","lastUpdatedTime":"2023-12-07T18:56:27.555721909Z","modifiedBy":{"id":"admin","name":"admin"}}]}[vincent@node stackrox]$ roxcurl /v2/compliance/scan/configurations | json_pp
{
   "configurations" : [
      {
         "clusterStatus" : [],
         "createdTime" : "2023-12-07T18:55:22.588916392Z",
         "id" : "c70743cf-05b5-43ff-a7c6-5a43472c3cc4",
         "lastUpdatedTime" : "2023-12-07T18:55:22.588922454Z",
         "modifiedBy" : {
            "id" : "admin",
            "name" : "admin"
         },
         "scanConfig" : {
            "oneTimeScan" : false,
            "profiles" : [
               "rhcos4-high"
            ],
            "scanSchedule" : {
               "hour" : 0,
               "intervalType" : "DAILY",
               "minute" : 0
            }
         },
         "scanName" : "testscan"
      },
      {
         "clusterStatus" : [
            {
               "clusterId" : "7e1af9bf-3006-4533-af2b-1e47e1b27036",
               "clusterName" : "remote",
               "errors" : [
                  ""
               ]
            }
         ],
         "createdTime" : "2023-12-07T18:56:27.555716449Z",
         "id" : "52b6eedb-7bd8-4d3a-ae61-73483edfebde",
         "lastUpdatedTime" : "2023-12-07T18:56:27.555721909Z",
         "modifiedBy" : {
            "id" : "admin",
            "name" : "admin"
         },
         "scanConfig" : {
            "oneTimeScan" : false,
            "profiles" : [
               "rhcos4-high"
            ],
            "scanSchedule" : {
               "hour" : 0,
               "intervalType" : "DAILY",
               "minute" : 0
            }
         },
         "scanName" : "v2-testscan"
      }
   ]
}
[vincent@node stackrox]$ roxcurl /v2/compliance/scan/configurations/52b6eedb-7bd8-4d3a-ae61-73483edfebde -XDELETE
{}[vincent@node stackrox]$ roxcurl /v2/compliance/scan/configurations | json_pp
{
   "configurations" : [
      {
         "clusterStatus" : [],
         "createdTime" : "2023-12-07T18:55:22.588916392Z",
         "id" : "c70743cf-05b5-43ff-a7c6-5a43472c3cc4",
         "lastUpdatedTime" : "2023-12-07T18:55:22.588922454Z",
         "modifiedBy" : {
            "id" : "admin",
            "name" : "admin"
         },
         "scanConfig" : {
            "oneTimeScan" : false,
            "profiles" : [
               "rhcos4-high"
            ],
            "scanSchedule" : {
               "hour" : 0,
               "intervalType" : "DAILY",
               "minute" : 0
            }
         },
         "scanName" : "testscan"
      }
   ]
```

### Reminder for reviewers

Closed https://github.com/stackrox/stackrox/pull/8643 and opened this PR because there were issues with PR quay image push