### PR TITLE
fix(diag-bundle): fix diag bundle issues

### DIFF
--- a/central/debug/service/diagnostics.go
+++ b/central/debug/service/diagnostics.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"archive/zip"
 	"context"
 	"fmt"
 	"path"
@@ -32,7 +31,7 @@ type gatherResult struct {
 	files []k8sintrospect.File
 }
 
-func (s *serviceImpl) getK8sDiagnostics(ctx context.Context, zipWriter *zip.Writer, opts debugDumpOptions) error {
+func (s *serviceImpl) getK8sDiagnostics(ctx context.Context, zipWriter *zipWriter, opts debugDumpOptions) error {
 	gatherPool := concPool.NewWithResults[[]k8sintrospect.File]().WithContext(ctx)
 
 	clusterNameMap, err := s.getClusterNameMap(ctx)
@@ -81,7 +80,7 @@ func (s *serviceImpl) getK8sDiagnostics(ctx context.Context, zipWriter *zip.Writ
 	return writeGatherResultsToZIP(ctx, zipWriter, "kubernetes", gatherResults)
 }
 
-func (s *serviceImpl) pullSensorMetrics(ctx context.Context, zipWriter *zip.Writer, opts debugDumpOptions) error {
+func (s *serviceImpl) pullSensorMetrics(ctx context.Context, zipWriter *zipWriter, opts debugDumpOptions) error {
 	gatherPool := concPool.NewWithResults[[]k8sintrospect.File]().WithContext(ctx)
 
 	clusterNameMap, err := s.getClusterNameMap(ctx)
@@ -269,7 +268,7 @@ func getClusterNameForSensorConnection(conn connection.SensorConnection, usedClu
 
 // writeGatherResultsToZIP writes the given gather results to the ZIP with the defined prefix.
 // This respects context cancellation during writing the ZIP.
-func writeGatherResultsToZIP(ctx context.Context, zipWriter *zip.Writer, zipPrefix string,
+func writeGatherResultsToZIP(ctx context.Context, zipWriter *zipWriter, zipPrefix string,
 	gatherResults [][]k8sintrospect.File) error {
 	for _, files := range gatherResults {
 		for _, file := range files {
@@ -277,7 +276,7 @@ func writeGatherResultsToZIP(ctx context.Context, zipWriter *zip.Writer, zipPref
 			case <-ctx.Done():
 				return ctx.Err()
 			default:
-				err := writePrefixedFileToZip(zipWriter, zipPrefix, file)
+				err := zipWriter.writePrefixedFileToZip(zipPrefix, file)
 				if err != nil {
 					return err
 				}

--- a/central/debug/service/diagnostics.go
+++ b/central/debug/service/diagnostics.go
@@ -2,14 +2,15 @@ package service
 
 import (
 	"archive/zip"
-	"bytes"
 	"context"
 	"fmt"
 	"path"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
+	concPool "github.com/sourcegraph/conc/pool"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
@@ -25,127 +26,94 @@ var (
 	invalidPathElementChars = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
 )
 
-func sanitizeClusterName(rawClusterName string) string {
-	return invalidPathElementChars.ReplaceAllString(rawClusterName, "_")
+// Helper struct which holds all k8sintrospect.File gathered during either K8S diagnostic collection or
+// metrics collection.
+type gatherResult struct {
+	files []k8sintrospect.File
 }
 
-func filePayloadCallback(filesC chan<- k8sintrospect.File, clusterName string) func(ctx concurrency.ErrorWaitable, k8sInfo *central.TelemetryResponsePayload_KubernetesInfo) error {
-	return func(ctx concurrency.ErrorWaitable, k8sInfo *central.TelemetryResponsePayload_KubernetesInfo) error {
-		for _, k8sInfoFile := range k8sInfo.GetFiles() {
-			file := k8sintrospect.File{
-				Path:     path.Join(clusterName, k8sInfoFile.GetPath()),
-				Contents: k8sInfoFile.GetContents(),
-			}
-			select {
-			case filesC <- file:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		}
-		return nil
-	}
-}
+func (s *serviceImpl) getK8sDiagnostics(ctx context.Context, zipWriter *zip.Writer, opts debugDumpOptions) error {
+	gatherPool := concPool.NewWithResults[[]k8sintrospect.File]().WithContext(ctx)
 
-func pullK8sDiagnosticsFilesFromSensor(ctx context.Context, clusterName string, sensorConn connection.SensorConnection,
-	filesC chan<- k8sintrospect.File, wg *concurrency.WaitGroup, since time.Time) {
-	defer wg.Add(-1)
-
-	callback := filePayloadCallback(filesC, clusterName)
-
-	var err error
-	if sensorConn.HasCapability(centralsensor.PullTelemetryDataCap) {
-		err = sensorConn.Telemetry().PullKubernetesInfo(ctx, callback, since)
-	} else {
-		err = errors.New("sensor does not support pulling telemetry data")
-	}
-
+	clusterNameMap, err := s.getClusterNameMap(ctx)
 	if err != nil {
-		log.Warnw("Error pulling kubernetes info from sensor", logging.ClusterName(clusterName), logging.Err(err))
-		errFile := k8sintrospect.File{
-			Path:     path.Join(clusterName, "pull-error.txt"),
-			Contents: []byte(err.Error()),
-		}
-
-		select {
-		case filesC <- errFile:
-		case <-ctx.Done():
-		}
+		return err
 	}
+
+	usedNames := set.NewStringSet(centralClusterPrefix)
+	for _, sensorConn := range s.sensorConnMgr.GetActiveConnections() {
+		clusterName, valid := getClusterNameForSensorConnection(sensorConn, usedNames, clusterNameMap, opts)
+		if !valid {
+			continue
+		}
+		gatherPool.Go(func(ctx context.Context) ([]k8sintrospect.File, error) {
+			return pullK8sDiagnosticsFilesFromSensor(ctx, clusterName, sensorConn, opts.since)
+		})
+	}
+
+	// Add information about clusters for which we didn't have an active sensor connection.
+	if len(clusterNameMap) > 0 {
+		// This is simply creating a static k8sintrospect.File, hence the context can be safely ignored.
+		gatherPool.Go(func(_ context.Context) ([]k8sintrospect.File, error) {
+			return addMissingClustersInfo(clusterNameMap, opts.clusters)
+		})
+	}
+
+	// Pull data from the central cluster, irrespective of whether it might have been covered by the active
+	// sensor connections.
+	// We currently do not have a way to specify within the connection whether the sensor is co-located within the
+	// Central cluster.
+	if opts.withCentral {
+		gatherPool.Go(func(ctx context.Context) ([]k8sintrospect.File, error) {
+			return pullCentralClusterDiagnostics(ctx, opts.since)
+		})
+	}
+
+	var gatherResults [][]k8sintrospect.File
+	if ctxErr := concurrency.DoInWaitable(ctx, func() {
+		// The error can be safely ignored, since context cancellations will be propagated via concurrency.DoInWaitable
+		// and errors are contained within the gather results as files.
+		gatherResults, _ = gatherPool.Wait()
+	}); ctxErr != nil {
+		return ctxErr
+	}
+
+	return writeGatherResultsToZIP(ctx, zipWriter, "kubernetes", gatherResults)
 }
 
-func pullMetricsFromSensor(ctx context.Context, clusterName string, sensorConn connection.SensorConnection,
-	filesC chan<- k8sintrospect.File, wg *concurrency.WaitGroup) {
-	defer wg.Add(-1)
+func (s *serviceImpl) pullSensorMetrics(ctx context.Context, zipWriter *zip.Writer, opts debugDumpOptions) error {
+	gatherPool := concPool.NewWithResults[[]k8sintrospect.File]().WithContext(ctx)
 
-	callback := filePayloadCallback(filesC, clusterName)
-
-	var err error
-	if sensorConn.HasCapability(centralsensor.PullMetricsCap) {
-		err = sensorConn.Telemetry().PullMetrics(ctx, callback)
-	} else {
-		err = errors.New("sensor does not support pulling metrics")
-	}
-
+	clusterNameMap, err := s.getClusterNameMap(ctx)
 	if err != nil {
-		log.Warnw("Error pulling metrics from sensor", logging.ClusterName(clusterName), logging.Err(err))
-		errFile := k8sintrospect.File{
-			Path:     path.Join(clusterName, "pull-error.txt"),
-			Contents: []byte(err.Error()),
+		return err
+	}
+
+	usedNames := set.NewStringSet(centralClusterPrefix)
+	for _, sensorConn := range s.sensorConnMgr.GetActiveConnections() {
+		clusterName, valid := getClusterNameForSensorConnection(sensorConn, usedNames, clusterNameMap, opts)
+		if !valid {
+			continue
 		}
-
-		select {
-		case filesC <- errFile:
-		case <-ctx.Done():
-		}
-	}
-}
-
-func addMissingClustersInfo(ctx context.Context, remainingClusterNameMap map[string]string,
-	filesC chan<- k8sintrospect.File, wg *concurrency.WaitGroup, filterClusters []string) {
-	defer wg.Add(-1)
-
-	var missingClustersFileContents bytes.Buffer
-	fmt.Fprintln(&missingClustersFileContents, "Data from the following clusters is unavailable:")
-	for _, clusterName := range remainingClusterNameMap {
-		if filterClusters != nil && sliceutils.Find(filterClusters, clusterName) != -1 {
-			fmt.Fprintf(&missingClustersFileContents, "- %s (not requested by user)\n", clusterName)
-		} else {
-			fmt.Fprintf(&missingClustersFileContents, "- %s (no active connection)\n", clusterName)
-		}
+		gatherPool.Go(func(ctx context.Context) ([]k8sintrospect.File, error) {
+			return pullMetricsFromSensor(ctx, clusterName, sensorConn)
+		})
 	}
 
-	missingClustersFile := k8sintrospect.File{
-		Path:     "missing-clusters.txt",
-		Contents: missingClustersFileContents.Bytes(),
+	var gatherResults [][]k8sintrospect.File
+	if ctxErr := concurrency.DoInWaitable(ctx, func() {
+		// The error can be safely ignored, since context cancellations will be propagated via concurrency.DoInWaitable
+		// and errors are contained within the gather results as files.
+		gatherResults, _ = gatherPool.Wait()
+	}); ctxErr != nil {
+		return ctxErr
 	}
 
-	select {
-	case filesC <- missingClustersFile:
-	case <-ctx.Done():
-	}
-}
-
-func pullCentralClusterDiagnostics(ctx context.Context, filesC chan<- k8sintrospect.File, wg *concurrency.WaitGroup, since time.Time) {
-	defer wg.Add(-1)
-
-	restCfg, err := k8sutil.GetK8sInClusterConfig()
-	if err == nil {
-		err = k8sintrospect.Collect(ctx, mainClusterConfig, restCfg, k8sintrospect.SendToChan(filesC), since)
-	}
-	if err != nil {
-		errFile := k8sintrospect.File{
-			Path:     path.Join(centralClusterPrefix, "collect-error.txt"),
-			Contents: []byte(err.Error()),
-		}
-		select {
-		case filesC <- errFile:
-		case <-ctx.Done():
-		}
-	}
+	return writeGatherResultsToZIP(ctx, zipWriter, "sensor-metrics", gatherResults)
 }
 
 func (s *serviceImpl) getClusterNameMap(ctx context.Context) (map[string]string, error) {
-	// Build an ID -> Name map for clusters
+	// Build an ID -> Name map for clusters.
 	clusters, err := s.clusters.GetClusters(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to retrieve cluster list")
@@ -158,7 +126,111 @@ func (s *serviceImpl) getClusterNameMap(ctx context.Context) (map[string]string,
 	return clusterNameMap, nil
 }
 
-func getClusterCandidate(conn connection.SensorConnection, clusterNameMap map[string]string, opts debugDumpOptions) (string, string, bool) {
+func sanitizeClusterName(rawClusterName string) string {
+	return invalidPathElementChars.ReplaceAllString(rawClusterName, "_")
+}
+
+func gatherResultCallback(res *gatherResult, clusterName string) func(ctx concurrency.ErrorWaitable,
+	k8sInfo *central.TelemetryResponsePayload_KubernetesInfo) error {
+	return func(_ concurrency.ErrorWaitable, chunk *central.TelemetryResponsePayload_KubernetesInfo) error {
+		for _, k8sInfoFile := range chunk.GetFiles() {
+			res.files = append(res.files, k8sintrospect.File{
+				Path:     path.Join(clusterName, k8sInfoFile.GetPath()),
+				Contents: k8sInfoFile.GetContents(),
+			})
+		}
+		return nil
+	}
+}
+
+func createErrorFile(clusterName string, err error) k8sintrospect.File {
+	return k8sintrospect.File{
+		Path:     path.Join(clusterName, "pull-error.txt"),
+		Contents: []byte(err.Error()),
+	}
+}
+
+func pullK8sDiagnosticsFilesFromSensor(ctx context.Context, clusterName string, sensorConn connection.SensorConnection,
+	since time.Time) ([]k8sintrospect.File, error) {
+	res := &gatherResult{}
+	callback := gatherResultCallback(res, clusterName)
+
+	if !sensorConn.HasCapability(centralsensor.PullTelemetryDataCap) {
+		return []k8sintrospect.File{createErrorFile(clusterName,
+			errors.New("sensor does not support pulling telemetry data"))}, nil
+	}
+	err := sensorConn.Telemetry().PullKubernetesInfo(ctx, callback, since)
+	if err != nil {
+		log.Warnw("Error pulling kubernetes info from sensor", logging.ClusterName(clusterName), logging.Err(err))
+		return []k8sintrospect.File{
+			createErrorFile(clusterName, err),
+		}, err
+	}
+	return res.files, nil
+}
+
+func pullMetricsFromSensor(ctx context.Context, clusterName string,
+	sensorConn connection.SensorConnection) ([]k8sintrospect.File, error) {
+	res := &gatherResult{}
+	callback := gatherResultCallback(res, clusterName)
+
+	if !sensorConn.HasCapability(centralsensor.PullMetricsCap) {
+		return []k8sintrospect.File{
+			createErrorFile(clusterName, errors.New("sensor does not support pulling metrics")),
+		}, nil
+	}
+	err := sensorConn.Telemetry().PullMetrics(ctx, callback)
+	if err != nil {
+		log.Warnw("Error pulling metrics from sensor", logging.ClusterName(clusterName), logging.Err(err))
+		return []k8sintrospect.File{
+			createErrorFile(clusterName, err),
+		}, nil
+	}
+	return res.files, nil
+}
+
+func addMissingClustersInfo(remainingClusterNameMap map[string]string,
+	filterClusters []string) ([]k8sintrospect.File, error) {
+	sb := strings.Builder{}
+	sb.WriteString("Data from the following clusters is unavailable:\n")
+	for _, clusterName := range remainingClusterNameMap {
+		if filterClusters != nil && sliceutils.Find(filterClusters, clusterName) != -1 {
+			sb.WriteString(fmt.Sprintf("- %s (not requested by user)\n", clusterName))
+		} else {
+			sb.WriteString(fmt.Sprintf("- %s (no active connection)\n", clusterName))
+		}
+	}
+
+	missingClustersFile := k8sintrospect.File{
+		Path:     "missing-clusters.txt",
+		Contents: []byte(sb.String()),
+	}
+	return []k8sintrospect.File{missingClustersFile}, nil
+}
+
+func pullCentralClusterDiagnostics(ctx context.Context, since time.Time) ([]k8sintrospect.File, error) {
+	var files []k8sintrospect.File
+	cb := func(_ concurrency.ErrorWaitable, file k8sintrospect.File) error {
+		files = append(files, file)
+		return nil
+	}
+
+	restCfg, err := k8sutil.GetK8sInClusterConfig()
+	if err == nil {
+		err = k8sintrospect.Collect(ctx, mainClusterConfig, restCfg, cb, since)
+	}
+	if err != nil {
+		return []k8sintrospect.File{createErrorFile(centralClusterPrefix, err)}, nil
+	}
+	return files, nil
+}
+
+// getClusterCandidate returns the cluster name based off the cluster ID associated with the given sensor connection.
+// Additionally, the cluster name will be filtered by the given debug dump options.
+// It will return the cluster name, a sanitized version of the cluster name without invalid path characters, and
+// a bool indicating whether the cluster name is valid, i.e. non-empty, or not.
+func getClusterCandidate(conn connection.SensorConnection, clusterNameMap map[string]string,
+	opts debugDumpOptions) (string, string, bool) {
 	clusterID := conn.ClusterID()
 	clusterName := clusterNameMap[clusterID]
 
@@ -176,106 +248,41 @@ func getClusterCandidate(conn connection.SensorConnection, clusterNameMap map[st
 	return clusterName, sanitizeClusterName(clusterName), true
 }
 
-func (s *serviceImpl) pullSensorMetrics(ctx context.Context, zipWriter *zip.Writer, opts debugDumpOptions) error {
-	filesC := make(chan k8sintrospect.File)
-	clusterNameMap, err := s.getClusterNameMap(ctx)
-	if err != nil {
-		return err
+// getClusterNameForSensorConnection returns the cluster name associated with the given sensor connection.
+// In case the cluster name has already been used beforehand, the name will be suffixed with an index.
+// In case the cluster isn't seen as valid (i.e. it has been filtered out by the given debug dump options),
+// it will return false.
+func getClusterNameForSensorConnection(conn connection.SensorConnection, usedClusterNames set.Set[string],
+	clusterIDToName map[string]string, opts debugDumpOptions) (string, bool) {
+	clusterName, candidateName, valid := getClusterCandidate(conn, clusterIDToName, opts)
+	if !valid {
+		return "", false
 	}
 
-	// Pull telemetry data from all active sensor connections
-	var wg concurrency.WaitGroup
-	usedNames := set.NewStringSet(centralClusterPrefix)
-
-	for _, sensorConn := range s.sensorConnMgr.GetActiveConnections() {
-		clusterName, candidateName, valid := getClusterCandidate(sensorConn, clusterNameMap, opts)
-		if !valid {
-			continue
-		}
-
-		i := 0
-		for !usedNames.Add(candidateName) {
-			candidateName = fmt.Sprintf("%s_%d", clusterName, i)
-			i++
-		}
-		clusterName = candidateName
-
-		wg.Add(1)
-		go pullMetricsFromSensor(ctx, clusterName, sensorConn, filesC, &wg)
+	i := 0
+	for !usedClusterNames.Add(candidateName) {
+		candidateName = fmt.Sprintf("%s_%d", clusterName, i)
+		i++
 	}
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-wg.Done():
-			log.Info("Finished writing Sensor data to diagnostic bundle")
-			return nil
-		case file := <-filesC:
-			err := writePrefixedFileToZip(zipWriter, "sensor-metrics", file)
-			if err != nil {
-				return err
-			}
-		}
-	}
+	return candidateName, true
 }
 
-func (s *serviceImpl) getK8sDiagnostics(ctx context.Context, zipWriter *zip.Writer, opts debugDumpOptions) error {
-	filesC := make(chan k8sintrospect.File)
-
-	clusterNameMap, err := s.getClusterNameMap(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Pull telemetry data from all active sensor connections
-	var wg concurrency.WaitGroup
-	usedNames := set.NewStringSet(centralClusterPrefix)
-
-	for _, sensorConn := range s.sensorConnMgr.GetActiveConnections() {
-		clusterName, candidateName, valid := getClusterCandidate(sensorConn, clusterNameMap, opts)
-		if !valid {
-			continue
-		}
-
-		i := 0
-		for !usedNames.Add(candidateName) {
-			candidateName = fmt.Sprintf("%s_%d", clusterName, i)
-			i++
-		}
-		clusterName = candidateName
-
-		wg.Add(1)
-		go pullK8sDiagnosticsFilesFromSensor(ctx, clusterName, sensorConn, filesC, &wg,
-			opts.since)
-	}
-
-	// Add information about clusters for which we didn't have an active sensor connection.
-	if len(clusterNameMap) > 0 {
-		wg.Add(1)
-		go addMissingClustersInfo(ctx, clusterNameMap, filesC, &wg, opts.clusters)
-	}
-
-	// Pull data from the central cluster.
-	// TODO: It would be nice if we could add a flag to a sensor connection that indicates whether this sensor is
-	// running colocated with central, so we could skip this.
-	if opts.withCentral {
-		wg.Add(1)
-		go pullCentralClusterDiagnostics(ctx, filesC, &wg, opts.since)
-	}
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-wg.Done():
-			log.Info("Finished writing Kubernetes data to diagnostic bundle")
-			return nil
-		case file := <-filesC:
-			err := writePrefixedFileToZip(zipWriter, "kubernetes", file)
-			if err != nil {
-				return err
+// writeGatherResultsToZIP writes the given gather results to the ZIP with the defined prefix.
+// This respects context cancellation during writing the ZIP.
+func writeGatherResultsToZIP(ctx context.Context, zipWriter *zip.Writer, zipPrefix string,
+	gatherResults [][]k8sintrospect.File) error {
+	for _, files := range gatherResults {
+		for _, file := range files {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				err := writePrefixedFileToZip(zipWriter, zipPrefix, file)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
+	return nil
 }

--- a/central/debug/service/diagnostics_test.go
+++ b/central/debug/service/diagnostics_test.go
@@ -33,7 +33,7 @@ func TestSanitizeClusterName(t *testing.T) {
 
 func TestGetK8sDiagnostics(t *testing.T) {
 	buf := &bytes.Buffer{}
-	writer := zip.NewWriter(buf)
+	writer := newZipWriter(buf)
 
 	ctrl := gomock.NewController(t)
 	connMgr := connectionMocks.NewMockManager(ctrl)
@@ -86,7 +86,7 @@ func TestGetK8sDiagnostics(t *testing.T) {
 
 func TestPullSensorMetrics(t *testing.T) {
 	buf := &bytes.Buffer{}
-	writer := zip.NewWriter(buf)
+	writer := newZipWriter(buf)
 
 	ctrl := gomock.NewController(t)
 	connMgr := connectionMocks.NewMockManager(ctrl)

--- a/central/debug/service/diagnostics_test.go
+++ b/central/debug/service/diagnostics_test.go
@@ -1,9 +1,22 @@
 package service
 
 import (
+	"archive/zip"
+	"bytes"
+	"context"
 	"testing"
+	"time"
 
+	clusterMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
+	"github.com/stackrox/rox/central/sensor/service/connection"
+	connectionMocks "github.com/stackrox/rox/central/sensor/service/connection/mocks"
+	"github.com/stackrox/rox/central/sensor/telemetry"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestSanitizeClusterName(t *testing.T) {
@@ -16,4 +29,124 @@ func TestSanitizeClusterName(t *testing.T) {
 	for input, expectedOutput := range cases {
 		assert.Equal(t, expectedOutput, sanitizeClusterName(input))
 	}
+}
+
+func TestGetK8sDiagnostics(t *testing.T) {
+	buf := &bytes.Buffer{}
+	writer := zip.NewWriter(buf)
+
+	ctrl := gomock.NewController(t)
+	connMgr := connectionMocks.NewMockManager(ctrl)
+	conn := connectionMocks.NewMockSensorConnection(ctrl)
+	clusters := clusterMocks.NewMockDataStore(ctrl)
+
+	conn.EXPECT().ClusterID().Return("123")
+	conn.EXPECT().HasCapability(centralsensor.PullTelemetryDataCap).Return(true)
+	telemetryCtrl := &telemetryController{
+		payload: &central.TelemetryResponsePayload_KubernetesInfo{
+			Files: []*central.TelemetryResponsePayload_KubernetesInfo_File{
+				{
+					Path:     "test/something",
+					Contents: []byte("test something"),
+				},
+			},
+		},
+	}
+
+	conn.EXPECT().Telemetry().Return(telemetryCtrl)
+	connMgr.EXPECT().GetActiveConnections().Return([]connection.SensorConnection{conn})
+	clusters.EXPECT().GetClusters(gomock.Any()).Return([]*storage.Cluster{
+		{
+			Id:   "1",
+			Name: "1",
+		},
+		{
+			Id:   "2",
+			Name: "2",
+		},
+	}, nil)
+
+	s := serviceImpl{clusters: clusters, sensorConnMgr: connMgr}
+
+	err := s.getK8sDiagnostics(context.Background(), writer, debugDumpOptions{})
+	assert.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	zipReader, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(len(buf.Bytes())))
+	assert.NoError(t, err)
+	assert.Len(t, zipReader.File, 2)
+
+	var zipFileNames []string
+	for _, file := range zipReader.File {
+		zipFileNames = append(zipFileNames, file.Name)
+	}
+
+	assert.ElementsMatch(t, []string{"kubernetes/missing-clusters.txt", "kubernetes/_123/test/something"}, zipFileNames)
+}
+
+func TestPullSensorMetrics(t *testing.T) {
+	buf := &bytes.Buffer{}
+	writer := zip.NewWriter(buf)
+
+	ctrl := gomock.NewController(t)
+	connMgr := connectionMocks.NewMockManager(ctrl)
+	conn := connectionMocks.NewMockSensorConnection(ctrl)
+	clusters := clusterMocks.NewMockDataStore(ctrl)
+
+	conn.EXPECT().ClusterID().Return("123")
+	conn.EXPECT().HasCapability(centralsensor.PullMetricsCap).Return(true)
+	telemetryCtrl := &telemetryController{
+		payload: &central.TelemetryResponsePayload_KubernetesInfo{
+			Files: []*central.TelemetryResponsePayload_KubernetesInfo_File{
+				{
+					Path:     "test/something",
+					Contents: []byte("test something"),
+				},
+			},
+		},
+	}
+
+	conn.EXPECT().Telemetry().Return(telemetryCtrl)
+	connMgr.EXPECT().GetActiveConnections().Return([]connection.SensorConnection{conn})
+	clusters.EXPECT().GetClusters(gomock.Any()).Return([]*storage.Cluster{
+		{
+			Id:   "1",
+			Name: "1",
+		},
+		{
+			Id:   "2",
+			Name: "2",
+		},
+	}, nil)
+
+	s := serviceImpl{clusters: clusters, sensorConnMgr: connMgr}
+
+	err := s.pullSensorMetrics(context.Background(), writer, debugDumpOptions{})
+	assert.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	zipReader, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(len(buf.Bytes())))
+	assert.NoError(t, err)
+	assert.Len(t, zipReader.File, 1)
+
+	var zipFileNames []string
+	for _, file := range zipReader.File {
+		zipFileNames = append(zipFileNames, file.Name)
+	}
+
+	assert.ElementsMatch(t, []string{"sensor-metrics/_123/test/something"}, zipFileNames)
+}
+
+type telemetryController struct {
+	telemetry.Controller
+	payload *central.TelemetryResponsePayload_KubernetesInfo
+}
+
+func (t *telemetryController) PullKubernetesInfo(ctx context.Context, cb telemetry.KubernetesInfoChunkCallback,
+	_ time.Time) error {
+	return cb(ctx, t.payload)
+}
+
+func (t *telemetryController) PullMetrics(ctx context.Context, cb telemetry.MetricsInfoChunkCallback) error {
+	return cb(ctx, t.payload)
 }

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -313,6 +313,8 @@ func addJSONToZip(zipWriter *zipWriter, fileName string, jsonObj interface{}) er
 }
 
 func zipPrometheusMetrics(ctx context.Context, zipWriter *zipWriter, name string) error {
+	// Write to the buffer first instead of directly to the zip writer, this way we hold the lock _only_ for the copy
+	// time.
 	buf := &bytes.Buffer{}
 	if err := prometheusutil.ExportText(ctx, buf); err != nil {
 		return err
@@ -328,6 +330,8 @@ func zipPrometheusMetrics(ctx context.Context, zipWriter *zipWriter, name string
 }
 
 func getMemory(zipWriter *zipWriter) error {
+	// Write to the buffer first instead of directly to the zip writer, this way we hold the lock _only_ for the copy
+	// time.
 	buf := &bytes.Buffer{}
 	if err := pprof.WriteHeapProfile(buf); err != nil {
 		return err
@@ -343,6 +347,8 @@ func getMemory(zipWriter *zipWriter) error {
 }
 
 func getCPU(ctx context.Context, zipWriter *zipWriter, duration time.Duration) error {
+	// Write to the buffer first instead of directly to the zip writer, this way we hold the lock _only_ for the copy
+	// time.
 	buf := &bytes.Buffer{}
 	if err := pprof.StartCPUProfile(buf); err != nil {
 		return err
@@ -367,6 +373,8 @@ func getCPU(ctx context.Context, zipWriter *zipWriter, duration time.Duration) e
 }
 
 func getMutex(zipWriter *zipWriter) error {
+	// Write to the buffer first instead of directly to the zip writer, this way we hold the lock _only_ for the copy
+	// time.
 	buf := &bytes.Buffer{}
 	p := pprof.Lookup("mutex")
 	if err := p.WriteTo(buf, 0); err != nil {
@@ -384,6 +392,8 @@ func getMutex(zipWriter *zipWriter) error {
 }
 
 func getGoroutines(zipWriter *zipWriter) error {
+	// Write to the buffer first instead of directly to the zip writer, this way we hold the lock _only_ for the copy
+	// time.
 	buf := &bytes.Buffer{}
 	p := pprof.Lookup("goroutine")
 	if err := p.WriteTo(buf, 2); err != nil {

--- a/central/debug/service/zip.go
+++ b/central/debug/service/zip.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/k8sintrospect"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -35,7 +36,7 @@ func (z *zipWriter) LockWrite() {
 }
 
 func (z *zipWriter) UnlockWrite() {
-	z.mutex.Unlock()
+	concurrency.UnsafeUnlock(&z.mutex)
 }
 
 func (z *zipWriter) writePrefixedFileToZip(prefix string, file k8sintrospect.File) error {

--- a/central/debug/service/zip.go
+++ b/central/debug/service/zip.go
@@ -15,15 +15,34 @@ var now = func() time.Time {
 	return time.Now()
 }
 
-var (
-	zipWriterMutex sync.Mutex
-)
+type zipWriter struct {
+	writer *zip.Writer
+	mutex  sync.Mutex
+}
 
-func writePrefixedFileToZip(zipWriter *zip.Writer, prefix string, file k8sintrospect.File) error {
-	zipWriterMutex.Lock()
-	defer zipWriterMutex.Unlock()
+func newZipWriter(w io.Writer) *zipWriter {
+	return &zipWriter{
+		writer: zip.NewWriter(w),
+	}
+}
+
+func (z *zipWriter) Close() error {
+	return z.writer.Close()
+}
+
+func (z *zipWriter) LockWrite() {
+	z.mutex.Lock()
+}
+
+func (z *zipWriter) UnlockWrite() {
+	z.mutex.Unlock()
+}
+
+func (z *zipWriter) writePrefixedFileToZip(prefix string, file k8sintrospect.File) error {
+	z.mutex.Lock()
+	defer z.mutex.Unlock()
 	fullPath := path.Join(prefix, file.Path)
-	fileWriter, err := zipWriterWithCurrentTimestamp(zipWriter, fullPath)
+	fileWriter, err := z.writerWithCurrentTimestampNoLock(fullPath)
 	if err != nil {
 		return err
 	}
@@ -33,13 +52,16 @@ func writePrefixedFileToZip(zipWriter *zip.Writer, prefix string, file k8sintros
 	return nil
 }
 
-func zipWriterWithCurrentTimestamp(zipWriter *zip.Writer, fileName string) (io.Writer, error) {
+// writerWithCurrentTimestampNoLock creates an io.Writer for a ZIP file with the given name.
+// NOTE: The stdlib's zip.Writer cannot operate under concurrency, hence every write operation
+// with the returned io.Writer has to be operated under the given mutex.
+func (z *zipWriter) writerWithCurrentTimestampNoLock(fileName string) (io.Writer, error) {
 	header := &zip.FileHeader{
 		Name:     fileName,
 		Method:   zip.Deflate,
 		Modified: now(),
 	}
-	writer, err := zipWriter.CreateHeader(header)
+	writer, err := z.writer.CreateHeader(header)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to create zip file %q", fileName)
 	}

--- a/central/debug/service/zip.go
+++ b/central/debug/service/zip.go
@@ -8,13 +8,20 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/k8sintrospect"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 var now = func() time.Time {
 	return time.Now()
 }
 
+var (
+	zipWriterMutex sync.Mutex
+)
+
 func writePrefixedFileToZip(zipWriter *zip.Writer, prefix string, file k8sintrospect.File) error {
+	zipWriterMutex.Lock()
+	defer zipWriterMutex.Unlock()
 	fullPath := path.Join(prefix, file.Path)
 	fileWriter, err := zipWriterWithCurrentTimestamp(zipWriter, fullPath)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/sergi/go-diff v1.3.1
 	github.com/sigstore/cosign/v2 v2.2.2
 	github.com/sigstore/sigstore v1.8.1
+	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
 	github.com/stackrox/external-network-pusher v0.0.0-20231115153210-b82d72f500a2
@@ -347,7 +348,6 @@ require (
 	github.com/sigstore/timestamp-authority v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.2.1 // indirect
-	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.10.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/viper v1.17.0 // indirect

--- a/pkg/concurrency/do.go
+++ b/pkg/concurrency/do.go
@@ -21,3 +21,17 @@ func DoWithTimeout(w Waitable, action func(), timeout time.Duration) bool {
 	}
 	return false
 }
+
+// DoInWaitable performs an action asynchronously bound to a waitable.
+// It blocks until either the action is performed, or the waitable is done,
+// and returns the waitable's error in case the waitable is done first.
+func DoInWaitable(w ErrorWaitable, action func()) error {
+	var wg WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Add(-1)
+		action()
+	}()
+
+	return WaitForErrorInContext(w, &wg)
+}

--- a/pkg/concurrency/do_test.go
+++ b/pkg/concurrency/do_test.go
@@ -1,0 +1,36 @@
+package concurrency
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDoInWaitable(t *testing.T) {
+	// 1. Action which finishes _after_ cancellation should return an error with context.Canceled.
+	neverFinishAction := func() {
+		c := make(chan int)
+		<-c
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	AfterFunc(10*time.Millisecond, func() {
+		cancel()
+	}, context.Background())
+	err := DoInWaitable(ctx, neverFinishAction)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	// 2. Action which finishes _before_ cancellation should return no error and the action should have
+	// been finished.
+	var finished bool
+	finishAction := func() {
+		finished = true
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	err = DoInWaitable(ctx, finishAction)
+	assert.NoError(t, err)
+	assert.True(t, finished)
+}

--- a/pkg/concurrency/error_wait.go
+++ b/pkg/concurrency/error_wait.go
@@ -49,6 +49,17 @@ func WaitForErrorUntil(ew ErrorWaitable, cancelCond Waitable) (Error, bool) {
 	}
 }
 
+// WaitForErrorInContext waits until the given ErrorWaitable is triggered, in which case the return value is the same
+// as for CheckError. If the parent Waitable is triggered before the ErrorWaitable is triggered, nil is returned.
+func WaitForErrorInContext(ew ErrorWaitable, parentContext Waitable) Error {
+	select {
+	case <-ew.Done():
+		return ew.Err()
+	case <-parentContext.Done():
+		return nil
+	}
+}
+
 // WaitForErrorWithTimeout waits for the given ErrorWaitable and returns the error (equivalent to `CheckError(ew)`) once
 // this happens. If the given timeout expires beforehand, `nil, false` is returnd.
 func WaitForErrorWithTimeout(ew ErrorWaitable, timeout time.Duration) (Error, bool) {

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -52,6 +52,7 @@ var (
 	// ProcessIndicatorBufferSize indicates how many process indicators will be kept in Sensor while offline.
 	ProcessIndicatorBufferSize = RegisterIntegerSetting("ROX_SENSOR_PROCESS_INDICATOR_BUFFER_SIZE", 1000)
 
+<<<<<<< HEAD
 	// DetectorProcessIndicatorBufferSize indicates how many process indicators will be kept in Sensor while offline in the detector.
 	DetectorProcessIndicatorBufferSize = RegisterIntegerSetting("ROX_SENSOR_DETECTOR_PROCESS_INDICATOR_BUFFER_SIZE", 1000)
 
@@ -60,4 +61,9 @@ var (
 
 	// DiagnosticBundleTimeout defines the timeout for the diagnostic bundle creation on Sensor side.
 	DiagnosticBundleTimeout = registerDurationSetting("ROX_DIAG_BUNDLE_TIMEOUT", 2*time.Minute)
+=======
+	// DiagnosticDataCollectionTimeout defines the timeout for the diagnostic data collection on Sensor side.
+	DiagnosticDataCollectionTimeout = registerDurationSetting("ROX_DIAGNOSTIC_DATA_COLLECTION_TIMEOUT",
+		2*time.Minute)
+>>>>>>> 27d04cb4e5 (Address review comments.)
 )

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -52,18 +52,13 @@ var (
 	// ProcessIndicatorBufferSize indicates how many process indicators will be kept in Sensor while offline.
 	ProcessIndicatorBufferSize = RegisterIntegerSetting("ROX_SENSOR_PROCESS_INDICATOR_BUFFER_SIZE", 1000)
 
-<<<<<<< HEAD
 	// DetectorProcessIndicatorBufferSize indicates how many process indicators will be kept in Sensor while offline in the detector.
 	DetectorProcessIndicatorBufferSize = RegisterIntegerSetting("ROX_SENSOR_DETECTOR_PROCESS_INDICATOR_BUFFER_SIZE", 1000)
 
 	// DetectorNetworkFlowBufferSize indicates how many network flows will be kept in Sensor while offline in the detector.
 	DetectorNetworkFlowBufferSize = RegisterIntegerSetting("ROX_SENSOR_DETECTOR_NETWORK_FLOW_BUFFER_SIZE", 1000)
 
-	// DiagnosticBundleTimeout defines the timeout for the diagnostic bundle creation on Sensor side.
-	DiagnosticBundleTimeout = registerDurationSetting("ROX_DIAG_BUNDLE_TIMEOUT", 2*time.Minute)
-=======
 	// DiagnosticDataCollectionTimeout defines the timeout for the diagnostic data collection on Sensor side.
 	DiagnosticDataCollectionTimeout = registerDurationSetting("ROX_DIAGNOSTIC_DATA_COLLECTION_TIMEOUT",
 		2*time.Minute)
->>>>>>> 27d04cb4e5 (Address review comments.)
 )

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -2,8 +2,8 @@ package env
 
 import "time"
 
-// These environment variables are used in the deployment file
-// Please check the files before deleting
+// These environment variables are used in the deployment file.
+// Please check the files before deleting.
 var (
 	// CentralEndpoint is used to provide Central's reachable endpoint to a sensor.
 	CentralEndpoint = RegisterSetting("ROX_CENTRAL_ENDPOINT", WithDefault("central.stackrox.svc:443"),
@@ -26,7 +26,7 @@ var (
 	// LocalImageScanningEnabled is used to specify if Sensor should attempt to scan images via a local Scanner.
 	LocalImageScanningEnabled = RegisterBooleanSetting("ROX_LOCAL_IMAGE_SCANNING_ENABLED", false)
 
-	// EventPipelineQueueSize is used to specify the size of the eventPipeline's queues
+	// EventPipelineQueueSize is used to specify the size of the eventPipeline's queues.
 	EventPipelineQueueSize = RegisterIntegerSetting("ROX_EVENT_PIPELINE_QUEUE_SIZE", 1000)
 
 	// ConnectionRetryInitialInterval defines how long it takes for sensor to retry gRPC connection when it first disconnects.
@@ -43,7 +43,7 @@ var (
 	// RegistryTLSCheckTTL will set the duration for which registry TLS checks will be cached.
 	RegistryTLSCheckTTL = registerDurationSetting("ROX_SENSOR_REGISTRY_TLS_CHECK_CACHE_TTL", 15*time.Minute)
 
-	// DeduperStateSyncTimeout defines the maximum time Sensor will wait for the expected deduper state coming from Central
+	// DeduperStateSyncTimeout defines the maximum time Sensor will wait for the expected deduper state coming from Central.
 	DeduperStateSyncTimeout = registerDurationSetting("ROX_DEDUPER_STATE_TIMEOUT", 30*time.Second)
 
 	// NetworkFlowBufferSize holds the size of how many network flows updates will be kept in Sensor while offline.
@@ -57,4 +57,7 @@ var (
 
 	// DetectorNetworkFlowBufferSize indicates how many network flows will be kept in Sensor while offline in the detector.
 	DetectorNetworkFlowBufferSize = RegisterIntegerSetting("ROX_SENSOR_DETECTOR_NETWORK_FLOW_BUFFER_SIZE", 1000)
+
+	// DiagnosticBundleTimeout defines the timeout for the diagnostic bundle creation on Sensor side.
+	DiagnosticBundleTimeout = registerDurationSetting("ROX_DIAG_BUNDLE_TIMEOUT", 2*time.Minute)
 )

--- a/pkg/k8sintrospect/collect.go
+++ b/pkg/k8sintrospect/collect.go
@@ -17,18 +17,6 @@ type File struct {
 // FileCallback is a callback function to process a single file.
 type FileCallback func(ctx concurrency.ErrorWaitable, file File) error
 
-// SendToChan returns a file callback that sends to the given channel, bound by the given context.
-func SendToChan(filesC chan<- File) FileCallback {
-	return func(ctx concurrency.ErrorWaitable, f File) error {
-		select {
-		case filesC <- f:
-			return nil
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-}
-
 // Collect collects Kubernetes data relevant to the given config. If cb returns an error, processing stops and the error
 // is passed through.
 func Collect(ctx context.Context, collectionCfg Config, k8sClientConfig *rest.Config, cb FileCallback, since time.Time) error {

--- a/sensor/kubernetes/telemetry/command_handler.go
+++ b/sensor/kubernetes/telemetry/command_handler.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"runtime/pprof"
+	"sync/atomic"
 	"time"
 
 	"github.com/gogo/protobuf/types"
@@ -13,6 +15,8 @@ import (
 	"github.com/stackrox/rox/pkg/batcher"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/k8sintrospect"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/prometheusutil"
@@ -26,21 +30,23 @@ import (
 )
 
 const (
-	clusterInfoChunkSize = 2 * (1 << 20) // Bytes per streaming chunk, 2MB chosen arbitrarily
-	gatherTimeout        = 30 * time.Second
+	clusterInfoChunkSize = 2 * (1 << 20) // Bytes per streaming chunk, 2MB chosen arbitrarily.
 
-	maxK8sFileSize = 2 * (1 << 20) // maximum file size for Kubernetes files (YAMLs, logs)
+	maxK8sFileSize = 2 * (1 << 20) // maximum file size for Kubernetes files (YAMLs, logs).
 )
 
 var (
 	log = logging.LoggerForModule()
+
+	diagnosticBundleTimeout = env.DiagnosticBundleTimeout.DurationSetting()
 )
 
 type commandHandler struct {
 	responsesC      chan *message.ExpiringMessage
 	clusterGatherer *gatherers.ClusterGatherer
 
-	stopSig concurrency.ErrorSignal
+	stopSig          concurrency.ErrorSignal
+	centralReachable atomic.Bool
 
 	pendingContextCancels      map[string]context.CancelFunc
 	pendingContextCancelsMutex sync.Mutex
@@ -81,7 +87,15 @@ func (h *commandHandler) Stop(err error) {
 	h.stopSig.SignalWithError(err)
 }
 
-func (h *commandHandler) Notify(common.SensorComponentEvent) {}
+func (h *commandHandler) Notify(e common.SensorComponentEvent) {
+	switch e {
+	case common.SensorComponentEventCentralReachable:
+		h.centralReachable.Store(true)
+	case common.SensorComponentEventOfflineMode:
+		h.centralReachable.Store(false)
+		h.cancelPendingRequests()
+	}
+}
 
 func (h *commandHandler) ProcessMessage(msg *central.MsgToSensor) error {
 	switch m := msg.GetMsg().(type) {
@@ -98,7 +112,7 @@ func (h *commandHandler) processCancelRequest(req *central.CancelPullTelemetryDa
 	requestID := req.GetRequestId()
 
 	if requestID == "" {
-		return errors.New("received invalid telemetry cancellation request with empty request ID")
+		return errox.InvalidArgs.New("received invalid telemetry request with empty request ID")
 	}
 
 	h.pendingContextCancelsMutex.Lock()
@@ -113,15 +127,32 @@ func (h *commandHandler) processCancelRequest(req *central.CancelPullTelemetryDa
 	return nil
 }
 
+// cancelPendingRequests cancels all pending requests currently executed by the command handler.
+func (h *commandHandler) cancelPendingRequests() {
+	h.pendingContextCancelsMutex.Lock()
+	defer h.pendingContextCancelsMutex.Unlock()
+
+	for reqID, cancel := range h.pendingContextCancels {
+		if cancel != nil {
+			log.Infof("Cancelling telemetry pull request %s due to Central connection interruption", reqID)
+			delete(h.pendingContextCancels, reqID)
+		}
+	}
+}
+
 func (h *commandHandler) processRequest(req *central.PullTelemetryDataRequest) error {
 	if req.GetRequestId() == "" {
-		return errors.New("received invalid telemetry request with empty request ID")
+		return errox.InvalidArgs.New("received invalid telemetry request with empty request ID")
 	}
 	go h.dispatchRequest(req)
 	return nil
 }
 
 func (h *commandHandler) sendResponse(ctx concurrency.ErrorWaitable, resp *central.PullTelemetryDataResponse) error {
+	if !h.centralReachable.Load() {
+		log.Debugf("Sending telemetry response called while in offline mode, Telemetry response %s discarded",
+			resp.GetRequestId())
+	}
 	msg := &central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_TelemetryDataResponse{
 			TelemetryDataResponse: resp,
@@ -160,13 +191,13 @@ func (h *commandHandler) dispatchRequest(req *central.PullTelemetryDataRequest) 
 		ctx, cancel = context.WithCancel(ctx)
 		log.Infof("Received telemetry data request %s without a timeout", requestID)
 	}
+	defer cancel()
 
 	// Store the context in order to be able to react to cancellations.
 	concurrency.WithLock(&h.pendingContextCancelsMutex, func() {
 		h.pendingContextCancels[requestID] = cancel
 	})
 	defer func() {
-		cancel()
 		concurrency.WithLock(&h.pendingContextCancelsMutex, func() {
 			delete(h.pendingContextCancels, requestID)
 		})
@@ -225,6 +256,9 @@ func createKubernetesPayload(file k8sintrospect.File) *central.TelemetryResponse
 func (h *commandHandler) handleKubernetesInfoRequest(ctx context.Context,
 	sendMsgCb func(concurrency.ErrorWaitable, *central.TelemetryResponsePayload) error,
 	since *types.Timestamp) error {
+	subCtx, cancel := context.WithTimeout(ctx, diagnosticBundleTimeout)
+	defer cancel()
+
 	restCfg, err := rest.InClusterConfig()
 	if err != nil {
 		return errors.Wrap(err, "could not instantiate Kubernetes REST client config")
@@ -238,11 +272,14 @@ func (h *commandHandler) handleKubernetesInfoRequest(ctx context.Context,
 	if err != nil {
 		return errors.Wrap(err, "error parsing since timestamp")
 	}
-	return k8sintrospect.Collect(ctx, k8sintrospect.DefaultConfigWithSecrets(), restCfg, fileCb, sinceTs)
+
+	err = k8sintrospect.Collect(subCtx, k8sintrospect.DefaultConfigWithSecrets(), restCfg, fileCb, sinceTs)
+	return err
 }
 
-func (h *commandHandler) handleClusterInfoRequest(ctx context.Context, sendMsgCb func(concurrency.ErrorWaitable, *central.TelemetryResponsePayload) error) error {
-	subCtx, cancel := context.WithTimeout(ctx, gatherTimeout)
+func (h *commandHandler) handleClusterInfoRequest(ctx context.Context,
+	sendMsgCb func(concurrency.ErrorWaitable, *central.TelemetryResponsePayload) error) error {
+	subCtx, cancel := context.WithTimeout(ctx, diagnosticBundleTimeout)
 	defer cancel()
 	clusterInfo := h.clusterGatherer.Gather(subCtx)
 	jsonBytes, err := json.Marshal(clusterInfo)
@@ -277,15 +314,16 @@ func createMetricsPayload(file string, contents []byte) *central.TelemetryRespon
 	}
 }
 
-func (h *commandHandler) handleMetricsInfoRequest(ctx context.Context, sendMsgCb func(concurrency.ErrorWaitable, *central.TelemetryResponsePayload) error) error {
-	subCtx, cancel := context.WithTimeout(ctx, gatherTimeout)
+func (h *commandHandler) handleMetricsInfoRequest(ctx context.Context,
+	sendMsgCb func(concurrency.ErrorWaitable, *central.TelemetryResponsePayload) error) error {
+	subCtx, cancel := context.WithTimeout(ctx, diagnosticBundleTimeout)
 	defer cancel()
 
 	fileCb := func(ctx concurrency.ErrorWaitable, file string, contents []byte) error {
 		return sendMsgCb(ctx, createMetricsPayload(file, contents))
 	}
 	w := bytes.NewBuffer(nil)
-	err := prometheusutil.ExportText(w)
+	err := prometheusutil.ExportText(subCtx, w)
 	if err != nil {
 		return err
 	}
@@ -293,7 +331,7 @@ func (h *commandHandler) handleMetricsInfoRequest(ctx context.Context, sendMsgCb
 		return err
 	}
 	w = bytes.NewBuffer(nil)
-	if err := pprof.WriteHeapProfile(w); err != nil {
+	if err := writeHeapProfile(subCtx, w); err != nil {
 		return err
 	}
 	if err := fileCb(subCtx, "heap.pb.gz", w.Bytes()); err != nil {
@@ -303,5 +341,20 @@ func (h *commandHandler) handleMetricsInfoRequest(ctx context.Context, sendMsgCb
 }
 
 func (h *commandHandler) Capabilities() []centralsensor.SensorCapability {
-	return []centralsensor.SensorCapability{centralsensor.PullTelemetryDataCap, centralsensor.CancelTelemetryPullCap, centralsensor.PullMetricsCap}
+	return []centralsensor.SensorCapability{
+		centralsensor.PullTelemetryDataCap,
+		centralsensor.CancelTelemetryPullCap,
+		centralsensor.PullMetricsCap,
+	}
+}
+
+// writeHeapProfile is a wrapper around pprof.WriteHeapProfile which respects context cancellation.
+func writeHeapProfile(ctx context.Context, w io.Writer) error {
+	var err error
+	if ctxErr := concurrency.DoInWaitable(ctx, func() {
+		err = pprof.WriteHeapProfile(w)
+	}); ctxErr != nil {
+		return ctxErr
+	}
+	return err
 }

--- a/sensor/kubernetes/telemetry/command_handler.go
+++ b/sensor/kubernetes/telemetry/command_handler.go
@@ -38,7 +38,7 @@ const (
 var (
 	log = logging.LoggerForModule()
 
-	diagnosticBundleTimeout = env.DiagnosticBundleTimeout.DurationSetting()
+	diagnosticBundleTimeout = env.DiagnosticDataCollectionTimeout.DurationSetting()
 )
 
 type commandHandler struct {
@@ -152,6 +152,7 @@ func (h *commandHandler) sendResponse(ctx concurrency.ErrorWaitable, resp *centr
 	if !h.centralReachable.Load() {
 		log.Debugf("Sending telemetry response called while in offline mode, Telemetry response %s discarded",
 			resp.GetRequestId())
+		return nil
 	}
 	msg := &central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_TelemetryDataResponse{
@@ -273,8 +274,7 @@ func (h *commandHandler) handleKubernetesInfoRequest(ctx context.Context,
 		return errors.Wrap(err, "error parsing since timestamp")
 	}
 
-	err = k8sintrospect.Collect(subCtx, k8sintrospect.DefaultConfigWithSecrets(), restCfg, fileCb, sinceTs)
-	return err
+	return k8sintrospect.Collect(subCtx, k8sintrospect.DefaultConfigWithSecrets(), restCfg, fileCb, sinceTs)
 }
 
 func (h *commandHandler) handleClusterInfoRequest(ctx context.Context,

--- a/sensor/kubernetes/telemetry/gatherers/cluster.go
+++ b/sensor/kubernetes/telemetry/gatherers/cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/providers"
@@ -11,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/telemetry/data"
 	"github.com/stackrox/rox/pkg/telemetry/gatherers"
 	"github.com/stackrox/rox/sensor/common/store"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -37,7 +39,7 @@ func NewClusterGatherer(k8sClient kubernetes.Interface, deploymentStore store.De
 func (c *ClusterGatherer) Gather(ctx context.Context) *data.ClusterInfo {
 	errorList := errorhelpers.NewErrorList("")
 
-	orchestrator, err := c.getOrchestrator()
+	orchestrator, err := c.getOrchestrator(ctx)
 	errorList.AddError(err)
 
 	providerMetadata := providers.GetMetadata(ctx)
@@ -62,8 +64,18 @@ func (c *ClusterGatherer) Gather(ctx context.Context) *data.ClusterInfo {
 	}
 }
 
-func (c *ClusterGatherer) getOrchestrator() (*data.OrchestratorInfo, error) {
-	serverVersion, err := c.k8sClient.Discovery().ServerVersion()
+func (c *ClusterGatherer) getOrchestrator(ctx context.Context) (*data.OrchestratorInfo, error) {
+	var (
+		serverVersion *version.Info
+		err           error
+	)
+	// The default API client we use does not have a global timeout set and the discovery API does not respect context
+	// cancellation, hence need to wrap this with concurrency.DoWithinContext.
+	if ctxErr := concurrency.DoInWaitable(ctx, func() {
+		serverVersion, err = c.k8sClient.Discovery().ServerVersion()
+	}); ctxErr != nil {
+		return nil, ctxErr
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/sensor/kubernetes/telemetry/gatherers/cluster.go
+++ b/sensor/kubernetes/telemetry/gatherers/cluster.go
@@ -70,7 +70,7 @@ func (c *ClusterGatherer) getOrchestrator(ctx context.Context) (*data.Orchestrat
 		err           error
 	)
 	// The default API client we use does not have a global timeout set and the discovery API does not respect context
-	// cancellation, hence need to wrap this with concurrency.DoWithinContext.
+	// cancellation, hence need to wrap this with concurrency.DoInWaitable.
 	if ctxErr := concurrency.DoInWaitable(ctx, func() {
 		serverVersion, err = c.k8sClient.Discovery().ServerVersion()
 	}); ctxErr != nil {


### PR DESCRIPTION
## Description

We've recently had issues with the diagnostic bundle generation, specifically an issue where the metrics and Kubernetes info requests would run into timeouts due to not responding in-time.

The logs when the timeout occurs look like the following:
```log
debug/service: 2023/12/07 13:12:28.426410 diagnostics.go:63: Warn: Error pulling kubernetes info from sensor {"cluster_name": "remote", "error": "sensor didn't sent any data in last 5m0s"}
debug/service: 2023/12/07 13:17:28.432909 diagnostics.go:90: Warn: Error pulling metrics from sensor {"cluster_name": "remote", "error": "sensor didn't sent any data in last 5m0s"}
```

Alternatively, if Central was running into a client timeout (e.g. `roxctl` timeout) the logs look as follows:
```log
debug/service: 2023/12/07 14:44:00.982499 service.go:615: Error: Could not get K8s diagnostics: "context canceled"
debug/service: 2023/12/07 14:44:00.982734 diagnostics.go:63: Warn: Error pulling kubernetes info from sensor {"cluster_name": "remote", "error": "context error: context canceled"}
debug/service: 2023/12/07 14:44:00.983003 service.go:619: Error: Could not get sensor metrics: "failed to retrieve cluster list: creating transaction: context canceled"
```

There are multiple issues at hand:

Sensor seems to be "stuck" somewhere during collecting metrics / k8s info. This is mainly due to the fact that the timeout associated with the telemetry request is set to 1 hour:
```log
kubernetes/telemetry: 2023/12/07 12:57:03.550648 command_handler.go:158: Info: Received telemetry data request 716169ca-91f4-47c4-b75b-7b8febf05a25 with a timeout of 59m59.687s
kubernetes/telemetry: 2023/12/07 12:57:07.115138 command_handler.go:158: Info: Received telemetry data request c12e98ae-8b98-4e45-8f06-2d9a92131a48 with a timeout of 59m56.122s
```

Additionally, Central does not respect context cancellation correctly, as it is still attempting to write files even if a timeout has been reached:
```log
debug/service: 2023/12/07 14:44:01.178307 service.go:626: Error: unable to create zip file "telemetry-data.json": unable to create zip file "telemetry-data.json": http2: stream closed
debug/service: 2023/12/07 14:44:01.178645 service.go:291: Error: unable to create zip file "auth-providers.json": unable to create zip file "auth-providers.json": http2: stream closed
...
```

The PR has the following changes to address these things, as well as general QoL changes refactoring the existing code and making the concurrency handling less brittle (split by Central & Sensor changes):
_Central:_
- The K8S info and metrics collection has been refactored to get rid of writing files to the channel; and uses `conc` to structure the concurrency related parts more clearly.
- Context cancellation is now properly handled in all places (`debug service`; `diagnostics collection`; `telemetry controller`).
- The collection of data for a diagnostic bundle has been made concurrent. First, Central specific data will be fetched concurrently, then Sensor / telemetry data.
- The hardcoded timeout of 1o seconds for fetching cluster information from Sensors has been removed and the overall client timeout will be respected rather; this previously led to errors being reported in the `telemetry-data.json`.

_Sensor:_
- The telemetry command handler now reacts upon Central becoming unreachable; discarding any in-progress telemetry requests.
- Each telemetry gathering has been made context-aware where it previously wasn't; respecting now context cancellations.
- Previously, the `debugDumpHardTimeout (1 hour)` was used as context deadline during gathering (e.g. for k8s API calls); this has been now changed and a new timeout has been introduced controllable via the `ROX_DIAGNOSTIC_BUNDLE_TIMEOUT` environment variable.

_What has not been fixed (yet)_:
One issue that hasn't been addressed yet is that when the request context is cancelled by the client (either abort or deadline exceeded); the resulting ZIP may become corrupt. While the ZIP writer is now closed as soon as a context cancellation is hit, it still does not guarantee that at the time of context cancellation no other go routine is writing to the ZIP writer.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

(tested with multiple _external_ clusters to avoid lower network latency due to Central / Sensor being in the same cluster):

- Create a diagnostic bundle with a low timeout (specify custom timeout of 10s):
- Observe within the logs that everything is "cleaned up" properly, the writer is closed.

- Create a diagnostic bundle with the "normal" timeout:
- Verify the diagnostic bundle contents to be complete.

- Create a diagnostic bundle, after initializing the bundle creation bounce a sensor.
- Observe that the connection lost error is returned and added in the `pull-errors.txt` for the cluster, without additionally running into a timeout (i.e. the 5 minute one by `roxctl`).

- Create a diagnostic bundle, after initializing the bundle creation create a network policy disallowing Sensor to connect to the K8S API server (i.e. running into a timeout during K8S info gathering
- Observe a timeout being reported by Sensor, a EOS message sent to Central, and the diagnostic bundle containing the error in the `pull-errors.txt` for the cluster.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
