### PR TITLE
ROX-17800,ROX-19883: Fix declarative config test flakes

### DIFF
--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -49,9 +49,9 @@ class DeclarativeConfigTest extends BaseSpecification {
     static final private int CREATED_RESOURCES = 7
     static final private int MOUNTED_RESOURCES = 2
 
-    static final private int RETRIES = 75
+    static final private int RETRIES = 60
     static final private int DELETION_RETRIES = 60
-    static final private int PAUSE_SECS = 2
+    static final private int PAUSE_SECS = 3
 
     // Values used within testing for permission sets.
     // These include:
@@ -309,10 +309,18 @@ splunk:
 
         // Verify the groups are created successfully, and specify the origin declarative.
         def expectedGroups = [VALID_DEFAULT_GROUP, VALID_DECLARATIVE_GROUP]
-        verifyDeclarativeGroups(authProvider.getId(), expectedGroups)
+        def groupsResponse = GroupService.getGroups(
+                GroupServiceOuterClass.GetGroupsRequest.newBuilder().setAuthProviderId(authProvider.getId()).build())
+        def expectedProperties = expectedGroups.props
+        verifyAll(groupsResponse.getGroupsList().props) {
+            it.key == expectedProperties.key
+            it.value == expectedProperties.value
+            it.traits.origin == expectedProperties.traits.origin
+            it.authProviderId.every { it == authProvider.id }
+        }
 
         // Verify the notifier is created successfully, and does specify the origin declarative.
-        verifyDeclarativeNotifier(VALID_NOTIFIER)
+        assert verifyDeclarativeNotifier(VALID_NOTIFIER)
 
         when:
         // Update the config map to contain an invalid permission set YAML.
@@ -470,8 +478,8 @@ splunk:
         then:
         withRetry(RETRIES, PAUSE_SECS) {
             def response = DeclarativeConfigHealthService.getDeclarativeConfigHealthInfo()
-            // Expect 6 integration health status for the created resources and 2 for declarative config mounts.
-            assert response.healthsCount == CREATED_RESOURCES - 1 + MOUNTED_RESOURCES
+            // Expect 5 integration health status for the created resources and 2 for declarative config mounts.
+            assert response.healthsCount == CREATED_RESOURCES - 2 + MOUNTED_RESOURCES
 
             for (integrationHealth in response.getHealthsList()) {
                 // Config map health will be healthy and do not indicate an error.
@@ -759,20 +767,24 @@ splunk:
     private Role verifyDeclarativeRole(Role expectedRole, String permissionSetID, String accessScopeID) {
         def role = RoleService.getRole(expectedRole.getName())
         assert role : "declarative role ${expectedRole.getName()} does not exist"
-        assert role.getName() == expectedRole.getName()
-        assert role.getDescription() == expectedRole.getDescription()
-        assert role.getTraits().getOrigin() == expectedRole.getTraits().getOrigin()
-        assert role.getAccessScopeId() == accessScopeID
-        assert role.getPermissionSetId() == permissionSetID
+        verifyAll(role) {
+            getName() == expectedRole.getName()
+            getDescription() == expectedRole.getDescription()
+            getTraits().getOrigin() == expectedRole.getTraits().getOrigin()
+            getAccessScopeId() == accessScopeID
+            getPermissionSetId() == permissionSetID
+        }
         return role
     }
 
     private Role verifyDeclarativeRole(Role expectedRole) {
         def role = RoleService.getRole(expectedRole.getName())
         assert role : "declarative role ${expectedRole.getName()} does not exist"
-        assert role.getName() == expectedRole.getName()
-        assert role.getDescription() == expectedRole.getDescription()
-        assert role.getTraits().getOrigin() == expectedRole.getTraits().getOrigin()
+        verifyAll(role) {
+            getName() == expectedRole.getName()
+            getDescription() == expectedRole.getDescription()
+            getTraits().getOrigin() == expectedRole.getTraits().getOrigin()
+        }
         return role
     }
 
@@ -785,10 +797,12 @@ splunk:
             it.getName() == expectedPermissionSet.getName()
         }
         assert permissionSet
-        assert permissionSet.getDescription() == expectedPermissionSet.getDescription()
-        assert permissionSet.getTraits().getOrigin() == expectedPermissionSet.getTraits().getOrigin()
-        assert permissionSet.getResourceToAccessMap() == expectedPermissionSet.getResourceToAccessMap()
-        assert permissionSet.getId()
+        verifyAll(permissionSet) {
+            getDescription() == expectedPermissionSet.getDescription()
+            getTraits().getOrigin() == expectedPermissionSet.getTraits().getOrigin()
+            getResourceToAccessMap() == expectedPermissionSet.getResourceToAccessMap()
+            getId() != ""
+        }
         return permissionSet
     }
 
@@ -801,33 +815,13 @@ splunk:
             it.getName() == expectedAccessScope.getName()
         }
         assert accessScope
