### PR TITLE
ROX-21575: Add query locks part 2

### DIFF
--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -34,29 +34,25 @@ const (
 	// Explain Analyze indicated that 2 statements for PLOP is faster than one.
 	deleteOrphanedPLOPDeploymentsAndPI = `DELETE FROM listening_endpoints WHERE processindicatorid in (SELECT id from process_indicators pi WHERE NOT EXISTS
 		(SELECT 1 FROM deployments WHERE pi.deploymentid = deployments.Id) AND 
-		(signal_time < now() at time zone 'utc' - INTERVAL '%d MINUTES' OR signal_time is NULL))
-		FOR UPDATE`
+		(signal_time < now() at time zone 'utc' - INTERVAL '%d MINUTES' OR signal_time is NULL) FOR UPDATE)`
 
 	deleteOrphanedPLOPPods = `DELETE FROM listening_endpoints WHERE processindicatorid in (SELECT id from process_indicators pi WHERE NOT EXISTS
 		(SELECT 1 FROM pods WHERE pi.poduid = pods.Id) AND 
-		(signal_time < now() at time zone 'utc' - INTERVAL '%d MINUTES' OR signal_time is NULL))
-		FOR UPDATE`
+		(signal_time < now() at time zone 'utc' - INTERVAL '%d MINUTES' OR signal_time is NULL) FOR UPDATE)`
 
 	// Unfortunately if a listening endpoint is marked as being open there is no indication of how old it is.
 	// This leads to a possible race condition where a listening endpoint reaches the database before the deployment,
 	// and the pruning job happens to run before the deployment information arrives in the database.
 	// This should be rare, so this should be acceptable. This could be improved by adding a timestamp to the listening endpoints table
 	deleteOrphanedPLOPDeployments = `DELETE FROM listening_endpoints WHERE NOT EXISTS
-		(SELECT 1 FROM deployments WHERE listening_endpoints.deploymentid = deployments.Id)
-		FOR UPDATE`
+		(SELECT 1 FROM deployments WHERE listening_endpoints.deploymentid = deployments.Id FOR UPDATE)`
 
 	// Unfortunately if a listening endpoint is marked as being open there is no indication of how old it is.
 	// This leads to a possible race condition where a listening endpoint reaches the database before the pod,
 	// and the pruning job happens to run before the pod information arrives in the database.
 	// This should be rare, so this should be acceptable. This could be improved by adding a timestamp to the listening endpoints table
 	deleteOrphanedPLOPPodsWithPodUID = `DELETE FROM listening_endpoints WHERE poduid IS NOT NULL AND NOT EXISTS
-		(SELECT 1 FROM pods WHERE listening_endpoints.poduid = pods.Id)
-		FOR UPDATE`
+		(SELECT 1 FROM pods WHERE listening_endpoints.poduid = pods.Id FOR UPDATE)`
 
 	deleteOrphanedProcesses = `WITH orphan_proc AS 
 		(SELECT id FROM process_indicators pi WHERE NOT EXISTS 
@@ -109,7 +105,7 @@ const (
 	pruneAdministrationEvents = `DELETE FROM %s WHERE lastoccurredat < now() at time zone 'utc' - INTERVAL '%d MINUTES'`
 
 	// Delete orphaned PLOPs
-	pruneOrphanedPLOPs = `DELETE FROM listening_endpoints WHERE closetimestamp < now() at time zone 'utc' - INTERVAL '%d MINUTES FOR UPDATE`
+	pruneOrphanedPLOPs = `DELETE FROM listening_endpoints WHERE closetimestamp < now() at time zone 'utc' - INTERVAL '%d MINUTES'`
 )
 
 var (

--- a/central/processlisteningonport/datastore/datastore.go
+++ b/central/processlisteningonport/datastore/datastore.go
@@ -26,6 +26,8 @@ type DataStore interface {
 	WalkAll(ctx context.Context, fn WalkFn) error
 	RemoveProcessListeningOnPort(ctx context.Context, ids []string) error
 	RemovePlopsByPod(ctx context.Context, id string) error
+	Lock()
+	Unlock()
 }
 
 // New creates a data store object to access the database. Since some

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -235,8 +235,10 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 		}
 	}
 
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
+	//ds.mutex.Lock()
+	//defer ds.mutex.Unlock()
+	ds.Lock()
+	defer ds.Unlock()
 
 	// Now save actual PLOP objects
 	return ds.storage.UpsertMany(ctx, plopObjects)
@@ -518,9 +520,19 @@ func (ds *datastoreImpl) RemovePlopsByPod(ctx context.Context, id string) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
+	//ds.mutex.Lock()
+	//defer ds.mutex.Unlock()
+	ds.Lock()
+	defer ds.Unlock()
 
 	q := search.NewQueryBuilder().AddExactMatches(search.PodUID, id).ProtoQuery()
 	return ds.storage.DeleteByQuery(ctx, q)
