### PR TITLE
fix(delegator): Clone image built in enricher

### DIFF
--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -532,12 +532,7 @@ func (s *serviceImpl) informScanWaiter(reqID string, img *storage.Image, scanErr
 		return
 	}
 
-	var image *storage.Image
-	if img != nil {
-		image = img.Clone()
-	}
-
-	if err := s.scanWaiterManager.Send(reqID, image, scanErr); err != nil {
+	if err := s.scanWaiterManager.Send(reqID, img.Clone(), scanErr); err != nil {
 		log.Errorw("Failed to send results to scan waiter",
 			logging.String("request_id", reqID), logging.Err(err))
 	}

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -505,6 +505,7 @@ func (s *serviceImpl) EnrichLocalImageInternal(ctx context.Context, request *v1.
 	}
 
 	s.informScanWaiter(request.GetRequestId(), img.Clone(), err)
+
 	return internalScanRespFromImage(img), nil
 }
 

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -450,7 +450,7 @@ func (s *serviceImpl) EnrichLocalImageInternal(ctx context.Context, request *v1.
 		// If the image exists and scan / signature verification results do not need an update yet, return it.
 		// Otherwise, reprocess the image.
 		if imgExists && !forceScanUpdate && !forceSigVerificationUpdate {
-			s.informScanWaiter(request.GetRequestId(), existingImg.Clone(), nil)
+			s.informScanWaiter(request.GetRequestId(), existingImg, nil)
 			return internalScanRespFromImage(existingImg), nil
 		}
 	}
@@ -504,7 +504,7 @@ func (s *serviceImpl) EnrichLocalImageInternal(ctx context.Context, request *v1.
 		err = errors.New(request.GetError())
 	}
 
-	s.informScanWaiter(request.GetRequestId(), img.Clone(), err)
+	s.informScanWaiter(request.GetRequestId(), img, err)
 	return internalScanRespFromImage(img), nil
 }
 
@@ -532,7 +532,12 @@ func (s *serviceImpl) informScanWaiter(reqID string, img *storage.Image, scanErr
 		return
 	}
 
-	if err := s.scanWaiterManager.Send(reqID, img, scanErr); err != nil {
+	var image *storage.Image
+	if img != nil {
+		image = img.Clone()
+	}
+
+	if err := s.scanWaiterManager.Send(reqID, image, scanErr); err != nil {
 		log.Errorw("Failed to send results to scan waiter",
 			logging.String("request_id", reqID), logging.Err(err))
 	}

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -504,7 +504,7 @@ func (s *serviceImpl) EnrichLocalImageInternal(ctx context.Context, request *v1.
 		err = errors.New(request.GetError())
 	}
 
-	s.informScanWaiter(request.GetRequestId(), img, err)
+	s.informScanWaiter(request.GetRequestId(), img.Clone(), err)
 	return internalScanRespFromImage(img), nil
 }
 

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -450,7 +450,7 @@ func (s *serviceImpl) EnrichLocalImageInternal(ctx context.Context, request *v1.
 		// If the image exists and scan / signature verification results do not need an update yet, return it.
 		// Otherwise, reprocess the image.
 		if imgExists && !forceScanUpdate && !forceSigVerificationUpdate {
-			s.informScanWaiter(request.GetRequestId(), existingImg, nil)
+			s.informScanWaiter(request.GetRequestId(), existingImg.Clone(), nil)
 			return internalScanRespFromImage(existingImg), nil
 		}
 	}

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -505,7 +505,6 @@ func (s *serviceImpl) EnrichLocalImageInternal(ctx context.Context, request *v1.
 	}
 
 	s.informScanWaiter(request.GetRequestId(), img.Clone(), err)
-
 	return internalScanRespFromImage(img), nil
 }
 


### PR DESCRIPTION
## Description

A race condition existed in delegated scanning, believe this fix addresses the race condition - however we were not able to reproduce the exact `panic` which triggered the investigation.


## Checklist
- [ ] ~Investigated and inspected CI test results~
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Deployed `main:4.3.x-nightly-20231207-rcd` nightly and triggered parrallel delegating scans via `roxctl` on fresh start, produced the below trace.  After some time ability to reproduce lessened.

