### PR TITLE
refactor(CI): change retry/pause for quay test

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -850,7 +850,7 @@ class ImageScanningTest extends BaseSpecification {
 
     private static ImageOuterClass.Image expectedDigestImageFromScan(String imageName, String source) {
         ImageOuterClass.Image imageDetail = null
-        withRetry(30, 2) {
+        withRetry(3, 15) {
             imageDetail = ImageService.scanImage(imageName, false, true)
         }
         validateImageMetadata(imageDetail, source)


### PR DESCRIPTION
## Description

In its current form, if quay is persistently erroring on the scan API call, the retries + pauses of `expectedDigestImageFromScan() + ImageService.scanImage()` will result in the junit global 800s timout being reached before the test gives up. This results in poor state handling in the Groovy test / Spock framework world. (#9059). One option is to increase the globalTimeout for this test as other tests do. But a max of 800s for an image scan response seems already pretty long. So instead this PR follows the option of reducing the retries and pauses between them.

### Timing before the change
```
=30*(10*15+2)
=4560 seconds <-- without the time in making the API calls
```

### Timing after this change
```
=3*(10*15+15)
=495 seconds <-- without the time in making the API calls
```

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
