### PR TITLE
chore(ui): Revert "collect coverage for UI unittests"

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -40,11 +40,7 @@ start: deps
 .PHONY: test
 test: deps $(SOURCES)
 	@echo "+ $@"
-ifdef CI
-	cd apps/platform; yarn test-coverage
-else
-	cd apps/platform; yarn test
-endif
+	yarn test
 
 .PHONY: test-e2e
 test-e2e: deps $(SOURCES)

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -40,7 +40,7 @@ start: deps
 .PHONY: test
 test: deps $(SOURCES)
 	@echo "+ $@"
-	yarn test
+	cd apps/platform; yarn test
 
 .PHONY: test-e2e
 test-e2e: deps $(SOURCES)


### PR DESCRIPTION
This reverts commit 6d53f574a3d4485a7a4b755de4387dc248e21b2c.

## Description

Revert a prior commit that caused UI tests to generate coverage file in CI. Keeps the change to the `apps/platform` directory.

I did not revert https://github.com/stackrox/stackrox/pull/8948 as it seems like that was a fix that is independent of the codecov integration and something we want to keep.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
