### PR TITLE
ROX-21409: Install compliance operator from upstream sources

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -361,9 +361,12 @@ deploy_optional_e2e_components() {
 install_the_compliance_operator() {
     csv=$(oc get csv -n openshift-compliance -o json | jq ".items[] | select(.metadata.name | test(\"compliance-operator\")).metadata.name")
     if [[ $csv == "" ]]; then
-        # ref: https://docs.openshift.com/container-platform/4.13/security/compliance_operator/compliance-operator-installation.html
+        # Install from subscription, but point to the upstream images available
+        # in https://github.com/complianceascode/compliance-operator/pkgs/container/compliance-operator.
+        # Similar process as documented in https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-installation.html
         info "Installing the compliance operator"
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/namespace.yaml"
+        oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/catalog-source.yaml"
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/operator-group.yaml"
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/subscription.yaml"
         wait_for_object_to_appear openshift-compliance deploy/compliance-operator

--- a/tests/e2e/yaml/compliance-operator/catalog-source.yaml
+++ b/tests/e2e/yaml/compliance-operator/catalog-source.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: compliance-operator
+  namespace: openshift-marketplace
+spec:
+  displayName: Compliance Operator Upstream
+  publisher: github.com/complianceascode/compliance-operator
+  sourceType: grpc
+  image: ghcr.io/complianceascode/compliance-operator-catalog:latest

--- a/tests/e2e/yaml/compliance-operator/subscription.yaml
+++ b/tests/e2e/yaml/compliance-operator/subscription.yaml
@@ -4,8 +4,7 @@ metadata:
   name: compliance-operator-sub
   namespace: openshift-compliance
 spec:
-  channel: "stable"
-  installPlanApproval: Automatic
+  channel: alpha
   name: compliance-operator
-  source: redhat-operators
+  source: compliance-operator
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Previously, we were installing the complinace operator from downstream sources using a subscription, which is fine, but installing from upstream sources gives us earlier access to upstream features that haven't been released downstream yet.

This is useful for integration work where ACS relies on compliance operator features that aren't available downstream yet. This also gives us early feedback for any compliance operator features or fixes that may break integrations in ACS.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

View the compliance integration job logs to make sure the Compliance Operator is being installed from upstream (ghci.io) instead of downstream Red Hat sources.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
