### PR TITLE
ROX-21202: Add fallback to non-enhanced Deployments

### DIFF
--- a/central/detection/service/service.go
+++ b/central/detection/service/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/central/detection/deploytime"
 	"github.com/stackrox/rox/central/enrichment"
 	imageDatastore "github.com/stackrox/rox/central/image/datastore"
+	networkPolicyDS "github.com/stackrox/rox/central/networkpolicies/datastore"
 	"github.com/stackrox/rox/central/risk/manager"
 	"github.com/stackrox/rox/central/role/sachelper"
 	"github.com/stackrox/rox/central/sensor/enhancement"
@@ -42,6 +43,7 @@ func New(
 	clusterSACHelper sachelper.ClusterSacHelper,
 	connManager connection.Manager,
 	broker *enhancement.Broker,
+	netpols networkPolicyDS.DataStore,
 ) Service {
 	return &serviceImpl{
 		clusters:           clusters,
@@ -56,5 +58,6 @@ func New(
 		clusterSACHelper:   clusterSACHelper,
 		connManager:        connManager,
 		enhancementWatcher: broker,
+		netpols:            netpols,
 	}
 }

--- a/central/detection/service/service_impl.go
+++ b/central/detection/service/service_impl.go
@@ -228,7 +228,7 @@ func (s *serviceImpl) enrichAndDetect(ctx context.Context, enrichmentContext enr
 	var appliedNetpols *augmentedobjs.NetworkPoliciesApplied
 	appliedNetpols, err = s.getAppliedNetpolsForDeployment(ctx, enrichmentContext, deployment)
 	if err != nil {
-		log.Warnf("Could not find applied network policies for deployment %s. Continuing with deployment enrichment.", deployment.GetName())
+		log.Warnf("Could not find applied network policies for deployment %s. Continuing with deployment enrichment. Error: %s", deployment.GetName(), err)
 	} else {
 		log.Debugf("Found applied network policies for deployment %s: %+v", deployment.GetName(), appliedNetpols)
 	}
@@ -256,7 +256,7 @@ func (s *serviceImpl) enrichAndDetect(ctx context.Context, enrichmentContext enr
 func (s *serviceImpl) getAppliedNetpolsForDeployment(ctx context.Context, enrichmentContext enricher.EnrichmentContext, deployment *storage.Deployment) (*augmentedobjs.NetworkPoliciesApplied, error) {
 	storedPolicies, err := s.netpols.GetNetworkPolicies(ctx, enrichmentContext.ClusterID, enrichmentContext.Namespace)
 	if err != nil {
-		return nil, errox.InvalidArgs.New("failed to find network policies for deployment").CausedBy(err)
+		return nil, errors.Wrapf(err, "failed to find network policies for cluster %s and namespace %s", enrichmentContext.ClusterID, enrichmentContext.Namespace)
 	}
 	matchedPolicies := networkpolicy.FilterForDeployment(storedPolicies, deployment)
 	return networkpolicy.GenerateNetworkPoliciesAppliedObj(matchedPolicies), nil

--- a/central/detection/service/service_impl.go
+++ b/central/detection/service/service_impl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stackrox/rox/pkg/booleanpolicy"
 	"github.com/stackrox/rox/pkg/booleanpolicy/augmentedobjs"
 	"github.com/stackrox/rox/pkg/booleanpolicy/networkpolicy"
+	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/detection"
 	deploytimePkg "github.com/stackrox/rox/pkg/detection/deploytime"
 	"github.com/stackrox/rox/pkg/errorhelpers"
@@ -405,8 +406,8 @@ func (s *serviceImpl) DetectDeployTimeFromYAML(ctx context.Context, req *apiV1.D
 	}
 
 	// TODO(ROX-21342): Ensure central doesn't crash if user doesn't provide cluster info
-	// If a cluster is provided, enhance deployments with additional info from Sensor
-	if eCtx.ClusterID != "" {
+	// If a cluster is provided and Sensor has the capability, enhance deployments with additional info from Sensor
+	if eCtx.ClusterID != "" && s.connManager.GetConnection(eCtx.ClusterID).HasCapability(centralsensor.SensorEnhancedDeploymentCheckCap) {
 		conn := s.connManager.GetConnection(eCtx.ClusterID)
 		if conn == nil {
 			return nil, errox.InvalidArgs.New("connection to cluster is not ready - try again later")

--- a/central/detection/service/service_impl_test.go
+++ b/central/detection/service/service_impl_test.go
@@ -692,9 +692,10 @@ func TestFetchOptionFromRequest(t *testing.T) {
 }
 
 func TestGetAppliedNetpolsForDeployment(t *testing.T) {
+	mockClusterID := uuid.NewV4().String()
 	mockCtrl := gomock.NewController(t)
 	mockNetpolDS := networkPolicyMockStore.NewMockDataStore(mockCtrl)
-	mockNetpolDS.EXPECT().GetNetworkPolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+	mockNetpolDS.EXPECT().GetNetworkPolicies(gomock.Any(), mockClusterID, "ns").Return(
 		[]*storage.NetworkPolicy{
 			{Id: uuid.NewV4().String(), Spec: &storage.NetworkPolicySpec{PodSelector: &storage.LabelSelector{MatchLabels: map[string]string{"app": "match"}}}},
 			{Id: uuid.NewV4().String(), Spec: &storage.NetworkPolicySpec{PodSelector: &storage.LabelSelector{MatchLabels: map[string]string{"nomatch": "nomatch"}}}},
@@ -702,7 +703,7 @@ func TestGetAppliedNetpolsForDeployment(t *testing.T) {
 	s := serviceImpl{
 		netpols: mockNetpolDS,
 	}
-	eCtx := enricher.EnrichmentContext{Namespace: "ns", ClusterID: uuid.NewV4().String()}
+	eCtx := enricher.EnrichmentContext{Namespace: "ns", ClusterID: mockClusterID}
 	d := storage.Deployment{Id: uuid.NewV4().String(), PodLabels: map[string]string{"app": "match"}}
 
 	actual, err := s.getAppliedNetpolsForDeployment(context.Background(), eCtx, &d)

--- a/central/detection/service/singleton.go
+++ b/central/detection/service/singleton.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/central/detection/deploytime"
 	"github.com/stackrox/rox/central/enrichment"
 	imageDatastore "github.com/stackrox/rox/central/image/datastore"
+	networkpolicyDatastore "github.com/stackrox/rox/central/networkpolicies/datastore"
 	"github.com/stackrox/rox/central/notifier/processor"
 	"github.com/stackrox/rox/central/risk/manager"
 	"github.com/stackrox/rox/central/role/sachelper"
@@ -36,6 +37,7 @@ func initialize() {
 		sachelper.NewClusterSacHelper(clusterDS),
 		connection.ManagerSingleton(),
 		enhancement.BrokerSingleton(),
+		networkpolicyDatastore.Singleton(),
 	)
 }
 

--- a/central/sensor/service/pipeline/enhancements/pipeline.go
+++ b/central/sensor/service/pipeline/enhancements/pipeline.go
@@ -36,7 +36,6 @@ func GetPipeline() pipeline.Fragment {
 
 func (p pipelineImpl) OnFinish(_ string) {}
 
-// TODO(ROX-21202): Add capabilities
 func (p pipelineImpl) Capabilities() []centralsensor.CentralCapability {
 	return nil
 }

--- a/pkg/booleanpolicy/networkpolicy/networkpolicy.go
+++ b/pkg/booleanpolicy/networkpolicy/networkpolicy.go
@@ -36,6 +36,7 @@ func GenerateNetworkPoliciesAppliedObj(networkPolicies map[string]*storage.Netwo
 func FilterForDeployment(networkPolicies []*storage.NetworkPolicy, deployment *storage.Deployment) map[string]*storage.NetworkPolicy {
 	matchedNetworkPolicies := map[string]*storage.NetworkPolicy{}
 	for _, p := range networkPolicies {
+		//FIXME: Debugging this shows that the labels are instead in deployment.GetLabels()
 		if labels.MatchLabels(p.GetSpec().GetPodSelector(), deployment.GetPodLabels()) {
 			matchedNetworkPolicies[p.GetId()] = p
 		}

--- a/pkg/booleanpolicy/networkpolicy/networkpolicy.go
+++ b/pkg/booleanpolicy/networkpolicy/networkpolicy.go
@@ -36,7 +36,6 @@ func GenerateNetworkPoliciesAppliedObj(networkPolicies map[string]*storage.Netwo
 func FilterForDeployment(networkPolicies []*storage.NetworkPolicy, deployment *storage.Deployment) map[string]*storage.NetworkPolicy {
 	matchedNetworkPolicies := map[string]*storage.NetworkPolicy{}
 	for _, p := range networkPolicies {
-		//FIXME: Debugging this shows that the labels are instead in deployment.GetLabels()
 		if labels.MatchLabels(p.GetSpec().GetPodSelector(), deployment.GetPodLabels()) {
 			matchedNetworkPolicies[p.GetId()] = p
 		}

--- a/pkg/images/enricher/enricher.go
+++ b/pkg/images/enricher/enricher.go
@@ -72,6 +72,9 @@ type EnrichmentContext struct {
 	// Used to override the delegated registry configuration.
 	ClusterID string
 
+	// Namespace contains the name of the namespace used to filter NetworkPolicies for Deployments.
+	Namespace string
+
 	Source *RequestSource
 }
 

--- a/pkg/protoconv/resources/resources.go
+++ b/pkg/protoconv/resources/resources.go
@@ -227,6 +227,7 @@ func (w *DeploymentWrap) populateFields(obj interface{}) {
 	w.populateReplicas(spec, obj)
 
 	var podSpec v1.PodSpec
+	var podMeta metav1.ObjectMeta
 
 	switch o := obj.(type) {
 	case *openshiftAppsV1.DeploymentConfig:
@@ -253,9 +254,11 @@ func (w *DeploymentWrap) populateFields(obj interface{}) {
 			return
 		}
 		podSpec = podTemplate.Spec
+		podMeta = podTemplate.ObjectMeta
 	}
 
 	w.PopulateDeploymentFromPodSpec(podSpec)
+	w.PopulateDeploymentFromPodMeta(podMeta)
 }
 
 // PopulateDeploymentFromPodSpec fills in the initialized wrap with data from the passed pod spec
@@ -270,6 +273,11 @@ func (w *DeploymentWrap) PopulateDeploymentFromPodSpec(podSpec v1.PodSpec) {
 	w.populateImagePullSecrets(podSpec)
 
 	w.populateContainers(podSpec)
+}
+
+// PopulateDeploymentFromPodMeta fills in the initialized wrap with data from the passed pod meta
+func (w *DeploymentWrap) PopulateDeploymentFromPodMeta(podMeta metav1.ObjectMeta) {
+	w.PodLabels = podMeta.GetLabels()
 }
 
 func (w *DeploymentWrap) populateTolerations(podSpec v1.PodSpec) {

--- a/pkg/protoconv/resources/resources_test.go
+++ b/pkg/protoconv/resources/resources_test.go
@@ -152,7 +152,8 @@ func TestNewDeploymentFromStaticResourcePopulatesPodLabels(t *testing.T) {
 			},
 		},
 	}
-	d, _ := NewDeploymentFromStaticResource(deployment, "Deployment", "", "")
+	d, err := NewDeploymentFromStaticResource(deployment, "Deployment", "", "")
+	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"app": "nginx"}, d.GetPodLabels())
 }
 

--- a/pkg/protoconv/resources/resources_test.go
+++ b/pkg/protoconv/resources/resources_test.go
@@ -141,6 +141,21 @@ func TestCronJobPopulateSpec(t *testing.T) {
 	assert.Equal(t, deploymentWrap.Containers[0].Name, "container2")
 }
 
+func TestNewDeploymentFromStaticResourcePopulatesPodLabels(t *testing.T) {
+	deployment := &appsV1.Deployment{
+		Spec: appsV1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "nginx"},
+				},
+				Spec: v1.PodSpec{Containers: []v1.Container{{Name: "nginx"}}},
+			},
+		},
+	}
+	d, _ := NewDeploymentFromStaticResource(deployment, "Deployment", "", "")
+	assert.Equal(t, map[string]string{"app": "nginx"}, d.GetPodLabels())
+}
+
 func TestIsTrackedReference(t *testing.T) {
 	cases := []struct {
 		ref       metav1.OwnerReference


### PR DESCRIPTION
## Description

This PR adds a fallback behaviour for Central to fall back to the old behaviour if Sensor doesn't have the capability to enhance deployments.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- [x] Evaluated and added CHANGELOG entry if required
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
This behaviour can be switched on and off with the feature flag `ROX_CLUSTER_AWARE_DEPLOYMENT_CHECK`.
The flag is currently off by default, leading to the capability not being added to the list of Sensor caps.
(Find used `nginx.yaml` at the bottom of this PR description)

1. Deploy locally with no changes to feature flag (off by default)
2. Enable debug logging in Sensor: `kubectl set env deployment/sensor LOGLEVEL=debug -n stackrox`
3. Run a deployment check with provided cluster and namespace: `bin/linux_amd64/roxctl deployment check --file ~/Downloads/nginx.yaml --cluster remote --namespace stackrox`
4. Observe *no log messages* being generated on Sensor
5. Add capability to Sensor by switching on FF: `kubectl set env deployment/sensor ROX_CLUSTER_AWARE_DEPLOYMENT_CHECK=false -n stackrox`
6. Run command from 3. again
7. Observe log messages in Sensor "Received deploymentEnhancement message with x deployments"

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.


---

 Addendum: nginx.yaml

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  namespace: stackrox
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80

---

apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: multi-port-egress
  namespace: stackrox
spec:
  podSelector:
    matchLabels:
      app: nginx
  policyTypes:
    - Ingress
  ingress:
    - from:
        - ipBlock:
            cidr: 10.0.0.0/24
      ports:
        - protocol: TCP
          port: 32000
          endPort: 32768

```
