### PR TITLE
fix(CI): send the scheduled report to the correct channel

### DIFF
--- a/.github/workflows/ci-failures-report.yml
+++ b/.github/workflows/ci-failures-report.yml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       test:
-        description: Slack to #acs-slack-integration-testing
+        description: Slack to \#acs-slack-integration-testing
         required: true
-        default: false
+        default: true
         type: boolean
   schedule:
   - cron: 0 12 * * 1

--- a/.github/workflows/ci-failures-report.yml
+++ b/.github/workflows/ci-failures-report.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       test:
-        description: Slack to \#acs-slack-integration-testing
+        description: "Slack to #acs-slack-integration-testing"
         required: true
         default: true
         type: boolean

--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -137,7 +137,7 @@ _EO_UPDATE_
 slack_top_10_failures() {
     local job_name_match="${1:-qa}"
     local subject="${2:-Top 10 QA E2E Test failures for the last 7 days}"
-    local is_test="${3:-true}"
+    local is_test="${3:-false}"
 
     local sql
     # shellcheck disable=SC2016


### PR DESCRIPTION
## Description

Change the default to the main eng channel so that the scheduled job (which has no inputs) goes where we want it to.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

- https://github.com/stackrox/stackrox/actions/runs/7391734703
- https://redhat-internal.slack.com/archives/CELUQKESC/p1704239761481789

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
