### PR TITLE
ROX-20716: Enable history for ClusterEntities Store

### DIFF
--- a/pkg/env/integersetting.go
+++ b/pkg/env/integersetting.go
@@ -17,6 +17,11 @@ func (s *IntegerSetting) EnvVar() string {
 	return s.envVar
 }
 
+// DefaultValue returns the default vaule for the setting
+func (s *IntegerSetting) DefaultValue() int {
+	return s.defaultValue
+}
+
 // Setting returns the string form of the integer environment variable
 func (s *IntegerSetting) Setting() string {
 	return fmt.Sprintf("%d", s.IntegerSetting())

--- a/sensor/common/clusterentities/entity_status.go
+++ b/sensor/common/clusterentities/entity_status.go
@@ -12,8 +12,8 @@ type entityStatus struct {
 	isHistorical bool
 }
 
-// markHistorical is called when entity would be deleted.
-// Istead, we mark it as historcal and keep it as long as ticksLeft
+// markHistorical is called when entity is deleted from the cluster.
+// Instead of deleting it from memory, we mark it as historical and keep it as long as ticksLeft
 func (es *entityStatus) markHistorical(ticksLeft uint16) {
 	if !es.isHistorical {
 		es.ticksLeft = ticksLeft

--- a/sensor/kubernetes/listener/resources/env.go
+++ b/sensor/kubernetes/listener/resources/env.go
@@ -14,4 +14,4 @@ import "github.com/stackrox/rox/pkg/env"
 // for connections that are in fact not external.
 // Setting this value too high will result in higher memory consumption of Sensor (especially in clusters with many
 // deletions or dynamic changes to services or IP addresses).
-var pastEndpointsMemorySize = env.RegisterIntegerSetting("ROX_PAST_ENDPOINTS_MEMORY_SIZE", 0)
+var pastEndpointsMemorySize = env.RegisterIntegerSetting("ROX_PAST_ENDPOINTS_MEMORY_SIZE", 20)

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -37,7 +37,7 @@ type CleanableStore interface {
 func InitializeStore() *StoreProvider {
 	memSizeSetting := pastEndpointsMemorySize.IntegerSetting()
 	if memSizeSetting < 0 {
-		memSizeSetting = 20
+		memSizeSetting = pastEndpointsMemorySize.DefaultValue()
 	}
 	log.Infof("Initializing cluster entities store with memory that will last for %d ticks", memSizeSetting)
 	deployStore := newDeploymentStore()


### PR DESCRIPTION
## Description

Enabling the history added in #8782.

This allows to get rid of incorrectly reported 'External Entities' on the network graph for cases where Collector Afterglow reports a connection close after the related deployment (source or destination) has been changed (e.g., IP address change for a service) or deleted.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added - in #8782
- [ ] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
    - Manual upgrade steps are not required as default value (used for cases when the env var is missing) will work well.


### N/A
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

I tested this setting in #8782.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
