### PR TITLE
ROX-21677: add `--enable-telemetry` parameter to `roxctl helm output`

### DIFF
--- a/roxctl/helm/output/output.go
+++ b/roxctl/helm/output/output.go
@@ -45,6 +45,7 @@ func Command(cliEnvironment env.Environment) *cobra.Command {
 	c.PersistentFlags().StringVar(&helmOutputCmd.outputDir, "output-dir", "", "path to the output directory for Helm chart (default: './stackrox-<chart name>-chart')")
 	c.PersistentFlags().BoolVar(&helmOutputCmd.removeOutputDir, "remove", false, "remove the output directory if it already exists")
 	c.PersistentFlags().BoolVar(&helmOutputCmd.rhacs, "rhacs", false, "render RHACS chart flavor")
+	c.PersistentFlags().BoolVar(&helmOutputCmd.telemetry, "enable-telemetry", version.IsReleaseVersion(), "whether to enable telemetry")
 
 	deprecationNote := fmt.Sprintf("use '--%s=%s' instead", flags.ImageDefaultsFlagName, defaults.ImageFlavorNameRHACSRelease)
 	utils.Must(c.PersistentFlags().MarkDeprecated("rhacs", deprecationNote))
@@ -63,6 +64,7 @@ type helmOutputCommand struct {
 	removeOutputDir bool
 	rhacs           bool
 	imageFlavor     string
+	telemetry       bool
 
 	// values injected from either Construct, parent command or for abstracting external dependencies
 	chartName               string
@@ -152,7 +154,10 @@ func (cfg *helmOutputCommand) getChartMetaValues(release bool) (*charts.MetaValu
 
 	values := charts.GetMetaValuesForFlavor(imageFlavor)
 
-	if (version.IsReleaseVersion() || pkgEnv.TelemetryStorageKey.Setting() != "") &&
+	// For testing purposes, running a non-release roxctl version, provide
+	// TelemetryStorageKey with the test value and set --enable-telemetry=true
+	// for to enable telemetry.
+	if cfg.telemetry && (version.IsReleaseVersion() || pkgEnv.TelemetryStorageKey.Setting() != "") &&
 		pkgEnv.TelemetryStorageKey.Setting() != phonehome.DisabledKey {
 		values.TelemetryEnabled = true
 		values.TelemetryKey = pkgEnv.TelemetryStorageKey.Setting()

--- a/roxctl/helm/output/output.go
+++ b/roxctl/helm/output/output.go
@@ -156,7 +156,7 @@ func (cfg *helmOutputCommand) getChartMetaValues(release bool) (*charts.MetaValu
 
 	// For testing purposes, running a non-release roxctl version, provide
 	// TelemetryStorageKey with the test value and set --enable-telemetry=true
-	// for to enable telemetry.
+	// to get telemetry enabled by default in the resulting chart.
 	if cfg.telemetry && (version.IsReleaseVersion() || pkgEnv.TelemetryStorageKey.Setting() != "") &&
 		pkgEnv.TelemetryStorageKey.Setting() != phonehome.DisabledKey {
 		values.TelemetryEnabled = true

--- a/roxctl/helm/output/output_test.go
+++ b/roxctl/helm/output/output_test.go
@@ -5,11 +5,17 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/buildinfo"
+	pkgEnv "github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome"
+	"github.com/stackrox/rox/pkg/version/testutils"
 	env "github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/io"
 	"github.com/stackrox/rox/roxctl/common/printer"
 	"github.com/stackrox/rox/roxctl/helm/internal/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -29,6 +35,64 @@ func (suite *helmOutputTestSuite) SetupTest() {
 	suite.helmOutputCommand = helmOutputCommand{}
 	suite.helmOutputCommand.env = env.NewTestCLIEnvironment(suite.T(), testIO, printer.DefaultColorPrinter())
 	suite.errOur = errOut
+}
+
+func TestTelemetryConfiguration(t *testing.T) {
+	dirtyVersion := "1.2.3-dirty"
+	releaseVersion := "1.2.3"
+	var disabledInDebug any
+	if !buildinfo.ReleaseBuild || buildinfo.TestBuild {
+		disabledInDebug = phonehome.DisabledKey
+	}
+
+	testIO, _, _, _ := io.TestIO()
+	cmd := helmOutputCommand{
+		imageFlavor: "opensource",
+		env:         env.NewTestCLIEnvironment(t, testIO, printer.DefaultColorPrinter()),
+	}
+
+	type result struct {
+		enabled bool
+		key     interface{}
+	}
+
+	disabled := result{enabled: false, key: phonehome.DisabledKey}
+
+	testCases := []struct {
+		testName  string
+		version   string
+		telemetry bool
+		key       string
+		expected  result
+	}{
+		{testName: "test1", version: dirtyVersion, telemetry: true, key: "", expected: disabled},
+		{testName: "test2", version: dirtyVersion, telemetry: false, key: "", expected: disabled},
+		{testName: "test3", version: dirtyVersion, telemetry: true, key: "KEY", expected: result{enabled: true, key: "KEY"}},
+		{testName: "test4", version: dirtyVersion, telemetry: false, key: "KEY", expected: disabled},
+
+		{testName: "test5", version: releaseVersion, telemetry: true, key: "", expected: result{enabled: buildinfo.ReleaseBuild && !buildinfo.TestBuild, key: disabledInDebug}},
+		{testName: "test6", version: releaseVersion, telemetry: false, key: "", expected: disabled},
+		{testName: "test7", version: releaseVersion, telemetry: true, key: "KEY", expected: result{enabled: true, key: "KEY"}},
+		{testName: "test8", version: releaseVersion, telemetry: false, key: "KEY", expected: disabled},
+
+		{testName: "test9", version: dirtyVersion, telemetry: true, key: phonehome.DisabledKey, expected: disabled},
+		{testName: "test10", version: dirtyVersion, telemetry: false, key: phonehome.DisabledKey, expected: disabled},
+		{testName: "test11", version: releaseVersion, telemetry: true, key: phonehome.DisabledKey, expected: disabled},
+		{testName: "test12", version: releaseVersion, telemetry: false, key: phonehome.DisabledKey, expected: disabled},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			t.Setenv(pkgEnv.TelemetryStorageKey.EnvVar(), testCase.key)
+			testutils.SetMainVersion(t, testCase.version)
+
+			cmd.telemetry = testCase.telemetry
+			values, err := cmd.getChartMetaValues(true)
+			require.NoError(t, err, err)
+			assert.Equal(t, testCase.expected.enabled, values.TelemetryEnabled)
+			assert.Equal(t, testCase.expected.key, values.TelemetryKey)
+		})
+	}
 }
 
 func (suite *helmOutputTestSuite) TestInvalidCommandArgs() {


### PR DESCRIPTION
## Description

Aligning the command line parameter with `roxctl central generate`.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Unit test. Manually in command line.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
