### PR TITLE
fix(scanner): Fix FixedInVersion parsing

### DIFF
--- a/scanner/e2etests/testdata/image_tests.json
+++ b/scanner/e2etests/testdata/image_tests.json
@@ -5459,7 +5459,6 @@
         "required_feature_flag": null
     },
     {
-        "disabled_reason": "ROX-20729: unexpected fixedby and description in CVE-2021-41411",
         "image": "quay.io/rhacs-eng/qa:drools-CVE-2021-41411",
         "registry": "https://quay.io",
         "username": "QUAY_RHACS_ENG_RO_USERNAME",
@@ -5469,12 +5468,13 @@
         "expected_features": [
             {
                 "Name": "org.drools:drools-core",
+                "NamespaceName": "rhel:8",
                 "VersionFormat": "JavaSourceType",
                 "Version": "6.4.0.Final",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2021-41411",
-                        "Description": "drools \u003c=7.59.x is affected by an XML External Entity (XXE) vulnerability in KieModuleMarshaller.java. The Validator class is not used correctly, resulting in the XXE injection vulnerability.",
+                        "Description": "XML External Entity Reference in drools",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-41411",
                         "Severity": "Critical",
                         "Metadata": {

--- a/scanner/mappers/mappers_test.go
+++ b/scanner/mappers/mappers_test.go
@@ -638,6 +638,73 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 				},
 			},
 		},
+		"when vuln with plain fixedIn then convert": {
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"foo": {
+					Issued:         now,
+					FixedInVersion: "1.2.3",
+				},
+			},
+			want: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"foo": {
+					Issued:         protoNow,
+					FixedInVersion: "1.2.3",
+				},
+			},
+		},
+		"when vuln with range and no fixedIn then use upper limit": {
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"foo": {
+					Issued: now,
+					Range: &claircore.Range{
+						Upper: claircore.Version{
+							Kind: "test",
+							V:    [10]int32{0, 1, 2, 3},
+						},
+					},
+				},
+			},
+			want: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"foo": {
+					Issued:         protoNow,
+					FixedInVersion: "1.2.3",
+				},
+			},
+		},
+		"when vuln with range and with fixeIn then use fixedIn": {
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"foo": {
+					Issued:         now,
+					FixedInVersion: "4.5.6",
+					Range: &claircore.Range{
+						Upper: claircore.Version{
+							Kind: "test",
+							V:    [10]int32{0, 1, 2, 3},
+						},
+					},
+				},
+			},
+			want: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"foo": {
+					Issued:         protoNow,
+					FixedInVersion: "4.5.6",
+				},
+			},
+		},
+		"when vuln urlencoded fixeIn then use fixed value in fixedIn": {
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"foo": {
+					Issued:         now,
+					FixedInVersion: "fixed=4.5.6",
+				},
+			},
+			want: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"foo": {
+					Issued:         protoNow,
+					FixedInVersion: "4.5.6",
+				},
+			},
+		},
 	}
 	ctx := context.Background()
 	for name, tt := range tests {


### PR DESCRIPTION
## Description

This patch addresses an issue when parsing the value for the `FixedInVersion` from ClairCore vulnerability reports where the data was not handling certain cases correctly:

1. **Enhanced Parsing of `fixedInVersion` Field**: In `mappers.go`, a new function `fixedInVersion` has been added. This function addresses a parsing issue where `FixedInVersion` values were incorrectly handled when URL-encoded or needed to be extracted from the `Range.Upper` field.
1. **Updated Unit Tests**: New test scenarios in `mappers_test.go` ensure that the `fixedInVersion` function accurately handles different formats of the `FixedInVersion` value. The `image_tests.json` file has been updated to correct an outdated and incorrect description for CVE-2021-41411.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Spin-up scanner then:

```
go test -v ./e2etests -run TestImage/rhel:8/quay.io/rhacs-eng/qa:drools-CVE-2021-41411 -count=1
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
