### PR TITLE
fix(perf): Optimize image pruning selection

### DIFF
--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -526,9 +526,10 @@ func (g *garbageCollectorImpl) collectImages(config *storage.PrivateConfig) {
 			log.Errorf("[Image pruning] searching pods: %v", err)
 			continue
 		}
-		if len(podResults) == 0 {
-			imagesToPrune = append(imagesToPrune, result.ID)
+		if len(podResults) != 0 {
+			continue
 		}
+		imagesToPrune = append(imagesToPrune, result.ID)
 	}
 	if len(imagesToPrune) > 0 {
 		log.Infof("[Image Pruning] Removing %d images", len(imagesToPrune))


### PR DESCRIPTION
## Description

Don't run the query evaluation for pods if the query for deployments returns values that exclude the image from pruning

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Unit test

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