```
delegatedregistryconfig/delegator: 2023/12/07 16:53:33.245292 delegator.go:112: Info: Sent scan request "67591ecb-a274-49f2-9b46-544e83c163fa" to cluster "fb849453-4155-44a5-9868-e4d8e6309a85" for "docker.io/library/nginx:latest" with inferred namespace ""
==================
WARNING: DATA RACE
Read at 0x00c010775320 by goroutine 226555:
  github.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).delegateEnrichImage()
      github.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:181 +0x386
  github.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).EnrichImage()
      github.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:220 +0xbd
  github.com/stackrox/rox/pkg/images/enricher.EnrichImageByName()
      github.com/stackrox/rox/pkg/images/enricher/util.go:24 +0x3ce
  github.com/stackrox/rox/central/image/service.(*serviceImpl).ScanImage()
      github.com/stackrox/rox/central/image/service/service_impl.go:324 +0x291
  github.com/stackrox/rox/generated/api/v1._ImageService_ScanImage_Handler.func1()
      github.com/stackrox/rox/generated/api/v1/image_service.pb.go:1863 +0x88
  github.com/stackrox/rox/pkg/grpc/metrics.(*grpcMetricsImpl).UnaryMonitoringInterceptor()
      github.com/stackrox/rox/pkg/grpc/metrics/grpc_metrics_impl.go:103 +0x139
  github.com/stackrox/rox/pkg/grpc/metrics.GRPCMetrics.UnaryMonitoringInterceptor-fm()
      <autogenerated>:1 +0xae
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:33 +0x139
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/sac/observe.AuthzTraceInterceptor.func1()
      github.com/stackrox/rox/pkg/sac/observe/interceptors.go:18 +0xac
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/authz/interceptor.AuthCheckerInterceptor.func1()
      github.com/stackrox/rox/pkg/grpc/authz/interceptor/interceptor.go:62 +0x9d
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/central/audit.(*audit).UnaryServerInterceptor.func1()
      github.com/stackrox/rox/central/audit/audit.go:150 +0xab
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/authz/interceptor.AuthContextUpdaterInterceptor.func1()
      github.com/stackrox/rox/pkg/grpc/authz/interceptor/interceptor.go:38 +0x18b
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-middleware/ratelimit.UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/ratelimit/ratelimit.go:24 +0x138
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/errors.ErrorToGrpcCodeInterceptor()
      github.com/stackrox/rox/pkg/grpc/errors/interceptor.go:66 +0x6b
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 +0xca
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:53 +0x250
  github.com/stackrox/rox/generated/api/v1._ImageService_ScanImage_Handler()
      github.com/stackrox/rox/generated/api/v1/image_service.pb.go:1865 +0x1dd
  google.golang.org/grpc.(*Server).processUnaryRPC()
      google.golang.org/grpc@v1.59.0/server.go:1343 +0x1953
  google.golang.org/grpc.(*Server).handleStream()
      google.golang.org/grpc@v1.59.0/server.go:1737 +0x1353
  google.golang.org/grpc.(*Server).serveStreams.func1.1()
      google.golang.org/grpc@v1.59.0/server.go:986 +0x12c

Previous write at 0x00c010775320 by goroutine 227640:
  github.com/stackrox/rox/pkg/images/utils.FilterSuppressedCVEsNoClone()
      github.com/stackrox/rox/pkg/images/utils/utils.go:233 +0x3bb
  github.com/stackrox/rox/central/image/service.internalScanRespFromImage()
      github.com/stackrox/rox/central/image/service/service_impl.go:199 +0x30
  github.com/stackrox/rox/central/image/service.(*serviceImpl).EnrichLocalImageInternal()
      github.com/stackrox/rox/central/image/service/service_impl.go:508 +0x1339
  github.com/stackrox/rox/generated/api/v1._ImageService_EnrichLocalImageInternal_Handler.func1()
      github.com/stackrox/rox/generated/api/v1/image_service.pb.go:1917 +0x88
  github.com/stackrox/rox/pkg/grpc/metrics.(*grpcMetricsImpl).UnaryMonitoringInterceptor()
      github.com/stackrox/rox/pkg/grpc/metrics/grpc_metrics_impl.go:103 +0x139
  github.com/stackrox/rox/pkg/grpc/metrics.GRPCMetrics.UnaryMonitoringInterceptor-fm()
      <autogenerated>:1 +0xae
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:33 +0x139
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/sac/observe.AuthzTraceInterceptor.func1()
      github.com/stackrox/rox/pkg/sac/observe/interceptors.go:18 +0xac
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/authz/interceptor.AuthCheckerInterceptor.func1()
      github.com/stackrox/rox/pkg/grpc/authz/interceptor/interceptor.go:62 +0x9d
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/central/audit.(*audit).UnaryServerInterceptor.func1()
      github.com/stackrox/rox/central/audit/audit.go:150 +0xab
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/authz/interceptor.AuthContextUpdaterInterceptor.func1()
      github.com/stackrox/rox/pkg/grpc/authz/interceptor/interceptor.go:38 +0x18b
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-middleware/ratelimit.UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/ratelimit/ratelimit.go:24 +0x138
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/errors.ErrorToGrpcCodeInterceptor()
      github.com/stackrox/rox/pkg/grpc/errors/interceptor.go:66 +0x6b
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 +0xca
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:53 +0x250
  github.com/stackrox/rox/generated/api/v1._ImageService_EnrichLocalImageInternal_Handler()
      github.com/stackrox/rox/generated/api/v1/image_service.pb.go:1919 +0x1dd
  google.golang.org/grpc.(*Server).processUnaryRPC()
      google.golang.org/grpc@v1.59.0/server.go:1343 +0x1953
  google.golang.org/grpc.(*Server).handleStream()
      google.golang.org/grpc@v1.59.0/server.go:1737 +0x1353
  google.golang.org/grpc.(*Server).serveStreams.func1.1()
      google.golang.org/grpc@v1.59.0/server.go:986 +0x12c

Goroutine 226555 (running) created at:
  google.golang.org/grpc.(*Server).serveStreams.func1()
      google.golang.org/grpc@v1.59.0/server.go:997 +0x254
  google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
      google.golang.org/grpc@v1.59.0/internal/transport/http2_server.go:625 +0x4dde
  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
      google.golang.org/grpc@v1.59.0/internal/transport/http2_server.go:667 +0x252
  google.golang.org/grpc.(*Server).serveStreams()
      google.golang.org/grpc@v1.59.0/server.go:979 +0x38b
  google.golang.org/grpc.(*Server).handleRawConn.func1()
      google.golang.org/grpc@v1.59.0/server.go:920 +0x64

Goroutine 227640 (running) created at:
  google.golang.org/grpc.(*Server).serveStreams.func1()
      google.golang.org/grpc@v1.59.0/server.go:997 +0x254
  google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
      google.golang.org/grpc@v1.59.0/internal/transport/http2_server.go:625 +0x4dde
  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
      google.golang.org/grpc@v1.59.0/internal/transport/http2_server.go:667 +0x252
  google.golang.org/grpc.(*Server).serveStreams()
      google.golang.org/grpc@v1.59.0/server.go:979 +0x38b
  google.golang.org/grpc.(*Server).handleRawConn.func1()
      google.golang.org/grpc@v1.59.0/server.go:920 +0x64
==================
==================
WARNING: DATA RACE
Read at 0x00c01741df08 by goroutine 226555:
  github.com/stackrox/rox/generated/storage.(*EmbeddedImageScanComponent).GetVulns()
      github.com/stackrox/rox/generated/storage/image.pb.go:1066 +0x177
  github.com/stackrox/rox/central/cve/image/datastore.(*datastoreImpl).EnrichImageWithSuppressedCVEs()
      github.com/stackrox/rox/central/cve/image/datastore/datastore_impl.go:217 +0x162
  github.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).delegateEnrichImage()
      github.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:183 +0x421
  github.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).EnrichImage()
      github.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:220 +0xbd
  github.com/stackrox/rox/pkg/images/enricher.EnrichImageByName()
      github.com/stackrox/rox/pkg/images/enricher/util.go:24 +0x3ce
  github.com/stackrox/rox/central/image/service.(*serviceImpl).ScanImage()
      github.com/stackrox/rox/central/image/service/service_impl.go:324 +0x291
  github.com/stackrox/rox/generated/api/v1._ImageService_ScanImage_Handler.func1()
      github.com/stackrox/rox/generated/api/v1/image_service.pb.go:1863 +0x88
  github.com/stackrox/rox/pkg/grpc/metrics.(*grpcMetricsImpl).UnaryMonitoringInterceptor()
      github.com/stackrox/rox/pkg/grpc/metrics/grpc_metrics_impl.go:103 +0x139
  github.com/stackrox/rox/pkg/grpc/metrics.GRPCMetrics.UnaryMonitoringInterceptor-fm()
      <autogenerated>:1 +0xae
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:33 +0x139
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/sac/observe.AuthzTraceInterceptor.func1()
      github.com/stackrox/rox/pkg/sac/observe/interceptors.go:18 +0xac
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/authz/interceptor.AuthCheckerInterceptor.func1()
      github.com/stackrox/rox/pkg/grpc/authz/interceptor/interceptor.go:62 +0x9d
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/central/audit.(*audit).UnaryServerInterceptor.func1()
      github.com/stackrox/rox/central/audit/audit.go:150 +0xab
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/authz/interceptor.AuthContextUpdaterInterceptor.func1()
      github.com/stackrox/rox/pkg/grpc/authz/interceptor/interceptor.go:38 +0x18b
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-middleware/ratelimit.UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/ratelimit/ratelimit.go:24 +0x138
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/errors.ErrorToGrpcCodeInterceptor()
      github.com/stackrox/rox/pkg/grpc/errors/interceptor.go:66 +0x6b
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 +0xca
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:53 +0x250
  github.com/stackrox/rox/generated/api/v1._ImageService_ScanImage_Handler()
      github.com/stackrox/rox/generated/api/v1/image_service.pb.go:1865 +0x1dd
  google.golang.org/grpc.(*Server).processUnaryRPC()
      google.golang.org/grpc@v1.59.0/server.go:1343 +0x1953
  google.golang.org/grpc.(*Server).handleStream()
      google.golang.org/grpc@v1.59.0/server.go:1737 +0x1353
  google.golang.org/grpc.(*Server).serveStreams.func1.1()
      google.golang.org/grpc@v1.59.0/server.go:986 +0x12c

Previous write at 0x00c01741df08 by goroutine 227640:
  github.com/stackrox/rox/pkg/images/utils.FilterSuppressedCVEsNoClone()
      github.com/stackrox/rox/pkg/images/utils/utils.go:230 +0x2ce
  github.com/stackrox/rox/central/image/service.internalScanRespFromImage()
      github.com/stackrox/rox/central/image/service/service_impl.go:199 +0x30
  github.com/stackrox/rox/central/image/service.(*serviceImpl).EnrichLocalImageInternal()
      github.com/stackrox/rox/central/image/service/service_impl.go:508 +0x1339
  github.com/stackrox/rox/generated/api/v1._ImageService_EnrichLocalImageInternal_Handler.func1()
      github.com/stackrox/rox/generated/api/v1/image_service.pb.go:1917 +0x88
  github.com/stackrox/rox/pkg/grpc/metrics.(*grpcMetricsImpl).UnaryMonitoringInterceptor()
      github.com/stackrox/rox/pkg/grpc/metrics/grpc_metrics_impl.go:103 +0x139
  github.com/stackrox/rox/pkg/grpc/metrics.GRPCMetrics.UnaryMonitoringInterceptor-fm()
      <autogenerated>:1 +0xae
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:33 +0x139
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/sac/observe.AuthzTraceInterceptor.func1()
      github.com/stackrox/rox/pkg/sac/observe/interceptors.go:18 +0xac
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/authz/interceptor.AuthCheckerInterceptor.func1()
      github.com/stackrox/rox/pkg/grpc/authz/interceptor/interceptor.go:62 +0x9d
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/central/audit.(*audit).UnaryServerInterceptor.func1()
      github.com/stackrox/rox/central/audit/audit.go:150 +0xab
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/authz/interceptor.AuthContextUpdaterInterceptor.func1()
      github.com/stackrox/rox/pkg/grpc/authz/interceptor/interceptor.go:38 +0x18b
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-middleware/ratelimit.UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/ratelimit/ratelimit.go:24 +0x138
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/errors.ErrorToGrpcCodeInterceptor()
      github.com/stackrox/rox/pkg/grpc/errors/interceptor.go:66 +0x6b
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 +0xca
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:53 +0x250
  github.com/stackrox/rox/generated/api/v1._ImageService_EnrichLocalImageInternal_Handler()
      github.com/stackrox/rox/generated/api/v1/image_service.pb.go:1919 +0x1dd
  google.golang.org/grpc.(*Server).processUnaryRPC()
      google.golang.org/grpc@v1.59.0/server.go:1343 +0x1953
  google.golang.org/grpc.(*Server).handleStream()
      google.golang.org/grpc@v1.59.0/server.go:1737 +0x1353
  google.golang.org/grpc.(*Server).serveStreams.func1.1()
      google.golang.org/grpc@v1.59.0/server.go:986 +0x12c

Goroutine 226555 (running) created at:
  google.golang.org/grpc.(*Server).serveStreams.func1()
      google.golang.org/grpc@v1.59.0/server.go:997 +0x254
  google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
      google.golang.org/grpc@v1.59.0/internal/transport/http2_server.go:625 +0x4dde
  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
      google.golang.org/grpc@v1.59.0/internal/transport/http2_server.go:667 +0x252
  google.golang.org/grpc.(*Server).serveStreams()
      google.golang.org/grpc@v1.59.0/server.go:979 +0x38b
  google.golang.org/grpc.(*Server).handleRawConn.func1()
      google.golang.org/grpc@v1.59.0/server.go:920 +0x64

Goroutine 227640 (running) created at:
  google.golang.org/grpc.(*Server).serveStreams.func1()
      google.golang.org/grpc@v1.59.0/server.go:997 +0x254
  google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
      google.golang.org/grpc@v1.59.0/internal/transport/http2_server.go:625 +0x4dde
  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
      google.golang.org/grpc@v1.59.0/internal/transport/http2_server.go:667 +0x252
  google.golang.org/grpc.(*Server).serveStreams()
      google.golang.org/grpc@v1.59.0/server.go:979 +0x38b
  google.golang.org/grpc.(*Server).handleRawConn.func1()
      google.golang.org/grpc@v1.59.0/server.go:920 +0x64
==================
==================
WARNING: DATA RACE
Read at 0x00c01720e850 by goroutine 226555:
  github.com/stackrox/rox/central/cve/image/datastore.(*datastoreImpl).EnrichImageWithSuppressedCVEs()
      github.com/stackrox/rox/central/cve/image/datastore/datastore_impl.go:217 +0x204
  github.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).delegateEnrichImage()
      github.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:183 +0x421
  github.com/stackrox/rox/pkg/images/enricher.(*enricherImpl).EnrichImage()
      github.com/stackrox/rox/pkg/images/enricher/enricher_impl.go:220 +0xbd
  github.com/stackrox/rox/pkg/images/enricher.EnrichImageByName()
      github.com/stackrox/rox/pkg/images/enricher/util.go:24 +0x3ce
  github.com/stackrox/rox/central/image/service.(*serviceImpl).ScanImage()
      github.com/stackrox/rox/central/image/service/service_impl.go:324 +0x291
  github.com/stackrox/rox/generated/api/v1._ImageService_ScanImage_Handler.func1()
      github.com/stackrox/rox/generated/api/v1/image_service.pb.go:1863 +0x88
  github.com/stackrox/rox/pkg/grpc/metrics.(*grpcMetricsImpl).UnaryMonitoringInterceptor()
      github.com/stackrox/rox/pkg/grpc/metrics/grpc_metrics_impl.go:103 +0x139
  github.com/stackrox/rox/pkg/grpc/metrics.GRPCMetrics.UnaryMonitoringInterceptor-fm()
      <autogenerated>:1 +0xae
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:33 +0x139
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/sac/observe.AuthzTraceInterceptor.func1()
      github.com/stackrox/rox/pkg/sac/observe/interceptors.go:18 +0xac
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/authz/interceptor.AuthCheckerInterceptor.func1()
      github.com/stackrox/rox/pkg/grpc/authz/interceptor/interceptor.go:62 +0x9d
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/central/audit.(*audit).UnaryServerInterceptor.func1()
      github.com/stackrox/rox/central/audit/audit.go:150 +0xab
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/authz/interceptor.AuthContextUpdaterInterceptor.func1()
      github.com/stackrox/rox/pkg/grpc/authz/interceptor/interceptor.go:38 +0x18b
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-middleware/ratelimit.UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/ratelimit/ratelimit.go:24 +0x138
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/errors.ErrorToGrpcCodeInterceptor()
      github.com/stackrox/rox/pkg/grpc/errors/interceptor.go:66 +0x6b
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 +0xca
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:53 +0x250
  github.com/stackrox/rox/generated/api/v1._ImageService_ScanImage_Handler()
      github.com/stackrox/rox/generated/api/v1/image_service.pb.go:1865 +0x1dd
  google.golang.org/grpc.(*Server).processUnaryRPC()
      google.golang.org/grpc@v1.59.0/server.go:1343 +0x1953
  google.golang.org/grpc.(*Server).handleStream()
      google.golang.org/grpc@v1.59.0/server.go:1737 +0x1353
  google.golang.org/grpc.(*Server).serveStreams.func1.1()
      google.golang.org/grpc@v1.59.0/server.go:986 +0x12c

Previous write at 0x00c01720e850 by goroutine 227640:
  github.com/stackrox/rox/pkg/images/utils.FilterSuppressedCVEsNoClone()
      github.com/stackrox/rox/pkg/images/utils/utils.go:227 +0x672
  github.com/stackrox/rox/central/image/service.internalScanRespFromImage()
      github.com/stackrox/rox/central/image/service/service_impl.go:199 +0x30
  github.com/stackrox/rox/central/image/service.(*serviceImpl).EnrichLocalImageInternal()
      github.com/stackrox/rox/central/image/service/service_impl.go:508 +0x1339
  github.com/stackrox/rox/generated/api/v1._ImageService_EnrichLocalImageInternal_Handler.func1()
      github.com/stackrox/rox/generated/api/v1/image_service.pb.go:1917 +0x88
  github.com/stackrox/rox/pkg/grpc/metrics.(*grpcMetricsImpl).UnaryMonitoringInterceptor()
      github.com/stackrox/rox/pkg/grpc/metrics/grpc_metrics_impl.go:103 +0x139
  github.com/stackrox/rox/pkg/grpc/metrics.GRPCMetrics.UnaryMonitoringInterceptor-fm()
      <autogenerated>:1 +0xae
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:33 +0x139
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/sac/observe.AuthzTraceInterceptor.func1()
      github.com/stackrox/rox/pkg/sac/observe/interceptors.go:18 +0xac
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/authz/interceptor.AuthCheckerInterceptor.func1()
      github.com/stackrox/rox/pkg/grpc/authz/interceptor/interceptor.go:62 +0x9d
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/central/audit.(*audit).UnaryServerInterceptor.func1()
      github.com/stackrox/rox/central/audit/audit.go:150 +0xab
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/authz/interceptor.AuthContextUpdaterInterceptor.func1()
      github.com/stackrox/rox/pkg/grpc/authz/interceptor/interceptor.go:38 +0x18b
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/contextutil.UnaryServerInterceptor.func1()
      github.com/stackrox/rox/pkg/contextutil/contextupdater.go:65 +0xa5
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-middleware/ratelimit.UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/ratelimit/ratelimit.go:24 +0x138
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/stackrox/rox/pkg/grpc/errors.ErrorToGrpcCodeInterceptor()
      github.com/stackrox/rox/pkg/grpc/errors/interceptor.go:66 +0x6b
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2.1()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0xda
  github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1()
      github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 +0xca
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func2()
      github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:53 +0x250
  github.com/stackrox/rox/generated/api/v1._ImageService_EnrichLocalImageInternal_Handler()
      github.com/stackrox/rox/generated/api/v1/image_service.pb.go:1919 +0x1dd
  google.golang.org/grpc.(*Server).processUnaryRPC()
      google.golang.org/grpc@v1.59.0/server.go:1343 +0x1953
  google.golang.org/grpc.(*Server).handleStream()
      google.golang.org/grpc@v1.59.0/server.go:1737 +0x1353
  google.golang.org/grpc.(*Server).serveStreams.func1.1()
      google.golang.org/grpc@v1.59.0/server.go:986 +0x12c

Goroutine 226555 (running) created at:
  google.golang.org/grpc.(*Server).serveStreams.func1()
      google.golang.org/grpc@v1.59.0/server.go:997 +0x254
  google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
      google.golang.org/grpc@v1.59.0/internal/transport/http2_server.go:625 +0x4dde
  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
      google.golang.org/grpc@v1.59.0/internal/transport/http2_server.go:667 +0x252
  google.golang.org/grpc.(*Server).serveStreams()
      google.golang.org/grpc@v1.59.0/server.go:979 +0x38b
  google.golang.org/grpc.(*Server).handleRawConn.func1()
      google.golang.org/grpc@v1.59.0/server.go:920 +0x64

Goroutine 227640 (running) created at:
  google.golang.org/grpc.(*Server).serveStreams.func1()
      google.golang.org/grpc@v1.59.0/server.go:997 +0x254
  google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
      google.golang.org/grpc@v1.59.0/internal/transport/http2_server.go:625 +0x4dde
  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
      google.golang.org/grpc@v1.59.0/internal/transport/http2_server.go:667 +0x252
  google.golang.org/grpc.(*Server).serveStreams()
      google.golang.org/grpc@v1.59.0/server.go:979 +0x38b
  google.golang.org/grpc.(*Server).handleRawConn.func1()
      google.golang.org/grpc@v1.59.0/server.go:920 +0x64
==================
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
