### PR TITLE
ROX-21219: Disable animations for PF charts

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Status/Dashboard/Widgets/HorizontalBarChart.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Status/Dashboard/Widgets/HorizontalBarChart.tsx
@@ -27,7 +27,6 @@ function HorizontalBarChart({ passingRateData }: HorizontalBarChartProps) {
     return (
         <div ref={setWidgetContainer}>
             <Chart
-                animate={{ duration: 300 }}
                 domainPadding={{ x: [20, 20] }}
                 height={defaultChartHeight}
                 width={widgetContainerResizeEntry?.contentRect.width}

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImagesChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImagesChart.tsx
@@ -119,7 +119,6 @@ function AgingImagesChart({ searchFilter, timeRanges, timeRangeCounts }: AgingIm
             <Chart
                 ariaDesc="Aging images grouped by date of last update"
                 ariaTitle="Aging images"
-                animate={{ duration: 300 }}
                 domainPadding={{ x: [50, 50] }}
                 height={defaultChartHeight}
                 width={widgetContainerResizeEntry?.contentRect.width} // Victory defaults to 450

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandardChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandardChart.tsx
@@ -36,7 +36,6 @@ function ComplianceLevelsByStandardChart({ complianceData }: ComplianceLevelsByS
             <Chart
                 ariaDesc="Compliance coverage percentages by standard across the selected resource scope"
                 ariaTitle="Compliance coverage by standard"
-                animate={{ duration: 300 }}
                 domainPadding={{ x: [20, 20] }}
                 height={defaultChartHeight}
                 width={widgetContainerResizeEntry?.contentRect.width}

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategoryChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategoryChart.tsx
@@ -239,7 +239,6 @@ function ViolationsByPolicyCategoryChart({
         <div ref={setWidgetContainer}>
             <Chart
                 ariaDesc="Number of violations by policy category, grouped by severity"
-                animate={{ duration: 300 }}
                 domainPadding={{ x: [20, 20] }}
                 events={getInteractiveLegendEvents({
                     chartNames: [Object.values(severityLabels)],


### PR DESCRIPTION
## Description

The recommendation from the PatternFly team to upgrade to the latest PF-charts library did not make a difference on the broken charts, so I opted to disable animations entirely.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the dashboard without interacting with the charts:
![image](https://github.com/stackrox/stackrox/assets/1292638/765868a3-fd09-4efd-8779-5fe2bd79b598)


Load compliance 2.0 without interacting with the charts:
![image](https://github.com/stackrox/stackrox/assets/1292638/d2769f35-6d72-47d8-a610-17a025f27725)
