### PR TITLE
ROX-21437: Fix test failures due to newline character in deploy name

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveSingle.test.js
@@ -145,7 +145,7 @@ describe('Workload CVE Image CVE Single page', () => {
         // Test the the deployment links navigate to the correct page
         cy.get(`${selectors.firstTableRow} td[data-label="Deployment"] a`).then(
             ([$deploymentLink]) => {
-                const deploymentName = $deploymentLink.innerText;
+                const deploymentName = $deploymentLink.innerText.replace('\n', '');
                 cy.wrap($deploymentLink).click();
                 cy.get(`h1:contains("${deploymentName}")`);
             }


### PR DESCRIPTION
## Description

Fixes an occasional e2e test flake on ocp-4-13 when the test hits a deployment with a long-ish name. The long name causes the `<Truncate>` component to split the text into two lines, and the newline character fails when comparing text on the second page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Create a deployment with a long-ish name and verify the text is split across newlines. Run Cypress test before and after the change.
![image](https://github.com/stackrox/stackrox/assets/1292638/c5ed01cc-89e2-4cc4-a5e1-c4e78c702d19)
![image](https://github.com/stackrox/stackrox/assets/1292638/4dbde20b-4db0-44b3-9887-a2945777530b)
![image](https://github.com/stackrox/stackrox/assets/1292638/e5579202-f357-4c6c-b9b5-af67c52ac71d)
![image](https://github.com/stackrox/stackrox/assets/1292638/c6847f82-8ffb-443a-acaa-47c95b0e978c)
