### PR TITLE
ROX-21051: Buffer network flow updates

### DIFF
--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -48,4 +48,7 @@ var (
 
 	// DeduperStateSyncTimeout defines the maximum time Sensor will wait for the expected deduper state coming from Central
 	DeduperStateSyncTimeout = registerDurationSetting("ROX_DEDUPER_STATE_TIMEOUT", 30*time.Second)
+
+	// NetworkFlowBufferSize holds the size of how many network flows updates will be kept in Sensor while offline.
+	NetworkFlowBufferSize = RegisterIntegerSetting("ROX_SENSOR_NETFLOW_OFFLINE_BUFFER_SIZE", 100)
 )

--- a/sensor/common/metrics/init.go
+++ b/sensor/common/metrics/init.go
@@ -16,6 +16,7 @@ func init() {
 		processEnrichmentDrops,
 		processEnrichmentLRUCacheSize,
 		sensorIndicatorChannelFullCounter,
+		networkFlowBufferGauge,
 		totalNetworkFlowsSentCounter,
 		totalNetworkFlowsReceivedCounter,
 		totalNetworkEndpointsSentCounter,

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -76,6 +76,13 @@ var (
 		Help:      "A counter of the total number of times we've dropped indicators from the indicators channel because it was full",
 	})
 
+	networkFlowBufferGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "network_flow_buffer_size",
+		Help:      "A gauge of the current size of the Network Flow buffer in Sensor (updated every 30s)",
+	})
+
 	totalNetworkFlowsSentCounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
@@ -254,6 +261,11 @@ func IncrementTotalResourcesSyncSent(value int) {
 // SetResourcesSyncedSize sets the latest resources synced message size transmitted to central.
 func SetResourcesSyncedSize(size int) {
 	resourcesSyncedMessageSize.Set(float64(size))
+}
+
+// SetNetworkFlowBufferSizeGauge set network flow buffer size gauge.
+func SetNetworkFlowBufferSizeGauge(v int) {
+	networkFlowBufferGauge.Set(float64(v))
 }
 
 // IncrementTotalNetworkFlowsSentCounter registers the total number of flows processed

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -741,6 +741,7 @@ func (b *sendNetflowsSuite) updateConn(pair *connectionPair) {
 }
 
 func (b *sendNetflowsSuite) expectLookups(n int) {
+	b.mockEntity.EXPECT().RecordTick().AnyTimes()
 	expectEntityLookupContainerHelper(b.mockEntity, n, clusterentities.ContainerMetadata{
 		DeploymentID: srcID,
 	}, true)()

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -865,7 +865,6 @@ func mustReadTimeout[T any](t *testing.T, ch chan T) T {
 			require.True(t, more, "channel should never close")
 		}
 		result = v
-		return v
 	case <-time.After(waitTimeout):
 		t.Fatal("blocked on reading from channel")
 	}

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -9,12 +9,16 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
+	mocksDetector "github.com/stackrox/rox/sensor/common/detector/mocks"
+	mocksManager "github.com/stackrox/rox/sensor/common/networkflow/manager/mocks"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -68,6 +72,10 @@ var (
 			ProcessArgs:         "port: 80",
 		},
 	}
