### PR TITLE
ROX-21619: Cosmetic Improvements for Helm Chart post-Install Notes

### DIFF
--- a/image/templates/helm/stackrox-central/templates/NOTES.txt.htpl
+++ b/image/templates/helm/stackrox-central/templates/NOTES.txt.htpl
@@ -1,15 +1,14 @@
 {{- $_ := include "srox.init" . -}}
 
-StackRox {{.Chart.AppVersion}} has been installed.
+StackRox Central Services has been installed.
 
 [< if not .Operator >]
 Central Services Configuration Summary:
 
-  Name:                                        {{ ._rox.clusterName }}
+  Stackrox Version:                            {{ .Chart.AppVersion }}
   Kubernetes Version:                          {{ ._rox._apiServer.version }}
   Kubernetes Namespace:                        {{ .Release.Namespace }}
   Helm Release Name:                           {{ .Release.Name }}
-  Central Endpoint:                            {{ ._rox.centralEndpoint }}
   OpenShift Cluster:                           {{ if eq ._rox.env.openshift 0 -}} false {{ else -}} {{ ._rox.env.openshift }} {{ end }}
 [<- if .FeatureFlags.ROX_SCANNER_V4 >]
   Scanner V4 Installation Method:              {{ ._rox.scannerV4._installMode }}


### PR DESCRIPTION
## Description

See https://issues.redhat.com/browse/ROX-21619. This PR:

* removes the bogus `clusterName` and `centralEndpoint` from the post-installation NOTES -- these two got accidentally copied over from the secured-cluster-services Helm chart.
* slightly improve the way the StackRox version is reported.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~~Unit test and regression tests added~~
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes~~

## Testing Performed

No testing performed besides CI, as this is just a cosmetic change.

