### PR TITLE
ROX-16811: Encode CVSS scores in the RHEL vuln severity field

### DIFF
--- a/scanner/updater/rhel/parse_test.go
+++ b/scanner/updater/rhel/parse_test.go
@@ -3,6 +3,7 @@ package rhel
 import (
 	"context"
 	"encoding/xml"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -89,6 +90,22 @@ func TestParse(t *testing.T) {
 	count := make(map[string]int)
 	for _, vuln := range vs {
 		count[vuln.Repo.Name]++
+		s, err := url.ParseQuery(vuln.Severity)
+		if err != nil {
+			t.Fatalf("invalid severity: %s", vuln.Severity)
+		}
+		if got, want := s.Get("cvss3_score"), "7.5"; got != want {
+			t.Fatalf("unexpected CVSS3 score: got: %s, want: %s", got, want)
+		}
+		if got, want := s.Get("cvss3_vector"), "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"; got != want {
+			t.Fatalf("unexpected CVSS3 vector: got: %s, want: %s", got, want)
+		}
+		if got, want := s.Get("cvss2_score"), ""; got != want {
+			t.Fatalf("unexpected CVSS2 score: got: %s, want: %s", got, want)
+		}
+		if got, want := s.Get("severity"), "Important"; got != want {
+			t.Fatalf("unexpected severity: got: %s, want: %s", got, want)
+		}
 	}
 
 	const (

--- a/scanner/updater/rhel/parser.go
+++ b/scanner/updater/rhel/parser.go
@@ -5,6 +5,9 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"net/url"
+	"strconv"
+	"strings"
 
 	"github.com/quay/goval-parser/oval"
 	"github.com/quay/zlog"
@@ -20,7 +23,7 @@ import (
 // Parse treats the data inside the provided io.ReadCloser as Red Hat
 // flavored OVAL XML. The distribution associated with vulnerabilities
 // is configured via the Updater. The repository associated with
-// vulnerabilies is based on the affected CPE list.
+// vulnerabilities is based on the affected CPE list.
 func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vulnerability, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "rhel/Updater.Parse")
 	zlog.Info(ctx).Msg("starting parse")
@@ -64,7 +67,7 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 				Description:        def.Description,
 				Issued:             def.Advisory.Issued.Date,
 				Links:              ovalutil.Links(def),
-				Severity:           def.Advisory.Severity,
+				Severity:           severity(ctx, def),
 				NormalizedSeverity: common.NormalizeSeverity(def.Advisory.Severity),
 				Repo: &claircore.Repository{
 					Name: affected,
@@ -82,6 +85,77 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 		return nil, err
 	}
 	return vulns, nil
+}
+
+// severity returns the urlencoded Severity, CVSS scores and vectors based on the
+// OVAL definition. For advisories, the CVSS score is the maximum of all the
+// related CVEs' scores.
+func severity(ctx context.Context, def oval.Definition) string {
+	var cvss3, cvss2 struct {
+		score  float64
+		vector string
+	}
+
+	// For CVEs, there will only be 1 item in this slice.
+	// For RHSAs, RHBAs, etc., there will typically be 1 or more.
+	for _, cve := range def.Advisory.Cves {
+		if cve.Cvss3 != "" {
+			score, vector, found := strings.Cut(cve.Cvss3, "/")
+			if !found {
+				zlog.Warn(ctx).
+					Str("CVSS3", cve.Cvss3).
+					Msg("unexpected format")
+				continue
+			}
+			parsedScore, err := strconv.ParseFloat(score, 64)
+			if err != nil {
+				zlog.Warn(ctx).
+					Str("Vulnerability", def.Title).
+					Err(err).
+					Msg("parsing CVSS3")
+				continue
+			}
+			if parsedScore > cvss3.score {
+				cvss3.score = parsedScore
+				cvss3.vector = vector
+			}
+		}
+
+		if cve.Cvss2 != "" {
+			score, vector, found := strings.Cut(cve.Cvss2, "/")
+			if !found {
+				zlog.Warn(ctx).
+					Str("CVSS2", cve.Cvss2).
+					Msg("unexpected format")
+				continue
+			}
+			parsedScore, err := strconv.ParseFloat(score, 64)
+			if err != nil {
+				zlog.Warn(ctx).
+					Str("Vulnerability", def.Title).
+					Err(err).
+					Msg("parsing CVSS3")
+				continue
+			}
+			if parsedScore > cvss2.score {
+				cvss2.score = parsedScore
+				cvss2.vector = vector
+			}
+		}
+	}
+	severity := make(url.Values)
+	if def.Advisory.Severity != "" {
+		severity.Add("severity", def.Advisory.Severity)
+	}
+	if cvss3.score > 0 && cvss3.vector != "" {
+		severity.Add("cvss3_score", fmt.Sprintf("%.1f", cvss3.score))
+		severity.Add("cvss3_vector", cvss3.vector)
+	}
+	if cvss2.score > 0 && cvss2.vector != "" {
+		severity.Add("cvss2_score", fmt.Sprintf("%.1f", cvss2.score))
+		severity.Add("cvss2_vector", cvss2.vector)
+	}
+	return severity.Encode()
 }
 
 func isSkippableDefinitionType(defType ovalutil.DefinitionType, ignoreUnpatched bool) bool {


### PR DESCRIPTION
## Description

We want the scores so we can return them to customers. We encode fox maximum flexibility. This is temporary: Once SAF/VEX is ready, we will adopt that.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

UTs.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
