### PR TITLE
ROX-21473: Fix obstructed table action menus in Workload CVEs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -303,6 +303,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                                     <Td isActionCell>
                                         {isDownloadAvailable && (
                                             <ActionsColumn
+                                                menuAppendTo={() => document.body}
                                                 items={rowActions}
                                                 isDisabled={areDownloadActionsDisabled}
                                             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -278,6 +278,7 @@ function CVEsTable({
                                 {createTableActions && (
                                     <Td className="pf-u-px-0">
                                         <ActionsColumn
+                                            menuAppendTo={() => document.body}
                                             items={createTableActions({
                                                 cve,
                                                 summary,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -204,6 +204,7 @@ function ImageVulnerabilitiesTable({
                                 {createTableActions && (
                                     <Td className="pf-u-px-0">
                                         <ActionsColumn
+                                            menuAppendTo={() => document.body}
                                             items={createTableActions({
                                                 cve,
                                                 summary,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -196,6 +196,7 @@ function ImagesTable({
                                     <Td isActionCell>
                                         {name?.tag && (
                                             <ActionsColumn
+                                                menuAppendTo={() => document.body}
                                                 items={[
                                                     {
                                                         title: watchImageMenuText,


### PR DESCRIPTION
## Description

Fixes table action menus that are cut off when opened, due to appearing inside the table container.

This fix appends the DOM element to `document.body`, which ensures the element is positioned above the container, even when it would otherwise overflow.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CVE List:
![image](https://github.com/stackrox/stackrox/assets/1292638/762cd186-2017-401b-8084-4cf8a4a4862b)

Images List:
![image](https://github.com/stackrox/stackrox/assets/1292638/a5a9fbaf-7e58-4b9f-b4e2-53c51f221c41)

Image single:
![image](https://github.com/stackrox/stackrox/assets/1292638/dcc9be4e-0194-4a77-a932-d42fa42c4c22)

Vuln Reporting Jobs:
![image](https://github.com/stackrox/stackrox/assets/1292638/5e8e0fe9-0158-4960-9e8a-7e6725fdf69d)
