### PR TITLE
chore(scannerdefinitions): reduce log noise

### DIFF
--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -478,7 +478,7 @@ func (h *httpHandler) startUpdaterAndOpenFile(u *requestedUpdater) (*os.File, ti
 	if u == nil {
 		return nil, time.Time{}, errors.New("Fail to initialize updater")
 	}
-	log.Info("Initializing updater")
+	log.Debug("Initializing updater")
 	u.Start()
 	osFile, modTime, err := u.file.Open()
 	if err != nil {


### PR DESCRIPTION
## Description

Reducing the amount of log noise coming from the scannerdefinitions handler. This will especially become an issue once this version would be deployed in ACSCS.

Sample logs that are being created (note the frequency of the logs as well as the little information they seem to provide):
```log
scannerdefinitions/handler: 2024/01/07 08:31:18.885669 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:31:56.051325 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:32:11.560074 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:32:17.567578 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:32:57.714584 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:32:58.077319 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:34:11.389788 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:34:11.390577 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:36:18.882059 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:36:56.051384 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:37:11.558820 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:37:17.566547 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:37:57.714871 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:37:58.078681 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:39:11.394780 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:41:18.882809 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:41:56.050624 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:42:11.559771 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:42:17.567996 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:42:57.716367 handler.go:481:8556 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:46:18.881436 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:46:56.049796 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:47:11.561048 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:47:17.575540 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:47:57.714988 handler.go:481: Info: Initializing updater
scannerdefinitions/han1/07 08:49:11.390323 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:51:18.883840 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:51:56.049731 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:52:11.560589 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:52:17.567960 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:52:57.714752 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:52:58.078712/handler: 2024/01/07 08:54:11.391924 handler.go:481: Info: Initializing updater
scannerdefinitions/handler: 2024/01/07 08:56:18.881639 handler.go:481: Info: Initializing updater
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

N/A
### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
