### PR TITLE
ROX-21127: Refactor cluster init bundles pages

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleDescription.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleDescription.tsx
@@ -8,11 +8,11 @@ import {
 
 import { ClusterInitBundle } from 'services/ClustersService';
 
-export type InitBundleViewProps = {
+export type InitBundleDescriptionProps = {
     initBundle: ClusterInitBundle;
 };
 
-function InitBundleView({ initBundle }: InitBundleViewProps): ReactElement {
+function InitBundleDescription({ initBundle }: InitBundleDescriptionProps): ReactElement {
     return (
         <DescriptionList isCompact isHorizontal className="pf-u-background-color-100 pf-u-p-lg">
             <DescriptionListGroup>
@@ -43,4 +43,4 @@ function InitBundleView({ initBundle }: InitBundleViewProps): ReactElement {
     );
 }
 
-export default InitBundleView;
+export default InitBundleDescription;

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
@@ -1,7 +1,0 @@
-import React, { ReactElement } from 'react';
-
-function InitBundleForm(): ReactElement {
-    return <>TODO Form</>;
-}
-
-export default InitBundleForm;

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
@@ -1,0 +1,106 @@
+import React, { ReactElement, useState } from 'react';
+import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
+
+import useRestQuery from 'hooks/useRestQuery';
+import { fetchClusterInitBundles, revokeClusterInitBundles } from 'services/ClustersService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+import InitBundleDescription from './InitBundleDescription';
+import InitBundlesHeader from './InitBundlesHeader';
+
+export type InitBundlePageProps = {
+    hasWriteAccessForInitBundles: boolean;
+    id: string;
+};
+
+function InitBundlePage({ hasWriteAccessForInitBundles, id }: InitBundlePageProps): ReactElement {
+    const [isRevoking, setIsRevoking] = useState(false);
+    const [errorMessageForRevoke, setErrorMessageForRevoke] = useState('');
+
+    const {
+        data: dataForFetch,
+        loading: isFetching,
+        error: errorForFetch,
+    } = useRestQuery(fetchClusterInitBundles);
+
+    const initBundle = dataForFetch?.response?.items.find(
+        (initBundleArg) => initBundleArg.id === id
+    );
+
+    function onClickRevoke() {
+        setIsRevoking(true);
+        // TODO investigate second argument and add confirmation modal.
+        revokeClusterInitBundles([id], [])
+            .then(() => {
+                setErrorMessageForRevoke('');
+            })
+            .catch((error) => {
+                setErrorMessageForRevoke(getAxiosErrorMessage(error));
+            })
+            .finally(() => {
+                setIsRevoking(false);
+            });
+    }
+
+    const alignRightElement =
+        hasWriteAccessForInitBundles && initBundle ? (
+            <Button
+                variant="danger"
+                isDisabled={isRevoking}
+                isLoading={isRevoking}
+                onClick={onClickRevoke}
+            >
+                Revoke bundle
+            </Button>
+        ) : null;
+
+    /* eslint-disable no-nested-ternary */
+    return (
+        <>
+            <InitBundlesHeader
+                alignRightElement={alignRightElement}
+                titleNotInitBundles="Cluster init bundle"
+            />
+            <PageSection component="div">
+                {isFetching ? (
+                    <Bullseye>
+                        <Spinner isSVG />
+                    </Bullseye>
+                ) : errorForFetch ? (
+                    <Alert
+                        variant="warning"
+                        title="Unable to fetch cluster init bundles"
+                        component="div"
+                        isInline
+                    >
+                        {getAxiosErrorMessage(errorForFetch)}
+                    </Alert>
+                ) : initBundle ? (
+                    <>
+                        {errorMessageForRevoke && (
+                            <Alert
+                                variant="danger"
+                                title="Unable to revoke cluster init bundle"
+                                component="div"
+                                isInline
+                            >
+                                {errorMessageForRevoke}
+                            </Alert>
+                        )}
+                        <InitBundleDescription initBundle={initBundle} />
+                    </>
+                ) : (
+                    <Alert
+                        variant="warning"
+                        title="Unable to find cluster init bundle"
+                        component="div"
+                        isInline
+                    />
+                )}
+            </PageSection>
+        </>
+    );
+    /* eslint-enable no-nested-ternary */
+}
+
+export default InitBundlePage;

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
@@ -57,10 +57,7 @@ function InitBundlePage({ hasWriteAccessForInitBundles, id }: InitBundlePageProp
     /* eslint-disable no-nested-ternary */
     return (
         <>
-            <InitBundlesHeader
-                headerActions={headerActions}
-                titleNotInitBundles="Cluster init bundle"
-            />
+            <InitBundlesHeader headerActions={headerActions} title="Cluster init bundle" />
             <PageSection component="div">
                 {isFetching ? (
                     <Bullseye>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
@@ -42,7 +42,7 @@ function InitBundlePage({ hasWriteAccessForInitBundles, id }: InitBundlePageProp
             });
     }
 
-    const alignRightElement =
+    const headerActions =
         hasWriteAccessForInitBundles && initBundle ? (
             <Button
                 variant="danger"
@@ -58,7 +58,7 @@ function InitBundlePage({ hasWriteAccessForInitBundles, id }: InitBundlePageProp
     return (
         <>
             <InitBundlesHeader
-                alignRightElement={alignRightElement}
+                headerActions={headerActions}
                 titleNotInitBundles="Cluster init bundle"
             />
             <PageSection component="div">

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizard.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizard.tsx
@@ -1,0 +1,13 @@
+import React, { ReactElement } from 'react';
+
+import InitBundlesHeader from './InitBundlesHeader';
+
+function InitBundleWizard(): ReactElement {
+    return (
+        <>
+            <InitBundlesHeader titleNotInitBundles="Create bundle" />;
+        </>
+    );
+}
+
+export default InitBundleWizard;

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizard.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizard.tsx
@@ -5,7 +5,7 @@ import InitBundlesHeader from './InitBundlesHeader';
 function InitBundleWizard(): ReactElement {
     return (
         <>
-            <InitBundlesHeader titleNotInitBundles="Create bundle" />;
+            <InitBundlesHeader title="Create bundle" />;
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesHeader.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesHeader.tsx
@@ -1,0 +1,58 @@
+import React, { ReactElement } from 'react';
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    Flex,
+    FlexItem,
+    PageSection,
+    Text,
+    Title,
+} from '@patternfly/react-core';
+
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import PageTitle from 'Components/PageTitle';
+import { clustersBasePath, clustersInitBundlesPath } from 'routePaths';
+
+const titleInitBundles = 'Cluster init bundles';
+
+export type InitBundlesHeaderProps = {
+    alignRightElement?: ReactElement | null;
+    titleNotInitBundles?: string;
+};
+
+function InitBundlesHeader({
+    alignRightElement,
+    titleNotInitBundles,
+}: InitBundlesHeaderProps): ReactElement {
+    const title = titleNotInitBundles ?? titleInitBundles;
+    return (
+        <PageSection component="div" variant="light">
+            <PageTitle title={title} />
+            <Flex direction={{ default: 'column' }}>
+                <Breadcrumb>
+                    <BreadcrumbItemLink to={clustersBasePath}>Clusters</BreadcrumbItemLink>
+                    {titleNotInitBundles && (
+                        <BreadcrumbItemLink to={clustersInitBundlesPath}>
+                            {titleInitBundles}
+                        </BreadcrumbItemLink>
+                    )}
+                    <BreadcrumbItem isActive>{title}</BreadcrumbItem>
+                </Breadcrumb>
+                <Flex alignItems={{ default: 'alignItemsCenter' }}>
+                    <FlexItem flex={{ default: 'flex_1' }}>
+                        <Title headingLevel="h1">{title}</Title>
+                        <Text>
+                            Cluster init bundles contain secrets for secured cluster services to
+                            authenticate with Central.
+                        </Text>
+                    </FlexItem>
+                    {alignRightElement && (
+                        <FlexItem align={{ default: 'alignRight' }}>{alignRightElement}</FlexItem>
+                    )}
+                </Flex>
+            </Flex>
+        </PageSection>
+    );
+}
+
+export default InitBundlesHeader;

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesHeader.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesHeader.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import {
     Breadcrumb,
     BreadcrumbItem,
@@ -16,12 +16,12 @@ import { clustersBasePath, clustersInitBundlesPath } from 'routePaths';
 const titleInitBundles = 'Cluster init bundles';
 
 export type InitBundlesHeaderProps = {
-    alignRightElement?: ReactElement | null;
+    headerActions?: ReactNode | null;
     titleNotInitBundles?: string;
 };
 
 function InitBundlesHeader({
-    alignRightElement,
+    headerActions,
     titleNotInitBundles,
 }: InitBundlesHeaderProps): ReactElement {
     const title = titleNotInitBundles ?? titleInitBundles;
@@ -46,8 +46,8 @@ function InitBundlesHeader({
                             authenticate with Central.
                         </Text>
                     </FlexItem>
-                    {alignRightElement && (
-                        <FlexItem align={{ default: 'alignRight' }}>{alignRightElement}</FlexItem>
+                    {headerActions && (
+                        <FlexItem align={{ default: 'alignRight' }}>{headerActions}</FlexItem>
                     )}
                 </Flex>
             </Flex>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesHeader.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesHeader.tsx
@@ -13,25 +13,21 @@ import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import PageTitle from 'Components/PageTitle';
 import { clustersBasePath, clustersInitBundlesPath } from 'routePaths';
 
-const titleInitBundles = 'Cluster init bundles';
+export const titleInitBundles = 'Cluster init bundles';
 
 export type InitBundlesHeaderProps = {
     headerActions?: ReactNode | null;
-    titleNotInitBundles?: string;
+    title: string;
 };
 
-function InitBundlesHeader({
-    headerActions,
-    titleNotInitBundles,
-}: InitBundlesHeaderProps): ReactElement {
-    const title = titleNotInitBundles ?? titleInitBundles;
+function InitBundlesHeader({ headerActions, title }: InitBundlesHeaderProps): ReactElement {
     return (
         <PageSection component="div" variant="light">
             <PageTitle title={title} />
             <Flex direction={{ default: 'column' }}>
                 <Breadcrumb>
                     <BreadcrumbItemLink to={clustersBasePath}>Clusters</BreadcrumbItemLink>
-                    {titleNotInitBundles && (
+                    {title !== titleInitBundles && (
                         <BreadcrumbItemLink to={clustersInitBundlesPath}>
                             {titleInitBundles}
                         </BreadcrumbItemLink>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
@@ -1,0 +1,61 @@
+import React, { ReactElement } from 'react';
+import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
+
+import LinkShim from 'Components/PatternFly/LinkShim';
+import useRestQuery from 'hooks/useRestQuery';
+import { fetchClusterInitBundles } from 'services/ClustersService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { clustersInitBundlesPath } from 'routePaths';
+
+import InitBundlesHeader from './InitBundlesHeader';
+import InitBundlesTable from './InitBundlesTable';
+
+export type InitBundlesPageProps = {
+    hasWriteAccessForInitBundles: boolean;
+};
+
+function InitBundlesPage({ hasWriteAccessForInitBundles }: InitBundlesPageProps): ReactElement {
+    const alignRightElement = hasWriteAccessForInitBundles ? (
+        <Button
+            variant="primary"
+            component={LinkShim}
+            href={`${clustersInitBundlesPath}?action=create`}
+        >
+            Create bundle
+        </Button>
+    ) : null;
+
+    const {
+        data: dataForFetch,
+        loading: isFetching,
+        error: errorForFetch,
+    } = useRestQuery(fetchClusterInitBundles);
+
+    /* eslint-disable no-nested-ternary */
+    return (
+        <>
+            <InitBundlesHeader alignRightElement={alignRightElement} />
+            <PageSection component="div">
+                {isFetching ? (
+                    <Bullseye>
+                        <Spinner isSVG />
+                    </Bullseye>
+                ) : errorForFetch ? (
+                    <Alert
+                        variant="warning"
+                        title="Unable to fetch cluster init bundles"
+                        component="div"
+                        isInline
+                    >
+                        {getAxiosErrorMessage(errorForFetch)}
+                    </Alert>
+                ) : (
+                    <InitBundlesTable initBundles={dataForFetch?.response?.items ?? []} />
+                )}
+            </PageSection>
+        </>
+    );
+    /* eslint-enable no-nested-ternary */
+}
+
+export default InitBundlesPage;

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
@@ -15,7 +15,7 @@ export type InitBundlesPageProps = {
 };
 
 function InitBundlesPage({ hasWriteAccessForInitBundles }: InitBundlesPageProps): ReactElement {
-    const alignRightElement = hasWriteAccessForInitBundles ? (
+    const headerActions = hasWriteAccessForInitBundles ? (
         <Button
             variant="primary"
             component={LinkShim}
@@ -34,7 +34,7 @@ function InitBundlesPage({ hasWriteAccessForInitBundles }: InitBundlesPageProps)
     /* eslint-disable no-nested-ternary */
     return (
         <>
-            <InitBundlesHeader alignRightElement={alignRightElement} />
+            <InitBundlesHeader headerActions={headerActions} />
             <PageSection component="div">
                 {isFetching ? (
                     <Bullseye>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
@@ -7,7 +7,7 @@ import { fetchClusterInitBundles } from 'services/ClustersService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { clustersInitBundlesPath } from 'routePaths';
 
-import InitBundlesHeader from './InitBundlesHeader';
+import InitBundlesHeader, { titleInitBundles } from './InitBundlesHeader';
 import InitBundlesTable from './InitBundlesTable';
 
 export type InitBundlesPageProps = {
@@ -34,7 +34,7 @@ function InitBundlesPage({ hasWriteAccessForInitBundles }: InitBundlesPageProps)
     /* eslint-disable no-nested-ternary */
     return (
         <>
-            <InitBundlesHeader headerActions={headerActions} />
+            <InitBundlesHeader headerActions={headerActions} title={titleInitBundles} />
             <PageSection component="div">
                 {isFetching ? (
                     <Bullseye>


### PR DESCRIPTION
## Description

Prerequisite to add cluster init bundle wizard, although discussion continues about its contents.

By the way, there is only an endpoint to fetch bundles, not to fetch a bundle by id:
https://github.com/stackrox/stackrox/blob/master/proto/api/v1/cluster_init_service.proto#L82-L86

### Residue

1. InitBundlePage: Investigate second argument of service function and add confirmation modal for **Revoke bundle**.
2. InitBundlesRoute: Replace replace resources with Admin role.
3. Write integration tests.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

In stackrox/ui folder before `yarn deploy`

```sh
export ROX_MOVE_INIT_BUNDLES_UI=true
```

### Manual testing

1. Visit /main/clusters/init-bundles
    ![clusters_init-bundles](https://github.com/stackrox/stackrox/assets/11862657/d72cc9fa-78bb-4dce-bbc1-9def4682a598)

2. Click link to /main/clusters/init-bundles/id
    ![clusters_init-bundles_id](https://github.com/stackrox/stackrox/assets/11862657/cabcb5c1-b331-4faf-b475-a5d14c69b8fb)

