### PR TITLE
ROX-20936: Fix 'too_many_pings' in Compliance

### DIFF
--- a/pkg/clientconn/client.go
+++ b/pkg/clientconn/client.go
@@ -285,7 +285,14 @@ func AuthenticatedGRPCConnection(endpoint string, server mtls.Subject, extraConn
 	}
 
 	var dialOpts []grpc.DialOption
-	dialOpts = append(dialOpts, keepAliveDialOption())
+	// To avoid getting 'Client received GoAway with error code ENHANCE_YOUR_CALM and debug data equal to ASCII "too_many_pings"'
+	// from Sensor in Compliance, we must match the client and server settings for keepalive
+	// See: https://github.com/grpc/grpc/blob/master/doc/keepalive.md#faq
+	dialOpts = append(dialOpts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
+		Time:                10 * time.Second,
+		Timeout:             40 * time.Second,
+		PermitWithoutStream: false,
+	}))
 	if clientConnOpts.MaxMsgRecvSize > 0 {
 		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(clientConnOpts.MaxMsgRecvSize)))
 	}

--- a/pkg/clientconn/client.go
+++ b/pkg/clientconn/client.go
@@ -435,16 +435,3 @@ func NewHTTPClient(serviceIdentity mtls.Subject, serviceEndpoint string, timeout
 		Transport: transport,
 	}, nil
 }
-
-// Parameters for keep alive.
-func keepAliveDialOption() grpc.DialOption {
-	// Since we are holding open a GRPC stream, enable keep alive.
-	// Ping every minute of inactivity, and wait 30 seconds. Do this even when no streams are open (though
-	// one should always be open with central.)
-	params := keepalive.ClientParameters{
-		Time:                10 * time.Second,
-		Timeout:             30 * time.Second,
-		PermitWithoutStream: true,
-	}
-	return grpc.WithKeepaliveParams(params)
-}


### PR DESCRIPTION
## Description

This PR configures the keepalive params of the connection between Compliance (Node scanning) and Sensor, so that the client and server match and we no longer get  `too_many_pings` in the logs.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

1. I manually checked if the node scanning feature still works (in the UI).

2. Manual test on OCP:

- Regular deployment with `./deploy/openshift/deploy.sh`
- Setting compliance to spam sensor: `ocs set env daemonsets/collector --containers="compliance" ROX_NODE_SCANNING_INITIAL_BACKOFF="1s" ROX_NODE_SCANNING_MAX_INITIAL_WAIT="1s" ROX_NODE_SCANNING_INTERVAL="1m"`
- Observing Compliance logs for few hours (overnight)


Before (note the version):

