### PR TITLE
chore(scanner): misc Scanner v4 DB updates

### DIFF
--- a/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
@@ -77,6 +77,8 @@ spec:
         env:
         - name: PGDATA
           value: "/var/lib/postgresql/data/pgdata"
+        - name: POSTGRES_HOST_AUTH_METHOD
+          value: "scram-sha-256"
         - name: POSTGRES_PASSWORD_FILE
           value: "/run/secrets/stackrox.io/secrets/password"
         command:
@@ -96,10 +98,10 @@ spec:
       - name: db
         image: {{ ._rox.scannerV4.db.image.fullRef | quote }}
         env:
-        - name: POSTGRES_HOST_AUTH_METHOD
-          value: "scram-sha-256"
         - name: PGDATA
           value: "/var/lib/postgresql/data/pgdata"
+        - name: POSTGRES_HOST_AUTH_METHOD
+          value: "scram-sha-256"
         ports:
         - name: tcp-postgresql
           containerPort: 5432

--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -135,7 +135,7 @@ scanner-image: image/scanner/bin/scanner copy-scripts $(OSSLS_NOTICE_DEP)
 	$(DOCKERBUILD) -t stackrox/$(image-prefix):$(TAG) -f image/scanner/Dockerfile image/scanner
 
 .PHONY: db-image
-db-image: copy-db-scripts
+db-image:
 	@echo "+ $@"
 	$(DOCKERBUILD) -t stackrox/$(image-prefix)-db:$(TAG) $(DB_DOCKERBUILD_ARGS) -f image/db/Dockerfile image/db
 
@@ -164,11 +164,6 @@ SCRIPTS := restore-all-dir-contents import-additional-cas save-dir-contents
 copy-scripts: $(addprefix ../image/rhel/static-bin/,$(SCRIPTS))
 	@echo "+ $@"
 	$(SILENT)cp $^ image/scanner/scripts
-
-.PHONY: copy-db-scripts
-copy-db-scripts: ../image/postgres/scripts/init-entrypoint.sh
-	@echo "+ $@"
-	$(SILENT)cp $^ image/db/scripts
 
 ##################
 ## Certificates ##

--- a/scanner/e2etests/helmchart/templates/db-deployment.yaml
+++ b/scanner/e2etests/helmchart/templates/db-deployment.yaml
@@ -26,6 +26,13 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - init-entrypoint.sh
+        env:
+        - name: PGDATA
+          value: "/var/lib/postgresql/data/pgdata"
+        - name: POSTGRES_HOST_AUTH_METHOD
+          value: "scram-sha-256"
+        - name: POSTGRES_PASSWORD_FILE
+          value: "/run/secrets/stackrox.io/secrets/password"
         resources:
           limits:
             cpu: 2
@@ -46,6 +53,11 @@ spec:
       - name: db
         image: "{{ (printf "%s/%s:%s" .Values.image.repository .Values.app.db.name .Values.image.tag ) }}"
         imagePullPolicy: IfNotPresent
+        env:
+        - name: PGDATA
+          value: "/var/lib/postgresql/data/pgdata"
+        - name: POSTGRES_HOST_AUTH_METHOD
+          value: "scram-sha-256"
         ports:
         - name: postgresql
           protocol: TCP
@@ -66,6 +78,8 @@ spec:
         - name: tls-volume
           mountPath: /run/secrets/stackrox.io/certs
           readOnly: true
+        - name: shared-memory
+          mountPath: /dev/shm
       volumes:
       - name: config
         configMap:
@@ -83,6 +97,11 @@ spec:
             path: server.key
           - key: ca.pem
             path: root.crt
+      - name: shared-memory
+        emptyDir:
+          medium: Memory
+          # Keep this in sync with shared_buffers in config-templates/scanner-v4-db/postgresql.conf.default
+          sizeLimit: 250Mi
       - name: password
         secret:
           secretName: {{ .Values.app.db.name }}-password

--- a/scanner/image/db/.gitignore
+++ b/scanner/image/db/.gitignore
@@ -1,1 +1,0 @@
-scripts/init-entrypoint.sh

--- a/scanner/image/db/Dockerfile
+++ b/scanner/image/db/Dockerfile
@@ -20,8 +20,7 @@ LABEL name="scanner-db" \
 
 # If this is updated, be sure to update postgres_major in download.sh and the signature file.
 ENV PG_MAJOR=15
-ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/" \
-    PGDATA="/var/lib/postgresql/data/pgdata"
+ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/"
 ENV LANG=en_US.utf8
 
 COPY signatures/RPM-GPG-KEY-PGDG-15 /

--- a/scanner/image/db/scripts/docker-entrypoint.sh
+++ b/scanner/image/db/scripts/docker-entrypoint.sh
@@ -10,7 +10,7 @@ set -Eeo pipefail
 
 ### STACKROX MODIFIED - Fast shutdown to kill and rollback in-flight transactions.
 shutdown() {
-  pg_ctl -D /var/lib/postgresql/data/pgdata stop -m fast
+  pg_ctl -D "$PGDATA" stop -m fast
 }
 trap shutdown SIGINT SIGTERM
 
@@ -361,7 +361,8 @@ _main() {
 	### STACKROX MODIFIED - Start Postgres as a child process and
 	### prevent multiple pods on the same node from using this instance.
 	### Note: this may not be needed with ReadWriteOncePod.
-	flock /var/lib/postgresql/data/pglock "$@" &
+	local ROX_PGLOCK_DIR="$PGDATA/.."
+	flock "$ROX_PGLOCK_DIR/pglock" "$@" &
 	child=$!
 	echo "Waiting for child process $child to exit"
 	wait "$child"

--- a/scanner/image/db/scripts/init-entrypoint.sh
+++ b/scanner/image/db/scripts/init-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -Eeo pipefail
+
+# Initialize DB if it does not exist
+if [ ! -s "$PGDATA/PG_VERSION" ]; then
+  initdb --auth-host="$POSTGRES_HOST_AUTH_METHOD" --auth-local="$POSTGRES_HOST_AUTH_METHOD" --pwfile "$POSTGRES_PASSWORD_FILE" --data-checksums
+fi


### PR DESCRIPTION
## Description

Various updates:

* Use the PGDATA environment variable instead of the hardcoded value
* Use the POSTGRES_PASSWORD_FILE environment variable instead of the hardcoded value
  * Part of this was also to create a unique init-entrypoint.sh script for Scanner v4 DB to give Scanner v4 DB independence from Central DB. This file also uses an env var instead of of hardcoding `scram-sha-256`
* Remove PGDATA from Dockerfile, as it's not needed
* Add env vars to Scanner v4 test Helm chart, as downstream Scanner v4 DB failed to start without these changes (does not have PGDATA hardcoded into the Dockerfile)
* Other Helm chart updates

Note: I considered changing PGDATA from `/var/lib/postgresql/data/pgdata` to the typical `/var/lib/pgdql/data`, but this had permission issues in the downstream image (creator and user are not the same). Because of this, I kept it the same, non-standard directory.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Run `make e2e-deploy` and make sure Scanner v4 DB starts up properly. To test with the downstream image, ask me about that offline

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
