### PR TITLE
ROX-18375: [Operator] Set core_bpf a default collection method

### DIFF
--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -276,10 +276,10 @@ func (t TaintTolerationPolicy) Pointer() *TaintTolerationPolicy {
 
 // CollectorContainerSpec defines settings for the collector container.
 type CollectorContainerSpec struct {
-	// The method for system-level data collection. EBPF is recommended.
+	// The method for system-level data collection. CORE_BPF is recommended.
 	// If you select "NoCollection", you will not be able to see any information about network activity
 	// and process executions. The remaining settings in these section will not have any effect.
-	//+kubebuilder:default=EBPF
+	//+kubebuilder:default=CORE_BPF
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:EBPF", "urn:alm:descriptor:com.tectonic.ui:select:CORE_BPF", "urn:alm:descriptor:com.tectonic.ui:select:NoCollection"}
 	Collection *CollectionMethod `json:"collection,omitempty"`
 

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -464,10 +464,10 @@ spec:
                       for collecting process and networking activity at the host level.
                     properties:
                       collection:
-                        default: EBPF
+                        default: CORE_BPF
                         description: The method for system-level data collection.
-                          EBPF is recommended. If you select "NoCollection", you will
-                          not be able to see any information about network activity
+                          CORE_BPF is recommended. If you select "NoCollection", you
+                          will not be able to see any information about network activity
                           and process executions. The remaining settings in these
                           section will not have any effect.
                         enum:

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -729,7 +729,7 @@ spec:
           please select 'AvoidTaints' here.
         displayName: Taint Toleration
         path: perNode.taintToleration
-      - description: The method for system-level data collection. EBPF is recommended.
+      - description: The method for system-level data collection. CORE_BPF is recommended.
           If you select "NoCollection", you will not be able to see any information
           about network activity and process executions. The remaining settings in
           these section will not have any effect.

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -464,10 +464,10 @@ spec:
                       for collecting process and networking activity at the host level.
                     properties:
                       collection:
-                        default: EBPF
+                        default: CORE_BPF
                         description: The method for system-level data collection.
-                          EBPF is recommended. If you select "NoCollection", you will
-                          not be able to see any information about network activity
+                          CORE_BPF is recommended. If you select "NoCollection", you
+                          will not be able to see any information about network activity
                           and process executions. The remaining settings in these
                           section will not have any effect.
                         enum:

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -574,7 +574,7 @@ spec:
           collecting process and networking activity at the host level.
         displayName: Collector Settings
         path: perNode.collector
-      - description: The method for system-level data collection. EBPF is recommended.
+      - description: The method for system-level data collection. CORE_BPF is recommended.
           If you select "NoCollection", you will not be able to see any information
           about network activity and process executions. The remaining settings in
           these section will not have any effect.


### PR DESCRIPTION
## Description

Make core_bpf a default one for the Operator. Values translation is not changed on purpose (it's going to be the target of another PR), only the default value. Part of https://github.com/stackrox/collector/issues/1470

## Checklist
- [x] Investigated and inspected CI test results
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

No need for unit or regression tests.

## Testing Performed

Deployed central services and a secured cluster following instructions in `operator/README.md`, verified that the resulting cluster has core_bpf collection method configured.