### PR TITLE
ROX-20669: Remove `react-numeric-input` from package.json 

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -66,7 +66,6 @@
         "react-helmet": "^6.1.0",
         "react-modal": "^3.12.1",
         "react-monaco-editor": "^0.51.0",
-        "react-numeric-input": "^2.2.3",
         "react-onclickoutside": "^6.12.2",
         "react-popper": "0.9.0",
         "react-redux": "^7.2.6",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -14623,11 +14623,6 @@ react-motion@^0.5.2:
     prop-types "^15.5.8"
     raf "^3.1.0"
 
-react-numeric-input@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/react-numeric-input/-/react-numeric-input-2.2.3.tgz#4bf5918c3eafed851a80df1eb992d941002bb552"
-  integrity sha1-S/WRjD6v7YUagN8euZLZQQArtVI=
-
 react-onclickoutside@^6.12.2:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.12.2.tgz#8e6cf80c7d17a79f2c908399918158a7b02dda01"


### PR DESCRIPTION
turns out we aren't using this at all anymore. 🔥 