### PR TITLE
ROX-21401: Fix initial sync event order

### DIFF
--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -572,34 +572,6 @@ func (c *sensorConnection) Run(ctx context.Context, server central.SensorService
 
 	}
 
-	if connectionCapabilities.Contains(centralsensor.DelegatedRegistryCap) {
-		// Sync delegated registry config.
-		msg, err := c.getDelegatedRegistryConfigMsg(ctx)
-		if err != nil {
-			return errors.Wrapf(err, "unable to get delegated registry config msg for %q", c.clusterID)
-		}
-		if msg != nil {
-			if err := server.Send(msg); err != nil {
-				return errors.Wrapf(err, "unable to sync initial delegated registry config to cluster %q", c.clusterID)
-			}
-
-			log.Infof("Sent delegated registry config %q to cluster %q", msg.GetDelegatedRegistryConfig(), c.clusterID)
-		}
-
-		// Sync integrations.
-		msg, err = c.getImageIntegrationMsg(ctx)
-		if err != nil {
-			return errors.Wrapf(err, "unable to get image integrations msg for %q", c.clusterID)
-		}
-		if msg != nil {
-			if err := server.Send(msg); err != nil {
-				return errors.Wrapf(err, "unable to sync initial image integrations to cluster %q", c.clusterID)
-			}
-
-			log.Infof("Sent %d image integrations to cluster %q", len(msg.GetImageIntegrations().GetUpdatedIntegrations()), c.clusterID)
-		}
-	}
-
 	if features.SensorReconciliationOnReconnect.Enabled() && connectionCapabilities.Contains(centralsensor.SendDeduperStateOnReconnect) {
 		// Sensor is capable of doing the reconciliation by itself if receives the hashes from central.
 		log.Infof("Sensor (%s) can do client reconciliation: sending deduper state", c.clusterID)
@@ -635,6 +607,37 @@ func (c *sensorConnection) Run(ctx context.Context, server central.SensorService
 		log.Infof("Successfully sent deduper state to sensor (%s)", c.clusterID)
 	} else {
 		log.Infof("Sensor (%s) cannot receive deduper state", c.clusterID)
+	}
+
+	// Any messages after this will be processed by Sensor components and can go in any order.
+	// Don't change the order of any messages above!
+
+	if connectionCapabilities.Contains(centralsensor.DelegatedRegistryCap) {
+		// Sync delegated registry config.
+		msg, err := c.getDelegatedRegistryConfigMsg(ctx)
+		if err != nil {
+			return errors.Wrapf(err, "unable to get delegated registry config msg for %q", c.clusterID)
+		}
+		if msg != nil {
+			if err := server.Send(msg); err != nil {
+				return errors.Wrapf(err, "unable to sync initial delegated registry config to cluster %q", c.clusterID)
+			}
+
+			log.Infof("Sent delegated registry config %q to cluster %q", msg.GetDelegatedRegistryConfig(), c.clusterID)
+		}
+
+		// Sync integrations.
+		msg, err = c.getImageIntegrationMsg(ctx)
+		if err != nil {
+			return errors.Wrapf(err, "unable to get image integrations msg for %q", c.clusterID)
+		}
+		if msg != nil {
+			if err := server.Send(msg); err != nil {
+				return errors.Wrapf(err, "unable to sync initial image integrations to cluster %q", c.clusterID)
+			}
+
+			log.Infof("Sent %d image integrations to cluster %q", len(msg.GetImageIntegrations().GetUpdatedIntegrations()), c.clusterID)
+		}
 	}
 
 	go c.runSend(server)


### PR DESCRIPTION
## Description

Sensor client reconciliation will fail if delegated scanning is enabled. This happens because sensor expects the deduper state to arrive at the end of the synchronous sync between Central and Sensor. If delegated scanning is enabled, Central will first send registry config and image integrations. 

After the sync, sensor shouldn't care about message ordering, since messages are processed by individual components. 

This shouldn't have caused any crash loops, because sensor will fallback to classic reconciliation when this happens. But it makes client reconciliation impossible when delegated scanning is enabled, potentially causes some tests to flake due to extra time added in the reconciliation (i.e. the connection fails in the first try, and then tries to reconnect with a back-off time)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [ ] CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
