### PR TITLE
fix: Revert "ROX-21573: Telemetry heartbeat event"

### DIFF
--- a/pkg/telemetry/phonehome/gatherer.go
+++ b/pkg/telemetry/phonehome/gatherer.go
@@ -78,9 +78,6 @@ func (g *gatherer) identify() {
 	if !reflect.DeepEqual(g.lastData, data) {
 		// Issue an event so that the new data become visible on analytics:
 		g.telemeter.Track("Updated "+g.clientType+" Identity", nil, append(g.opts, telemeter.WithTraits(data))...)
-	} else {
-		// No changes in properties, just send a heartbeat event:
-		g.telemeter.Track(g.clientType+" Heartbeat", nil, g.opts...)
 	}
 	g.lastData = data
 }

--- a/pkg/telemetry/phonehome/gatherer_test.go
+++ b/pkg/telemetry/phonehome/gatherer_test.go
@@ -33,8 +33,6 @@ func (s *gathererTestSuite) TestGatherer() {
 
 	t.EXPECT().Track("Updated Test Identity", nil,
 		matchOptions(telemeter.WithTraits(map[string]any{"key": "value"}))).Times(1)
-	t.EXPECT().Track("Test Heartbeat", nil,
-		matchOptions(telemeter.WithTraits(nil))).Times(1)
 
 	props := make(map[string]any)
 	var i int64


### PR DESCRIPTION
Reverts stackrox/stackrox#9215 due to a unit test flake.