### PR TITLE
ROX-21283: no panic for dev builds if no TLS cert

### DIFF
--- a/pkg/env/metrics.go
+++ b/pkg/env/metrics.go
@@ -2,11 +2,6 @@ package env
 
 import (
 	"net"
-	"path/filepath"
-
-	"github.com/pkg/errors"
-	"github.com/stackrox/rox/pkg/errox"
-	"github.com/stackrox/rox/pkg/fileutils"
 )
 
 const (
@@ -48,25 +43,6 @@ func validatePort(setting Setting) error {
 	return nil
 }
 
-func validateTLS() error {
-	certFile := filepath.Join(SecureMetricsCertDir.Setting(), TLSCertFileName)
-	if ok, err := fileutils.Exists(certFile); !ok {
-		if err != nil {
-			log.Errorf("failed to validate file %q: %s", certFile, err.Error())
-		}
-		return errors.Wrapf(errox.NotFound, "secure metrics certificate file %q not found", certFile)
-	}
-
-	keyFile := filepath.Join(SecureMetricsCertDir.Setting(), TLSKeyFileName)
-	if ok, err := fileutils.Exists(keyFile); !ok {
-		if err != nil {
-			log.Errorf("failed to validate file %q: %s", keyFile, err.Error())
-		}
-		return errors.Wrapf(errox.NotFound, "secure metrics key file %q not found", keyFile)
-	}
-	return nil
-}
-
 // ValidateMetricsSetting returns an error if the environment variable is invalid.
 func ValidateMetricsSetting() error {
 	if !MetricsEnabled() {
@@ -84,9 +60,6 @@ func MetricsEnabled() bool {
 func ValidateSecureMetricsSetting() error {
 	if !SecureMetricsEnabled() {
 		return nil
-	}
-	if err := validateTLS(); err != nil {
-		return err
 	}
 	return validatePort(SecureMetricsPort)
 }

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -147,8 +147,8 @@ func secureMetricsEnabled() bool {
 
 func (s *Server) secureMetricsValid() bool {
 	if err := env.ValidateSecureMetricsSetting(); err != nil {
-		utils.Should(errors.Wrap(err, "invalid secure metrics setting"))
-		log.Error(errors.Wrap(err, "secure metrics server is disabled"))
+		log.Error("Invalid secure metrics setting: ", err)
+		log.Warn("Secure metrics server is disabled")
 		return false
 	}
 	return true
@@ -175,7 +175,7 @@ func runForeverTLS(server *http.Server) {
 	if server == nil {
 		return
 	}
-	if err := server.ListenAndServeTLS(certFilePath(), keyFilePath()); !errors.Is(err, http.ErrServerClosed) {
+	if err := server.ListenAndServeTLS("", ""); !errors.Is(err, http.ErrServerClosed) {
 		// The HTTPS server should never terminate.
 		log.Panicf("Unexpected termination of secure metrics server %q: %v", server.Addr, err)
 	}

--- a/pkg/metrics/tls.go
+++ b/pkg/metrics/tls.go
@@ -20,18 +20,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func certFilePath() string {
-	certDir := env.SecureMetricsCertDir.Setting()
-	certFile := filepath.Join(certDir, env.TLSCertFileName)
-	return certFile
-}
-
-func keyFilePath() string {
-	certDir := env.SecureMetricsCertDir.Setting()
-	keyFile := filepath.Join(certDir, env.TLSKeyFileName)
-	return keyFile
-}
-
 // nilTLSConfigurer is a no-op configurer.
 type nilTLSConfigurer struct{}
 


### PR DESCRIPTION
## Description

In rare cases the TLS certificate for the secure metrics endpoint has not yet been created/mounted into container before the metrics server is being started. In such cases, we currently panic in dev builds via `utils.Should`. However, this may create a CI flake, see https://issues.redhat.com/browse/ROX-21283 for an example.

Since we watch for cert changes anyway, we don't have to validate that the cert exists on startup. Instead, we may serve without TLS certificate. This causes scrapes to fail until the cert is loaded.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
