### PR TITLE
fix(e2e): Document test is executed in Manifest based environments

### DIFF
--- a/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
@@ -176,6 +176,7 @@ class CertRotationTest extends BaseSpecification {
         return true
     }
 
+    // This test is skipped in Operator and Helm, upgrader only works in Manifest based installations
     def "Test sensor cert rotation with upgrader succeeds for non-Helm clusters"() {
         when:
         "Check that the cluster is not Helm-managed"

--- a/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
@@ -177,9 +177,9 @@ class CertRotationTest extends BaseSpecification {
     }
 
     // This test is skipped in Operator and Helm, upgrader only works in Manifest based installations
-    def "Test sensor cert rotation with upgrader succeeds for non-Helm clusters"() {
+    def "Test sensor cert rotation with upgrader succeeds for manifest based installed clusters"() {
         when:
-        "Check that the cluster is not Helm-managed"
+        "Check that the cluster is manifest installed"
         def cluster = ClusterService.getCluster()
         assert cluster
 


### PR DESCRIPTION
## Description
Add doc that test is only executed in Manifest based environments 

