### PR TITLE
ROX-17185: retry gql queries in e2e tests

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/ComplianceService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ComplianceService.groovy
@@ -17,6 +17,8 @@ import org.apache.http.conn.ssl.NoopHostnameVerifier
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory
 import org.apache.http.conn.ssl.TrustAllStrategy
 import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler
+import org.apache.http.impl.client.DefaultServiceUnavailableRetryStrategy
 import org.apache.http.impl.client.HttpClients
 import org.apache.http.ssl.SSLContextBuilder
 
@@ -115,8 +117,12 @@ class ComplianceService extends BaseService {
                 .build()
         HostnameVerifier allowAllHosts = new NoopHostnameVerifier()
         SSLConnectionSocketFactory connectionFactory = new SSLConnectionSocketFactory(sslContext, allowAllHosts)
+        int maxRetryCount = 3
+        int retryIntervalMs = 5000
         CloseableHttpClient client = HttpClients
                 .custom()
+                .setRetryHandler(new DefaultHttpRequestRetryHandler(maxRetryCount, true))
+                .setServiceUnavailableRetryStrategy(new DefaultServiceUnavailableRetryStrategy(maxRetryCount, retryIntervalMs))
                 .setSSLSocketFactory(connectionFactory)
                 .build()
 

--- a/qa-tests-backend/src/main/groovy/services/ComplianceService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ComplianceService.groovy
@@ -121,8 +121,10 @@ class ComplianceService extends BaseService {
         int retryIntervalMs = 5000
         CloseableHttpClient client = HttpClients
                 .custom()
-                .setRetryHandler(new DefaultHttpRequestRetryHandler(maxRetryCount, true))
-                .setServiceUnavailableRetryStrategy(new DefaultServiceUnavailableRetryStrategy(maxRetryCount, retryIntervalMs))
+                .setRetryHandler(
+                        new DefaultHttpRequestRetryHandler(maxRetryCount, true))
+                .setServiceUnavailableRetryStrategy(
+                        new DefaultServiceUnavailableRetryStrategy(maxRetryCount, retryIntervalMs))
                 .setSSLSocketFactory(connectionFactory)
                 .build()
 

--- a/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
@@ -134,7 +134,7 @@ class GraphQLService {
         private Response parseResponse(HttpResponse response)  {
             def bsa = new ByteArrayOutputStream()
             response.getEntity().writeTo(bsa)
-            def status = response.getStatusLine()
+            StatusLine status = response.getStatusLine()
             log.debug "GraphQL response: $status: " + (
                 bsa.size() < MAX_LOG_CHARS ? bsa : bsa.toString().take(MAX_LOG_CHARS) + "...")
             if (status.statusCode != 200) {

--- a/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
@@ -153,11 +153,14 @@ class GraphQLService {
                 .build()
             HostnameVerifier allowAllHosts = new NoopHostnameVerifier()
             SSLConnectionSocketFactory connectionFactory = new SSLConnectionSocketFactory(sslContext, allowAllHosts)
+
+            int maxRetryCount = 3
+            int retryIntervalMs = 5000
             CloseableHttpClient client = HttpClients
                     .custom()
                     .setSSLSocketFactory(connectionFactory)
-                    .setRetryHandler(new DefaultHttpRequestRetryHandler(3, true))
-                    .setServiceUnavailableRetryStrategy(new DefaultServiceUnavailableRetryStrategy())
+                    .setRetryHandler(new DefaultHttpRequestRetryHandler(maxRetryCount, true))
+                    .setServiceUnavailableRetryStrategy(new DefaultServiceUnavailableRetryStrategy(maxRetryCount, retryIntervalMs))
                     .build()
             return client
         }

--- a/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
@@ -13,6 +13,8 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory
 import org.apache.http.conn.ssl.TrustAllStrategy
 import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler
+import org.apache.http.impl.client.DefaultServiceUnavailableRetryStrategy
 import org.apache.http.impl.client.HttpClients
 import org.apache.http.ssl.SSLContextBuilder
 import util.Env
@@ -124,13 +126,8 @@ class GraphQLService {
             CloseableHttpClient client = buildClient()
             HttpPost httpPost = buildRequest(headers, content)
 
-            try {
-                HttpResponse response = client.execute(httpPost)
-                return parseResponse(response)
-            } catch (Exception e) {
-                log.error("failed to GQL post", e)
-            }
-            return new Response()
+            HttpResponse response = client.execute(httpPost)
+            return parseResponse(response)
         }
 
         private Response parseResponse(HttpResponse response)  {
@@ -153,6 +150,8 @@ class GraphQLService {
             CloseableHttpClient client = HttpClients
                     .custom()
                     .setSSLSocketFactory(connectionFactory)
+                    .setRetryHandler(new DefaultHttpRequestRetryHandler(3, true))
+                    .setServiceUnavailableRetryStrategy(new DefaultServiceUnavailableRetryStrategy())
                     .build()
             return client
         }

--- a/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
@@ -159,8 +159,10 @@ class GraphQLService {
             CloseableHttpClient client = HttpClients
                     .custom()
                     .setSSLSocketFactory(connectionFactory)
-                    .setRetryHandler(new DefaultHttpRequestRetryHandler(maxRetryCount, true))
-                    .setServiceUnavailableRetryStrategy(new DefaultServiceUnavailableRetryStrategy(maxRetryCount, retryIntervalMs))
+                    .setRetryHandler(
+                            new DefaultHttpRequestRetryHandler(maxRetryCount, true))
+                    .setServiceUnavailableRetryStrategy(
+                            new DefaultServiceUnavailableRetryStrategy(maxRetryCount, retryIntervalMs))
                     .build()
             return client
         }


### PR DESCRIPTION
## Description

For some reason when HTTP client encourage an error we only log it and return empty response. This makes addresing CI failure problematic as failing assertion might be misleading and the root cause of the problem is in the log. This PR replaces this behaviour with not catching exception at all and allowing it to bubble up to a test so it will be obvious why test failed.
Another change to minimize networking issues negatively impacting our test success rate this PR adds retrying of failed request either for IO exception as well as 501 errors.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
