### PR TITLE
ROX-21384: Stop listeners 'on reconnect' instead of 'on disconnect'

### DIFF
--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -135,7 +135,7 @@ func (s *eventPipelineSuite) Test_OfflineMode() {
 
 	// Expect listener to be reset (i.e. started twice and stopped once)
 	s.listener.EXPECT().StartWithContext(gomock.Any()).Times(2)
-	s.listener.EXPECT().Stop(gomock.Any()).Times(1)
+	s.listener.EXPECT().Stop(gomock.Any()).Times(2)
 
 	s.Require().NoError(s.pipeline.Start())
 	s.pipeline.Notify(common.SensorComponentEventCentralReachable)


### PR DESCRIPTION
## Description

In order to capture runtime events while Sensor is offline, we need to maintain the resource stores populated and the dispatchers running. The context will be cancel for the listeners when Sensor goes offline, this ensures no new messages are queued or sent while Sensor is offline.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
