### PR TITLE
ROX-21128: Add InitBundleWizard steps

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
 
 import useRestQuery from 'hooks/useRestQuery';
@@ -14,6 +15,7 @@ export type InitBundlePageProps = {
 };
 
 function InitBundlePage({ hasWriteAccessForInitBundles, id }: InitBundlePageProps): ReactElement {
+    const history = useHistory();
     const [isRevoking, setIsRevoking] = useState(false);
     const [errorMessageForRevoke, setErrorMessageForRevoke] = useState('');
 
@@ -33,11 +35,11 @@ function InitBundlePage({ hasWriteAccessForInitBundles, id }: InitBundlePageProp
         revokeClusterInitBundles([id], [])
             .then(() => {
                 setErrorMessageForRevoke('');
+                setIsRevoking(false);
+                history.goBack(); // to table
             })
             .catch((error) => {
                 setErrorMessageForRevoke(getAxiosErrorMessage(error));
-            })
-            .finally(() => {
                 setIsRevoking(false);
             });
     }

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizard.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizard.tsx
@@ -8,13 +8,7 @@ import { generateClusterInitBundle } from 'services/ClustersService'; // Cluster
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import InitBundlesHeader from './InitBundlesHeader';
-import {
-    InitBundleWizardValues,
-    downloadBundle,
-    initialValues,
-    nameOfStep1,
-    nameOfStep2,
-} from './InitBundleWizard.utils';
+import { InitBundleWizardValues, downloadBundle, initialValues } from './InitBundleWizard.utils';
 import InitBundleWizardStep1 from './InitBundleWizardStep1';
 import InitBundleWizardStep2 from './InitBundleWizardStep2';
 
@@ -78,13 +72,13 @@ function InitBundleWizard(): ReactElement {
                     steps={[
                         {
                             id: 1,
-                            name: nameOfStep1,
+                            name: 'Select options',
                             component: <InitBundleWizardStep1 formik={formik} />,
                             enableNext: isValid,
                         },
                         {
                             id: 2,
-                            name: nameOfStep2,
+                            name: 'Download bundle',
                             component: (
                                 <InitBundleWizardStep2
                                     errorMessage={errorMessage}

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizard.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizard.tsx
@@ -1,11 +1,103 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { Divider, PageSection, Wizard } from '@patternfly/react-core';
+import { useFormik } from 'formik';
+import * as yup from 'yup';
+
+import { generateClusterInitBundle } from 'services/ClustersService'; // ClusterInitBundle
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import InitBundlesHeader from './InitBundlesHeader';
+import {
+    InitBundleWizardValues,
+    downloadBundle,
+    initialValues,
+    nameOfStep1,
+    nameOfStep2,
+} from './InitBundleWizard.utils';
+import InitBundleWizardStep1 from './InitBundleWizardStep1';
+import InitBundleWizardStep2 from './InitBundleWizardStep2';
+
+// https://github.com/stackrox/stackrox/blob/master/central/clusterinit/backend/validation.go#L11
+const nameValidatorRegExp = /^[a-zA-Z0-9._-]+$/;
+
+const validationSchema: yup.ObjectSchema<InitBundleWizardValues> = yup.object().shape({
+    name: yup
+        .string()
+        .trim()
+        .matches(
+            nameValidatorRegExp,
+            'Name can have only the following characters: letters, digits, period, underscore, hyphen (but no spaces)'
+        )
+        .required('Bundle name is required'),
+    installation: yup.string().trim().required(), // Select
+    platform: yup.string().trim().required(), // Radio
+});
 
 function InitBundleWizard(): ReactElement {
+    const history = useHistory();
+    const [errorMessage, setErrorMessage] = useState('');
+    const formik = useFormik({
+        initialValues,
+        onSubmit: (values, { setSubmitting }) => {
+            setSubmitting(true);
+            const { installation, name } = values;
+            generateClusterInitBundle({ name })
+                .then(({ response }) => {
+                    setErrorMessage('');
+                    downloadBundle(installation, response); // TODO try catch?
+                    setSubmitting(false);
+                    history.goBack(); // to table
+                })
+                .catch((error) => {
+                    setErrorMessage(getAxiosErrorMessage(error));
+                    setSubmitting(false);
+                });
+        },
+        validateOnMount: true, // disable Next when Name is empty
+        validationSchema,
+    });
+    const { isSubmitting, isValid, submitForm } = formik;
+
     return (
         <>
-            <InitBundlesHeader title="Create bundle" />;
+            <InitBundlesHeader title="Create bundle" />
+            <Divider component="div" />
+            <PageSection
+                variant="light"
+                isFilled
+                hasOverflowScroll
+                padding={{ default: 'noPadding' }}
+                className="pf-u-h-100"
+            >
+                <Wizard
+                    onClose={() => {
+                        history.goBack();
+                    }}
+                    onSave={submitForm}
+                    steps={[
+                        {
+                            id: 1,
+                            name: nameOfStep1,
+                            component: <InitBundleWizardStep1 formik={formik} />,
+                            enableNext: isValid,
+                        },
+                        {
+                            id: 2,
+                            name: nameOfStep2,
+                            component: (
+                                <InitBundleWizardStep2
+                                    errorMessage={errorMessage}
+                                    formik={formik}
+                                />
+                            ),
+                            nextButtonText: 'Download',
+                            canJumpTo: isValid,
+                            enableNext: isValid && !isSubmitting,
+                        },
+                    ]}
+                />
+            </PageSection>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizard.utils.ts
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizard.utils.ts
@@ -1,0 +1,57 @@
+import FileSaver from 'file-saver';
+import { FormikProps } from 'formik';
+
+import { GenerateClusterInitBundleResponse } from 'services/ClustersService';
+
+export const nameOfStep1 = 'Select options';
+export const nameOfStep2 = 'Download bundle';
+
+export const installationOptions: Record<string, string> = {
+    Operator: 'Operator (recommended)',
+    Helm: 'Helm chart',
+} as const;
+
+export type InstallationKey = keyof typeof installationOptions;
+
+export const platformOptions: Record<string, string> = {
+    OpenShift: 'OpenShift',
+    EKS: 'EKS',
+    AKS: 'AKS',
+    GKE: 'GKE',
+} as const;
+
+export type PlatformKey = keyof typeof platformOptions;
+
+export type InitBundleWizardValues = {
+    installation: InstallationKey;
+    name: string;
+    platform: PlatformKey;
+};
+
+export const initialValues: InitBundleWizardValues = {
+    installation: 'Operator',
+    name: '',
+    platform: 'OpenShift',
+};
+
+export type InitBundleWizardFormikProps = FormikProps<InitBundleWizardValues>;
+
+export function downloadBundle(
+    installation: InstallationKey,
+    response: GenerateClusterInitBundleResponse
+) {
+    const { helmValuesBundle, kubectlBundle } = response;
+    const bundle = installation === 'Helm' ? helmValuesBundle : kubectlBundle;
+    // TODO atob is deprecated
+    const decoded = typeof bundle === 'string' ? atob(bundle) : '';
+
+    const file = new Blob([decoded], {
+        type: 'application/x-yaml',
+    });
+    const name =
+        installation === 'Helm'
+            ? 'Helm-values-cluster-init-bundle'
+            : 'Operator-secrets-cluster-init-bundle';
+
+    FileSaver.saveAs(file, `${name}.yaml`);
+}

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizard.utils.ts
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizard.utils.ts
@@ -3,9 +3,6 @@ import { FormikProps } from 'formik';
 
 import { GenerateClusterInitBundleResponse } from 'services/ClustersService';
 
-export const nameOfStep1 = 'Select options';
-export const nameOfStep2 = 'Download bundle';
-
 export const installationOptions: Record<string, string> = {
     Operator: 'Operator (recommended)',
     Helm: 'Helm chart',

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep1.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep1.tsx
@@ -90,8 +90,8 @@ function InitBundleWizardStep1({ formik }: InitBundleWizardStep1Props): ReactEle
                 >
                     <Select
                         variant="single"
-                        toggleAriaLabel="Search entity selection menu toggle"
-                        aria-label="Select an entity to filter by"
+                        toggleAriaLabel="Installation method menu toggle"
+                        aria-label="Select an installation method"
                         isDisabled={values.platform !== 'OpenShift'}
                         onToggle={installationToggle.onToggle}
                         onSelect={(_event, value) => {

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep1.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep1.tsx
@@ -17,7 +17,6 @@ import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import {
     InitBundleWizardFormikProps,
     installationOptions,
-    nameOfStep1,
     platformOptions,
 } from './InitBundleWizard.utils';
 
@@ -35,7 +34,7 @@ function InitBundleWizardStep1({ formik }: InitBundleWizardStep1Props): ReactEle
 
     return (
         <Flex direction={{ default: 'column' }}>
-            <Title headingLevel="h2">{nameOfStep1}</Title>
+            <Title headingLevel="h2">Select options</Title>
             <Form>
                 <FormLabelGroup
                     fieldId="name"

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep1.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep1.tsx
@@ -1,0 +1,122 @@
+import React, { ReactElement } from 'react';
+import {
+    Alert,
+    Flex,
+    Form,
+    FormGroup,
+    Radio,
+    Select,
+    SelectOption,
+    TextInput,
+    Title,
+} from '@patternfly/react-core';
+
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+
+import {
+    InitBundleWizardFormikProps,
+    installationOptions,
+    nameOfStep1,
+    platformOptions,
+} from './InitBundleWizard.utils';
+
+export type InitBundleWizardStep1Props = {
+    formik: InitBundleWizardFormikProps;
+};
+
+function InitBundleWizardStep1({ formik }: InitBundleWizardStep1Props): ReactElement {
+    const { errors, handleBlur, setFieldValue, touched, values } = formik;
+    const installationToggle = useSelectToggle();
+
+    function onChange(value, event) {
+        return setFieldValue(event.target.id, value);
+    }
+
+    return (
+        <Flex direction={{ default: 'column' }}>
+            <Title headingLevel="h2">{nameOfStep1}</Title>
+            <Form>
+                <FormLabelGroup
+                    fieldId="name"
+                    label="Name"
+                    isRequired
+                    errors={errors}
+                    touched={touched}
+                >
+                    <TextInput
+                        type="text"
+                        id="name"
+                        name="name"
+                        isRequired
+                        value={values.name}
+                        onBlur={handleBlur}
+                        onChange={onChange}
+                    />
+                </FormLabelGroup>
+                <Alert
+                    variant="info"
+                    isInline
+                    title="You can use one bundle for multiple clusters on the same platform with the same installation method."
+                    component="p"
+                />
+                <FormGroup fieldId="platform" label="Platform of secured clusters" isRequired>
+                    <Flex
+                        direction={{ default: 'column' }}
+                        spaceItems={{ default: 'spaceItemsSm' }}
+                    >
+                        {Object.entries(platformOptions).map(([platformKey, platformLabel]) => (
+                            <Radio
+                                key={platformKey}
+                                name={platformKey}
+                                value={platformKey}
+                                onChange={() => {
+                                    setFieldValue('platform', platformKey);
+                                    if (platformKey !== 'OpenShift') {
+                                        setFieldValue('installation', 'Helm');
+                                    }
+                                }}
+                                label={platformLabel}
+                                id={platformKey}
+                                isChecked={values.platform === platformKey}
+                            />
+                        ))}
+                    </Flex>
+                </FormGroup>
+                <FormGroup
+                    fieldId="installation"
+                    label="Installation method for secured cluster services"
+                    isRequired
+                >
+                    <Select
+                        variant="single"
+                        toggleAriaLabel="Search entity selection menu toggle"
+                        aria-label="Select an entity to filter by"
+                        isDisabled={values.platform !== 'OpenShift'}
+                        onToggle={installationToggle.onToggle}
+                        onSelect={(_event, value) => {
+                            setFieldValue('installation', value);
+                        }}
+                        selections={values.installation}
+                        isOpen={installationToggle.isOpen}
+                        // className="pf-u-flex-basis-0"
+                    >
+                        {Object.entries(installationOptions)
+                            .filter(
+                                ([installationKey]) =>
+                                    values.platform === 'OpenShift' ||
+                                    installationKey !== 'Operator'
+                            )
+                            .map(([installationKey, installationLabel]) => (
+                                <SelectOption key={installationKey} value={installationKey}>
+                                    {installationLabel}
+                                </SelectOption>
+                            ))}
+                    </Select>
+                </FormGroup>
+            </Form>
+        </Flex>
+    );
+}
+
+export default InitBundleWizardStep1;

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep2.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep2.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Alert, Flex, Title } from '@patternfly/react-core';
 
-import { InitBundleWizardFormikProps, nameOfStep2 } from './InitBundleWizard.utils';
+import { InitBundleWizardFormikProps } from './InitBundleWizard.utils';
 
 export type InitBundleWizardStep2Props = {
     errorMessage: string;
@@ -15,7 +15,7 @@ function InitBundleWizardStep2({ errorMessage, formik }: InitBundleWizardStep2Pr
     return (
         <Flex direction={{ default: 'column' }}>
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
-                <Title headingLevel="h2">{nameOfStep2}</Title>
+                <Title headingLevel="h2">Download bundle</Title>
                 <p>
                     {values.installation === 'Operator'
                         ? 'Use this bundle to install secured cluster services on OpenShift with an Operator.'

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep2.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep2.tsx
@@ -1,0 +1,42 @@
+import React, { ReactElement } from 'react';
+import { Alert, Flex, Title } from '@patternfly/react-core';
+
+import { InitBundleWizardFormikProps, nameOfStep2 } from './InitBundleWizard.utils';
+
+export type InitBundleWizardStep2Props = {
+    errorMessage: string;
+    formik: InitBundleWizardFormikProps;
+};
+
+function InitBundleWizardStep2({ errorMessage, formik }: InitBundleWizardStep2Props): ReactElement {
+    const { values } = formik;
+
+    /* eslint-disable no-nested-ternary */
+    return (
+        <Flex direction={{ default: 'column' }}>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+                <Title headingLevel="h2">{nameOfStep2}</Title>
+                <p>
+                    {values.installation === 'Operator'
+                        ? 'Use this bundle to install secured cluster services on OpenShift with an Operator.'
+                        : values.platform === 'OpenShift'
+                          ? 'Use this bundle to install secured cluster services on OpenShift with a Helm chart.'
+                          : 'Use this bundle to install secured cluster services on xKS with a Helm chart.'}
+                </p>
+            </Flex>
+            {errorMessage && (
+                <Alert
+                    variant="danger"
+                    isInline
+                    title="Unable to create or download bundle"
+                    component="p"
+                >
+                    {errorMessage}
+                </Alert>
+            )}
+        </Flex>
+    );
+    /* eslint-enable no-nested-ternary */
+}
+
+export default InitBundleWizardStep2;

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesHeader.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesHeader.tsx
@@ -35,13 +35,16 @@ function InitBundlesHeader({ headerActions, title }: InitBundlesHeaderProps): Re
                     <BreadcrumbItem isActive>{title}</BreadcrumbItem>
                 </Breadcrumb>
                 <Flex alignItems={{ default: 'alignItemsCenter' }}>
-                    <FlexItem flex={{ default: 'flex_1' }}>
+                    <Flex
+                        direction={{ default: 'column' }}
+                        spaceItems={{ default: 'spaceItemsSm' }}
+                    >
                         <Title headingLevel="h1">{title}</Title>
                         <Text>
                             Cluster init bundles contain secrets for secured cluster services to
                             authenticate with Central.
                         </Text>
-                    </FlexItem>
+                    </Flex>
                     {headerActions && (
                         <FlexItem align={{ default: 'alignRight' }}>{headerActions}</FlexItem>
                     )}

--- a/ui/apps/platform/src/services/ClustersService.ts
+++ b/ui/apps/platform/src/services/ClustersService.ts
@@ -230,8 +230,14 @@ export function fetchClusterInitBundles(): Promise<{ response: { items: ClusterI
         });
 }
 
+export type GenerateClusterInitBundleResponse = {
+    meta?: ClusterInitBundle;
+    helmValuesBundle?: string; // bytes
+    kubectlBundle?: string; // bytes
+};
+
 export function generateClusterInitBundle(data: { name: string }): Promise<{
-    response: { meta?: ClusterInitBundle; helmValuesBundle?: string; kubectlBundle?: string };
+    response: GenerateClusterInitBundleResponse;
 }> {
     return axios
         .post<{ meta: ClusterInitBundle; helmValuesBundle: string; kubectlBundle: string }>(


### PR DESCRIPTION
## Description

### InitBundlePage

1. Add `history.goBack()` to table after click **Revoke bundle**.

### InitBundleWizard

1. Import `downloadBundle` function from utils.
2. Add `validationSchema` especially for name.
3. Add formik state.
4. Factor out step names.

### InitBundleWizardStep1

1. Add `TextInput` for **Name**.
2. Add `Radio` for **Platform**.
3. Add `Select` for **Installation**.

### InitBundleWizardStep2

1. Add sentence about platform and installation.

### Residue

1. InitBundlePage: investigate second argument and add confirmation modal.
2. Display icon in `TextInput` whenever name is not valid?
3. InitBundleWizardStep1: investigate whether `Select` needs **append to** idiom.
4. InitBundleWizardStep2: display bundle file name and collaborate with Kerry and Mansur about information.
5. Are there extra unexpected requests?
6. Add confirmation modal for **Revoke bundle**.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_MOVE_INIT_BUNDLES_UI=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 946 = 3947798 - 3946852
        total: 29235 = 10404526 - 10375291
    * `ls -al build/static/js/*.js | wc -l`
        0 = 89 - 89 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/clusters/init-bundles
    * See GET /v1/cluster-init/init-bundles request
    * See default bundle.
    ![1_init-bundles](https://github.com/stackrox/stackrox/assets/11862657/53c86485-9318-471f-87bd-20a930083e6a)

2. Click **Create bundle**
    * See step 1 **Select options** with **Next** button disabled.
    ![2_step1](https://github.com/stackrox/stackrox/assets/11862657/7e1fad32-1a44-4645-a448-6ee6fd5b7293)

3. Press tab.
    * See **Bundle name is required**
    ![3_Bundle_name_is_required](https://github.com/stackrox/stackrox/assets/11862657/b3f910ff-9b96-453e-94df-0ae2af3c997f)

4. Type a name which has a space.
    * See validation message.
    ![4_has_space](https://github.com/stackrox/stackrox/assets/11862657/ad7ca4ac-aaff-46bc-91cb-0c25b1b12114)

5. Type a valid name, and then click **Next**.
    * See step 2 **Download bundle** with **Download** button enabled.
    ![5_Next_to step2](https://github.com/stackrox/stackrox/assets/11862657/6d12aa79-293c-4099-abb5-914abc8fa04f)

6. Click **Download**.
    * See POST /v1/cluster-init/init-bundles and then GET /v1/cluster-init/init-bundles requests.
    * See Operator-secrets-cluster-init-bundle.yaml file in Downloads folder.
    * See bundles table with new bundle.
    ![6_Download_to_table](https://github.com/stackrox/stackrox/assets/11862657/81336ba6-1a5b-4486-8f30-f52b2743e63b)

7. Click name link of new bundle.
    * See GET /v1/cluster-init/init-bundles request. By the way, only plural bundles, no endpoint with id for single bundle.
    * See bundle page.
    ![7_link_to-bundle](https://github.com/stackrox/stackrox/assets/11862657/6dd05d81-fc39-4465-9476-c595df8f774c)

8. Click **Revoke bundle**. See **Residue** item 6 for confirmation modal.
    * See PATCH /v1/cluster-init/init-bundles/revoke and GET /v1/cluster-init/init-bundles requests.
    * See bundles table without revoked bundle.
    ![8_Revoke_to_table](https://github.com/stackrox/stackrox/assets/11862657/5ef2f402-e767-402d-89c8-22d322c5596a)