-        assert accessScope.getDescription() == expectedAccessScope.getDescription()
-        assert accessScope.getTraits().getOrigin() == expectedAccessScope.getTraits().getOrigin()
-        assert accessScope.getRules() == expectedAccessScope.getRules()
-        assert accessScope.getId()
-        return accessScope
-    }
-
-    // verifyDeclarativeGroups will verify that the expected groups exist within the API and share the same
-    // values.
-    // The number of groups found within the list of expected groups will be returned.
-    private verifyDeclarativeGroups(String authProviderID, List<Group> expectedGroups) {
-        def groupsResponse = GroupService.getGroups(
-                GroupServiceOuterClass.GetGroupsRequest.newBuilder().setAuthProviderId(authProviderID).build())
-        assert groupsResponse.getGroupsCount() == expectedGroups.size()
-        def verifiedGroups = 0
-        for (group in groupsResponse.getGroupsList()) {
-            for (expectedGroup in expectedGroups) {
-                if (group.getRoleName() == expectedGroup.getRoleName()) {
-                    verifiedGroups++
-                    assert group.getProps().getKey() == expectedGroup.getProps().getKey()
-                    assert group.getProps().getValue() == expectedGroup.getProps().getValue()
-                    assert group.getProps().getAuthProviderId() == authProviderID
-                    assert group.getProps().getTraits().getOrigin() == expectedGroup.getProps().getTraits().getOrigin()
-                }
-            }
+        verifyAll(accessScope) {
+            getDescription() == expectedAccessScope.getDescription()
+            getTraits().getOrigin() == expectedAccessScope.getTraits().getOrigin()
+            getRules() == expectedAccessScope.getRules()
+            getId() != ""
         }
-        assert verifiedGroups == expectedGroups.size()
+        return accessScope
     }
 
     // verifyDeclarativeAuthProvider will verify that the expected auth provider exists within the API and
@@ -847,30 +841,35 @@ splunk:
             authProvider = authProviderResponse.getAuthProviders(0)
         }
         assert authProvider
-        assert authProvider.getName() == expectedAuthProvider.getName()
-        assert authProvider.getType() == expectedAuthProvider.getType()
-        assert authProvider.getLoginUrl()
-        assert authProvider.getUiEndpoint() == expectedAuthProvider.getUiEndpoint()
-        assert authProvider.getTraits().getOrigin() == expectedAuthProvider.getTraits().getOrigin()
-        assert authProvider.getActive()
-        assert authProvider.getEnabled()
-        assert authProvider.getConfigMap() == expectedAuthProvider.getConfigMap()
+        verifyAll(authProvider) {
+            getName() == expectedAuthProvider.getName()
+            getType() == expectedAuthProvider.getType()
+            getLoginUrl() != ""
+            getUiEndpoint() == expectedAuthProvider.getUiEndpoint()
+            getTraits().getOrigin() == expectedAuthProvider.getTraits().getOrigin()
+            getActive()
+            getEnabled()
+            getConfigMap() == expectedAuthProvider.getConfigMap()
+        }
         return authProvider
     }
 
     // verifyDeclarativeNotifier will verify that the expected auth provider exists within the API and
     // shares the same values.
     // The retrieved notifier from the API will be returned, which will have the ID field populated.
-    private verifyDeclarativeNotifier(Notifier expectedNotifier) {
+    private Notifier verifyDeclarativeNotifier(Notifier expectedNotifier) {
         def notifier = NotifierService.getNotifierClient().getNotifiers(
                 NotifierServiceOuterClass.GetNotifiersRequest
                         .newBuilder().build())
                 .notifiersList.find { it.getName() == VALID_NOTIFIER.getName() }
         assert notifier
-        assert notifier.getTraits().getOrigin() == expectedNotifier.getTraits().getOrigin()
-        assert notifier.getType() == "splunk"
-        // Skipping the HTTP token since it will be obscured by the API.
-        assert notifier.getSplunk().getHttpEndpoint() == expectedNotifier.getSplunk().getHttpEndpoint()
-        assert notifier.getSplunk().getSourceTypesMap() == expectedNotifier.getSplunk().getSourceTypesMap()
+        verifyAll(notifier) {
+            getTraits().getOrigin() == expectedNotifier.getTraits().getOrigin()
+            getType() == "splunk"
+            // Skipping the HTTP token since it will be obscured by the API.
+            getSplunk().getHttpEndpoint() == expectedNotifier.getSplunk().getHttpEndpoint()
+            getSplunk().getSourceTypesMap() == expectedNotifier.getSplunk().getSourceTypesMap()
+        }
+        return notifier
     }
 }


### PR DESCRIPTION
## Description

This PR includes fixes for two flakes within declarative config tests, which are loosely related.

The main issue between both seems to be that the lock wasn't held for the complete critical section, which could lead to rare overwrites.

The locks have been fixed, and the timeout has been slightly increased as well for the E2E test.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing.
- affected unit test run 10000x without failures.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
