### PR TITLE
ROX-21622: Make operator able to replace central TLS leaf cert

### DIFF
--- a/operator/pkg/central/extensions/reconcile_admin_password.go
+++ b/operator/pkg/central/extensions/reconcile_admin_password.go
@@ -95,7 +95,7 @@ func (r *reconcileAdminPasswordExtensionRun) Execute(ctx context.Context) error 
 		return err
 	}
 
-	if err := r.EnsureSecret(ctx, defaultPasswordSecretName, r.validateHtpasswdSecretData, r.generateHtpasswdSecretData, true); err != nil {
+	if err := r.EnsureSecret(ctx, defaultPasswordSecretName, r.validateHtpasswdSecretData, r.generateHtpasswdSecretData); err != nil {
 		return errors.Wrap(err, "reconciling central-htpasswd secret")
 	}
 

--- a/operator/pkg/central/extensions/reconcile_central_db_password.go
+++ b/operator/pkg/central/extensions/reconcile_central_db_password.go
@@ -91,7 +91,7 @@ func (r *reconcileCentralDBPasswordExtensionRun) Execute(ctx context.Context) er
 
 	// At this point, r.password was set via readAndSetPasswordFromReferencedSecret above (user-specified mode), or is unset,
 	// in which case the auto-generation logic will take effect.
-	if err := r.EnsureSecret(ctx, canonicalCentralDBPasswordSecretName, r.validateSecretData, r.generateDBPassword, true); err != nil {
+	if err := r.EnsureSecret(ctx, canonicalCentralDBPasswordSecretName, r.validateSecretData, r.generateDBPassword); err != nil {
 		return errors.Wrapf(err, "reconciling %s secret", canonicalCentralDBPasswordSecretName)
 	}
 	return nil

--- a/operator/pkg/central/extensions/reconcile_tls.go
+++ b/operator/pkg/central/extensions/reconcile_tls.go
@@ -26,9 +26,8 @@ const (
 	// InitBundleReconcilePeriod is the maximum period required for reconciliation of an init bundle.
 	// It must be sufficient to renew an ephemeral init bundle certificate which has relatively short lifetime (within a matter of hours).
 	// NB: keep in sync with crypto.ephemeralProfileWithExpirationInHoursCertLifetime
-	InitBundleReconcilePeriod   = 1 * time.Hour
-	initBundleGracePeriod       = 90 * time.Minute // half of cert validity period
-	fixExistingInitBundleSecret = true
+	InitBundleReconcilePeriod = 1 * time.Hour
+	initBundleGracePeriod     = 90 * time.Minute // half of cert validity period
 )
 
 // ReconcileCentralTLSExtensions returns an extension that takes care of creating the central-tls and related
@@ -63,10 +62,8 @@ func (r *createCentralTLSExtensionRun) Execute(ctx context.Context) error {
 		// reconcileInitBundleSecrets not called due to ROX-9023. TODO(ROX-9969): call after the init-bundle cert rotation stabilization.
 	}
 
-	// If we find a broken central-tls secret, do NOT try to auto-fix it. Doing so would invalidate all previously issued certificates
-	// (including sensor certificates and init bundles), and is very unlikely to result in a working state.
-	if err := r.EnsureSecret(ctx, "central-tls", r.validateAndConsumeCentralTLSData, r.generateCentralTLSData, false); err != nil {
-		return errors.Wrap(err, "reconciling central-tls secret")
+	if err := r.EnsureSecret(ctx, "central-tls", r.validateAndConsumeCentralTLSData, r.generateCentralTLSData); err != nil {
+		return errors.Wrap(err, "error reconciling central-tls secret")
 	}
 
 	if err := r.reconcileCentralDBTLSSecret(ctx); err != nil {
@@ -103,7 +100,7 @@ func (r *createCentralTLSExtensionRun) reconcileInitBundleSecrets(ctx context.Co
 		generateFunc := func(_ types.SecretDataMap) (types.SecretDataMap, error) {
 			return r.generateInitBundleTLSData(slugCaseService+"-", serviceType)
 		}
-		if err := r.EnsureSecret(ctx, secretName, validateFunc, generateFunc, fixExistingInitBundleSecret); err != nil {
+		if err := r.EnsureSecret(ctx, secretName, validateFunc, generateFunc); err != nil {
 			return errors.Wrapf(err, "reconciling %s secret", secretName)
 		}
 	}
@@ -137,46 +134,93 @@ func (r *createCentralTLSExtensionRun) validateAndConsumeCentralTLSData(fileMap 
 	return nil
 }
 
-func (r *createCentralTLSExtensionRun) generateCentralTLSData(_ types.SecretDataMap) (types.SecretDataMap, error) {
-	var err error
-	r.ca, err = certgen.GenerateCA()
+func (r *createCentralTLSExtensionRun) generateCentralTLSData(old types.SecretDataMap) (types.SecretDataMap, error) {
+	var (
+		err        error
+		newFileMap types.SecretDataMap
+	)
+	r.ca, newFileMap, err = validateOrGenerateCA(r.ca, old)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating new CA")
+		return nil, err
 	}
 
-	fileMap := make(types.SecretDataMap)
-	certgen.AddCAToFileMap(fileMap, r.ca)
-
-	if err := certgen.IssueCentralCert(fileMap, r.ca, mtls.WithNamespace(r.centralObj.GetNamespace())); err != nil {
-		return nil, errors.Wrap(err, "issuing central service certificate")
+	if err := certgen.IssueCentralCert(newFileMap, r.ca, mtls.WithNamespace(r.centralObj.GetNamespace())); err != nil {
+		return nil, errors.Wrap(err, "error issuing central service certificate")
 	}
 
-	jwtKey, err := certgen.GenerateJWTSigningKey()
-	if err != nil {
-		return nil, errors.Wrap(err, "generating JWT signing key")
+	if oldJWTKey, oldJWTKeyOK := old[certgen.JWTKeyPEMFileName]; oldJWTKeyOK {
+		// The impact of replacing the JWT key is unclear.
+		// Avoid re-generating JWT key if it exists, out of an abundance of caution.
+		// Perhaps this can be changed in the future if we have a way of validating such key.
+		newFileMap[certgen.JWTKeyPEMFileName] = oldJWTKey
+	} else {
+		jwtKey, err := certgen.GenerateJWTSigningKey()
+		if err != nil {
+			return nil, errors.Wrap(err, "generating JWT signing key")
+		}
+		certgen.AddJWTSigningKeyToFileMap(newFileMap, jwtKey)
 	}
-	certgen.AddJWTSigningKeyToFileMap(fileMap, jwtKey)
 
-	return fileMap, nil
+	// Since integrity of the central-tls secret is critical to the whole system,
+	// we additionally verify it here. Ideally this would be done on the ReconcileSecret level,
+	// for all its invocations, but unfortunately some verification functions are currently not idempotent.
+	if err := r.validateAndConsumeCentralTLSData(newFileMap, true); err != nil {
+		return nil, errors.Wrap(err, "post-generation validation failed")
+	}
+
+	return newFileMap, nil
+}
+
+func validateOrGenerateCA(oldCA mtls.CA, oldFileMap types.SecretDataMap) (mtls.CA, types.SecretDataMap, error) {
+	newFileMap := make(types.SecretDataMap)
+
+	caCert, caCertPresent := oldFileMap[mtls.CACertFileName]
+	caKey, caKeyPresent := oldFileMap[mtls.CAKeyFileName]
+	if caCertPresent && caKeyPresent {
+		// There is an existing CA in the secret. Avoid changing at all cost it, as doing so would immediately cause
+		// all previously issued certificates (including sensor certificates and init bundles) to become invalid,
+		// and this is very unlikely to result in a working state.
+		newFileMap[mtls.CACertFileName] = caCert
+		newFileMap[mtls.CAKeyFileName] = caKey
+		if oldCA == nil {
+			// validateAndConsumeCentralTLSData must have decided the CA is completely unusable.
+			// There is not much we can do in this situation, so let's try and provide a useful error message at least.
+			_, err := certgen.LoadCAFromFileMap(oldFileMap)
+			return nil, nil, errors.Wrap(err, "invalid CA in the existing secret, please delete it to allow re-generation")
+		}
+		return oldCA, newFileMap, errors.Wrap(oldCA.CheckProperties(), "invalid properties of CA in the existing secret, please delete it to allow re-generation")
+	} else if !caCertPresent && !caKeyPresent {
+		ca, err := certgen.GenerateCA()
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "error creating new CA")
+		}
+		certgen.AddCAToFileMap(newFileMap, ca)
+		return ca, newFileMap, nil
+	}
+	const msg = "malformed secret (%s present but %s missing), please delete it to allow re-generation"
+	if !caCertPresent {
+		return nil, nil, fmt.Errorf(msg, mtls.CAKeyFileName, mtls.CACertFileName)
+	}
+	return nil, nil, fmt.Errorf(msg, mtls.CACertFileName, mtls.CAKeyFileName)
 }
 
 func (r *createCentralTLSExtensionRun) reconcileCentralDBTLSSecret(ctx context.Context) error {
 	if r.centralObj.Spec.Central.ShouldManageDB() {
-		return r.EnsureSecret(ctx, "central-db-tls", r.validateCentralDBTLSData, r.generateCentralDBTLSData, true)
+		return r.EnsureSecret(ctx, "central-db-tls", r.validateCentralDBTLSData, r.generateCentralDBTLSData)
 	}
 	return r.DeleteSecret(ctx, "central-db-tls")
 }
 
 func (r *createCentralTLSExtensionRun) reconcileScannerTLSSecret(ctx context.Context) error {
 	if r.centralObj.Spec.Scanner.IsEnabled() {
-		return r.EnsureSecret(ctx, "scanner-tls", r.validateScannerTLSData, r.generateScannerTLSData, true)
+		return r.EnsureSecret(ctx, "scanner-tls", r.validateScannerTLSData, r.generateScannerTLSData)
 	}
 	return r.DeleteSecret(ctx, "scanner-tls")
 }
 
 func (r *createCentralTLSExtensionRun) reconcileScannerDBTLSSecret(ctx context.Context) error {
 	if r.centralObj.Spec.Scanner.IsEnabled() {
-		return r.EnsureSecret(ctx, "scanner-db-tls", r.validateScannerDBTLSData, r.generateScannerDBTLSData, true)
+		return r.EnsureSecret(ctx, "scanner-db-tls", r.validateScannerDBTLSData, r.generateScannerDBTLSData)
 	}
 	return r.DeleteSecret(ctx, "scanner-db-tls")
 }

--- a/operator/pkg/common/extensions/reconcile_scanner_db_password.go
+++ b/operator/pkg/common/extensions/reconcile_scanner_db_password.go
@@ -60,7 +60,7 @@ func (r *reconcileScannerDBPasswordExtensionRun) Execute(ctx context.Context) er
 
 func (r *reconcileScannerDBPasswordExtensionRun) reconcilePasswordSecret(ctx context.Context, shouldExist bool) error {
 	if shouldExist {
-		return r.EnsureSecret(ctx, r.passwordResourceName, r.validateScannerDBPasswordData, r.generateScannerDBPasswordData, true)
+		return r.EnsureSecret(ctx, r.passwordResourceName, r.validateScannerDBPasswordData, r.generateScannerDBPasswordData)
 	}
 	return r.DeleteSecret(ctx, r.passwordResourceName)
 }

--- a/operator/pkg/common/extensions/secret_reconciliator_test.go
+++ b/operator/pkg/common/extensions/secret_reconciliator_test.go
@@ -114,7 +114,7 @@ func (s *secretReconcilerTestSuite) Test_ShouldNotExist_OnExistingUnmanaged_Shou
 	s.NoError(err)
 }
 
-func (s *secretReconcilerTestSuite) Test_ShouldExist_OnNonExisting_ShouldCreateSecretWithOwnerRef() {
+func (s *secretReconcilerTestSuite) Test_ShouldExist_OnNonExisting_ShouldCreateSecretWithOwnerRef_Success() {
 	validateFn := func(types.SecretDataMap, bool) error {
 		s.Require().Fail("this function should not be called")
 		panic("unexpected")
@@ -128,7 +128,7 @@ func (s *secretReconcilerTestSuite) Test_ShouldExist_OnNonExisting_ShouldCreateS
 		}, nil
 	}
 
-	err := s.reconciliator.EnsureSecret(s.ctx, "absent-secret", validateFn, generateFn, false)
+	err := s.reconciliator.EnsureSecret(s.ctx, "absent-secret", validateFn, generateFn)
 	s.Require().NoError(err)
 	s.NotEmpty(markerID, "generate function has not been called")
 
@@ -140,6 +140,26 @@ func (s *secretReconcilerTestSuite) Test_ShouldExist_OnNonExisting_ShouldCreateS
 	s.EqualValues(secret.GetOwnerReferences(), []metav1.OwnerReference{*metav1.NewControllerRef(s.centralObj, platform.CentralGVK)})
 
 	s.Equal(markerID, string(secret.Data["generated"]))
+}
+
+func (s *secretReconcilerTestSuite) Test_ShouldExist_OnNonExisting_ShouldCreateSecretWithOwnerRef_Failure() {
+	validateFn := func(types.SecretDataMap, bool) error {
+		s.Require().Fail("this function should not be called")
+		panic("unexpected")
+	}
+	failGenerationErr := pkgErrors.New("generation failed")
+	generateFn := func(_ types.SecretDataMap) (types.SecretDataMap, error) {
+		return nil, failGenerationErr
+	}
+
+	err := s.reconciliator.EnsureSecret(s.ctx, "absent-secret", validateFn, generateFn)
+	s.ErrorIs(err, failGenerationErr)
+
+	secret := &v1.Secret{}
+	key := ctrlClient.ObjectKey{Namespace: testutils.TestNamespace, Name: "absent-secret"}
+	err = s.client.Get(context.Background(), key, secret)
+
+	s.Truef(errors.IsNotFound(err), "secret should still be missing, found %+v", secret)
 }
 
 func (s *secretReconcilerTestSuite) Test_ShouldExist_OnExistingManaged_PassingValidation_ShouldDoNothing() {
@@ -161,7 +181,7 @@ func (s *secretReconcilerTestSuite) Test_ShouldExist_OnExistingManaged_PassingVa
 		panic("unexpected")
 	}
 
-	err = s.reconciliator.EnsureSecret(s.ctx, "existing-managed-secret", validateFn, generateFn, false)
+	err = s.reconciliator.EnsureSecret(s.ctx, "existing-managed-secret", validateFn, generateFn)
 	s.Require().NoError(err)
 	s.True(validated)
 
@@ -172,7 +192,7 @@ func (s *secretReconcilerTestSuite) Test_ShouldExist_OnExistingManaged_PassingVa
 	s.Equal(initSecret, secret)
 }
 
-func (s *secretReconcilerTestSuite) Test_ShouldExist_OnExistingManaged_FailingValidation_NoFixExisting_ShouldFail() {
+func (s *secretReconcilerTestSuite) Test_ShouldExist_OnExistingManaged_FailingValidation_ShouldFix() {
 	failValidationErr := pkgErrors.New("failed validation")
 	validateFn := func(data types.SecretDataMap, managed bool) error {
 		s.Equal("existing-managed-secret", string(data["secret-name"]))
@@ -186,32 +206,7 @@ func (s *secretReconcilerTestSuite) Test_ShouldExist_OnExistingManaged_FailingVa
 		}, nil
 	}
 
-	err := s.reconciliator.EnsureSecret(s.ctx, "existing-managed-secret", validateFn, generateFn, false)
-	s.ErrorIs(err, failValidationErr)
-
-	secret := &v1.Secret{}
-	key := ctrlClient.ObjectKey{Namespace: testutils.TestNamespace, Name: "existing-managed-secret"}
-	err = s.client.Get(context.Background(), key, secret)
-	s.Require().NoError(err)
-
-	s.Equal("existing-managed-secret", string(secret.Data["secret-name"]))
-}
-
-func (s *secretReconcilerTestSuite) Test_ShouldExist_OnExistingManaged_FailingValidation_WithFixExisting_ShouldFix() {
-	failValidationErr := pkgErrors.New("failed validation")
-	validateFn := func(data types.SecretDataMap, managed bool) error {
-		s.Equal("existing-managed-secret", string(data["secret-name"]))
-		s.True(managed)
-		return failValidationErr
-	}
-
-	generateFn := func(_ types.SecretDataMap) (types.SecretDataMap, error) {
-		return types.SecretDataMap{
-			"new-secret-data": []byte("foo"),
-		}, nil
-	}
-
-	err := s.reconciliator.EnsureSecret(s.ctx, "existing-managed-secret", validateFn, generateFn, true)
+	err := s.reconciliator.EnsureSecret(s.ctx, "existing-managed-secret", validateFn, generateFn)
 	s.NoError(err)
 
 	secret := &v1.Secret{}
@@ -241,7 +236,7 @@ func (s *secretReconcilerTestSuite) Test_ShouldExist_OnExistingUnmanaged_Passing
 		panic("unexpected")
 	}
 
-	err = s.reconciliator.EnsureSecret(s.ctx, "existing-secret", validateFn, generateFn, false)
+	err = s.reconciliator.EnsureSecret(s.ctx, "existing-secret", validateFn, generateFn)
 	s.Require().NoError(err)
 	s.True(validated)
 
@@ -269,7 +264,7 @@ func (s *secretReconcilerTestSuite) Test_ShouldExist_OnExistingUnmanaged_Failing
 		panic("unexpected")
 	}
 
-	err = s.reconciliator.EnsureSecret(s.ctx, "existing-secret", validateFn, generateFn, false)
+	err = s.reconciliator.EnsureSecret(s.ctx, "existing-secret", validateFn, generateFn)
 	s.ErrorIs(err, failValidationErr)
 
 	secret := &v1.Secret{}


### PR DESCRIPTION
## Description

Before, it avoided touching an existing central-tls secret altogether. There was a special boolean arg in secret reconciliator just for that single purpose.

Instead, make use of the parameter for passing existing secret content, added in #9258 to reuse pre-existing CA fields, but otherwise regenerate the leaf cert. Avoid touching JWT key at least for now, since I have not investigated what the impact would be, and this should be the safe path, given the past behaviour.

FTR, a [followup PR](https://github.com/stackrox/stackrox/pull/9305) changes the cert validation to trigger a refresh some time ahead of the expiry date.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Rebase on master when #9258 is merged, and remove above note from description
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI with the new cases should be enough.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
