### PR TITLE
ROX-21202: Add fallback to non-enhanced Deployments

### DIFF
--- a/central/detection/service/service_impl.go
+++ b/central/detection/service/service_impl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stackrox/rox/pkg/booleanpolicy"
 	"github.com/stackrox/rox/pkg/booleanpolicy/augmentedobjs"
 	"github.com/stackrox/rox/pkg/booleanpolicy/networkpolicy"
+	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/detection"
 	deploytimePkg "github.com/stackrox/rox/pkg/detection/deploytime"
 	"github.com/stackrox/rox/pkg/errorhelpers"
@@ -405,8 +406,8 @@ func (s *serviceImpl) DetectDeployTimeFromYAML(ctx context.Context, req *apiV1.D
 	}
 
 	// TODO(ROX-21342): Ensure central doesn't crash if user doesn't provide cluster info
-	// If a cluster is provided, enhance deployments with additional info from Sensor
-	if eCtx.ClusterID != "" {
+	// If a cluster is provided and Sensor has the capability, enhance deployments with additional info from Sensor
+	if eCtx.ClusterID != "" && s.connManager.GetConnection(eCtx.ClusterID).HasCapability(centralsensor.SensorEnhancedDeploymentCheckCap) {
 		conn := s.connManager.GetConnection(eCtx.ClusterID)
 		if conn == nil {
 			return nil, errox.InvalidArgs.New("connection to cluster is not ready - try again later")

--- a/central/sensor/service/pipeline/enhancements/pipeline.go
+++ b/central/sensor/service/pipeline/enhancements/pipeline.go
@@ -34,22 +34,22 @@ func GetPipeline() pipeline.Fragment {
 	return NewEnhancementPipeline(enhancement.BrokerSingleton())
 }
 
-func (p pipelineImpl) OnFinish(_ string) {}
+func (p *pipelineImpl) OnFinish(_ string) {}
 
-func (p pipelineImpl) Capabilities() []centralsensor.CentralCapability {
+func (p *pipelineImpl) Capabilities() []centralsensor.CentralCapability {
 	return nil
 }
 
-func (p pipelineImpl) Match(msg *central.MsgFromSensor) bool {
+func (p *pipelineImpl) Match(msg *central.MsgFromSensor) bool {
 	return msg.GetDeploymentEnhancementResponse() != nil
 }
 
 // Run runs the pipeline template on the input and returns the output
-func (p pipelineImpl) Run(_ context.Context, _ string, msg *central.MsgFromSensor, _ common.MessageInjector) error {
+func (p *pipelineImpl) Run(_ context.Context, _ string, msg *central.MsgFromSensor, _ common.MessageInjector) error {
 	p.broker.NotifyDeploymentReceived(msg.GetDeploymentEnhancementResponse())
 	return nil
 }
 
-func (p pipelineImpl) Reconcile(_ context.Context, _ string, _ *reconciliation.StoreMap) error {
+func (p *pipelineImpl) Reconcile(_ context.Context, _ string, _ *reconciliation.StoreMap) error {
 	return nil
 }

--- a/central/sensor/service/pipeline/enhancements/pipeline.go
+++ b/central/sensor/service/pipeline/enhancements/pipeline.go
@@ -36,7 +36,6 @@ func GetPipeline() pipeline.Fragment {
 
 func (p pipelineImpl) OnFinish(_ string) {}
 
-// TODO(ROX-21202): Add capabilities
 func (p pipelineImpl) Capabilities() []centralsensor.CentralCapability {
 	return nil
 }


### PR DESCRIPTION
## Description

This PR adds a fallback behaviour for Central to fall back to the old behaviour if Sensor doesn't have the capability to enhance deployments.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- [x] Evaluated and added CHANGELOG entry if required
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
This behaviour can be switched on and off with the feature flag `ROX_CLUSTER_AWARE_DEPLOYMENT_CHECK`.
The flag is currently off by default, leading to the capability not being added to the list of Sensor caps.
(Find used `nginx.yaml` at the bottom of this PR description)

1. Deploy locally with no changes to feature flag (off by default)
2. Enable debug logging in Sensor: `kubectl set env deployment/sensor LOGLEVEL=debug -n stackrox`
3. Run a deployment check with provided cluster and namespace: `bin/linux_amd64/roxctl deployment check --file ~/Downloads/nginx.yaml --cluster remote --namespace stackrox`
4. Observe *no log messages* being generated on Sensor
5. Add capability to Sensor by switching on FF: `kubectl set env deployment/sensor ROX_CLUSTER_AWARE_DEPLOYMENT_CHECK=false -n stackrox`
6. Run command from 3. again
7. Observe log messages in Sensor "Received deploymentEnhancement message with x deployments"

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.


---

 Addendum: nginx.yaml

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  namespace: stackrox
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80

---

apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: multi-port-egress
  namespace: stackrox
spec:
  podSelector:
    matchLabels:
      app: nginx
  policyTypes:
    - Ingress
  ingress:
    - from:
        - ipBlock:
            cidr: 10.0.0.0/24
      ports:
        - protocol: TCP
          port: 32000
          endPort: 32768

```
