### PR TITLE
fix(data-race): fix network flow manager tests

### DIFF
--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -624,10 +624,10 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 			state.expectEntityLookupContainer.runIfSet()
 			state.expectEntityLookupEndpoint.runIfSet()
 			state.expectDetector.runIfSet()
-			m.Notify(state.notify)
-			fakeTicker <- time.Now()
 			// We do not test ticking here, but without this line, the test would deadlock.
 			mockEntity.EXPECT().RecordTick().AnyTimes()
+			m.Notify(state.notify)
+			fakeTicker <- time.Now()
 			if state.expectedSensorMessage != nil {
 				select {
 				case <-time.After(10 * time.Second):
@@ -681,10 +681,10 @@ func (s *NetworkFlowManagerTestSuite) TestExpireMessage() {
 		}
 	})
 	mockDetector.EXPECT().ProcessNetworkFlow(gomock.Any(), gomock.Any()).Times(1)
+	mockEntity.EXPECT().RecordTick().AnyTimes()
 	addHostConnection(m, createHostnameConnections(hostname).withConnectionPair(createConnectionPair()))
 	m.Notify(common.SensorComponentEventCentralReachable)
 	fakeTicker <- time.Now()
-	mockEntity.EXPECT().RecordTick().AnyTimes()
 	select {
 	case <-time.After(10 * time.Second):
 		s.Fail("timeout waiting for sensor message")


### PR DESCRIPTION
## Description

After #8782 was merged a data race was introduce in some of the networkflow manager tests.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Unit tests should pass in CI
- [x] Run the tests manually with: `go test -race -count=100 github.com/stackrox/rox/sensor/common/networkflow/manager`

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
