### PR TITLE
test(helm): cover extraction of pull secrets from the default SA

### DIFF
--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -45,6 +45,19 @@ tests:
     tests:
     - name: "should fail with no extra secrets"
       expectError: true
+    - name: "should succeed with pull secrets referenced in default SA"
+      server:
+        objects:
+        - apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: default
+            namespace: stackrox
+          imagePullSecrets:
+          - name: from-default-1
+          - name: from-default-2
+      expect: |
+        .serviceaccounts[] | saRefersTo(["from-default-1", "from-default-2"])
     - name: "should succeed with useExisting"
       expect: |
         .serviceaccounts[] | saRefersTo(["extra-secret1", "extra-secret2"])
@@ -85,6 +98,19 @@ tests:
         password: ""
     expect: |
       authForCentral | assertThat(. == "foo:")
+  - name: "secrets from default SA are referenced, if present"
+    server:
+      objects:
+      - apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: default
+          namespace: stackrox
+        imagePullSecrets:
+        - name: from-default-1
+        - name: from-default-2
+    expect: |
+      .serviceaccounts[] | saRefersTo(["from-default-1", "from-default-2"])
   - name: "useExisting secrets are referenced, if specified"
     set:
       imagePullSecrets.useExisting: ["extra-secret1", "extra-secret2"]

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -42,6 +42,19 @@ tests:
     tests:
     - name: "should fail with no extra secrets"
       expectError: true
+    - name: "should succeed with pull secrets referenced in default SA"
+      server:
+        objects:
+        - apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: default
+            namespace: stackrox
+          imagePullSecrets:
+          - name: from-default-1
+          - name: from-default-2
+      expect: |
+        .serviceaccounts[] | saRefersTo(["from-default-1", "from-default-2"])
     - name: "should succeed with useExisting"
       expect: |
         .serviceaccounts[] | saRefersTo(["extra-secret1", "extra-secret2"])
@@ -92,6 +105,19 @@ tests:
     expect: |
       authForMain | assertThat(. == "foo:")
       authForCollector | assertThat(. == "foo:")
+  - name: "secrets from default SA are referenced, if present"
+    server:
+      objects:
+      - apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: default
+          namespace: stackrox
+        imagePullSecrets:
+        - name: from-default-1
+        - name: from-default-2
+    expect: |
+      .serviceaccounts[] | saRefersTo(["from-default-1", "from-default-2"])
   - name: "useExisting secrets are referenced, if specified"
     set:
       imagePullSecrets.useExisting: ["extra-secret1", "extra-secret2"]


### PR DESCRIPTION
## Description

Now that we use a helmtest version with support for testing the `lookup` function, add test coverage for extraction of pull secret names from the default service account.

This was a warm-up for a fix to ROX-9156, but useful on its own.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
