### PR TITLE
fix(scanv4): Skip deploying Scanner v4 components if central is already deployed.

### DIFF
--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -163,7 +163,22 @@
 
 {{- end -}}
 
+{{- if eq $.Chart.Name "stackrox-secured-cluster-services" -}}
+  {{/* Special handling for the secured-cluster-services chart in case it gets deployed
+       to the same namespace as central-services. */}}
+  {{ $centralDeployment := dict }}
+  {{ include "srox.safeLookup" (list $ $centralDeployment "apps/v1" "Deployment" $.Release.Namespace "central") }}
+  {{ if $centralDeployment.result }}
+    {{ include "srox.note" (list $ "Detected central running in the same namespace. Not deploying scanner-v4-indexer from this chart and configuring sensor to use existing scanner-v4-indexer instance, if any.") }}
+    {{ $_ := set $._rox.sensor.localImageScanning "enabled" "true" }}
+    {{ $_ := set $components "indexer" false }}
+    {{/* Matcher on secured-cluster is unsupported, but just in case make sure it is disabled. */}}
+    {{ $_ := set $components "matcher" false }}
+  {{ end }}
+{{- end }}
+
 {{/* Propagate information about Scanner V4 setup. */}}
+{{- $_ := set $._rox "_scannerV4Enabled" (not $scannerV4Cfg.disable) -}}
 {{- $_ := set $._rox.scannerV4 "_indexerEnabled" (get $components "indexer") -}}
 {{- $_ := set $._rox.scannerV4 "_matcherEnabled" (get $components "matcher") -}}
 {{- if or (get $components "indexer") (get $components "matcher") -}}

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -126,9 +126,9 @@ spec:
         - name: ROX_INSTALL_METHOD
           value: {{ ._rox.env.installMethod | quote }}
         [<- if .FeatureFlags.ROX_SCANNER_V4 >]
-        {{- if not ._rox.scannerV4.disable }}
+        {{- if ._rox._scannerV4Enabled }}
         - name: ROX_SCANNER_V4_ENABLED
-          value: "{{ not ._rox.scannerV4.disable }}"
+          value: "true"
         {{- end }}
         [<- end >]
         {{- include "srox.envVars" (list . "deployment" "central" "central") | nindent 8 }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -273,18 +273,6 @@
 
 {{ include "srox.scannerV4Init" (list $ $scannerV4Cfg) }}
 
-{{ if ._rox.scannerV4._indexerEnabled }}
-  {{/* Disable scanner V4 indexer in case a central deployment exists. */}}
-  {{ $centralDeployment := dict }}
-  {{ include "srox.safeLookup" (list $ $centralDeployment "apps/v1" "Deployment" $.Release.Namespace "central") }}
-  {{ if $centralDeployment.result }}
-    {{ include "srox.note" (list $ "Detected central running in the same namespace. Not deploying scanner-v4-indexer from this chart and configuring sensor to use existing scanner-v4-indexer instance, if any.") }}
-    {{ $_ := set $._rox.sensor.localImageScanning "enabled" "true" }}
-    {{ $_ := set $._rox.scannerV4 "_indexerEnabled" false }}
-    {{ $_ := set $._rox.scannerV4 "_dbEnabled" false }}
-  {{ end }}
-{{ end }}
-
 {{ if ._rox.scannerV4._dbEnabled }}
   {{ include "srox.scannerV4Volume" $ }}
 {{ end }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -109,14 +109,14 @@ spec:
         - name: ROX_LOCAL_IMAGE_SCANNING_ENABLED
           value: "true"
         [<- if .FeatureFlags.ROX_SCANNER_V4 >]
-        {{- if not ._rox.scannerV4.disable }}
+        {{- if ._rox._scannerV4Enabled }}
         - name: ROX_SCANNER_V4_GRPC_ENDPOINT
           value: {{ printf "scanner-v4-indexer.%s.svc:8443" .Release.Namespace }}
         - name: ROX_SCANNER_V4_ENABLED
           value: "true"
         {{- end }}
         [<- end >]
-        {{- end }}
+        {{- end }}{{/* ._rox.sensor.localImageScanning.enabled */}}
         - name: ROX_HELM_CLUSTER_CONFIG_FP
           value: {{ quote ._rox._configFP }}
         [<- end >]


### PR DESCRIPTION
David, I'd suggest something like this? Haven't tested this on a cluster yet, though.