### PR TITLE
ROX-20338: Disable failing CI test

### DIFF
--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -16,6 +16,7 @@ import services.ClusterService
 import util.ApplicationHealth
 import util.Timer
 
+import org.junit.Ignore
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.IgnoreIf
@@ -88,6 +89,7 @@ class TLSChallengeTest extends BaseSpecification {
     }
 
     @Tag("SensorBounceNext")
+    @Ignore("ROX-20338")
     def "Verify sensor can communicate with central behind an untrusted load balancer"() {
         when:
         "Deploying Sensor without root CA certs can't connect to load balancer"


### PR DESCRIPTION
## Description

As in the title. 
We are working on a fix in https://issues.redhat.com/browse/ROX-21401

Related: #9090 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

- I didn't

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
