### PR TITLE
ROX-21198: Enrich deployments with Network Policies in Central

### DIFF
--- a/central/detection/service/service.go
+++ b/central/detection/service/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/central/detection/deploytime"
 	"github.com/stackrox/rox/central/enrichment"
 	imageDatastore "github.com/stackrox/rox/central/image/datastore"
+	networkPolicyDS "github.com/stackrox/rox/central/networkpolicies/datastore"
 	"github.com/stackrox/rox/central/risk/manager"
 	"github.com/stackrox/rox/central/role/sachelper"
 	"github.com/stackrox/rox/central/sensor/enhancement"
@@ -42,6 +43,7 @@ func New(
 	clusterSACHelper sachelper.ClusterSacHelper,
 	connManager connection.Manager,
 	broker *enhancement.Broker,
+	netpols networkPolicyDS.DataStore,
 ) Service {
 	return &serviceImpl{
 		clusters:           clusters,
@@ -56,5 +58,6 @@ func New(
 		clusterSACHelper:   clusterSACHelper,
 		connManager:        connManager,
 		enhancementWatcher: broker,
+		netpols:            netpols,
 	}
 }

--- a/central/detection/service/service_impl.go
+++ b/central/detection/service/service_impl.go
@@ -228,7 +228,7 @@ func (s *serviceImpl) enrichAndDetect(ctx context.Context, enrichmentContext enr
 	var appliedNetpols *augmentedobjs.NetworkPoliciesApplied
 	appliedNetpols, err = s.getAppliedNetpolsForDeployment(ctx, enrichmentContext, deployment)
 	if err != nil {
-		log.Warnf("Could not find applied network policies for deployment %s. Continuing with deployment enrichment.", deployment.GetName())
+		log.Warnf("Could not find applied network policies for deployment %s. Continuing with deployment enrichment. Error: %s", deployment.GetName(), err)
 	} else {
 		log.Debugf("Found applied network policies for deployment %s: %+v", deployment.GetName(), appliedNetpols)
 	}
@@ -256,7 +256,7 @@ func (s *serviceImpl) enrichAndDetect(ctx context.Context, enrichmentContext enr
 func (s *serviceImpl) getAppliedNetpolsForDeployment(ctx context.Context, enrichmentContext enricher.EnrichmentContext, deployment *storage.Deployment) (*augmentedobjs.NetworkPoliciesApplied, error) {
 	storedPolicies, err := s.netpols.GetNetworkPolicies(ctx, enrichmentContext.ClusterID, enrichmentContext.Namespace)
 	if err != nil {
-		return nil, errox.InvalidArgs.New("failed to find network policies for deployment").CausedBy(err)
+		return nil, errors.Wrapf(err, "failed to find network policies for cluster %s and namespace %s", enrichmentContext.ClusterID, enrichmentContext.Namespace)
 	}
 	matchedPolicies := networkpolicy.FilterForDeployment(storedPolicies, deployment)
 	return networkpolicy.GenerateNetworkPoliciesAppliedObj(matchedPolicies), nil

--- a/central/detection/service/service_impl_test.go
+++ b/central/detection/service/service_impl_test.go
@@ -692,9 +692,10 @@ func TestFetchOptionFromRequest(t *testing.T) {
 }
 
 func TestGetAppliedNetpolsForDeployment(t *testing.T) {
+	mockClusterID := uuid.NewV4().String()
 	mockCtrl := gomock.NewController(t)
 	mockNetpolDS := networkPolicyMockStore.NewMockDataStore(mockCtrl)
-	mockNetpolDS.EXPECT().GetNetworkPolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+	mockNetpolDS.EXPECT().GetNetworkPolicies(gomock.Any(), mockClusterID, "ns").Return(
 		[]*storage.NetworkPolicy{
 			{Id: uuid.NewV4().String(), Spec: &storage.NetworkPolicySpec{PodSelector: &storage.LabelSelector{MatchLabels: map[string]string{"app": "match"}}}},
 			{Id: uuid.NewV4().String(), Spec: &storage.NetworkPolicySpec{PodSelector: &storage.LabelSelector{MatchLabels: map[string]string{"nomatch": "nomatch"}}}},
@@ -702,7 +703,7 @@ func TestGetAppliedNetpolsForDeployment(t *testing.T) {
 	s := serviceImpl{
 		netpols: mockNetpolDS,
 	}
-	eCtx := enricher.EnrichmentContext{Namespace: "ns", ClusterID: uuid.NewV4().String()}
+	eCtx := enricher.EnrichmentContext{Namespace: "ns", ClusterID: mockClusterID}
 	d := storage.Deployment{Id: uuid.NewV4().String(), PodLabels: map[string]string{"app": "match"}}
 
 	actual, err := s.getAppliedNetpolsForDeployment(context.Background(), eCtx, &d)

--- a/central/detection/service/singleton.go
+++ b/central/detection/service/singleton.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/central/detection/deploytime"
 	"github.com/stackrox/rox/central/enrichment"
 	imageDatastore "github.com/stackrox/rox/central/image/datastore"
+	networkpolicyDatastore "github.com/stackrox/rox/central/networkpolicies/datastore"
 	"github.com/stackrox/rox/central/notifier/processor"
 	"github.com/stackrox/rox/central/risk/manager"
 	"github.com/stackrox/rox/central/role/sachelper"
@@ -36,6 +37,7 @@ func initialize() {
 		sachelper.NewClusterSacHelper(clusterDS),
 		connection.ManagerSingleton(),
 		enhancement.BrokerSingleton(),
+		networkpolicyDatastore.Singleton(),
 	)
 }
 

--- a/pkg/booleanpolicy/networkpolicy/networkpolicy.go
+++ b/pkg/booleanpolicy/networkpolicy/networkpolicy.go
@@ -36,6 +36,7 @@ func GenerateNetworkPoliciesAppliedObj(networkPolicies map[string]*storage.Netwo
 func FilterForDeployment(networkPolicies []*storage.NetworkPolicy, deployment *storage.Deployment) map[string]*storage.NetworkPolicy {
 	matchedNetworkPolicies := map[string]*storage.NetworkPolicy{}
 	for _, p := range networkPolicies {
+		//FIXME: Debugging this shows that the labels are instead in deployment.GetLabels()
 		if labels.MatchLabels(p.GetSpec().GetPodSelector(), deployment.GetPodLabels()) {
 			matchedNetworkPolicies[p.GetId()] = p
 		}

--- a/pkg/booleanpolicy/networkpolicy/networkpolicy.go
+++ b/pkg/booleanpolicy/networkpolicy/networkpolicy.go
@@ -36,7 +36,6 @@ func GenerateNetworkPoliciesAppliedObj(networkPolicies map[string]*storage.Netwo
 func FilterForDeployment(networkPolicies []*storage.NetworkPolicy, deployment *storage.Deployment) map[string]*storage.NetworkPolicy {
 	matchedNetworkPolicies := map[string]*storage.NetworkPolicy{}
 	for _, p := range networkPolicies {
-		//FIXME: Debugging this shows that the labels are instead in deployment.GetLabels()
 		if labels.MatchLabels(p.GetSpec().GetPodSelector(), deployment.GetPodLabels()) {
 			matchedNetworkPolicies[p.GetId()] = p
 		}

--- a/pkg/images/enricher/enricher.go
+++ b/pkg/images/enricher/enricher.go
@@ -72,6 +72,9 @@ type EnrichmentContext struct {
 	// Used to override the delegated registry configuration.
 	ClusterID string
 
+	// Namespace contains the name of the namespace used to filter NetworkPolicies for Deployments.
+	Namespace string
+
 	Source *RequestSource
 }
 

--- a/pkg/protoconv/resources/resources.go
+++ b/pkg/protoconv/resources/resources.go
@@ -227,6 +227,7 @@ func (w *DeploymentWrap) populateFields(obj interface{}) {
 	w.populateReplicas(spec, obj)
 
 	var podSpec v1.PodSpec
+	var podMeta metav1.ObjectMeta
 
 	switch o := obj.(type) {
 	case *openshiftAppsV1.DeploymentConfig:
@@ -253,9 +254,11 @@ func (w *DeploymentWrap) populateFields(obj interface{}) {
 			return
 		}
 		podSpec = podTemplate.Spec
+		podMeta = podTemplate.ObjectMeta
 	}
 
 	w.PopulateDeploymentFromPodSpec(podSpec)
+	w.PopulateDeploymentFromPodMeta(podMeta)
 }
 
 // PopulateDeploymentFromPodSpec fills in the initialized wrap with data from the passed pod spec
@@ -270,6 +273,11 @@ func (w *DeploymentWrap) PopulateDeploymentFromPodSpec(podSpec v1.PodSpec) {
 	w.populateImagePullSecrets(podSpec)
 
 	w.populateContainers(podSpec)
+}
+
+// PopulateDeploymentFromPodMeta fills in the initialized wrap with data from the passed pod meta
+func (w *DeploymentWrap) PopulateDeploymentFromPodMeta(podMeta metav1.ObjectMeta) {
+	w.PodLabels = podMeta.GetLabels()
 }
 
 func (w *DeploymentWrap) populateTolerations(podSpec v1.PodSpec) {

--- a/pkg/protoconv/resources/resources_test.go
+++ b/pkg/protoconv/resources/resources_test.go
@@ -152,7 +152,8 @@ func TestNewDeploymentFromStaticResourcePopulatesPodLabels(t *testing.T) {
 			},
 		},
 	}
-	d, _ := NewDeploymentFromStaticResource(deployment, "Deployment", "", "")
+	d, err := NewDeploymentFromStaticResource(deployment, "Deployment", "", "")
+	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"app": "nginx"}, d.GetPodLabels())
 }
 

--- a/pkg/protoconv/resources/resources_test.go
+++ b/pkg/protoconv/resources/resources_test.go
@@ -141,6 +141,21 @@ func TestCronJobPopulateSpec(t *testing.T) {
 	assert.Equal(t, deploymentWrap.Containers[0].Name, "container2")
 }
 
+func TestNewDeploymentFromStaticResourcePopulatesPodLabels(t *testing.T) {
+	deployment := &appsV1.Deployment{
+		Spec: appsV1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "nginx"},
+				},
+				Spec: v1.PodSpec{Containers: []v1.Container{{Name: "nginx"}}},
+			},
+		},
+	}
+	d, _ := NewDeploymentFromStaticResource(deployment, "Deployment", "", "")
+	assert.Equal(t, map[string]string{"app": "nginx"}, d.GetPodLabels())
+}
+
 func TestIsTrackedReference(t *testing.T) {
 	cases := []struct {
 		ref       metav1.OwnerReference


### PR DESCRIPTION
## Description

This PR extends the capabilities Central has when `roxctl deployment check` is called.
Now Central is enriching a Deployment with Network Policies that would apply to it, were it deployed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed
1. Deploy to any cluster
1. Set up a new API token in Central and export it for roxctl to use
1. Set Central loglevel to debug
1. Use `roxctl` from PR https://github.com/stackrox/stackrox/pull/9110 to check a deployment (see addendum):
    - `./roxctl deployment check --cluster remote --namespace stackrox --file ./nginx.yaml`
1. Observe logline in Central with `Determined applied network policies for deployment nginx-deployment: ...` listing empty Network Policies
1. Apply the yaml to the Namespace (mainly creating the Network Policy): 
    - `kubectl -n stackrox apply -f ./nginx.yaml`
1. Observe logline in Central with `Determined applied network policies for deployment nginx-deployment: ...` **listing the Network Policy**



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.

---

Addendum: nginx.yaml
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  namespace: stackrox
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80

---

apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: multi-port-egress
  namespace: stackrox
spec:
  podSelector:
    matchLabels:
      app: nginx
  policyTypes:
    - Ingress
  ingress:
    - from:
        - ipBlock:
            cidr: 10.0.0.0/24
      ports:
        - protocol: TCP
          port: 32000
          endPort: 32768
```
