### PR TITLE
ROX-21054: process indicators offline v3

### DIFF
--- a/pkg/channelmultiplexer/channelmultiplexer.go
+++ b/pkg/channelmultiplexer/channelmultiplexer.go
@@ -41,6 +41,7 @@ func (c *ChannelMultiplexer[T]) Run() {
 
 	output := FanIn[T](ctx, c.inputChannels...)
 	go func() {
+		defer close(c.outputCommands)
 		for o := range output {
 			c.outputCommands <- o
 		}

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -51,4 +51,7 @@ var (
 
 	// NetworkFlowBufferSize holds the size of how many network flows updates will be kept in Sensor while offline.
 	NetworkFlowBufferSize = RegisterIntegerSetting("ROX_SENSOR_NETFLOW_OFFLINE_BUFFER_SIZE", 100)
+
+	// ProcessIndicatorBufferSize indicates how many process indicators will be kept in Sensor while offline.
+	ProcessIndicatorBufferSize = RegisterIntegerSetting("ROX_SENSOR_PROCESS_INDICATOR_OFFLINE_BUFFER_SIZE", 100)
 )

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -53,5 +53,5 @@ var (
 	NetworkFlowBufferSize = RegisterIntegerSetting("ROX_SENSOR_NETFLOW_OFFLINE_BUFFER_SIZE", 100)
 
 	// ProcessIndicatorBufferSize indicates how many process indicators will be kept in Sensor while offline.
-	ProcessIndicatorBufferSize = RegisterIntegerSetting("ROX_SENSOR_PROCESS_INDICATOR_OFFLINE_BUFFER_SIZE", 100)
+	ProcessIndicatorBufferSize = RegisterIntegerSetting("ROX_SENSOR_PROCESS_INDICATOR_BUFFER_SIZE", 1000)
 )

--- a/sensor/common/metrics/init.go
+++ b/sensor/common/metrics/init.go
@@ -23,6 +23,8 @@ func init() {
 		totalNetworkEndpointsReceivedCounter,
 		totalProcessesSentCounter,
 		totalProcessesReceivedCounter,
+		processSignalBufferGauge,
+		processSignalDroppedCount,
 		sensorEvents,
 		k8sObjectCounts,
 		k8sObjectProcessingDuration,

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -125,6 +125,20 @@ var (
 		Help:      "A counter of the total number of processes received by Sensor from Collector",
 	})
 
+	processSignalBufferGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "process_signal_buffer_size",
+		Help:      "A gauge of the current size of the Process Indicator buffer in Sensor",
+	})
+
+	processSignalDroppedCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "process_signal_dropper_counter",
+		Help:      "A counter of the total number of process indicators that were dropped",
+	})
+
 	sensorEvents = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
@@ -296,6 +310,16 @@ func IncrementTotalProcessesSentCounter(numberOfProcesses int) {
 // IncrementTotalProcessesReceivedCounter increments the total number of endpoints received
 func IncrementTotalProcessesReceivedCounter(numberOfProcesses int) {
 	totalProcessesReceivedCounter.Add(float64(numberOfProcesses))
+}
+
+// SetProcessSignalBufferSizeGauge set process signal buffer size gauge.
+func SetProcessSignalBufferSizeGauge(number int) {
+	processSignalBufferGauge.Set(float64(number))
+}
+
+// IncrementProcessSignalDroppedCount increments the number of times the process signal was dropped.
+func IncrementProcessSignalDroppedCount() {
+	processSignalDroppedCount.Inc()
 }
 
 // IncrementProcessEnrichmentDrops increments the number of times we could not enrich.

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -136,7 +136,7 @@ var (
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
 		Name:      "process_signal_dropper_counter",
-		Help:      "A counter of the total number of process indicators that were dropped",
+		Help:      "A counter of the total number of process indicators that were dropped if the buffer was full",
 	})
 
 	sensorEvents = prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/sensor/common/processsignal/pipeline.go
+++ b/sensor/common/processsignal/pipeline.go
@@ -167,6 +167,7 @@ func (p *Pipeline) sendIndicatorEvent() {
 				},
 			}),
 		)
+		metrics.SetProcessSignalBufferSizeGauge(len(p.indicators))
 	}
 }
 
@@ -177,6 +178,7 @@ func (p *Pipeline) sendToCentral(msg *message.ExpiringMessage) {
 		case <-p.stopper.Flow().StopRequested():
 			return
 		default:
+			metrics.IncrementProcessSignalDroppedCount()
 			log.Errorf("The output channel is full. Dropping process indicator event for deployment %s with id %s and process name %s",
 				msg.GetEvent().GetProcessIndicator().GetDeploymentId(),
 				msg.GetEvent().GetProcessIndicator().GetId(),

--- a/sensor/common/processsignal/pipeline.go
+++ b/sensor/common/processsignal/pipeline.go
@@ -72,7 +72,7 @@ func NewProcessPipeline(indicators chan *message.ExpiringMessage, clusterEntitie
 	}
 	// If we are in offline v3 the context won't be cancelled on disconnect, so we can create it here and forget about it.
 	if features.SensorCapturesIntermediateEvents.Enabled() {
-		p.createNewContext()
+		p.msgCtx = context.Background()
 	}
 	go p.sendIndicatorEvent()
 	return p

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -125,7 +125,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	complianceCommandHandler := compliance.NewCommandHandler(complianceService)
 
 	// Create Process Pipeline
-	indicators := make(chan *message.ExpiringMessage)
+	indicators := make(chan *message.ExpiringMessage, env.ProcessIndicatorBufferSize.IntegerSetting())
 	processPipeline := processsignal.NewProcessPipeline(indicators, storeProvider.Entities(), processfilter.Singleton(), policyDetector)
 	processSignals := signalService.New(processPipeline, indicators)
 	networkFlowManager :=


### PR DESCRIPTION
## Description

Process Indicator events are now sent to a buffered channel.

- If the FF `ROX_CAPTURE_INTERMEDIATE_EVENTS` is enabled, the events won't be expired. 
- If the buffer is full, the event will be dropped. This is to avoid Sensor OOMing if we are offline.
- Metrics for the buffer size and the number of events dropped have been added.
- The buffer size is configurable with `ROX_SENSOR_PROCESS_INDICATOR_OFFLINE_BUFFER_SIZE`

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- [x] New unit tests.
- [x] Manual testing:
  - Deploy ACS
  - Break the connection between Central and Sensor
  - Create a pod and run some commands: `kubectl -n test run talk --rm -it --image alpine -- /bin/sh`
  - Re-establish the connection between Central and Sensor
  - Observe that the PIs are in CentralDB: `select deploymentid, signal_name, signal_args, signal_time from process_indicators as pi inner join deployments as d on pi.deploymentid = d.id and d.name = 'talk';`

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
