### PR TITLE
chore(perf): Make data repo creation async in Compliance

### DIFF
--- a/central/compliance/manager/data_promise.go
+++ b/central/compliance/manager/data_promise.go
@@ -13,25 +13,23 @@ import (
 )
 
 type dataPromise interface {
-	WaitForResult(cancel concurrency.Waitable) (framework.ComplianceDataRepository, error)
+	WaitForResult(ctx context.Context) (framework.ComplianceDataRepository, error)
 }
 
 type fixedDataPromise struct {
-	dataRepo framework.ComplianceDataRepository
-	err      error
+	dataRepoFactory data.RepositoryFactory
+	domain          framework.ComplianceDomain
 }
 
-func newFixedDataPromise(ctx context.Context, dataRepoFactory data.RepositoryFactory, domain framework.ComplianceDomain) dataPromise {
-	dataRepo, err := dataRepoFactory.CreateDataRepository(ctx, domain)
-
+func newFixedDataPromise(dataRepoFactory data.RepositoryFactory, domain framework.ComplianceDomain) dataPromise {
 	return &fixedDataPromise{
-		dataRepo: dataRepo,
-		err:      err,
+		dataRepoFactory: dataRepoFactory,
+		domain:          domain,
 	}
 }
 
-func (p *fixedDataPromise) WaitForResult(_ concurrency.Waitable) (framework.ComplianceDataRepository, error) {
-	return p.dataRepo, p.err
+func (p *fixedDataPromise) WaitForResult(ctx context.Context) (framework.ComplianceDataRepository, error) {
+	return p.dataRepoFactory.CreateDataRepository(ctx, p.domain)
 }
 
 // scrapePromise allows access to compliance data in an asynchronous way, allowing multiple runs to wait on the same
@@ -77,8 +75,8 @@ func (p *scrapePromise) finish(ctx context.Context, scrapeResult map[string]*com
 	p.finishedSig.SignalWithError(err)
 }
 
-func (p *scrapePromise) WaitForResult(cancel concurrency.Waitable) (framework.ComplianceDataRepository, error) {
-	err, done := p.finishedSig.WaitUntil(cancel)
+func (p *scrapePromise) WaitForResult(ctx context.Context) (framework.ComplianceDataRepository, error) {
+	err, done := p.finishedSig.WaitUntil(ctx)
 	if !done {
 		return nil, errors.New("cancelled while waiting for compliance results")
 	}

--- a/central/compliance/manager/manager_impl.go
+++ b/central/compliance/manager/manager_impl.go
@@ -355,7 +355,7 @@ func (m *manager) createAndLaunchRuns(ctx context.Context, clusterStandardPairs 
 				dataPromise = scrapeBasedPromise
 			} else {
 				if scrapeLessPromise == nil {
-					scrapeLessPromise = newFixedDataPromise(elevatedCtx, perClusterDataRepoOnce, domain)
+					scrapeLessPromise = newFixedDataPromise(perClusterDataRepoOnce, domain)
 				}
 				dataPromise = scrapeLessPromise
 			}


### PR DESCRIPTION
## Description

Decouples the trigger call for compliance which is synchronous to be asynchronous to fix a 60s timeout in the compliance UI

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Will run a scale test to see that all compliance checks run immediately

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
