### PR TITLE
fix(CI): use a different image for quay scans

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -42,7 +42,7 @@ class ImageScanningTest extends BaseSpecification {
 
     static final private String UBI8_0_IMAGE = "registry.access.redhat.com/ubi8:8.0-208"
     static final private String RHEL7_IMAGE = "quay.io/rhacs-eng/qa-multi-arch:rhel7-minimal-7.5-422"
-    static final private String QUAY_IMAGE_WITH_CLAIR_SCAN_DATA = "quay.io/rhacs-eng/qa:struts-app"
+    static final private String QUAY_IMAGE_WITH_CLAIR_SCAN_DATA = "quay.io/rhacs-eng/qa:nginx-unprivileged"
     static final private String GCR_IMAGE   = "us.gcr.io/stackrox-ci/qa-multi-arch/registry-image:0.2"
     static final private String NGINX_IMAGE = "quay.io/rhacs-eng/qa:nginx-1-12-1"
     static final private String OCI_IMAGE   = "quay.io/rhacs-eng/qa:oci-manifest"

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -38,8 +38,8 @@ environment.
 Options:
   -c, --config-only - configure the cluster for test but do not run
     any tests. [qa flavor only]
-  --run-tests-only - reuse prior configuration and run tests. [qa
-    flavor only]
+  --test-only - reuse prior configuration and run tests. [qa flavor
+    only]
   -d, --gather-debug - enable debug log gathering to '${QA_TEST_DEBUG_LOGS}'.
     [qa flavor only]
   -s, --spin-cycle=<count> - repeat the test portion until a failure


### PR DESCRIPTION
## Description

The current image (struts-app) gets a 520 response from quay. This causes the ImageScanningTest testcase to fail by reaching the 800s global timeout. This causes subsequent tests to fail (ImageIntegration, VulnMgmtTest) as the quay integration is not deleted when the global timeout is reached. A future PR/issue will address fixing that.

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-ocp-4-11-merge-qa-e2e-tests/1735366241893224448

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

Tested locally and CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
