### PR TITLE
fix(deploy-scripts): Enable Helm by default in deploy scripts

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -130,6 +130,15 @@ function launch_central {
 
     echo "Generating central config..."
 
+
+    if [[ -z "$CI" && -z "${CENTRAL_HELM_DEPLOY:-}" && -x "$(command -v helm)" && "$(helm version --short)" == v3.* ]]; then
+      echo >&2 "================================================================================================"
+      echo >&2 "NOTE: Based on your environment, you are using the Helm-based deployment method."
+      echo >&2 "      To disable the Helm based installation set CENTRAL_HELM_DEPLOY=false"
+      echo >&2 "================================================================================================"
+      OUTPUT_FORMAT="helm"
+    fi
+
     local EXTRA_ARGS=()
     local EXTRA_DOCKER_ARGS=()
     local STORAGE_ARGS=()


### PR DESCRIPTION
## Description

Enable Helm by default in deploy scripts.
Behaviour does not change in CI.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
 - CI
 - Local deployment