### PR TITLE
ROX-20871: Support notifier rekeying

### DIFF
--- a/central/notifier/datastore/datastore.go
+++ b/central/notifier/datastore/datastore.go
@@ -24,6 +24,7 @@ type DataStore interface {
 	AddNotifier(ctx context.Context, notifier *storage.Notifier) (string, error)
 	UpdateNotifier(ctx context.Context, notifier *storage.Notifier) error
 	UpsertNotifier(ctx context.Context, notifier *storage.Notifier) (string, error)
+	UpsertManyNotifiers(ctx context.Context, notifiers []*storage.Notifier) error
 	RemoveNotifier(ctx context.Context, id string) error
 }
 

--- a/central/notifier/datastore/internal/store/mocks/store.go
+++ b/central/notifier/datastore/internal/store/mocks/store.go
@@ -129,3 +129,17 @@ func (mr *MockStoreMockRecorder) Upsert(ctx, obj any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*MockStore)(nil).Upsert), ctx, obj)
 }
+
+// UpsertMany mocks base method.
+func (m *MockStore) UpsertMany(ctx context.Context, objs []*storage.Notifier) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertMany", ctx, objs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertMany indicates an expected call of UpsertMany.
+func (mr *MockStoreMockRecorder) UpsertMany(ctx, objs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertMany", reflect.TypeOf((*MockStore)(nil).UpsertMany), ctx, objs)
+}

--- a/central/notifier/datastore/internal/store/store.go
+++ b/central/notifier/datastore/internal/store/store.go
@@ -15,5 +15,6 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storage.Notifier, []int, error)
 	Exists(ctx context.Context, id string) (bool, error)
 	Upsert(ctx context.Context, obj *storage.Notifier) error
+	UpsertMany(ctx context.Context, objs []*storage.Notifier) error
 	Delete(ctx context.Context, id string) error
 }

--- a/central/notifier/datastore/mocks/datastore.go
+++ b/central/notifier/datastore/mocks/datastore.go
@@ -190,6 +190,20 @@ func (mr *MockDataStoreMockRecorder) UpdateNotifier(ctx, notifier any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNotifier", reflect.TypeOf((*MockDataStore)(nil).UpdateNotifier), ctx, notifier)
 }
 
