### PR TITLE
chore(scanner): cleanup client-side OS conversion

### DIFF
--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -186,9 +186,17 @@ func normalizedSeverity(severity v4.VulnerabilityReport_Vulnerability_Severity) 
 // If there are zero known distributions for the image or if there are multiple distributions,
 // return "unknown", as StackRox only supports a single base-OS at this time.
 func os(report *v4.VulnerabilityReport) string {
-	if len(report.GetContents().GetDistributions()) == 1 {
-		for _, dist := range report.GetContents().GetDistributions() {
-			return dist.Did + ":" + dist.VersionId
+	dists := report.GetContents().GetDistributions()
+	if len(dists) == 1 {
+		for _, dist := range dists {
+			version := dist.VersionId
+			// If the version ID is not populated, the fallback to the version.
+			// This is required for Alpine-based images at this time.
+			if version == "" {
+				version = dist.Version
+			}
+			//nolint:staticcheck SA4004 Need to fetch the one and only element in the map.
+			return dist.Did + ":" + version
 		}
 	}
 

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -187,18 +187,10 @@ func normalizedSeverity(severity v4.VulnerabilityReport_Vulnerability_Severity) 
 // return "unknown", as StackRox only supports a single base-OS at this time.
 func os(report *v4.VulnerabilityReport) string {
 	dists := report.GetContents().GetDistributions()
-	if len(dists) == 1 {
-		for _, dist := range dists {
-			version := dist.VersionId
-			// If the version ID is not populated, the fallback to the version.
-			// This is required for Alpine-based images at this time.
-			if version == "" {
-				version = dist.Version
-			}
-			//nolint:staticcheck SA4004 Need to fetch the one and only element in the map.
-			return dist.Did + ":" + version
-		}
+	if len(dists) != 1 {
+		return "unknown"
 	}
 
-	return "unknown"
+	dist := dists[0]
+	return dist.Did + ":" + dist.VersionId
 }

--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -101,7 +101,7 @@ func TestConvert(t *testing.T) {
 }
 
 func TestOS(t *testing.T) {
-	testcases := []struct{
+	testcases := []struct {
 		expected string
 		report   *v4.VulnerabilityReport
 	}{
@@ -154,7 +154,7 @@ func TestOS(t *testing.T) {
 					Distributions: []*v4.Distribution{
 						{
 							Did:       "alpine",
-							VersionId: "",
+							VersionId: "3.18",
 							Version:   "3.18",
 						},
 					},
@@ -168,7 +168,7 @@ func TestOS(t *testing.T) {
 					Distributions: []*v4.Distribution{
 						{
 							Did:       "alpine",
-							VersionId: "",
+							VersionId: "3.18",
 							Version:   "3.18",
 						},
 						{

--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -99,3 +99,91 @@ func TestConvert(t *testing.T) {
 	assert.Equal(t, expected.Components, actual.Components)
 	assert.Equal(t, expected.OperatingSystem, actual.OperatingSystem)
 }
+
+func TestOS(t *testing.T) {
+	testcases := []struct{
+		expected string
+		report   *v4.VulnerabilityReport
+	}{
+		{
+			expected: "rhel:9",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Distributions: []*v4.Distribution{
+						{
+							Did:       "rhel",
+							VersionId: "9",
+							Version:   "9",
+						},
+					},
+				},
+			},
+		},
+		{
+			expected: "ubuntu:22.04",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Distributions: []*v4.Distribution{
+						{
+							Did:       "ubuntu",
+							VersionId: "22.04",
+							Version:   "22.04 (Jammy)",
+						},
+					},
+				},
+			},
+		},
+		{
+			expected: "debian:12",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Distributions: []*v4.Distribution{
+						{
+							Did:       "debian",
+							VersionId: "12",
+							Version:   "12 (bookworm)",
+						},
+					},
+				},
+			},
+		},
+		{
+			expected: "alpine:3.18",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Distributions: []*v4.Distribution{
+						{
+							Did:       "alpine",
+							VersionId: "",
+							Version:   "3.18",
+						},
+					},
+				},
+			},
+		},
+		{
+			expected: "unknown",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Distributions: []*v4.Distribution{
+						{
+							Did:       "alpine",
+							VersionId: "",
+							Version:   "3.18",
+						},
+						{
+							Did: "idk",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.expected, func(t *testing.T) {
+			name := os(testcase.report)
+			assert.Equal(t, testcase.expected, name)
+		})
+	}
+}


### PR DESCRIPTION
## Description

**NOTE: Original purpose of PR will be implemented in https://github.com/stackrox/stackrox/pull/9345. This PR now just does simple cleanup**

I noticed `VersionId` is not populated for Alpine. See https://github.com/quay/claircore/blob/v1.5.20/alpine/distributionscanner.go#L110

I also checked the Scanner v4 DB and saw the following:

```
# SELECT did, version_id, version FROM dist;
  did   | version_id |     version     
--------+------------+-----------------
 rhel   | 9          | 9
 rhel   | 8          | 8
 debian | 12         | 12 (bookworm)
 debian | 11         | 11 (bullseye)
 ubuntu | 22.04      | 22.04 (Jammy)
 alpine |            | 3.18
 alpine |            | 3.16
 alpine |            | 3.17
 alpine |            | 3.11
 alpine |            | 3.8
 alpine |            | 3.14
 debian | 9          | 9 (stretch)
 alpine |            | 3.10
 alpine |            | 3.9
 alpine |            | 3.12
 alpine |            | 3.15
 ubuntu | 20.04      | 20.04 (Focal)
 alpine |            | 3.19
 alpine |            | 3.13
 alpine |            | 3.2
 ubuntu | 18.04      | 18.04 (Bionic)
 debian | 10         | 10 (buster)
 ubuntu | 14.04      | 14.04 (Trusty)
 ubuntu | 16.04      | 16.04 (Xenial)
 rhel   | 7          | 7
 debian | 8          | 8 (jessie)
 ubuntu | 21.10      | 21.10 (Impish)
 debian | 7          | 7 (wheezy)
 ubuntu | 22.10      | 22.10 (Kinetic)
 amzn   | 2018.03    | 2018.03
 alpine |            | 3.7
 ubuntu | 23.10      | 23.10 (Mantic)
 ubuntu | 23.04      | 23.04 (Lunar)
(33 rows)
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
