### PR TITLE
ROX-18313: Fix compliance integration test runner

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -24,7 +24,7 @@ external-backup-tests:
 
 .PHONY: compliance-tests
 compliance-tests:
-	../scripts/go-test.sh -cover -v -run compliance_operator_test.go 2>&1 | tee test.log
+	../scripts/go-test.sh -cover -v -run TestCompliance 2>&1 | tee test.log
 	@$(MAKE) report JUNIT_OUT=compliance-tests-results
 
 include ../make/stackrox.mk

--- a/tests/compliance_operator_test.go
+++ b/tests/compliance_operator_test.go
@@ -155,7 +155,7 @@ func getDynamicClientGenerator(t *testing.T) dynamic.Interface {
 	return dynamicClientGenerator
 }
 
-func TestDeleteAndAddRule(t *testing.T) {
+func TestComplianceOperatorDeleteAndAddRule(t *testing.T) {
 	checkBaseResults(t)
 
 	dynamicClientGenerator := getDynamicClientGenerator(t)
@@ -195,7 +195,7 @@ func TestDeleteAndAddRule(t *testing.T) {
 	checkBaseResults(t)
 }
 
-func TestDeleteAndAddScanSettingBinding(t *testing.T) {
+func TestComplianceOperatorDeleteAndAddScanSettingBinding(t *testing.T) {
 	checkBaseResults(t)
 
 	dynamicClientGenerator := getDynamicClientGenerator(t)
@@ -227,7 +227,7 @@ func TestDeleteAndAddScanSettingBinding(t *testing.T) {
 	checkBaseResults(t)
 }
 
-func TestDeleteAndAddProfile(t *testing.T) {
+func TestComplianceOperatorDeleteAndAddProfile(t *testing.T) {
 	checkBaseResults(t)
 
 	dynamicClientGenerator := getDynamicClientGenerator(t)
@@ -259,7 +259,7 @@ func TestDeleteAndAddProfile(t *testing.T) {
 	checkBaseResults(t)
 }
 
-func TestUpdateProfile(t *testing.T) {
+func TestComplianceOperatorUpdateProfile(t *testing.T) {
 	checkBaseResults(t)
 
 	dynamicClientGenerator := getDynamicClientGenerator(t)


### PR DESCRIPTION
Currently, we have e2e testing that exercises the Compliance Operator integration, which is invoked with all e2e/integration tests.

But, there is also a compliance-specific e2e suite that only sets up and runs compliance-related integration tests using:

  make -C tests compliance-tests

Right now, this suite doesn't run any tests because the go test invocation uses `-run compliance_operator_test.go`, when it's expecting a regular expression:

  The argument to the -run, -bench, and -fuzz command-line flags is an
  unanchored regular expression that matches the test's name.

This commit uses a consistent substring in all the compliance-related tests, and then using that string as a regular expression in go test invocation, so they are discovered when you use the `compliance-tests` target.

This isn't a problem when we run all e2e tests using `run.sh` because we do test discovery without using `-run`, or a regular expression, so all compliance-related tests are discovered.

This will become more useful when we have compliance tests running with a dedicated e2e test that gets invoked on all compliance-related changes.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

This change should be apparent in the test logs when using the Prow compliance e2e test job.