+}
+
+func (ds *datastoreImpl) Lock() {
+	ds.mutex.Lock()
+}
+
+func (ds *datastoreImpl) Unlock() {
+	ds.mutex.Unlock()
 }

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -1902,15 +1902,15 @@ func (suite *PLOPDataStoreTestSuite) TestDeletePods() {
 
 	// Create a map to associate PodIds and PodUids. This is done to assign PodUids since makeRandomPlops
 	// doesn't do that. Also it is used in deleting PLOPs by PodUids.
-	podUidMap := make(map[string]string)
+	podUIDMap := make(map[string]string)
 
 	plopObjects := suite.makeRandomPlops(nport, nprocess, npod, fixtureconsts.Deployment1)
 
 	for _, plop := range plopObjects {
-		podUid, exists := podUidMap[plop.Process.PodId]
+		podUid, exists := podUIDMap[plop.Process.PodId]
 		if !exists {
 			plop.PodUid = uuid.NewV4().String()
-			podUidMap[plop.Process.PodId] = plop.PodUid
+			podUIDMap[plop.Process.PodId] = plop.PodUid
 		} else {
 			plop.PodUid = podUid
 		}
@@ -1940,7 +1940,7 @@ func (suite *PLOPDataStoreTestSuite) TestDeletePods() {
 	}()
 
 	// The pods are deleted and all PLOPs are deleted by pod
-	for _, podUid := range podUidMap {
+	for _, podUid := range podUIDMap {
 		suite.NoError(suite.datastore.RemovePlopsByPod(suite.hasWriteCtx, podUid))
 		// Sleep a little bit to increase the chance that the PLOPs will be deleted by RemovePlopsByPod at
 		// the same time as they are being deleted by the call to UpsertMany in AddProcessListeningOnPort.

--- a/central/processlisteningonport/datastore/mocks/datastore.go
+++ b/central/processlisteningonport/datastore/mocks/datastore.go
@@ -75,6 +75,18 @@ func (mr *MockDataStoreMockRecorder) GetProcessListeningOnPort(ctx, deployment a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProcessListeningOnPort", reflect.TypeOf((*MockDataStore)(nil).GetProcessListeningOnPort), ctx, deployment)
 }
 
+// Lock mocks base method.
+func (m *MockDataStore) Lock() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Lock")
+}
+
+// Lock indicates an expected call of Lock.
+func (mr *MockDataStoreMockRecorder) Lock() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Lock", reflect.TypeOf((*MockDataStore)(nil).Lock))
+}
+
 // RemovePlopsByPod mocks base method.
 func (m *MockDataStore) RemovePlopsByPod(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()
@@ -101,6 +113,18 @@ func (m *MockDataStore) RemoveProcessListeningOnPort(ctx context.Context, ids []
 func (mr *MockDataStoreMockRecorder) RemoveProcessListeningOnPort(ctx, ids any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveProcessListeningOnPort", reflect.TypeOf((*MockDataStore)(nil).RemoveProcessListeningOnPort), ctx, ids)
+}
+
+// Unlock mocks base method.
+func (m *MockDataStore) Unlock() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Unlock")
+}
+
+// Unlock indicates an expected call of Unlock.
+func (mr *MockDataStoreMockRecorder) Unlock() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unlock", reflect.TypeOf((*MockDataStore)(nil).Unlock))
 }
 
 // WalkAll mocks base method.

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	pruneInterval      = 5 * time.Minute
+	pruneInterval      = 1 * time.Hour
 	orphanWindow       = 30 * time.Minute
 	baselineBatchLimit = 10000
 	clusterGCFreq      = 24 * time.Hour

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	pruneInterval      = 1 * time.Hour
+	pruneInterval      = 5 * time.Minute
 	orphanWindow       = 30 * time.Minute
 	baselineBatchLimit = 10000
 	clusterGCFreq      = 24 * time.Hour


### PR DESCRIPTION
## Description

There are postgres errors such as the following resulting from pruning

```
2024-01-05 00:23:39.366 UTC [7678] DETAIL:  Process 7678 waits for ShareLock on transaction 1718495; blocked by process 6750.
	Process 6750 waits for ShareLock on transaction 1718264; blocked by process 7678.
	Process 7678: DELETE FROM listening_endpoints WHERE poduid IS NOT NULL AND NOT EXISTS
			(SELECT 1 FROM pods WHERE listening_endpoints.poduid = pods.Id)
	Process 6750: delete from listening_endpoints where listening_endpoints.PodUid = $1
2024-01-05 00:23:39.366 UTC [7678] HINT:  See server log for query details.
2024-01-05 00:23:39.366 UTC [7678] CONTEXT:  while deleting tuple (93996,16) in relation "listening_endpoints"
2024-01-05 00:23:39.366 UTC [7678] STATEMENT:  DELETE FROM listening_endpoints WHERE poduid IS NOT NULL AND NOT EXISTS
			(SELECT 1 FROM pods WHERE listening_endpoints.poduid = pods.Id)
```

This PR fixes those error by adding locks. This PR is built on top of https://github.com/stackrox/stackrox/pull/9222

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [x] Ran scale tests and did not observe the errors
- [x] Ran scale tests on another branch and saw the errors
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

The change doesn't merit user facing documentation and there is no change to the upgrade process.

## Testing Performed

Ran scale tests. Observed no errors in central-db after over two hours.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
