### PR TITLE
refactor(operator.pkg): introduce helm values enrichers.

### DIFF
--- a/operator/pkg/central/reconciler/reconciler.go
+++ b/operator/pkg/central/reconciler/reconciler.go
@@ -5,11 +5,12 @@ import (
 	"github.com/stackrox/rox/image"
 	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"github.com/stackrox/rox/operator/pkg/central/extensions"
-	"github.com/stackrox/rox/operator/pkg/central/values/translation"
+	centralTranslation "github.com/stackrox/rox/operator/pkg/central/values/translation"
 	commonExtensions "github.com/stackrox/rox/operator/pkg/common/extensions"
 	"github.com/stackrox/rox/operator/pkg/proxy"
 	"github.com/stackrox/rox/operator/pkg/reconciler"
 	"github.com/stackrox/rox/operator/pkg/utils"
+	"github.com/stackrox/rox/operator/pkg/values/translation"
 	"github.com/stackrox/rox/pkg/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -52,7 +53,9 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 
 	return reconciler.SetupReconcilerWithManager(
 		mgr, platform.CentralGVK, image.CentralServicesChartPrefix,
-		proxy.InjectProxyEnvVars(translation.New(mgr.GetClient()), proxyEnv, mgr.GetLogger()),
+		translation.WithEnrichment(
+			centralTranslation.New(mgr.GetClient()),
+			proxy.NewProxyEnvVarsInjector(proxyEnv, mgr.GetLogger())),
 		opts...,
 	)
 }

--- a/operator/pkg/proxy/translation.go
+++ b/operator/pkg/proxy/translation.go
@@ -52,7 +52,7 @@ type proxyEnvVarsInjector struct {
 var _ translation.Enricher = &proxyEnvVarsInjector{}
 
 // Enrich injects proxy configuration environment variables.
-func (i *proxyEnvVarsInjector) Enrich(ctx context.Context, obj k8sutil.Object, vals chartutil.Values) (chartutil.Values, error) {
+func (i *proxyEnvVarsInjector) Enrich(_ context.Context, obj k8sutil.Object, vals chartutil.Values) (chartutil.Values, error) {
 	proxyVals := getProxyConfigHelmValues(obj, i.proxyEnv)
 
 	mergedVals := chartutil.CoalesceTables(vals, proxyVals)

--- a/operator/pkg/proxy/translation.go
+++ b/operator/pkg/proxy/translation.go
@@ -5,37 +5,27 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/operator-framework/helm-operator-plugins/pkg/values"
+	"github.com/stackrox/rox/operator/pkg/values/translation"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"helm.sh/helm/v3/pkg/chartutil"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func getProxyConfigHelmValues(obj k8sutil.Object, proxyEnvVars map[string]string) (chartutil.Values, error) {
+func getProxyConfigHelmValues(obj k8sutil.Object, proxyEnvVars map[string]string) chartutil.Values {
 	if len(proxyEnvVars) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	secretName := getProxyEnvSecretName(obj)
 
 	envVarsMap := map[string]interface{}{}
 	for envVarName := range proxyEnvVars {
-		src := v1.EnvVarSource{
-			SecretKeyRef: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
-					Name: secretName,
-				},
-				Key: envVarName,
-			},
-		}
-		uSrc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&src)
-		if err != nil {
-			return nil, err
-		}
 		envVarsMap[envVarName] = map[string]interface{}{
-			"valueFrom": uSrc,
+			"valueFrom": map[string]interface{}{
+				"secretKeyRef": map[string]interface{}{
+					"key":  envVarName,
+					"name": secretName,
+				},
+			},
 		}
 	}
 
@@ -43,29 +33,37 @@ func getProxyConfigHelmValues(obj k8sutil.Object, proxyEnvVars map[string]string
 		"customize": map[string]interface{}{
 			"envVars": envVarsMap,
 		},
-	}, nil
+	}
 }
 
