### PR TITLE
ROX-21575: Listening endpoints should not be deleted multiple times

### DIFF
--- a/central/pod/datastore/datastore_impl_real_test.go
+++ b/central/pod/datastore/datastore_impl_real_test.go
@@ -72,7 +72,7 @@ func (s *PodDatastoreSuite) SetupTest() {
 	s.indicatorDataStore, _ = processIndicatorDataStore.New(
 		indicatorStorage, plopStorage, indicatorSearcher, nil)
 
-	s.plopDS = plopDataStore.New(plopStorage, s.indicatorDataStore)
+	s.plopDS = plopDataStore.New(plopStorage, s.indicatorDataStore, s.postgres.DB)
 
 	s.filter = filter.NewFilter(5, 5, []int{5, 4, 3, 2, 1})
 

--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -80,14 +80,8 @@ const (
 	pruneLogImbues = `DELETE FROM log_imbues WHERE timestamp < now() at time zone 'utc' - INTERVAL '%d MINUTES'`
 
 	pruneAdministrationEvents = `DELETE FROM %s WHERE lastoccurredat < now() at time zone 'utc' - INTERVAL '%d MINUTES'`
-<<<<<<< HEAD
 
 	pruneDiscoveredClusters = `DELETE FROM %s WHERE lastupdatedat < now() at time zone 'utc' - INTERVAL '%d MINUTES'`
-
-	// Delete orphaned PLOPs
-	pruneOrphanedPLOPs = `DELETE FROM listening_endpoints WHERE closetimestamp < now() at time zone 'utc' - INTERVAL '%d MINUTES'`
-=======
->>>>>>> 6f7d96fab5 (X-Smart-Squash: Squashed 31 commits:)
 )
 
 var (

--- a/central/postgres/pruning_test.go
+++ b/central/postgres/pruning_test.go
@@ -17,7 +17,6 @@ import (
 	discoveredClustersDS "github.com/stackrox/rox/central/discoveredclusters/datastore"
 	podStore "github.com/stackrox/rox/central/pod/datastore"
 	processIndicatorDatastore "github.com/stackrox/rox/central/processindicator/datastore"
-	plopPostgresStore "github.com/stackrox/rox/central/processlisteningonport/store/postgres"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
@@ -289,13 +288,12 @@ func (s *PostgresPruningSuite) TestGetOrphanedPodIDs() {
 
 func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 	cases := []struct {
-		name                  string
-		initialProcesses      []*storage.ProcessIndicator
-		initialPlops          []*storage.ProcessListeningOnPortStorage
-		deployments           set.FrozenStringSet
-		pods                  set.FrozenStringSet
-		expectedDeletions     []string
-		expectedPlopDeletions []string
+		name              string
+		initialProcesses  []*storage.ProcessIndicator
+		initialPlops      []*storage.ProcessListeningOnPortStorage
+		deployments       set.FrozenStringSet
+		pods              set.FrozenStringSet
+		expectedDeletions []string
 	}{
 		{
 			name: "no deployments nor pods - remove all old indicators",
@@ -315,14 +313,6 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 			deployments:       set.NewFrozenStringSet(),
 			pods:              set.NewFrozenStringSet(),
 			expectedDeletions: []string{fixtureconsts.ProcessIndicatorID1, fixtureconsts.ProcessIndicatorID2, fixtureconsts.ProcessIndicatorID3},
-			expectedPlopDeletions: []string{
-				fixtureconsts.PlopUID1,
-				fixtureconsts.PlopUID2,
-				fixtureconsts.PlopUID3,
-				fixtureconsts.PlopUID4,
-				fixtureconsts.PlopUID5,
-				fixtureconsts.PlopUID6,
-			},
 		},
 		{
 			name: "no deployments nor pods - remove no new orphaned indicators",
@@ -336,10 +326,9 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 				fixtures.GetPlopStorage2(),
 				fixtures.GetPlopStorage3(),
 			},
-			deployments:           set.NewFrozenStringSet(),
-			pods:                  set.NewFrozenStringSet(),
-			expectedDeletions:     nil,
-			expectedPlopDeletions: nil,
+			deployments:       set.NewFrozenStringSet(),
+			pods:              set.NewFrozenStringSet(),
+			expectedDeletions: nil,
 		},
 		{
 			name: "all pods separate deployments - remove no indicators",
@@ -353,10 +342,9 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 				fixtures.GetPlopStorage2(),
 				fixtures.GetPlopStorage3(),
 			},
-			deployments:           set.NewFrozenStringSet(fixtureconsts.Deployment6, fixtureconsts.Deployment5, fixtureconsts.Deployment3),
-			pods:                  set.NewFrozenStringSet(fixtureconsts.PodUID1, fixtureconsts.PodUID2, fixtureconsts.PodUID3),
-			expectedDeletions:     nil,
-			expectedPlopDeletions: nil,
+			deployments:       set.NewFrozenStringSet(fixtureconsts.Deployment6, fixtureconsts.Deployment5, fixtureconsts.Deployment3),
+			pods:              set.NewFrozenStringSet(fixtureconsts.PodUID1, fixtureconsts.PodUID2, fixtureconsts.PodUID3),
+			expectedDeletions: nil,
 		},
 		{
 			name: "all pods same deployment - remove no indicators",
@@ -365,10 +353,9 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 				newIndicatorWithDeploymentAndPod(fixtureconsts.ProcessIndicatorID2, 1*time.Hour, fixtureconsts.Deployment6, fixtureconsts.PodUID2),
 				newIndicatorWithDeploymentAndPod(fixtureconsts.ProcessIndicatorID3, 1*time.Hour, fixtureconsts.Deployment6, fixtureconsts.PodUID3),
 			},
-			deployments:           set.NewFrozenStringSet(fixtureconsts.Deployment6),
-			pods:                  set.NewFrozenStringSet(fixtureconsts.PodUID1, fixtureconsts.PodUID2, fixtureconsts.PodUID3),
-			expectedDeletions:     nil,
-			expectedPlopDeletions: nil,
+			deployments:       set.NewFrozenStringSet(fixtureconsts.Deployment6),
+			pods:              set.NewFrozenStringSet(fixtureconsts.PodUID1, fixtureconsts.PodUID2, fixtureconsts.PodUID3),
+			expectedDeletions: nil,
 		},
 		{
 			name: "some pods separate deployments - remove some indicators",
@@ -382,10 +369,9 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 				fixtures.GetPlopStorage2(),
 				fixtures.GetPlopStorage3(),
 			},
-			deployments:           set.NewFrozenStringSet(fixtureconsts.Deployment3),
-			pods:                  set.NewFrozenStringSet(fixtureconsts.PodUID3),
-			expectedDeletions:     []string{fixtureconsts.ProcessIndicatorID1},
-			expectedPlopDeletions: []string{fixtureconsts.PlopUID1},
+			deployments:       set.NewFrozenStringSet(fixtureconsts.Deployment3),
+			pods:              set.NewFrozenStringSet(fixtureconsts.PodUID3),
+			expectedDeletions: []string{fixtureconsts.ProcessIndicatorID1},
 		},
 		{
 			name: "some pods same deployment - remove some indicators",
@@ -399,10 +385,9 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 				fixtures.GetPlopStorage2(),
 				fixtures.GetPlopStorage3(),
 			},
-			deployments:           set.NewFrozenStringSet(fixtureconsts.Deployment6),
-			pods:                  set.NewFrozenStringSet(fixtureconsts.PodUID3),
-			expectedDeletions:     []string{fixtureconsts.ProcessIndicatorID1},
-			expectedPlopDeletions: []string{fixtureconsts.PlopUID1},
+			deployments:       set.NewFrozenStringSet(fixtureconsts.Deployment6),
+			pods:              set.NewFrozenStringSet(fixtureconsts.PodUID3),
+			expectedDeletions: []string{fixtureconsts.ProcessIndicatorID1},
 		},
 	}
 	for _, c := range cases {
@@ -430,22 +415,11 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 			s.NoError(err)
 			s.Equal(len(c.initialProcesses), countFromDB)
 
-			plopStore := plopPostgresStore.NewFullStore(s.testDB.DB)
-			err = plopStore.UpsertMany(s.ctx, c.initialPlops)
-			s.NoError(err)
-			plopCount, err := plopStore.Count(s.ctx)
-			s.NoError(err)
-			s.Equal(len(c.initialPlops), plopCount)
-
 			PruneOrphanedProcessIndicators(s.ctx, s.testDB.DB, orphanWindow)
 
 			countFromDB, err = processDatastore.Count(s.ctx, nil)
 			s.NoError(err)
 			s.Equal(len(c.initialProcesses)-len(c.expectedDeletions), countFromDB)
-
-			plopCount, err = plopStore.Count(s.ctx)
-			s.NoError(err)
-			s.Equal(len(c.initialPlops)-len(c.expectedPlopDeletions), plopCount)
 
 			// Cleanup
 			var cleanupIDs []string
@@ -454,119 +428,6 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 			}
 			s.NoError(processDatastore.RemoveProcessIndicators(s.ctx, cleanupIDs))
 
