### PR TITLE
ROX-21562: Enable Scanner v4 Tests on OCP

### DIFF
--- a/scripts/ci/jobs/ocp_scanner_v4_tests.py
+++ b/scripts/ci/jobs/ocp_scanner_v4_tests.py
@@ -3,6 +3,26 @@
 """
 Run the Scanner V4 tests in an OCP cluster
 """
+import os
+from runners import ClusterTestRunner
+from clusters import AutomationFlavorsCluster
+from ci_tests import ScannerV4Test
+from pre_tests import PreSystemTests
+from post_tests import NullPostTest, FinalPost
+
+os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["STORE_METRICS"] = "true"
+os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_BASELINE_GENERATION_DURATION"] = "5m"
+
+ClusterTestRunner(
+    cluster=AutomationFlavorsCluster(),
+    pre_test=PreSystemTests(),
+    test=ScannerV4Test(),
+    post_test=NullPostTest(),
+    final_post=FinalPost(),
+).run()
+
 
 # At the moment this is just here for letting CI pass when a new CI test step has been added
 # to the openshift/release repo.

--- a/scripts/ci/jobs/ocp_scanner_v4_tests.py
+++ b/scripts/ci/jobs/ocp_scanner_v4_tests.py
@@ -22,9 +22,3 @@ ClusterTestRunner(
     post_test=NullPostTest(),
     final_post=FinalPost(),
 ).run()
-
-
-# At the moment this is just here for letting CI pass when a new CI test step has been added
-# to the openshift/release repo.
-
-print("UNIMPLEMENTED")


### PR DESCRIPTION
## Description

This PR provides an implementation for the following CI tests: `ocp-4-11-scanner-v4-tests` and `ocp-4-14-scanner-v4-tests`

They will run the same tests as the pre-existing `gke-scanner-v4-tests` tests, but on OCP.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

The tests were validated by analyzing the logs of `ocp-4-11-scanner-v4-tests` and `ocp-4-14-scanner-v4-tests`.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
