### PR TITLE
refactor(helm): Set _rox.env.installMethod in both charts.

### DIFF
--- a/image/templates/helm/shared/templates/_set_install_method.tpl.htpl
+++ b/image/templates/helm/shared/templates/_set_install_method.tpl.htpl
@@ -1,0 +1,17 @@
+{{/*
+  srox.setInstallMethod $
+
+  Sets $.env.installMethod to one of: "operator", "helm", "manifest".
+*/}}
+
+{{ define "srox.setInstallMethod" }}
+{{ $ := index . 0 }}
+
+[< if .Operator >]
+{{ $_ := set $._rox.env "installMethod" "operator" }}
+[< else if .KubectlOutput >]
+{{ $_ := set $._rox.env "installMethod" "manifest" }}
+[< else >]
+{{ $_ := set $._rox.env "installMethod" "helm" }}
+[< end >]
+{{ end }}

--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -152,13 +152,7 @@
 {{ include "srox.autoSensePodSecurityPolicies" (list $) }}
 [<- end >]
 
-[< if .Operator >]
-{{ $_ := set $env "installMethod" "operator" }}
-[< else if .KubectlOutput >]
-{{ $_ := set $env "installMethod" "manifest" }}
-[< else >]
-{{ $_ := set $env "installMethod" "helm" }}
-[< end >]
+{{ include "srox.setInstallMethod" (list $) }}
 
 {{/* Apply defaults */}}
 {{ $defaultsCfg := dict }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -104,6 +104,8 @@
 {{ include "srox.autoSensePodSecurityPolicies" (list $) }}
 [<- end >]
 
+{{ include "srox.setInstallMethod" (list $) }}
+
 {{ include "srox.applyDefaults" $ }}
 
 {{/* Expand applicable config values */}}


### PR DESCRIPTION
## Description

In preparation for a fix for ROX-9156, make install method available in both helm charts, such that it can be used by `srox.configureImagePullSecrets` without restrictions.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
