### PR TITLE
ROX-21197: Add a feature flag for cluster aware checks

### DIFF
--- a/pkg/centralsensor/caps_list.go
+++ b/pkg/centralsensor/caps_list.go
@@ -13,6 +13,9 @@ const (
 	// SensorDetectionCap identifies the capability to run detection from sensor
 	SensorDetectionCap SensorCapability = "SensorDetection"
 
+	// SensorEnhancedDeploymentCheckCap identifies the capability for sensor to enhance roxctl deployment check
+	SensorEnhancedDeploymentCheckCap SensorCapability = "SensorEnhancedDeploymentCheck"
+
 	// ComplianceInNodesCap identifies the capability to run compliance in compliance pods
 	ComplianceInNodesCap SensorCapability = "ComplianceInNodes"
 

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -61,6 +61,9 @@ var (
 	// UnifiedCVEDeferral enables APIs and UI pages for unified deferral workflow.
 	UnifiedCVEDeferral = registerFeature("Enable new unified Vulnerability deferral workflow", "ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL", false)
 
+	// ClusterAwareDeploymentCheck enables roxctl deployment check to check deployments on the cluster level.
+	ClusterAwareDeploymentCheck = registerFeature("Enables cluster level check for the 'roxctl deployment check' command.", "ROX_CLUSTER_AWARE_DEPLOYMENT_CHECK", false)
+
 	// WorkloadCVEsFixabilityFilters enables Workload CVE UI controls for fixability filters and default filters
 	WorkloadCVEsFixabilityFilters = registerFeature("Enables Workload CVE fixability filters", "ROX_WORKLOAD_CVES_FIXABILITY_FILTERS", false)
 

--- a/sensor/common/deploymentenhancer/component.go
+++ b/sensor/common/deploymentenhancer/component.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
@@ -113,7 +114,9 @@ func (d *DeploymentEnhancer) enhanceDeployment(deployment *storage.Deployment) {
 
 // Capabilities return the capabilities of this component
 func (d *DeploymentEnhancer) Capabilities() []centralsensor.SensorCapability {
-	// TODO(ROX-21197): Add Capability
+	if features.ClusterAwareDeploymentCheck.Enabled() {
+		return []centralsensor.SensorCapability{centralsensor.AuditLogEventsCap}
+	}
 	return nil
 }
 

--- a/sensor/common/deploymentenhancer/component.go
+++ b/sensor/common/deploymentenhancer/component.go
@@ -115,7 +115,7 @@ func (d *DeploymentEnhancer) enhanceDeployment(deployment *storage.Deployment) {
 // Capabilities return the capabilities of this component
 func (d *DeploymentEnhancer) Capabilities() []centralsensor.SensorCapability {
 	if features.ClusterAwareDeploymentCheck.Enabled() {
-		return []centralsensor.SensorCapability{centralsensor.AuditLogEventsCap}
+		return []centralsensor.SensorCapability{centralsensor.SensorEnhancedDeploymentCheckCap}
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

Add the flag ROX_CLUSTER_AWARE_DEPLOYMENT_CHECK to be used in Sensor

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
