### PR TITLE
fix(CI): use the correct link to the groovy log

### DIFF
--- a/qa-tests-backend/scripts/lib.sh
+++ b/qa-tests-backend/scripts/lib.sh
@@ -106,7 +106,7 @@ get_spec_log_url() {
     else
         url="${url}/logs"
     fi
-    url="${url}/${JOB_NAME}/${BUILD_ID}/artifacts/${JOB_NAME_SAFE}/stackrox-e2e/artifacts"
+    url="${url}/${JOB_NAME}/${BUILD_ID}/artifacts/${JOB_NAME_SAFE}/${OPENSHIFT_CI_STEP_NAME}/artifacts"
     url="${url}/${log##"${ARTIFACT_DIR}"/}"
 
     echo "${url}"


### PR DESCRIPTION
## Description

Once https://github.com/openshift/release/pull/47162 merges, this will fix the "Groovy Test Logs" links in the prow UI.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

Links work.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
