### PR TITLE
ROX-21345: Ensure DeploymentEnhancer message queue never blocks

### DIFF
--- a/sensor/common/deploymentenhancer/component.go
+++ b/sensor/common/deploymentenhancer/component.go
@@ -51,8 +51,13 @@ func (d *DeploymentEnhancer) ProcessMessage(msg *central.MsgToSensor) error {
 		return errox.ReferencedObjectNotFound.New("received empty message")
 	}
 	log.Debugf("Received message to process in DeploymentEnhancer: %+v", toEnhance)
-	d.deploymentsQueue <- toEnhance
-	return nil
+
+	select {
+	case d.deploymentsQueue <- toEnhance:
+		return nil
+	default:
+		return errox.ResourceExhausted.Newf("DeploymentEnhancer queue has reached its limit of %d", deploymentQueueSize)
+	}
 }
 
 // Start starts the component

--- a/sensor/common/deploymentenhancer/component_test.go
+++ b/sensor/common/deploymentenhancer/component_test.go
@@ -105,10 +105,9 @@ func (s *ComponentTestSuite) TestEnhanceDeploymentsEmptyMessages() {
 }
 
 func (s *ComponentTestSuite) TestMsgQueueOverfill() {
-	dQueue := make(chan *central.DeploymentEnhancementRequest, 1)
 	de := DeploymentEnhancer{
 		responsesC:       make(chan *message.ExpiringMessage),
-		deploymentsQueue: dQueue,
+		deploymentsQueue: make(chan *central.DeploymentEnhancementRequest, 1),
 		storeProvider:    s.mockStoreProvider,
 	}
 	s.NoError(de.ProcessMessage(generateMsgToSensor()))


### PR DESCRIPTION
## Description

DeploymentEnhancer has an internal queue in which all incoming requests are queued.
This PR introduces changes to handle when the queue is full, ensuring `ProcessMessage` does not block.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Automated tests + manual testing.
Manual testing was conducted by decreasing `deploymentQueueSize` to 1, deploying the image, and running multiple `roxctl deployment check` commands in parallel, looking for the introduced error message in the Sensor logs.


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
