### PR TITLE
ROX-21608: Drop `IsExternal`, rename `IsExternalDB`

### DIFF
--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -176,9 +176,9 @@ func (c *CentralComponentSpec) GetAdminPasswordGenerationDisabled() bool {
 	return pointer.BoolDeref(c.AdminPasswordGenerationDisabled, false)
 }
 
-// IsExternalDB returns true if central DB is not managed by the Operator
-func (c *CentralComponentSpec) IsExternalDB() bool {
-	return c != nil && c.DB.IsExternal()
+// ShouldManageDB returns true if central DB should be managed by the Operator.
+func (c *CentralComponentSpec) ShouldManageDB() bool {
+	return c == nil || c.DB == nil || c.DB.ConnectionStringOverride == nil
 }
 
 // GetNotifierSecretsEncryptionEnabled provides a way to retrieve the NotifierSecretsEncryption.Enabled setting that is safe to use on a nil receiver object.
@@ -229,7 +229,7 @@ type CentralDBSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Administrator Password",order=1
 	PasswordSecret *LocalSecretReference `json:"passwordSecret,omitempty"`
 
-	// Specify a connection string that corresponds to an external database. If set, the operator will not manage Central DB.
+	// Specify a connection string that corresponds to a database managed elsewhere. If set, the operator will not manage the Central DB.
 	// When using this option, you must explicitly set a password secret; automatically generating a password will not
 	// be supported.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=2,displayName="Connection String"
@@ -275,14 +275,6 @@ func (c *CentralDBSpec) GetPasswordSecret() *LocalSecretReference {
 		return nil
 	}
 	return c.PasswordSecret
-}
-
-// IsExternal specifies that the database should not be managed by the Operator
-func (c *CentralDBSpec) IsExternal() bool {
-	if c == nil {
-		return false
-	}
-	return c.ConnectionStringOverride != nil
 }
 
 // GetPersistence returns the persistence for Central DB

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -74,10 +74,10 @@ spec:
                         type: object
                       connectionString:
                         description: Specify a connection string that corresponds
-                          to an external database. If set, the operator will not manage
-                          Central DB. When using this option, you must explicitly
-                          set a password secret; automatically generating a password
-                          will not be supported.
+                          to a database managed elsewhere. If set, the operator will
+                          not manage the Central DB. When using this option, you must
+                          explicitly set a password secret; automatically generating
+                          a password will not be supported.
                         type: string
                       isEnabled:
                         default: Default

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -172,10 +172,10 @@ spec:
           in the "password" item in the "central-db-password" secret.
         displayName: Administrator Password
         path: central.db.passwordSecret
-      - description: Specify a connection string that corresponds to an external database.
-          If set, the operator will not manage Central DB. When using this option,
-          you must explicitly set a password secret; automatically generating a password
-          will not be supported.
+      - description: Specify a connection string that corresponds to a database managed
+          elsewhere. If set, the operator will not manage the Central DB. When using
+          this option, you must explicitly set a password secret; automatically generating
+          a password will not be supported.
         displayName: Connection String
         path: central.db.connectionString
       - description: Configures how Central DB should store its persistent data. You

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -74,10 +74,10 @@ spec:
                         type: object
                       connectionString:
                         description: Specify a connection string that corresponds
-                          to an external database. If set, the operator will not manage
-                          Central DB. When using this option, you must explicitly
-                          set a password secret; automatically generating a password
-                          will not be supported.
+                          to a database managed elsewhere. If set, the operator will
+                          not manage the Central DB. When using this option, you must
+                          explicitly set a password secret; automatically generating
+                          a password will not be supported.
                         type: string
                       isEnabled:
                         default: Default

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -148,10 +148,10 @@ spec:
           effect.
         displayName: Scanner Component
         path: scanner.scannerComponent
-      - description: Specify a connection string that corresponds to an external database.
-          If set, the operator will not manage Central DB. When using this option,
-          you must explicitly set a password secret; automatically generating a password
-          will not be supported.
+      - description: Specify a connection string that corresponds to a database managed
+          elsewhere. If set, the operator will not manage the Central DB. When using
+          this option, you must explicitly set a password secret; automatically generating
+          a password will not be supported.
         displayName: Connection String
         path: central.db.connectionString
       - description: The size of the persistent volume when created through the claim.

