### PR TITLE
fix(e2e-tests): Fix RESOURCE_EXHAUSTED in e2e NWG tests 

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
@@ -17,8 +17,8 @@ import util.Timer
 class NetworkGraphService extends BaseService {
     static getNetworkGraphClient() {
         return NetworkGraphServiceGrpc.newBlockingStub(getChannel())
-            .withMaxInboundMessageSize(2*4209569)
-            .withMaxOutboundMessageSize(2*4209569)
+            .withMaxInboundMessageSize(2*4194304) // Twice the default size
+            .withMaxOutboundMessageSize(2*4194304)
     }
 
     static getNetworkGraph(Timestamp since = null, String query = null, String scopeQuery = null) {

--- a/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
@@ -17,6 +17,8 @@ import util.Timer
 class NetworkGraphService extends BaseService {
     static getNetworkGraphClient() {
         return NetworkGraphServiceGrpc.newBlockingStub(getChannel())
+            .withMaxInboundMessageSize(2*4209569)
+            .withMaxOutboundMessageSize(2*4209569)
     }
 
     static getNetworkGraph(Timestamp since = null, String query = null, String scopeQuery = null) {

--- a/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
@@ -94,6 +94,10 @@ class NetworkGraphService extends BaseService {
                         GetExternalNetworkEntitiesRequest.newBuilder().setClusterId(clusterId).build()
                 GetExternalNetworkEntitiesResponse response =
                         getNetworkGraphClient().getExternalNetworkEntities(request)
+
+                // Potential of causing io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED
+                log.info "getExternalNetworkEntities response: ${response}"
+                log.info "getExternalNetworkEntities allEntities: ${response.getEntitiesList()}"
                 NetworkEntity matchingEntity =
                         response
                                 .getEntitiesList()

--- a/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
@@ -95,9 +95,7 @@ class NetworkGraphService extends BaseService {
                 GetExternalNetworkEntitiesResponse response =
                         getNetworkGraphClient().getExternalNetworkEntities(request)
 
-                // Potential of causing io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED
-                log.info "getExternalNetworkEntities response: ${response}"
-                log.info "getExternalNetworkEntities allEntities: ${response.getEntitiesList()}"
+                // Calling response.getEntitiesList() may cause io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED
                 NetworkEntity matchingEntity =
                         response
                                 .getEntitiesList()


### PR DESCRIPTION
## Description

This could help limit the ExternalNetworkSourcesTest failing with `io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: gRPC message exceeds maximum size 4194304: 4210009`.

## Checklist
- [x] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
