### PR TITLE
ROX-21569: Add repo mapping URL to indexer config

### DIFF
--- a/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
@@ -21,6 +21,8 @@ indexer:
       client_encoding=UTF8
     password_file: /run/secrets/stackrox.io/secrets/password
   get_layer_timeout: 1m
+  repository_to_cpe_url: https://sensor.stackrox.svc/scanner/definitions?type=repo2cpe
+  name_to_cpe_url: https://sensor.stackrox.svc/scanner/definitions?type=name2cpe
 matcher:
   enable: false
 log_level: info

--- a/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
@@ -21,8 +21,13 @@ indexer:
       client_encoding=UTF8
     password_file: /run/secrets/stackrox.io/secrets/password
   get_layer_timeout: 1m
+  {{- if ._rox.env.centralServices }}
+  repository_to_cpe_url: https://central.stackrox.svc/api/extensions/scannerdefinitions?type=repo2cpe
+  name_to_cpe_url: https://central.stackrox.svc/api/extensions/scannerdefinitions?type=name2cpe
+  {{- else }}
   repository_to_cpe_url: https://sensor.stackrox.svc/scanner/definitions?type=repo2cpe
   name_to_cpe_url: https://sensor.stackrox.svc/scanner/definitions?type=name2cpe
+  {{- end }}
 matcher:
   enable: false
 log_level: info

--- a/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
@@ -25,8 +25,8 @@ indexer:
   repository_to_cpe_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?type=repo2cpe
   name_to_cpe_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?type=name2cpe
   {{- else }}
-  repository_to_cpe_url: https://sensor.stackrox.svc/scanner/definitions?type=repo2cpe
-  name_to_cpe_url: https://sensor.stackrox.svc/scanner/definitions?type=name2cpe
+  repository_to_cpe_url: https://sensor.{{ .Release.Namespace }}.svc/scanner/definitions?type=repo2cpe
+  name_to_cpe_url: https://sensor.{{ .Release.Namespace }}.svc/scanner/definitions?type=name2cpe
   {{- end }}
 matcher:
   enable: false

--- a/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
@@ -22,8 +22,8 @@ indexer:
     password_file: /run/secrets/stackrox.io/secrets/password
   get_layer_timeout: 1m
   {{- if ._rox.env.centralServices }}
-  repository_to_cpe_url: https://central.stackrox.svc/api/extensions/scannerdefinitions?type=repo2cpe
-  name_to_cpe_url: https://central.stackrox.svc/api/extensions/scannerdefinitions?type=name2cpe
+  repository_to_cpe_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?type=repo2cpe
+  name_to_cpe_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?type=name2cpe
   {{- else }}
   repository_to_cpe_url: https://sensor.stackrox.svc/scanner/definitions?type=repo2cpe
   name_to_cpe_url: https://sensor.stackrox.svc/scanner/definitions?type=name2cpe

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -224,3 +224,10 @@ tests:
     .serviceaccounts["scanner-v4"] | assertThat(. != null)
     .serviceaccounts["scanner-v4"] | .imagePullSecrets[] | select(.name == "stackrox")
     .serviceaccounts["scanner-v4"] | .imagePullSecrets[] | select(.name == "stackrox-scanner")
+
+- name: "indexer should be using central endpoints when deployed as part of central-services"
+  set:
+    scannerV4.disable: false
+  expect: |
+    .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.repository_to_cpe_url | assertThat(contains("https://central.stackrox.svc/api/extensions/scannerdefinitions"))
+    .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.name_to_cpe_url | assertThat(contains("https://central.stackrox.svc/api/extensions/scannerdefinitions"))


### PR DESCRIPTION
## Description
The indexer must get repository mapping data from correct URL:
indexer in security cluster should send request to Senor endpoint
indexer in central cluster should send request to Central endpoint

## Checklist
- [ ] Investigated and inspected CI test results