### PR TITLE
chore(ui): Remove duplicate rendering of NG simulator sidebar

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -8,25 +8,36 @@ import { CustomModel, CustomNodeModel } from './types/topology.type';
 import { Simulation } from './utils/getSimulation';
 
 import './Topology.css';
-import useNetworkPolicySimulator from './hooks/useNetworkPolicySimulator';
+import {
+    NetworkPolicySimulator,
+    SetNetworkPolicyModification,
+} from './hooks/useNetworkPolicySimulator';
 import SimulationFrame from './simulation/SimulationFrame';
 import TopologyComponent from './TopologyComponent';
 import { EdgeState } from './components/EdgeStateSelect';
 import { NetworkScopeHierarchy } from './types/networkScopeHierarchy';
 
 export type NetworkGraphProps = {
+    isReadyForVisualization: boolean;
     model: CustomModel;
     simulation: Simulation;
     selectedNode?: CustomNodeModel;
     edgeState: EdgeState;
+    simulator: NetworkPolicySimulator;
+    setNetworkPolicyModification: SetNetworkPolicyModification;
     scopeHierarchy: NetworkScopeHierarchy;
+    isSimulating: boolean;
 };
 function NetworkGraph({
+    isReadyForVisualization,
     model,
     simulation,
     selectedNode,
     edgeState,
+    simulator,
+    setNetworkPolicyModification,
     scopeHierarchy,
+    isSimulating,
 }: NetworkGraphProps) {
     const controller = useMemo(() => {
         const newController = new Visualization();
@@ -35,21 +46,12 @@ function NetworkGraph({
         newController.registerComponentFactory(stylesComponentFactory);
         return newController;
     }, []);
-    const { simulator, setNetworkPolicyModification } = useNetworkPolicySimulator({
-        simulation,
-        scopeHierarchy,
-    });
-
-    const isSimulating =
-        simulator.state === 'GENERATED' ||
-        simulator.state === 'UNDO' ||
-        simulator.state === 'UPLOAD' ||
-        (simulation.isOn && simulation.type === 'baseline');
 
     return (
         <SimulationFrame isSimulating={isSimulating}>
             <VisualizationProvider controller={controller}>
                 <TopologyComponent
+                    isReadyForVisualization={isReadyForVisualization}
                     model={model}
                     simulation={simulation}
                     simulator={simulator}

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -33,6 +33,7 @@ import {
     namespaceBadgeColor,
     namespaceBadgeText,
 } from './common/NetworkGraphIcons';
+import useNetworkPolicySimulator from './hooks/useNetworkPolicySimulator';
 import { NetworkScopeHierarchy } from './types/networkScopeHierarchy';
 
 export type Models = {
@@ -272,6 +273,7 @@ function fadeOutUnconnectedNodes(
 }
 
 type NetworkGraphContainerProps = {
+    isReadyForVisualization: boolean;
     models: Models;
     edgeState: EdgeState;
     displayOptions: DisplayOption[];
@@ -289,6 +291,7 @@ type NetworkGraphContainerProps = {
 //
 // 1 (edgeState) -> 2 (selectedNode/edgeState) -> 3 (displayOptions)
 function NetworkGraphContainer({
+    isReadyForVisualization,
     models,
     edgeState,
     displayOptions,
@@ -296,6 +299,11 @@ function NetworkGraphContainer({
     clusterDeploymentCount,
     scopeHierarchy,
 }: NetworkGraphContainerProps) {
+    const { simulator, setNetworkPolicyModification } = useNetworkPolicySimulator({
+        simulation,
+        scopeHierarchy,
+    });
+
     // these are the unfiltered, unmodified data models
     const { activeModel, extraneousModel } = models;
 
@@ -353,13 +361,23 @@ function NetworkGraphContainer({
         edges: modifiedEdges,
     };
 
+    const isSimulating =
+        simulator.state === 'GENERATED' ||
+        simulator.state === 'UNDO' ||
+        simulator.state === 'UPLOAD' ||
+        (simulation.isOn && simulation.type === 'baseline');
+
     return (
         <NetworkGraph
+            isReadyForVisualization={isReadyForVisualization}
             model={updatedModel}
             simulation={simulation}
+            simulator={simulator}
+            setNetworkPolicyModification={setNetworkPolicyModification}
             selectedNode={selectedNode}
             edgeState={edgeState}
             scopeHierarchy={scopeHierarchy}
+            isSimulating={isSimulating}
         />
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -5,10 +5,15 @@
     --pf-c-page__main-section--PaddingRight: 0;
 }
 
-.pf-topology-resizable-side-bar {
-    /* we use the page header min height thrice to account for: nav header + page header + secondary header */
-    /* @TODO: Consider a more future-proof way of doing this. See https://github.com/stackrox/stackrox/pull/3703#discussion_r1014292340 */
-    height: calc(100vh - (var(--pf-c-page__header--MinHeight) * 3));
+/* Prevent the network graph from overflowing the parent flex container */
+.network-graph {
+    min-height: 0;
+    flex-shrink: 1;
+}
+
+/* Prevent the network graph from overflowing the parent flex container */
+.pf-topology-container {
+    min-height: 0;
 }
 
 /* simple solution to prevent user from making sidebar too narrow */

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -11,11 +11,6 @@
     height: calc(100vh - (var(--pf-c-page__header--MinHeight) * 3));
 }
 
-/* Similar to above, but for the simulation drawer when the secondary header is not visible */
-.cluster-simulation-drawer-panel {
-    height: calc(100vh - (var(--pf-c-page__header--MinHeight) * 2));
-}
-
 /* simple solution to prevent user from making sidebar too narrow */
 .pf-c-drawer__panel.pf-m-resizable {
     min-width: 430px !important;
@@ -37,6 +32,7 @@
 [data-testid="network-graph-toolbar"] {
     z-index: 250;
 }
+
 [data-testid="network-graph-toolbar"] .pf-search-shim,
 [data-testid="network-graph-toolbar"] .react-select__menu {
     z-index: 250;
@@ -59,7 +55,8 @@ div#topology-resize-panel table td {
     fill: #6853ae;
 }
 
-.related-namespace.pf-m-selected text, .related-namespace.pf-m-selected .pf-topology__node__action-icon svg {
+.related-namespace.pf-m-selected text,
+.related-namespace.pf-m-selected .pf-topology__node__action-icon svg {
     fill: #ffffff;
 }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
-import { PageSection, Popover } from '@patternfly/react-core';
+import { Popover } from '@patternfly/react-core';
 import {
     SELECTION_EVENT,
     SelectionEventListener,

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Popover } from '@patternfly/react-core';
+import { PageSection, Popover } from '@patternfly/react-core';
 import {
     SELECTION_EVENT,
     SelectionEventListener,
@@ -15,8 +15,8 @@ import {
 } from '@patternfly/react-topology';
 
 import { networkBasePath } from 'routePaths';
-import useFetchDeploymentCount from 'hooks/useFetchDeploymentCount';
 import usePermissions from 'hooks/usePermissions';
+import useFetchDeploymentCount from 'hooks/useFetchDeploymentCount';
 import DeploymentSideBar from './deployment/DeploymentSideBar';
 import NamespaceSideBar from './namespace/NamespaceSideBar';
 import CidrBlockSideBar from './cidr/CidrBlockSideBar';
@@ -30,14 +30,15 @@ import { CustomModel, CustomNodeModel } from './types/topology.type';
 import { Simulation } from './utils/getSimulation';
 import LegendContent from './components/LegendContent';
 
+import { EdgeState } from './components/EdgeStateSelect';
+import { deploymentTabs } from './utils/deploymentUtils';
+import EmptyUnscopedState from './components/EmptyUnscopedState';
 import {
     NetworkPolicySimulator,
     SetNetworkPolicyModification,
 } from './hooks/useNetworkPolicySimulator';
-import { EdgeState } from './components/EdgeStateSelect';
-import { deploymentTabs } from './utils/deploymentUtils';
-import { getSearchFilterFromScopeHierarchy } from './utils/simulatorUtils';
 import { NetworkScopeHierarchy } from './types/networkScopeHierarchy';
+import { getSearchFilterFromScopeHierarchy } from './utils/simulatorUtils';
 
 // TODO: move these type defs to a central location
 export const UrlDetailType = {
@@ -56,6 +57,7 @@ function getUrlParamsForEntity(type, id): [UrlDetailTypeValue, string] {
 }
 
 export type TopologyComponentProps = {
+    isReadyForVisualization: boolean;
     model: CustomModel;
     simulation: Simulation;
     selectedNode?: CustomNodeModel;
@@ -66,6 +68,7 @@ export type TopologyComponentProps = {
 };
 
 const TopologyComponent = ({
+    isReadyForVisualization,
     model,
     simulation,
     selectedNode,
@@ -234,24 +237,34 @@ const TopologyComponent = ({
             sideBarOpen={!!selectedNode || simulation.isOn}
             sideBarResizable
             controlBar={
-                <TopologyControlBar
-                    controlButtons={createTopologyControlButtons({
-                        ...defaultControlButtonsOptions,
-                        zoomInCallback,
-                        zoomOutCallback,
-                        fitToScreenCallback,
-                        resetViewCallback,
-                    })}
-                />
+                isReadyForVisualization ? (
+                    <TopologyControlBar
+                        controlButtons={createTopologyControlButtons({
+                            ...defaultControlButtonsOptions,
+                            zoomInCallback,
+                            zoomOutCallback,
+                            fitToScreenCallback,
+                            resetViewCallback,
+                        })}
+                    />
+                ) : undefined
             }
         >
-            <VisualizationSurface state={{ selectedIds }} />
-            <Popover
-                aria-label="Network graph legend"
-                bodyContent={<LegendContent />}
-                hasAutoWidth
-                reference={() => document.getElementById('legend') as HTMLButtonElement}
-            />
+            {isReadyForVisualization ? (
+                <>
+                    <VisualizationSurface state={{ selectedIds }} />
+                    <Popover
+                        aria-label="Network graph legend"
+                        bodyContent={<LegendContent />}
+                        hasAutoWidth
+                        reference={() => document.getElementById('legend') as HTMLButtonElement}
+                    />
+                </>
+            ) : (
+                <div className="pf-u-h-100 pf-u-w-100 pf-u-background-color-100">
+                    <EmptyUnscopedState />
+                </div>
+            )}
         </TopologyView>
     );
 };


### PR DESCRIPTION
## Description

Removes the conditionally rendered `Drawer` component and the second rendering of the simulator sidebar on the Network Graph. This moves the conditional rendering from the top level of `NetworkGraphPage` directly to the child elements of `TopologyComponent`.

For reference, the component hierarchy is:

`NetworkGraphPage` -> `NetworkGraphContainer` -> `NetworkGraph` -> `TopologyComponent`

This also fixes another papercut that impacted this change: removing the page overflow when a system config banner is displayed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Test opening the simulation sidebar with no namespaces selected:
![image](https://github.com/stackrox/stackrox/assets/1292638/6a693a48-badf-4525-a691-c25858fd902f)

Test with namespaces selected:
![image](https://github.com/stackrox/stackrox/assets/1292638/4de0ab75-c7dd-4132-b6d1-c98a2d7a05fd)
![image](https://github.com/stackrox/stackrox/assets/1292638/6ba9f128-429d-4853-9a58-a07f028b4fac)
![image](https://github.com/stackrox/stackrox/assets/1292638/e248bddf-db66-492d-b7ab-d12deb1d5ab8)

Test that changing cluster/namespace selections re-renders the graph correctly:

https://github.com/stackrox/stackrox/assets/1292638/337b35d3-d073-40de-a670-1be4e523e571



### Test layout changes:

No overflow when deployment sidebar is displayed
![image](https://github.com/stackrox/stackrox/assets/1292638/4426736c-3988-42a1-806f-622b1f2c704f)

No overflow in simulator sidebar with no namespaces
![image](https://github.com/stackrox/stackrox/assets/1292638/8bf1dea0-4134-45e7-a290-a21bb1586157)

No overflow in simulator sidebar with namespaces
![image](https://github.com/stackrox/stackrox/assets/1292638/51884e1d-4607-4f92-b8fc-7de10c300f8f)

No overflow in simulator sidebar when a banner is displayed
![image](https://github.com/stackrox/stackrox/assets/1292638/a2838d35-c44d-4a72-a587-eeccb4e3a702)



