### PR TITLE
refactor: Telemetry gatherer tests with custom ticker

### DIFF
--- a/pkg/telemetry/phonehome/gatherer.go
+++ b/pkg/telemetry/phonehome/gatherer.go
@@ -42,6 +42,8 @@ type gatherer struct {
 	// procs groups the goroutines, launched by the gatherer,
 	// allowing tests to wait for their termination.
 	procs sync.WaitGroup
+	// tickerFactory allows for setting a custom ticker for ad-hoc gathering.
+	tickerFactory func(time.Duration) *time.Ticker
 }
 
 func newGatherer(clientType string, t telemeter.Telemeter, p time.Duration) *gatherer {
@@ -49,6 +51,8 @@ func newGatherer(clientType string, t telemeter.Telemeter, p time.Duration) *gat
 		clientType: clientType,
 		telemeter:  t,
 		period:     p,
+
+		tickerFactory: time.NewTicker,
 	}
 }
 
@@ -97,7 +101,7 @@ func (g *gatherer) loop() {
 	// Send initial data on start:
 	g.procs.Add(1)
 	g.identify()
-	ticker := time.NewTicker(g.period)
+	ticker := g.tickerFactory(g.period)
 	defer ticker.Stop()
 	for !g.stopSig.IsDone() {
 		select {

--- a/pkg/telemetry/phonehome/gatherer.go
+++ b/pkg/telemetry/phonehome/gatherer.go
@@ -97,8 +97,10 @@ func (g *gatherer) loop() {
 	defer ticker.Stop()
 	for !g.stopSig.IsDone() {
 		select {
-		case <-ticker.C:
-			go g.identify()
+		case _, ok := <-ticker.C:
+			if ok {
+				go g.identify()
+			}
 		case <-g.stopSig.Done():
 			return
 		}

--- a/pkg/telemetry/phonehome/gatherer.go
+++ b/pkg/telemetry/phonehome/gatherer.go
@@ -39,9 +39,6 @@ type gatherer struct {
 	lastData    map[string]any
 	opts        []telemeter.Option
 
-	// procs groups the goroutines, launched by the gatherer,
-	// allowing tests to wait for their termination.
-	procs sync.WaitGroup
 	// tickerFactory allows for setting a custom ticker for ad-hoc gathering.
 	tickerFactory func(time.Duration) *time.Ticker
 }
@@ -79,8 +76,6 @@ func (g *gatherer) gather() map[string]any {
 }
 
 func (g *gatherer) identify() {
-	defer g.procs.Done()
-
 	// TODO: might make sense to abort if !TryLock(), but that's harder to test.
 	g.gathering.Lock()
 	defer g.gathering.Unlock()
@@ -96,17 +91,13 @@ func (g *gatherer) identify() {
 }
 
 func (g *gatherer) loop() {
-	defer g.procs.Done()
-
 	// Send initial data on start:
-	g.procs.Add(1)
 	g.identify()
 	ticker := g.tickerFactory(g.period)
 	defer ticker.Stop()
 	for !g.stopSig.IsDone() {
 		select {
 		case <-ticker.C:
-			g.procs.Add(1)
 			go g.identify()
 		case <-g.stopSig.Done():
 			return
@@ -125,7 +116,6 @@ func (g *gatherer) Start(opts ...telemeter.Option) {
 		concurrency.WithLock(&g.gathering, func() {
 			g.opts = opts
 		})
-		g.procs.Add(1)
 		go g.loop()
 	}
 }

--- a/pkg/telemetry/phonehome/gatherer_test.go
+++ b/pkg/telemetry/phonehome/gatherer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter/mocks"
 	"github.com/stretchr/testify/suite"
@@ -56,4 +57,53 @@ func (s *gathererTestSuite) TestGatherer() {
 	g.procs.Wait()
 	s.Equal("value", props["key"], "the gathering function should have been called")
 	s.Equal(int64(2), i)
+}
+
+func (s *gathererTestSuite) TestGathererTicker() {
+	t := mocks.NewMockTelemeter(gomock.NewController(s.T()))
+
+	t.EXPECT().Track("Updated Test Identity", nil,
+		matchOptions(telemeter.WithTraits(map[string]any{"key": "value"}))).Times(1)
+	t.EXPECT().Track("Test Heartbeat", nil,
+		matchOptions(telemeter.WithTraits(nil))).Times(3)
+
+	var i int64
+
+	g := newGatherer("Test", t, 24*time.Hour)
+	tickChan := make(chan time.Time)
+	g.tickerFactory = func(time.Duration) *time.Ticker {
+		return &time.Ticker{C: tickChan}
+	}
+	g.AddGatherer(func(context.Context) (map[string]any, error) {
+		atomic.AddInt64(&i, 1)
+		return map[string]any{"key": "value"}, nil
+	})
+	g.Start()
+	tickChan <- time.Now()
+	tickChan <- time.Now()
+	tickChan <- time.Now()
+	g.Stop()
+	g.procs.Wait()
+	s.Equal(int64(4), i)
+}
+
+func (s *gathererTestSuite) TestAddTotal() {
+	props := make(map[string]any)
+	err := AddTotal(context.Background(), props, "key 1", func(context.Context) (int, error) {
+		return 42, nil
+	})
+	s.NoError(err)
+	s.Equal(42, props["Total key 1"])
+
+	err = AddTotal(context.Background(), props, "key 2", func(context.Context) (int, error) {
+		return 43, nil
+	})
+	s.NoError(err)
+	s.Equal(43, props["Total key 2"])
+
+	failure := errors.New("test error")
+	err = AddTotal(context.Background(), props, "key 3", func(context.Context) (int, error) {
+		return 42, failure
+	})
+	s.ErrorIs(err, failure)
 }


### PR DESCRIPTION
## Description

1. `Stop` is called in the `EXPECT.Track.Do()` chain instead of from the gathering function;
2. Removed `procs WaitGroup`, as (1) ensures `Track` is called before `Stop()`;
3. New tests with custom ticker to invoke gathering procedures ad-hoc.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Added unit tests.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