-			for _, deploymentID := range c.deployments.AsSlice() {
-				s.NoError(deploymentDS.RemoveDeployment(s.ctx, fixtureconsts.Cluster1, deploymentID))
-			}
-
-			for _, podID := range c.pods.AsSlice() {
-				s.NoError(podDS.RemovePod(s.ctx, podID))
-			}
-
-		})
-	}
-}
-
-func (s *PostgresPruningSuite) TestRemoveOrphanedPLOPs() {
-	cases := []struct {
-		name                  string
-		initialPlops          []*storage.ProcessListeningOnPortStorage
-		deployments           set.FrozenStringSet
-		pods                  set.FrozenStringSet
-		expectedPlopDeletions []string
-	}{
-		{
-			name: "no deployments nor pods - remove plops since there are no pods",
-			initialPlops: []*storage.ProcessListeningOnPortStorage{
-				fixtures.GetPlopStorage1(),
-				fixtures.GetPlopStorage2(),
-				fixtures.GetPlopStorage3(),
-				fixtures.GetPlopStorage4(),
-				fixtures.GetPlopStorage5(),
-				fixtures.GetPlopStorage6(),
-			},
-			deployments:           set.NewFrozenStringSet(),
-			pods:                  set.NewFrozenStringSet(),
-			expectedPlopDeletions: []string{fixtureconsts.PlopUID1, fixtureconsts.PlopUID2, fixtureconsts.PlopUID3, fixtureconsts.PlopUID4, fixtureconsts.PlopUID5, fixtureconsts.PlopUID6},
-		},
-		{
-			name: "deployments one missing pod - remove plops with PodUid with no matching pod even though there are deployments",
-			initialPlops: []*storage.ProcessListeningOnPortStorage{
-				fixtures.GetPlopStorage1(),
-				fixtures.GetPlopStorage2(),
-				fixtures.GetPlopStorage3(),
-				fixtures.GetPlopStorage4(),
-				fixtures.GetPlopStorage5(),
-				fixtures.GetPlopStorage6(),
-			},
-			deployments:           set.NewFrozenStringSet(fixtureconsts.Deployment6, fixtureconsts.Deployment5, fixtureconsts.Deployment3),
-			pods:                  set.NewFrozenStringSet(fixtureconsts.PodUID1, fixtureconsts.PodUID2),
-			expectedPlopDeletions: []string{fixtureconsts.PlopUID6},
-		},
-		{
-			name: "one missing deployments no missing pods - remove plops with no matching deployments even though there are matching pods",
-			initialPlops: []*storage.ProcessListeningOnPortStorage{
-				fixtures.GetPlopStorage1(),
-				fixtures.GetPlopStorage2(),
-				fixtures.GetPlopStorage3(),
-				fixtures.GetPlopStorage4(),
-				fixtures.GetPlopStorage5(),
-				fixtures.GetPlopStorage6(),
-			},
-			deployments:           set.NewFrozenStringSet(fixtureconsts.Deployment5, fixtureconsts.Deployment3),
-			pods:                  set.NewFrozenStringSet(fixtureconsts.PodUID1, fixtureconsts.PodUID2, fixtureconsts.PodUID3),
-			expectedPlopDeletions: []string{fixtureconsts.PlopUID1, fixtureconsts.PlopUID4},
-		},
-		{
-			name: "no missing deployments or pods but plops are expired - remove all expired plops",
-			initialPlops: []*storage.ProcessListeningOnPortStorage{
-				fixtures.GetPlopStorage4(),
-				fixtures.GetPlopStorageExpired1(),
-				fixtures.GetPlopStorageExpired2(),
-				fixtures.GetPlopStorageExpired3(),
-			},
-			deployments:           set.NewFrozenStringSet(fixtureconsts.Deployment6, fixtureconsts.Deployment5, fixtureconsts.Deployment3),
-			pods:                  set.NewFrozenStringSet(fixtureconsts.PodUID1, fixtureconsts.PodUID2, fixtureconsts.PodUID3),
-			expectedPlopDeletions: []string{fixtureconsts.PlopUID7, fixtureconsts.PlopUID8, fixtureconsts.PlopUID9},
-		},
-	}
-	for _, c := range cases {
-		s.T().Run(c.name, func(t *testing.T) {
-			s.testDB.Teardown(s.T())
-			s.testDB = pgtest.ForT(s.T())
-			// Add deployments if necessary
-			deploymentDS, err := deploymentStore.GetTestPostgresDataStore(s.T(), s.testDB.DB)
-			s.Nil(err)
-			for _, deploymentID := range c.deployments.AsSlice() {
-				s.NoError(deploymentDS.UpsertDeployment(s.ctx, &storage.Deployment{Id: deploymentID, ClusterId: fixtureconsts.Cluster1}))
-			}
-
-			podDS, err := podStore.GetTestPostgresDataStore(s.T(), s.testDB.DB)
-			s.Nil(err)
-			for _, podID := range c.pods.AsSlice() {
-				err := podDS.UpsertPod(s.ctx, &storage.Pod{Id: podID, ClusterId: fixtureconsts.Cluster1})
-				s.Nil(err)
-			}
-
-			plopStore := plopPostgresStore.NewFullStore(s.testDB.DB)
-			err = plopStore.UpsertMany(s.ctx, c.initialPlops)
-			s.NoError(err)
-			plopCount, err := plopStore.Count(s.ctx)
-			s.NoError(err)
-			s.Equal(len(c.initialPlops), plopCount)
-
-			PruneOrphanedPLOPs(s.ctx, s.testDB.DB, orphanWindow)
-
-			plopCount, err = plopStore.Count(s.ctx)
-			s.NoError(err)
-			s.Equal(len(c.initialPlops)-len(c.expectedPlopDeletions), plopCount)
-
-			ids, err := plopStore.GetIDs(s.ctx)
-			s.NoError(err)
-			for id := range ids {
-				s.NotContains(c.expectedPlopDeletions, id)
-			}
-
-			// Cleanup
 			for _, deploymentID := range c.deployments.AsSlice() {
 				s.NoError(deploymentDS.RemoveDeployment(s.ctx, fixtureconsts.Cluster1, deploymentID))
 			}

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -613,7 +613,7 @@ func (ds *datastoreImpl) readRowsToFindPLOPsWithNoProcessInformation(rows pgx.Ro
 	return ids, nil
 }
 
-// First gets PLOPs with no matching process indicators and then checks the 
+// First gets PLOPs with no matching process indicators and then checks the
 // serialized data to check for process information.
 func (ds *datastoreImpl) getPLOPsToDelete(ctx context.Context) ([]string, error) {
 	rows, err := ds.pool.Query(ctx, getPotentiallyOrphanedPLOPs)

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -636,9 +636,7 @@ func (ds *datastoreImpl) getPLOPsToDelete(ctx context.Context) ([]string, error)
 // process information and deletes them. PLOPs can have no matching process indicators, but such PLOPs need
 // to have process information.
 func (ds *datastoreImpl) RemovePLOPsWithoutProcessIndicatorOrProcessInfo(ctx context.Context) (int64, error) {
-
 	plopsToDelete, err := ds.getPLOPsToDelete(ctx)
-
 	if err != nil {
 		return 0, err
 	}
@@ -647,11 +645,9 @@ func (ds *datastoreImpl) RemovePLOPsWithoutProcessIndicatorOrProcessInfo(ctx con
 	defer ds.mutex.Unlock()
 
 	err = ds.storage.DeleteMany(ctx, plopsToDelete)
-	numRecordsToDelete := len(plopsToDelete)
-
 	if err != nil {
 		return 0, err
 	}
 
-	return int64(numRecordsToDelete), nil
+	return int64(len(plopsToDelete)), nil
 }

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -613,6 +613,8 @@ func (ds *datastoreImpl) readRowsToFindPLOPsWithNoProcessInformation(rows pgx.Ro
 	return ids, nil
 }
 
+// First gets PLOPs with no matching process indicators and then checks the 
+// serialized data to check for process information.
 func (ds *datastoreImpl) getPLOPsToDelete(ctx context.Context) ([]string, error) {
 	rows, err := ds.pool.Query(ctx, getPotentiallyOrphanedPLOPs)
 

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/jackc/pgx/v5"
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/metrics"
 	countMetrics "github.com/stackrox/rox/central/metrics"
 	processIndicatorStore "github.com/stackrox/rox/central/processindicator/datastore"
@@ -628,6 +627,9 @@ func (ds *datastoreImpl) getPLOPsToDelete(ctx context.Context) ([]string, error)
 	return plopsToDelete, err
 }
 
+// RemovePLOPsWithoutProcessIndicatorOrProcessInfo Finds PLOPs without a matching process indicator and no
+// process information and deletes them. PLOPs can have no matching process indicators, but such PLOPs need
+// to have process information.
 func (ds *datastoreImpl) RemovePLOPsWithoutProcessIndicatorOrProcessInfo(ctx context.Context) (int64, error) {
 
 	plopsToDelete, err := ds.getPLOPsToDelete(ctx)
@@ -646,5 +648,5 @@ func (ds *datastoreImpl) RemovePLOPsWithoutProcessIndicatorOrProcessInfo(ctx con
 		return 0, err
 	}
 
-	return numRecordsToDelete, nil
+	return int64(numRecordsToDelete), nil
 }

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -617,16 +617,12 @@ func (ds *datastoreImpl) readRowsToFindPLOPsWithNoProcessInformation(rows pgx.Ro
 // serialized data to check for process information.
 func (ds *datastoreImpl) getPLOPsToDelete(ctx context.Context) ([]string, error) {
 	rows, err := ds.pool.Query(ctx, getPotentiallyOrphanedPLOPs)
-
 	if err != nil {
 		return nil, err
 	}
-
 	defer rows.Close()
 
-	plopsToDelete, err := ds.readRowsToFindPLOPsWithNoProcessInformation(rows)
-
-	return plopsToDelete, err
+	return ds.readRowsToFindPLOPsWithNoProcessInformation(rows)
 }
 
 // RemovePLOPsWithoutProcessIndicatorOrProcessInfo Finds PLOPs without a matching process indicator and no

--- a/central/processlisteningonport/datastore/mocks/datastore.go
+++ b/central/processlisteningonport/datastore/mocks/datastore.go
@@ -12,6 +12,7 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	datastore "github.com/stackrox/rox/central/processlisteningonport/datastore"
 	storage "github.com/stackrox/rox/generated/storage"
@@ -73,6 +74,47 @@ func (m *MockDataStore) GetProcessListeningOnPort(ctx context.Context, deploymen
 func (mr *MockDataStoreMockRecorder) GetProcessListeningOnPort(ctx, deployment any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProcessListeningOnPort", reflect.TypeOf((*MockDataStore)(nil).GetProcessListeningOnPort), ctx, deployment)
+}
+
+// PruneOrphanedPLOPs mocks base method.
+func (m *MockDataStore) PruneOrphanedPLOPs(ctx context.Context, orphanWindow time.Duration) int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PruneOrphanedPLOPs", ctx, orphanWindow)
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// PruneOrphanedPLOPs indicates an expected call of PruneOrphanedPLOPs.
+func (mr *MockDataStoreMockRecorder) PruneOrphanedPLOPs(ctx, orphanWindow any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneOrphanedPLOPs", reflect.TypeOf((*MockDataStore)(nil).PruneOrphanedPLOPs), ctx, orphanWindow)
+}
+
+// PruneOrphanedPLOPsByProcessIndicators mocks base method.
+func (m *MockDataStore) PruneOrphanedPLOPsByProcessIndicators(ctx context.Context, orphanWindow time.Duration) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "PruneOrphanedPLOPsByProcessIndicators", ctx, orphanWindow)
+}
+
+// PruneOrphanedPLOPsByProcessIndicators indicates an expected call of PruneOrphanedPLOPsByProcessIndicators.
+func (mr *MockDataStoreMockRecorder) PruneOrphanedPLOPsByProcessIndicators(ctx, orphanWindow any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneOrphanedPLOPsByProcessIndicators", reflect.TypeOf((*MockDataStore)(nil).PruneOrphanedPLOPsByProcessIndicators), ctx, orphanWindow)
+}
+
+// RemovePLOPsWithoutProcessIndicatorOrProcessInfo mocks base method.
+func (m *MockDataStore) RemovePLOPsWithoutProcessIndicatorOrProcessInfo(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemovePLOPsWithoutProcessIndicatorOrProcessInfo", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemovePLOPsWithoutProcessIndicatorOrProcessInfo indicates an expected call of RemovePLOPsWithoutProcessIndicatorOrProcessInfo.
+func (mr *MockDataStoreMockRecorder) RemovePLOPsWithoutProcessIndicatorOrProcessInfo(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePLOPsWithoutProcessIndicatorOrProcessInfo", reflect.TypeOf((*MockDataStore)(nil).RemovePLOPsWithoutProcessIndicatorOrProcessInfo), ctx)
 }
 
 // RemovePlopsByPod mocks base method.

--- a/central/processlisteningonport/datastore/pruning.go
+++ b/central/processlisteningonport/datastore/pruning.go
@@ -29,6 +29,7 @@ const (
 
 	// Finds PLOPs without matching process indicators. Not all of these PLOPs are orphaned. There is a further check to see
 	// if the serialized data has process information. PLOPs without process information are then deleted.
-	getPotentiallyOrphanedPLOPs = `SELECT plop.serialized FROM listening_endpoints plop LEFT OUTER JOIN process_indicators proc
-		ON plop.processindicatorid = proc.id WHERE proc.id IS NULL`
+	getPotentiallyOrphanedPLOPs = `SELECT plop.serialized FROM listening_endpoints plop where NOT EXISTS
+			(select 1 FROM process_indicators proc where plop.processindicatorid = proc.id)`
+
 )

--- a/central/processlisteningonport/datastore/pruning.go
+++ b/central/processlisteningonport/datastore/pruning.go
@@ -1,0 +1,34 @@
+package datastore
+
+const (
+	// Explain Analyze indicated that 2 statements for PLOP is faster than one.
+	deleteOrphanedPLOPDeploymentsAndPI = `DELETE FROM listening_endpoints WHERE processindicatorid in (SELECT id from process_indicators pi WHERE NOT EXISTS
+                (SELECT 1 FROM deployments WHERE pi.deploymentid = deployments.Id) AND
+                (signal_time < now() at time zone 'utc' - INTERVAL '%d MINUTES' OR signal_time is NULL))`
+
+	deleteOrphanedPLOPPods = `DELETE FROM listening_endpoints WHERE processindicatorid in (SELECT id from process_indicators pi WHERE NOT EXISTS
+                (SELECT 1 FROM pods WHERE pi.poduid = pods.Id) AND
+                (signal_time < now() at time zone 'utc' - INTERVAL '%d MINUTES' OR signal_time is NULL))`
+
+	// Unfortunately if a listening endpoint is marked as being open there is no indication of how old it is.
+	// This leads to a possible race condition where a listening endpoint reaches the database before the deployment,
+	// and the pruning job happens to run before the deployment information arrives in the database.
+	// This should be rare, so this should be acceptable. This could be improved by adding a timestamp to the listening endpoints table
+	deleteOrphanedPLOPDeployments = `DELETE FROM listening_endpoints WHERE NOT EXISTS
+                (SELECT 1 FROM deployments WHERE listening_endpoints.deploymentid = deployments.Id)`
+
+	// Unfortunately if a listening endpoint is marked as being open there is no indication of how old it is.
+	// This leads to a possible race condition where a listening endpoint reaches the database before the pod,
+	// and the pruning job happens to run before the pod information arrives in the database.
+	// This should be rare, so this should be acceptable. This could be improved by adding a timestamp to the listening endpoints table
+	deleteOrphanedPLOPPodsWithPodUID = `DELETE FROM listening_endpoints WHERE poduid IS NOT NULL AND NOT EXISTS
+                (SELECT 1 FROM pods WHERE listening_endpoints.poduid = pods.Id)`
+
+	// Delete orphaned PLOPs
+	pruneOrphanedPLOPs = `DELETE FROM listening_endpoints WHERE closetimestamp < now() at time zone 'utc' - INTERVAL '%d MINUTES'`
+
+	// Finds PLOPs without matching process indicators. Not all of these PLOPs are orphaned. There is a further check to see
+	// if the serialized data has process information. PLOPs without process information are then deleted.
+	getPotentiallyOrphanedPLOPs = `SELECT plop.serialized FROM listening_endpoints plop LEFT OUTER JOIN process_indicators proc
+		ON plop.processindicatorid = proc.id WHERE proc.id IS NULL`
+)

--- a/central/processlisteningonport/datastore/pruning.go
+++ b/central/processlisteningonport/datastore/pruning.go
@@ -31,5 +31,4 @@ const (
 	// if the serialized data has process information. PLOPs without process information are then deleted.
 	getPotentiallyOrphanedPLOPs = `SELECT plop.serialized FROM listening_endpoints plop where NOT EXISTS
 			(select 1 FROM process_indicators proc where plop.processindicatorid = proc.id)`
-
 )

--- a/central/processlisteningonport/datastore/singleton.go
+++ b/central/processlisteningonport/datastore/singleton.go
@@ -16,7 +16,8 @@ var (
 func initialize() {
 	plopStore := pgStore.NewFullStore(globaldb.GetPostgres())
 	indicatorDataStore := processIndicatorDataStore.Singleton()
-	dataStore = New(plopStore, indicatorDataStore)
+	pool := globaldb.GetPostgres()
+	dataStore = New(plopStore, indicatorDataStore, pool)
 }
 
 // Singleton provides the interface for non-service external interaction.

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -439,16 +439,13 @@ func (g *garbageCollectorImpl) removeOrphanedProcessBaselines(deployments set.Fr
 // or have a PodUid and belong to a deployment or pod that does not exist.
 func (g *garbageCollectorImpl) removeOrphanedPLOPs() {
 	prunedCount := g.plops.PruneOrphanedPLOPs(pruningCtx, orphanWindow)
-
 	log.Infof("[PLOP pruning] Found %d orphaned process listening on port objects",
 		prunedCount)
 
 	prunedCount, err := g.plops.RemovePLOPsWithoutProcessIndicatorOrProcessInfo(pruningCtx)
-
 	if err != nil {
-		log.Error(errors.Wrap(err, "error removing PLOPs with no matching process indicator or process information"))
+		log.Errorf("error removing PLOPs with no matching process indicator or process information: %v", err)
 	}
-
 	log.Infof("[PLOP pruning] Pruning of %d orphaned PLOPs with no matching process indicator or process information complete", prunedCount)
 }
 

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -445,11 +445,11 @@ func (g *garbageCollectorImpl) removeOrphanedPLOPs() {
 
 	prunedCount, err := g.plops.RemovePLOPsWithoutProcessIndicatorOrProcessInfo(pruningCtx)
 
-	log.Infof("[PLOP pruning] Pruning of %d orphaned PLOPs with no matching process indicator or process information complete", prunedCount)
-
 	if err != nil {
 		log.Error(errors.Wrap(err, "error removing PLOPs with no matching process indicator or process information"))
 	}
+
+	log.Infof("[PLOP pruning] Pruning of %d orphaned PLOPs with no matching process indicator or process information complete", prunedCount)
 }
 
 func (g *garbageCollectorImpl) removeExpiredAdministrationEvents(config *storage.PrivateConfig) {

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stackrox/rox/central/postgres"
 	processBaselineDatastore "github.com/stackrox/rox/central/processbaseline/datastore"
 	processDatastore "github.com/stackrox/rox/central/processindicator/datastore"
+	plopDataStore "github.com/stackrox/rox/central/processlisteningonport/datastore"
 	k8sRoleDataStore "github.com/stackrox/rox/central/rbac/k8srole/datastore"
 	roleBindingDataStore "github.com/stackrox/rox/central/rbac/k8srolebinding/datastore"
 	"github.com/stackrox/rox/central/reports/common"
@@ -89,6 +90,7 @@ func newGarbageCollector(alerts alertDatastore.DataStore,
 	k8sRoleBindings roleBindingDataStore.DataStore,
 	logimbueStore logimbueDataStore.Store,
 	reportSnapshotDS snapshotDS.DataStore,
+	plops plopDataStore.DataStore,
 	blobStore blobDatastore.Datastore) GarbageCollector {
 	return &garbageCollectorImpl{
 		alerts:          alerts,
@@ -111,6 +113,7 @@ func newGarbageCollector(alerts alertDatastore.DataStore,
 		stopper:         concurrency.NewStopper(),
 		postgres:        globaldb.GetPostgres(),
 		reportSnapshot:  reportSnapshotDS,
+		plops:           plops,
 		blobStore:       blobStore,
 	}
 }
@@ -137,6 +140,7 @@ type garbageCollectorImpl struct {
 	logimbueStore   logimbueDataStore.Store
 	stopper         concurrency.Stopper
 	reportSnapshot  snapshotDS.DataStore
+	plops           plopDataStore.DataStore
 	blobStore       blobDatastore.Datastore
 }
 
@@ -365,6 +369,10 @@ func clusterIDsToNegationQuery(clusterIDSet set.FrozenStringSet) *v1.Query {
 }
 
 func (g *garbageCollectorImpl) removeOrphanedProcesses() {
+	g.plops.PruneOrphanedPLOPsByProcessIndicators(pruningCtx, orphanWindow)
+
+	log.Info("[PLOP pruning by processes] Pruning of orphaned PLOPs by processes complete")
+
 	postgres.PruneOrphanedProcessIndicators(pruningCtx, g.postgres, orphanWindow)
 	log.Info("[Process pruning] Pruning of orphaned processes complete")
 }
@@ -430,10 +438,18 @@ func (g *garbageCollectorImpl) removeOrphanedProcessBaselines(deployments set.Fr
 // removeOrphanedPLOPs: cleans up ProcessListeningOnPort objects that are expired
 // or have a PodUid and belong to a deployment or pod that does not exist.
 func (g *garbageCollectorImpl) removeOrphanedPLOPs() {
-	prunedCount := postgres.PruneOrphanedPLOPs(pruningCtx, g.postgres, orphanWindow)
+	prunedCount := g.plops.PruneOrphanedPLOPs(pruningCtx, orphanWindow)
 
 	log.Infof("[PLOP pruning] Found %d orphaned process listening on port objects",
 		prunedCount)
+
+	prunedCount, err := g.plops.RemovePLOPsWithoutProcessIndicatorOrProcessInfo(pruningCtx)
+
+	log.Infof("[PLOP pruning] Pruning of %d orphaned PLOPs with no matching process indicator or process information complete", prunedCount)
+
+	if err != nil {
+		log.Error(errors.Wrap(err, "error removing PLOPs with no matching process indicator or process information"))
+	}
 }
 
 func (g *garbageCollectorImpl) removeExpiredAdministrationEvents(config *storage.PrivateConfig) {

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -37,6 +37,7 @@ import (
 	processBaselineDatastoreMocks "github.com/stackrox/rox/central/processbaseline/datastore/mocks"
 	processIndicatorDatastore "github.com/stackrox/rox/central/processindicator/datastore"
 	processIndicatorDatastoreMocks "github.com/stackrox/rox/central/processindicator/datastore/mocks"
+	plopDatastore "github.com/stackrox/rox/central/processlisteningonport/datastore"
 	plopDatastoreMocks "github.com/stackrox/rox/central/processlisteningonport/datastore/mocks"
 	plopStore "github.com/stackrox/rox/central/processlisteningonport/store/postgres"
 	"github.com/stackrox/rox/central/ranking"
@@ -555,7 +556,7 @@ func (s *PruningTestSuite) TestImagePruning() {
 
 			gc := newGarbageCollector(alerts, nodes, images, nil, deployments, pods,
 				nil, nil, nil, config, nil, nil, nil,
-				nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
+				nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
 
 			// Add images, deployments, and pods into the datastores
 			if c.deployment != nil {
@@ -816,7 +817,7 @@ func (s *PruningTestSuite) TestClusterPruning() {
 
 			gc := newGarbageCollector(nil, nil, nil, clusterDS, deploymentsDS, nil,
 				nil, nil, nil, nil, nil, nil,
-				nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
+				nil, nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
 			gc.collectClusters(c.config)
 
 			// Now get all clusters and compare the names to ensure only the expected ones exist
@@ -942,7 +943,7 @@ func (s *PruningTestSuite) TestClusterPruningCentralCheck() {
 
 			gc := newGarbageCollector(nil, nil, nil, clusterDS, deploymentsDS, nil,
 				nil, nil, nil, nil, nil, nil,
-				nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
+				nil, nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
 			gc.collectClusters(getCluserRetentionConfig(60, 90, 72))
 
 			// Now get all clusters and compare the names to ensure only the expected ones exist
@@ -1117,7 +1118,7 @@ func (s *PruningTestSuite) TestAlertPruning() {
 
 			gc := newGarbageCollector(alerts, nodes, images, nil, deployments, nil,
 				nil, nil, nil, config, nil, nil,
-				nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
+				nil, nil, nil, nil, nil, nil, nil, nil).(*garbageCollectorImpl)
 
 			// Add alerts into the datastores
 			for _, alert := range c.alerts {
@@ -1274,10 +1275,12 @@ func (s *PruningTestSuite) TestRemoveOrphanedProcesses() {
 	for _, c := range cases {
 		s.T().Run(c.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			processes := processIndicatorDatastoreMocks.NewMockDataStore(ctrl)
 			db := pgtest.ForT(t)
+			processes := processIndicatorDatastoreMocks.NewMockDataStore(ctrl)
+			plopDS := plopDatastore.GetTestPostgresDataStore(t, db)
 			gci := &garbageCollectorImpl{
 				processes: processes,
+				plops:     plopDS,
 				postgres:  db.DB,
 			}
 
@@ -1439,8 +1442,10 @@ func (s *PruningTestSuite) TestRemoveOrphanedPLOPs() {
 		s.T().Run(c.name, func(t *testing.T) {
 			db := pgtest.ForT(t)
 			plopDBstore := plopStore.NewFullStore(db)
+			plopDS := plopDatastore.GetTestPostgresDataStore(t, db)
 			gci := &garbageCollectorImpl{
 				postgres: db,
+				plops:    plopDS,
 			}
 
 			// Populate some actual data so the query returns what needs deleted

--- a/central/pruning/singleton.go
+++ b/central/pruning/singleton.go
@@ -14,6 +14,7 @@ import (
 	podDatastore "github.com/stackrox/rox/central/pod/datastore"
 	processBaselineDatastore "github.com/stackrox/rox/central/processbaseline/datastore"
 	processDatastore "github.com/stackrox/rox/central/processindicator/datastore"
+	plopDataStore "github.com/stackrox/rox/central/processlisteningonport/datastore"
 	k8sRoleDataStore "github.com/stackrox/rox/central/rbac/k8srole/datastore"
 	k8srolebindingStore "github.com/stackrox/rox/central/rbac/k8srolebinding/datastore"
 	snapshotDataStore "github.com/stackrox/rox/central/reports/snapshot/datastore"
@@ -49,6 +50,7 @@ func Singleton() GarbageCollector {
 			k8srolebindingStore.Singleton(),
 			logimbueStore.Singleton(),
 			snapshotDataStore.Singleton(),
+			plopDataStore.Singleton(),
 			blobDS.Singleton())
 	})
 	return gc


### PR DESCRIPTION
## Description

Currently there is a bug in which postgresql tries to run two queries that delete the same rows from the listening_endpoints table at the same time. One query tries to delete listening endpoints by pod. This query is run when a pod is deleted. The other query is a result of trying to update the listening endpoint when it is reported closed. An upsert is performed, but in the current implementation this involves doing a deletion. To fix this situation locks are added to  AddProcessListeningOnPort and RemovePlopsByPod, so that the deletes that they perform are not done at the same time.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Unit test is flaky in master
- [x] Unit test passes 1000 times in this branch
- [x] Error observed when running scale test in master
- [x] No error when running scale test in this branch
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

The user facing changes are not significant and there is no impact on upgrading.

## Testing Performed

### Here I tell how I validated my change

#### Scale tests

The following was done for the master branch and this branch

```
cd scale/dev/

./cluster.sh jouko-0104-scale-test-2

 infractl artifacts jouko-0104-scale-test-2 --download-dir /tmp/artifacts-jouko-0104-scale-test-2

export KUBECONFIG=/tmp/artifacts-jouko-0104-scale-test-2/kubeconfig 

./run-many.sh long-running 10
```
The difference being that different cluster names where used.

With master the following was found in the central log

```
sensor/service/connection: 2024/02/08 16:06:14.774191 connection_impl.go:208: Error: Error handling sensor message: processing message from sensor: copy from objects failed: unable to delete the records: could not delete from "listening_endpoints" with query delete from listening_endpoints where listening_endpoints.Id = ANY($1::uuid[]): ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02)
```

and the following was found in the central-db log

```
2024-02-08 07:21:31.777 UTC [11732] LOG:  could not receive data from client: Connection reset by peer
2024-02-08 15:06:02.714 UTC [50711] ERROR:  deadlock detected
2024-02-08 15:06:02.714 UTC [50711] DETAIL:  Process 50711 waits for ShareLock on transaction 14586532; blocked by process 49728.
        Process 49728 waits for ShareLock on transaction 14586627; blocked by process 50711.
        Process 50711: delete from listening_endpoints where listening_endpoints.PodUid = $1 returning listening_endpoints.Id::text
        Process 49728: delete from listening_endpoints where listening_endpoints.Id = ANY($1::uuid[])
2024-02-08 15:06:02.714 UTC [50711] HINT:  See server log for query details.
2024-02-08 15:06:02.714 UTC [50711] CONTEXT:  while deleting tuple (174845,1) in relation "listening_endpoints"
2024-02-08 15:06:02.714 UTC [50711] STATEMENT:  delete from listening_endpoints where listening_endpoints.PodUid = $1 returning listening_endpoints.Id::text
2024-02-08 15:06:03.581 UTC [49744] ERROR:  deadlock detected
2024-02-08 15:06:03.581 UTC [49744] DETAIL:  Process 49744 waits for ShareLock on transaction 14586532; blocked by process 49728.

```

In this branch the central logs and central-db logs did not show any postgresql related errors.

This was the entire contents of the central-db log after 13 hours.
```

PostgreSQL Database directory appears to contain a database; Skipping initialization

Waiting for child process 14 to exit
2024-02-06 23:10:19.466 UTC [15] LOG:  starting PostgreSQL 13.13 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-20), 64-bit
2024-02-06 23:10:19.466 UTC [15] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2024-02-06 23:10:19.466 UTC [15] LOG:  listening on IPv6 address "::", port 5432
2024-02-06 23:10:19.617 UTC [15] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2024-02-06 23:10:19.743 UTC [15] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
2024-02-06 23:10:19.748 UTC [16] LOG:  database system was shut down at 2024-02-06 23:09:49 UTC
2024-02-06 23:10:19.758 UTC [15] LOG:  database system is ready to accept connections
2024-02-07 00:34:22.489 UTC [6801] LOG:  could not receive data from client: Connection reset by peer
2024-02-07 03:35:50.992 UTC [22028] LOG:  could not receive data from client: Connection reset by peer
2024-02-07 06:37:56.281 UTC [38151] LOG:  could not receive data from client: Connection reset by peer
2024-02-07 07:38:33.600 UTC [44241] LOG:  could not receive data from client: Connection reset by peer
2024-02-07 08:39:23.897 UTC [50336] LOG:  could not receive data from client: Connection reset by peer
2024-02-07 10:40:31.185 UTC [62467] LOG:  could not receive data from client: Connection reset by peer
```

`could not receive data from client: Connection reset by peer` also appeared in master and I don't believe that it is related to the issue addressed in this PR.

There were no postgres errors in the central logs, which were checked obtained once an hour. 

The sizes of the some of the tables were checked once an hour. Here is a typical result

```
Number of listening_endpoints
  count
---------
 1045755

Number of network_flows_v2
  count
---------
 3683727

Number of process_indicators
 count
--------
 316462
```


The following is an example of pruning in the central log from this branch

```
pruning: 2024/02/07 12:10:59.114722 pruning.go:157: Info: [Pruning] Starting a garbage collection cycle
pruning: 2024/02/07 12:10:59.170683 pruning.go:528: Info: [Image pruning] Found 0 image search results
pruning: 2024/02/07 12:11:00.066760 pruning.go:467: Info: [Alert pruning] Found 39 orphaned alerts
pruning: 2024/02/07 12:11:10.212268 pruning.go:517: Info: [Network Flow pruning] Completed
pruning: 2024/02/07 12:11:10.389205 pruning.go:229: Info: [Pruning] Found no orphaned pods...
pruning: 2024/02/07 12:11:10.818999 pruning.go:251: Info: [Pruning] Found no orphaned nodes...
pruning: 2024/02/07 12:11:26.946563 pruning.go:368: Info: [PLOP pruning by processes] Pruning of orphaned PLOPs by processes complete
pruning: 2024/02/07 12:11:28.071495 pruning.go:371: Info: [Process pruning] Pruning of orphaned processes complete
pruning: 2024/02/07 12:13:20.296962 pruning.go:430: Info: [Process baseline pruning] Removed 34978 process baselines
pruning: 2024/02/07 12:13:50.396396 pruning.go:439: Info: [PLOP pruning] Found 1248986 orphaned process listening on port objects
pruning: 2024/02/07 12:14:08.663806 pruning.go:444: Info: [PLOP pruning] Pruning of 634 orphaned PLOPs with no matching process indicator or process information complete
pruning: 2024/02/07 12:14:08.690564 pruning.go:271: Info: [Pruning] Found no orphaned service accounts...
pruning: 2024/02/07 12:14:08.724206 pruning.go:271: Info: [Pruning] Found no orphaned K8S roles...
pruning: 2024/02/07 12:14:08.784235 pruning.go:271: Info: [Pruning] Found no orphaned K8S role bindings...
pruning: 2024/02/07 12:14:09.910760 pruning.go:852: Info: [Risk pruning] Removing 4 deployment risks
pruning: 2024/02/07 12:14:10.024813 pruning.go:865: Info: [Risk pruning] Removing 0 image risks
pruning: 2024/02/07 12:14:10.130600 pruning.go:878: Info: [Risk pruning] Removing 0 image component risks
pruning: 2024/02/07 12:14:10.317051 pruning.go:891: Info: [Risk pruning] Removing 0 node risks
pruning: 2024/02/07 12:14:10.320609 pruning.go:612: Info: [Cluster Pruning] pruning is disabled.
pruning: 2024/02/07 12:14:10.331638 pruning.go:604: Info: [Downloadable Report Pruning] Removed 0 blobs and freed 0 bytes
pruning: 2024/02/07 12:14:10.384071 pruning.go:176: Info: [Pruning] Finished garbage collection cycle
```

Pruning took about 3 minutes and 11 seconds.

From these two lines
```
pruning: 2024/02/07 12:11:10.818999 pruning.go:251: Info: [Pruning] Found no orphaned nodes...
pruning: 2024/02/07 12:11:26.946563 pruning.go:368: Info: [PLOP pruning by processes] Pruning of orphaned PLOPs by processes complete
```
it can be determined that pruning PLOPs without pods or deployments via process indicators took about 16 seconds. 

```
pruning: 2024/02/07 12:13:20.296962 pruning.go:430: Info: [Process baseline pruning] Removed 34978 process baselines
pruning: 2024/02/07 12:13:50.396396 pruning.go:439: Info: [PLOP pruning] Found 1248986 orphaned process listening on port objects
```
These two lines show that pruning PLOPs with no pod or deployments takes about 30 seconds.

Finally
```
pruning: 2024/02/07 12:13:50.396396 pruning.go:439: Info: [PLOP pruning] Found 1248986 orphaned process listening on port objects
pruning: 2024/02/07 12:14:08.663806 pruning.go:444: Info: [PLOP pruning] Pruning of 634 orphaned PLOPs with no matching process indicator or process information complete
```
Shows that removing PLOPs with no matching process indicators or process information took about 18 seconds.

For comparison here is an example of pruning in the master branch

```
pruning: 2024/02/08 16:03:59.138427 pruning.go:156: Info: [Pruning] Starting a garbage collection cycle
pruning: 2024/02/08 16:03:59.179289 pruning.go:512: Info: [Image pruning] Found 0 image search results
pruning: 2024/02/08 16:03:59.675374 pruning.go:451: Info: [Alert pruning] Found 13 orphaned alerts
pruning: 2024/02/08 16:04:11.995598 pruning.go:501: Info: [Network Flow pruning] Completed
pruning: 2024/02/08 16:04:12.719846 pruning.go:228: Info: [Pruning] Found no orphaned pods...
pruning: 2024/02/08 16:04:15.001993 pruning.go:250: Info: [Pruning] Found no orphaned nodes...
pruning: 2024/02/08 16:04:26.613382 pruning.go:365: Info: [Process pruning] Pruning of orphaned processes complete
pruning: 2024/02/08 16:05:40.426522 pruning.go:423: Info: [Process baseline pruning] Removed 32197 process baselines
pruning: 2024/02/08 16:06:12.206593 pruning.go:431: Info: [PLOP pruning] Found 1257610 orphaned process listening on port objects
pruning: 2024/02/08 16:06:12.233743 pruning.go:270: Info: [Pruning] Found no orphaned service accounts...
pruning: 2024/02/08 16:06:12.262035 pruning.go:270: Info: [Pruning] Found no orphaned K8S roles...
pruning: 2024/02/08 16:06:12.309618 pruning.go:270: Info: [Pruning] Found no orphaned K8S role bindings...
pruning: 2024/02/08 16:06:12.901989 pruning.go:836: Info: [Risk pruning] Removing 0 deployment risks
pruning: 2024/02/08 16:06:13.630541 pruning.go:849: Info: [Risk pruning] Removing 0 image risks
pruning: 2024/02/08 16:06:13.730415 pruning.go:862: Info: [Risk pruning] Removing 0 image component risks
pruning: 2024/02/08 16:06:14.200823 pruning.go:875: Info: [Risk pruning] Removing 0 node risks
pruning: 2024/02/08 16:06:14.203724 pruning.go:596: Info: [Cluster Pruning] pruning is disabled.
pruning: 2024/02/08 16:06:14.215375 pruning.go:588: Info: [Downloadable Report Pruning] Removed 0 blobs and freed 0 bytes
pruning: 2024/02/08 16:06:14.300933 pruning.go:175: Info: [Pruning] Finished garbage collection cycle
```

In this case pruning took about 2 minutes and 15 seconds.

##### Timing AddProcessListeningOnPort

One concern is that the changes made here might lead to AddProcessListeningOnPort taking a longer time. The average time taken by that function was measured for master and this branch.

For this branch
```
rox_central_datastore_function_duration_sum{Function="AddProcessListeningOnPort",Type="ProcessListeningOnPort"} 3.203539109854994e+06
rox_central_datastore_function_duration_count{Function="AddProcessListeningOnPort",Type="ProcessListeningOnPort"} 3163
```

Thus the average call to AddProcessListeningOnPort took 1012 in this branch.

For master
```
rox_central_datastore_function_duration_sum{Function="AddProcessListeningOnPort",Type="ProcessListeningOnPort"} 1.5151000833139962e+06
rox_central_datastore_function_duration_count{Function="AddProcessListeningOnPort",Type="ProcessListeningOnPort"} 1462
```

Thus the average call to AddProcessListeningOnPort took 1036 in the master branch. There is no significant difference in the timing for the two different branches.


#### Unit test

Added a unit test that tries to force the situation where listening endpoints are deleted twice at the same time. This unit test failed 55 times out of 1000 runs, when the locks were commented out, with the following error

```
    datastore_impl_test.go:2187: 
        	Error Trace:	/home/jvirtane/go/src/github.com/stackrox/stackrox/central/processlisteningonport/datastore/datastore_impl_test.go:2187
        	            				/usr/local/go/src/runtime/asm_amd64.s:1598
        	Error:      	Received unexpected error:
        	            	ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02)
        	            	could not delete from "listening_endpoints" with query delete from listening_endpoints where listening_endpoints.Id = ANY($1::uuid[])
        	            	github.com/stackrox/rox/pkg/search/postgres.RunDeleteRequestForSchema.func1
        	            		/home/jvirtane/go/src/github.com/stackrox/stackrox/pkg/search/postgres/common.go:877
        	            	github.com/stackrox/rox/pkg/postgres/pgutils.Retry.func1
        	            		/home/jvirtane/go/src/github.com/stackrox/stackrox/pkg/postgres/pgutils/retry.go:19
        	            	github.com/stackrox/rox/pkg/postgres/pgutils.Retry2[...].func1
        	            		/home/jvirtane/go/src/github.com/stackrox/stackrox/pkg/postgres/pgutils/retry.go:30
        	            	github.com/stackrox/rox/pkg/postgres/pgutils.Retry3[...]
        	            		/home/jvirtane/go/src/github.com/stackrox/stackrox/pkg/postgres/pgutils/retry.go:70
        	            	github.com/stackrox/rox/pkg/postgres/pgutils.Retry2[...]
        	            		/home/jvirtane/go/src/github.com/stackrox/stackrox/pkg/postgres/pgutils/retry.go:33
        	            	github.com/stackrox/rox/pkg/postgres/pgutils.Retry
        	            		/home/jvirtane/go/src/github.com/stackrox/stackrox/pkg/postgres/pgutils/retry.go:21
        	            	github.com/stackrox/rox/pkg/search/postgres.RunDeleteRequestForSchema
        	            		/home/jvirtane/go/src/github.com/stackrox/stackrox/pkg/search/postgres/common.go:874
        	            	github.com/stackrox/rox/pkg/search/postgres.(*genericStore[...]).DeleteMany
        	            		/home/jvirtane/go/src/github.com/stackrox/stackrox/pkg/search/postgres/store.go:347
        	            	github.com/stackrox/rox/central/processlisteningonport/store/postgres.copyFromListeningEndpoints
        	            		/home/jvirtane/go/src/github.com/stackrox/stackrox/central/processlisteningonport/store/postgres/store.go:190
        	            	github.com/stackrox/rox/pkg/search/postgres.(*genericStore[...]).copyFrom
        	            		/home/jvirtane/go/src/github.com/stackrox/stackrox/pkg/search/postgres/store.go:486
        	            	github.com/stackrox/rox/pkg/search/postgres.(*genericStore[...]).UpsertMany.func1
...
```

The unit test was run with the following script

```
#!/usr/bin/env bash
set -eou pipefail

nerror=0
for ((a=0;a<1000;a=a+1)); do
  echo $a
  error_code=0
  go test -tags=sql_integration -v -run TestPLOPDataStore/TestDeletePods || error_code=$?
  if [[ "$error_code" != "0" ]]; then
	  nerror=$((nerror + 1))
          echo "nerror= $nerror"
  fi
done
echo "nerror= $nerror"

```

With the changes here the unit tests passed 1,000 times in a row.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
