### PR TITLE
ROX-21213: Fix Compliance operator status errors regarding CRDs

### DIFF
--- a/sensor/kubernetes/complianceoperator/updater.go
+++ b/sensor/kubernetes/complianceoperator/updater.go
@@ -230,7 +230,7 @@ func checkRequiredComplianceCRDsExist(resourceList *metav1.APIResourceList) erro
 
 	errorList := errorhelpers.NewErrorList("checking for CRDs required for compliance")
 	for _, requiredResource := range complianceoperator.GetRequiredResources() {
-		if detectedKinds.Contains(requiredResource.Kind) {
+		if !detectedKinds.Contains(requiredResource.Kind) {
 			errorList.AddError(errors.Errorf("required GroupVersionKind %q not found", requiredResource.GroupVersionKind().String()))
 		}
 	}


### PR DESCRIPTION
## Description

Fix an evaluation condition for compliance CRD, now it returns the correct evaluation.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests, also deployed and tested the patch on a cluster

### Here I tell how I validated my change

* Added mock test for testing following cases in sensor:
  * All required CRDs exist, and it should not have any errors
  * One required CRD is missing, and it should contains the missing crd kind in the error
  * Required Kinds list is empty, and it should return errors

tested on a cluster with the patch:
```
[vincent@node workflow]$ roxcurl /v2/compliance/integrations | json_pp
{
   "integrations" : [
      {
         "clusterId" : "a6a8c1d2-2b6e-4d0b-830e-3acdd2df5e59",
         "clusterName" : "remote",
         "id" : "329572d4-6178-471f-91f0-e453f0cdbddd",
         "namespace" : "openshift-compliance",
         "statusErrors" : [],
         "version" : ""
      }
   ]
}
```