```
│ No certificates found in /usr/local/share/ca-certificates                                                                                                                                                                                                            
│ No certificates found in /etc/pki/injected-ca-trust                                                                                                                                                                                                                
│ collection/compliance: 2024/01/08 16:42:54.655996 node_scanner.go:45: Info: Initialized gRPC connection to node-inventory container                                                                                                                                  
│ collection/compliance: 2024/01/08 16:42:54.656186 compliance.go:50: Info: Running StackRox Version: 4.3.x-631-gaf6b510092                                                                                                                                            
│ pkg/metrics: 2024/01/08 16:42:54.656260 server.go:142: Warn: Secure metrics server is disabled                                                                                                                                                                     
│ pkg/metrics: 2024/01/08 16:42:54.656342 server.go:125: Warn: Metrics server is disabled                                                                                                                                                                             
│ pkg/metrics: 2024/01/08 16:42:54.656381 server.go:142: Warn: Secure metrics server is disabled                                                                                                                                                                       │
│ pkg/metrics: 2024/01/08 16:42:54.656450 server.go:125: Warn: Metrics server is disabled                                                                                                                                                                              
│ pkg/metrics: 2024/01/08 16:42:54.656485 server.go:142: Warn: Secure metrics server is disabled                                                                                                                                                                       
│ collection/compliance: 2024/01/08 16:42:54.657782 compliance.go:65: Info: Initialized gRPC stream connection to Sensor                                                                                                                                               
│ collection/intervals: 2024/01/08 16:42:54.657925 intervals.go:64: Info: Scanning intervals: base interval: 1m0s, maximum absolute deviation from base: 1m0s, first scan starts not later than in: 1s                                                                 
│ collection/intervals: 2024/01/08 16:42:54.657952 intervals.go:72: Info: Initial scanning in 616.35134ms                                                                                                                                                              
│ collection/compliance: 2024/01/08 16:42:54.694135 compliance.go:282: Info: Successfully connected to Sensor at sensor.stackrox.svc:443                                                                                                                               
│ collection/compliance: 2024/01/08 16:42:55.274490 compliance.go:126: Info: Scanning node "piotr-01-08-99pc-rb7qj-worker-b-cfn6k"                                                                                                                                     
│ collection/intervals: 2024/01/08 16:42:57.612766 intervals.go:82: Info: Next node scan in 1m48.128418698s                                                                                                                                                            
│ collection/compliance: 2024/01/08 16:42:57.612841 compliance.go:126: Info: Scanning node "piotr-01-08-99pc-rb7qj-worker-b-cfn6k"                                                                                                                                     
│ collection/intervals: 2024/01/08 16:42:57.619450 intervals.go:82: Info: Next node scan in 41.598030849s                                                                                                                                                              
│ 2024/01/08 16:43:27 ERROR: [transport] Client received GoAway with error code ENHANCE_YOUR_CALM and debug data equal to ASCII "too_many_pings".                                                                                                                      
│ collection/compliance: 2024/01/08 16:43:39.224050 compliance.go:126: Info: Scanning node "piotr-01-08-99pc-rb7qj-worker-b-cfn6k"                                                                                                                                     
│ collection/intervals: 2024/01/08 16:43:39.228174 intervals.go:82: Info: Next node scan in 1m28.993506076s                                                                                                                                                            
│ 2024/01/08 16:44:39 ERROR: [transport] Client received GoAway with error code ENHANCE_YOUR_CALM and debug data equal to ASCII "too_many_pings".                                                                                                                      
│ collection/compliance: 2024/01/08 16:45:08.221857 compliance.go:126: Info: Scanning node "piotr-01-08-99pc-rb7qj-worker-b-cfn6k"                                                                                                                                     
│ collection/intervals: 2024/01/08 16:45:08.230182 intervals.go:82: Info: Next node scan in 1m54.239516394s
```

After:

```
No certificates found in /usr/local/share/ca-certificates
No certificates found in /etc/pki/injected-ca-trust
collection/compliance: 2024/01/08 16:48:07.047172 node_scanner.go:45: Info: Initialized gRPC connection to node-inventory container
collection/compliance: 2024/01/08 16:48:07.047320 compliance.go:50: Info: Running StackRox Version: 4.3.x-626-g78b7bd2397
pkg/metrics: 2024/01/08 16:48:07.047374 server.go:142: Warn: Secure metrics server is disabled
pkg/metrics: 2024/01/08 16:48:07.047441 server.go:125: Warn: Metrics server is disabled
pkg/metrics: 2024/01/08 16:48:07.047462 server.go:142: Warn: Secure metrics server is disabled
pkg/metrics: 2024/01/08 16:48:07.047519 server.go:125: Warn: Metrics server is disabled
pkg/metrics: 2024/01/08 16:48:07.047585 server.go:142: Warn: Secure metrics server is disabled
collection/compliance: 2024/01/08 16:48:07.048593 compliance.go:65: Info: Initialized gRPC stream connection to Sensor
collection/intervals: 2024/01/08 16:48:07.048657 intervals.go:64: Info: Scanning intervals: base interval: 1m0s, maximum absolute deviation from base: 1m0s, first scan starts not later than in: 1s
collection/intervals: 2024/01/08 16:48:07.048673 intervals.go:72: Info: Initial scanning in 532.978803ms
collection/compliance: 2024/01/08 16:48:07.086540 compliance.go:282: Info: Successfully connected to Sensor at sensor.stackrox.svc:443
collection/compliance: 2024/01/08 16:48:07.581801 compliance.go:126: Info: Scanning node "piotr-01-08-99pc-rb7qj-worker-c-mn8cf"
collection/intervals: 2024/01/08 16:48:09.779830 intervals.go:82: Info: Next node scan in 55.857394293s
collection/compliance: 2024/01/08 16:48:09.779881 compliance.go:126: Info: Scanning node "piotr-01-08-99pc-rb7qj-worker-c-mn8cf"
collection/intervals: 2024/01/08 16:48:09.783992 intervals.go:82: Info: Next node scan in 1m15.620288609s
collection/compliance: 2024/01/08 16:49:25.407523 compliance.go:126: Info: Scanning node "piotr-01-08-99pc-rb7qj-worker-c-mn8cf"
collection/intervals: 2024/01/08 16:49:25.412079 intervals.go:82: Info: Next node scan in 13.335713363s

```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
