### PR TITLE
chore(CI): misc JUNIT fixes

### DIFF
--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -69,6 +69,9 @@ compatibility_test() {
         get_ECR_docker_pull_password
     fi
 
+    rm -f FAIL
+    remove_qa_test_results
+
     info "Running compatibility tests"
 
     if [[ "${ORCHESTRATOR_FLAVOR}" == "openshift" ]]; then

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -83,8 +83,9 @@ test_part_1() {
     export CLUSTER="${ORCHESTRATOR_FLAVOR^^}"
 
     rm -f FAIL
-    local test_target
+    remove_qa_test_results
 
+    local test_target
     if is_openshift_CI_rehearse_PR; then
         info "On an openshift rehearse PR, running BAT tests only..."
         test_target="bat-test"

--- a/qa-tests-backend/scripts/run-part-2.sh
+++ b/qa-tests-backend/scripts/run-part-2.sh
@@ -21,6 +21,8 @@ run_tests_part_2() {
     export CLUSTER="${ORCHESTRATOR_FLAVOR^^}"
 
     rm -f FAIL
+    remove_qa_test_results
+
     make -C qa-tests-backend sensor-bounce-test || touch FAIL
 
     store_qa_test_results "part-2-tests"

--- a/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
@@ -49,8 +49,10 @@ class GraphQLResourcePaginationTest extends BaseSpecification {
         where:
         topResource  | topLevelQuery | topLevelSortOption | topLevelSortOptionDesc | subResource
 
-        "deployment" | "Namespace:stackrox+Deployment:c"       | new SortOption("Deployment", true) | "Sort(Deployment)" | "images"
-        "deployment" | "Namespace:stackrox+Deployment:central" | new SortOption("Deployment", true) | "Sort(Deployment)" | "secrets"
+        "deployment" | "Namespace:stackrox+Deployment:c"       | new SortOption("Deployment", true) \
+            | "Sort(Deployment)" | "images"
+        "deployment" | "Namespace:stackrox+Deployment:central" | new SortOption("Deployment", true) \
+            | "Sort(Deployment)" | "secrets"
 
         "cluster"    | "" | null | "Sort(null)" | "subjects"
         "cluster"    | "" | null | "Sort(null)" | "serviceAccounts"

--- a/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
@@ -11,7 +11,7 @@ class GraphQLResourcePaginationTest extends BaseSpecification {
 
     @Unroll
     @Tag("BAT")
-    def "Verify graphql/sublist pagination #topResource #topLevelQuery #topLevelSortOption #subResource"() {
+    def "Verify graphql/sublist pagination #topResource #topLevelQuery #topLevelSortOptionDesc #subResource"() {
         given:
         "Ensure on GKE"
         Assume.assumeTrue(orchestrator.isGKE())
@@ -47,28 +47,28 @@ class GraphQLResourcePaginationTest extends BaseSpecification {
         assert sublistGraphQLQuery == "" || resultRet.getValue()["${topResource}"]["${subResource}"].size() != 0
 
         where:
-        topResource  | topLevelQuery | topLevelSortOption | subResource
+        topResource  | topLevelQuery | topLevelSortOption | topLevelSortOptionDesc | subResource
 
-        "deployment" | "Namespace:stackrox+Deployment:c"       | new SortOption("Deployment", true) | "images"
-        "deployment" | "Namespace:stackrox+Deployment:central" | new SortOption("Deployment", true) | "secrets"
+        "deployment" | "Namespace:stackrox+Deployment:c"       | new SortOption("Deployment", true) | "Sort(Deployment)" | "images"
+        "deployment" | "Namespace:stackrox+Deployment:central" | new SortOption("Deployment", true) | "Sort(Deployment)" | "secrets"
 
-        "cluster"    | "" | null | "subjects"
-        "cluster"    | "" | null | "serviceAccounts"
-        "cluster"    | "" | null | "k8sRoles"
+        "cluster"    | "" | null | "Sort(null)" | "subjects"
+        "cluster"    | "" | null | "Sort(null)" | "serviceAccounts"
+        "cluster"    | "" | null | "Sort(null)" | "k8sRoles"
 
-        "node"       | "" | null | ""
+        "node"       | "" | null | "Sort(null)" | ""
 
         // TODO: re-activate once fixed against postgres
-        //"image"      | "Image:main" | null | "deployments"
+        //"image"      | "Image:main" | null | "Sort(null)" | "deployments"
 
-        "secret"     | "Secret:scanner-db-password" | null | "deployments"
+        "secret"     | "Secret:scanner-db-password" | null | "Sort(null)" | "deployments"
 
-        "subject"    | "Subject:kubelet" | null | "k8sRoles"
+        "subject"    | "Subject:kubelet" | null | "Sort(null)" | "k8sRoles"
 
-        "k8sRole"    | "Role:system:node-bootstrapper" | null | "subjects"
-        "k8sRole"    | "Namespace:stackrox+Role:edit"  | null | "serviceAccounts"
+        "k8sRole"    | "Role:system:node-bootstrapper" | null | "Sort(null)" | "subjects"
+        "k8sRole"    | "Namespace:stackrox+Role:edit"  | null | "Sort(null)" | "serviceAccounts"
 
-        "serviceAccount" | "Service Account:\"central\"" | null |  "k8sRoles"
+        "serviceAccount" | "Service Account:\"central\"" | null | "Sort(null)" | "k8sRoles"
     }
 
     @Unroll

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1111,6 +1111,10 @@ store_qa_test_results() {
     done
 }
 
+remove_qa_test_results() {
+    rm -rf qa-tests-backend/build/test-results
+}
+
 stored_test_results() {
     echo "${ARTIFACT_DIR}/junit-$1"
 }

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -171,6 +171,9 @@ test_upgrade_paths() {
 
     wait_for_central_reconciliation
 
+    rm -f FAIL
+    remove_qa_test_results
+
     info "Running smoke tests"
     CLUSTER="$CLUSTER_TYPE_FOR_TEST" make -C qa-tests-backend smoke-test || touch FAIL
     store_qa_test_results "upgrade-paths-smoke-tests"
@@ -197,7 +200,7 @@ helm_upgrade_to_latest_postgres() {
 
 
     local root_certificate_path="$(mktemp -d)/root_certs_values.yaml"
-    create_certificate_values_file $root_certificate_path
+    create_certificate_values_file "$root_certificate_path"
 
     ########################################################################################
     # Use helm to upgrade to current Postgres release.                                     #

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -65,6 +65,9 @@ validate_upgrade() {
         echo "${API_TOKEN}" | "${TEST_ROOT}/bin/${TEST_HOST_PLATFORM}/roxctl" --insecure-skip-tls-verify --insecure -e "${API_ENDPOINT}" --token-file /dev/stdin central whoami > /dev/null
     fi
 
+    rm -f FAIL
+    remove_qa_test_results
+
     info "Validating the upgrade with upgrade tests: $stage_description"
 
     CLUSTER="$CLUSTER_TYPE_FOR_TEST" \

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -260,6 +260,9 @@ test_upgrade_paths() {
 
     wait_for_central_reconciliation
 
+    rm -f FAIL
+    remove_qa_test_results
+
     info "Running smoke tests"
     CLUSTER="$CLUSTER_TYPE_FOR_TEST" make -C qa-tests-backend smoke-test || touch FAIL
     store_qa_test_results "upgrade-paths-smoke-tests"
@@ -292,7 +295,7 @@ helm_upgrade_to_postgres() {
     fi
 
     local root_certificate_path="$(mktemp -d)/root_certs_values.yaml"
-    create_certificate_values_file $root_certificate_path
+    create_certificate_values_file "$root_certificate_path"
 
     ########################################################################################
     # Use helm to upgrade to a Postgres release.  3.73.2 for now.                          #


### PR DESCRIPTION
## Description

GraphQLResourcePaginationTest used variable test names which makes it difficult to consider pass/fail rate. e.g. `Verify graphql/sublist pagination deployment Namespace:stackrox+Deployment:central <objects.SortOption@29ae2517 field=Deployment reversed=true> secrets`.

Its a good idea for CI runs of `qa-backend-tests` to start with a clear test results folder. Failure to do so can result in duplicate JUNIT records and metrics. As is currently the case with qa-e2e jobs due to the part-1/part-2 separation.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

CI + affected test jobs:
- [x] upgrade
- [x]  compatibility

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
