### PR TITLE
fix(perf): Constrain flows to deployment destinations

### DIFF
--- a/central/compliance/checks/common/checks.go
+++ b/central/compliance/checks/common/checks.go
@@ -478,7 +478,7 @@ func CheckSecretsInEnv(ctx framework.ComplianceContext) {
 // CheckRuntimeSupportInCluster checks if runtime is enabled and collector
 // is sending process and network data.
 func CheckRuntimeSupportInCluster(ctx framework.ComplianceContext) {
-	if ctx.Data().Cluster().GetCollectionMethod() != storage.CollectionMethod_NO_COLLECTION && ctx.Data().HasProcessIndicators() && len(ctx.Data().NetworkFlows()) > 0 {
+	if ctx.Data().Cluster().GetCollectionMethod() != storage.CollectionMethod_NO_COLLECTION && ctx.Data().HasProcessIndicators() && len(ctx.Data().NetworkFlowsWithDeploymentDst()) > 0 {
 		framework.PassNowf(ctx, "Runtime support is enabled (or collector service is running) for cluster %s. Network visualization for active network connections is possible.", ctx.Data().Cluster().GetName())
 	}
 	framework.Failf(ctx, "Runtime support is not enabled (or collector service is not running) for cluster %s. Network visualization for active network connections is not possible.", ctx.Data().Cluster().GetName())

--- a/central/compliance/checks/hipaa_164/check308a1iia/check_test.go
+++ b/central/compliance/checks/hipaa_164/check308a1iia/check_test.go
@@ -59,7 +59,7 @@ func (s *suiteImpl) TestFail() {
 	data.EXPECT().ImageIntegrations().AnyTimes().Return(imageIntegrations)
 	data.EXPECT().Images().AnyTimes().Return(images)
 	data.EXPECT().HasProcessIndicators().AnyTimes().Return(false)
-	data.EXPECT().NetworkFlows().AnyTimes().Return(nil)
+	data.EXPECT().NetworkFlowsWithDeploymentDst().AnyTimes().Return(nil)
 
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
@@ -119,7 +119,7 @@ func (s *suiteImpl) TestPass() {
 	data.EXPECT().ImageIntegrations().AnyTimes().Return(imageIntegrations)
 	data.EXPECT().Images().AnyTimes().Return(images)
 	data.EXPECT().HasProcessIndicators().AnyTimes().Return(true)
-	data.EXPECT().NetworkFlows().AnyTimes().Return(flows)
+	data.EXPECT().NetworkFlowsWithDeploymentDst().AnyTimes().Return(flows)
 
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)

--- a/central/compliance/checks/pcidss32/check225/check.go
+++ b/central/compliance/checks/pcidss32/check225/check.go
@@ -23,13 +23,10 @@ func init() {
 func clusterIsCompliant(ctx framework.ComplianceContext) {
 	// Map deployments to flows where it is the destination.
 	deploymentIDToIncomingFlows := make(map[string][]*storage.NetworkFlow)
-	for _, flow := range ctx.Data().NetworkFlows() {
+	for _, flow := range ctx.Data().NetworkFlowsWithDeploymentDst() {
 		dst := flow.GetProps().GetDstEntity()
-		if flow.GetProps().GetDstEntity().GetType() == storage.NetworkEntityInfo_DEPLOYMENT {
-			deploymentIDToIncomingFlows[dst.GetId()] = append(deploymentIDToIncomingFlows[dst.GetId()], flow)
-		}
+		deploymentIDToIncomingFlows[dst.GetId()] = append(deploymentIDToIncomingFlows[dst.GetId()], flow)
 	}
-
 	// Map enabled ports
 	framework.ForEachDeployment(ctx, func(ctx framework.ComplianceContext, deployment *storage.Deployment) {
 		deploymentIsCompliant(ctx, deployment, deploymentIDToIncomingFlows[deployment.GetId()])

--- a/central/compliance/checks/pcidss32/check225/check_test.go
+++ b/central/compliance/checks/pcidss32/check225/check_test.go
@@ -72,7 +72,7 @@ func (s *suiteImpl) TestUnusedPorts() {
 	}
 
 	data := mocks.NewMockComplianceDataRepository(s.mockCtrl)
-	data.EXPECT().NetworkFlows().AnyTimes().Return(flows)
+	data.EXPECT().NetworkFlowsWithDeploymentDst().AnyTimes().Return(flows)
 
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
@@ -145,7 +145,7 @@ func (s *suiteImpl) TestPass() {
 	}
 
 	data := mocks.NewMockComplianceDataRepository(s.mockCtrl)
-	data.EXPECT().NetworkFlows().AnyTimes().Return(flows)
+	data.EXPECT().NetworkFlowsWithDeploymentDst().AnyTimes().Return(flows)
 
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
@@ -162,7 +162,7 @@ func (s *suiteImpl) TestPass() {
 		deploymentResults := checkResults.ForChild(deployment)
 		s.NoError(deploymentResults.Error())
 		s.Len(deploymentResults.Evidence(), 1)
-		s.Equal(framework.FailStatus, deploymentResults.Evidence()[0].Status)
+		s.Equal(framework.PassStatus, deploymentResults.Evidence()[0].Status)
 	}
 }
 

--- a/central/compliance/framework/data.go
+++ b/central/compliance/framework/data.go
@@ -34,7 +34,7 @@ type ComplianceDataRepository interface {
 	ScannerIntegrations() []ImageMatcher
 	SSHProcessIndicators() []*storage.ProcessIndicator
 	HasProcessIndicators() bool
-	NetworkFlows() []*storage.NetworkFlow
+	NetworkFlowsWithDeploymentDst() []*storage.NetworkFlow
 	PolicyCategories() map[string]set.StringSet
 	Notifiers() []*storage.Notifier
 	K8sRoles() []*storage.K8SRole

--- a/central/compliance/framework/mocks/data.go
+++ b/central/compliance/framework/mocks/data.go
@@ -244,18 +244,18 @@ func (mr *MockComplianceDataRepositoryMockRecorder) K8sRoles() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "K8sRoles", reflect.TypeOf((*MockComplianceDataRepository)(nil).K8sRoles))
 }
 
-// NetworkFlows mocks base method.
-func (m *MockComplianceDataRepository) NetworkFlows() []*storage.NetworkFlow {
+// NetworkFlowsWithDeploymentDst mocks base method.
+func (m *MockComplianceDataRepository) NetworkFlowsWithDeploymentDst() []*storage.NetworkFlow {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NetworkFlows")
+	ret := m.ctrl.Call(m, "NetworkFlowsWithDeploymentDst")
 	ret0, _ := ret[0].([]*storage.NetworkFlow)
 	return ret0
 }
 
-// NetworkFlows indicates an expected call of NetworkFlows.
-func (mr *MockComplianceDataRepositoryMockRecorder) NetworkFlows() *gomock.Call {
+// NetworkFlowsWithDeploymentDst indicates an expected call of NetworkFlowsWithDeploymentDst.
+func (mr *MockComplianceDataRepositoryMockRecorder) NetworkFlowsWithDeploymentDst() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkFlows", reflect.TypeOf((*MockComplianceDataRepository)(nil).NetworkFlows))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkFlowsWithDeploymentDst", reflect.TypeOf((*MockComplianceDataRepository)(nil).NetworkFlowsWithDeploymentDst))
 }
 
 // NetworkPolicies mocks base method.

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store_test.go
@@ -332,5 +332,5 @@ func (s *NetworkflowStoreSuite) TestGetMatching() {
 	filteredFlows, _, err := s.store.GetMatchingFlows(s.ctx, deploymentIngressFlowsPredicate, nil)
 	s.Nil(err)
 
-	s.Equal([]*storage.NetworkFlow{flows[1], flows[2]}, filteredFlows)
+	s.ElementsMatch([]*storage.NetworkFlow{flows[1], flows[2]}, filteredFlows)
 }

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store_test.go
@@ -332,5 +332,9 @@ func (s *NetworkflowStoreSuite) TestGetMatching() {
 	filteredFlows, _, err := s.store.GetMatchingFlows(s.ctx, deploymentIngressFlowsPredicate, nil)
 	s.Nil(err)
 
+	log.Infof("Expected: %s %s", flows[1], flows[2])
+	for idx, flow := range filteredFlows {
+		log.Infof("Actual %d: %s", idx, flow)
+	}
 	s.ElementsMatch([]*storage.NetworkFlow{flows[1], flows[2]}, filteredFlows)
 }


### PR DESCRIPTION
## Description

Don't load egress flows or any flow that is not terminating at a deployment, which is what is used for the compliance check. The other length check is still reasonable in terms of having a deployment that has received at least 1 ingress flow

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Unit test modifications

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