+)
+
+const (
+	waitTimeout = 20 * time.Millisecond
 )
 
 func TestNetworkFlowManager(t *testing.T) {
@@ -695,6 +703,182 @@ func (s *NetworkFlowManagerTestSuite) TestExpireMessage() {
 		s.Assert().True(msg.IsExpired(), "the message should be expired")
 	}
 	m.Stop(nil)
+}
+
+func TestSendNetworkFlows(t *testing.T) {
+	t.Setenv(features.SensorCapturesIntermediateEvents.EnvVar(), "true")
+	suite.Run(t, new(sendNetflowsSuite))
+}
+
+type sendNetflowsSuite struct {
+	suite.Suite
+	mockCtrl     *gomock.Controller
+	mockEntity   *mocksManager.MockEntityStore
+	m            *networkFlowManager
+	mockDetector *mocksDetector.MockDetector
+	fakeTicker   chan time.Time
+}
+
+const (
+	srcID = "src-id"
+	dstID = "dst-id"
+)
+
+func (b *sendNetflowsSuite) SetupTest() {
+	b.mockCtrl = gomock.NewController(b.T())
+	b.m, b.mockEntity, _, b.mockDetector = createManager(b.mockCtrl)
+
+	b.fakeTicker = make(chan time.Time)
+	go b.m.enrichConnections(b.fakeTicker)
+}
+
+func (b *sendNetflowsSuite) TeardownTest() {
+	b.m.done.Signal()
+}
+
+func (b *sendNetflowsSuite) updateConn(pair *connectionPair) {
+	addHostConnection(b.m, createHostnameConnections("hostname").withConnectionPair(pair))
+}
+
+func (b *sendNetflowsSuite) expectLookups(n int) {
+	expectEntityLookupContainerHelper(b.mockEntity, n, clusterentities.ContainerMetadata{
+		DeploymentID: srcID,
+	}, true)()
+	expectEntityLookupEndpointHelper(b.mockEntity, n, []clusterentities.LookupResult{
+		{
+			Entity:         networkgraph.Entity{ID: dstID},
+			ContainerPorts: []uint16{80},
+		},
+	})()
+}
+
+func (b *sendNetflowsSuite) expectDetections(n int) {
+	expectDetectorHelper(b.mockDetector, n)()
+}
+
+func (b *sendNetflowsSuite) TestUpdateConnectionGeneratesNetflow() {
+	b.expectLookups(1)
+	b.expectDetections(1)
+
+	b.updateConn(createConnectionPair())
+	b.thenTickerTicks()
+	b.assertOneUpdatedConnection()
+}
+
+func (b *sendNetflowsSuite) TestUnchangedConnection() {
+	b.expectLookups(2)
+	b.expectDetections(1)
+
+	pair := createConnectionPair()
+	pair.status.lastSeen = timestamp.InfiniteFuture
+	b.updateConn(pair)
+	b.thenTickerTicks()
+	b.assertOneUpdatedConnection()
+
+	// There should be no second update, the connection did not change
+	b.thenTickerTicks()
+	mustNotRead(b.T(), b.m.sensorUpdates)
+}
+
+func (b *sendNetflowsSuite) TestSendTwoUpdatesOnConnectionChanged() {
+	b.expectLookups(2)
+	b.expectDetections(2)
+
+	pair := createConnectionPair()
+	oneHourAgo := timestamp.NowMinus(time.Hour)
+	pair.status.lastSeen = timestamp.FromProtobuf(oneHourAgo)
+	b.updateConn(pair)
+	b.thenTickerTicks()
+	b.assertOneUpdatedConnection()
+
+	pair.status.lastSeen = timestamp.Now()
+	b.updateConn(pair)
+	b.thenTickerTicks()
+	b.assertOneUpdatedConnection()
+}
+
+func (b *sendNetflowsSuite) TestUpdatesGetBufferedWhenUnread() {
+	b.expectLookups(4)
+	b.expectDetections(4)
+
+	// four times without reading
+	for i := 0; i < 4; i++ {
+		ts := timestamp.NowMinus(time.Duration(4-i) * time.Hour)
+		pair := createConnectionPair()
+		pair.status.lastSeen = timestamp.FromProtobuf(ts)
+		b.updateConn(pair)
+		b.thenTickerTicks()
+		time.Sleep(100 * time.Millisecond) // Immediately ticking without waiting causes unexpected behavior
+	}
+
+	// should be able to read four buffered updates in sequence
+	for i := 0; i < 4; i++ {
+		b.assertOneUpdatedConnection()
+	}
+}
+
+func (b *sendNetflowsSuite) TestCallsDetectionEvenOnFullBuffer() {
+	b.expectLookups(6)
+	b.expectDetections(6)
+
+	for i := 0; i < 6; i++ {
+		ts := timestamp.NowMinus(time.Duration(6-i) * time.Hour)
+		pair := createConnectionPair()
+		pair.status.lastSeen = timestamp.FromProtobuf(ts)
+		b.updateConn(pair)
+		b.thenTickerTicks()
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Will only store 5 network flow updates, as it's the maximum buffer size in the test
+	for i := 0; i < 5; i++ {
+		b.assertOneUpdatedConnection()
+	}
+
+	mustNotRead(b.T(), b.m.sensorUpdates)
+}
+
+func (b *sendNetflowsSuite) thenTickerTicks() {
+	mustSendWithoutBlock(b.T(), b.fakeTicker, time.Now())
+}
+
+func (b *sendNetflowsSuite) assertOneUpdatedConnection() {
+	msg := mustReadTimeout(b.T(), b.m.sensorUpdates)
+	netflowUpdate, ok := msg.Msg.(*central.MsgFromSensor_NetworkFlowUpdate)
+	b.Require().True(ok, "message is NetworkFlowUpdate")
+	b.Assert().Len(netflowUpdate.NetworkFlowUpdate.GetUpdated(), 1, "one updated connection")
+}
+
+func mustNotRead[T any](t *testing.T, ch chan T) {
+	select {
+	case <-ch:
+		t.Fatal("should not receive in channel")
+	case <-time.After(waitTimeout):
+	}
+}
+
+func mustReadTimeout[T any](t *testing.T, ch chan T) T {
+	var result T
+	select {
+	case v, more := <-ch:
+		if !more {
+			require.True(t, more, "channel should never close")
+		}
+		result = v
+		return v
+	case <-time.After(waitTimeout):
+		t.Fatal("blocked on reading from channel")
+	}
+	return result
+}
+
+func mustSendWithoutBlock[T any](t *testing.T, ch chan T, v T) {
+	select {
+	case ch <- v:
+		return
+	case <-time.After(waitTimeout):
+		t.Fatal("blocked on sending to channel")
+	}
 }
 
 // endregion

--- a/sensor/common/networkflow/manager/testing_test.go
+++ b/sensor/common/networkflow/manager/testing_test.go
@@ -29,7 +29,7 @@ func createManager(mockCtrl *gomock.Controller) (*networkFlowManager, *mocksMana
 		policyDetector:    mockDetector,
 		done:              concurrency.NewSignal(),
 		connectionsByHost: make(map[string]*hostConnections),
-		sensorUpdates:     make(chan *message.ExpiringMessage),
+		sensorUpdates:     make(chan *message.ExpiringMessage, 5),
 		publicIPs:         newPublicIPsManager(),
 		centralReady:      concurrency.NewSignal(),
 		enricherTicker:    ticker,


### PR DESCRIPTION
## Description

This PR introduces buffering for Network Flow Updates.

- Buffer will not be read by gRPC component while offline
- Network Flow Manager does not need to control offline-mode anymore, as it always writes data into a buffer
- Buffer size if controlled by environment variable `ROX_SENSOR_NETFLOW_OFFLINE_BUFFER_SIZE`
- If buffer is full, the flow is not appended and current state isn't updated. Therefore next tick will carry over updated flows.
- If buffer is full, the flow updates are still sent to detection.
- New metric `network_flow_buffer_size` gauges how filled the buffer is


## Checklist
- [x] Fix unit tests on network flow manager
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] New unit test in `manager_impl`
- [x] Local sensor filling and offloading buffer with fake data
- [x] Test with real workloads
- [x] No leaks when buffer is full

1. Deploy ACS
2. Create deployment A
3. Stop connection between sensor and central (you can use chaos proxy or teardown central)
4. Generate flow from deployment A (can be as simple as making an HTTP call to a public endpoint)
5. Observe metric `network_flow_buffer_size` increase after 30s 
6. Reconnect central and sensor
7. Observe metric `network_flow_buffer_size` decrease after 30s 
8. Network flow is shown in the Network Graph

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
