### PR TITLE
fix(CI): gke-version-compat-test: use a clean dir for each version

### DIFF
--- a/.openshift-ci/compatibility_test.py
+++ b/.openshift-ci/compatibility_test.py
@@ -10,7 +10,7 @@ from post_tests import PostClusterTest, FinalPost
 from runners import ClusterTestSetsRunner
 
 
-def make_compatibility_test_runner(cluster):
+def make_compatibility_test_runner(cluster, test_versions):
     return ClusterTestSetsRunner(
         cluster=cluster,
         sets=[
@@ -20,7 +20,7 @@ def make_compatibility_test_runner(cluster):
                 "test": QaE2eTestCompatibility(),
                 "post_test": PostClusterTest(
                     check_stackrox_logs=True,
-                    artifact_destination_prefix="compatibility",
+                    artifact_destination_prefix=test_versions,
                 ),
             },
         ],

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -87,7 +87,10 @@ for test_tuple in test_tuples:
     os.environ["CENTRAL_CHART_VERSION_OVERRIDE"] = test_tuple.central_version
     os.environ["SENSOR_CHART_VERSION_OVERRIDE"] = test_tuple.sensor_version
     try:
-        make_compatibility_test_runner(cluster=gkecluster).run()
+        make_compatibility_test_runner(
+            cluster=gkecluster,
+            test_versions=f'{test_tuple.central_version}--{test_tuple.sensor_version}',
+        ).run()
     except Exception as e:
         print(
             f'Exception "{str(e)}" raised in compatibility test for '


### PR DESCRIPTION
## Description

#9164 has made it a requirement that k8s-logs are saved to a clean dir. But that was not the case for gke-version-compatibility-test. This PR has the test use a dir based on the versions being tested.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

- [x] - CI + the artifacts gathered should be based on the versions tested.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
