### PR TITLE
feat(scannerctl): scale test support

### DIFF
--- a/scanner/cmd/scannerctl/authn/auth.go
+++ b/scanner/cmd/scannerctl/authn/auth.go
@@ -1,0 +1,37 @@
+package authn
+
+import (
+	"errors"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+)
+
+// BasicAuthSetting is the environment variable which specifies the basic authentication
+// scannerctl uses. It should be in the form username:password.
+const BasicAuthSetting = "ROX_SCANNERCTL_BASIC_AUTH"
+
+// ParseBasic parses basic authentication from the environment
+// or, if set, the given string.
+func ParseBasic(auth string) (authn.Authenticator, error) {
+	if auth == "" {
+		auth = os.Getenv(BasicAuthSetting)
+	}
+	if auth == "" {
+		log.Println("auth unspecified: using anonymous auth")
+		return authn.Anonymous, nil
+	}
+
+	u, p, ok := strings.Cut(auth, ":")
+	if !ok {
+		return nil, errors.New("invalid basic auth: expecting the username and the " +
+			"password with a colon (aladdin:opensesame)")
+	}
+
+	return &authn.Basic{
+		Username: u,
+		Password: p,
+	}, nil
+}

--- a/scanner/cmd/scannerctl/scale.go
+++ b/scanner/cmd/scannerctl/scale.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/scanner/cmd/scannerctl/authn"
+	"github.com/stackrox/rox/scanner/indexer"
+)
+
+// scaleStats specifies the stats we want to track when performing scale tests.
+type scaleStats struct {
+	preFailure atomic.Int64
+
+	indexSuccess atomic.Int64
+	indexFailure atomic.Int64
+
+	matchSuccess atomic.Int64
+	matchFailure atomic.Int64
+}
+
+func (s *scaleStats) String() string {
+	var ret strings.Builder
+	ret.WriteRune('\n')
+	ret.WriteString(fmt.Sprintf("pre-scanning failure: %d\n", s.preFailure.Load()))
+	ret.WriteString(fmt.Sprintf("index success: %d\n", s.indexSuccess.Load()))
+	ret.WriteString(fmt.Sprintf("index failure: %d\n", s.indexFailure.Load()))
+	ret.WriteString(fmt.Sprintf("match success: %d\n", s.matchSuccess.Load()))
+	ret.WriteString(fmt.Sprintf("match failure: %d\n", s.matchFailure.Load()))
+	ret.WriteRune('\n')
+	return ret.String()
+}
+
+// scaleCmd creates the scale command.
+func scaleCmd(ctx context.Context) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "scale <registry> [OPTIONS]",
+		Short: "Perform scale tests via querying for the first N images in the given repository.",
+		Args:  cobra.ExactArgs(1),
+	}
+	flags := cmd.PersistentFlags()
+	basicAuth := flags.String(
+		"auth",
+		"",
+		fmt.Sprintf("Use the specified basic auth credentials (warning: debug "+
+			"only and unsafe, use env var %s).", authn.BasicAuthSetting))
+	images := flags.Int(
+		"images",
+		1000,
+		"Specify the number of images from the given repository to scan")
+	workers := flags.Int(
+		"workers",
+		15,
+		"Specify the number of parallel scans")
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		// Create scanner client.
+		scanner, err := factory.Create(ctx)
+		if err != nil {
+			return fmt.Errorf("create client: %w", err)
+		}
+		// Extract basic auth username and password.
+		auth, err := authn.ParseBasic(*basicAuth)
+		if err != nil {
+			return err
+		}
+		repoName := args[0]
+		repo, err := name.NewRepository(repoName, name.StrictValidation)
+		if err != nil {
+			panic("programmer error")
+		}
+		puller, err := remote.NewPuller(remote.WithAuth(auth))
+		if err != nil {
+			log.Fatalf("creating puller: %v", err)
+		}
+		lister, err := puller.Lister(ctx, repo)
+		if err != nil {
+			log.Fatalf("creating lister: %v", err)
+		}
+		tags := make([]string, 0, *images)
+		for lister.HasNext() {
+			ts, err := lister.Next(ctx)
+			if err != nil {
+				log.Fatalf("listing tags: %v", err)
+			}
+			tags = append(tags, ts.Tags...)
+			if len(tags) >= *images {
+				tags = tags[:*images]
+				break
+			}
+		}
+		log.Printf("scale testing with %d images", len(tags))
+
+		tagsC := make(chan string)
+		go func() {
+			for _, tag := range tags {
+				tagsC <- tag
+			}
+			close(tagsC)
+		}()
+
+		var stats scaleStats
+		var wg sync.WaitGroup
+		for i := 0; i < *workers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for tag := range tagsC {
+					ref, err := name.ParseReference(repoName+":"+tag, name.StrictValidation)
+					if err != nil {
+						stats.preFailure.Add(1)
+						log.Printf("could not parse reference for tag %s: %v", tag, err)
+						return
+					}
+					d, err := indexer.GetDigestFromReference(ref, auth)
+					if err != nil {
+						stats.preFailure.Add(1)
+						log.Printf("could not get digest for image %v: %v", ref, err)
+						return
+					}
+					err = doWithTimeout(ctx, 5*time.Minute, func(ctx context.Context) error {
+						log.Printf("indexing image %v", ref)
+						_, err := scanner.GetOrCreateImageIndex(ctx, d, auth)
+						if err != nil {
+							stats.indexFailure.Add(1)
+							return fmt.Errorf("indexing image %v: %w", ref, err)
+						}
+						stats.indexSuccess.Add(1)
+
+						log.Printf("matching image %v", ref)
+						// Though this method both indexes and matches, we know the indexing has already completed,
+						// and this method will just verify the index still exists. We don't account for
+						// this verification's potential failures at this time.
+						_, err = scanner.IndexAndScanImage(ctx, d, auth)
+						if err != nil {
+							stats.matchFailure.Add(1)
+							return fmt.Errorf("matching image %v: %w", ref, err)
+						}
+						stats.matchSuccess.Add(1)
+
+						return nil
+					})
+					if err != nil {
+						log.Printf("error scanning image %v: %v", ref, err)
+					}
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		log.Printf("scale tests complete: %v", &stats)
+
+		return nil
+	}
+	return &cmd
+}
+
+func doWithTimeout(ctx context.Context, timeout time.Duration, f func(context.Context) error) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return f(ctx)
+}

