### PR TITLE
fix(ui): Select table row containing scanned CVEs

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
@@ -226,7 +226,11 @@ describe('Entities single views', () => {
 
         // click on the first deployment in the list
         interactAndWaitForVulnerabilityManagementEntity(() => {
-            cy.get(`${selectors.tableBodyRows}:eq(0) .rt-td:nth-child(2)`).click();
+            cy.get(
+                `${selectors.tableBodyRows}:has(.rt-td:eq(2) a:contains("CVE")) .rt-td:nth-child(2)`
+            )
+                .first()
+                .click();
         }, entitiesKey1);
 
         // now, go to the components for that deployment


### PR DESCRIPTION
## Description

Fix for flake: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-ocp-4-11-merge-ui-e2e-tests/1737565432228876288

This occurs when the test selects a deployment from the table that does not have any associated components. This will be the case if:
1. The deployment has no scanned images
2. The deployment image scanning is in-progress
3. The deployment image scanning is complete, but there are no CVEs

This happens because the test selects the first row from the table. In the case of the flake, this is a deployment with images that have not been scanned:
![image](https://github.com/stackrox/stackrox/assets/1292638/69fc185d-f596-44cb-a3b9-2f7da1c2a586)

This test has been updated to select the first row of the table that contains an "Image CVEs" cell with a link that contains the text "CVE", which only occurs when the deployment has a scanned image with CVEs.

This is not ideal because:
- It still relies on _some_ deployment to have scanned images, which may not always be true. (The odds are much better now though, as it checks up to 20 candidates instead of just a single one).
- It relies on somewhat arbitrary DOM structure.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local Cypress run:
![image](https://github.com/stackrox/stackrox/assets/1292638/db7cdd4d-a768-4659-b351-88a6d28f8c37)

Awaiting Green CI

