### PR TITLE
ROX-21621: Refresh central services leaf certs before they expire.

### DIFF
--- a/operator/pkg/central/extensions/reconcile_tls.go
+++ b/operator/pkg/central/extensions/reconcile_tls.go
@@ -28,7 +28,6 @@ const (
 	// It must be sufficient to renew an ephemeral init bundle certificate which has relatively short lifetime (within a matter of hours).
 	// NB: keep in sync with crypto.ephemeralProfileWithExpirationInHoursCertLifetime
 	InitBundleReconcilePeriod = 1 * time.Hour
-	initBundleGracePeriod     = 90 * time.Minute // half of cert validity period
 )
 
 // ReconcileCentralTLSExtensions returns an extension that takes care of creating the central-tls and related
@@ -56,7 +55,7 @@ func (r *createCentralTLSExtensionRun) Execute(ctx context.Context) error {
 	if r.centralObj.DeletionTimestamp != nil {
 		for _, prefix := range []string{"central", "central-db", "scanner", "scanner-db", "scanner-v4-matcher", "scanner-v4-indexer", "scanner-v4-db"} {
 			if err := r.DeleteSecret(ctx, prefix+"-tls"); err != nil {
-				return errors.Wrapf(err, "reconciling %s-tls secret", prefix)
+				return errors.Wrapf(err, "reconciling %s-tls secret failed", prefix)
 			}
 		}
 		return nil
@@ -64,18 +63,18 @@ func (r *createCentralTLSExtensionRun) Execute(ctx context.Context) error {
 	}
 
 	if err := r.EnsureSecret(ctx, "central-tls", r.validateAndConsumeCentralTLSData, r.generateCentralTLSData); err != nil {
-		return errors.Wrap(err, "error reconciling central-tls secret")
+		return errors.Wrap(err, "reconciling central-tls secret failed")
 	}
 
 	if err := r.reconcileCentralDBTLSSecret(ctx); err != nil {
-		return errors.Wrap(err, "reconciling central-db-tls secret")
+		return errors.Wrap(err, "reconciling central-db-tls secret failed")
 	}
 
 	if err := r.reconcileScannerTLSSecret(ctx); err != nil {
-		return errors.Wrap(err, "reconciling scanner-tls secret")
+		return errors.Wrap(err, "reconciling scanner-tls secret failed")
 	}
 	if err := r.reconcileScannerDBTLSSecret(ctx); err != nil {
-		return errors.Wrap(err, "reconciling scanner-db-tls secret")
+		return errors.Wrap(err, "reconciling scanner-db-tls secret failed")
 	}
 
 	if features.ScannerV4Support.Enabled() {
@@ -104,18 +103,18 @@ func (r *createCentralTLSExtensionRun) reconcileInitBundleSecrets(ctx context.Co
 		secretName := slugCaseService + "-tls"
 		if !bundleSecretShouldExist {
 			if err := r.DeleteSecret(ctx, secretName); err != nil {
-				return errors.Wrapf(err, "deleting %s secret", secretName)
+				return errors.Wrapf(err, "deleting %s secret failed", secretName)
 			}
 			continue
 		}
 		validateFunc := func(fileMap types.SecretDataMap, _ bool) error {
-			return r.validateInitBundleTLSData(serviceType, slugCaseService+"-", fileMap)
+			return r.validateServiceTLSData(serviceType, slugCaseService+"-", fileMap)
 		}
 		generateFunc := func(_ types.SecretDataMap) (types.SecretDataMap, error) {
 			return r.generateInitBundleTLSData(slugCaseService+"-", serviceType)
 		}
 		if err := r.EnsureSecret(ctx, secretName, validateFunc, generateFunc); err != nil {
-			return errors.Wrapf(err, "reconciling %s secret", secretName)
+			return errors.Wrapf(err, "reconciling %s secret failed", secretName)
 		}
 	}
 	return nil
@@ -137,13 +136,13 @@ func (r *createCentralTLSExtensionRun) validateAndConsumeCentralTLSData(fileMap 
 	var err error
 	r.ca, err = certgen.LoadCAFromFileMap(fileMap)
 	if err != nil {
-		return errors.Wrap(err, "loading CA")
+		return errors.Wrap(err, "loading CA failed")
 	}
 	if err := r.ca.CheckProperties(); err != nil {
 		return errors.Wrap(err, "loaded service CA certificate is invalid")
 	}
-	if err := certgen.VerifyServiceCert(fileMap, r.ca, storage.ServiceType_CENTRAL_SERVICE, ""); err != nil {
-		return errors.Wrap(err, "verifying existing central CA")
+	if err := r.validateServiceTLSData(storage.ServiceType_CENTRAL_SERVICE, "", fileMap); err != nil {
+		return errors.Wrap(err, "verifying existing central service TLS certificate failed")
 	}
 	return nil
 }
@@ -159,7 +158,7 @@ func (r *createCentralTLSExtensionRun) generateCentralTLSData(old types.SecretDa
 	}
 
 	if err := certgen.IssueCentralCert(newFileMap, r.ca, mtls.WithNamespace(r.centralObj.GetNamespace())); err != nil {
-		return nil, errors.Wrap(err, "error issuing central service certificate")
+		return nil, errors.Wrap(err, "issuing central service certificate failed")
 	}
 
 	if oldJWTKey, oldJWTKeyOK := old[certgen.JWTKeyPEMFileName]; oldJWTKeyOK {
@@ -170,7 +169,7 @@ func (r *createCentralTLSExtensionRun) generateCentralTLSData(old types.SecretDa
 	} else {
 		jwtKey, err := certgen.GenerateJWTSigningKey()
 		if err != nil {
-			return nil, errors.Wrap(err, "generating JWT signing key")
+			return nil, errors.Wrap(err, "generating JWT signing key failed")
 		}
 		certgen.AddJWTSigningKeyToFileMap(newFileMap, jwtKey)
 	}
@@ -206,7 +205,7 @@ func validateOrGenerateCA(oldCA mtls.CA, oldFileMap types.SecretDataMap) (mtls.C
 	} else if !caCertPresent && !caKeyPresent {
 		ca, err := certgen.GenerateCA()
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "error creating new CA")
+			return nil, nil, errors.Wrap(err, "creating new CA failed")
 		}
 		certgen.AddCAToFileMap(newFileMap, ca)
 		return ca, newFileMap, nil
@@ -261,7 +260,7 @@ func (r *createCentralTLSExtensionRun) reconcileScannerV4DBTLSSecret(ctx context
 }
 
 func (r *createCentralTLSExtensionRun) validateServiceTLSData(serviceType storage.ServiceType, fileNamePrefix string, fileMap types.SecretDataMap) error {
-	if err := certgen.VerifyServiceCert(fileMap, r.ca, serviceType, fileNamePrefix); err != nil {
+	if err := certgen.VerifyCert(fileMap, fileNamePrefix, r.getValidateCert(serviceType)); err != nil {
 		return err
 	}
 	if err := certgen.VerifyCACertInFileMap(fileMap, r.ca); err != nil {
@@ -270,37 +269,36 @@ func (r *createCentralTLSExtensionRun) validateServiceTLSData(serviceType storag
 	return nil
 }
 
-func (r *createCentralTLSExtensionRun) validateInitBundleTLSData(serviceType storage.ServiceType, fileNamePrefix string, fileMap types.SecretDataMap) error {
-	if err := certgen.VerifyCert(fileMap, fileNamePrefix, r.getValidateInitBundleCert(serviceType)); err != nil {
-		return err
-	}
-	if err := certgen.VerifyCACertInFileMap(fileMap, r.ca); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (r *createCentralTLSExtensionRun) getValidateInitBundleCert(serviceType storage.ServiceType) certgen.ValidateCertFunc {
+func (r *createCentralTLSExtensionRun) getValidateCert(serviceType storage.ServiceType) certgen.ValidateCertFunc {
 	validateService := certgen.GetValidateServiceCertFunc(r.ca, serviceType)
 	return func(certificate *x509.Certificate) error {
 		if err := validateService(certificate); err != nil {
 			return err
 		}
-		if err := checkInitBundleCertRenewal(certificate, time.Now()); err != nil {
+		if err := checkCertRenewal(certificate, time.Now()); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func checkInitBundleCertRenewal(certificate *x509.Certificate, currentTime time.Time) error {
+func checkCertRenewal(certificate *x509.Certificate, currentTime time.Time) error {
 	startTime := certificate.NotBefore
-	if currentTime.Before(startTime) {
-		return fmt.Errorf("init bundle secret requires update, certificate lifetime starts in the future, not before: %s", startTime)
+	endTime := certificate.NotAfter
+	if !endTime.After(startTime) {
+		return fmt.Errorf("certificate expires at %s before it begins to be valid at %s", endTime, startTime)
 	}
-	refreshTime := certificate.NotAfter.Add(-initBundleGracePeriod)
+	if currentTime.Before(startTime) {
+		return fmt.Errorf("certificate lifetime start %s is in the future", startTime)
+	}
+	if currentTime.After(endTime) {
+		return fmt.Errorf("certificate expired at %s", endTime)
+	}
+	validityDuration := endTime.Sub(startTime)
+	halfOfValidityDuration := time.Duration(validityDuration.Nanoseconds()/2) * time.Nanosecond
+	refreshTime := startTime.Add(halfOfValidityDuration)
 	if currentTime.After(refreshTime) {
-		return fmt.Errorf("init bundle secret requires update, certificate is expired (or going to expire soon), not after: %s, renew threshold: %s", certificate.NotAfter, refreshTime)
+		return fmt.Errorf("certificate is past half of its validity, %s", refreshTime)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

Refresh the cert after half of its validity period passes. This way there is still plenty of time for:
- the central/central-db/scanner* pods to restart and pick up the new cert, e.g. as a result of an ACS or node upgrade, even before we add auto-reload of certs at runtime to all these components
- a human to intervene before expiry in case this auto-refresh is unsuccessful for whatever reason

This change also updates a few error messages for consistency.

Possible future work:
- change the operator to trigger another reconcile shortly after the earliest refresh time of all encountered certificates. In practice this is not an issue, half of validity period (~6 months) of these certs is a multiple of the forced reconcile period (11 hours), so might not be worth the complexity.
- change all components to pick up the new certs dynamically. Again, in practice this is not an issue, since they will likely be restarted for other reason(s) in the remaining validity time after rotation. I don't think it's worth documenting this caveat in the meantime.

Note: this PR builds on #9220 so please only look at the last commit. Still against `master` to let CI run.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Ran manual test described velow
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~


## Testing Performed

### Here I tell how I validated my change

1. created a [temporary followup change](https://github.com/stackrox/stackrox/pull/9328) to reduce the default cert lifetime to ~30 minutes
2. built images with this change
3. provisioned a `Central` deployment with operator
4. grabed the `central-tls` secret for comparison later
5. waited 16 minutes
6. annotated the `Central` CR to trigger a reconcile
7. grabbed the new `central-tls` secret and compared it to the old one
8. verified that the only changes were `cert.pem`, `key.pem` and `resourceVersion` (i.e. the CA is untouched)
9. inspected the old and new cert and made sure the validity periods are as expected
10. bounced the pods and made sure they come up healthy, and there are no related TLS errors or warnings in the logs

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
