### PR TITLE
test(operator): use an explicit image pull secret

### DIFF
--- a/operator/tests/common/central-cr.yaml
+++ b/operator/tests/common/central-cr.yaml
@@ -3,6 +3,8 @@ kind: Central
 metadata:
   name: stackrox-central-services
 spec:
+  imagePullSecrets:
+  - name: e2e-test-pull-secret
   # Resource settings should be in sync with /deploy/common/local-dev-values.yaml
   central:
     adminPasswordSecret:

--- a/operator/tests/common/image-pull-secrets.yaml
+++ b/operator/tests/common/image-pull-secrets.yaml
@@ -6,7 +6,7 @@ commands:
     set -eu # shell in CI does not grok -o pipefail
     secret=$(mktemp)
     registry_hostname=quay.io
-    ../../../../deploy/common/pull-secret.sh stackrox ${registry_hostname} > $secret
+    ../../../../deploy/common/pull-secret.sh e2e-test-pull-secret ${registry_hostname} > $secret
     kubectl -n $NAMESPACE create -f $secret
     echo "Created pull secret for ${registry_hostname} in $NAMESPACE"
     rm $secret

--- a/operator/tests/common/secured-cluster-cr.yaml
+++ b/operator/tests/common/secured-cluster-cr.yaml
@@ -4,6 +4,8 @@ metadata:
   name: stackrox-secured-cluster-services
 spec:
   clusterName: testing-cluster
+  imagePullSecrets:
+  - name: e2e-test-pull-secret
   admissionControl:
     resources:
       requests:


### PR DESCRIPTION
## Description

There are several "magic" secret names that are referred to by our ServiceAccounts. `stackrox` is one of them.

This change to switch to an explicitly named, non-magic secret is in preparation for a ROX-9156 bugfix, which will remove references to non-existing magic secrets and add e2e test steps checking effects of addition and removal of "magic" secrets.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI is enough.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
