### PR TITLE
fix(ui): Disable cache for nextFetchPolicy on deployment page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -129,6 +129,7 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
         { id: string; query: string; statusesForExceptionCount: string[] }
     >(summaryQuery, {
         fetchPolicy: 'no-cache',
+        nextFetchPolicy: 'no-cache',
         variables: {
             id: deploymentId,
             query,
@@ -160,6 +161,7 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
         }
     >(deploymentVulnerabilitiesQuery, {
         fetchPolicy: 'no-cache',
+        nextFetchPolicy: 'no-cache',
         variables: {
             id: deploymentId,
             query,


### PR DESCRIPTION
## Description

Fixes a related cache issue on the Workload CVE deployment page. This issue can be reproduced by the following:

- Visit an individual Workload CVE Deployment page
- Perform an action that causes a second request to be sent (change the page, change the perPage, sort a column, etc.)
- The correct data will be displayed in the table
- **Wait between 5 and 30 seconds**
- Another request is sent, which ignores the `fetchPolicy: 'no-cache'` option, updates the cache and displays invalid data.

_I don't know exactly why this occurs, or why this fix is the answer._ I can reliably reproduce the behavior before/after the change, and it reliably only happens on the Deployment single page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Before this change:

Visit a deployment page:
![image](https://github.com/stackrox/stackrox/assets/1292638/6e1eb66f-df73-4bcb-9158-4ffde825dbb8)

Set the perPage to a new value:
![image](https://github.com/stackrox/stackrox/assets/1292638/e3a850f8-83ec-4be1-ac89-c567da334966)

Just wait a little while (the first 20 second of this video were trimmed off):

https://github.com/stackrox/stackrox/assets/1292638/a1788381-7c6e-4589-af65-3d8edcbb1929