--- a/scanner/cmd/scannerctl/scan.go
+++ b/scanner/cmd/scannerctl/scan.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stackrox/rox/scanner/cmd/scannerctl/authn"
+	"github.com/stackrox/rox/scanner/indexer"
+)
+
+// scanCmd creates the scan command.
+func scanCmd(ctx context.Context) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "scan http(s)://<image-reference>",
+		Short: "Perform vulnerability scans.",
+		Args:  cobra.ExactArgs(1),
+	}
+	flags := cmd.PersistentFlags()
+	basicAuth := flags.String(
+		"auth",
+		"",
+		fmt.Sprintf("Use the specified basic auth credentials (warning: debug "+
+			"only and unsafe, use env var %s).", authn.BasicAuthSetting))
+	imageDigest := flags.String(
+		"digest",
+		"",
+		"Use the specified image digest in "+
+			"the image manifest ID. The default is to retrieve the image digest from "+
+			"the registry and use that.")
+	indexOnly := flags.Bool(
+		"index-only",
+		false,
+		"Only index the specified image")
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		// Create scanner client.
+		scanner, err := factory.Create(ctx)
+		if err != nil {
+			return fmt.Errorf("create client: %w", err)
+		}
+		// Extract basic auth username and password.
+		auth, err := authn.ParseBasic(*basicAuth)
+		if err != nil {
+			return err
+		}
+		// Get the image digest, from the URL or command option.
+		imageURL := args[0]
+		ref, err := indexer.GetDigestFromURL(imageURL, auth)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve image hash id: %w", err)
+		}
+		if *imageDigest == "" {
+			*imageDigest = ref.DigestStr()
+			log.Printf("image digest: %s", *imageDigest)
+		}
+		if *imageDigest != ref.DigestStr() {
+			log.Printf("WARNING: the actual image digest %q is different from %q",
+				ref.DigestStr(), *imageDigest)
+		}
+		var report any
+		if *indexOnly {
+			var ir *v4.IndexReport
+			ir, err = scanner.GetOrCreateImageIndex(ctx, ref, auth)
+			report = ir
+		} else {
+			var vr *v4.VulnerabilityReport
+			vr, err = scanner.IndexAndScanImage(ctx, ref, auth)
+			report = vr
+		}
+
+		if err != nil {
+			return fmt.Errorf("scanning: %w", err)
+		}
+		reportJSON, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return fmt.Errorf("decoding report: %w", err)
+		}
+		fmt.Println(string(reportJSON))
+		return nil
+	}
+	return &cmd
+}


### PR DESCRIPTION
## Description

Extends `scannerctl` with the ability to run scale tests. At the moment, the scale tests just pull a bunch of images from some specified repository.

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Deploy Scanner v4 for yourself and try it out.

I followed the steps from https://github.com/stackrox/stackrox/pull/8869 to create a Helm chart to deploy StackRox with Scanner v4. Be sure to replace the tags for the Scanner v4-related images with whatever you want to run.

Note: `secret_values.yaml` consists of the following:

```
imagePullSecrets:
  username: <TODO>
  password: <TODO>
```

Once deployed (from the scanner directory):

```
$ make bin/scannerctl
$ ./bin/scannerctl --insecure-skip-tls-verify --matcher-address ":8444" scale <your repo here>
```

Note: You'll need to port forward the indexer and matcher. I set the matcher's port to 8444 on my machine

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
