### PR TITLE
fix: ROX-21573, wait for gathering goroutines to terminate in tests

### DIFF
--- a/pkg/telemetry/phonehome/gatherer_test.go
+++ b/pkg/telemetry/phonehome/gatherer_test.go
@@ -48,10 +48,12 @@ func (s *gathererTestSuite) TestGatherer() {
 	})
 	g.Start()
 	<-g.ctx.Done()
+	g.procs.Wait()
 	s.Equal("value", props["key"], "the gathering function should have been called")
 	s.Equal(int64(1), i)
 	g.Start()
 	<-g.ctx.Done()
+	g.procs.Wait()
 	s.Equal("value", props["key"], "the gathering function should have been called")
 	s.Equal(int64(2), i)
 }


### PR DESCRIPTION
## Description

As the test gathering procedure calls `Stop()`, there was a race condition between cancelling the context and calling `Track()`.
The first is read by the test as a way to wait for the termination, before checking the result, while the `Track()` call could happen after the check.

The PR adds a wait group, which can be used in tests to ensure all gathering goroutines are terminated before checking the outcome.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

I added a `time.Sleep(time.Second)` call to the `identify()` function, and so reproduced the race condition problem.
I added `Wait()` calls for the `procs` WaitGroup in the test to ensure the `loop` and `identify` goroutines are terminated before checking the `Track()` calls.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
