### PR TITLE
chore: Fewer manual mutex unlocks

### DIFF
--- a/central/cve/fetcher/orchestrator.go
+++ b/central/cve/fetcher/orchestrator.go
@@ -73,7 +73,7 @@ func (m *orchestratorCVEManager) Reconcile() {
 }
 
 func (m *orchestratorCVEManager) Scan(version string, cveType utils.CVEType) ([]*storage.EmbeddedVulnerability, error) {
-	scanners := map[string]types.OrchestratorScanner{}
+	scanners := make(map[string]types.OrchestratorScanner)
 
 	concurrency.WithLock(&m.mutex, func() {
 		for k, v := range m.scanners {

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -544,13 +544,13 @@ func (l *loopImpl) riskLoop() {
 		case <-l.stopSig.Done():
 			return
 		case <-l.deploymentRiskTicker.C:
-			l.deploymentRiskLock.Lock()
-			if l.deploymentRiskSet.Cardinality() > 0 {
-				// goroutine to ensure this is non-blocking.
-				go l.sendDeployments(l.deploymentRiskSet.AsSlice())
-				l.deploymentRiskSet.Clear()
-			}
-			l.deploymentRiskLock.Unlock()
+			concurrency.WithLock(&l.deploymentRiskLock, func() {
+				if l.deploymentRiskSet.Cardinality() > 0 {
+					// goroutine to ensure this is non-blocking.
+					go l.sendDeployments(l.deploymentRiskSet.AsSlice())
+					l.deploymentRiskSet.Clear()
+				}
+			})
 		}
 	}
 }

--- a/pkg/backgroundtasks/manager_impl.go
+++ b/pkg/backgroundtasks/manager_impl.go
@@ -133,13 +133,13 @@ func (m *managerImpl) Start() {
 			m.parallel <- struct{}{}
 			t := <-m.pendingTasks
 			ctx, cancel := context.WithCancel(parentCtx)
-			m.cancelFuncTasksMutex.Lock(t.id)
-			if t.cancel != nil {
-				cancel()
-			}
 
-			t.cancel = cancel
-			m.cancelFuncTasksMutex.Unlock(t.id)
+			m.cancelFuncTasksMutex.DoWithLock(t.id, func() {
+				if t.cancel != nil {
+					cancel()
+				}
+				t.cancel = cancel
+			})
 
 			m.startTaskExec(ctx, t)
 		}

--- a/pkg/nodes/enricher/enricher_impl.go
+++ b/pkg/nodes/enricher/enricher_impl.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/nodes/converter"
 	pkgScanners "github.com/stackrox/rox/pkg/scanners"
@@ -77,12 +78,13 @@ func (e *enricherImpl) EnrichNode(node *storage.Node) error {
 func (e *enricherImpl) enrichWithScan(node *storage.Node, nodeInventory *storage.NodeInventory) error {
 	errorList := errorhelpers.NewErrorList(fmt.Sprintf("error scanning node %s:%s", node.GetClusterName(), node.GetName()))
 
-	e.lock.RLock()
 	scanners := make([]types.NodeScannerWithDataSource, 0, len(e.scanners))
-	for _, scanner := range e.scanners {
-		scanners = append(scanners, scanner)
-	}
-	e.lock.RUnlock()
+
+	concurrency.WithRLock(&e.lock, func() {
+		for _, scanner := range e.scanners {
+			scanners = append(scanners, scanner)
+		}
+	})
 
 	if len(scanners) == 0 {
 		errorList.AddError(errors.New("no node scanners are integrated"))

--- a/pkg/nodes/enricher/enricher_impl.go
+++ b/pkg/nodes/enricher/enricher_impl.go
@@ -78,12 +78,12 @@ func (e *enricherImpl) EnrichNode(node *storage.Node) error {
 func (e *enricherImpl) enrichWithScan(node *storage.Node, nodeInventory *storage.NodeInventory) error {
 	errorList := errorhelpers.NewErrorList(fmt.Sprintf("error scanning node %s:%s", node.GetClusterName(), node.GetName()))
 
-	scanners := make([]types.NodeScannerWithDataSource, 0, len(e.scanners))
-
-	concurrency.WithRLock(&e.lock, func() {
+	scanners := concurrency.WithRLock1(&e.lock, func() []types.NodeScannerWithDataSource {
+		scanners := make([]types.NodeScannerWithDataSource, 0, len(e.scanners))
 		for _, scanner := range e.scanners {
 			scanners = append(scanners, scanner)
 		}
+		return scanners
 	})
 
 	if len(scanners) == 0 {

--- a/qa-tests-backend/test-images/syslog/syslog.go
+++ b/qa-tests-backend/test-images/syslog/syslog.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
 	"gopkg.in/mcuadros/go-syslog.v2"
 )
@@ -63,9 +64,9 @@ func syslogServer() {
 	go func(channel syslog.LogPartsChannel) {
 		for logParts := range channel {
 			log.Println(logParts)
-			lock.Lock()
-			dataPosted = append(dataPosted, fmt.Sprint(logParts))
-			lock.Unlock()
+			concurrency.WithLock(&lock, func() {
+				dataPosted = append(dataPosted, fmt.Sprint(logParts))
+			})
 		}
 	}(channel)
 	server.Wait()


### PR DESCRIPTION
## Description

For all non-assignment operations in critical sections, use `With[R]Lock` instead of locking and undeferred unlocking. This way we avoid blocked mutexes, make the code future proof, and reduce the frequency of the undeferred unlocking pattern.

For educational purposes, maybe we should go even further and rewrite all assignments as well to eliminate undeferred unlocking altogether (and create a linter). So instead of:
```
	c.lock.RLock()
	pod, ok := c.cache[id]
	c.lock.RUnlock()
```
something like
```
	pod, ok := concurrency.WithRLock2(&c.lock, func() (pod *storage.Pod, ok bool) {
		pod, ok = c.cache[id]; return
	})
```

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI run

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
