### PR TITLE
ROX-21144: Reset pagination between vulns and resource tabs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -18,6 +18,7 @@ import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 
 import NotFoundMessage from 'Components/NotFoundMessage';
+import useURLPagination from 'hooks/useURLPagination';
 import { getOverviewCvesPath } from '../searchUtils';
 import DeploymentPageHeader, {
     DeploymentMetadata,
@@ -45,6 +46,8 @@ const deploymentMetadataQuery = gql`
 function DeploymentPage() {
     const { deploymentId } = useParams() as { deploymentId: string };
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
+
+    const pagination = useURLPagination(20);
 
     const metadataRequest = useQuery<{ deployment: DeploymentMetadata | null }, { id: string }>(
         deploymentMetadataQuery,
@@ -99,7 +102,10 @@ function DeploymentPage() {
                     >
                         <Tabs
                             activeKey={activeTabKey}
-                            onSelect={(e, key) => setActiveTabKey(key)}
+                            onSelect={(e, key) => {
+                                setActiveTabKey(key);
+                                pagination.setPage(1);
+                            }}
                             component={TabsComponent.nav}
                             className="pf-u-pl-md pf-u-background-color-100"
                             mountOnEnter
@@ -110,14 +116,20 @@ function DeploymentPage() {
                                 eventKey="Vulnerabilities"
                                 title={<TabTitleText>Vulnerabilities</TabTitleText>}
                             >
-                                <DeploymentPageVulnerabilities deploymentId={deploymentId} />
+                                <DeploymentPageVulnerabilities
+                                    deploymentId={deploymentId}
+                                    pagination={pagination}
+                                />
                             </Tab>
                             <Tab
                                 className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
                                 eventKey="Resources"
                                 title={<TabTitleText>Resources</TabTitleText>}
                             >
-                                <DeploymentPageResources deploymentId={deploymentId} />
+                                <DeploymentPageResources
+                                    deploymentId={deploymentId}
+                                    pagination={pagination}
+                                />
                             </Tab>
                         </Tabs>
                     </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
@@ -11,15 +11,16 @@ import {
 import { gql, useQuery } from '@apollo/client';
 import { Pagination as PaginationParam } from 'services/types';
 
-import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import { defaultImageSortFields, imagesDefaultSort } from '../sortUtils';
 import TableErrorComponent from '../components/TableErrorComponent';
 import ImageResourceTable, { ImageResources, imageResourcesFragment } from './ImageResourceTable';
 
 export type DeploymentPageResourcesProps = {
     deploymentId: string;
+    pagination: UseURLPaginationResult;
 };
 
 const deploymentResourcesQuery = gql`
@@ -32,8 +33,8 @@ const deploymentResourcesQuery = gql`
     }
 `;
 
-function DeploymentPageResources({ deploymentId }: DeploymentPageResourcesProps) {
-    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+function DeploymentPageResources({ deploymentId, pagination }: DeploymentPageResourcesProps) {
+    const { page, perPage, setPage, setPerPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
         sortFields: defaultImageSortFields,
         defaultSortOption: imagesDefaultSort,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -18,7 +18,7 @@ import {
 } from '@patternfly/react-core';
 import { gql, useQuery } from '@apollo/client';
 
-import useURLPagination from 'hooks/useURLPagination';
+import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
 import { Pagination as PaginationParam } from 'services/types';
@@ -95,15 +95,19 @@ const searchOptions: SearchOption[] = [
 
 export type DeploymentPageVulnerabilitiesProps = {
     deploymentId: string;
+    pagination: UseURLPaginationResult;
 };
 
-function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabilitiesProps) {
+function DeploymentPageVulnerabilities({
+    deploymentId,
+    pagination,
+}: DeploymentPageVulnerabilitiesProps) {
     const currentVulnerabilityState = useVulnerabilityState();
 
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
 
-    const { page, setPage, perPage, setPerPage } = useURLPagination(20);
+    const { page, setPage, perPage, setPerPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
         sortFields: defaultSortFields,
         defaultSortOption: {
@@ -139,12 +143,6 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
 
     const summaryData = summaryRequest.data ?? summaryRequest.previousData;
 
-    const pagination = {
-        offset: (page - 1) * perPage,
-        limit: perPage,
-        sortOption,
-    };
-
     const vulnerabilityRequest = useQuery<
         {
             deployment:
@@ -165,7 +163,11 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
         variables: {
             id: deploymentId,
             query,
-            pagination,
+            pagination: {
+                offset: (page - 1) * perPage,
+                limit: perPage,
+                sortOption,
+            },
             statusesForExceptionCount: getStatusesForExceptionCount(currentVulnerabilityState),
         },
     });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -23,6 +23,7 @@ import PageTitle from 'Components/PageTitle';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import useURLPagination from 'hooks/useURLPagination';
 import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import ImagePageVulnerabilities from './ImagePageVulnerabilities';
 import ImagePageResources from './ImagePageResources';
@@ -74,6 +75,8 @@ function ImagePage() {
     });
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
     const { invalidateAll: refetchAll } = useInvalidateVulnerabilityQueries();
+
+    const pagination = useURLPagination(20);
 
     const imageData = data && data.image;
     const imageName = imageData?.name
@@ -137,7 +140,10 @@ function ImagePage() {
                 >
                     <Tabs
                         activeKey={activeTabKey}
-                        onSelect={(e, key) => setActiveTabKey(key)}
+                        onSelect={(e, key) => {
+                            setActiveTabKey(key);
+                            pagination.setPage(1);
+                        }}
                         component={TabsComponent.nav}
                         className="pf-u-pl-md pf-u-background-color-100"
                         mountOnEnter
@@ -158,6 +164,7 @@ function ImagePage() {
                                     }
                                 }
                                 refetchAll={refetchAll}
+                                pagination={pagination}
                             />
                         </Tab>
                         <Tab
@@ -165,7 +172,7 @@ function ImagePage() {
                             eventKey="Resources"
                             title={<TabTitleText>Resources</TabTitleText>}
                         >
-                            <ImagePageResources imageId={imageId} />
+                            <ImagePageResources imageId={imageId} pagination={pagination} />
                         </Tab>
                     </Tabs>
                 </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
@@ -11,7 +11,7 @@ import {
 import { gql, useQuery } from '@apollo/client';
 import { Pagination as PaginationParam } from 'services/types';
 
-import useURLPagination from 'hooks/useURLPagination';
+import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { deploymentsDefaultSort, defaultDeploymentSortFields } from '../sortUtils';
@@ -23,6 +23,7 @@ import DeploymentResourceTable, {
 
 export type ImagePageResourcesProps = {
     imageId: string;
+    pagination: UseURLPaginationResult;
 };
 
 const imageResourcesQuery = gql`
@@ -35,8 +36,8 @@ const imageResourcesQuery = gql`
     }
 `;
 
-function ImagePageResources({ imageId }: ImagePageResourcesProps) {
-    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+function ImagePageResources({ imageId, pagination }: ImagePageResourcesProps) {
+    const { page, perPage, setPage, setPerPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
         sortFields: defaultDeploymentSortFields,
         defaultSortOption: deploymentsDefaultSort,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -19,7 +19,7 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { gql, useQuery } from '@apollo/client';
 
 import useURLSearch from 'hooks/useURLSearch';
-import useURLPagination from 'hooks/useURLPagination';
+import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
 import { Pagination as PaginationParam } from 'services/types';
 import { getHasSearchApplied } from 'utils/searchUtils';
@@ -99,12 +99,14 @@ export type ImagePageVulnerabilitiesProps = {
         tag: string;
     };
     refetchAll: () => void;
+    pagination: UseURLPaginationResult;
 };
 
 function ImagePageVulnerabilities({
     imageId,
     imageName,
     refetchAll,
+    pagination,
 }: ImagePageVulnerabilitiesProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isUnifiedDeferralsEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL');
@@ -113,7 +115,7 @@ function ImagePageVulnerabilities({
 
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
-    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const { page, perPage, setPage, setPerPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
         sortFields: defaultSortFields,
         defaultSortOption: {
@@ -122,12 +124,6 @@ function ImagePageVulnerabilities({
         },
         onSort: () => setPage(1),
     });
-
-    const pagination = {
-        offset: (page - 1) * perPage,
-        limit: perPage,
-        sortOption,
-    };
 
     const { data, previousData, loading, error } = useQuery<
         {
@@ -146,7 +142,11 @@ function ImagePageVulnerabilities({
         variables: {
             id: imageId,
             query: getVulnStateScopedQueryString(querySearchFilter, currentVulnerabilityState),
-            pagination,
+            pagination: {
+                offset: (page - 1) * perPage,
+                limit: perPage,
+                sortOption,
+            },
             statusesForExceptionCount: getStatusesForExceptionCount(currentVulnerabilityState),
         },
     });


### PR DESCRIPTION
## Description

Fixes a bug where moving to a page > 1 on the Vulnerabilities tab of an Image/Deployment page and then clicking on the Resources tab would not reset the page number. This led to an empty table in most cases, even when there was valid data.

This is fixed by moving the `useUrlPagination()` call up to the parent component, and passing the result down to each of the Vulnerabilities and Resources tabs. Previously, each of the tabs individually called this hook and made the page reset on tab change inaccessible.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit an image detail page, and progress the table to a page beyond the first.

![image](https://github.com/stackrox/stackrox/assets/1292638/ac2c0b47-3e29-408b-8903-18fb06ea872e)
![image](https://github.com/stackrox/stackrox/assets/1292638/570e970d-d996-4c02-a87a-e0200626918d)

Click the Resources tab and verify that the page is reset to page 1.
![image](https://github.com/stackrox/stackrox/assets/1292638/f3d57e68-9f99-40fe-8c48-5268e9eef463)

Repeat the above procedure on a deployment detail page.
