### PR TITLE
fix(admin-events): fix domain mapping for integrations

### DIFF
--- a/pkg/administration/events/domain.go
+++ b/pkg/administration/events/domain.go
@@ -11,9 +11,9 @@ const (
 
 var (
 	moduleToDomain = map[*regexp.Regexp]string{
-		regexp.MustCompile(`^reprocessor|image/service`): imageScanningDomain,
-		regexp.MustCompile(`^pkg/notifiers(/|$)`):        integrationDomain,
-		regexp.MustCompile(`^apitoken/expiration`):       authenticationDomain,
+		regexp.MustCompile(`^reprocessor|image/service`):         imageScanningDomain,
+		regexp.MustCompile(`^pkg/notifiers(/|$)|notifiers(/|$)`): integrationDomain,
+		regexp.MustCompile(`^apitoken/expiration`):               authenticationDomain,
 	}
 )
 


### PR DESCRIPTION
## Description

Implementations for notifier specific types have moved from `pkg/notifiers` to `central/notifiers` which results in the domain mapping not being done correctly from log messages emitted from the new location, which in turn leads to hints not being rendered correctly.

This fixes this.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- N/A.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
