### PR TITLE
ROX-21271: Add error handling to violations page exclusions action

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
@@ -4,7 +4,6 @@ import {
     Alert,
     AlertActionCloseButton,
     AlertGroup,
-    AlertVariant,
     Breadcrumb,
     BreadcrumbItem,
     Dropdown,
@@ -252,7 +251,7 @@ function PolicyDetail({
                 <AlertGroup isToast isLiveRegion>
                     {toasts.map(({ key, variant, title, children }: Toast) => (
                         <Alert
-                            variant={AlertVariant[variant]}
+                            variant={variant}
                             title={title}
                             timeout={4000}
                             onTimeout={() => removeToast(key)}

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
@@ -7,7 +7,6 @@ import {
     Spinner,
     AlertGroup,
     AlertActionCloseButton,
-    AlertVariant,
     Divider,
     Button,
 } from '@patternfly/react-core';
@@ -241,7 +240,7 @@ function PoliciesTablePage({
             <AlertGroup isToast isLiveRegion>
                 {toasts.map(({ key, variant, title, children }: Toast) => (
                     <Alert
-                        variant={AlertVariant[variant]}
+                        variant={variant}
                         title={title}
                         timeout={4000}
                         onTimeout={() => removeToast(key)}

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
@@ -11,7 +11,6 @@ import {
     ToolbarItem,
     AlertGroup,
     Alert,
-    AlertVariant,
     AlertActionCloseButton,
 } from '@patternfly/react-core';
 
@@ -116,7 +115,7 @@ function PolicyCategoriesPage(): React.ReactElement {
             <AlertGroup isToast isLiveRegion>
                 {toasts.map(({ key, variant, title, children }: Toast) => (
                     <Alert
-                        variant={AlertVariant[variant]}
+                        variant={variant}
                         title={title}
                         component="div"
                         timeout={4000}

--- a/ui/apps/platform/src/Containers/Violations/Modals/ExcludeConfirmation.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Modals/ExcludeConfirmation.tsx
@@ -1,18 +1,28 @@
 import React, { ReactElement } from 'react';
 import pluralize from 'pluralize';
-import { Modal, ModalVariant, Button } from '@patternfly/react-core';
+import { Alert, Button, Flex, Modal, ModalVariant, Text } from '@patternfly/react-core';
 
 import { excludeDeployments } from 'services/PoliciesService';
-import { ListAlert } from 'types/alert.proto';
+import { DeploymentListAlert, ListAlert } from 'types/alert.proto';
+import useRestMutation from 'hooks/useRestMutation';
+import { Empty } from 'services/types';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 // Filter the excludableAlerts displayed down to the ones checked, and group them into a map from policy ID to a list of
 // deployment names, then exclude every policy ID, deployment name pair in the map.
-function excludeAlerts(checkedAlertIds, excludableAlerts) {
-    const checkedAlertsSet = new Set(checkedAlertIds);
+function excludeAlerts({
+    selectedAlertIds,
+    excludableAlerts,
+}: {
+    selectedAlertIds: string[];
+    excludableAlerts: ListAlert[];
+}): Promise<Empty[]> {
+    const checkedAlertsSet = new Set(selectedAlertIds);
 
     const policyToDeployments = {};
     excludableAlerts
         .filter(({ id }) => checkedAlertsSet.has(id))
+        .filter((alert): alert is DeploymentListAlert => 'deployment' in alert)
         .forEach(({ policy, deployment }) => {
             if (!policyToDeployments[policy.id]) {
                 policyToDeployments[policy.id] = [deployment.name];
@@ -43,30 +53,56 @@ function ExcludeConfirmation({
     cancelModal,
     isOpen,
 }: ExcludeConfirmationProps): ReactElement {
-    function excludeDeploymentsAction() {
-        excludeAlerts(selectedAlertIds, excludableAlerts).then(closeModal, closeModal);
-    }
+    const { mutate, isLoading, error, reset } = useRestMutation(excludeAlerts, {
+        onSuccess: () => {
+            closeModal();
+            reset();
+        },
+    });
 
     const numSelectedRows = selectedAlertIds.length;
     return (
         <Modal
             isOpen={isOpen}
-            variant={ModalVariant.small}
+            variant={ModalVariant.medium}
             actions={[
-                <Button key="confirm" variant="primary" onClick={excludeDeploymentsAction}>
+                <Button
+                    key="confirm"
+                    variant="primary"
+                    isDisabled={isLoading}
+                    isLoading={isLoading}
+                    onClick={() => mutate({ selectedAlertIds, excludableAlerts })}
+                >
                     Confirm
                 </Button>,
                 <Button key="cancel" variant="link" onClick={cancelModal}>
                     Cancel
                 </Button>,
             ]}
-            onClose={cancelModal}
+            onClose={() => {
+                cancelModal();
+                reset();
+            }}
             aria-label="Confirm excluding violations"
         >
-            {`Are you sure you want to exclude ${numSelectedRows} ${pluralize(
-                'violation',
-                numSelectedRows
-            )}?`}
+            <Flex direction={{ default: 'column' }}>
+                <Text>
+                    {`Are you sure you want to exclude deployments from ${numSelectedRows} policy ${pluralize(
+                        'violation',
+                        numSelectedRows
+                    )}?`}
+                </Text>
+                {error && (
+                    <Alert
+                        variant="danger"
+                        title="There was an error excluding one or more deployments"
+                        component="p"
+                        isInline
+                    >
+                        {getAxiosErrorMessage(error)}
+                    </Alert>
+                )}
+            </Flex>
         </Modal>
     );
 }

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -277,6 +277,7 @@ function ViolationsTablePanel({
                                     {hasActions && (
                                         <Td>
                                             <ActionsColumn
+                                                menuAppendTo={() => document.body}
                                                 isDisabled={actionItems.length === 0}
                                                 items={actionItems}
                                             />

--- a/ui/apps/platform/src/hooks/patternfly/useToasts.tsx
+++ b/ui/apps/platform/src/hooks/patternfly/useToasts.tsx
@@ -1,6 +1,7 @@
+import { AlertProps } from '@patternfly/react-core';
 import { ReactNode, useState } from 'react';
 
-export type AlertVariantType = 'default' | 'info' | 'success' | 'danger' | 'warning';
+export type AlertVariantType = AlertProps['variant'];
 
 export type Toast = {
     title: string;
@@ -11,8 +12,8 @@ export type Toast = {
 
 type UseToasts = {
     toasts: Toast[];
-    addToast: (title, variant?: AlertVariantType, children?: ReactNode) => void;
-    removeToast: (key) => void;
+    addToast: (title: string, variant?: AlertVariantType, children?: ReactNode) => void;
+    removeToast: (key: string) => void;
 };
 
 function useToasts(): UseToasts {
@@ -22,12 +23,12 @@ function useToasts(): UseToasts {
         return `${new Date().toISOString()} ${Math.random()}`;
     }
 
-    function addToast(title, variant = 'default' as AlertVariantType, children) {
+    function addToast(title: string, variant: AlertVariantType = 'default', children: ReactNode) {
         const key = getUniqueId();
         setToasts((prevToasts) => [{ title, variant, key, children }, ...prevToasts]);
     }
 
-    function removeToast(key) {
+    function removeToast(key: string) {
         setToasts((prevToasts) => [...prevToasts.filter((el) => el.key !== key)]);
     }
 

--- a/ui/apps/platform/src/types/alert.proto.ts
+++ b/ui/apps/platform/src/types/alert.proto.ts
@@ -144,7 +144,7 @@ export type ViolationState = 'ACTIVE' | 'SNOOZED' | 'RESOLVED' | 'ATTEMPTED';
 
 export type ListAlert = DeploymentListAlert | ResourceListAlert;
 
-type DeploymentListAlert = {
+export type DeploymentListAlert = {
     commonEntityInfo: CommonEntityInfo & {
         resourceType: 'DEPLOYMENT';
     };


### PR DESCRIPTION
## Description

Adds error handling to the "Exclude deployment from policy" menu option on the Violations page. Fixes [ROX-21270](https://issues.redhat.com/browse/ROX-21270), where an error was occurring but it was not clear why clicking the action button seemed to have no effect.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

On the violations page, exclude deployments via the row menu as well as the bulk dropdown. The happy path should remain the same:

https://github.com/stackrox/stackrox/assets/1292638/5a137fdf-e6ac-463b-bc4a-f0cbf222580a

Test both actions again, this time with a simulated error at the network level:

https://github.com/stackrox/stackrox/assets/1292638/92eb926e-5250-45ee-b503-436df3034eee




