### PR TITLE
chore(scanner): differentiate dev and release Scanner v4

### DIFF
--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -20,6 +20,11 @@ jobs:
     uses: ./.github/workflows/build.yaml
     secrets: inherit
 
+  build-scanner-v4:
+    name: Build Scanner v4
+    uses: ./.github/workflows/scanner-build.yaml
+    secrets: inherit
+
   check-is-release:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -29,14 +29,8 @@ jobs:
       run: |
         source './scripts/ci/lib.sh'
 
-        matrix='{ "build_and_push": { "name":[], "goos":[], "goarch":[] } }'
-
-        # The base matrix
-        matrix="$(jq '.build_and_push.name += ["default"]' <<< "$matrix")"
-        matrix="$(jq '.build_and_push.goos += ["linux"]' <<< "$matrix")"
-        # If this is updated, be sure to update architectures in push-manifests job below.
         # TODO(ROX-21746): add arm64 back
-        matrix="$(jq '.build_and_push.goarch += ["amd64", "ppc64le", "s390x"]' <<< "$matrix")"
+        matrix='{ "build_and_push": { "name":["default"], "goos":["linux"], "goarch":["amd64", "ppc64le", "s390x"] } }'
 
         # Conditionally add a prerelease build (binaries built with GOTAGS=release)
         if ! is_tagged; then
@@ -106,7 +100,6 @@ jobs:
 
   push-manifests:
     needs:
-    - define-job-matrix
     - build-and-push
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -14,14 +14,51 @@ on:
     - synchronize
 
 jobs:
+  define-job-matrix:
+    outputs:
+      matrix: ${{ steps.define-job-matrix.outputs.matrix }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Define the matrix for build jobs
+      id: define-job-matrix
+      run: |
+        source './scripts/ci/lib.sh'
+
+        matrix='{ "build_and_push": { "name":[], "goos":[], "goarch":[] } }'
+
+        # The base matrix
+        matrix="$(jq '.build_and_push.name += ["default"]' <<< "$matrix")"
+        matrix="$(jq '.build_and_push.goos += ["linux"]' <<< "$matrix")"
+        # If this is updated, be sure to update architectures in push-manifests job below.
+        # TODO(ROX-21746): add arm64 back
+        matrix="$(jq '.build_and_push.goarch += ["amd64", "ppc64le", "s390x"]' <<< "$matrix")"
+
+        # Conditionally add a prerelease build (binaries built with GOTAGS=release)
+        if ! is_tagged; then
+          if ! is_in_PR_context || pr_has_label ci-build-prerelease; then
+            matrix="$(jq '.build_and_push.name += ["prerelease"]' <<< "$matrix")"
+          fi
+        fi
+
+        echo "Job matrix after conditionals:"
+        jq <<< "$matrix"
+
+        condensed="$(jq -c <<< "$matrix")"
+        echo "matrix=$condensed" >> "$GITHUB_OUTPUT"
+
   build-and-push:
+    needs: define-job-matrix
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        # If this is updated, be sure to update architectures in push-manifests below.
-        # TODO(ROX-21746): add arm64 back
-        goarch: ['amd64', 'ppc64le', 's390x']
-        goos: ['linux']
+      # Supports two go binary builds:
+      # default    - built with environment defaults (see handle-tagged-build & env.mk)
+      # prerelease - built with GOTAGS=release
+      matrix: ${{ fromJson(needs.define-job-matrix.outputs.matrix).build_and_push }}
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61
       env:
@@ -47,6 +84,15 @@ jobs:
         # Prevent fatal error "detected dubious ownership in repository" from recent git.
         git config --global --add safe.directory "$(pwd)"
 
+    - uses: ./.github/actions/handle-tagged-build
+
+    - name: Setup Go build environment for release
+      if: |
+        contains(github.event.pull_request.labels.*.name, 'ci-release-build')
+          ||
+        matrix.name == 'prerelease'
+      run: echo "GOTAGS=release" >> "$GITHUB_ENV"
+
     - name: Build Scanner and ScannerDB images
       run: make -C scanner GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} images
 
@@ -59,9 +105,10 @@ jobs:
         push_scanner_image_set ${{ matrix.goarch }}
 
   push-manifests:
-    runs-on: ubuntu-latest
     needs:
+    - define-job-matrix
     - build-and-push
+    runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61
       env:

--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -8,16 +8,6 @@ export PATH
 # Set to empty string to echo some command lines which are hidden by default.
 SILENT ?= @
 
-TAG := # make sure tag is never injectable as an env var
-
-ifdef CI
-ifneq ($(NIGHTLY_TAG),)
-	TAG := $(NIGHTLY_TAG)
-else ifneq ($(RELEASE_TAG),)
-	TAG := $(RELEASE_TAG)
-endif
-endif
-
 ifeq ($(TAG),)
 	TAG := $(shell $(MAKE) -C ../ --quiet --no-print-directory tag)
 endif
@@ -33,7 +23,8 @@ GOOS := $(HOST_OS)
 GO_BUILD_FLAGS = CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH}
 GO_BUILD_CMD   = $(GO_BUILD_FLAGS) go build \
                    -trimpath \
-                   -ldflags="-X github.com/stackrox/rox/scanner/internal/version.Version=$(TAG)"
+                   -ldflags="-X github.com/stackrox/rox/scanner/internal/version.Version=$(TAG)" \
+                   -tags=$(GOTAGS)
 GO_TEST_CMD    = $(GO_BUILD_FLAGS) go test
 
 DOCKERBUILD := $(CURDIR)/../scripts/docker-build.sh


### PR DESCRIPTION
## Description

https://github.com/stackrox/stackrox/pull/9272 introduced the need to differentiate between release and dev Scanner, so this PR ensures a release build is made upon release.

See 

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

```
$ make -C scanner bin/scanner
+ bin/scanner
CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags="-X github.com/stackrox/rox/scanner/internal/version.Version=4.3.x-638-g7e4c0238fb" -tags= -o bin/scanner ./cmd/scanner
$ go version -m scanner/bin/scanner | grep "tags"

$ export BUILD_TAG=4.4.0
$ make -C scanner bin/scanner
+ bin/scanner
CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags="-X github.com/stackrox/rox/scanner/internal/version.Version=4.4.0" -tags=release -o bin/scanner ./cmd/scanner
rtannenb:~/go/src/github.com/stackrox/stackrox$ go version -m scanner/bin/scanner | grep "tags"
	build	-tags=release
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
