### PR TITLE
ROX-7401: Change entity not found logs 

### DIFF
--- a/sensor/common/metrics/init.go
+++ b/sensor/common/metrics/init.go
@@ -17,6 +17,7 @@ func init() {
 		processEnrichmentLRUCacheSize,
 		sensorIndicatorChannelFullCounter,
 		networkFlowBufferGauge,
+		entitiesNotFound,
 		totalNetworkFlowsSentCounter,
 		totalNetworkFlowsReceivedCounter,
 		totalNetworkEndpointsSentCounter,

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -83,6 +83,13 @@ var (
 		Help:      "A gauge of the current size of the Network Flow buffer in Sensor (updated every 30s)",
 	})
 
+	entitiesNotFound = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "detector_network_flow_entity_not_found",
+		Help:      "Total number of entities not found when processing Network Flows",
+	}, []string{"kind", "orientation"})
+
 	totalNetworkFlowsSentCounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
@@ -222,6 +229,14 @@ var (
 		[]string{"central_id", "hosting", "install_method", "sensor_id"},
 	)
 )
+
+// IncrementEntityNotFound increments an instance of entity not found
+func IncrementEntityNotFound(kind, orientation string) {
+	entitiesNotFound.With(prometheus.Labels{
+		"kind":        kind,
+		"orientation": orientation,
+	}).Inc()
+}
 
 // IncrementDetectorCacheHit increments the number of deployments deduped by the detector
 func IncrementDetectorCacheHit() {


### PR DESCRIPTION
## Description

Remove entity not found logs in cases where the deployment or external source is not found. This case can happen if Network Flows are processed for entities that no longer exist in the cluster (i.e. pod was deleted). The flows are simply dropped in this case, but in some large environments, the sensor logs were flooded with log lines. 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] CI passed
- [ ] Metric increased in a scenario where logs would be shown

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
