### PR TITLE
fix(metrics): support cgroupv2 CPU metrics

### DIFF
--- a/pkg/metrics/testdata/throttle/cgroup1/sys/fs/cgroup/cpu/cpu.stat
+++ b/pkg/metrics/testdata/throttle/cgroup1/sys/fs/cgroup/cpu/cpu.stat
@@ -1,0 +1,5 @@
+nr_periods 10
+nr_throttled 11
+throttled_time 1208573224
+nr_bursts 0
+burst_time 0

--- a/pkg/metrics/testdata/throttle/cgroup2/sys/fs/cgroup/cpu.stat
+++ b/pkg/metrics/testdata/throttle/cgroup2/sys/fs/cgroup/cpu.stat
@@ -1,0 +1,9 @@
+usage_usec 1745487
+user_usec 1529925
+system_usec 215561
+core_sched.force_idle_usec 0
+nr_periods 39
+nr_throttled 20
+throttled_usec 22
+nr_bursts 0
+burst_usec 0

--- a/pkg/metrics/throttle_test.go
+++ b/pkg/metrics/throttle_test.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCGroup1(t *testing.T) {
+	fsys := os.DirFS("testdata/throttle/cgroup1")
+	_, err := fs.Stat(fsys, cgroup2CPUStatFile)
+	require.True(t, errors.Is(err, fs.ErrNotExist))
+	b, err := fs.ReadFile(fsys, cgroupCPUStatFile)
+	require.NoError(t, err)
+
+	vals := parseStats(cgroupCPUStatFile, b, cgroupStats)
+	assert.Equal(t, 10, vals.periods)
+	assert.Equal(t, 11, vals.throttled)
+	assert.Equal(t, 1208573224, vals.throttledTime)
+}
+
+func TestCGroup2(t *testing.T) {
+	fsys := os.DirFS("testdata/throttle/cgroup2")
+	_, err := fs.Stat(fsys, cgroupCPUStatFile)
+	require.True(t, errors.Is(err, fs.ErrNotExist))
+	b, err := fs.ReadFile(fsys, cgroup2CPUStatFile)
+	require.NoError(t, err)
+
+	vals := parseStats(cgroup2CPUStatFile, b, cgroup2Stats)
+	assert.Equal(t, 39, vals.periods)
+	assert.Equal(t, 20, vals.throttled)
+	assert.Equal(t, 22, vals.throttledTime)
+}


### PR DESCRIPTION
## Description

The current throttle metrics only support `cgroup v1`. `cgroup v2` has a slightly different structure (all stats in a single, flat directory, and the throttled time changed name/semantics).

This change adds support for `cgroup v2` as well as keeping support for `cgroup v1`.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Scanner v4 runs these metrics, so I ran Scanner v4 with debug logs. I no longer see the following log:

```
pkg/metrics: 2023/12/15 17:20:14.171894 throttle.go:51: Debug: error reading file /sys/fs/cgroup/cpu/cpu.stat: open /sys/fs/cgroup/cpu/cpu.stat: no such file or directory
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
