### PR TITLE
ROX-18526: add fine-grained authorization to Scanner v4 endpoints

### DIFF
--- a/pkg/grpc/authz/idcheck/id_check.go
+++ b/pkg/grpc/authz/idcheck/id_check.go
@@ -5,6 +5,11 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz"
 )
 
+// CentralOnly returns a serviceType authorizer that checks for the Central type.
+func CentralOnly() authz.Authorizer {
+	return Wrap(serviceType(storage.ServiceType_CENTRAL_SERVICE))
+}
+
 // SensorsOnly returns a serviceType authorizer that checks for the Sensor type.
 func SensorsOnly() authz.Authorizer {
 	return Wrap(serviceType(storage.ServiceType_SENSOR_SERVICE))

--- a/scanner/services/indexer.go
+++ b/scanner/services/indexer.go
@@ -143,6 +143,7 @@ func (s *indexerService) RegisterServiceServer(grpcServer *grpc.Server) {
 // AuthFuncOverride specifies the auth criteria for this API.
 func (s *indexerService) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
 	auth := indexerAuth
+	// If this a dev build, allow anonymous traffic for testing purposes.
 	if !buildinfo.ReleaseBuild {
 		auth = allow.Anonymous()
 	}

--- a/scanner/services/indexer.go
+++ b/scanner/services/indexer.go
@@ -8,13 +8,32 @@ import (
 	"github.com/quay/claircore"
 	"github.com/quay/zlog"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
+	"github.com/stackrox/rox/pkg/grpc/authz/idcheck"
+	"github.com/stackrox/rox/pkg/grpc/authz/or"
+	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/scanner/indexer"
 	"github.com/stackrox/rox/scanner/mappers"
 	"github.com/stackrox/rox/scanner/services/validators"
 	"google.golang.org/grpc"
 )
+
+var indexerAuth = func() authz.Authorizer {
+	if buildinfo.ReleaseBuild {
+		return perrpc.FromMap(map[authz.Authorizer][]string{
+			or.SensorOr(idcheck.CentralOnly()): {
+				"/scanner.v4.Indexer/CreateIndexReport",
+				"/scanner.v4.Indexer/GetIndexReport",
+				"/scanner.v4.Indexer/HasIndexReport",
+			},
+		})
+	}
+	// Allow direct contact with Indexer in dev environments.
+	return allow.Anonymous()
+}()
 
 type indexerService struct {
 	v4.UnimplementedIndexerServer
@@ -129,8 +148,7 @@ func (s *indexerService) RegisterServiceServer(grpcServer *grpc.Server) {
 
 // AuthFuncOverride specifies the auth criteria for this API.
 func (s *indexerService) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
-	// TODO: Setup permissions for indexer.
-	return ctx, allow.Anonymous().Authorized(ctx, fullMethodName)
+	return ctx, indexerAuth.Authorized(ctx, fullMethodName)
 }
 
 // RegisterServiceHandler registers this service with the given gRPC Gateway endpoint.

--- a/scanner/services/indexer_test.go
+++ b/scanner/services/indexer_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/quay/claircore"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stackrox/rox/pkg/buildinfo"
+	"github.com/stackrox/rox/pkg/grpc/testutils"
 	"github.com/stackrox/rox/scanner/indexer/mocks"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
@@ -57,6 +59,12 @@ func (s *indexerServiceTestSuite) setupMock(hashID string, optCount int, report 
 		EXPECT().
 		IndexContainerImage(gomock.Any(), gomock.Eq(hashID), gomock.Eq(imageURL), gomock.Len(optCount)).
 		Return(report, err)
+}
+
+func (s *indexerServiceTestSuite) TestAuthz() {
+	if buildinfo.ReleaseBuild {
+		testutils.AssertAuthzWorks(s.T(), &indexerService{})
+	}
 }
 
 func (s *indexerServiceTestSuite) Test_CreateIndexReport_whenUsername_thenAuthEnabled() {

--- a/scanner/services/indexer_test.go
+++ b/scanner/services/indexer_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/quay/claircore"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
-	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/grpc/testutils"
 	"github.com/stackrox/rox/scanner/indexer/mocks"
 	"github.com/stretchr/testify/suite"
@@ -62,9 +61,7 @@ func (s *indexerServiceTestSuite) setupMock(hashID string, optCount int, report 
 }
 
 func (s *indexerServiceTestSuite) TestAuthz() {
-	if buildinfo.ReleaseBuild {
-		testutils.AssertAuthzWorks(s.T(), &indexerService{})
-	}
+	testutils.AssertAuthzWorks(s.T(), &indexerService{})
 }
 
 func (s *indexerServiceTestSuite) Test_CreateIndexReport_whenUsername_thenAuthEnabled() {

--- a/scanner/services/matcher.go
+++ b/scanner/services/matcher.go
@@ -124,6 +124,7 @@ func (s *matcherService) RegisterServiceServer(grpcServer *grpc.Server) {
 // AuthFuncOverride specifies the auth criteria for this API.
 func (s *matcherService) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
 	auth := matcherAuth
+	// If this a dev build, allow anonymous traffic for testing purposes.
 	if !buildinfo.ReleaseBuild {
 		auth = allow.Anonymous()
 	}

--- a/scanner/services/matcher_test.go
+++ b/scanner/services/matcher_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/pkg/cpe"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
-	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/grpc/testutils"
 	indexerMocks "github.com/stackrox/rox/scanner/indexer/mocks"
 	matcherMocks "github.com/stackrox/rox/scanner/matcher/mocks"
@@ -38,9 +37,7 @@ func (s *matcherServiceTestSuite) TearDownTest() {
 }
 
 func (s *matcherServiceTestSuite) TestAuthz() {
-	if buildinfo.ReleaseBuild {
-		testutils.AssertAuthzWorks(s.T(), &matcherService{})
-	}
+	testutils.AssertAuthzWorks(s.T(), &matcherService{})
 }
 
 func (s *matcherServiceTestSuite) Test_matcherService_NewMatcherService() {

--- a/scanner/services/matcher_test.go
+++ b/scanner/services/matcher_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/pkg/cpe"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stackrox/rox/pkg/buildinfo"
+	"github.com/stackrox/rox/pkg/grpc/testutils"
 	indexerMocks "github.com/stackrox/rox/scanner/indexer/mocks"
 	matcherMocks "github.com/stackrox/rox/scanner/matcher/mocks"
 	"github.com/stretchr/testify/suite"
@@ -33,6 +35,12 @@ func (s *matcherServiceTestSuite) SetupTest() {
 
 func (s *matcherServiceTestSuite) TearDownTest() {
 	s.mockCtrl.Finish()
+}
+
+func (s *matcherServiceTestSuite) TestAuthz() {
+	if buildinfo.ReleaseBuild {
+		testutils.AssertAuthzWorks(s.T(), &matcherService{})
+	}
 }
 
 func (s *matcherServiceTestSuite) Test_matcherService_NewMatcherService() {


### PR DESCRIPTION
## Description

For release builds, only:

* Indexer: Central and Sensor
* Matcher: Central

For dev builds, allow access from anywhere at this time. This is useful when testing Scanner v4, only, without the Central/Sensor interactions (for example: via `kubectl port-forward`). For release builds, use the fine-grained auth rules to prevent anyone/anything (except Central and/or Sensor) from doing anything

Note: the production network policies already enforce these rules, but having the finer-grained auth prevents anyone from using `kubectl port-forward` to reach the Indexer and/or Matcher.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Unit tests

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
