### PR TITLE
feat(test): Remove duplicate SensorHello tests and feature flag

### DIFF
--- a/sensor/tests/connection/connection_test.go
+++ b/sensor/tests/connection/connection_test.go
@@ -17,7 +17,6 @@ var (
 )
 
 func Test_SensorHello(t *testing.T) {
-	t.Setenv("ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT", "true")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", "1s")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL", "2s")
 
@@ -39,34 +38,9 @@ func Test_SensorHello(t *testing.T) {
 		assert.Equal(t, central.SensorHello_RECONNECT, hello2.GetSensorState())
 	}))
 
-}
-
-func Test_SensorHello2(t *testing.T) {
-	t.Setenv("ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT", "true")
-	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", "1s")
-	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL", "2s")
-
-	c, err := helper.NewContextWithConfig(t, helper.CentralConfig{
-		InitialSystemPolicies: nil,
-		CertFilePath:          "../../../tools/local-sensor/certs/",
-	})
-	t.Cleanup(c.Stop)
-
-	require.NoError(t, err)
-
-	c.RunTest(t, helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {
-		hello1 := testContext.WaitForHello(t, 3*time.Minute)
-		require.NotNil(t, hello1)
-		assert.Equal(t, central.SensorHello_STARTUP, hello1.GetSensorState())
-		testContext.RestartFakeCentralConnection()
-		hello2 := testContext.WaitForHello(t, 3*time.Minute)
-		require.NotNil(t, hello2)
-		assert.Equal(t, central.SensorHello_RECONNECT, hello2.GetSensorState())
-	}))
 }
 
 func Test_SensorReconnects(t *testing.T) {
-	t.Setenv("ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT", "true")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", "1s")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL", "2s")
 


### PR DESCRIPTION
## Description

- SensorHello2 was created to make sure multiple local sensor instances could be executed in a single sensor integration test
- Preventing sensor restarts feature flag is already enabled by default

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [ ] CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
