### PR TITLE
ROX-20237: Enable Snyk SAST scanner in RHTAP

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -10,3 +10,4 @@
 /bin/
 /linux-gocache/
 /operator/*/bin/
+.dccache

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 /linux-gocache/
 /operator/*/bin/
 /qa-tests-backend/
+.dccache

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ shellcheck-reports
 
 # Direnv
 .direnv/
+
+# Snyk
+.dccache

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,22 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+ignore: {}
+patch: {}
+exclude:
+  global:
+    - '.openshift-ci'
+    - '.github/workflows/scripts/scanner-update-nvd.py'
+    - '.github/workflows/scripts/check-image-vulnerabilities.py'
+    - 'central'
+    - 'compliance'
+    - 'govulncheck/main.go'
+    - 'migrator'
+    - 'operator'
+    - 'pkg'
+    - 'roxctl'
+    - 'scale/tests'
+    - 'scripts/certification/format_csv.py'
+    - 'sensor'
+    - 'tests'
+    - 'tools'
+    - 'ui'


### PR DESCRIPTION
## Description

The check is enabled if the `snyk-secret` is present in RHTAP. Right now, I removed it to not interfere with other builds.
A process needs to be established to review the findings eventually. 

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Two pipeline runs for this PR:

- [Task log (178 issues found)](https://github.com/stackrox/stackrox/files/13658679/operator-on-pull-request-kvjbp-sast-snyk-check.log)
- [Task log with all files with issues ignored](https://github.com/stackrox/stackrox/files/13658682/central-db-on-pull-request-pc7rx-sast-snyk-check.log)