### PR TITLE
fix(scannerv4): Add ScannerV4 Component to TLS Hostname(s)

### DIFF
--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -92,7 +92,7 @@
         {{- $_ := set $._rox.scannerV4.indexer.serviceTLS "generate" true -}}
       {{- end -}}
     {{- end }}
-    {{ $cryptoSpec := dict "CN" "SCANNER_SERVICE: Scanner V4 Indexer" "dnsBase" "scanner-v4" }}
+    {{ $cryptoSpec := dict "CN" "SCANNER_SERVICE: Scanner V4 Indexer" "dnsBase" "scanner-v4-indexer" }}
     {{ include "srox.configureCrypto" (list $ "scannerV4.indexer.serviceTLS" $cryptoSpec) }}
   {{- end -}}
 {{ end }}
@@ -112,7 +112,7 @@
         {{- $_ := set $._rox.scannerV4.matcher.serviceTLS "generate" true -}}
       {{- end -}}
     {{- end }}
-    {{ $cryptoSpec := dict "CN" "SCANNER_SERVICE: Scanner V4 Matcher" "dnsBase" "scanner-v4" }}
+    {{ $cryptoSpec := dict "CN" "SCANNER_SERVICE: Scanner V4 Matcher" "dnsBase" "scanner-v4-matcher" }}
     {{ include "srox.configureCrypto" (list $ "scannerV4.matcher.serviceTLS" $cryptoSpec) }}
   {{- end -}}
 {{ end }}

--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -92,7 +92,7 @@
         {{- $_ := set $._rox.scannerV4.indexer.serviceTLS "generate" true -}}
       {{- end -}}
     {{- end }}
-    {{ $cryptoSpec := dict "CN" "SCANNER_SERVICE: Scanner V4 Indexer" "dnsBase" "scanner-v4-indexer" }}
+    {{ $cryptoSpec := dict "CN" "SCANNER_V4_INDEXER_SERVICE: Scanner V4 Indexer" "dnsBase" "scanner-v4-indexer" }}
     {{ include "srox.configureCrypto" (list $ "scannerV4.indexer.serviceTLS" $cryptoSpec) }}
   {{- end -}}
 {{ end }}
@@ -112,7 +112,7 @@
         {{- $_ := set $._rox.scannerV4.matcher.serviceTLS "generate" true -}}
       {{- end -}}
     {{- end }}
-    {{ $cryptoSpec := dict "CN" "SCANNER_SERVICE: Scanner V4 Matcher" "dnsBase" "scanner-v4-matcher" }}
+    {{ $cryptoSpec := dict "CN" "SCANNER_V4_MATCHER_SERVICE: Scanner V4 Matcher" "dnsBase" "scanner-v4-matcher" }}
     {{ include "srox.configureCrypto" (list $ "scannerV4.matcher.serviceTLS" $cryptoSpec) }}
   {{- end -}}
 {{ end }}
@@ -146,7 +146,7 @@
 
   {{- if eq $.Chart.Name "stackrox-central-services" -}}
     {{/* Only generate certificate when installing central-services. */}}
-    {{ $cryptoSpec := dict "CN" "SCANNER_DB_SERVICE: Scanner V4 DB" "dnsBase" "scanner-v4-db" }}
+    {{ $cryptoSpec := dict "CN" "SCANNER_V4_DB_SERVICE: Scanner V4 DB" "dnsBase" "scanner-v4-db" }}
     {{ include "srox.configureCrypto" (list $ "scannerV4.db.serviceTLS" $cryptoSpec) }}
   {{- end -}}
 {{ end }}


### PR DESCRIPTION
## Description

Adds the Scanner V4 component (indexer|matcher) to the helm generated Cert TLS Subject Alternative Names. Also updates the common names to match [`ServiceType`'s](https://github.com/stackrox/stackrox/blob/5cd9f69072c17146661fe63bfda293fa08b10003/proto/storage/service_identity.proto#L21).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

On an infra cluster installed scanner v4, and examined the the generated TLS certs for the appropriate SAN's.

Before the change:

```
$ k get secret scanner-v4-indexer-tls -o json | jq -r '.data."cert.pem"' | base64 -d | openssl x509 -text -noout | grep -i "subject alt" -A1
            X509v3 Subject Alternative Name: 
                DNS:scanner-v4.stackrox, DNS:scanner-v4.stackrox.svc, DNS:scanner-v4.stackrox.svc.cluster.local


$ k get secret scanner-v4-matcher-tls -o json | jq -r '.data."cert.pem"' | base64 -d | openssl x509 -text -noout | grep -i "subject alt" -A1
            X509v3 Subject Alternative Name: 
                DNS:scanner-v4.stackrox, DNS:scanner-v4.stackrox.svc, DNS:scanner-v4.stackrox.svc.cluster.local
```

After the change: 

```
$ secret=scanner-v4-indexer-tls
$ k get secret $secret -o json | jq -r '.data."cert.pem"' | base64 -d | openssl x509 -text -noout 2>&1 | grep -iE "subject alt|subject:" -A1 | grep -ivE "warning|Public Key Info"
        Subject: CN=SCANNER_V4_INDEXER_SERVICE: Scanner V4 Indexer
--
            X509v3 Subject Alternative Name: 
                DNS:scanner-v4-indexer.stackrox, DNS:scanner-v4-indexer.stackrox.svc, DNS:scanner-v4-indexer.stackrox.svc.cluster.local

$ secret=scanner-v4-matcher-tls
$ k get secret $secret -o json | jq -r '.data."cert.pem"' | base64 -d | openssl x509 -text -noout 2>&1 | grep -iE "subject alt|subject:" -A1 | grep -ivE "warning|Public Key Info"
        Subject: CN=SCANNER_V4_MATCHER_SERVICE: Scanner V4 Matcher
--
            X509v3 Subject Alternative Name: 
                DNS:scanner-v4-matcher.stackrox, DNS:scanner-v4-matcher.stackrox.svc, DNS:scanner-v4-matcher.stackrox.svc.cluster.local

$ secret=scanner-v4-db-tls
$ k get secret $secret -o json | jq -r '.data."cert.pem"' | base64 -d | openssl x509 -text -noout 2>&1 | grep -iE "subject alt|subject:" -A1 | grep -ivE "warning|Public Key Info"
        Subject: CN=SCANNER_V4_DB_SERVICE: Scanner V4 DB
--
            X509v3 Subject Alternative Name: 
                DNS:scanner-v4-db.stackrox, DNS:scanner-v4-db.stackrox.svc, DNS:scanner-v4-db.stackrox.svc.cluster.local
```
Also executed a scan via `roxctl` and confirmed central logs do not contain the previously observed `x509` cert errors:

```
$ rctl image scan --image=nginx 2>/dev/null | jq '.scan.dataSource'
{
  "id": "a87471e6-9678-4e66-8348-91e302b6de07",
  "name": "Scanner V4"
}
```