### PR TITLE
fix(helm): remove helm release namespace note from the central chart

### DIFF
--- a/image/templates/helm/stackrox-central/templates/NOTES.txt.htpl
+++ b/image/templates/helm/stackrox-central/templates/NOTES.txt.htpl
@@ -7,7 +7,7 @@ Central Services Configuration Summary:
 
   Name:                                        {{ ._rox.clusterName }}
   Kubernetes Version:                          {{ ._rox._apiServer.version }}
-  Kubernetes Namespace:                        {{ ._rox._namespace }}{{ if ne .Release.Namespace ._rox._namespace }}[NOTE: Helm release is attached to namespace {{ .Release.Namespace }}]{{ end }}
+  Kubernetes Namespace:                        {{ .Release.Namespace }}
   Helm Release Name:                           {{ .Release.Name }}
   Central Endpoint:                            {{ ._rox.centralEndpoint }}
   OpenShift Cluster:                           {{ if eq ._rox.env.openshift 0 -}} false {{ else -}} {{ ._rox.env.openshift }} {{ end }}


### PR DESCRIPTION
## Description
There's no `._rox._namespace` property in the Central helm chart, it exists only in the secured cluster services chart. Therefore, the modified condition doesn't make sense because `._rox._namespace` is not defined.
In older versions of helm (3.7.2) the installation fails with the following error:
```
Error: UPGRADE FAILED: template: stackrox-central-services/templates/NOTES.txt:10:75: executing "stackrox-central-services/templates/NOTES.txt" at <ne .Release.Namespace ._rox._namespace>: error calling ne: incompatible types for comparison
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
```
docker run -it --rm -v "$(pwd):/usr/src/stackrox" quay.io/stackrox-io/roxctl:$(make tag) helm output central-services --image-defaults opensource --output-dir /usr/src/stackrox/stackrox-central-services-chart --remove
docker run --rm -v "$(pwd):/usr/src/stackrox" -v ~/.kube:/root/.kube  --net=host alpine/helm:3.7.2 upgrade -i --namespace=stackrox stackrox-central-services /usr/src/stackrox/stackrox-central-services-chart --values /usr/src/stackrox/tmp/helm/values/values-central-dev.yaml --create-namespace
```
The latest version 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
