### PR TITLE
feat(notify-sync): notify components when the sync is done

### DIFF
--- a/sensor/common/sensor/central_communication.go
+++ b/sensor/common/sensor/central_communication.go
@@ -12,7 +12,7 @@ import (
 
 // CentralCommunication interface allows you to start and stop the consumption/production loops.
 type CentralCommunication interface {
-	Start(client central.SensorServiceClient, centralReachable *concurrency.Flag, handler config.Handler, detector detector.Detector)
+	Start(client central.SensorServiceClient, centralReachable *concurrency.Flag, syncDone *concurrency.Signal, handler config.Handler, detector detector.Detector)
 	Stop(error)
 	Stopped() concurrency.ReadOnlyErrorSignal
 }


### PR DESCRIPTION
## Description

Some components might benefit from knowing when the sync with Central has finished (see [this comment]( https://github.com/stackrox/stackrox/pull/8889/files#r1422707054)).

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] The test `Test_StartCentralCommunication` now checks for the `syncDone` signal.
- [x] Check Sensor's logs to verify that now the components receive the new notification.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