+// UpsertManyNotifiers mocks base method.
+func (m *MockDataStore) UpsertManyNotifiers(ctx context.Context, notifiers []*storage.Notifier) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertManyNotifiers", ctx, notifiers)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertManyNotifiers indicates an expected call of UpsertManyNotifiers.
+func (mr *MockDataStoreMockRecorder) UpsertManyNotifiers(ctx, notifiers any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertManyNotifiers", reflect.TypeOf((*MockDataStore)(nil).UpsertManyNotifiers), ctx, notifiers)
+}
+
 // UpsertNotifier mocks base method.
 func (m *MockDataStore) UpsertNotifier(ctx context.Context, notifier *storage.Notifier) (string, error) {
 	m.ctrl.T.Helper()

--- a/central/notifier/processor/singleton.go
+++ b/central/notifier/processor/singleton.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/integrationhealth/reporter"
 	"github.com/stackrox/rox/central/notifier/datastore"
+	encConfigDatastore "github.com/stackrox/rox/central/notifier/encconfig/datastore"
 	notifierUtils "github.com/stackrox/rox/central/notifiers/utils"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
@@ -46,36 +47,77 @@ func initialize() {
 	// When alerts are generated, we will want to notify.
 	pr = New(ns, reporter.Singleton())
 
-	cryptoKey := ""
-	if env.EncNotifierCreds.BooleanSetting() {
-		var err error
-		cryptoKey, _, err = notifierUtils.GetActiveNotifierEncryptionKey()
-		if err != nil {
-			utils.Should(errors.Wrap(err, "Error reading encryption key, notifiers will be unable to send notifications"))
-		}
-	}
-
-	protoNotifiers, err := datastore.Singleton().GetNotifiers(ctx)
+	notifierDatastore := datastore.Singleton()
+	protoNotifiers, err := notifierDatastore.GetNotifiers(ctx)
 	if err != nil {
 		log.Panicf("unable to fetch notifiers: %v", err)
 	}
 
-	// Create actionable notifiers from the loaded protos.
-	for _, protoNotifier := range protoNotifiers {
-		// Check if the notifier creds are need to be encrypted
-		encCredsModified, err := notifierUtils.SecureNotifier(protoNotifier, cryptoKey)
+	if env.EncNotifierCreds.BooleanSetting() {
+		var notifiersToUpsert []*storage.Notifier
+		cryptoKey, activeIndex, err := notifierUtils.GetActiveNotifierEncryptionKey()
 		if err != nil {
-			// Don't send out error from crypto lib
-			utils.Should(fmt.Errorf("Error securing notifier %s, notifications to this notifier will fail", protoNotifier.GetId()))
-			continue
+			utils.Should(errors.Wrap(err, "Error reading encryption key, notifiers will be unable to send notifications"))
 		}
-		if encCredsModified {
-			_, err = datastore.Singleton().UpsertNotifier(ctx, protoNotifier)
+		encConfigDataStore := encConfigDatastore.Singleton()
+		encConfig, err := encConfigDataStore.GetConfig()
+		if err != nil {
+			utils.Should(errors.Wrap(err, "Error getting notifier encryption config"))
+		}
+		if encConfig == nil {
+			utils.Should(errors.New("Invalid notifier encryption config, should be non-nil"))
+		}
+
+		var oldKey string
+		var needsRekey bool
+		if activeIndex != int(encConfig.ActiveKeyIndex) {
+			needsRekey = true
+			oldKey, err = notifierUtils.GetNotifierEncryptionKeyAtIndex(int(encConfig.ActiveKeyIndex))
 			if err != nil {
-				utils.Should(errors.Wrapf(err, "error upserting secured notifier with %v (%v) and type %v", protoNotifier.GetId(), protoNotifier.GetName(), protoNotifier.GetType()))
-				continue
+				utils.Should(errors.Wrap(err, "Error reading old encryption key, notifiers will be unable to send notifications"))
 			}
 		}
+		for _, protoNotifier := range protoNotifiers {
+			secured, err := notifierUtils.IsNotifierSecured(protoNotifier)
+			if err != nil {
+				utils.Should(errors.Wrapf(err, "Error checking id the notifier %s is secured, notifications to this notifier may fail",
+					protoNotifier.GetId()))
+				continue
+			}
+			if secured {
+				if needsRekey {
+					err = notifierUtils.RekeyNotifier(protoNotifier, oldKey, cryptoKey)
+					if err != nil {
+						utils.Should(fmt.Errorf("error rekeying notifier %s, notifications to this notifier will fail", protoNotifier.GetId()))
+						continue
+					}
+					notifiersToUpsert = append(notifiersToUpsert, protoNotifier)
+				}
+			} else {
+				err := notifierUtils.SecureNotifier(protoNotifier, cryptoKey)
+				if err != nil {
+					// Don't send out error from crypto lib
+					utils.Should(fmt.Errorf("Error securing notifier %s, notifications to this notifier will fail", protoNotifier.GetId()))
+					continue
+				}
+				notifiersToUpsert = append(notifiersToUpsert, protoNotifier)
+			}
+		}
+		err = notifierDatastore.UpsertManyNotifiers(ctx, notifiersToUpsert)
+		if err != nil {
+			utils.Should(errors.Wrap(err, "Error upserting secured notifiers, several ntifiers may be unable to send notifications"))
+		}
+		if needsRekey {
+			encConfig.ActiveKeyIndex = int32(activeIndex)
+			err = encConfigDataStore.UpsertConfig(encConfig)
+			if err != nil {
+				utils.Should(errors.Wrapf(err, "Error updating active key index to %d", activeIndex))
+			}
+		}
+	}
+
+	// Create actionable notifiers from the loaded protos.
+	for _, protoNotifier := range protoNotifiers {
 		notifier, err := notifiers.CreateNotifier(protoNotifier)
 		if err != nil {
 			utils.Should(errors.Wrapf(err, "error creating notifier with %v (%v) and type %v", protoNotifier.GetId(), protoNotifier.GetName(), protoNotifier.GetType()))

--- a/central/notifier/service/service_impl.go
+++ b/central/notifier/service/service_impl.go
@@ -143,7 +143,7 @@ func (s *serviceImpl) UpdateNotifier(ctx context.Context, request *v1.UpdateNoti
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 	if request.GetUpdatePassword() {
-		_, err := notifierUtils.SecureNotifier(request.GetNotifier(), s.cryptoKey)
+		err := notifierUtils.SecureNotifier(request.GetNotifier(), s.cryptoKey)
 		if err != nil {
 			// Don't send out error from crypto lib
 			return nil, errors.New("Error securing notifier")
@@ -172,7 +172,7 @@ func (s *serviceImpl) PostNotifier(ctx context.Context, request *storage.Notifie
 	if err := validation.ValidateNotifierConfig(request, true); err != nil {
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
-	_, err := notifierUtils.SecureNotifier(request, s.cryptoKey)
+	err := notifierUtils.SecureNotifier(request, s.cryptoKey)
 	if err != nil {
 		// Don't send out error from crypto lib
 		return nil, errors.New("Error securing notifier")
@@ -211,7 +211,7 @@ func (s *serviceImpl) TestUpdatedNotifier(ctx context.Context, request *v1.Updat
 		return nil, err
 	}
 	if request.GetUpdatePassword() {
-		_, err := notifierUtils.SecureNotifier(request.GetNotifier(), s.cryptoKey)
+		err := notifierUtils.SecureNotifier(request.GetNotifier(), s.cryptoKey)
 		if err != nil {
 			// Don't send out error from crypto lib
 			return nil, errors.New("Error securing notifier")

--- a/central/notifiers/utils/encryption.go
+++ b/central/notifiers/utils/encryption.go
@@ -67,104 +67,136 @@ func parseKeyChainBytes(data []byte) (*KeyChain, error) {
 	return &chain, nil
 }
 
-// SecureNotifier secures the secrets in the given notifier and returns true if the encrypted creds were modified,
-// false otherwise
-func SecureNotifier(notifier *storage.Notifier, key string) (bool, error) {
+// SecureNotifier secures the secrets in the given unsecured notifier
+func SecureNotifier(notifier *storage.Notifier, key string) error {
 	if !env.EncNotifierCreds.BooleanSetting() {
-		return false, nil
+		return nil
 	}
 	if notifier.GetConfig() == nil {
-		return false, nil
+		return nil
+	}
+	secured, err := IsNotifierSecured(notifier)
+	if err != nil || secured {
+		return err
+	}
+	creds, err := getCredentials(notifier)
+	if err != nil || creds == "" {
+		return err
 	}
 
 	cryptoCodec := cryptocodec.Singleton()
-	var err error
+	notifier.NotifierSecret, err = cryptoCodec.Encrypt(key, creds)
+	if err != nil {
+		return err
+	}
+	cleanupCredentials(notifier)
+	return nil
+}
+
+// IsNotifierSecured returns true if the given notifier is already secured
+func IsNotifierSecured(notifier *storage.Notifier) (bool, error) {
+	if !env.EncNotifierCreds.BooleanSetting() {
+		return false, nil
+	}
+	creds, err := getCredentials(notifier)
+	if err != nil {
+		return false, nil
+	}
+	if notifier.GetType() == pkgNotifiers.AWSSecurityHubType {
+		creds := notifier.GetAwsSecurityHub().GetCredentials()
+		return notifier.NotifierSecret != "" && creds.GetAccessKeyId() == "" && creds.GetSecretAccessKey() == "", nil
+	}
+	return notifier.NotifierSecret != "" && creds == "", nil
+}
+
+// RekeyNotifier rekeys an already secured notifier using the new key
+func RekeyNotifier(notifier *storage.Notifier, oldKey string, newKey string) error {
+	if !env.EncNotifierCreds.BooleanSetting() {
+		return nil
+	}
+	secured, err := IsNotifierSecured(notifier)
+	if err != nil || !secured {
+		return err
+	}
+	cryptoCodec := cryptocodec.Singleton()
+	creds, err := cryptoCodec.Decrypt(oldKey, notifier.NotifierSecret)
+	if err != nil {
+		return err
+	}
+	notifier.NotifierSecret, err = cryptoCodec.Encrypt(newKey, creds)
+	return err
+}
+
+func getCredentials(notifier *storage.Notifier) (string, error) {
+	if notifier.GetConfig() == nil {
+		return "", nil
+	}
+	switch notifier.GetType() {
+	case pkgNotifiers.JiraType:
+		return notifier.GetJira().GetPassword(), nil
+	case pkgNotifiers.EmailType:
+		return notifier.GetEmail().GetPassword(), nil
+	case pkgNotifiers.CSCCType:
+		return notifier.GetCscc().GetServiceAccount(), nil
+	case pkgNotifiers.SplunkType:
+		return notifier.GetSplunk().GetHttpToken(), nil
+	case pkgNotifiers.PagerDutyType:
+		return notifier.GetPagerduty().GetApiKey(), nil
+	case pkgNotifiers.GenericType:
+		return notifier.GetGeneric().GetPassword(), nil
+	case pkgNotifiers.AWSSecurityHubType:
+		creds := notifier.GetAwsSecurityHub().GetCredentials()
+		if creds != nil {
+			marshalled, err := creds.Marshal()
+			if err != nil {
+				return "", err
+			}
+			return string(marshalled), nil
+		}
+	}
+	return "", nil
+}
+
+func cleanupCredentials(notifier *storage.Notifier) {
+	if notifier.GetConfig() == nil {
+		return
+	}
 	switch notifier.GetType() {
 	case pkgNotifiers.JiraType:
 		jira := notifier.GetJira()
-		if jira != nil && jira.GetPassword() != "" {
-			notifier.NotifierSecret, err = cryptoCodec.Encrypt(key, jira.GetPassword())
-			if err != nil {
-				return false, err
-			}
+		if jira != nil {
 			jira.Password = ""
-			return true, nil
 		}
-
 	case pkgNotifiers.EmailType:
 		email := notifier.GetEmail()
-		if email != nil && email.GetPassword() != "" {
-			notifier.NotifierSecret, err = cryptoCodec.Encrypt(key, email.GetPassword())
-			if err != nil {
-				return false, err
-			}
+		if email != nil {
 			email.Password = ""
-			return true, nil
 		}
-
 	case pkgNotifiers.CSCCType:
 		cscc := notifier.GetCscc()
-		if cscc != nil && cscc.GetServiceAccount() != "" {
-			notifier.NotifierSecret, err = cryptoCodec.Encrypt(key, cscc.GetServiceAccount())
-			if err != nil {
-				return false, err
-			}
+		if cscc != nil {
 			cscc.ServiceAccount = ""
-			return true, nil
 		}
-
 	case pkgNotifiers.SplunkType:
 		splunk := notifier.GetSplunk()
-		if splunk != nil && splunk.GetHttpToken() != "" {
-			notifier.NotifierSecret, err = cryptoCodec.Encrypt(key, splunk.GetHttpToken())
-			if err != nil {
-				return false, err
-			}
+		if splunk != nil {
 			splunk.HttpToken = ""
-			return true, nil
 		}
-
 	case pkgNotifiers.PagerDutyType:
 		pagerDuty := notifier.GetPagerduty()
-		if pagerDuty != nil && pagerDuty.GetApiKey() != "" {
-			notifier.NotifierSecret, err = cryptoCodec.Encrypt(key, pagerDuty.GetApiKey())
-			if err != nil {
-				return false, err
-			}
+		if pagerDuty != nil {
 			pagerDuty.ApiKey = ""
-			return true, nil
 		}
-
 	case pkgNotifiers.GenericType:
 		generic := notifier.GetGeneric()
-		if generic != nil && generic.GetPassword() != "" {
-			notifier.NotifierSecret, err = cryptoCodec.Encrypt(key, generic.GetPassword())
-			if err != nil {
-				return false, err
-			}
+		if generic != nil {
 			generic.Password = ""
-			return true, nil
 		}
-
 	case pkgNotifiers.AWSSecurityHubType:
-		awsSecurityHub := notifier.GetAwsSecurityHub()
-		if awsSecurityHub == nil {
-			return false, nil
-		}
-		creds := awsSecurityHub.GetCredentials()
-		if creds != nil && creds.GetAccessKeyId() != "" && creds.GetSecretAccessKey() != "" {
-			marshalled, err := creds.Marshal()
-			if err != nil {
-				return false, err
-			}
-			notifier.NotifierSecret, err = cryptoCodec.Encrypt(key, string(marshalled))
-			if err != nil {
-				return false, err
-			}
+		creds := notifier.GetAwsSecurityHub().GetCredentials()
+		if creds != nil {
 			creds.AccessKeyId = ""
 			creds.SecretAccessKey = ""
-			return true, nil
 		}
 	}
-	return false, nil
 }

--- a/central/notifiers/utils/encryption.go
+++ b/central/notifiers/utils/encryption.go
@@ -76,8 +76,11 @@ func SecureNotifier(notifier *storage.Notifier, key string) error {
 		return nil
 	}
 	secured, err := IsNotifierSecured(notifier)
-	if err != nil || secured {
+	if err != nil {
 		return err
+	}
+	if secured {
+		return nil
 	}
 	creds, err := getCredentials(notifier)
 	if err != nil || creds == "" {


### PR DESCRIPTION
## Description

Updated central startup task to allow rekeying of notifier secrets

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Manual testing by encrypting and rekeying email notifier.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