-// InjectProxyEnvVars wraps a Translator to inject proxy configuration environment variables.
-func InjectProxyEnvVars(translator values.Translator, proxyEnv map[string]string, log logr.Logger) values.Translator {
-	return values.TranslatorFunc(func(ctx context.Context, obj *unstructured.Unstructured) (chartutil.Values, error) {
-		vals, err := translator.Translate(ctx, obj)
-		if err != nil {
-			return nil, err
-		}
+// NewProxyEnvVarsInjector returns an object which injects proxy env vars into enriched chart values.
+func NewProxyEnvVarsInjector(proxyEnv map[string]string, log logr.Logger) *proxyEnvVarsInjector {
+	return &proxyEnvVarsInjector{
+		proxyEnv: proxyEnv,
+		log:      log,
+	}
+}
 
-		proxyVals, _ := getProxyConfigHelmValues(obj, proxyEnv) // ignore errors for now
+type proxyEnvVarsInjector struct {
+	proxyEnv map[string]string
+	log      logr.Logger
+}
 
-		mergedVals := chartutil.CoalesceTables(vals, proxyVals)
+var _ translation.Enricher = &proxyEnvVarsInjector{}
 
-		mergedVals, conflicts := deleteValueFromIfValueExists(mergedVals)
-		if len(conflicts) > 0 {
-			err := fmt.Errorf("conflicts: %s for %s/%s", conflicts, obj.GetNamespace(), obj.GetName())
-			log.Error(err, "injecting proxy env vars")
-		}
+// Enrich injects proxy configuration environment variables.
+func (i *proxyEnvVarsInjector) Enrich(ctx context.Context, obj k8sutil.Object, vals chartutil.Values) (chartutil.Values, error) {
+	proxyVals := getProxyConfigHelmValues(obj, i.proxyEnv)
 
-		return mergedVals, nil
-	})
+	mergedVals := chartutil.CoalesceTables(vals, proxyVals)
+
+	mergedVals, conflicts := deleteValueFromIfValueExists(mergedVals)
+	if len(conflicts) > 0 {
+		err := fmt.Errorf("conflicts: %s for %s/%s", conflicts, obj.GetNamespace(), obj.GetName())
+		i.log.Error(err, "injecting proxy env vars")
+	}
+
+	return mergedVals, nil
 }
 
 // deleteValueFromIfValueExists deletes the valueFrom key from customize.envVars entries

--- a/operator/pkg/securedcluster/reconciler/reconciler.go
+++ b/operator/pkg/securedcluster/reconciler/reconciler.go
@@ -8,8 +8,9 @@ import (
 	"github.com/stackrox/rox/operator/pkg/proxy"
 	"github.com/stackrox/rox/operator/pkg/reconciler"
 	"github.com/stackrox/rox/operator/pkg/securedcluster/extensions"
-	"github.com/stackrox/rox/operator/pkg/securedcluster/values/translation"
+	scTranslation "github.com/stackrox/rox/operator/pkg/securedcluster/values/translation"
 	"github.com/stackrox/rox/operator/pkg/utils"
+	"github.com/stackrox/rox/operator/pkg/values/translation"
 	"github.com/stackrox/rox/pkg/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -43,7 +44,9 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 	return reconciler.SetupReconcilerWithManager(
 		mgr, platform.SecuredClusterGVK,
 		image.SecuredClusterServicesChartPrefix,
-		proxy.InjectProxyEnvVars(translation.NewTranslator(mgr.GetClient()), proxyEnv, mgr.GetLogger()),
+		translation.WithEnrichment(
+			scTranslation.New(mgr.GetClient()),
+			proxy.NewProxyEnvVarsInjector(proxyEnv, mgr.GetLogger())),
 		opts...,
 	)
 }

--- a/operator/pkg/securedcluster/values/translation/translation.go
+++ b/operator/pkg/securedcluster/values/translation/translation.go
@@ -40,8 +40,8 @@ var (
 	baseValuesYAML []byte
 )
 
