### PR TITLE
chore(ui): Skip ui-e2e test for Google Cloud SCC integration

### DIFF
--- a/ui/apps/platform/cypress/integration/integrations/notifiers.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/notifiers.test.js
@@ -223,7 +223,7 @@ describe('Notifier Integrations', () => {
             // Test does not delete, because it did not create.
         });
 
-        it('should create a new Google Cloud SCC integration', () => {
+        it.skip('should create a new Google Cloud SCC integration', () => {
             const integrationName = generateNameWithDate('Nova Google Cloud SCC');
             const integrationType = 'cscc';
 


### PR DESCRIPTION
## Description

### Problem

Test is failing on ocp-11 and ocp-13 although not gke after #9068

### Solution

Temporarily skip over the weekend pending investigation about need to enter data in another field of the form.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited regression tests

## Testing Performed