### PR TITLE
fix(CI): reduce image failure e2e test spam

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Define the matrix for build jobs
         id: define-job-matrix
         run: |
-          source './scripts/ci/lb.sh'
+          source './scripts/ci/lib.sh'
 
           matrix='{ "pre_build_go_binaries": { "name":[], "arch":[] }, "build_and_push_main": { "name":[], "arch":[] }, "push_main_multiarch_manifests": { "name":[] } }'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Define the matrix for build jobs
         id: define-job-matrix
         run: |
-          source './scripts/ci/lib.sh'
+          source './scripts/ci/lb.sh'
 
           matrix='{ "pre_build_go_binaries": { "name":[], "arch":[] }, "build_and_push_main": { "name":[], "arch":[] }, "push_main_multiarch_manifests": { "name":[] } }'
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1671,7 +1671,7 @@ EOT
 }
 
 is_system_test_without_images() {
-    case "${CI_JOB_NAME:-missing}" in
+    case "${JOB_NAME:-missing}" in
         *-e2e-tests|*-upgrade-tests|*-version-compatibility-tests)
             [[ ! -f "${STATE_IMAGES_AVAILABLE}" ]]
             ;;

--- a/scripts/ci/test_state.sh
+++ b/scripts/ci/test_state.sh
@@ -2,5 +2,5 @@
 
 # State files used to track test progress across script invocations.
 
-export STATE_IMAGES_AVAILABLE="/tmp/stackrox_ci_state_images_available"
-export STATE_DEPLOYED="/tmp/stackrox_ci_state_deployed"
+export STATE_IMAGES_AVAILABLE="${SHARED_DIR:-/tmp}/stackrox_ci_state_images_available"
+export STATE_DEPLOYED="${SHARED_DIR:-/tmp}/stackrox_ci_state_deployed"


### PR DESCRIPTION
## Description

After #8958 changed the context where slack messages are generated (from the job dispatch step to job end step) we started to get a slack message for every e2e test that fails when images are not built. This was previously ignored by checking for the images available state breadcrumb. This PR moves the breadcrumb to the shared location so it will be available in the end step.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

- [x] Run with `ci-test-junit-processing`. Force an image build failure. 
  - [x] Expect no messages in #acs-slack-ci-integration-testing. 
  - [x] Expect a log from the skip. `INFO: Fri Dec 15 23:52:41 UTC 2023: Skipping slack message for a system test failure when images were not found`

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
