### PR TITLE
feat(logs): adjust message on incorrect ClusterID failure

### DIFF
--- a/pkg/centralsensor/init_cert.go
+++ b/pkg/centralsensor/init_cert.go
@@ -44,8 +44,7 @@ func GetClusterID(explicitID, idFromCert string) (string, error) {
 
 	if IsInitCertClusterID(id) {
 		return "", errors.Errorf("no concrete cluster ID was specified in conjunction with wildcard ID %q. "+
-			"This may be caused by Central data not being persisted between restarts; you may try deploying Central with STORAGE=pvc. "+
-			"For other potential solutions reffer to https://access.redhat.com/solutions/6972449", id)
+			"For potential solutions refer to https://access.redhat.com/solutions/6972449", id)
 	}
 
 	return id, nil


### PR DESCRIPTION
## Description

Central no longer uses `STOARAGE=pvc` to enable persistence. The linked KBA still seems valid though.  

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Did not. 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
