### PR TITLE
add exclusion scope for webterminal

### DIFF
--- a/pkg/defaults/policies/files/pod_exec.json
+++ b/pkg/defaults/policies/files/pod_exec.json
@@ -47,6 +47,15 @@
           "namespace": "openshift-etcd"
         }
       }
+      },
+      {
+      "name": "Don't alert on deployment workspace\\w{16} in namespace openshift-terminal",
+      "deployment": {
+        "name": "workspace\\w{16}",
+        "scope": {
+          "namespace": "openshift-terminal"
+        }
+      }
     }
   ],
   "severity": "HIGH_SEVERITY",


### PR DESCRIPTION
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. I accesses webterminal in my openshift cluster, which resulted in an alert.
2. I created a copy of the default policy. 
3. Afterwards I created the policy as in the commit, imported it into ACS and overwrote the original default policy. 
4. Now i accessed webterminal again. ACS  created a violation for the copy, but not for the overwritten default policy.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
