### PR TITLE
chore(ui): Fix errors and close loophole in airbnb-base lint rules

### DIFF
--- a/ui/apps/platform/config-overrides.js
+++ b/ui/apps/platform/config-overrides.js
@@ -2,9 +2,11 @@ const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
 module.exports = {
     jest: function override(config) {
+        /* eslint-disable no-param-reassign */
         config.transform['^.+\\.css$'] = '<rootDir>/react-app-rewired/jest/cssTransform.js';
         config.transform['^(?!.*\\.(js|jsx|mjs|cjs|ts|tsx|css|json)$)'] =
             '<rootDir>/react-app-rewired/jest/fileTransform.js';
+        /* eslint-enable no-param-reassign */
         return config;
     },
     webpack: function override(config) {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.js
@@ -75,7 +75,7 @@ describe('Workload CVE overview page tests', () => {
             cy.get(selectors.filterChipGroupItems).should('have.lengthOf', 1);
 
             // Ensure the correct search filter is present in the request
-            cy.wait('@' + opname).should((xhr) => {
+            cy.wait(`@${opname}`).should((xhr) => {
                 expect(xhr.request.body.variables.query).to.contain(
                     'SEVERITY:CRITICAL_VULNERABILITY_SEVERITY'
                 );

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -91,6 +91,261 @@ module.exports = [
                 },
             ],
 
+            // Turn on rules from airbnb best-practices config that are not in ESLint recommended.
+            // https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/best-practices.js
+            'array-callback-return': ['error', { allowImplicit: true }],
+            'block-scoped-var': 'error',
+            // 'class-methods-use-this' is intentional omission
+            'consistent-return': 'error',
+            'default-case': ['error', { commentPattern: '^no default$' }],
+            'default-case-last': 'error',
+            // 'default-param-last' is intentional omission
+            'dot-notation': ['error', { allowKeywords: true }],
+            eqeqeq: ['error', 'always', { null: 'ignore' }],
+            'grouped-accessor-pairs': 'error',
+            'guard-for-in': 'error',
+            'max-classes-per-file': ['error', 1],
+            'no-alert': 'warn',
+            'no-caller': 'error',
+            'no-constructor-return': 'error',
+            'no-else-return': ['error', { allowElseIf: false }], // TODO
+            'no-empty-function': [
+                'error',
+                {
+                    allow: ['arrowFunctions', 'functions', 'methods'],
+                },
+            ],
+            'no-eval': 'error',
+            'no-extend-native': 'error',
+            'no-extra-bind': 'error',
+            'no-extra-label': 'error',
+            'no-implied-eval': 'error',
+            'no-iterator': 'error',
+            'no-labels': ['error', { allowLoop: false, allowSwitch: false }],
+            'no-lone-blocks': 'error',
+            'no-loop-func': 'error',
+            'no-multi-str': 'error',
+            'no-new': 'error',
+            'no-new-func': 'error',
+            'no-new-wrappers': 'error',
+            'no-octal-escape': 'error',
+            'no-param-reassign': [
+                'error',
+                {
+                    props: true,
+                    ignorePropertyModificationsFor: [
+                        'acc', // for reduce accumulators
+                        'accumulator', // for reduce accumulators
+                        'e', // for e.returnvalue
+                        'ctx', // for Koa routing
+                        'context', // for Koa routing
+                        'req', // for Express requests
+                        'request', // for Express requests
+                        'res', // for Express responses
+                        'response', // for Express responses
+                        '$scope', // for Angular 1 scopes
+                        'staticContext', // for ReactRouter context
+                    ],
+                },
+            ],
+            'no-proto': 'error',
+            'no-restricted-properties': [
+                'error',
+                {
+                    object: 'arguments',
+                    property: 'callee',
+                    message: 'arguments.callee is deprecated',
+                },
+                {
+                    object: 'global',
+                    property: 'isFinite',
+                    message: 'Please use Number.isFinite instead',
+                },
+                {
+                    object: 'self',
+                    property: 'isFinite',
+                    message: 'Please use Number.isFinite instead',
+                },
+                {
+                    object: 'window',
+                    property: 'isFinite',
+                    message: 'Please use Number.isFinite instead',
+                },
+                {
+                    object: 'global',
+                    property: 'isNaN',
+                    message: 'Please use Number.isNaN instead',
+                },
+                {
+                    object: 'self',
+                    property: 'isNaN',
+                    message: 'Please use Number.isNaN instead',
+                },
+                {
+                    object: 'window',
+                    property: 'isNaN',
+                    message: 'Please use Number.isNaN instead',
+                },
+                {
+                    property: '__defineGetter__',
+                    message: 'Please use Object.defineProperty instead.',
+                },
+                {
+                    property: '__defineSetter__',
+                    message: 'Please use Object.defineProperty instead.',
+                },
+                {
+                    object: 'Math',
+                    property: 'pow',
+                    message: 'Use the exponentiation operator (**) instead.',
+                },
+            ],
+            'no-return-assign': ['error', 'always'],
+            'no-script-url': 'error',
+            'no-self-compare': 'error',
+            'no-sequences': 'error',
+            'no-throw-literal': 'error',
+            'no-unused-expressions': [
+                'error',
+                {
+                    allowShortCircuit: false,
+                    allowTernary: false,
+                    allowTaggedTemplates: false,
+                },
+            ],
+            'no-useless-concat': 'error',
+            'no-useless-return': 'error',
+            'no-void': 'error',
+            'prefer-promise-reject-errors': ['error', { allowEmptyReject: true }],
+            /*
+            'prefer-regex-literals': [
+                'error',
+                {
+                    disallowRedundantWrapping: true,
+                },
+            ],
+            */ // decide either is omitted intentionally, fix 3 errors, or disable comments
+            // radix: 'error', // TODO comment in after making sure no semantic merge conflict
+            'vars-on-top': 'error',
+            yoda: 'error',
+
+            // Turn on rules from airbnb errors config that are not in ESLint recommended.
+            // https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/errors.js
+            'for-direction': 'error',
+            'getter-return': ['error', { allowImplicit: true }],
+            'no-async-promise-executor': 'error',
+            'no-compare-neg-zero': 'error',
+            'no-cond-assign': ['error', 'always'],
+            'no-constant-condition': 'warn',
+            'no-control-regex': 'error',
+            'no-debugger': 'error',
+            'no-dupe-args': 'error',
+            'no-dupe-else-if': 'error',
+            'no-dupe-keys': 'error',
+            'no-duplicate-case': 'error',
+            'no-empty': 'error',
+            'no-empty-character-class': 'error',
+            'no-ex-assign': 'error',
+            'no-extra-boolean-cast': 'error',
+            'no-extra-semi': 'error',
+            'no-func-assign': 'error',
+            'no-import-assign': 'error',
+            'no-inner-declarations': 'error',
+            'no-invalid-regexp': 'error',
+            'no-irregular-whitespace': 'error',
+            'no-loss-of-precision': 'error',
+            'no-misleading-character-class': 'error',
+            'no-obj-calls': 'error',
+            'no-prototype-builtins': 'error',
+            'no-regex-spaces': 'error',
+            'no-setter-return': 'error',
+            'no-sparse-arrays': 'error',
+            'no-unexpected-multiline': 'error',
+            'no-unreachable': 'error',
+            'no-unsafe-finally': 'error',
+            'no-unsafe-negation': 'error',
+            'no-unsafe-optional-chaining': ['error', { disallowArithmeticOperators: true }],
+            'no-useless-backreference': 'error',
+            'use-isnan': 'error',
+            'valid-typeof': ['error', { requireStringLiterals: true }],
+
+            'no-await-in-loop': 'error',
+            // 'no-promise-executor-return': 'error', // fix 5 errors
+            'no-template-curly-in-string': 'error',
+            'no-unreachable-loop': [
+                'error',
+                {
+                    ignore: [],
+                },
+            ],
+
+            // Turn on rules from airbnb es6 config that are not in ESLint recommended.
+            // https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/es6.js
+            // 'arrow-body-style' is intentional omission
+            'constructor-super': 'error',
+            'no-class-assign': 'error',
+            'no-const-assign': 'error',
+            'no-dupe-class-members': 'error',
+            'no-new-symbol': 'error',
+            'no-this-before-super': 'error',
+            'require-yield': 'error',
+            // 'no-restricted-exports' is intentional omission
+            'no-useless-computed-key': 'error',
+            'no-useless-constructor': 'error',
+            'no-useless-rename': [
+                'error',
+                {
+                    ignoreDestructuring: false,
+                    ignoreImport: false,
+                    ignoreExport: false,
+                },
+            ],
+            'no-var': 'error',
+            'object-shorthand': [
+                'error',
+                'always',
+                {
+                    ignoreConstructors: false,
+                    avoidQuotes: true,
+                },
+            ],
+            'prefer-arrow-callback': [
+                'error',
+                {
+                    allowNamedFunctions: false,
+                    allowUnboundThis: true,
+                },
+            ],
+            'prefer-const': [
+                'error',
+                {
+                    destructuring: 'any',
+                    ignoreReadBeforeAssign: true,
+                },
+            ],
+            'prefer-destructuring': [
+                'error',
+                {
+                    VariableDeclarator: {
+                        array: false,
+                        object: true,
+                    },
+                    AssignmentExpression: {
+                        array: true,
+                        object: false,
+                    },
+                },
+                {
+                    enforceForRenamedProperties: false,
+                },
+            ],
+            'prefer-numeric-literals': 'error',
+            'prefer-rest-params': 'error',
+            'prefer-spread': 'error',
+            'prefer-template': 'error',
+            'rest-spread-spacing': ['error', 'never'], // deprecated
+            'symbol-description': 'error',
+
             // Turn on rules from airbnb import config that are not in import errors config.
             // https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/imports.js
             'import/first': 'error',
@@ -111,6 +366,70 @@ module.exports = [
             'import/no-webpack-loader-syntax': 'error',
             'import/order': ['error', { groups: [['builtin', 'external', 'internal']] }],
             // 'import/prefer-default-export' is intentional omission
+
+            // Turn on rules from airbnb style config that are not in ESLint recommended.
+            // https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js
+            // camelcase is intentional omission
+            /*
+            // Discuss with team whether or not to turn on this rule
+            'max-len': [
+                'error',
+                100,
+                2,
+                {
+                    ignoreUrls: true,
+                    ignoreComments: false,
+                    ignoreRegExpLiterals: true,
+                    ignoreStrings: true,
+                    ignoreTemplateLiterals: true,
+                },
+            ],
+            */
+            'new-cap': [
+                'error',
+                {
+                    newIsCap: true,
+                    newIsCapExceptions: [],
+                    capIsNew: false,
+                    capIsNewExceptions: ['Immutable.Map', 'Immutable.Set', 'Immutable.List'],
+                },
+            ],
+            'no-array-constructor': 'error',
+            'no-bitwise': 'error',
+            'no-continue': 'error',
+            'no-multi-assign': ['error'],
+            'no-nested-ternary': 'error',
+            'no-plusplus': 'error',
+            'no-restricted-syntax': [
+                'error',
+                {
+                    selector: 'ForInStatement',
+                    message:
+                        'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+                },
+                {
+                    selector: 'ForOfStatement',
+                    message:
+                        'iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations.',
+                },
+                {
+                    selector: 'LabeledStatement',
+                    message:
+                        'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+                },
+                {
+                    selector: 'WithStatement',
+                    message:
+                        '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+                },
+            ],
+            // 'no-underscore-dangle' is intentional omission
+            'no-unneeded-ternary': ['error', { defaultAssignment: false }],
+            'one-var': ['error', 'never'],
+            'operator-assignment': ['error', 'always'],
+            'prefer-exponentiation-operator': 'error',
+            'prefer-object-spread': 'error',
+            'unicode-bom': ['error', 'never'],
 
             'prettier/prettier': 'error',
         },
@@ -162,9 +481,6 @@ module.exports = [
         rules: {
             // Turn off rules from ESLint recommended configuration.
 
-            // Omit warnings for anonymous functions to skip individual tests.
-            'func-names': 'off',
-
             // Allow chai-style expect(x).to.be.true chain.
             'no-unused-expressions': 'off',
 
@@ -211,6 +527,10 @@ module.exports = [
                     ],
                 },
             ],
+
+            // Turn on rules from airbnb strict config that are not in ESLint recommended.
+            // https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/strict.js
+            strict: ['error', 'never'], // babel inserts `'use strict';` for us
 
             'import/no-extraneous-dependencies': [
                 'error',
@@ -282,7 +602,7 @@ module.exports = [
             // https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/index.js
             ...pluginReactHooks.configs.recommended.rules,
 
-            // 'react-hooks/exhaustive-deps': 'warn', // TODO fix errors and then change from default warn to error? or generic warnings as errors?
+            // 'react-hooks/exhaustive-deps': 'warn', // TODO fix errors and then change from default warn to error?
         },
     },
     {

--- a/ui/apps/platform/src/Components/visuals/Sunburst.js
+++ b/ui/apps/platform/src/Components/visuals/Sunburst.js
@@ -22,6 +22,7 @@ function highlightPathData(data, highlightedNames) {
     if (data.children) {
         data.children.map((child) => highlightPathData(child, highlightedNames));
     }
+    // eslint-disable-next-line no-param-reassign
     data.style = {
         ...data.style,
         fillOpacity: highlightedNames && !highlightedNames.includes(data.name) ? 0.3 : 1,

--- a/ui/apps/platform/src/global/initializeAnalytics.js
+++ b/ui/apps/platform/src/global/initializeAnalytics.js
@@ -1,4 +1,8 @@
 /* eslint-disable no-console */
+/* eslint-disable no-multi-assign */
+/* eslint-disable no-plusplus */
+/* eslint-disable no-unused-expressions */
+/* eslint-disable prefer-rest-params */
 
 // the code below is generated from segment api with the exception of the writeKey/userId parameters as well as the analyticsIdentity call
 // segment intends for the write key to be hardcoded but we are pulling it from the telemetry config service call and adding it using a parameter


### PR DESCRIPTION
## Description

Follow up residue for eslint-config-airbnb-base after #8813

### Potential problem

If software quality criteria becomes less strict, then cherry pick of commits into patch release branches might report errors according to earlier configurations and versions of devDependencies.

### Analysis

Usually software quality criteria has become more strict in ESLint, Prettier, and TypeScript, therefore when an upgrade causes many errors, it is possible to fix them **in batches**, because the changes are **not errors**  according to earlier configurations and versions of devDependencies.

However, deleting airbnb config opened a loophole:
* Some rules had been turned on, **but are not now**.
* However, some of them are deprecated because redundant with Prettier.

The following do not require any change:
* Some rules had been turned on, **and are now** because they are also in eslint recommended.
* Some rules that had been turned off, **and are now** because they are not in eslint recommended.

### Solution

1. Explicitly turn on rules from eslint-config-airbnb-base
    * that are not in ESLint recommended
        https://github.com/eslint/eslint/blob/main/packages/js/src/configs/eslint-recommended.js
    * and are not deprecated for ESLint 9
        https://eslint.org/blog/2023/10/deprecating-formatting-rules/#the-deprecated-rules
2. Comment out a few rules:
    * Until we can fix errors.
    * Pending discussion with the team.
3. Delete unneeded override for omitted `'func-names': 'warn'` configuration.

### Residue

1. Follow up with eslint-config-airbnb
    * react-a11y
    * react-hooks
    * react

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui and ui/apps/platform
2. `yarn build` in ui
3. `yarn start` in ui