### PR TITLE
ROX-21519: make the Scanner v4 client max response size configurable

### DIFF
--- a/pkg/env/scannerv4.go
+++ b/pkg/env/scannerv4.go
@@ -1,0 +1,7 @@
+package env
+
+import "github.com/stackrox/rox/pkg/size"
+
+var (
+	ScannerV4MaxRespMsgSize = RegisterIntegerSetting("ROX_SCANNER_V4_GRPC_MAX_RESPONSE_SIZE", 64*size.MB)
+)

--- a/pkg/env/scannerv4.go
+++ b/pkg/env/scannerv4.go
@@ -3,5 +3,7 @@ package env
 import "github.com/stackrox/rox/pkg/size"
 
 var (
-	ScannerV4MaxRespMsgSize = RegisterIntegerSetting("ROX_SCANNER_V4_GRPC_MAX_RESPONSE_SIZE", 64*size.MB)
+	// ScannerV4MaxRespMsgSize sets the maximum response size (in bytes) a Scanner v4 client may receive.
+	// ROX_GRPC_MAX_MESSAGE_SIZE is the related server-side configuration.
+	ScannerV4MaxRespMsgSize = RegisterIntegerSetting("ROX_SCANNER_V4_GRPC_MAX_RESPONSE_SIZE", 12*size.MB)
 )

--- a/pkg/scannerv4/client/client.go
+++ b/pkg/scannerv4/client/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/quay/zlog"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/clientconn"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/utils"
@@ -100,7 +101,12 @@ func createGRPCConn(ctx context.Context, o connOptions) (*grpc.ClientConn, error
 		connOpt.TLS.UseClientCert = clientconn.MustUseClientCert
 		connOpt.TLS.ServerName = o.serverName
 	}
-	return clientconn.GRPCConnection(ctx, o.mTLSSubject, o.address, connOpt)
+
+	callOpts := []grpc.CallOption{
+		grpc.MaxCallRecvMsgSize(env.ScannerV4MaxRespMsgSize.IntegerSetting()),
+	}
+
+	return clientconn.GRPCConnection(ctx, o.mTLSSubject, o.address, connOpt, grpc.WithDefaultCallOptions(callOpts...))
 }
 
 // GetOrCreateImageIndex calls the Indexer's gRPC endpoint to first


### PR DESCRIPTION
## Description

It is possible a `VulnerabilityReport` is larger than the default 4MiB which the go-gRPC client allows, by default. This PR bumps the default to 64MiB and includes a new environment variable `ROX_SCANNER_V4_GRPC_MAX_RESPONSE_SIZE` to allow users to configure the setting.

I ran into this issue in tests.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
