### PR TITLE
ROX-21616: Use NVD CVSS scores enrichments and OSV CVSS scores

### DIFF
--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -481,8 +481,6 @@ func convertMapToSlice[IN any, OUT any](convF func(*IN) *OUT, in map[string]*IN)
 // urlencoded string or expected to be extracted from Range.Upper.
 func fixedInVersion(v *claircore.Vulnerability) string {
 	fixedIn := v.FixedInVersion
-	// Instead of matching the updater name, we simply attempt to retrieve from the
-	// severity.
 	if fixedIn == "" && v.Range != nil {
 		// If fixed in is empty but range is provided, use that.
 		fixedIn = v.Range.Upper.String()

--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -497,7 +497,7 @@ func fixedInVersion(v *claircore.Vulnerability) string {
 // returns a mapping of vulnerability IDs to CVSS Scores V3.
 func nvdScoresMap(enrichments map[string][]json.RawMessage) (map[string]nvdschema.CVSSV30, error) {
 	cvss := enrichments[cvss.Type]
-	if len(cvss) <= 0 {
+	if len(cvss) == 0 {
 		return nil, nil
 	}
 	// TODO(ROX-21264): ClairCore only supports CVSS v3.1, so we assume CVSSV30 --

--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -513,7 +513,7 @@ func nvdScoresMap(enrichments map[string][]json.RawMessage) (map[string]nvdschem
 	}
 	ret := make(map[string]nvdschema.CVSSV30)
 	for id, l := range scores {
-		// There not criteria for selecting more than one enrichment record, assume the
+		// There is no criteria for selecting more than one enrichment record, assume the
 		// first is the right one.
 		ret[id] = l[0]
 	}

--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -508,7 +508,7 @@ func nvdScoresMap(enrichments map[string][]json.RawMessage) (map[string]nvdschem
 	if err != nil {
 		return nil, err
 	}
-	if len(scores) <= 0 {
+	if len(scores) == 0 {
 		return nil, nil
 	}
 	ret := make(map[string]nvdschema.CVSSV30)
@@ -602,8 +602,8 @@ func severityAndScores(vuln *claircore.Vulnerability, nvdScores map[string]nvdsc
 		if nvd, ok := nvdScores[vuln.ID]; ok {
 			switch {
 			case strings.HasPrefix(nvd.Version, "2"):
-				values.v3Score = float32(nvd.BaseScore)
-				values.v3Vector = nvd.VectorString
+				values.v2Score = float32(nvd.BaseScore)
+				values.v2Vector = nvd.VectorString
 			case strings.HasPrefix(nvd.Version, "3"):
 				values.v3Score = float32(nvd.BaseScore)
 				values.v3Vector = nvd.VectorString

--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -10,14 +10,15 @@ import (
 	"strconv"
 	"strings"
 
+	nvdschema "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
+	"github.com/facebookincubator/nvdtools/cvss2"
+	"github.com/facebookincubator/nvdtools/cvss3"
 	"github.com/gogo/protobuf/types"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/enricher/cvss"
 	"github.com/quay/claircore/pkg/cpe"
 	"github.com/quay/zlog"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
-	"github.com/stackrox/rox/pkg/cvss/cvssv2"
-	"github.com/stackrox/rox/pkg/cvss/cvssv3"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 )
 
@@ -64,7 +65,11 @@ func ToProtoV4VulnerabilityReport(ctx context.Context, r *claircore.Vulnerabilit
 	if r == nil {
 		return nil, nil
 	}
-	vulnerabilities, err := toProtoV4VulnerabilitiesMap(ctx, r.Vulnerabilities, r.Enrichments[cvss.Type])
+	scores, err := nvdScoresMap(r.Enrichments)
+	if err != nil {
+		return nil, fmt.Errorf("internal error: parsing nvd scores: %w", err)
+	}
+	vulnerabilities, err := toProtoV4VulnerabilitiesMap(ctx, r.Vulnerabilities, scores)
 	if err != nil {
 		return nil, fmt.Errorf("internal error: %w", err)
 	}
@@ -248,7 +253,11 @@ func toProtoV4PackageVulnerabilitiesMap(ccPkgVulnerabilities map[string][]string
 	return pkgVulns
 }
 
-func toProtoV4VulnerabilitiesMap(ctx context.Context, vulns map[string]*claircore.Vulnerability, _ []json.RawMessage) (map[string]*v4.VulnerabilityReport_Vulnerability, error) {
+func toProtoV4VulnerabilitiesMap(
+	ctx context.Context,
+	vulns map[string]*claircore.Vulnerability,
+	nvdScores map[string]nvdschema.CVSSV30,
+) (map[string]*v4.VulnerabilityReport_Vulnerability, error) {
 	if vulns == nil {
 		return nil, nil
 	}
@@ -277,7 +286,7 @@ func toProtoV4VulnerabilitiesMap(ctx context.Context, vulns map[string]*claircor
 			repoID = v.Repo.ID
 		}
 		normalizedSeverity := toProtoV4VulnerabilitySeverity(ctx, v.NormalizedSeverity)
-		sev, err := parseSeverity(v)
+		sev, err := severityAndScores(v, nvdScores)
 		if err != nil {
 			return nil, err
 		}
@@ -302,7 +311,7 @@ func toProtoV4VulnerabilitiesMap(ctx context.Context, vulns map[string]*claircor
 		}
 		vulnerabilities[k] = &v4.VulnerabilityReport_Vulnerability{
 			Id:                 v.ID,
-			Name:               getVulnName(v),
+			Name:               vulnerabilityName(v),
 			Description:        v.Description,
 			Issued:             issued,
 			Link:               v.Links,
@@ -316,96 +325,6 @@ func toProtoV4VulnerabilitiesMap(ctx context.Context, vulns map[string]*claircor
 		}
 	}
 	return vulnerabilities, nil
-}
-
-// fixedInVersion returns the string to populate FixedInVersion, typically
-// provided the report's `FixedInVersion` as a plain string, but, in some OSV
-// updaters, it can be an urlencoded string or expected to be extracted from
-// Range.Upper.
-func fixedInVersion(v *claircore.Vulnerability) string {
-	fixedIn := v.FixedInVersion
-	if fixedIn == "" && v.Range != nil {
-		// If fixed in is empty but range is provided, use that.
-		fixedIn = v.Range.Upper.String()
-	} else {
-		// Try to parse url encoded params; if expected values are not found leave it.
-		if q, err := url.ParseQuery(fixedIn); err == nil && q.Has("fixed") {
-			fixedIn = q.Get("fixed")
-		}
-	}
-	return fixedIn
-}
-
-// severityValues contains information that can be encoded in the severity of vulnerabilities.
-type severityValues struct {
-	severity string
-	v2Vector string
-	v2Score  float32
-	v3Vector string
-	v3Score  float32
-}
-
-// parseSeverity parses the severity information encoded in the severity field.
-// The information is distribution dependant.  If errors are found in the
-// encoded information, partial values are returned with an error.
-func parseSeverity(v *claircore.Vulnerability) (s severityValues, err error) {
-	var did string
-	if v.Dist != nil {
-		did = v.Dist.DID
-	}
-	switch did {
-	case "rhel":
-		var q url.Values
-		if q, err = url.ParseQuery(v.Severity); err != nil {
-			err = fmt.Errorf("invalid RHEL severity: %w", err)
-			break
-		}
-		s.severity = q.Get("severity")
-		// Look for CVSS fields. When at least one vector is found, we consider that the
-		// CVSS information exists, but return partial results in the case of failures.
-		errList := errorhelpers.NewErrorList("invalid RHEL CVSS")
-		s.v2Vector = q.Get("cvss2_vector")
-		if s.v2Vector != "" {
-			if _, err := cvssv2.ParseCVSSV2(s.v2Vector); err != nil {
-				errList.AddError(fmt.Errorf("v2 vector: %w", err))
-			} else if f, err := strconv.ParseFloat(q.Get("cvss2_score"), 32); err != nil {
-				errList.AddError(fmt.Errorf("v2 score: %w", err))
-			} else {
-				s.v2Score = float32(f)
-			}
-		}
-		s.v3Vector = q.Get("cvss3_vector")
-		if s.v3Vector != "" {
-			if _, err := cvssv3.ParseCVSSV3(s.v3Vector); err != nil {
-				errList.AddError(fmt.Errorf("v3 vector: %w", err))
-			} else if f, err := strconv.ParseFloat(q.Get("cvss3_score"), 32); err == nil {
-				s.v3Score = float32(f)
-			} else {
-				errList.AddError(fmt.Errorf("v3 score: %w", err))
-			}
-		}
-		err = errList.ToError()
-	default:
-		s.severity = v.Severity
-	}
-	return s, err
-}
-
-// getVulnName returns the first vulnerability name that matches a known
-// vulnerability name pattern from the report, or the original name if none
-// found.
-func getVulnName(vuln *claircore.Vulnerability) string {
-	for _, p := range vulnNamePatterns {
-		v := p.FindString(vuln.Name)
-		if v != "" {
-			return v
-		}
-		v = p.FindString(vuln.Links)
-		if v != "" {
-			return v
-		}
-	}
-	return vuln.Name
 }
 
 func toProtoV4VulnerabilitySeverity(ctx context.Context, ccSeverity claircore.Severity) v4.VulnerabilityReport_Vulnerability_Severity {
@@ -424,15 +343,6 @@ func toCPEString(c cpe.WFN) string {
 
 func toDigestString(digest claircore.Digest) string {
 	return digest.String()
-}
-
-// convertMapToSlice converts generic maps keyed by strings to a slice using a
-// provided conversion function.
-func convertMapToSlice[IN any, OUT any](convF func(*IN) *OUT, in map[string]*IN) (out []*OUT) {
-	for _, i := range in {
-		out = append(out, convF(i))
-	}
-	return out
 }
 
 func toClairCoreCPE(s string) (cpe.WFN, error) {
@@ -555,4 +465,171 @@ func convertSliceToMap[IN any, OUT any](in []*IN, convF func(*IN) (string, *OUT,
 		m[k] = ccV
 	}
 	return m, nil
+}
+
+// convertMapToSlice converts generic maps keyed by strings to a slice using a
+// provided conversion function.
+func convertMapToSlice[IN any, OUT any](convF func(*IN) *OUT, in map[string]*IN) (out []*OUT) {
+	for _, i := range in {
+		out = append(out, convF(i))
+	}
+	return out
+}
+
+// fixedInVersion returns the fixed in string, typically provided the report's
+// `FixedInVersion` as a plain string, but, in some OSV updaters, it can be an
+// urlencoded string or expected to be extracted from Range.Upper.
+func fixedInVersion(v *claircore.Vulnerability) string {
+	fixedIn := v.FixedInVersion
+	// Instead of matching the updater name, we simply attempt to retrieve from the
+	// severity.
+	if fixedIn == "" && v.Range != nil {
+		// If fixed in is empty but range is provided, use that.
+		fixedIn = v.Range.Upper.String()
+	} else {
+		// Try to parse url encoded params; if expected values are not found leave it.
+		if q, err := url.ParseQuery(fixedIn); err == nil && q.Has("fixed") {
+			fixedIn = q.Get("fixed")
+		}
+	}
+	return fixedIn
+}
+
+// nvdScoresMap look for NVD CVSS in the vulnerability report enrichments and
+// returns a mapping of vulnerability IDs to CVSS Scores V3.
+func nvdScoresMap(enrichments map[string][]json.RawMessage) (map[string]nvdschema.CVSSV30, error) {
+	cvss := enrichments[cvss.Type]
+	if len(cvss) <= 0 {
+		return nil, nil
+	}
+	// TODO(ROX-21264): ClairCore only supports CVSS v3.1, so we assume CVSSV30 --
+	//                  need to update this when we start using our own CVSS score enricher.
+	var scores map[string][]nvdschema.CVSSV30
+	// The CVSS enrichment always contains only one element.
+	err := json.Unmarshal(cvss[0], &scores)
+	if err != nil {
+		return nil, err
+	}
+	if len(scores) <= 0 {
+		return nil, nil
+	}
+	ret := make(map[string]nvdschema.CVSSV30)
+	for id, l := range scores {
+		// There not criteria for selecting more than one enrichment record, assume the
+		// first is the right one.
+		ret[id] = l[0]
+	}
+	return ret, nil
+}
+
+// severityValues contains severity information that can retrieved from a
+// ClairCore vulnerability report.
+type severityValues struct {
+	severity string
+	v2Vector string
+	v2Score  float32
+	v3Vector string
+	v3Score  float32
+}
+
+var (
+	osvUpdaterPattern  = regexp.MustCompile(`^osv/.*`)
+	rhelUpdaterPattern = regexp.MustCompile(`^RHEL\d+-`)
+)
+
+// severityAndScores returns the severity and scores information out of a
+// ClairCore vulnerability. The returned information is dependent on the
+// underlying updater. If errors are found in the encoded information, partial
+// values might be returned with an error.
+func severityAndScores(vuln *claircore.Vulnerability, nvdScores map[string]nvdschema.CVSSV30) (severityValues, error) {
+	var values severityValues
+	errList := errorhelpers.NewErrorList("parsing severity and CVSS scores")
+	switch {
+	case osvUpdaterPattern.MatchString(vuln.Updater):
+		if vuln.Severity == "" {
+			errList.AddStrings("severity is empty")
+			break
+		}
+		// ClairCore has no CVSS version indicator for OSV data, assuming CVSS V2 if
+		// prefixed with a V3 version.
+		if strings.HasPrefix(vuln.Severity, "CVSS:3") {
+			if _, err := cvss3.VectorFromString(vuln.Severity); err != nil {
+				errList.AddError(err)
+			} else {
+				values.v3Vector = vuln.Severity
+			}
+		} else if _, err := cvss2.VectorFromString(vuln.Severity); err != nil {
+			errList.AddError(err)
+		} else {
+			values.v2Vector = vuln.Severity
+		}
+	case rhelUpdaterPattern.MatchString(vuln.Updater):
+		if vuln.Severity == "" {
+			errList.AddStrings("severity is empty")
+			break
+		}
+		q, err := url.ParseQuery(vuln.Severity)
+		if err != nil {
+			errList.AddError(err)
+			break
+		}
+		values.severity = q.Get("severity")
+		// Look for CVSS fields. When at least one vector is found, we consider that the
+		// CVSS information exists, but return partial results in the case of failures.
+		if v := q.Get("cvss2_vector"); v != "" {
+			s := q.Get("cvss2_score")
+			if _, err := cvss2.VectorFromString(v); err != nil {
+				errList.AddError(fmt.Errorf("v2 vector: %w", err))
+			} else if f, err := strconv.ParseFloat(s, 32); err != nil {
+				errList.AddError(fmt.Errorf("v2 score %q: %w", s, err))
+			} else {
+				values.v2Vector = v
+				values.v2Score = float32(f)
+			}
+		}
+		if v := q.Get("cvss3_vector"); v != "" {
+			s := q.Get("cvss3_score")
+			if _, err := cvss3.VectorFromString(v); err != nil {
+				errList.AddError(fmt.Errorf("v3 vector: %w", err))
+			} else if f, err := strconv.ParseFloat(s, 32); err != nil {
+				errList.AddError(fmt.Errorf("v3 score %q: %w", s, err))
+			} else {
+				values.v3Vector = v
+				values.v3Score = float32(f)
+			}
+		}
+	default:
+		// Everything else uses NVD.
+		values.severity = vuln.Severity
+		if nvd, ok := nvdScores[vuln.ID]; ok {
+			switch {
+			case strings.HasPrefix(nvd.Version, "2"):
+				values.v3Score = float32(nvd.BaseScore)
+				values.v3Vector = nvd.VectorString
+			case strings.HasPrefix(nvd.Version, "3"):
+				values.v3Score = float32(nvd.BaseScore)
+				values.v3Vector = nvd.VectorString
+			default:
+				errList.AddError(fmt.Errorf("unsupported CVSS score version: %s", nvd.Version))
+			}
+		}
+	}
+	return values, errList.ToError()
+}
+
+// vulnerabilityName searches the best known candidate for the vulnerability name
+// in the vulnerability details. It works by matching data against well-known
+// name patterns, and defaults to the original name if nothing is found.
+func vulnerabilityName(vuln *claircore.Vulnerability) string {
+	for _, p := range vulnNamePatterns {
+		v := p.FindString(vuln.Name)
+		if v != "" {
+			return v
+		}
+		v = p.FindString(vuln.Links)
+		if v != "" {
+			return v
+		}
+	}
+	return vuln.Name
 }

--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -549,7 +549,7 @@ func severityAndScores(vuln *claircore.Vulnerability, nvdScores map[string]nvdsc
 			break
 		}
 		// ClairCore has no CVSS version indicator for OSV data, assuming CVSS V2 if
-		// prefixed with a V3 version.
+		// not prefixed with a V3 version.
 		if strings.HasPrefix(vuln.Severity, "CVSS:3") {
 			if _, err := cvss3.VectorFromString(vuln.Severity); err != nil {
 				errList.AddError(err)

--- a/scanner/mappers/mappers_test.go
+++ b/scanner/mappers/mappers_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	nvdschema "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
 	"github.com/gogo/protobuf/types"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/pkg/cpe"
@@ -609,6 +610,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 	assert.NoError(t, err)
 	tests := map[string]struct {
 		ccVulnerabilities map[string]*claircore.Vulnerability
+		nvdScores         map[string]nvdschema.CVSSV30
 		want              map[string]*v4.VulnerabilityReport_Vulnerability
 		wantErr           string
 	}{
@@ -729,7 +731,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 						"cvss3_vector": []string{"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
 						"cvss3_score":  []string{"9.9"},
 					}.Encode(),
-					Dist: &claircore.Distribution{DID: "rhel"},
+					Updater: "RHEL8-updater",
 				},
 			},
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
@@ -754,7 +756,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 						"cvss2_vector": []string{"AV:N/AC:L/Au:N/C:P/I:P/A:P"},
 						"cvss2_score":  []string{"1.1"},
 					}.Encode(),
-					Dist: &claircore.Distribution{DID: "rhel"},
+					Updater: "RHEL8-updater",
 				},
 			},
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
@@ -781,7 +783,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 						"cvss3_vector": []string{"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
 						"cvss3_score":  []string{"9.9"},
 					}.Encode(),
-					Dist: &claircore.Distribution{DID: "rhel"},
+					Updater: "RHEL8-updater",
 				},
 			},
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
@@ -809,10 +811,10 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 						"severity":     []string{"sample severity"},
 						"cvss2_vector": []string{"invalid cvss2 vector"},
 					}.Encode(),
-					Dist: &claircore.Distribution{DID: "rhel"},
+					Updater: "RHEL8-updater",
 				},
 			},
-			wantErr: "invalid RHEL CVSS error: v2 vector",
+			wantErr: `v2 vector: need two values separated by :, got "invalid cvss2 vector"`,
 		},
 		"when severity with CVSSv3 is invalid then return error": {
 			ccVulnerabilities: map[string]*claircore.Vulnerability{
@@ -822,16 +824,61 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 						"severity":     []string{"sample severity"},
 						"cvss3_vector": []string{"invalid cvss3 vector"},
 					}.Encode(),
-					Dist: &claircore.Distribution{DID: "rhel"},
+					Updater: "RHEL8-updater",
 				},
 			},
-			wantErr: "invalid RHEL CVSS error: v3 vector",
+			wantErr: `v3 vector: vector missing "CVSS:" prefix: "INVALID CVSS3 VECTOR"`,
+		},
+		"when OSV and severity with CVSSv3 then return": {
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"foo": {
+					Issued:   now,
+					Severity: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+					Updater:  "osv/sample-updater",
+				},
+			},
+			want: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"foo": {
+					Issued: protoNow,
+					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
+						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
+							Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+						},
+					},
+				},
+			},
+		},
+		"when unknown updater then return NVD scores": {
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"foo": {
+					ID:      "foo",
+					Issued:  now,
+					Updater: "unknown updater",
+				},
+			},
+			nvdScores: map[string]nvdschema.CVSSV30{
+				"foo": {
+					Version:      "3.1",
+					VectorString: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+				},
+			},
+			want: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"foo": {
+					Id:     "foo",
+					Issued: protoNow,
+					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
+						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
+							Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+						},
+					},
+				},
+			},
 		},
 	}
 	ctx := context.Background()
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := toProtoV4VulnerabilitiesMap(ctx, tt.ccVulnerabilities, nil)
+			got, err := toProtoV4VulnerabilitiesMap(ctx, tt.ccVulnerabilities, tt.nvdScores)
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 			} else {
@@ -860,7 +907,7 @@ func Test_convertToNormalizedSeverity(t *testing.T) {
 	assert.Equal(t, int(claircore.Critical), 5)
 }
 
-func Test_getVulnName(t *testing.T) {
+func Test_vulnerabilityName(t *testing.T) {
 	testcases := map[string]struct {
 		name     string
 		links    string
@@ -911,7 +958,7 @@ func Test_getVulnName(t *testing.T) {
 	for name, testcase := range testcases {
 		t.Run(name, func(t *testing.T) {
 			v := &claircore.Vulnerability{Name: testcase.name, Links: testcase.links}
-			assert.Equal(t, testcase.expected, getVulnName(v))
+			assert.Equal(t, testcase.expected, vulnerabilityName(v))
 		})
 	}
 


### PR DESCRIPTION
## Description

1. Pull CVSS scores from OSV updaters presented in `Severity`.
2. Use CVSS enrichments to populate CVSS

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO I have scanning results with CVSS scores run locally, need to run this in a cluster and post results here.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