-// NewTranslator creates a translator
-func NewTranslator(client ctrlClient.Client) Translator {
+// New creates a translator
+func New(client ctrlClient.Client) Translator {
 	return Translator{client: client}
 }
 

--- a/operator/pkg/values/translation/enricher.go
+++ b/operator/pkg/values/translation/enricher.go
@@ -1,0 +1,34 @@
+package translation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/operator-framework/helm-operator-plugins/pkg/values"
+	"github.com/stackrox/rox/pkg/k8sutil"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Enricher reads helm values produced for an object by a Translator or another enricher, and returns new values.
+type Enricher interface {
+	Enrich(ctx context.Context, obj k8sutil.Object, vals chartutil.Values) (chartutil.Values, error)
+}
+
+// WithEnrichment chains a given translator with zero or more enrichers.
+func WithEnrichment(translator values.Translator, enrichers ...Enricher) values.Translator {
+	return values.TranslatorFunc(func(ctx context.Context, unstructured *unstructured.Unstructured) (chartutil.Values, error) {
+		values, err := translator.Translate(ctx, unstructured)
+		if err != nil {
+			return nil, err
+		}
+		for i, enricher := range enrichers {
+			enriched, err2 := enricher.Enrich(ctx, unstructured, values)
+			if err2 != nil {
+				return nil, fmt.Errorf("helm values enricher with index %d (%T) failed: %w", i, enricher, err2)
+			}
+			values = enriched
+		}
+		return values, nil
+	})
+}

--- a/operator/pkg/values/translation/enricher.go
+++ b/operator/pkg/values/translation/enricher.go
@@ -11,6 +11,7 @@ import (
 )
 
 // Enricher reads helm values produced for an object by a Translator or another enricher, and returns new values.
+// Note: mutates provided vals.
 type Enricher interface {
 	Enrich(ctx context.Context, obj k8sutil.Object, vals chartutil.Values) (chartutil.Values, error)
 }

--- a/operator/pkg/values/translation/enricher_test.go
+++ b/operator/pkg/values/translation/enricher_test.go
@@ -24,6 +24,7 @@ func (e enricher) Enrich(_ context.Context, _ k8sutil.Object, vals chartutil.Val
 }
 
 func TestWithEnrichment(t *testing.T) {
+	rootCause := fmt.Errorf("%s", "boom") // silence "no variadic arguments"
 	tests := map[string]struct {
 		translator values.Translator
 		enrichers  []Enricher
@@ -32,9 +33,9 @@ func TestWithEnrichment(t *testing.T) {
 	}{
 		"translator error": {
 			translator: values.TranslatorFunc(func(_ context.Context, obj *unstructured.Unstructured) (chartutil.Values, error) {
-				return nil, fmt.Errorf("boom")
+				return nil, rootCause
 			}),
-			wantErr: fmt.Errorf("boom"),
+			wantErr: rootCause,
 		},
 		"no enrichment": {
 			translator: values.TranslatorFunc(func(_ context.Context, obj *unstructured.Unstructured) (chartutil.Values, error) {
@@ -58,9 +59,9 @@ func TestWithEnrichment(t *testing.T) {
 			}),
 			enrichers: []Enricher{
 				enricher{key: "bar", val: "val3"},
-				enricher{err: fmt.Errorf("boom2")},
+				enricher{err: rootCause},
 			},
-			wantErr: fmt.Errorf("helm values enricher with index 1 (translation.enricher) failed: %w", fmt.Errorf("boom2")),
+			wantErr: fmt.Errorf("helm values enricher with index 1 (translation.enricher) failed: %w", rootCause),
 		},
 	}
 	for name, tt := range tests {

--- a/operator/pkg/values/translation/enricher_test.go
+++ b/operator/pkg/values/translation/enricher_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/operator-framework/helm-operator-plugins/pkg/values"
 	"github.com/stackrox/rox/pkg/k8sutil"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -68,8 +68,8 @@ func TestWithEnrichment(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			wrapped := WithEnrichment(tt.translator, tt.enrichers...)
 			vals, err := wrapped.Translate(context.Background(), nil)
-			require.Equal(t, tt.want, vals)
-			require.Equal(t, tt.wantErr, err)
+			assert.Equal(t, tt.want, vals)
+			assert.Equal(t, tt.wantErr, err)
 		})
 	}
 }

--- a/operator/pkg/values/translation/enricher_test.go
+++ b/operator/pkg/values/translation/enricher_test.go
@@ -1,0 +1,74 @@
+package translation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/operator-framework/helm-operator-plugins/pkg/values"
+	"github.com/stackrox/rox/pkg/k8sutil"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type enricher struct {
+	key string
+	val string
+	err error
+}
+
+func (e enricher) Enrich(_ context.Context, _ k8sutil.Object, vals chartutil.Values) (chartutil.Values, error) {
+	vals[e.key] = e.val
+	return vals, e.err
+}
+
+func TestWithEnrichment(t *testing.T) {
+	tests := map[string]struct {
+		translator values.Translator
+		enrichers  []Enricher
+		want       chartutil.Values
+		wantErr    error
+	}{
+		"translator error": {
+			translator: values.TranslatorFunc(func(_ context.Context, obj *unstructured.Unstructured) (chartutil.Values, error) {
+				return nil, fmt.Errorf("boom")
+			}),
+			wantErr: fmt.Errorf("boom"),
+		},
+		"no enrichment": {
+			translator: values.TranslatorFunc(func(_ context.Context, obj *unstructured.Unstructured) (chartutil.Values, error) {
+				return map[string]interface{}{"foo": "bar"}, nil
+			}),
+			want: map[string]interface{}{"foo": "bar"},
+		},
+		"with enrichment": {
+			translator: values.TranslatorFunc(func(_ context.Context, obj *unstructured.Unstructured) (chartutil.Values, error) {
+				return map[string]interface{}{"foo": "val1", "bar": "val2"}, nil
+			}),
+			enrichers: []Enricher{
+				enricher{key: "bar", val: "val3"},
+				enricher{key: "baz", val: "val4"},
+			},
+			want: map[string]interface{}{"foo": "val1", "bar": "val3", "baz": "val4"},
+		},
+		"enrichment error": {
+			translator: values.TranslatorFunc(func(_ context.Context, obj *unstructured.Unstructured) (chartutil.Values, error) {
+				return map[string]interface{}{"foo": "val1", "bar": "val2"}, nil
+			}),
+			enrichers: []Enricher{
+				enricher{key: "bar", val: "val3"},
+				enricher{err: fmt.Errorf("boom2")},
+			},
+			wantErr: fmt.Errorf("helm values enricher with index 1 (translation.enricher) failed: %w", fmt.Errorf("boom2")),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			wrapped := WithEnrichment(tt.translator, tt.enrichers...)
+			vals, err := wrapped.Translate(context.Background(), nil)
+			require.Equal(t, tt.want, vals)
+			require.Equal(t, tt.wantErr, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This refactors the way proxy-related env vars are being injected into helm values after the translator runs.

Previously this was achieved by having `proxy.InjectProxyEnvVars` take care of invoking the wrapped translator, and then massaging the resulting helm values. A fix for ROX-9156 that is in the works will need to add a similar piece of functionality, in the sense that it will also need to post-process the values. In order to avoid having to construct a matryoshka-style stack of translators with duplicated logic, this change introduces a `WithEnrichment` function which takes care of invoking the translator and then running any number of "enricher" objects that just massage the resulting values.

It also:
- simplifies `getProxyConfigHelmValues` by making impossible for it to return an error, and thus removes a scary-looking "ignore errors for now" code path that was previously notcovered by tests
- renames secured cluster `NewTranslator` to `New` to reduce stuttering and for consistency with central.

No changes in behaviour.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI should be enough.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
