### PR TITLE
fix(deploy-scripts): ROX-6382: Deploy Central via Helm Chart

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -292,16 +292,17 @@ function launch_central {
     ${KUBE_COMMAND:-kubectl} get namespace "${STACKROX_NAMESPACE}" &>/dev/null || \
       ${KUBE_COMMAND:-kubectl} create namespace "${STACKROX_NAMESPACE}"
 
-    if [[ -f "$unzip_dir/values-public.yaml" ]]; then
+    # Install Central via Helm
+    if [[ -f "$unzip_dir/helm/values-public.yaml" ]]; then
       if [[ -n "${REGISTRY_USERNAME}" ]]; then
-        $unzip_dir/scripts/setup.sh
+        $unzip_dir/helm/scripts/setup.sh
       fi
-      central_scripts_dir="$unzip_dir/scripts"
+      central_scripts_dir="$unzip_dir/helm/scripts"
 
       # New helm setup flavor
       helm_args=(
-        -f "$unzip_dir/values-public.yaml"
-        -f "$unzip_dir/values-private.yaml"
+        -f "$unzip_dir/helm/values-public.yaml"
+        -f "$unzip_dir/helm/values-private.yaml"
         --set-string imagePullSecrets.useExisting="stackrox;stackrox-scanner"
       )
 
@@ -364,7 +365,7 @@ function launch_central {
         )
       fi
 
-      local helm_chart="$unzip_dir/chart"
+      local helm_chart="$unzip_dir/helm/chart"
 
       if [[ -n "${CENTRAL_CHART_DIR_OVERRIDE}" ]]; then
         echo "Using override central helm chart from ${CENTRAL_CHART_DIR_OVERRIDE}"
@@ -380,6 +381,7 @@ function launch_central {
       helm upgrade --install -n stackrox stackrox-central-services "$helm_chart" \
           "${helm_args[@]}"
     else
+      echo "legacy manifest install"
       if [[ -n "${REGISTRY_USERNAME}" ]]; then
         $unzip_dir/central/scripts/setup.sh
       fi


### PR DESCRIPTION
## Description

ROX-6382: Deploy Central via Helm Chart

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

 - Deploy Helm locally via Deploy Scripts
 - Executed `logmein` script, logged in successfully
 - CI runs