### PR TITLE
ROX-20788: refactor ECR client

### DIFF
--- a/pkg/registries/ecr/ecr.go
+++ b/pkg/registries/ecr/ecr.go
@@ -122,23 +122,18 @@ func newRegistry(integration *storage.ImageIntegration, disableRepoList bool) (*
 	// If the ECR configuration provides Authorization Data, we do not initialize an
 	// ECR client, but instead, we create the registry immediately since the
 	// Authorization Data payload provides the credentials statically.
-	var cfg *docker.Config
+	cfg := &docker.Config{
+		Endpoint:        endpoint,
+		DisableRepoList: disableRepoList,
+	}
 	if authData := conf.GetAuthorizationData(); authData != nil {
-		cfg = &docker.Config{
-			Username:        authData.GetUsername(),
-			Password:        authData.GetPassword(),
-			Endpoint:        endpoint,
-			DisableRepoList: disableRepoList,
-		}
+		cfg.Username = authData.GetUsername()
+		cfg.Password = authData.GetPassword()
 	} else {
 		client, err := createECRClient(conf)
 		if err != nil {
-			log.Error("Failed to create client: ", err)
+			log.Error("Failed to create ECR client: ", err)
 			return nil, err
-		}
-		cfg = &docker.Config{
-			Endpoint:        endpoint,
-			DisableRepoList: disableRepoList,
 		}
 		cfg.Transport = newAWSTransport(cfg, client)
 	}

--- a/pkg/registries/ecr/ecr.go
+++ b/pkg/registries/ecr/ecr.go
@@ -1,17 +1,13 @@
 package ecr
 
 import (
-	"encoding/base64"
 	"fmt"
-	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	awsECR "github.com/aws/aws-sdk-go/service/ecr"
-	protobuftypes "github.com/gogo/protobuf/types"
 	"github.com/heroku/docker-registry-client/registry"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
@@ -31,11 +27,6 @@ type ecr struct {
 
 	config      *storage.ECRConfig
 	integration *storage.ImageIntegration
-
-	endpoint        string
-	service         *awsECR.ECR
-	expiryTime      time.Time
-	disableRepoList bool
 }
 
 // sanitizeConfiguration validates and cleans-up the integration configuration.
@@ -82,63 +73,9 @@ func sanitizeConfiguration(ecr *storage.ECRConfig) error {
 	return errorList.ToError()
 }
 
-func (e *ecr) refreshDockerClient() error {
-	if e.expiryTime.After(time.Now()) {
-		return nil
-	}
-	if e.integration.GetEcr().GetAuthorizationData() != nil {
-		// This integration has static authorization data, and we never refresh the
-		// tokens in central, rather we wait for sensor to update them.
-		return errors.New("failed to refresh the auto-generated integration credentials")
-	}
-	authToken, err := e.service.GetAuthorizationToken(&awsECR.GetAuthorizationTokenInput{})
-	if err != nil {
-		return err
-	}
-
-	if len(authToken.AuthorizationData) == 0 {
-		return fmt.Errorf("received empty authorization data in token: %s", authToken)
-	}
-
-	authData := authToken.AuthorizationData[0]
-
-	decoded, err := base64.StdEncoding.DecodeString(*authData.AuthorizationToken)
-	if err != nil {
-		return err
-	}
-	basicAuth := string(decoded)
-	colon := strings.Index(basicAuth, ":")
-	if colon == -1 {
-		return fmt.Errorf("malformed basic auth response from AWS '%s'", basicAuth)
-	}
-	return e.setRegistry(basicAuth[:colon], basicAuth[colon+1:], *authData.ExpiresAt)
-}
-
-// Metadata returns the metadata via this registry's implementation.
-func (e *ecr) Metadata(image *storage.Image) (*storage.ImageMetadata, error) {
-	if err := e.refreshDockerClient(); err != nil {
-		return nil, err
-	}
-	return e.Registry.Metadata(image)
-}
-
-// Config returns the config via this registry's implementation.
-func (e *ecr) Config() *types.Config {
-	// TODO(ROX-9868): Return nil-config to caller.
-	if err := e.refreshDockerClient(); err != nil {
-		log.Errorf("Error refreshing docker client for registry %q: %v", e.Name(), err)
-	}
-	return e.Registry.Config()
-}
-
-// Test tests the current registry and makes sure that it is working properly
+// Test tests the current registry and makes sure that it is working properly.
 func (e *ecr) Test() error {
-	if err := e.refreshDockerClient(); err != nil {
-		return err
-	}
-
 	_, err := e.Registry.Client.Repositories()
-
 	// the following code taken from generic Test method
 	if err != nil {
 		log.Errorf("error testing ECR integration: %v", err)
@@ -180,51 +117,37 @@ func newRegistry(integration *storage.ImageIntegration, disableRepoList bool) (*
 	reg := &ecr{
 		config:      conf,
 		integration: integration,
-		// docker endpoint
-		endpoint:        fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", conf.GetRegistryId(), conf.GetRegion()),
-		disableRepoList: disableRepoList,
 	}
+	endpoint := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", conf.GetRegistryId(), conf.GetRegion())
 	// If the ECR configuration provides Authorization Data, we do not initialize an
 	// ECR client, but instead, we create the registry immediately since the
 	// Authorization Data payload provides the credentials statically.
+	var cfg *docker.Config
 	if authData := conf.GetAuthorizationData(); authData != nil {
-		expiresAt, err := protobuftypes.TimestampFromProto(authData.GetExpiresAt())
-		if err != nil {
-			return nil, errors.New("invalid authorization data")
-		}
-		if err = reg.setRegistry(authData.GetUsername(), authData.GetPassword(), expiresAt); err != nil {
-			return nil, errors.Wrap(err, "failed to create registry client")
+		cfg = &docker.Config{
+			Username:        authData.GetUsername(),
+			Password:        authData.GetPassword(),
+			Endpoint:        endpoint,
+			DisableRepoList: disableRepoList,
 		}
 	} else {
-		service, err := createECRClient(conf)
+		client, err := createECRClient(conf)
 		if err != nil {
+			log.Error("Failed to create client: ", err)
 			return nil, err
 		}
-		reg.service = service
-		// Refreshing the client will force the creation of the registry client using AWS ECR.
-		if err := reg.refreshDockerClient(); err != nil {
-			return nil, err
+		cfg = &docker.Config{
+			Endpoint:        endpoint,
+			DisableRepoList: disableRepoList,
 		}
+		cfg.Transport = newAWSTransport(cfg, client)
 	}
-	return reg, nil
-}
-
-// setRegistry creates and sets the docker registry client based on the
-// credentials provided.
-func (e *ecr) setRegistry(username, password string, expiresAt time.Time) error {
-	conf := &docker.Config{
-		Endpoint:        e.endpoint,
-		Username:        username,
-		Password:        password,
-		DisableRepoList: e.disableRepoList,
-	}
-	client, err := docker.NewDockerRegistryWithConfig(conf, e.integration)
+	dockerRegistry, err := docker.NewDockerRegistryWithConfig(cfg, reg.integration)
 	if err != nil {
-		return err
+		return nil, errors.Wrap(err, "failed to create docker registry")
 	}
-	e.Registry = client
-	e.expiryTime = expiresAt
-	return err
+	reg.Registry = dockerRegistry
+	return reg, nil
 }
 
 // createECRClient creates an AWS ECR SDK client based on the integration config.

--- a/pkg/registries/ecr/ecr_test.go
+++ b/pkg/registries/ecr/ecr_test.go
@@ -42,7 +42,6 @@ func TestECRIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NoError(t, ecr.Test())
-	assert.Equal(t, fmt.Sprintf("%s.dkr.ecr.us-west-2.amazonaws.com", registryID), ecr.endpoint)
 
 	metadata, err := ecr.Metadata(&storage.Image{
 		Name: &storage.ImageName{

--- a/pkg/registries/ecr/ecr_test.go
+++ b/pkg/registries/ecr/ecr_test.go
@@ -42,6 +42,7 @@ func TestECRIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NoError(t, ecr.Test())
+	assert.Equal(t, fmt.Sprintf("%s.dkr.ecr.us-west-2.amazonaws.com", registryID), ecr.config.GetEndpoint())
 
 	metadata, err := ecr.Metadata(&storage.Image{
 		Name: &storage.ImageName{

--- a/pkg/registries/ecr/transport.go
+++ b/pkg/registries/ecr/transport.go
@@ -1,0 +1,70 @@
+package ecr
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"time"
+
+	awsECR "github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/heroku/docker-registry-client/registry"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/registries/docker"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+type awsTransport struct {
+	registry.Transport
+	config    *docker.Config
+	client    *awsECR.ECR
+	expiresAt *time.Time
+	mutex     sync.Mutex
+}
+
+func newAWSTransport(config *docker.Config, client *awsECR.ECR) *awsTransport {
+	transport := &awsTransport{config: config, client: client}
+	if err := transport.refreshNoLock(); err != nil {
+		log.Error("Failed to refresh token: ", err)
+	}
+	return transport
+}
+
+func (t *awsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	if t.isExpiredNoLock() {
+		if err := t.refreshNoLock(); err != nil {
+			return nil, err
+		}
+	}
+	return t.Transport.RoundTrip(req)
+}
+
+func (t *awsTransport) isExpiredNoLock() bool {
+	return t.expiresAt == nil || t.expiresAt.After(time.Now())
+}
+
+func (t *awsTransport) refreshNoLock() error {
+	authToken, err := t.client.GetAuthorizationToken(&awsECR.GetAuthorizationTokenInput{})
+	if err != nil {
+		return errors.Wrap(err, "failed to get authorization token")
+	}
+	if len(authToken.AuthorizationData) == 0 {
+		return errors.New("received empty authorization data in token")
+	}
+	authData := authToken.AuthorizationData[0]
+	decoded, err := base64.StdEncoding.DecodeString(*authData.AuthorizationToken)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode authorization token")
+	}
+	basicAuth := string(decoded)
+	colon := strings.Index(basicAuth, ":")
+	if colon == -1 {
+		return errors.New("malformed basic auth response from AWS")
+	}
+	t.expiresAt = authData.ExpiresAt
+	t.config.Username = basicAuth[:colon]
+	t.config.Password = basicAuth[colon+1:]
+	t.Transport = docker.DefaultTransport(t.config)
+	return nil
+}


### PR DESCRIPTION
## Description

This PR is a refactor of the AWS ECR integration. The goal is to get rid of the `refreshDockerClient` functionality, because it performs unprotected concurrent read/writes and may lead to a data race. As an alternative, we introduce a custom AWS transport, which performs the token refresh in a concurrency safe way.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Tested on test cluster (ROSA HCP):
* STS enabled ECR `Test` is successful after Central start.
* STS enabled ECR `Test` is successful after 12h when the first access token expires.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
