### PR TITLE
fix(unused): Remove unused network policies from compliance data

### DIFF
--- a/central/compliance/data/repository.go
+++ b/central/compliance/data/repository.go
@@ -32,7 +32,6 @@ type repository struct {
 	deployments map[string]*storage.Deployment
 
 	unresolvedAlerts             []*storage.ListAlert
-	networkPolicies              map[string]*storage.NetworkPolicy
 	deploymentsToNetworkPolicies map[string][]*storage.NetworkPolicy
 	policies                     map[string]*storage.Policy
 	images                       []*storage.ListImage
@@ -65,10 +64,6 @@ func (r *repository) Nodes() map[string]*storage.Node {
 
 func (r *repository) Deployments() map[string]*storage.Deployment {
 	return r.deployments
-}
-
-func (r *repository) NetworkPolicies() map[string]*storage.NetworkPolicy {
-	return r.networkPolicies
 }
 
 func (r *repository) DeploymentsToNetworkPolicies() map[string][]*storage.NetworkPolicy {
@@ -220,7 +215,6 @@ func (r *repository) init(ctx context.Context, domain framework.ComplianceDomain
 	if err != nil {
 		return err
 	}
-	r.networkPolicies = networkPoliciesByID(networkPolicies)
 
 	networkTree := f.netTreeMgr.GetNetworkTree(ctx, clusterID)
 	if networkTree == nil {

--- a/central/compliance/framework/data.go
+++ b/central/compliance/framework/data.go
@@ -24,7 +24,6 @@ type ComplianceDataRepository interface {
 	Deployments() map[string]*storage.Deployment
 
 	UnresolvedAlerts() []*storage.ListAlert
-	NetworkPolicies() map[string]*storage.NetworkPolicy
 	DeploymentsToNetworkPolicies() map[string][]*storage.NetworkPolicy
 	// Policies returns all policies, keyed by their name.
 	Policies() map[string]*storage.Policy

--- a/central/compliance/framework/mocks/data.go
+++ b/central/compliance/framework/mocks/data.go
@@ -258,20 +258,6 @@ func (mr *MockComplianceDataRepositoryMockRecorder) NetworkFlows() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkFlows", reflect.TypeOf((*MockComplianceDataRepository)(nil).NetworkFlows))
 }
 
-// NetworkPolicies mocks base method.
-func (m *MockComplianceDataRepository) NetworkPolicies() map[string]*storage.NetworkPolicy {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NetworkPolicies")
-	ret0, _ := ret[0].(map[string]*storage.NetworkPolicy)
-	return ret0
-}
-
-// NetworkPolicies indicates an expected call of NetworkPolicies.
-func (mr *MockComplianceDataRepositoryMockRecorder) NetworkPolicies() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkPolicies", reflect.TypeOf((*MockComplianceDataRepository)(nil).NetworkPolicies))
-}
-
 // NodeResults mocks base method.
 func (m *MockComplianceDataRepository) NodeResults() map[string]map[string]*compliance.ComplianceStandardResult {
 	m.ctrl.T.Helper()

--- a/central/compliance/manager/data_promise.go
+++ b/central/compliance/manager/data_promise.go
@@ -70,7 +70,6 @@ func (p *scrapePromise) finish(ctx context.Context, scrapeResult map[string]*com
 		log.Warnf("Did not collect scrape data for %+v", missingNodes)
 	}
 
-	log.Info("CreateDataRepository finish")
 	p.result, err = p.dataRepoFactory.CreateDataRepository(ctx, p.domain)
 	if err == nil {
 		p.result.AddHostScrapedData(scrapeResult)


### PR DESCRIPTION
## Description

Network policies are unused in the data repo so don't load them

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

The compiler checks usage

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
