### PR TITLE
fix: go template comment

### DIFF
--- a/image/templates/helm/stackrox-central/templates/_central_endpoints.tpl
+++ b/image/templates/helm/stackrox-central/templates/_central_endpoints.tpl
@@ -48,7 +48,7 @@
   {{ $containerPorts = append $containerPorts (dict "name" "monitoring" "containerPort" 9090) }}
   {{ $servicePorts = append $servicePorts (dict "name" "monitoring" "targetPort" "monitoring" "port" 9090) }}
 {{ end }}
-# The (...) safe-guard against nil pointer evaluations for Helm versions built with Go < 1.18.
+{{- /* The (...) safe-guard against nil pointer evaluations for Helm versions built with Go < 1.18. */}}
 {{ if ((($central.monitoring).openshift).enabled) }}
   {{ $containerPorts = append $containerPorts (dict "name" "monitoring-tls" "containerPort" 9091) }}
   {{ $servicePorts = append $servicePorts (dict "name" "monitoring-tls" "targetPort" "monitoring-tls" "port" 9091) }}


### PR DESCRIPTION
## Description

The comment I spot when downloaded the `scanner-tls.yaml` to update scanner certificates.
This PR does not fix the 597 empty lines, preceding the actual content of the file.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
below.

## Testing Performed

Tested go template syntax in go playground. CI.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
