### PR TITLE
ROX-18375: [Central] Set core_bpf a default collection method

### DIFF
--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -949,7 +949,7 @@ func addDefaults(cluster *storage.Cluster) error {
 	// For backwards compatibility reasons, if Collection Method is not set, or set
 	// to KERNEL_MODULE (which is unsupported) then honor defaults for runtime support
 	if collectionMethod == storage.CollectionMethod_UNSET_COLLECTION || collectionMethod == storage.CollectionMethod_KERNEL_MODULE {
-		cluster.CollectionMethod = storage.CollectionMethod_EBPF
+		cluster.CollectionMethod = storage.CollectionMethod_CORE_BPF
 	}
 	cluster.RuntimeSupport = cluster.GetCollectionMethod() != storage.CollectionMethod_NO_COLLECTION
 

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -62,7 +62,7 @@ export const clusterTablePollingInterval = 5000; // milliseconds
 export const clusterDetailPollingInterval = 3000; // milliseconds
 
 const defaultNewClusterType = 'KUBERNETES_CLUSTER';
-const defaultCollectionMethod = 'EBPF';
+const defaultCollectionMethod = 'CORE_BPF';
 
 export const newClusterDefault = {
     id: undefined,


### PR DESCRIPTION
## Description

Make core_bpf a default one when unset in the stored configuration and in the UI. Part of https://github.com/stackrox/collector/issues/1470

## Checklist
- [x] Investigated and inspected CI test results
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

No need for unit or regression tests.

## Testing Performed

Deployed ACS, verified that CORE_BPF is a default collection method suggested in the UI. Modified the database record for one secured cluster to have an unset collection method -- turns out it was transformed to `NO_COLLECTION` and never hits the "defaults" assignment logic, showing that an "unset" value is legacy and used exclusively as a defensive coding measure for corrupted data or ancient versions.