### PR TITLE
ROX-19054: Add upgrade logic to Scanner V4 CI test

### DIFF
--- a/deploy/common/ci-values.yaml
+++ b/deploy/common/ci-values.yaml
@@ -17,3 +17,29 @@ scanner:
   replicas: 1
   autoscaling:
     disable: true
+
+scannerV4:
+  matcher:
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "800m"
+      limits:
+        memory: "4Gi"
+        cpu: "2000m"
+  indexer:
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "800m"
+      limits:
+        memory: "4Gi"
+        cpu: "2000m"
+  db:
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "500m"
+      limits:
+        memory: "4Gi"
+        cpu: "2000m"

--- a/deploy/common/ci-values.yaml
+++ b/deploy/common/ci-values.yaml
@@ -22,7 +22,7 @@ scannerV4:
   matcher:
     resources:
       requests:
-        memory: "2Gi"
+        memory: "4Gi"
         cpu: "800m"
       limits:
         memory: "4Gi"

--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -81,6 +81,17 @@
   {{ include "srox.configureImage" (list $ $scannerV4Cfg.indexer.image) }}
   {{- if eq $.Chart.Name "stackrox-central-services" -}}
     {{/* Only generate certificate when installing central-services. */}}
+    {{- if kindIs "invalid" $._rox.scannerV4.indexer.serviceTLS.generate }}
+      {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
+      {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
+      {{- $lookupOut := dict -}}
+      {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-indexer-tls") -}}
+      {{- if not $lookupOut.result -}}
+        {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
+        {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
+        {{- $_ := set $._rox.scannerV4.indexer.serviceTLS "generate" true -}}
+      {{- end -}}
+    {{- end }}
     {{ $cryptoSpec := dict "CN" "SCANNER_SERVICE: Scanner V4 Indexer" "dnsBase" "scanner-v4" }}
     {{ include "srox.configureCrypto" (list $ "scannerV4.indexer.serviceTLS" $cryptoSpec) }}
   {{- end -}}
@@ -90,14 +101,49 @@
   {{ include "srox.configureImage" (list $ $scannerV4Cfg.matcher.image) }}
   {{- if eq $.Chart.Name "stackrox-central-services" -}}
     {{/* Only generate certificate when installing central-services. */}}
+    {{- if kindIs "invalid" $._rox.scannerV4.matcher.serviceTLS.generate }}
+      {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
+      {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
+      {{- $lookupOut := dict -}}
+      {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-matcher-tls") -}}
+      {{- if not $lookupOut.result -}}
+        {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
+        {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
+        {{- $_ := set $._rox.scannerV4.matcher.serviceTLS "generate" true -}}
+      {{- end -}}
+    {{- end }}
     {{ $cryptoSpec := dict "CN" "SCANNER_SERVICE: Scanner V4 Matcher" "dnsBase" "scanner-v4" }}
     {{ include "srox.configureCrypto" (list $ "scannerV4.matcher.serviceTLS" $cryptoSpec) }}
   {{- end -}}
 {{ end }}
 
 {{ if or (get $components "indexer") (get $components "matcher") }}
+  {{- if kindIs "invalid" $._rox.scannerV4.db.serviceTLS.generate }}
+    {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
+    {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
+    {{- $lookupOut := dict -}}
+    {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-db-tls") -}}
+    {{- if not $lookupOut.result -}}
+      {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
+      {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
+      {{- $_ := set $._rox.scannerV4.db.serviceTLS "generate" true -}}
+    {{- end -}}
+  {{- end }}
+  {{- if kindIs "invalid" $._rox.scannerV4.db.password.generate }}
+    {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
+    {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
+    {{- $lookupOut := dict -}}
+    {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-db-password") -}}
+    {{- if not $lookupOut.result -}}
+      {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
+      {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
+      {{- $_ := set $._rox.scannerV4.db.password "generate" true -}}
+    {{- end -}}
+  {{- end }}
+
   {{ include "srox.configureImage" (list $ $scannerV4Cfg.db.image) }}
   {{ include "srox.configurePassword" (list $ "scannerV4.db.password") }}
+
   {{- if eq $.Chart.Name "stackrox-central-services" -}}
     {{/* Only generate certificate when installing central-services. */}}
     {{ $cryptoSpec := dict "CN" "SCANNER_DB_SERVICE: Scanner V4 DB" "dnsBase" "scanner-v4-db" }}

--- a/pkg/renderer/templates/public_values.yaml.tpl
+++ b/pkg/renderer/templates/public_values.yaml.tpl
@@ -165,6 +165,38 @@ scanner:
     {{- end }}
   {{- end }}
 
+scannerV4:
+  indexer:
+    {{- if .K8sConfig.ImageOverrides.Main }}
+    image:
+      {{- if .K8sConfig.ImageOverrides.Main.Name }}
+      name: {{ .K8sConfig.ImageOverrides.Main.Name }}
+      {{- end }}
+      {{- if .K8sConfig.ImageOverrides.Main.Tag }}
+      tag: {{ .K8sConfig.ImageOverrides.Main.Tag }}
+      {{- end }}
+    {{- end }}
+  matcher:
+    {{- if .K8sConfig.ImageOverrides.Main }}
+    image:
+      {{- if .K8sConfig.ImageOverrides.Main.Name }}
+      name: {{ .K8sConfig.ImageOverrides.Main.Name }}
+      {{- end }}
+      {{- if .K8sConfig.ImageOverrides.Main.Tag }}
+      tag: {{ .K8sConfig.ImageOverrides.Main.Tag }}
+      {{- end }}
+    {{- end }}
+  db:
+    {{- if .K8sConfig.ImageOverrides.Main }}
+    image:
+      {{- if .K8sConfig.ImageOverrides.Main.Name }}
+      name: {{ .K8sConfig.ImageOverrides.Main.Name }}
+      {{- end }}
+      {{- if .K8sConfig.ImageOverrides.Main.Tag }}
+      tag: {{ .K8sConfig.ImageOverrides.Main.Tag }}
+      {{- end }}
+    {{- end }}
+
 {{- $envVars := deepCopy .EnvironmentMap -}}
 {{- $_ := unset $envVars "ROX_OFFLINE_MODE" -}}
 {{- $_ := unset $envVars "ROX_TELEMETRY_ENDPOINT" -}}

--- a/scripts/ci/jobs/gke_scanner_v4_tests.py
+++ b/scripts/ci/jobs/gke_scanner_v4_tests.py
@@ -11,8 +11,6 @@ from ci_tests import ScannerV4Test
 from post_tests import PostClusterTest, FinalPost
 
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
-os.environ["OUTPUT_FORMAT"] = "helm"
-os.environ["ROX_SCANNER_V4_ENABLED"] = "true"
 os.environ["STORE_METRICS"] = "true"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_BASELINE_GENERATION_DURATION"] = "5m"

--- a/tests/e2e/run-scanner-v4.sh
+++ b/tests/e2e/run-scanner-v4.sh
@@ -16,20 +16,62 @@ source "$ROOT/tests/scripts/setup-certs.sh"
 
 set -euo pipefail
 
+# Could also use
+#   CHART_BASE="/rhacs"
+#   export DEFAULT_IMAGE_REGISTRY="quay.io/rhacs-eng"
+# for the opensource flavour.
+CHART_BASE=""
+export DEFAULT_IMAGE_REGISTRY="quay.io/stackrox-io"
+CURRENT_MAIN_IMAGE_TAG=${CURRENT_MAIN_IMAGE_TAG:-} # Setting a tag can be useful for local testing.
+EARLIER_CHART_VERSION="4.3.0"
+EARLIER_MAIN_IMAGE_TAG=$EARLIER_CHART_VERSION
+
 scannerV4_test() {
     info "Starting ScannerV4 test"
 
     require_environment "ORCHESTRATOR_FLAVOR"
-    require_environment "ROX_SCANNER_V4_ENABLED"
+    export OUTPUT_FORMAT=helm
+    export ROX_SCANNER_V4_ENABLED=true
+    export USE_LOCAL_ROXCTL=true
 
     export_test_environment
 
-    setup_gcp
+    if [[ "$CI" = "true" ]]; then
+        setup_gcp
+    fi
     setup_deployment_env false false
     remove_existing_stackrox_resources
-    setup_default_TLS_certs
 
+    if [[ "$CI" = "true" ]]; then
+        setup_default_TLS_certs
+    fi
+
+    # Prepare earlier version
+    if [[ -z "${CHART_REPOSITORY:-}" ]]; then
+        CHART_REPOSITORY=$(mktemp -d "helm-charts.XXXXXX" -p /tmp)
+    fi
+    if [[ ! -e "${CHART_REPOSITORY}/.git" ]]; then
+        git clone --depth 1 -b main https://github.com/stackrox/helm-charts "${CHART_REPOSITORY}"
+    fi
+
+    # Deploy earlier version without Scanner V4.
+    export CENTRAL_CHART_DIR_OVERRIDE="${CHART_REPOSITORY}${CHART_BASE}/${EARLIER_CHART_VERSION}/central-services"
+    info "Deplying central-services using chart $CENTRAL_CHART_DIR_OVERRIDE"
+    if [[ -n "${EARLIER_MAIN_IMAGE_TAG:-}" ]]; then
+        export MAIN_IMAGE_TAG=$EARLIER_MAIN_IMAGE_TAG
+        info "Overriding MAIN_IMAGE_TAG=$EARLIER_MAIN_IMAGE_TAG"
+    fi
     deploy_stackrox
+    unset MAIN_IMAGE_TAG
+    unset CENTRAL_CHART_DIR_OVERRIDE
+
+    # Upgrade to HEAD chart.
+    info "Upgrading central-services using HEAD Helm chart"
+    if [[ -n "${CURRENT_MAIN_IMAGE_TAG:-}" ]]; then
+        export MAIN_IMAGE_TAG=$CURRENT_MAIN_IMAGE_TAG
+        info "Overriding MAIN_IMAGE_TAG=$CURRENT_MAIN_IMAGE_TAG"
+    fi
+    deploy_stackrox # This is doing an `helm upgrade --install ...` under the hood.
 
     run_scannerV4_test
 }

--- a/tests/e2e/run-scanner-v4.sh
+++ b/tests/e2e/run-scanner-v4.sh
@@ -16,10 +16,10 @@ source "$ROOT/tests/scripts/setup-certs.sh"
 
 set -euo pipefail
 
-# Could also use
+# Use
 #   CHART_BASE="/rhacs"
 #   export DEFAULT_IMAGE_REGISTRY="quay.io/rhacs-eng"
-# for the opensource flavour.
+# for the RHACS flavor.
 CHART_BASE=""
 export DEFAULT_IMAGE_REGISTRY="quay.io/stackrox-io"
 CURRENT_MAIN_IMAGE_TAG=${CURRENT_MAIN_IMAGE_TAG:-} # Setting a tag can be useful for local testing.


### PR DESCRIPTION
## Description

This PR turns the existing minimal Scanner v4 test into a basic Helm upgrade test.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes~~

## Testing Performed

1. CI.

2. Locally:

Source something like this:
```
export ORCHESTRATOR_FLAVOR=k8s
export OUTPUT_FORMAT="helm"
export ROX_SCANNER_V4_ENABLED="true"
export STORE_METRICS="true"
export ROX_POSTGRES_DATASTORE="true"
export ROX_BASELINE_GENERATION_DURATION="5m"
export CI=false
export CHART_REPOSITORY=/tmp/helm-charts
export QUAY_RHACS_ENG_RO_PASSWORD=...
export QUAY_RHACS_ENG_RO_USERNAME=...
export USE_LOCAL_ROXCTL=true
export CURRENT_MAIN_IMAGE_TAG="4.3.x-450-gf976c9f095"

if [[ -z "$KUBECONFIG" ]]; then
    echo "set KUBECONFIG"
fi

if [[ ! -x "$(command -v roxctl)" ]]; then
    export PATH="$PWD/bin/darwin_amd64:$PATH"
    echo "PATH=$PATH"
fi
```

and then execute `tests/e2e/run-scanner-v4.sh` against an Infra GKE cluster (instance type e2-standard-8).
