### PR TITLE
test(helm): Make some functions null-safe.

### DIFF
--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
@@ -12,7 +12,7 @@ defs: |
       . as $hay | all(needles[]; . as $needle | any($hay[]; . == $needle));
 
   def saRefersTo(pullSecretNames):
-      [.imagePullSecrets[] | .name] | assertThat(. | containsAll(pullSecretNames));
+      (.imagePullSecrets // []) | [.[] | .name] | assertThat(. | containsAll(pullSecretNames));
 
   # This treats the lists as multisets.
   def saOnlyRefersTo(pullSecretNames):

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/suite.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/suite.yaml
@@ -48,10 +48,10 @@ defs: |
       . as $hay | all(needles[]; . as $needle | all($hay[]; . != $needle));
 
   def saRefersTo(pullSecretNames):
-      [.imagePullSecrets[] | .name] | assertThat(. | containsAll(pullSecretNames));
+      (.imagePullSecrets // []) | [.[] | .name] | assertThat(. | containsAll(pullSecretNames));
 
   def saNotRefersTo(pullSecretNames):
-      [.imagePullSecrets[] | .name] | assertThat(. | containsNone(pullSecretNames));
+      (.imagePullSecrets // []) | [.[] | .name] | assertThat(. | containsNone(pullSecretNames));
 
   # This treats the lists as multisets.
   def saOnlyRefersTo(pullSecretNames):


### PR DESCRIPTION
## Description

In preparation for testing a fix for ROX-9156, make these helper functions treat a null list of secrets the same as an empty one, rather than crash.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
