### PR TITLE
chore(release): add a PR backport action

### DIFF
--- a/.github/workflows/backport-pr.yaml
+++ b/.github/workflows/backport-pr.yaml
@@ -1,0 +1,26 @@
+name: Backport PR to release branch
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    steps:
+      - uses: tibdex/backport@v2.0.4
+        with:
+          github_token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Per title. Adding a release to a PR e.g. `backport release-4.3` will cause the PR to be backported to release branch once merged or after merge if the label is added after merge.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

None. Reviewed https://github.com/tibdex/backport, Will fork and reassess if this does not work as expected.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
