### PR TITLE
ROX-21469: Remove error message onBlur from watched images modal

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesForm.tsx
@@ -25,20 +25,12 @@ function WatchedImagesForm({
     watchedImagesRequest,
     watchImage,
 }: WatchedImagesFormProps) {
-    const {
-        values,
-        errors,
-        touched,
-        handleChange,
-        handleBlur,
-        handleSubmit,
-        submitForm,
-        isSubmitting,
-    } = useFormik({
-        initialValues: { imageName: defaultWatchedImageName },
-        validationSchema,
-        onSubmit: addToWatchedImages,
-    });
+    const { values, errors, touched, handleChange, handleSubmit, submitForm, isSubmitting } =
+        useFormik({
+            initialValues: { imageName: defaultWatchedImageName },
+            validationSchema,
+            onSubmit: addToWatchedImages,
+        });
     const isNameFieldInvalid = !!(errors.imageName && touched.imageName);
     const nameFieldValidated = isNameFieldInvalid ? 'error' : 'default';
 
@@ -68,7 +60,6 @@ function WatchedImagesForm({
                     value={values.imageName}
                     validated={nameFieldValidated}
                     onChange={(_, e) => handleChange(e)}
-                    onBlur={handleBlur}
                     isDisabled={isSubmitting}
                     placeholder="registry.example.com/namespace/image-name:tag"
                     isRequired


### PR DESCRIPTION
## Description

Removes validation (and error message) from watched image modal when `onBlur` is triggered. This prevents a form error from being displayed when the user opens the modal and removes an image at the bottom of the list. The error will still be visible if the form is submitted with an empty value.

(This is a two-line change that looks larger due for formatting.)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Watch an image via VM 2.0
Open the modal again via the Manage Watched Images button
Remove an image from the list - no error is shown in the input at the top of the modal
![image](https://github.com/stackrox/stackrox/assets/1292638/416d3ed9-e6ce-4406-8451-b445384d9111)
![image](https://github.com/stackrox/stackrox/assets/1292638/997fd182-335d-4f9c-81d0-b879e79b4a71)

Attempt to submit the form with no value:
![image](https://github.com/stackrox/stackrox/assets/1292638/3d745693-c950-4e99-931b-ee581dd81a63)

Submit the form with a valid value:
![image](https://github.com/stackrox/stackrox/assets/1292638/4cb9887a-bafb-45af-8fde-d43db9b0c726)
