### PR TITLE
chore(ui): Create config for ui-component CI job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -549,8 +549,8 @@ endif
 ui-test:
 	make -C ui test
 
-.PHONY: ui-test-component
-ui-test-component:
+.PHONY: ui-component-tests
+ui-component-tests:
 	make -C ui test-component
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -549,6 +549,10 @@ endif
 ui-test:
 	make -C ui test
 
+.PHONY: ui-test-component
+ui-test-component:
+	make -C ui test-component
+
 .PHONY: test
 test: go-unit-tests ui-test shell-unit-tests
 

--- a/scripts/ci/jobs/ui-component-tests.sh
+++ b/scripts/ci/jobs/ui-component-tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+# shellcheck source=../../../scripts/ci/lib.sh
+source "$ROOT/scripts/ci/lib.sh"
+
+set -euo pipefail
+
+ui_component_tests() {
+    info "Starting UI component tests"
+    make ui-test-component || touch FAIL
+
+    store_test_results "ui/apps/platform/cypress/test-results/reports" "reports"
+
+    if is_OPENSHIFT_CI; then
+        cp -a ui/apps/platform/cypress/test-results/artifacts/* "${ARTIFACT_DIR}/" || true
+    fi
+
+    [[ ! -f FAIL ]] || die "UI component tests failed"
+}
+
+ui_component_tests "$*"

--- a/scripts/ci/jobs/ui-component-tests.sh
+++ b/scripts/ci/jobs/ui-component-tests.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 ui_component_tests() {
     info "Starting UI component tests"
-    make ui-test-component || touch FAIL
+    make ui-component-tests || touch FAIL
 
     store_test_results "ui/apps/platform/cypress/test-results/reports" "reports"
 

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -103,10 +103,10 @@
         "lint:fix": "eslint --fix --quiet .",
         "cypress-open": "./scripts/cypress.sh open --config defaultCommandTimeout=8000",
         "cypress-spec": "./scripts/cypress.sh run --spec",
-        "cypress-component": "./scripts/cypress.sh open --component",
+        "cypress-component": "./scripts/cypress-component.sh open --component",
         "test-e2e": "./scripts/cypress.sh run --reporter mocha-multi-reporters --reporter-options configFile=cypress/mocha.config.js",
         "test-e2e-local": "./scripts/cypress.sh run",
-        "test-component": "./scripts/cypress.sh run --reporter mocha-multi-reporters --reporter-options configFile=cypress/mocha.config.js --component",
+        "test-component": "./scripts/cypress-component.sh run --reporter mocha-multi-reporters --reporter-options configFile=cypress/mocha.config.js --component",
         "generate-graphql-possible-types": "ROX_AUTH_TOKEN=$(./scripts/get-auth-token.sh) node scripts/generate-graphql-possible-types.js",
         "eject": "react-app-rewired eject"
     },

--- a/ui/apps/platform/scripts/cypress-component.sh
+++ b/ui/apps/platform/scripts/cypress-component.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+artifacts_dir="${TEST_RESULTS_OUTPUT_DIR:-cypress/test-results}/artifacts"
+export CYPRESS_VIDEOS_FOLDER="${artifacts_dir}/videos"
+export CYPRESS_SCREENSHOTS_FOLDER="${artifacts_dir}/screenshots"
+
+DEBUG="*" NO_COLOR=1 cypress "$@" 2> /dev/null

--- a/ui/apps/platform/scripts/cypress-component.sh
+++ b/ui/apps/platform/scripts/cypress-component.sh
@@ -3,4 +3,5 @@ artifacts_dir="${TEST_RESULTS_OUTPUT_DIR:-cypress/test-results}/artifacts"
 export CYPRESS_VIDEOS_FOLDER="${artifacts_dir}/videos"
 export CYPRESS_SCREENSHOTS_FOLDER="${artifacts_dir}/screenshots"
 
+mkdir -p "$artifacts_dir" && touch "${artifacts_dir:-/tmp}/cypress-err.txt"
 DEBUG="*" NO_COLOR=1 cypress "$@" 2> "${artifacts_dir:-/tmp}/cypress-err.txt"

--- a/ui/apps/platform/scripts/cypress-component.sh
+++ b/ui/apps/platform/scripts/cypress-component.sh
@@ -3,4 +3,4 @@ artifacts_dir="${TEST_RESULTS_OUTPUT_DIR:-cypress/test-results}/artifacts"
 export CYPRESS_VIDEOS_FOLDER="${artifacts_dir}/videos"
 export CYPRESS_SCREENSHOTS_FOLDER="${artifacts_dir}/screenshots"
 
-DEBUG="*" NO_COLOR=1 cypress "$@" 2> /dev/null
+DEBUG="*" NO_COLOR=1 cypress "$@" 2> "${artifacts_dir:-/tmp}/cypress-err.txt"


### PR DESCRIPTION
## Description

Adds job configuration to run Cypress component tests via Prow. This job is currently optional and runs only when invoked explicitly.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Kick off prow CI job manually with `/test ui-component-tests`.

Tests complete successfully and:

JUnit output successfully reported in Prow dashboard
![image](https://github.com/stackrox/stackrox/assets/1292638/93444cd2-efb9-4d3c-bb2b-824ef6b5e979)

JUnit reports uploaded to GCP
![image](https://github.com/stackrox/stackrox/assets/1292638/741ab3b2-8ee4-47f3-ab72-fb87723a8f48)

Cypress test videos captured and uploaded to GCP
![image](https://github.com/stackrox/stackrox/assets/1292638/2fbf6453-90f2-4e8a-a730-4899a05dc239)
![image](https://github.com/stackrox/stackrox/assets/1292638/01f15aeb-e44c-4e39-abff-5e23db83cecc)

