### PR TITLE
chore(ui): Update prettier 3.1.1 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -159,7 +159,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^3.1.0",
+        "prettier": "^3.1.1",
         "randomstring": "^1.2.1",
         "react-app-rewired": "^2.2.1",
         "react-scripts": "^5.0.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -14116,10 +14116,10 @@ prettier@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
   integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
 
-prettier@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.1.0.tgz#c6d16474a5f764ea1a4a373c593b779697744d5e"
-  integrity sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==
+prettier@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.1.1.tgz#6ba9f23165d690b6cbdaa88cb0807278f7019848"
+  integrity sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==
 
 pretty-bytes@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
## Description

https://github.com/prettier/prettier/blob/main/CHANGELOG.md#311

1. https://github.com/prettier/prettier/blob/main/CHANGELOG.md#fix-unstable-and-ugly-formatting-for-comments-in-destructuring-patterns-15708-by-sosukesuzuki

    > Fix unstable and ugly formatting for comments in destructuring patterns

    This sounds familiar.

2. https://github.com/prettier/prettier/blob/main/CHANGELOG.md#support-import-attributes-15718-by-fisker

    > TypeScript 5.3 supports the latest updates to the import attributes proposal.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform
3. `yarn start` in ui