### PR TITLE
fix(test): Increase time out for process baseline delete test

### DIFF
--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -453,7 +453,7 @@ class ProcessBaselinesTest extends BaseSpecification {
                 waitForDeploymentBaselinesCreated(clusterId, deployment, containerName)
         assert(baselinesCreated)
         def baselineBeforeDelete = null
-        assert trueWithin(10, 3) {
+        assert trueWithin(70, 5) {
             baselineBeforeDelete = ProcessBaselineService.getProcessBaseline(clusterId, deployment, containerName)
             assert baselineBeforeDelete
             baselineBeforeDelete.elementsList.size() > 0

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -121,7 +121,7 @@ class ProcessBaselinesTest extends BaseSpecification {
     // some padding.
     @Rule
     @SuppressWarnings(["JUnitPublicProperty"])
-    Timeout globalTimeout = new Timeout(3*(BASELINE_WAIT_TIME + RISK_WAIT_TIME) + 300 + 120, TimeUnit.SECONDS)
+    Timeout globalTimeout = new Timeout(4*(BASELINE_WAIT_TIME + RISK_WAIT_TIME) + 300 + 120, TimeUnit.SECONDS)
 
     @Shared
     private Policy unauthorizedProcessExecution
@@ -440,7 +440,6 @@ class ProcessBaselinesTest extends BaseSpecification {
         DEPLOYMENTNGINX_REMOVEPROCESS           |   "nginx"
     }
 
-    @Tag("BAT")
     def "Delete process baselines via API"() {
         given:
         "a baseline is created"


### PR DESCRIPTION
## Description

This change increase the time out for process baseline test. The value is in align with what is used in RiskTest.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
