### PR TITLE
ROX-19790: Add UI analytics for Workload CVEs

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -32,6 +32,7 @@ import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
 import useToasts from 'hooks/patternfly/useToasts';
 import PageTitle from 'Components/PageTitle';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import useAnalytics, { COLLECTION_CREATED } from 'hooks/useAnalytics';
 import { CollectionPageAction } from './collections.utils';
 import CollectionFormDrawer, { CollectionFormDrawerProps } from './CollectionFormDrawer';
 import useCollection from './hooks/useCollection';
@@ -65,6 +66,8 @@ function CollectionsFormPage({
     const history = useHistory();
     const isXLargeScreen = useMediaQuery({ query: '(min-width: 1200px)' }); // --pf-global--breakpoint--xl
     const collectionId = pageAction.type !== 'create' ? pageAction.collectionId : undefined;
+
+    const { analyticsTrack } = useAnalytics();
 
     const { data, loading, error } = useCollection(collectionId);
 
@@ -206,6 +209,12 @@ function CollectionsFormPage({
                     onSubmit(collection)
                         .then(() => {
                             history.push({ pathname: `${collectionsBasePath}` });
+                            if (pageAction.type === 'create') {
+                                analyticsTrack({
+                                    event: COLLECTION_CREATED,
+                                    properties: { source: 'Collections' },
+                                });
+                            }
                         })
                         .catch((err) => {
                             scrollToTop();

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -121,7 +121,7 @@ function ApprovedDeferrals() {
                 <ToolbarContent>
                     <FilterAutocompleteSelect
                         searchFilter={searchFilter}
-                        setSearchFilter={setSearchFilter}
+                        onFilterChange={(newFilter) => setSearchFilter(newFilter)}
                         searchOptions={searchOptions}
                     />
                     <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -114,7 +114,7 @@ function ApprovedFalsePositives() {
                 <ToolbarContent>
                     <FilterAutocompleteSelect
                         searchFilter={searchFilter}
-                        setSearchFilter={setSearchFilter}
+                        onFilterChange={(newFilter) => setSearchFilter(newFilter)}
                         searchOptions={searchOptions}
                     />
                     <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -122,7 +122,7 @@ function DeniedRequests() {
                 <ToolbarContent>
                     <FilterAutocompleteSelect
                         searchFilter={searchFilter}
-                        setSearchFilter={setSearchFilter}
+                        onFilterChange={(newFilter) => setSearchFilter(newFilter)}
                         searchOptions={searchOptions}
                     />
                     <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -121,7 +121,7 @@ function PendingApprovals() {
                 <ToolbarContent>
                     <FilterAutocompleteSelect
                         searchFilter={searchFilter}
-                        setSearchFilter={setSearchFilter}
+                        onFilterChange={(newFilter) => setSearchFilter(newFilter)}
                         searchOptions={searchOptions}
                     />
                     <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useCreateReport.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useCreateReport.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 
 import { createReportConfiguration } from 'services/ReportsService';
 import { ReportConfiguration } from 'services/ReportsService.types';
+import useAnalytics, { VULNERABILITY_REPORT_CREATED } from 'hooks/useAnalytics';
 import { ReportFormValues } from '../forms/useReportFormValues';
 import { getReportConfigurationFromFormValues } from '../utils';
 
@@ -25,7 +26,39 @@ const defaultResult = {
     error: null,
 };
 
+function trackReportCreation(
+    analyticsTrack: ReturnType<typeof useAnalytics>['analyticsTrack'],
+    reportConfiguration: ReportConfiguration
+) {
+    const { severities, fixability, imageTypes } = reportConfiguration.vulnReportFilters;
+    const { notifiers } = reportConfiguration;
+
+    const hasEmailNotifier =
+        notifiers.length > 0 && notifiers.some((notifier) => notifier.emailConfig);
+    const isTemplateModified =
+        notifiers.length > 0 &&
+        notifiers.some(
+            (notifier) => notifier.emailConfig.customBody || notifier.emailConfig.customSubject
+        );
+    analyticsTrack({
+        event: VULNERABILITY_REPORT_CREATED,
+        properties: {
+            SEVERITY_CRITICAL: severities.includes('CRITICAL_VULNERABILITY_SEVERITY') ? 1 : 0,
+            SEVERITY_IMPORTANT: severities.includes('IMPORTANT_VULNERABILITY_SEVERITY') ? 1 : 0,
+            SEVERITY_MODERATE: severities.includes('MODERATE_VULNERABILITY_SEVERITY') ? 1 : 0,
+            SEVERITY_LOW: severities.includes('LOW_VULNERABILITY_SEVERITY') ? 1 : 0,
+            CVE_STATUS_FIXABLE: fixability.includes('FIXABLE') ? 1 : 0,
+            CVE_STATUS_NOT_FIXABLE: fixability.includes('NOT_FIXABLE') ? 1 : 0,
+            IMAGE_TYPE_DEPLOYED: imageTypes.includes('DEPLOYED') ? 1 : 0,
+            IMAGE_TYPE_WATCHED: imageTypes.includes('WATCHED') ? 1 : 0,
+            EMAIL_NOTIFIER: hasEmailNotifier ? 1 : 0,
+            TEMPLATE_MODIFIED: isTemplateModified ? 1 : 0,
+        },
+    });
+}
+
 function useCreateReport({ onCompleted }: UseCreateReportProps): CreateReportResult {
+    const { analyticsTrack } = useAnalytics();
     const [result, setResult] = useState<Result>(defaultResult);
 
     const createReport = useCallback((formValues: ReportFormValues) => {
@@ -46,6 +79,7 @@ function useCreateReport({ onCompleted }: UseCreateReportProps): CreateReportRes
                     error: null,
                 });
                 onCompleted(response);
+                trackReportCreation(analyticsTrack, reportConfiguration);
             })
             .catch((err) => {
                 setResult({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useRunReport.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useRunReport.ts
@@ -1,5 +1,9 @@
 import { useCallback, useState } from 'react';
 
+import useAnalytics, {
+    VULNERABILITY_REPORT_DOWNLOAD_GENERATED,
+    VULNERABILITY_REPORT_SENT_MANUALLY,
+} from 'hooks/useAnalytics';
 import { runReportRequest } from 'services/ReportsService';
 import { ReportNotificationMethod } from 'services/ReportsService.types';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -25,6 +29,7 @@ const defaultResult = {
 };
 
 function useRunReport({ onCompleted }: UseSaveReportProps): SaveReportResult {
+    const { analyticsTrack } = useAnalytics();
     const [result, setResult] = useState<Result>(defaultResult);
 
     const runReport = useCallback(
@@ -43,6 +48,12 @@ function useRunReport({ onCompleted }: UseSaveReportProps): SaveReportResult {
                         runError: null,
                     });
                     onCompleted({ reportNotificationMethod });
+
+                    if (reportNotificationMethod === 'EMAIL') {
+                        analyticsTrack(VULNERABILITY_REPORT_SENT_MANUALLY);
+                    } else if (reportNotificationMethod === 'DOWNLOAD') {
+                        analyticsTrack(VULNERABILITY_REPORT_DOWNLOAD_GENERATED);
+                    }
                 })
                 .catch((err) => {
                     setResult({
@@ -52,7 +63,7 @@ function useRunReport({ onCompleted }: UseSaveReportProps): SaveReportResult {
                     });
                 });
         },
-        [onCompleted]
+        [analyticsTrack, onCompleted]
     );
 
     return {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
@@ -30,6 +30,7 @@ import CollectionsFormModal, {
     CollectionFormModalAction,
 } from 'Containers/Collections/CollectionFormModal';
 import useRestQuery from 'hooks/useRestQuery';
+import useAnalytics, { COLLECTION_CREATED } from 'hooks/useAnalytics';
 
 const COLLECTION_PAGE_SIZE = 10;
 
@@ -54,6 +55,8 @@ function CollectionSelection({
     const isRouteEnabledForCollections = isRouteEnabled('collections');
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForCollections = hasReadWriteAccess('WorkflowAdministration');
+
+    const { analyticsTrack } = useAnalytics();
 
     const { isOpen, onToggle } = useSelectToggle();
     const [modalAction, setModalAction] = useState<CollectionFormModalAction>({ type: 'create' });
@@ -235,6 +238,11 @@ function CollectionSelection({
                                 ...oldCollections,
                                 collectionResponse,
                             ]);
+
+                            analyticsTrack({
+                                event: COLLECTION_CREATED,
+                                properties: { source: 'Vulnerability Reporting' },
+                            });
                         })
                     }
                 />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
@@ -1,4 +1,5 @@
 import { FormikProps, useFormik } from 'formik';
+
 import * as yup from 'yup';
 
 import { VulnerabilitySeverity, vulnerabilitySeverities } from 'types/cve.proto';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { gql, useQuery } from '@apollo/client';
 import {
     Alert,
@@ -39,6 +39,7 @@ import {
     COMPONENT_SEARCH_OPTION,
     COMPONENT_SOURCE_SEARCH_OPTION,
 } from 'Containers/Vulnerabilities/searchOptions';
+import useAnalytics, { WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED } from 'hooks/useAnalytics';
 import {
     getHiddenSeverities,
     getOverviewCvesPath,
@@ -67,7 +68,7 @@ import BySeveritySummaryCard, {
     ResourceCountsByCveSeverity,
 } from '../SummaryCards/BySeveritySummaryCard';
 import { resourceCountByCveSeverityAndStatusFragment } from '../SummaryCards/CvesByStatusSummaryCard';
-import { VulnerabilitySeverityLabel } from '../types';
+import { EntityTab, VulnerabilitySeverityLabel } from '../types';
 import VulnerabilityStateTabs from '../components/VulnerabilityStateTabs';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
 
@@ -170,6 +171,7 @@ const searchOptions: SearchOption[] = [
 ];
 
 function ImageCvePage() {
+    const { analyticsTrack } = useAnalytics();
     const currentVulnerabilityState = useVulnerabilityState();
 
     const urlParams = useParams();
@@ -296,6 +298,21 @@ function ImageCvePage() {
         tableLoading = deploymentDataRequest.loading;
     }
 
+    function trackEntityTabView(entityTab: EntityTab) {
+        analyticsTrack({
+            event: WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED,
+            properties: {
+                type: entityTab,
+                page: 'CVE Detail',
+            },
+        });
+    }
+
+    // Track the initial entity tab view
+    useEffect(() => {
+        trackEntityTabView(entityTab);
+    }, []);
+
     // If the `imageCVE` field is null, then the CVE ID passed via URL does not exist
     if (metadataRequest.data && metadataRequest.data.imageCVE === null) {
         return (
@@ -409,6 +426,7 @@ function ImageCvePage() {
                                     entityTabs={imageCveEntities}
                                     setSortOption={setSortOption}
                                     setPage={setPage}
+                                    onChange={trackEntityTabView}
                                 />
                                 {isFiltered && <DynamicTableLabel />}
                             </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -13,7 +13,7 @@ import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerab
 import CVEsTable, { cveListQuery, unfilteredImageCountQuery } from '../Tables/CVEsTable';
 import TableErrorComponent from '../components/TableErrorComponent';
 import { EntityCounts } from '../components/EntityTypeToggleGroup';
-import { DefaultFilters, VulnerabilitySeverityLabel } from '../types';
+import { DefaultFilters, EntityTab, VulnerabilitySeverityLabel } from '../types';
 import {
     getStatusesForExceptionCount,
     getVulnStateScopedQueryString,
@@ -33,6 +33,7 @@ export type CVEsTableContainerProps = {
     vulnerabilityState?: VulnerabilityState; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
     pagination: ReturnType<typeof useURLPagination>;
     isUnifiedDeferralsEnabled: boolean; // TODO Remove this when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
+    onEntityTabChange: (entityTab: EntityTab) => void;
 };
 
 function CVEsTableContainer({
@@ -41,6 +42,7 @@ function CVEsTableContainer({
     vulnerabilityState,
     pagination,
     isUnifiedDeferralsEnabled,
+    onEntityTabChange,
 }: CVEsTableContainerProps) {
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
@@ -110,6 +112,7 @@ function CVEsTableContainer({
                 pagination={pagination}
                 tableRowCount={countsData.imageCVECount}
                 isFiltered={isFiltered}
+                onEntityTabChange={onEntityTabChange}
             >
                 {canSelectRows && (
                     <ToolbarItem alignment={{ default: 'alignRight' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -13,13 +13,14 @@ import TableEntityToolbar from '../components/TableEntityToolbar';
 import { EntityCounts } from '../components/EntityTypeToggleGroup';
 import { getVulnStateScopedQueryString, parseQuerySearchFilter } from '../searchUtils';
 import { defaultDeploymentSortFields, deploymentsDefaultSort } from '../sortUtils';
-import { DefaultFilters, VulnerabilitySeverityLabel } from '../types';
+import { DefaultFilters, EntityTab, VulnerabilitySeverityLabel } from '../types';
 
 type DeploymentsTableContainerProps = {
     defaultFilters: DefaultFilters;
     countsData: EntityCounts;
     vulnerabilityState?: VulnerabilityState; // TODO Make this required when the ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL feature flag is removed
     pagination: ReturnType<typeof useURLPagination>;
+    onEntityTabChange: (entityTab: EntityTab) => void;
 };
 
 function DeploymentsTableContainer({
@@ -27,6 +28,7 @@ function DeploymentsTableContainer({
     countsData,
     vulnerabilityState,
     pagination,
+    onEntityTabChange,
 }: DeploymentsTableContainerProps) {
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
@@ -61,6 +63,7 @@ function DeploymentsTableContainer({
                 pagination={pagination}
                 tableRowCount={countsData.deploymentCount}
                 isFiltered={isFiltered}
+                onEntityTabChange={onEntityTabChange}
             />
             <Divider component="div" />
             {loading && !tableData && (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -12,7 +12,7 @@ import TableErrorComponent from '../components/TableErrorComponent';
 import { EntityCounts } from '../components/EntityTypeToggleGroup';
 import { getVulnStateScopedQueryString, parseQuerySearchFilter } from '../searchUtils';
 import { defaultImageSortFields, imagesDefaultSort } from '../sortUtils';
-import { DefaultFilters, VulnerabilitySeverityLabel } from '../types';
+import { DefaultFilters, EntityTab, VulnerabilitySeverityLabel } from '../types';
 import TableEntityToolbar from '../components/TableEntityToolbar';
 
 export { imageListQuery } from '../Tables/ImagesTable';
@@ -25,6 +25,7 @@ type ImagesTableContainerProps = {
     hasWriteAccessForWatchedImage: boolean;
     onWatchImage: ImagesTableProps['onWatchImage'];
     onUnwatchImage: ImagesTableProps['onUnwatchImage'];
+    onEntityTabChange: (entityTab: EntityTab) => void;
 };
 
 function ImagesTableContainer({
@@ -35,6 +36,7 @@ function ImagesTableContainer({
     hasWriteAccessForWatchedImage,
     onWatchImage,
     onUnwatchImage,
+    onEntityTabChange,
 }: ImagesTableContainerProps) {
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
@@ -68,6 +70,7 @@ function ImagesTableContainer({
                 pagination={pagination}
                 tableRowCount={countsData.imageCount}
                 isFiltered={isFiltered}
+                onEntityTabChange={onEntityTabChange}
             />
             <Divider component="div" />
             {loading && !tableData && (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -23,11 +23,15 @@ import useURLPagination from 'hooks/useURLPagination';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import usePermissions from 'hooks/usePermissions';
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import useAnalytics, { WATCH_IMAGE_MODAL_OPENED } from 'hooks/useAnalytics';
+import useAnalytics, {
+    WATCH_IMAGE_MODAL_OPENED,
+    WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED,
+} from 'hooks/useAnalytics';
 import useLocalStorage from 'hooks/useLocalStorage';
 import { SearchFilter } from 'types/search';
 import {
     DefaultFilters,
+    EntityTab,
     VulnMgmtLocalStorage,
     entityTabValues,
     isVulnMgmtLocalStorage,
@@ -125,6 +129,21 @@ function WorkloadCvesOverviewPage() {
         );
     }
 
+    function onEntityTabChange(entityTab: EntityTab) {
+        analyticsTrack({
+            event: WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED,
+            properties: {
+                type: entityTab,
+                page: 'Overview',
+            },
+        });
+    }
+
+    // Track the current entity tab when the page is initially visited.
+    useEffect(() => {
+        onEntityTabChange(activeEntityTabKey);
+    }, []);
+
     // When the page is initially visited and no local filters are applied, apply the default filters.
     //
     // Note that this _does not_ take into account a direct navigation via the left navigation when the user
@@ -205,6 +224,7 @@ function WorkloadCvesOverviewPage() {
                                     pagination={pagination}
                                     vulnerabilityState={currentVulnerabilityState}
                                     isUnifiedDeferralsEnabled={isUnifiedDeferralsEnabled}
+                                    onEntityTabChange={onEntityTabChange}
                                 />
                             )}
                             {activeEntityTabKey === 'Image' && (
@@ -223,6 +243,7 @@ function WorkloadCvesOverviewPage() {
                                         setUnwatchImageName(imageName);
                                         unwatchImageModalToggle.openSelect();
                                     }}
+                                    onEntityTabChange={onEntityTabChange}
                                 />
                             )}
                             {activeEntityTabKey === 'Deployment' && (
@@ -231,6 +252,7 @@ function WorkloadCvesOverviewPage() {
                                     countsData={countsData}
                                     pagination={pagination}
                                     vulnerabilityState={currentVulnerabilityState}
+                                    onEntityTabChange={onEntityTabChange}
                                 />
                             )}
                         </CardBody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
@@ -4,7 +4,25 @@ import cloneDeep from 'lodash/cloneDeep';
 import { useFormik, FormikProvider } from 'formik';
 import { Globe } from 'react-feather';
 
+import useAnalytics, { WORKLOAD_CVE_DEFAULT_FILTERS_CHANGED } from 'hooks/useAnalytics';
 import { DefaultFilters, FixableStatus, VulnerabilitySeverityLabel } from '../types';
+
+function analyticsTrackDefaultFilters(
+    analyticsTrack: ReturnType<typeof useAnalytics>['analyticsTrack'],
+    filters: DefaultFilters
+) {
+    analyticsTrack({
+        event: WORKLOAD_CVE_DEFAULT_FILTERS_CHANGED,
+        properties: {
+            SEVERITY_CRITICAL: filters.SEVERITY.includes('Critical') ? 1 : 0,
+            SEVERITY_IMPORTANT: filters.SEVERITY.includes('Important') ? 1 : 0,
+            SEVERITY_MODERATE: filters.SEVERITY.includes('Moderate') ? 1 : 0,
+            SEVERITY_LOW: filters.SEVERITY.includes('Low') ? 1 : 0,
+            CVE_STATUS_FIXABLE: filters.FIXABLE.includes('Fixable') ? 1 : 0,
+            CVE_STATUS_NOT_FIXABLE: filters.FIXABLE.includes('Not fixable') ? 1 : 0,
+        },
+    });
+}
 
 type DefaultFilterModalProps = {
     defaultFilters: DefaultFilters;
@@ -12,6 +30,7 @@ type DefaultFilterModalProps = {
 };
 
 function DefaultFilterModal({ defaultFilters, setLocalStorage }: DefaultFilterModalProps) {
+    const { analyticsTrack } = useAnalytics();
     const [isOpen, setIsOpen] = useState(false);
     const totalFilters = defaultFilters.SEVERITY.length + defaultFilters.FIXABLE.length;
 
@@ -20,6 +39,7 @@ function DefaultFilterModal({ defaultFilters, setLocalStorage }: DefaultFilterMo
         onSubmit: (values: DefaultFilters) => {
             setLocalStorage(values);
             setIsOpen(false);
+            analyticsTrackDefaultFilters(analyticsTrack, values);
         },
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/EntityTypeToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/EntityTypeToggleGroup.tsx
@@ -30,6 +30,7 @@ type EntityTabToggleGroupProps = {
     deploymentCount?: number;
     setSortOption: (sortOption: SortOption) => void;
     setPage: (num) => void;
+    onChange: (entityTab: EntityTab) => void;
 };
 
 function EntityTabToggleGroup({
@@ -40,6 +41,7 @@ function EntityTabToggleGroup({
     deploymentCount = 0,
     setSortOption,
     setPage,
+    onChange,
 }: EntityTabToggleGroupProps) {
     const [activeEntityTabKey, setActiveEntityTabKey] = useURLStringUnion('entityTab', entityTabs);
 
@@ -47,6 +49,7 @@ function EntityTabToggleGroup({
         setActiveEntityTabKey(entityTab);
         setSortOption(getDefaultSortOption(entityTab));
         setPage(1);
+        onChange(entityTab);
     }
 
     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/TableEntityToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/TableEntityToolbar.tsx
@@ -16,7 +16,7 @@ import {
 import WorkloadTableToolbar from './WorkloadTableToolbar';
 import { DynamicTableLabel } from './DynamicIcon';
 import EntityTypeToggleGroup, { EntityCounts } from './EntityTypeToggleGroup';
-import { DefaultFilters } from '../types';
+import { DefaultFilters, EntityTab } from '../types';
 
 type TableEntityToolbarProps = {
     defaultFilters: DefaultFilters;
@@ -25,6 +25,7 @@ type TableEntityToolbarProps = {
     pagination: UseURLPaginationResult;
     tableRowCount: number;
     isFiltered: boolean;
+    onEntityTabChange: (entityTab: EntityTab) => void;
     children?: React.ReactNode;
 };
 
@@ -45,6 +46,7 @@ function TableEntityToolbar({
     pagination,
     tableRowCount,
     isFiltered,
+    onEntityTabChange,
     children,
 }: TableEntityToolbarProps) {
     const { page, perPage, setPage, setPerPage } = pagination;
@@ -65,6 +67,7 @@ function TableEntityToolbar({
                             deploymentCount={countsData.deploymentCount}
                             setSortOption={setSortOption}
                             setPage={setPage}
+                            onChange={onEntityTabChange}
                         />
                     </ToolbarItem>
                     {isFiltered && (

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -3,13 +3,144 @@ import { useSelector } from 'react-redux';
 import { Telemetry } from 'types/config.proto';
 
 import { selectors } from 'reducers';
+import { UnionFrom, tupleTypeGuard } from 'utils/type.utils';
 
-// events constants
+// event name constants
 export const CLUSTER_CREATED = 'Cluster Created';
 export const INVITE_USERS_MODAL_OPENED = 'Invite Users Modal Opened';
 export const INVITE_USERS_SUBMITTED = 'Invite Users Submitted';
 export const WATCH_IMAGE_MODAL_OPENED = 'Watch Image Modal Opened';
 export const WATCH_IMAGE_SUBMITTED = 'Watch Image Submitted';
+
+export const WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED = 'Workload CVE Entity Context View';
+export const WORKLOAD_CVE_FILTER_APPLIED = 'Workload CVE Filter Applied';
+export const WORKLOAD_CVE_DEFAULT_FILTERS_CHANGED = 'Workload CVE Default Filters Changed';
+export const COLLECTION_CREATED = 'Collection Created';
+export const VULNERABILITY_REPORT_CREATED = 'Vulnerability Report Created';
+export const VULNERABILITY_REPORT_DOWNLOAD_GENERATED = 'Vulnerability Report Download Generated';
+export const VULNERABILITY_REPORT_SENT_MANUALLY = 'Vulnerability Report Sent Manually';
+export const GLOBAL_SNOOZE_CVE = 'Global Snooze CVE';
+
+/**
+ * Boolean fields should be tracked with 0 or 1 instead of true/false. This
+ * allows us to use the boolean fields in numeric aggregations in the
+ * analytics dashboard to retrieve an accurate count of the number of times
+ * a property was enabled for an event.
+ */
+type AnalyticsBoolean = 0 | 1;
+
+// search categories and type guards for tracking search filters on the Workload CVE pages
+export const searchCategoriesWithFilter = [
+    'CVE',
+    'IMAGE',
+    'COMPONENT',
+    'COMPONENT SOURCE',
+    'SEVERITY',
+    'FIXABLE',
+] as const;
+export const isSearchCategoryWithFilter = tupleTypeGuard(searchCategoriesWithFilter);
+export type SearchCategoryWithFilter = UnionFrom<typeof searchCategoriesWithFilter>;
+
+export const searchCategoriesWithoutFilter = ['DEPLOYMENT', 'NAMESPACE', 'CLUSTER'] as const;
+export const isSearchCategoryWithoutFilter = tupleTypeGuard(searchCategoriesWithoutFilter);
+export type SearchCategoryWithoutFilter = UnionFrom<typeof searchCategoriesWithoutFilter>;
+
+/**
+ * An AnalyticsEvent is either a simple string that represents the event name,
+ * or an object with an event name and additional properties.
+ */
+type AnalyticsEvent =
+    | typeof CLUSTER_CREATED
+    | typeof INVITE_USERS_MODAL_OPENED
+    | typeof INVITE_USERS_SUBMITTED
+    /** Tracks each time the user opens the "Watched Images" modal */
+    | typeof WATCH_IMAGE_MODAL_OPENED
+    /** Tracks each time the user submits a request to watch an image */
+    | typeof WATCH_IMAGE_SUBMITTED
+    /**
+     * Tracks each view of a CVE entity context (CVE, Image, or Deployment). This is
+     * controlled by the entity tabs on the Overview page and the CVE Detail page.
+     */
+    | {
+          event: typeof WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED;
+          properties: {
+              type: 'CVE' | 'Image' | 'Deployment';
+              page: 'Overview' | 'CVE Detail';
+          };
+      }
+    /**
+     * Tracks each time the user applies a filter on a Workload page.
+     * This is controlled by the main search bar on all Workload CVE pages.
+     * We only track the value of the applied filter when it does not represent
+     * specifics of a customer environment.
+     */
+    | {
+          event: typeof WORKLOAD_CVE_FILTER_APPLIED;
+          properties:
+              | { category: SearchCategoryWithFilter; filter: string }
+              | { category: SearchCategoryWithoutFilter };
+      }
+    /**
+     * Tracks each time the user changes the default filters on the Workload CVE overview page.
+     */
+    | {
+          event: typeof WORKLOAD_CVE_DEFAULT_FILTERS_CHANGED;
+          properties: {
+              SEVERITY_CRITICAL: AnalyticsBoolean;
+              SEVERITY_IMPORTANT: AnalyticsBoolean;
+              SEVERITY_MODERATE: AnalyticsBoolean;
+              SEVERITY_LOW: AnalyticsBoolean;
+              CVE_STATUS_FIXABLE: AnalyticsBoolean;
+              CVE_STATUS_NOT_FIXABLE: AnalyticsBoolean;
+          };
+      }
+    /**
+     * Tracks each time the user creates a collection.
+     */
+    | {
+          event: typeof COLLECTION_CREATED;
+          properties: {
+              source: 'Vulnerability Reporting' | 'Collections';
+          };
+      }
+    /**
+     *
+     */
+    | {
+          event: typeof VULNERABILITY_REPORT_CREATED;
+          properties: {
+              SEVERITY_CRITICAL: AnalyticsBoolean;
+              SEVERITY_IMPORTANT: AnalyticsBoolean;
+              SEVERITY_MODERATE: AnalyticsBoolean;
+              SEVERITY_LOW: AnalyticsBoolean;
+              CVE_STATUS_FIXABLE: AnalyticsBoolean;
+              CVE_STATUS_NOT_FIXABLE: AnalyticsBoolean;
+              IMAGE_TYPE_DEPLOYED: AnalyticsBoolean;
+              IMAGE_TYPE_WATCHED: AnalyticsBoolean;
+              EMAIL_NOTIFIER: AnalyticsBoolean;
+              TEMPLATE_MODIFIED: AnalyticsBoolean;
+          };
+      }
+    /**
+     * Tracks each time the user generates a vulnerability report download.
+     */
+    | typeof VULNERABILITY_REPORT_DOWNLOAD_GENERATED
+    /**
+     * Tracks each time the user sends a vulnerability report manually.
+     */
+    | typeof VULNERABILITY_REPORT_SENT_MANUALLY
+    /**
+     * Tracks each time the user snoozes a Node or Platform CVE via
+     * Vulnerability Management 1.0
+     */
+    | {
+          event: typeof GLOBAL_SNOOZE_CVE;
+          properties: {
+              type: 'NODE' | 'PLATFORM';
+              cve: string;
+              duration: string;
+          };
+      };
 
 const useAnalytics = () => {
     const telemetry = useSelector(selectors.publicConfigTelemetrySelector);
@@ -25,9 +156,15 @@ const useAnalytics = () => {
     );
 
     const analyticsTrack = useCallback(
-        (event: string, additionalProperties = {}): void => {
-            if (isTelemetryEnabled !== false) {
-                window.analytics?.track(event, additionalProperties);
+        (analyticsEvent: AnalyticsEvent): void => {
+            if (isTelemetryEnabled === false) {
+                return;
+            }
+
+            if (typeof analyticsEvent === 'string') {
+                window.analytics?.track(analyticsEvent);
+            } else {
+                window.analytics?.track(analyticsEvent.event, analyticsEvent.properties);
             }
         },
         [isTelemetryEnabled]

--- a/ui/apps/platform/src/utils/type.utils.ts
+++ b/ui/apps/platform/src/utils/type.utils.ts
@@ -38,3 +38,17 @@ export type JsonArray = JsonValue[];
  * A type that represents any value that can be serialized to JSON.
  */
 export type JsonValue = JsonPrimitive | JsonObject | JsonArray;
+
+/**
+ * Creates a type guard that checks if a value is one of a provided list of strings.
+ *
+ * @param values A const array of strings
+ * @returns A type guard that checks if a value is one of the provided strings
+ */
+export function tupleTypeGuard<const T extends readonly string[]>(
+    values: T
+): (value: unknown) => value is T[number] {
+    return (value: unknown): value is T[number] => values.some((arg) => arg === value);
+}
+
+export type UnionFrom<T extends readonly string[]> = T[number];


### PR DESCRIPTION
## Description

Adds analytics events as described in https://docs.google.com/document/d/1v0z2OK2B5nWmYHh4pNEoVd4YfIW0gOVomf7qgkvND2I/edit

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Set the central env var to the development analytics key.

Manual event testing and verification in the analytics dashboard.

Until I have access to share charts more easily - here is a link to internal Slack thread showing the events in Amplitude along with charts for each event type. https://redhat-internal.slack.com/archives/C03JMGWJYMD/p1702567215510979

