### PR TITLE
chore: Relax systemctl exec policy to allow `--version` calls

### DIFF
--- a/pkg/defaults/policies/files/exec-systemctl.json
+++ b/pkg/defaults/policies/files/exec-systemctl.json
@@ -33,6 +33,15 @@
               "value": "systemctl"
             }
           ]
+        },
+        {
+          "fieldName": "Process Arguments",
+          "negate": true,
+          "values": [
+            {
+              "value": "--version"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Description

Migration TBD.

Calling `systemctl --version` is not really a security issue because the information printed relates to features supported by systemd at the buildtime and not the capabilities of the host OS.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Verified it works as intended on the ACSCS dogfooding cluster.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
