### PR TITLE
chore: Add codecov.yml to disable GH annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+  annotations: false


### PR DESCRIPTION
## Description

Disables inline PR annotations for code detected as not covered by codecov.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Create a separate PR that includes this file and new uncovered code: https://github.com/stackrox/stackrox/pull/8972

Wait for codecov to run to completion and verify that annotations are not present.