--- a/operator/pkg/central/extensions/reconcile_central_db_password.go
+++ b/operator/pkg/central/extensions/reconcile_central_db_password.go
@@ -74,8 +74,8 @@ func (r *reconcileCentralDBPasswordExtensionRun) Execute(ctx context.Context) er
 	if centralSpec != nil && centralSpec.DB != nil {
 		dbSpec := centralSpec.DB
 		dbPasswordSecret := dbSpec.PasswordSecret
-		if dbSpec.IsExternal() && dbPasswordSecret == nil {
-			return errors.New("setting spec.central.db.passwordSecret is mandatory when using an external DB")
+		if dbSpec.ConnectionStringOverride != nil && dbPasswordSecret == nil {
+			return errors.New("setting spec.central.db.passwordSecret is mandatory when using an DB not managed by the operator")
 		}
 
 		if dbPasswordSecret != nil {

--- a/operator/pkg/central/extensions/reconcile_central_db_password_test.go
+++ b/operator/pkg/central/extensions/reconcile_central_db_password_test.go
@@ -203,7 +203,7 @@ func TestReconcileDBPassword(t *testing.T) {
 			Existing:      []*v1.Secret{canonicalPWSecretWithNoPassword},
 			ExpectedError: "secret must contain a non-empty",
 		},
-		"When using an external DB with specified password secret, that secret should be left untouched": {
+		"When not managing central DB, with specified password secret, that secret should be left untouched": {
 			Spec: v1alpha1.CentralSpec{
 				Central: &v1alpha1.CentralComponentSpec{
 					DB: &v1alpha1.CentralDBSpec{
@@ -216,7 +216,7 @@ func TestReconcileDBPassword(t *testing.T) {
 			},
 			Existing: []*v1.Secret{customPWSecretWithPW1, canonicalPWSecretWithPW1},
 		},
-		"When using an external DB, and no password secret is specified, an error should be raised": {
+		"When not managing central DB, and no password secret is specified, an error should be raised": {
 			Spec: v1alpha1.CentralSpec{
 				Central: &v1alpha1.CentralComponentSpec{
 					DB: &v1alpha1.CentralDBSpec{
@@ -224,7 +224,7 @@ func TestReconcileDBPassword(t *testing.T) {
 					},
 				},
 			},
-			ExpectedError: "setting spec.central.db.passwordSecret is mandatory when using an external DB",
+			ExpectedError: "setting spec.central.db.passwordSecret is mandatory when using an DB not managed by the operator",
 		},
 	}
 

--- a/operator/pkg/central/extensions/reconcile_pvc.go
+++ b/operator/pkg/central/extensions/reconcile_pvc.go
@@ -83,7 +83,7 @@ func getPersistenceByTarget(central *platform.Central, target PVCTarget) *platfo
 		}
 		return persistence
 	case PVCTargetCentralDB:
-		if central.Spec.Central.IsExternalDB() {
+		if !central.Spec.Central.ShouldManageDB() {
 			return nil
 		}
 		dbPersistence := central.Spec.Central.GetDB().GetPersistence()

--- a/operator/pkg/central/extensions/reconcile_tls.go
+++ b/operator/pkg/central/extensions/reconcile_tls.go
@@ -161,7 +161,7 @@ func (r *createCentralTLSExtensionRun) generateCentralTLSData() (types.SecretDat
 }
 
 func (r *createCentralTLSExtensionRun) reconcileCentralDBTLSSecret(ctx context.Context) error {
-	if !r.centralObj.Spec.Central.IsExternalDB() {
+	if r.centralObj.Spec.Central.ShouldManageDB() {
 		return r.EnsureSecret(ctx, "central-db-tls", r.validateCentralDBTLSData, r.generateCentralDBTLSData, true)
 	}
 	return r.DeleteSecret(ctx, "central-db-tls")

--- a/operator/tests/central/central-basic/76-switch-back-to-internal-central-db.yaml
+++ b/operator/tests/central/central-basic/76-switch-back-to-internal-central-db.yaml
@@ -11,7 +11,7 @@ delete:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   name: central-db
-# Clean up the external DB password secret, we no longer refer to it in this step.
+# Clean up the password secret for unmanaged DB, we no longer refer to it in this step.
 - apiVersion: v1
   kind: Secret
   name: my-central-db-password


### PR DESCRIPTION
## Description

This way this function:
- returns `true` when the feature (management of central-db) is enabled
- reduces potential to confuse DB managed/not managed with "rocksdb vs postgres"

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI should be sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
