### PR TITLE
chore(fix): Improve auth interceptor logging

### DIFF
--- a/pkg/grpc/authn/basic/extractor.go
+++ b/pkg/grpc/authn/basic/extractor.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/auth/authproviders"
-	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
 	"github.com/stackrox/rox/pkg/logging"
@@ -61,11 +60,12 @@ func (e *Extractor) IdentityForRequest(ctx context.Context, ri requestinfo.Reque
 	}
 
 	id, err := e.manager.IdentityForCreds(ctx, username, password, e.authProvider)
-	if errors.Is(err, errox.NotAuthorized) {
+	if err != nil {
 		logging.GetRateLimitedLogger().WarnL(ri.Hostname, "%q: %v", ri.Hostname, err)
-		return nil, err
+		return nil, fmt.Errorf("failed to identify user with username %q", username)
 	}
-	return id, err
+
+	return id, nil
 }
 
 // NewExtractor returns a new identity extractor for basic auth.

--- a/pkg/grpc/authn/extractor.go
+++ b/pkg/grpc/authn/extractor.go
@@ -2,10 +2,71 @@ package authn
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"
+	"gopkg.in/square/go-jose.v2/jwt"
 )
+
+type ExtractorError struct {
+	extractorType string
+	msg           string
+	err           error
+}
+
+var _ error = (*ExtractorError)(nil)
+
+func NewExtractorError(extractorType string, msg string, err error) *ExtractorError {
+	return &ExtractorError{
+		extractorType: extractorType,
+		msg:           msg,
+		err:           err,
+	}
+}
+
+func (e *ExtractorError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	return e.err
+}
+
+func (e *ExtractorError) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	return fmt.Sprintf("%v: cannot extract identity: %v", e.extractorType, e.msg)
+}
+
+func (e *ExtractorError) LogL(ri requestinfo.RequestInfo) {
+	if e == nil {
+		return
+	}
+
+	// We are handling some errors differently because
+	// they are frequent and expected.
+	logF := logging.GetRateLimitedLogger().WarnL
+	if errors.Is(e.Unwrap(), jwt.ErrExpired) {
+		logF = logging.GetRateLimitedLogger().DebugL
+	}
+
+	// We might print nil at the end, like:
+	//    "Cannot ... [basic] for hostname example.com: parse error: <nil>"
+	// but this is alright in our logs.
+	logF(
+		ri.Hostname,
+		"Cannot extract identity [%v] for hostname %v: %v: %v",
+		e.extractorType,
+		ri.Hostname,
+		e.msg,
+		e.err,
+	)
+}
 
 // ValidateCertChain can be implemented to provide cert chain validation callbacks
 type ValidateCertChain interface {
@@ -15,12 +76,12 @@ type ValidateCertChain interface {
 
 // IdentityExtractor extracts the identity of a user making a request from a request info.
 type IdentityExtractor interface {
-	IdentityForRequest(ctx context.Context, ri requestinfo.RequestInfo) (Identity, error)
+	IdentityForRequest(ctx context.Context, ri requestinfo.RequestInfo) (Identity, *ExtractorError)
 }
 
 type extractorList []IdentityExtractor
 
-func (l extractorList) IdentityForRequest(ctx context.Context, ri requestinfo.RequestInfo) (Identity, error) {
+func (l extractorList) IdentityForRequest(ctx context.Context, ri requestinfo.RequestInfo) (Identity, *ExtractorError) {
 	for _, extractor := range l {
 		if id, err := extractor.IdentityForRequest(ctx, ri); id != nil || err != nil {
 			return id, err

--- a/pkg/grpc/authn/extractor.go
+++ b/pkg/grpc/authn/extractor.go
@@ -11,20 +11,43 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
+// ExtractorError represents an error that occurs during identity extraction.
 type ExtractorError struct {
+	// extractorType identifies the type of identity extractor that encountered the error.
 	extractorType string
-	msg           string
-	err           error
+
+	// msg provides additional information or context about the error.
+	msg string
+
+	// err holds the underlying error.
+	err error
 }
 
-var _ error = (*ExtractorError)(nil)
-
+// NewExtractorError creates and returns a new instance of ExtractorError.
+//
+// Parameters:
+//   - extractorType: A string representing the type of identity extractor where the error occurred.
+//   - msg: A string providing additional information or context about the error.
+//   - err: The underlying error that caused the extraction failure.
+//
+// Returns:
+//   - An initialized pointer to an ExtractorError struct with the given parameters.
 func NewExtractorError(extractorType string, msg string, err error) *ExtractorError {
 	return &ExtractorError{
 		extractorType: extractorType,
 		msg:           msg,
 		err:           err,
 	}
+}
+
+var _ error = (*ExtractorError)(nil)
+
+func (e *ExtractorError) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	return fmt.Sprintf("%v: cannot extract identity: %v", e.extractorType, e.msg)
 }
 
 func (e *ExtractorError) Unwrap() error {
@@ -35,14 +58,10 @@ func (e *ExtractorError) Unwrap() error {
 	return e.err
 }
 
-func (e *ExtractorError) Error() string {
-	if e == nil {
-		return ""
-	}
-
-	return fmt.Sprintf("%v: cannot extract identity: %v", e.extractorType, e.msg)
-}
-
+// LogL logs the details of the ExtractorError, associating it with the provided RequestInfo.
+//
+// Parameters:
+//   - ri: The RequestInfo associated with the ExtractorError.
 func (e *ExtractorError) LogL(ri requestinfo.RequestInfo) {
 	if e == nil {
 		return

--- a/pkg/grpc/authn/extractor_test.go
+++ b/pkg/grpc/authn/extractor_test.go
@@ -1,0 +1,65 @@
+package authn
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/grpc/requestinfo"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+func TestExtractorErrorNilGuards(t *testing.T) {
+	var err *ExtractorError
+
+	assert.Equal(t, "", err.Error())
+	assert.Nil(t, err.Unwrap())
+	assert.NotPanics(t, func() {
+		err.LogL(requestinfo.RequestInfo{})
+	})
+}
+
+func TestExtractorErrorUnwrap(t *testing.T) {
+	jwtErr := jwt.ErrExpired
+	err := NewExtractorError("test", "test msg", jwtErr)
+	assert.ErrorIs(t, err.Unwrap(), jwt.ErrExpired)
+}
+
+func TestExtractorErrorRootErrorNotExposed(t *testing.T) {
+	rootErrMsg := "root"
+	errMsg := "error-msg"
+
+	internalErr := errors.New(rootErrMsg)
+	err := NewExtractorError("test", errMsg, internalErr)
+
+	assert.NotContains(t, err.Error(), rootErrMsg)
+	assert.Contains(t, err.Error(), errMsg)
+
+	errNoCreds := errox.NoCredentials.CausedBy(err)
+	assert.NotContains(t, errNoCreds.Error(), rootErrMsg)
+	assert.Contains(t, errNoCreds.Error(), errMsg)
+}
+
+func TestExtractorErrorRootErrorNotExposedByErrox(t *testing.T) {
+	rootErrMsg := "root"
+	errMsg := "error-msg"
+
+	internalErr := errors.New(rootErrMsg)
+	err := NewExtractorError("test", errMsg, internalErr)
+	errNoCreds := errox.NoCredentials.CausedBy(err)
+
+	assert.NotContains(t, errNoCreds.Error(), rootErrMsg)
+	assert.Contains(t, errNoCreds.Error(), errMsg)
+}
+
+func TestExtractorErrorRootErrorNil(t *testing.T) {
+	errMsg := "error-msg"
+	err := NewExtractorError("test", errMsg, nil)
+
+	assert.Nil(t, err.Unwrap())
+	assert.Contains(t, err.Error(), errMsg)
+	assert.NotPanics(t, func() {
+		err.LogL(requestinfo.RequestInfo{Hostname: "example.com"})
+	})
+}

--- a/pkg/grpc/authn/extractor_test.go
+++ b/pkg/grpc/authn/extractor_test.go
@@ -23,7 +23,7 @@ func TestExtractorErrorNilGuards(t *testing.T) {
 func TestExtractorErrorUnwrap(t *testing.T) {
 	jwtErr := jwt.ErrExpired
 	err := NewExtractorError("test", "test msg", jwtErr)
-	assert.ErrorIs(t, err.Unwrap(), jwt.ErrExpired)
+	assert.Equal(t, err.Unwrap(), jwt.ErrExpired)
 }
 
 func TestExtractorErrorRootErrorNotExposed(t *testing.T) {

--- a/pkg/grpc/authn/interceptor.go
+++ b/pkg/grpc/authn/interceptor.go
@@ -22,7 +22,7 @@ func (u contextUpdater) updateContext(ctx context.Context) (context.Context, err
 	ri := requestinfo.FromContext(ctx)
 	id, err := u.extractor.IdentityForRequest(ctx, ri)
 	if err != nil {
-		logging.GetRateLimitedLogger().DebugL(ri.Hostname, "Cannot extract identity: %v", err)
+		err.LogL(ri)
 
 		// Ignore id value if error is not nil.
 		return context.WithValue(ctx, identityErrorContextKey{}, errox.NoCredentials.CausedBy(err)), nil

--- a/pkg/grpc/authn/interceptor.go
+++ b/pkg/grpc/authn/interceptor.go
@@ -7,11 +7,6 @@ import (
 	"github.com/stackrox/rox/pkg/contextutil"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
-	"github.com/stackrox/rox/pkg/logging"
-)
-
-var (
-	log = logging.LoggerForModule()
 )
 
 type contextUpdater struct {

--- a/pkg/grpc/authn/interceptor.go
+++ b/pkg/grpc/authn/interceptor.go
@@ -27,7 +27,7 @@ func (u contextUpdater) updateContext(ctx context.Context) (context.Context, err
 		if errors.Is(err, jwt.ErrExpired) {
 			log.Debug("Cannot extract identity: token expired")
 		} else {
-			logging.GetRateLimitedLogger().WarnL(ri.Hostname, "Cannot extract identity: %v", err)
+			logging.GetRateLimitedLogger().DebugL(ri.Hostname, "Cannot extract identity: %v", err)
 		}
 		// Ignore id value if error is not nil.
 		return context.WithValue(ctx, identityErrorContextKey{}, errox.NoCredentials.CausedBy(err)), nil

--- a/pkg/grpc/authn/interceptor.go
+++ b/pkg/grpc/authn/interceptor.go
@@ -2,14 +2,12 @@ package authn
 
 import (
 	"context"
-	"errors"
 
 	"github.com/stackrox/rox/pkg/auth"
 	"github.com/stackrox/rox/pkg/contextutil"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
 	"github.com/stackrox/rox/pkg/logging"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 var (
@@ -24,11 +22,8 @@ func (u contextUpdater) updateContext(ctx context.Context) (context.Context, err
 	ri := requestinfo.FromContext(ctx)
 	id, err := u.extractor.IdentityForRequest(ctx, ri)
 	if err != nil {
-		if errors.Is(err, jwt.ErrExpired) {
-			log.Debug("Cannot extract identity: token expired")
-		} else {
-			logging.GetRateLimitedLogger().DebugL(ri.Hostname, "Cannot extract identity: %v", err)
-		}
+		logging.GetRateLimitedLogger().DebugL(ri.Hostname, "Cannot extract identity: %v", err)
+
 		// Ignore id value if error is not nil.
 		return context.WithValue(ctx, identityErrorContextKey{}, errox.NoCredentials.CausedBy(err)), nil
 	}

--- a/pkg/grpc/authn/service/extractor.go
+++ b/pkg/grpc/authn/service/extractor.go
@@ -3,11 +3,9 @@ package service
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/cryptoutils"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"
 )
 
@@ -16,7 +14,11 @@ type extractor struct {
 	validator authn.ValidateCertChain
 }
 
-func (e extractor) IdentityForRequest(ctx context.Context, ri requestinfo.RequestInfo) (authn.Identity, error) {
+func getExtractorError(msg string, err error) *authn.ExtractorError {
+	return authn.NewExtractorError("service", msg, err)
+}
+
+func (e extractor) IdentityForRequest(ctx context.Context, ri requestinfo.RequestInfo) (authn.Identity, *authn.ExtractorError) {
 	l := len(ri.VerifiedChains)
 	// For all mTLS communication, there will be exactly one verified chain.
 	// If there are multiple verified chains, no need to send an error -- it just
@@ -34,13 +36,7 @@ func (e extractor) IdentityForRequest(ctx context.Context, ri requestinfo.Reques
 	if e.validator != nil {
 		err := e.validator.ValidateClientCertificate(ctx, ri.VerifiedChains[0])
 		if err != nil {
-			logging.GetRateLimitedLogger().WarnL(
-				ri.Hostname,
-				"Client certificate validation failed for hostname %v: %v",
-				ri.Hostname,
-				err,
-			)
-			return nil, errors.New("client certificate validation failed")
+			return nil, getExtractorError("client certificate validation failed", err)
 		}
 	}
 

--- a/pkg/grpc/authn/servicecerttoken/extractor.go
+++ b/pkg/grpc/authn/servicecerttoken/extractor.go
@@ -3,9 +3,9 @@ package servicecerttoken
 import (
 	"context"
 	"crypto/x509"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/grpc/authn/service"
 	"github.com/stackrox/rox/pkg/grpc/common/authn/servicecerttoken"
@@ -20,18 +20,11 @@ type extractor struct {
 	validator  authn.ValidateCertChain
 }
 
-func logErrorAndReturnNilIdentity(ri requestinfo.RequestInfo, err error) (authn.Identity, error) {
-	logging.GetRateLimitedLogger().WarnL(
-		ri.Hostname,
-		"Cannot extract identity from service token for hostname %v: %v",
-		ri.Hostname,
-		err,
-	)
-
-	return nil, err
+func getExtractorError(msg string, err error) *authn.ExtractorError {
+	return authn.NewExtractorError("service-cert-token", msg, err)
 }
 
-func (e extractor) IdentityForRequest(ctx context.Context, ri requestinfo.RequestInfo) (authn.Identity, error) {
+func (e extractor) IdentityForRequest(ctx context.Context, ri requestinfo.RequestInfo) (authn.Identity, *authn.ExtractorError) {
 	token := authn.ExtractToken(ri.Metadata, servicecerttoken.TokenType)
 	if token == "" {
 		return nil, nil
@@ -39,44 +32,26 @@ func (e extractor) IdentityForRequest(ctx context.Context, ri requestinfo.Reques
 
 	cert, err := servicecerttoken.ParseToken(token, e.maxLeeway)
 	if err != nil {
-		logging.GetRateLimitedLogger().WarnL(
-			ri.Hostname,
-			"Could not parse service cert token for hostname %v: %v",
-			ri.Hostname,
-			err,
-		)
-		return nil, errors.New("could not parse service cert token")
+		return nil, getExtractorError("could not parse service cert token", err)
 	}
 
 	verifiedChains, err := cert.Verify(e.verifyOpts)
 	if err != nil {
-		logging.GetRateLimitedLogger().WarnL(
-			ri.Hostname,
-			"Could not verify certificate for hostname %v: %v",
-			ri.Hostname,
-			err,
-		)
-		return nil, errors.New("could not verify certificate")
+		return nil, getExtractorError("could not verify certificate", err)
 	}
 
 	if len(verifiedChains) != 1 {
-		return logErrorAndReturnNilIdentity(ri, errors.Errorf("UNEXPECTED: %d verified chains found", len(verifiedChains)))
+		return nil, getExtractorError(fmt.Sprintf("UNEXPECTED: %d verified chains found", len(verifiedChains)), nil)
 	}
 
 	if len(verifiedChains[0]) == 0 {
-		return logErrorAndReturnNilIdentity(ri, errors.New("UNEXPECTED: verified chain is empty"))
+		return nil, getExtractorError("UNEXPECTED: verified chain is empty", nil)
 	}
 
 	chain := requestinfo.ExtractCertInfoChains(verifiedChains)
 	if e.validator != nil {
 		if err := e.validator.ValidateClientCertificate(ctx, chain[0]); err != nil {
-			logging.GetRateLimitedLogger().ErrorL(
-				ri.Hostname,
-				"Could not validate client certificate from service cert token for hostname %v: %v",
-				ri.Hostname,
-				err,
-			)
-			return nil, errors.New("could not validate client certificate from service cert token")
+			return nil, getExtractorError("could not validate client certificate from service cert token", err)
 		}
 	}
 

--- a/pkg/grpc/authn/tokenbased/extractor.go
+++ b/pkg/grpc/authn/tokenbased/extractor.go
@@ -37,7 +37,7 @@ func (e *extractor) IdentityForRequest(ctx context.Context, ri requestinfo.Reque
 	}
 	token, err := e.validator.Validate(ctx, rawToken)
 	if err != nil {
-		logging.GetRateLimitedLogger().WarnL(
+		logging.GetRateLimitedLogger().DebugL(
 			ri.Hostname,
 			"Token validation failed for hostname %v: %v",
 			ri.Hostname,

--- a/pkg/grpc/authn/userpki/extractor.go
+++ b/pkg/grpc/authn/userpki/extractor.go
@@ -3,6 +3,7 @@ package userpki
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/auth/authproviders"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/grpc/authn"
@@ -73,13 +74,13 @@ func (i extractor) IdentityForRequest(ctx context.Context, ri requestinfo.Reques
 			}
 			resolvedRoles, err := provider.RoleMapper().FromUserDescriptor(ctx, ud)
 			if err != nil {
-				logging.GetRateLimitedLogger().DebugL(
+				logging.GetRateLimitedLogger().WarnL(
 					ri.Hostname,
 					"Token validation failed for hostname %v: %v",
 					ri.Hostname,
 					err,
 				)
-				return nil, err
+				return nil, errors.New("failed to resolve user roles")
 			}
 			identity.resolvedRoles = resolvedRoles
 			return identity, nil

--- a/pkg/grpc/authn/userpki/extractor.go
+++ b/pkg/grpc/authn/userpki/extractor.go
@@ -3,7 +3,6 @@ package userpki
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/auth/authproviders"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/grpc/authn"
@@ -34,7 +33,11 @@ type extractor struct {
 	manager ProviderContainer
 }
 
-func (i extractor) IdentityForRequest(ctx context.Context, ri requestinfo.RequestInfo) (authn.Identity, error) {
+func getExtractorError(msg string, err error) *authn.ExtractorError {
+	return authn.NewExtractorError("userpki", msg, err)
+}
+
+func (i extractor) IdentityForRequest(ctx context.Context, ri requestinfo.RequestInfo) (authn.Identity, *authn.ExtractorError) {
 	// this auth identity provider is only relevant for API usage outside of the browser app. Inside the browser app,
 	// tokens are used (with validation to ensure continuity of access). So we ignore certs if the authorization
 	// header is set.
@@ -74,13 +77,7 @@ func (i extractor) IdentityForRequest(ctx context.Context, ri requestinfo.Reques
 			}
 			resolvedRoles, err := provider.RoleMapper().FromUserDescriptor(ctx, ud)
 			if err != nil {
-				logging.GetRateLimitedLogger().WarnL(
-					ri.Hostname,
-					"Token validation failed for hostname %v: %v",
-					ri.Hostname,
-					err,
-				)
-				return nil, errors.New("failed to resolve user roles")
+				return nil, getExtractorError("failed to resolve user roles", err)
 			}
 			identity.resolvedRoles = resolvedRoles
 			return identity, nil

--- a/pkg/grpc/authn/userpki/extractor.go
+++ b/pkg/grpc/authn/userpki/extractor.go
@@ -73,7 +73,7 @@ func (i extractor) IdentityForRequest(ctx context.Context, ri requestinfo.Reques
 			}
 			resolvedRoles, err := provider.RoleMapper().FromUserDescriptor(ctx, ud)
 			if err != nil {
-				logging.GetRateLimitedLogger().WarnL(
+				logging.GetRateLimitedLogger().DebugL(
 					ri.Hostname,
 					"Token validation failed for hostname %v: %v",
 					ri.Hostname,


### PR DESCRIPTION
## Description

This PR improved auth interceptor logging. It introduces a new struct that will keep the original error and the message propagated to the API/UI user. With this, we are ensuring the following:
- we are going to log errors with complete information
- we will not expose sensitive information to the API/UI user

Changes made:
- added error struct that keeps root error and additional message
- added logging of error struct that will log the underlying error
- covered the situation that frequent/expected token expired is logged as debug
- changed `basic` extractor to return nil if an error occurred
- tweaked debug log in service token extractor

**Consideration**

If we doubt that logs could still be noisy, we can increase the rate limit period to 1min or 5min instead of 10sec.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

1. CI tests

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
