### PR TITLE
fix(perf): Add toggle to disable process baseline risk

### DIFF
--- a/central/risk/multipliers/deployment/process_baseline_violations.go
+++ b/central/risk/multipliers/deployment/process_baseline_violations.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/central/processbaseline/evaluator"
 	"github.com/stackrox/rox/central/risk/multipliers"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/stringutils"
 )
 
@@ -65,6 +66,9 @@ func formatProcess(process *storage.ProcessIndicator) string {
 }
 
 func (p *processBaselineMultiplier) Score(_ context.Context, deployment *storage.Deployment, _ map[string][]*storage.Risk_Result) *storage.Risk_Result {
+	if !env.ProcessBaselineRisk.BooleanSetting() {
+		return nil
+	}
 	violatingProcesses, err := p.evaluator.EvaluateBaselinesAndPersistResult(deployment)
 	if err != nil {
 		log.Errorf("Couldn't evaluate process baseline: %v", err)

--- a/pkg/env/process_baseline_risk.go
+++ b/pkg/env/process_baseline_risk.go
@@ -1,0 +1,6 @@
+package env
+
+var (
+	// ProcessBaselineRisk toggles whether to process baseline risk
+	ProcessBaselineRisk = RegisterBooleanSetting("ROX_PROCESS_BASELINE_RISK", true)
+)


### PR DESCRIPTION
## Description

Process baseline risk is consistently one of the most expensive operations against the database, this provides an environment variable to help alleviate it if it's not required from the user. I'll continue to look into optimizing the codepath

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Straightforward change

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
