### PR TITLE
ROX-18375: [Helm] Set core_bpf a default collection method

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/README.md.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/README.md.htpl
@@ -127,7 +127,7 @@ For example,
   ```
 - **Configure collection method**:
   ```sh
-  --set collector.collectionMethod=EBPF
+  --set collector.collectionMethod=CORE_BPF
   ```
 
 #### Using configuration YAML files and the `-f` command-line option
@@ -248,9 +248,9 @@ chart and their default values:
 |`image.main.registry`| Address of the registry you are using for main image.|`[< required "" .MainRegistry >]` |
 |`image.collector.registry`| Address of the registry you are using for collector image.|`[< required "" .CollectorRegistry >]` |
 |`sensor.endpoint`| Address of the Sensor endpoint including port number. No trailing slash.|`sensor.stackrox.svc:443` |
-|`collector.collectionMethod`|Either `EBPF`, `CORE_BPF`, or `NO_COLLECTION`. |`EBPF` |
+|`collector.collectionMethod`|Either `EBPF`, `CORE_BPF`, or `NO_COLLECTION`. |`CORE_BPF` |
 |`collector.disableTaintTolerations`|If you specify `false`, tolerations are applied to collector, and the collector pods can schedule onto all nodes with taints. If you specify it as `true`, no tolerations are applied, and the collector pods won't scheduled onto nodes with taints. |`false` |
-|`collector.slimMode`| Specify `true` if you want to use a slim Collector image for deploying Collector. Using slim Collector images requires Central to provide the matching kernel module or eBPF probe. If you are running the StackRox Kubernetes Security Platform in offline mode, you must download a kernel support package from [stackrox.io](https://install.stackrox.io/collector/support-packages/index.html) and upload it to Central for slim Collectors to function. Otherwise, you must ensure that Central can access the online probe repository hosted at https://collector-modules.stackrox.io/.|`false` |
+|`collector.slimMode`| Specify `true` if you want to use a slim Collector image for deploying Collector. Using slim Collector images and EBPF collection method requires Central to provide the matching eBPF probe. If you are running the StackRox Kubernetes Security Platform in offline mode and use EBPF collection method, you must download a kernel support package from [stackrox.io](https://install.stackrox.io/collector/support-packages/index.html) and upload it to Central for slim Collectors to function. Otherwise, you must ensure that Central can access the online probe repository hosted at https://collector-modules.stackrox.io/.|`false` |
 |`admissionControl.listenOnCreates`| This setting controls whether the cluster is configured to contact the StackRox Kubernetes Security Platform with `AdmissionReview` requests for `create` events on Kubernetes objects. |`false` |
 |`admissionControl.listenOnUpdates`|This setting controls whether the cluster is configured to contact the StackRox Kubernetes Security Platform with `AdmissionReview` requests for `update` events on Kubernetes objects.|`false` |
 |`admissionControl.listenOnEvents`|This setting controls whether the cluster is configured to contact the StackRox Kubernetes Security Platform with `AdmissionReview` requests for `update` Kubernetes events like `exec` and `portforward`.|`false` on OpenShift, `true` otherwise.|

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -102,7 +102,7 @@ admissionControl:
                 app: admission-control
 
 collector:
-  collectionMethod: "EBPF"
+  collectionMethod: "CORE_BPF"
   disableTaintTolerations: false
   nodescanningEndpoint: "127.0.0.1:8444"
   tolerations:

--- a/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
@@ -297,7 +297,7 @@
 #  #   - EBPF
 #  #   - CORE_BPF
 #  #   - NO_COLLECTION
-#  collectionMethod: EBPF
+#  collectionMethod: CORE_BPF
 #
 #  # Configure usage of taint tolerations. If `false`, tolerations are applied to collector,
 #  # and the collector pods can schedule onto all nodes with taints. If `true`, no tolerations
@@ -305,9 +305,9 @@
 #  disableTaintTolerations: false
 #
 #  # Configure whether slim Collector images should be used or not. Using slim Collector images
-#  # requires Central to provide the matching kernel module or eBPF probe. If you are running
-#  # the StackRox Kubernetes Security Platform in offline mode, you must download a kernel support
-#  # package from [stackrox.io](https://install.stackrox.io/collector/support-packages/index.html)
+#  # with the EBPF collection method requires Central to provide the matching eBPF probe. If you
+#  # are running the StackRox Kubernetes Security Platform in offline mode and use EBPF collection
+#  # method, you must download a kernel support package from [stackrox.io](https://install.stackrox.io/collector/support-packages/index.html)
 #  # and upload it to Central for slim Collectors to function. Otherwise, you must ensure that
 #  # Central can access the online probe repository hosted at https://collector-modules.stackrox.io/.
 #  slimMode: false

--- a/image/templates/helm/stackrox-secured-cluster/values.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/values.yaml.htpl
@@ -16,7 +16,7 @@ image:
     collector: [< required "" .CollectorRegistry >]
 
 config:
-  collectionMethod: [< default "EBPF" .CollectionMethod >]
+  collectionMethod: [< default "CORE_BPF" .CollectionMethod >]
   admissionControl:
     createService: [< default false .AdmissionController >]
     listenOnUpdates: [< default false .AdmissionControlListenOnUpdates >]

--- a/pkg/helm/config/testdata/helm-chart-configurations/simple.yaml
+++ b/pkg/helm/config/testdata/helm-chart-configurations/simple.yaml
@@ -14,6 +14,6 @@ admissionControl:
     enforceOnUpdates: true
 
 collector:
-  collectionMethod: EBPF
+  collectionMethod: CORE_BPF
   disableTaintTolerations: false
   slimMode: false

--- a/pkg/renderer/kubernetes_helm_test.go
+++ b/pkg/renderer/kubernetes_helm_test.go
@@ -57,7 +57,7 @@ func getDefaultMetaValues(t *testing.T) *charts.MetaValues {
 		ScannerSlimImageRemote: "scanner",
 		ScannerImageTag:        "3.0.11-slim",
 
-		CollectionMethod: "EBPF",
+		CollectionMethod: "CORE_BPF",
 
 		ClusterType: "KUBERNETES_CLUSTER",
 


### PR DESCRIPTION
## Description

Make core_bpf a default one for Helm charts. Part of https://github.com/stackrox/collector/issues/1470

## Checklist
- [x] Investigated and inspected CI test results
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

No need for unit or regression tests.

## Testing Performed

* Generated charts for central & secured cluster services

```
$ roxctl helm output central-services --image-defaults=development_build --debug
$ roxctl helm output secured-cluster-services --image-defaults=development_build --debug
```
* Deployed using helm

```
$ helm upgrade --install -n stackrox stackrox-central-services --create-namespace  ./stackrox-central-services-chart [...]
$ helm install -n stackrox stackrox-secured-cluster-services ./stackrox-secured-cluster-services-chart [...]
```

* Verified that the resulting cluster has the core_bpf collection method.