### PR TITLE
fix(CI): skip slack notifications for scheduled jobs

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1242,6 +1242,11 @@ send_slack_failure_summary() {
         return 0
     fi
 
+    if [[ "${JOB_TYPE:-unknown}" == "periodic" ]]; then
+        info "Skipping slack message for periodics (scheduled prow jobs)"
+        return 0
+    fi
+
     if is_system_test_without_images; then
         # Avoid multiple slack messages from the e2e tests waiting for images.
         info "Skipping slack message for a system test failure when images were not found"


### PR DESCRIPTION
## Description

Slack notification on failures is intended for and only supports merge to the main branch failures. Periodics cause: https://redhat-internal.slack.com/archives/CLUNQEEMA/p1702636813795079 due to missing state.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

- [x] run with `ci-test-junit-processing` ensure no regressions in slack failure notifications.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
