### PR TITLE
chore(ui): Fix errors and close loophole in airbnb react lint rules

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -431,6 +431,23 @@ module.exports = [
             'prefer-object-spread': 'error',
             'unicode-bom': ['error', 'never'],
 
+            // Turn on rules from airbnb variables config that are not in ESLint recommended.
+            // https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/variables.js
+            'no-label-var': 'error',
+            'no-restricted-globals': [
+                'error',
+                {
+                    name: 'isFinite',
+                    message: 'Use Number.isFinite instead',
+                },
+                {
+                    name: 'isNaN',
+                    message: 'Use Number.isNaN',
+                },
+            ],
+            // 'no-shadow': 'error', // fix 15 errors
+            'no-undef-init': 'error',
+
             'prettier/prettier': 'error',
         },
 
@@ -541,6 +558,8 @@ module.exports = [
                 },
             ],
 
+            // TODO compare eslint-plugin-jsx-a11y recommended and strict config to former airbnb-config-react react-a11y config.
+
             // TODO Reconfigure for using react-router Link
             'jsx-a11y/anchor-is-valid': [
                 'error',
@@ -565,20 +584,28 @@ module.exports = [
             // Turn off new rules until after we fix errors in follow-up contributions.
             'react/jsx-key': 'off', // more that 30 errors
 
+            // Turn on rules from airbnb react config that are not in eslint-plugin-react recommended.
+            'react/button-has-type': [
+                'error',
+                {
+                    button: true,
+                    submit: true,
+                    reset: false,
+                },
+            ],
             'react/forbid-prop-types': [
                 'error',
                 {
                     forbid: ['any', 'array'], // allow object
                 },
             ],
-
+            'react/jsx-boolean-value': ['error', 'never', { always: [] }],
             'react/jsx-filename-extension': [
                 'error',
                 {
                     extensions: ['.js', '.tsx'], // allow JSX in .js files
                 },
             ],
-
             'react/jsx-no-bind': [
                 'error',
                 {
@@ -589,15 +616,42 @@ module.exports = [
                     ignoreRefs: true,
                 },
             ],
-
+            'react/jsx-no-script-url': [
+                'error',
+                [
+                    {
+                        name: 'Link',
+                        props: ['to'],
+                    },
+                ],
+            ],
+            'react/jsx-pascal-case': [
+                'error',
+                {
+                    allowAllCaps: true,
+                    ignore: [],
+                },
+            ],
+            'react/no-array-index-key': 'error',
+            'react/no-danger': 'error',
+            'react/no-invalid-html-attribute': 'error',
+            'react/no-unused-prop-types': [
+                'error',
+                {
+                    customValidators: [],
+                    skipShapeProps: true,
+                },
+            ],
+            'react/no-unused-state': 'error',
             'react/prop-types': [
                 'error',
                 {
-                    skipUndeclared: true,
+                    skipUndeclared: true, // more specific than eslint-plugin-react
                 },
             ],
-
             'react/static-property-placement': ['error', 'static public field'],
+            'react/style-prop-object': 'error',
+            'react/void-dom-elements-no-children': 'error',
 
             // https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/index.js
             ...pluginReactHooks.configs.recommended.rules,

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -539,7 +539,7 @@ export function postFormatImageSigningPolicyGroup(policy: ClientPolicy): Policy 
         return policy as unknown as Policy;
     }
 
-    const serverPolicy = cloneDeep(policy) as Policy;
+    const serverPolicy = cloneDeep(policy) as unknown as Policy;
     policy.policySections.forEach((policySection, sectionIdx) => {
         const { policyGroups } = policySection;
         policyGroups.forEach((policyGroup, groupIdx) => {


### PR DESCRIPTION
## Description

Follow up residue for eslint-config-airbnb after #8813

### Potential problem

If software quality criteria becomes less strict, then cherry pick of commits into patch release branches might report errors according to earlier configurations and versions of devDependencies.

### Analysis

Usually software quality criteria has become more strict in ESLint, Prettier, and TypeScript, therefore when an upgrade causes many errors, it is possible to fix them **in batches**, because the changes are **not errors**  according to earlier configurations and versions of devDependencies.

However, deleting airbnb config opened a loophole:
* Some rules had been turned on, **but are not now**.
* However, some of them are deprecated because redundant with Prettier.

The following do not require any change:
* Some rules had been turned on, **and are now** because they are also in eslint recommended.
* Some rules that had been turned off, **and are now** because they are not in eslint recommended.

1. Compare config for **React**:
    * https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/rules/react.js
    * https://github.com/jsx-eslint/eslint-plugin-react/blob/master/configs/recommended.js
2. Compare config for **React hooks**:
    * https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/rules/react-hooks.js
    * https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/index.js#L14-L20

### Solution

1. Explicitly turn on rules from eslint-config-airbnb react config that are not in recommended config of other plugins.
2. Add rules from eslint-config-airbnb-base **variables** config that I missed in #8978
3. Fix yet another occurrence the following error:
    > TS2352: Conversion of type 'ClientPolicy' to type 'Policy' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.

### Residue

1. Compare config for **JSX accessibility**:
    * https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/rules/react-a11y.js
    * recommended https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/index.js#L46-L201
    * strict https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/index.js#L202-L294
2. Either fix errors or add disable comments, and then delete `'react-hooks/exhaustive-deps': 'warn'` temporary override of `'error'` from eslint-plugin-react-hooks recommended config.
3. Fix errors and turn on `reportUnusedDisableDirectives` in `linterOptions` object.
4. Fix errors and delete temporary omission of `eslint-comments/disable-enable-pair` rule.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform
3. `yarn start` in ui