### PR TITLE
fix(logger): ROX-21493: fix rate limited logger test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -496,7 +496,7 @@ go-unit-tests: build-prep test-prep
 	# Exercise the logging package for all supported logging levels to make sure that initialization works properly
 	for encoding in console json; do \
 		for level in debug info warn error fatal panic; do \
-			LOGENCODING=$$encoding LOGLEVEL=$$level CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test scripts/go-test.sh -p 4 -race -v ./pkg/logging/... > /dev/null; \
+			LOGENCODING=$$encoding LOGLEVEL=$$level CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test scripts/go-test.sh -p 4 -race -v ./pkg/logging/... | grep -v "iteration" > /dev/null; \
 		done; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -489,10 +489,10 @@ test-prep:
 
 .PHONY: go-unit-tests
 go-unit-tests: build-prep test-prep
-	#set -o pipefail ; \
-#	CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test scripts/go-test.sh -timeout 15m -race -cover -coverprofile test-output/coverage.out -v \
-#		$(shell git ls-files -- '*_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
-#		| tee $(GO_TEST_OUTPUT_PATH)
+	set -o pipefail ; \
+	CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test scripts/go-test.sh -timeout 15m -race -cover -coverprofile test-output/coverage.out -v \
+		$(shell git ls-files -- '*_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
+		| tee $(GO_TEST_OUTPUT_PATH)
 	# Exercise the logging package for all supported logging levels to make sure that initialization works properly
 	@echo "Run log tests"
 	for encoding in console json; do \

--- a/Makefile
+++ b/Makefile
@@ -489,11 +489,12 @@ test-prep:
 
 .PHONY: go-unit-tests
 go-unit-tests: build-prep test-prep
-	set -o pipefail ; \
-	CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test scripts/go-test.sh -timeout 15m -race -cover -coverprofile test-output/coverage.out -v \
-		$(shell git ls-files -- '*_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
-		| tee $(GO_TEST_OUTPUT_PATH)
+	#set -o pipefail ; \
+#	CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test scripts/go-test.sh -timeout 15m -race -cover -coverprofile test-output/coverage.out -v \
+#		$(shell git ls-files -- '*_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
+#		| tee $(GO_TEST_OUTPUT_PATH)
 	# Exercise the logging package for all supported logging levels to make sure that initialization works properly
+	@echo "Run log tests"
 	for encoding in console json; do \
 		for level in debug info warn error fatal panic; do \
 			LOGENCODING=$$encoding LOGLEVEL=$$level CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test scripts/go-test.sh -p 4 -race -v ./pkg/logging/... | grep -v "iteration"; \

--- a/Makefile
+++ b/Makefile
@@ -496,7 +496,7 @@ go-unit-tests: build-prep test-prep
 	# Exercise the logging package for all supported logging levels to make sure that initialization works properly
 	for encoding in console json; do \
 		for level in debug info warn error fatal panic; do \
-			LOGENCODING=$$encoding LOGLEVEL=$$level CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test scripts/go-test.sh -p 4 -race -v ./pkg/logging/... | grep -v "iteration" > /dev/null; \
+			LOGENCODING=$$encoding LOGLEVEL=$$level CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test scripts/go-test.sh -p 4 -race -v ./pkg/logging/... | grep -v "iteration"; \
 		done; \
 	done
 

--- a/pkg/logging/rate_limited_logger_test.go
+++ b/pkg/logging/rate_limited_logger_test.go
@@ -165,10 +165,13 @@ func (s *rateLimitedLoggerTestSuite) validateRateLimitedLogCount(expectedLogCoun
 func (s *rateLimitedLoggerTestSuite) TestRateLimitedFunctionsErrorLBurst() {
 	limiter := "test limiter"
 
-	logLineNum := getLogCallerLineNum(5)
+	logLineNum := getLogCallerLineNum(8)
 	prefix := getLogCallerPrefix(logLineNum)
 	resolvedErrorMsg := fmt.Sprintf(templateWithFields, "error", 2)
-	s.mockLogger.EXPECT().Logf(zapcore.ErrorLevel, "%s%s%s", prefix, resolvedErrorMsg, "").Times(1)
+
+	var variadicArgs []interface{}
+	variadicArgs = append(variadicArgs, prefix, resolvedErrorMsg, "")
+	s.mockLogger.EXPECT().Logf(zapcore.ErrorLevel, "%s%s%s", variadicArgs).Times(1)
 	for i := 0; i < 3*testBurstSize; i++ {
 		s.rlLogger.ErrorL(limiter, templateWithFields, "error", 2)
 	}
@@ -179,10 +182,13 @@ func (s *rateLimitedLoggerTestSuite) TestRateLimitedFunctionsErrorLBurst() {
 func (s *rateLimitedLoggerTestSuite) TestRateLimitedFunctionsWarnLBurst() {
 	limiter := "test limiter"
 
-	logLineNum := getLogCallerLineNum(5)
+	logLineNum := getLogCallerLineNum(8)
 	prefix := getLogCallerPrefix(logLineNum)
 	resolvedWarnMsg := fmt.Sprintf(templateWithFields, "warn", 2)
-	s.mockLogger.EXPECT().Logf(zapcore.WarnLevel, "%s%s%s", prefix, resolvedWarnMsg, "").Times(1)
+
+	var variadicArgs []interface{}
+	variadicArgs = append(variadicArgs, prefix, resolvedWarnMsg, "")
+	s.mockLogger.EXPECT().Logf(zapcore.WarnLevel, "%s%s%s", variadicArgs).Times(1)
 	for i := 0; i < 3*testBurstSize; i++ {
 		s.rlLogger.WarnL(limiter, templateWithFields, "warn", 2)
 	}
@@ -193,10 +199,13 @@ func (s *rateLimitedLoggerTestSuite) TestRateLimitedFunctionsWarnLBurst() {
 func (s *rateLimitedLoggerTestSuite) TestRateLimitedFunctionsInfoLBurst() {
 	limiter := "test limiter"
 
-	logLineNum := getLogCallerLineNum(5)
+	logLineNum := getLogCallerLineNum(8)
 	prefix := getLogCallerPrefix(logLineNum)
 	resolvedInfoMsg := fmt.Sprintf(templateWithFields, "info", 2)
-	s.mockLogger.EXPECT().Logf(zapcore.InfoLevel, "%s%s%s", prefix, resolvedInfoMsg, "").Times(1)
+
+	var variadicArgs []interface{}
+	variadicArgs = append(variadicArgs, prefix, resolvedInfoMsg, "")
+	s.mockLogger.EXPECT().Logf(zapcore.InfoLevel, "%s%s%s", variadicArgs).Times(1)
 	for i := 0; i < 3*testBurstSize; i++ {
 		s.rlLogger.InfoL(limiter, templateWithFields, "info", 2)
 	}


### PR DESCRIPTION
## Description

I've noticed a flake in the rate_limited_logger, instead of expecting variadic arguments it expected a slice. 
The assertion changed to a slice to match the variadic function arg of the log call.
Secondly the line number of the log line needed to be updated.

```
    rate_limited_logger.go:296: Unexpected call to *mocks.MockLogger.Logf([debug %s%s%s /code/pkg/logging/rate_limited_logger_test.go:213 -  This is a template for debug logs with 2 arguments to convert ]) at /code/pkg/logging/rate_limited_logger.go:296 because: 
        expected call at /code/pkg/logging/rate_limited_logger_test.go:211 doesn't match the argument at index 2.
        Got: [/code/pkg/logging/rate_limited_logger_test.go:213 -  This is a template for debug logs with 2 arguments to convert ] ([]interface {})
        Want: is equal to pkg/logging/rate_limited_logger_test.go:213 -  (string)
    controller.go:98: missing call(s) to *mocks.MockLogger.Logf(is equal to debug (zapcore.Level), is equal to %s%s%s (string), is equal to pkg/logging/rate_limited_logger_test.go:213 -  (string), is equal to This is a template for debug logs with 2 arguments to convert (string), is equal to  (string)) /code/pkg/logging/rate_limited_logger_test.go:211
    controller.go:98: aborting test due to missing call(s)I facing a flake in the rate_limited_logger. 
```

I've yet not understood why these tests succeeded on `master` but failed in my branch https://github.com/stackrox/stackrox/pull/8885.

Additionally the log tests are more verbose and omit the `iteration` calls. Before this change the only indication for this test failure was the exit code.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed


 - Fixed CI test