### PR TITLE
fix(ci): increase dependabot limits

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -112,7 +112,7 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'wednesday'
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
     labels:
     - "dependencies"
     - "area/operator"
@@ -128,7 +128,7 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'wednesday'
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
     labels:
     - "dependencies"
     - "area/scanner"


### PR DESCRIPTION
## Description

Limit of 1 is a bit problematic. Currently we have one PR open for operator tools that is failing CI and no new PR could be opened. If we increase this limit than we can have more PRs open at the same time.

Refs: 
- https://github.com/stackrox/stackrox/security/dependabot/204
- https://github.com/stackrox/stackrox/pull/8406

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
