### PR TITLE
fix: use proper jira filters

### DIFF
--- a/scripts/run-support-triage-report.sh
+++ b/scripts/run-support-triage-report.sh
@@ -17,8 +17,8 @@ total_issues_in_filter() {
 }
 
 slack_triage_report() {
-    local curr_filter=12388299
-    local prev_filter=12388044
+    local curr_filter=12413623
+    local prev_filter=12413975
 
     local curr
     curr=$(total_issues_in_filter $curr_filter)


### PR DESCRIPTION
## Description

It turns out I've used wrong jira filter
1. [Current On-Call Bugs to Triage r2](https://issues.redhat.com/browse/ROX-21444?filter=12388044)
2. [Previous On-Call Untriaged Bugs r2](https://issues.redhat.com/browse/ROX-21382?filter=12388046)

instead of


1. [Add this filter to your favorites Current On-Call Queue to Triage / ROX](https://issues.redhat.com/browse/ROX-21446?filter=12413623)
2. [Untriaged Bugs from Previous On-Call Week / ROX](https://issues.redhat.com/browse/ROX-21381?filter=12413975)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

run script locally and check the numbers
```
./scripts/run-support-triage-report.sh
Posting '<!subteam^S04SU9AHJ4C> There are 47 untriaged issues (not including 15 leftovers from previous duty)' to slack
./scripts/run-support-triage-report.sh: line 49: SLACK_WEBHOOK: unbound variable
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
