### PR TITLE
ROX-18452: Add ACS labels to SS and SSB CR

### DIFF
--- a/sensor/kubernetes/complianceoperator/utils.go
+++ b/sensor/kubernetes/complianceoperator/utils.go
@@ -29,7 +29,6 @@ func validateScanName(req scanNameGetter) error {
 }
 
 func convertCentralRequestToScanSetting(namespace string, request *central.ApplyComplianceScanConfigRequest_ScheduledScan) *v1alpha1.ScanSetting {
-	// TODO: Add ACS labels.
 	return &v1alpha1.ScanSetting{
 		TypeMeta: v1.TypeMeta{
 			Kind:       complianceoperator.ScanSetting.Kind,
@@ -38,6 +37,12 @@ func convertCentralRequestToScanSetting(namespace string, request *central.Apply
 		ObjectMeta: v1.ObjectMeta{
 			Name:      request.GetScanSettings().GetScanName(),
 			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "stackrox",
+			},
+			Annotations: map[string]string{
+				"owner": "stackrox",
+			},
 		},
 		Roles: []string{masterRole, workerRole},
 		ComplianceSuiteSettings: v1alpha1.ComplianceSuiteSettings{
@@ -64,7 +69,6 @@ func convertCentralRequestToScanSettingBinding(namespace string, request *centra
 		})
 	}
 
-	// TODO: Add ACS labels.
 	return &v1alpha1.ScanSettingBinding{
 		TypeMeta: v1.TypeMeta{
 			Kind:       complianceoperator.ScanSettingBinding.Kind,
@@ -73,6 +77,12 @@ func convertCentralRequestToScanSettingBinding(namespace string, request *centra
 		ObjectMeta: v1.ObjectMeta{
 			Name:      request.GetScanName(),
 			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "stackrox",
+			},
+			Annotations: map[string]string{
+				"owner": "stackrox",
+			},
 		},
 		Profiles: profileRefs,
 		SettingsRef: &v1alpha1.NamedObjectReference{

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -278,6 +278,66 @@ func TestComplianceV2DeleteComplianceScanConfigurations(t *testing.T) {
 	assert.Empty(t, scanconfigID)
 }
 
+func TestComplianceV2ComplianceObjectMetadata(t *testing.T){
+	ctx := context.Background()
+	conn := centralgrpc.GRPCConnectionToCentral(t)
+	service := v2.NewComplianceScanConfigurationServiceClient(conn)
+	serviceCluster := v1.NewClustersServiceClient(conn)
+	clusters, err := serviceCluster.GetClusters(ctx, &v1.GetClustersRequest{})
+	assert.NoError(t, err)
+	clusterID := clusters.GetClusters()[0].GetId()
+	testName := fmt.Sprintf("test-%s", uuid.NewV4().String())
+	req := &v2.ComplianceScanConfiguration{
+		ScanName: testName,
+		Id:       "",
+		Clusters: []string{clusterID},
+		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
+			OneTimeScan: false,
+			Profiles:    []string{"rhcos4-moderate-rev-4"},
+			Description: "test config",
+			ScanSchedule: &v2.Schedule{
+				IntervalType: 1,
+				Hour:         15,
+				Minute:       0,
+				Interval: &v2.Schedule_DaysOfWeek_{
+					DaysOfWeek: &v2.Schedule_DaysOfWeek{
+						Days: []int32{1, 2, 3, 4, 5, 6},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := service.CreateComplianceScanConfiguration(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, req.GetScanName(), resp.GetScanName())
+
+	query := &v2.RawQuery{Query: ""}
+	scanConfigs, err := service.ListComplianceScanConfigurations(ctx, query)
+	configs := scanConfigs.GetConfigurations()
+	scanconfigID := getscanConfigID(testName, configs)
+	defer deleteScanConfig(ctx, scanconfigID, service)
+
+	// Ensure the ScanSetting and ScanSettingBinding have ACS metadata
+	client := createDynamicClient(t)
+	var scanSetting complianceoperatorv1.ScanSetting
+	err = client.Get(context.TODO(), types.NamespacedName{Name: testName, Namespace: "openshift-compliance"}, &scanSetting)
+	require.NoError(t, err, "failed to get ScanSetting %s", testName)
+
+	assert.Contains(t, scanSetting.Labels, "app.kubernetes.io/name")
+	assert.Equal(t, scanSetting.Labels["app.kubernetes.io/name"], "stackrox")
+	assert.Contains(t, scanSetting.Annotations, "owner")
+	assert.Equal(t, scanSetting.Annotations["owner"], "stackrox")
+
+	var scanSettingBinding complianceoperatorv1.ScanSetting
+	err = client.Get(context.TODO(), types.NamespacedName{Name: testName, Namespace: "openshift-compliance"}, &scanSettingBinding)
+	require.NoError(t, err, "failed to get ScanSettingBinding %s", testName)
+	assert.Contains(t, scanSettingBinding.Labels, "app.kubernetes.io/name")
+	assert.Equal(t, scanSettingBinding.Labels["app.kubernetes.io/name"], "stackrox")
+	assert.Contains(t, scanSettingBinding.Annotations, "owner")
+	assert.Equal(t, scanSettingBinding.Annotations["owner"], "stackrox")
+}
+
 func deleteScanConfig(ctx context.Context, scanID string, service v2.ComplianceScanConfigurationServiceClient) error {
 	req := &v2.ResourceByID{
 		Id: scanID,


### PR DESCRIPTION
## Description

Add label and annotation to ScanSetting (SS) and ScanSettingBinding (SSB) created by StackRox.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
