### PR TITLE
chore(ui): Fix errors and turn on no-floating promises lint rule

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -629,7 +629,6 @@ module.exports = [
             '@typescript-eslint/no-unsafe-member-access': 'off',
 
             // Turn off new rules until after we fix errors in follow-up contributions.
-            '@typescript-eslint/no-floating-promises': 'off', // fix 7 errors
             '@typescript-eslint/no-misused-promises': 'off', // more than 100 errors
             '@typescript-eslint/no-unsafe-argument': 'off', // more than 300 errors
             '@typescript-eslint/require-await': 'off', // about 20 errors

--- a/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundaryCodeBlock.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundaryCodeBlock.tsx
@@ -26,9 +26,14 @@ function ErrorBoundaryCodeBlock({
     function onClickCopy() {
         // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText#browser_compatibility
         // Chrome 66 Edge 79 Firefox 63 Safari 13.1
-        navigator?.clipboard?.writeText(code).then(() => {
-            setWasCopied(true);
-        });
+        navigator?.clipboard
+            ?.writeText(code)
+            .then(() => {
+                setWasCopied(true);
+            })
+            .catch(() => {
+                // TODO addToast(title, message)
+            });
     }
 
     const actions = (

--- a/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
@@ -113,7 +113,6 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
                         kernelSupportAvailable,
                     } = clusterDefaults;
 
-                    // TODO add catch block to include error message as a property of the object.
                     setCentralEnv({
                         kernelSupportAvailable,
                         successfullyFetched: true,
@@ -128,6 +127,9 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
                         };
                         setSelectedCluster(updatedCluster);
                     }
+                })
+                .catch(() => {
+                    // TODO investigate how error affects ClusterEditForm
                 })
                 .finally(() => {
                     setLoadingCounter((prev) => prev - 1);

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -228,7 +228,7 @@ function ClustersTablePanel({
                 });
             })
             .catch(() => {
-                // TODO render error in dialog
+                // TODO render error in dialogand move finally code to then block.
             })
             .finally(() => {
                 setShowDialog(false);

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -222,12 +222,13 @@ function ClustersTablePanel({
             .then(() => {
                 setCheckedClusterIds([]);
 
-                // Although return works around typescript-eslint/no-floating-promises error,
-                // catch block would be better.
                 return fetchClustersWithRetentionInfo().then((clustersResponse) => {
                     setCurrentClusters(clustersResponse.clusters);
                     setClusterIdToRetentionInfo(clustersResponse.clusterIdToRetentionInfo);
                 });
+            })
+            .catch(() => {
+                // TODO render error in dialog
             })
             .finally(() => {
                 setShowDialog(false);

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -85,10 +85,14 @@ function CollectionsTable({
 
     function onConfirmDeleteCollection(collection: Collection) {
         setIsDeleting(true);
-        onCollectionDelete(collection).finally(() => {
-            setCollectionToDelete(null);
-            setIsDeleting(false);
-        });
+        onCollectionDelete(collection)
+            .catch(() => {
+                // TODO render error in dialog and move finally code to then block.
+            })
+            .finally(() => {
+                setCollectionToDelete(null);
+                setIsDeleting(false);
+            });
     }
 
     function onCancelDeleteCollection() {

--- a/ui/apps/platform/src/Containers/Policies/Modal/EnableDisableNotificationModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/EnableDisableNotificationModal.tsx
@@ -55,8 +55,9 @@ function EnableDisableNotificationModal({
     }
 
     function onConfirmEnableDisableNotifications() {
+        // TODO refactor to move handler into callback function?
         setEnableDisableType(null);
-        enableDisableNotificationHandler().finally(() => {});
+        return enableDisableNotificationHandler();
     }
 
     function onCancelEnableDisableNotifications() {

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -231,10 +231,14 @@ function PoliciesTable({
 
     function onConfirmDeletePolicy() {
         setIsDeleting(true);
-        deletePoliciesHandler(deletingIds).finally(() => {
-            setDeletingIds([]);
-            setIsDeleting(false);
-        });
+        deletePoliciesHandler(deletingIds)
+            .catch(() => {
+                // TODO render error in dialog and move finally code to then block.
+            })
+            .finally(() => {
+                setDeletingIds([]);
+                setIsDeleting(false);
+            });
     }
 
     function onCancelDeletePolicy() {

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
@@ -67,9 +67,13 @@ function GenerateDiagnosticBundle(): ReactElement {
             startingTimeObject,
             isStartingTimeValid,
         });
-        downloadDiagnostics(queryString).finally(() => {
-            setSubmitting(false);
-        });
+        downloadDiagnostics(queryString)
+            .catch(() => {
+                // TODO render error in DiagnosticBundleForm
+            })
+            .finally(() => {
+                setSubmitting(false);
+            });
     }
 
     const footerContent = (


### PR DESCRIPTION
## Description

https://typescript-eslint.io/rules/no-floating-promises/

> Require Promise-like statements to be handled appropriately.

> This rule reports when a Promise is created and not properly handled. Valid ways of handling a Promise-valued statement include:

* awaiting it
* returning it
* Calling its `.then()` with two arguments
* Calling its `.catch()` with one argument

### Residue

The benefit to prevent new errors outweighs cost of TODO comments:

1. ErrorBoundaryCodeBlock
    * Replace TODO comment with `addToast` call.
    * Factor out `ToastGroup` as suggested by David with props to compose `AlertGroup` and `useToasts` hook.
2. For delete actions, render error in modal.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform and then compute branch - master for the following in ui:
    * `wc build/static/js/*.js`
        main.js: -6 = 3946852 - 3946858
        total: 1204 = 10375291 - 10374087
    * `ls -al build/static/js/*.js | wc -l`
        0 = 89 - 89 files
3. `yarn start` in ui