### PR TITLE
ROX-21670: Skip Stackrox Scanner on Scanner V4 error

### DIFF
--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -585,7 +585,8 @@ func (e *enricherImpl) enrichWithScan(ctx context.Context, enrichmentContext Enr
 
 			if features.ScannerV4.Enabled() && scanner.GetScanner().Type() == types.ScannerV4 {
 				// Do not try to scan with additional scanners if Scanner V4 enabled and fails to scan an image.
-				// Per sorting logic in pkg/scanners this would result in the Clairify scanners being skipping.
+				// This would result in Clairify scanners being skipped per sorting logic in `GetAll` of
+				// `pkg/scanners/set_impl.go`.
 				log.Debugf("Scanner V4 encountered an error scanning image %q, skipping remaining scanners", image.GetName().GetFullName())
 				break
 			}

--- a/pkg/scanners/set_impl.go
+++ b/pkg/scanners/set_impl.go
@@ -19,6 +19,10 @@ var (
 	// scannerSortPriority determines the order in which to sort scanners
 	// based on scanner type. Types not included will default to 0 and
 	// be sorted to the top.
+	//
+	// Changing this priority may affect image enrichment logic, refer to
+	// `enrichWithScan` in `pkg/images/enricher/enricher_impl.go` for more
+	// details.
 	scannerSortPriority = map[string]int{
 		types.Clair:     1,
 		types.ScannerV4: 2,


### PR DESCRIPTION
## Description

Modifies the image enricher in Central to NOT fallback to the `Stackrox Scanner` if `Scanner V4` is enabled and encounters an error.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

With ACS deployed to an infra cluster:

#### Before Change
With Scanner V4 broken, executed a `roxctl` scan and observed the scan failure in the `indexer` logs, and a fallback/successful scan via the Stackrox Scanner:

```
$ rctl image scan --image=nginx --force 2>/dev/null | jq '.scan.dataSource'
{
  "id": "169b0d3f-8277-4900-bbce-1127077defae",
  "name": "Stackrox Scanner"
}
```

Indexer Logs
```
{"level":"info","host":"scanner-v4-indexer-7588f96f9c-rbdnf","resource_type":"containerimage","manifest":"sha512:bdefc1cbe20a36d49235e5374ef77c2ef8570ff9dbad0fa9a16a8548de983bb8cf8dcdf7808d2bdeff34baf1df415d44bf9a5e212d4f9e25bdc9db9e85dffb6e","kind":"repository","hash_id":"/v4/containerimage/sha256:9784f7985f6fba493ba30fb68419f50484fee8faaf677216cb95826f8491d2e9","component":"indexer/LayerScanner.scanLayer","layer":"sha256:51d6357098de68f5fc2e50afdaa73fc4fcbdeed2161adc9f14d1d8dae9d94d36","scanner":"rhel-repository-scanner","state":"ScanLayers","error":"rhel: unable to create a mappingFile object","time":"2024-01-11T00:07:47Z"}


{"level":"error","host":"scanner-v4-indexer-7588f96f9c-rbdnf","resource_type":"containerimage","hash_id":"/v4/containerimage/sha256:9784f7985f6fba493ba30fb68419f50484fee8faaf677216cb95826f8491d2e9","manifest":"sha512:bdefc1cbe20a36d49235e5374ef77c2ef8570ff9dbad0fa9a16a8548de983bb8cf8dcdf7808d2bdeff34baf1df415d44bf9a5e212d4f9e25bdc9db9e85dffb6e","state":"ScanLayers","component":"indexer/controller/Controller.Index","error":"failed to scan all layer contents: rhel: unable to create a mappingFile object","time":"2024-01-11T00:07:47Z","message":"error during scan"}


{"level":"error","host":"scanner-v4-indexer-7588f96f9c-rbdnf","component":"scanner/service/indexer.CreateIndexReport","resource_type":"containerimage","hash_id":"/v4/containerimage/sha256:9784f7985f6fba493ba30fb68419f50484fee8faaf677216cb95826f8491d2e9","error":"failed to scan all layer contents: rhel: unable to create a mappingFile object","time":"2024-01-11T00:07:47Z"}

```

#### After Change
With Scanner V4 broken, executed a `roxctl` scan and observed the scan failure via `roxctl` output:

```
$ rctl image scan --image=nginx --force

ERROR:	Scanning image failed: could not scan image: "nginx": rpc error: code = Internal desc = image enrichment error: error scanning image: docker.io/library/nginx:latest error: scanning "docker.io/library/nginx:latest" with scanner "Scanner V4": index and scan image report (reference: "index.docker.io/library/nginx@sha256:9784f7985f6fba493ba30fb68419f50484fee8faaf677216cb95826f8491d2e9"): get or create index: create index: rpc error: code = Internal desc = failed to scan all layer contents: rhel: unable to create a mappingFile object. Retrying after 3 seconds...
```

In Central logs observed the message indicating that remaining scanners have been skipped:

```
pkg/images/enricher: 2024/01/11 00:11:45.970261 enricher_impl.go:589: Debug: Scanner V4 encountered an error scanning image "docker.io/library/nginx:latest", skipping remaining scanners
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
