### PR TITLE
chore(tests): Add test to validate the default collection method

### DIFF
--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/collector-collection-method.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/collector-collection-method.test.yaml
@@ -1,0 +1,7 @@
+values:
+  imagePullSecrets:
+    allowNone: true
+tests:
+- name: "test default collection method is CORE_BPF"
+  expect: |
+   envVars(.daemonsets.collector; "collector")["COLLECTION_METHOD"] | assertThat(. == "CORE_BPF")


### PR DESCRIPTION
## Description

A helm chart test to check the collection method is CORE_BPF.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added

## Testing Performed

Local run of helm tests.