### PR TITLE
test(ui): Make image single page tests more robust

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.selectors.js
@@ -53,7 +53,6 @@ export const selectors = {
     tableRowSelectCheckbox: 'td input[type="checkbox"][aria-label^="Select row"]',
     tableRowSelectAllCheckbox: 'thead input[type="checkbox"][aria-label^="Select all rows"]',
     tableRowMenuToggle: 'td button[aria-label="Actions"]',
-    nonZeroCveSeverityCounts: '*[aria-label*="severity cve count"i]:not([aria-label^="0"])',
     nonZeroImageSeverityCounts:
         'td[data-label="Images by severity"] *[aria-label$="severity"i]:not([aria-label^="0"])',
     nonZeroCveSeverityCount: (severity) =>

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.js
@@ -1,5 +1,3 @@
-import upperFirst from 'lodash/upperFirst';
-
 import withAuth from '../../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../../helpers/features';
 
@@ -8,6 +6,7 @@ import {
     typeAndSelectResourceFilterValue,
     selectEntityTab,
     visitWorkloadCveOverview,
+    typeAndSelectCustomResourceFilterValue,
 } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 
@@ -20,11 +19,30 @@ describe('Workload CVE Image Single page', () => {
         }
     });
 
-    it('should correctly handle Image single page specific behavior', () => {
+    function visitFirstImage() {
         visitWorkloadCveOverview();
 
         selectEntityTab('Image');
+
+        // Clear any filters that may be applied to increase the likelihood of finding valid data
+        if (hasFeatureFlag('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS')) {
+            cy.get(selectors.clearFiltersButton).click();
+        }
+
+        // If unified deferrals are not enabled, there is a good chance none of the visible images will
+        // have CVEs, so we apply a wildcard filter to ensure only images with CVEs are visible
+        if (!hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL')) {
+            typeAndSelectCustomResourceFilterValue('CVE', '*');
+        }
+
+        // Ensure the data in the table has settled
+        cy.get(selectors.isUpdatingTable).should('not.exist');
+
         cy.get('tbody tr td[data-label="Image"] a').first().click();
+    }
+
+    it('should contain the correct search filters in the toolbar', () => {
+        visitFirstImage();
 
         // Check that only applicable resource menu items are present in the toolbar
         cy.get(selectors.searchOptionsDropdown).click();
@@ -37,16 +55,7 @@ describe('Workload CVE Image Single page', () => {
     });
 
     it('should display consistent data between the cards and the table test', () => {
-        visitWorkloadCveOverview();
-
-        selectEntityTab('Image');
-        // Find any image with at least one CVE
-
-        cy.get(
-            `tbody tr:has(td[data-label="CVEs by severity"] ${selectors.nonZeroCveSeverityCounts}) td[data-label="Image"] a`
-        )
-            .first()
-            .click();
+        visitFirstImage();
 
         // Check that the CVEs by severity totals in the card match the number in the "results found" text
         const cardSelector = selectors.summaryCard('CVEs by severity');
@@ -83,102 +92,47 @@ describe('Workload CVE Image Single page', () => {
         });
     });
 
-    it('should correctly apply severity filters', () => {
-        visitWorkloadCveOverview();
+    it('should correctly apply a severity filter', () => {
+        visitFirstImage();
+        // Check that no severities are hidden by default
+        cy.get(selectors.summaryCard('CVEs by severity'))
+            .find("*:contains('Results hidden')")
+            .should('not.exist');
 
-        // Clear default filters if enabled, to prevent inconsistencies when navigating to the image page
-        if (hasFeatureFlag('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS')) {
-            cy.get(selectors.clearFiltersButton).click();
-        }
+        const severityFilter = 'Critical';
 
-        selectEntityTab('Image');
+        applyLocalSeverityFilters(severityFilter);
 
-        // Find any image with at least one CVE
-        cy.get(
-            `tbody tr:has(td[data-label="CVEs by severity"] ${selectors.nonZeroCveSeverityCounts})`
-        )
-            .first()
-            .then(([$rowWithCves]) => {
-                // Get a nonzero count and severity from the table for the selected image
-                cy.wrap($rowWithCves)
-                    .get(selectors.nonZeroCveSeverityCounts)
-                    .then(([$nonZeroSeverityLabel]) => {
-                        const ariaLabel = $nonZeroSeverityLabel.getAttribute('aria-label');
-                        const [, countRaw, severityRaw] = ariaLabel.match(/(\d+) (\w+)/);
-                        const count = parseInt(countRaw, 10);
-                        const severity = upperFirst(severityRaw);
+        // Check that summary card severities are hidden correctly
+        cy.get(`${selectors.severityIcon('Critical')} + *:contains("Results hidden")`).should(
+            'not.exist'
+        );
+        cy.get(`${selectors.severityIcon('Important')} + *:contains("Results hidden")`);
+        cy.get(`${selectors.severityIcon('Moderate')} + *:contains("Results hidden")`);
+        cy.get(`${selectors.severityIcon('Low')} + *:contains("Results hidden")`);
 
-                        const bySeverityCard = selectors.summaryCard('CVEs by severity');
-                        const byStatusCard = `.pf-c-card[aria-busy="false"]${selectors.summaryCard(
-                            'CVEs by status'
-                        )}`;
+        // Check that table rows are filtered
+        cy.get(selectors.filteredViewLabel);
 
-                        // Click the link in the table to visit the image page
-                        cy.wrap($rowWithCves).find('td[data-label="Image"] a').click();
+        // Ensure the table is not in a loading state
+        cy.get(selectors.isUpdatingTable).should('not.exist');
 
-                        // Check the severity and count in the summary card against the data from the original table
-                        cy.get(`${bySeverityCard} ${selectors.iconText(`${count} ${severity}`)}`);
-
-                        // Apply a severity filter that matches the chosen severity
-                        applyLocalSeverityFilters(severity);
-
-                        // Check that all of the other severities in the card read "Results hidden"
-                        cy.get(`${bySeverityCard} ${selectors.iconText(severity)}`);
-                        cy.get(`${bySeverityCard} ${selectors.iconText('Results hidden')}`).should(
-                            'have.length',
-                            3
-                        );
-
-                        // Check that the filtered view label is present
-                        cy.get(selectors.filteredViewLabel);
-
-                        // Check that the row count in the header above the table matches the CVE count for the image
-                        cy.get(`*`).contains(new RegExp(`${count} results? found`));
-
-                        // Check that the count and severity in the summary card still match after the filter is applied
-                        cy.get(`${bySeverityCard} ${selectors.iconText(`${count} ${severity}`)}`);
-
-                        // Check that the total number of fixable + not fixable matches the total number of CVEs
-                        cy.get(
-                            [
-                                `${byStatusCard} ${selectors.iconText('with available fixes')}`,
-                                `${byStatusCard} ${selectors.iconText('without fixes')}`,
-                            ].join(',')
-                        ).then(([$fixable, $notFixable]) => {
-                            const fixableCount = parseInt(
-                                $fixable.innerText.replace(/\D/g, ''),
-                                10
-                            );
-                            const notFixableCount = parseInt(
-                                $notFixable.innerText.replace(/\D/g, ''),
-                                10
-                            );
-                            expect(fixableCount + notFixableCount).to.equal(count);
-                        });
-
-                        // Check that every row in the table has the correct severity
-                        cy.get(`table tbody tr td[data-label="CVE severity"]`).each(($severity) => {
-                            expect($severity.text()).to.equal(severity);
-                        });
-                    });
+        // Check that every row in the table has the correct severity
+        // Query for table rows via jQuery to avoid a Cypress error in the case where there are no rows
+        cy.get('table tbody').then(($table) => {
+            const $cells = $table.find('tr td[data-label="CVE severity"]');
+            // This tests the invariant that if a single severity filter is applied, all rows in the table
+            // will have that same severity. This check also holds if the filter removes all rows from the table.
+            $cells.each((_, $cell) => {
+                const severity = $cell.innerText;
+                expect(severity).to.equal(severityFilter);
             });
+        });
     });
 
     // This test should correctly apply a CVE name filter to the CVEs table
     it('should correctly apply CVE name filters', () => {
-        // Visit the workload CVE overview page
-        visitWorkloadCveOverview();
-
-        selectEntityTab('Image');
-
-        // Select any image that has CVEs in the table
-        // and click the link in the row to visit the image page
-        cy.get(
-            `tbody tr:has(td[data-label="CVEs by severity"] ${selectors.nonZeroCveSeverityCounts})`
-        )
-            .first()
-            .find('td[data-label="Image"] a')
-            .click();
+        visitFirstImage();
 
         // Get any table row and extract the CVE name from the column with the CVE data label
         cy.get('tbody tr td[data-label="CVE"]')


### PR DESCRIPTION
## Description

Apply's the following changes to the Workload CVE image single page tests in order to reduce CI flakes:

1. Instead of checking the CVE severity counts in each table row to find an image with vulnerabilities, simply apply a filter of `CVE:*`. This will guarantee the table only contains images with vulns, regardless of the feature flag set in use.
2. Instead of finding what severity CVEs are non-zero for the selected image, just apply `Severity:Critical` and test the invariants that would be true for that case, regardless of whether or not that image has Critical CVEs.

Will close
https://issues.redhat.com/browse/ROX-21438
https://issues.redhat.com/browse/ROX-21439
https://issues.redhat.com/browse/ROX-21440

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local Cypress runs with UNIFIED_DEFERRALS enabled and disabled.

Await CI
