### PR TITLE
fix(scanner): Set Alpine Version from VersionID

### DIFF
--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -187,6 +187,23 @@ func toProtoV4Package(p *claircore.Package) (*v4.Package, error) {
 	}, nil
 }
 
+// versionID returns the distribution version ID.
+//
+// TODO(ROX-21678): `VersionId` is currently not populated for Alpine[1],
+//                  temporarily falling back to the version.
+//
+// [1]: https://github.com/quay/claircore/blob/88ccfbecee88d7b326b9a2fb3ab5b5f4cfa0b610/alpine/distributionscanner.go#L110-L113
+func versionID(d *claircore.Distribution) string {
+	vID := d.VersionID
+	if vID == "" {
+		switch d.DID {
+		case "alpine":
+			vID = d.Version
+		}
+	}
+	return vID
+}
+
 func toProtoV4Distribution(d *claircore.Distribution) *v4.Distribution {
 	if d == nil {
 		return nil
@@ -197,7 +214,7 @@ func toProtoV4Distribution(d *claircore.Distribution) *v4.Distribution {
 		Name:            d.Name,
 		Version:         d.Version,
 		VersionCodeName: d.VersionCodeName,
-		VersionId:       d.VersionID,
+		VersionId:       versionID(d),
 		Arch:            d.Arch,
 		Cpe:             toCPEString(d.CPE),
 		PrettyName:      d.PrettyName,

--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -188,15 +188,14 @@ func toProtoV4Package(p *claircore.Package) (*v4.Package, error) {
 }
 
 // versionID returns the distribution version ID.
-//
-// TODO(ROX-21678): `VersionId` is currently not populated for Alpine[1],
-//                  temporarily falling back to the version.
-//
-// [1]: https://github.com/quay/claircore/blob/88ccfbecee88d7b326b9a2fb3ab5b5f4cfa0b610/alpine/distributionscanner.go#L110-L113
 func versionID(d *claircore.Distribution) string {
 	vID := d.VersionID
 	if vID == "" {
 		switch d.DID {
+		// TODO(ROX-21678): `VersionId` is currently not populated for Alpine[1],
+		//                  temporarily falling back to the version.
+		//
+		// [1]: https://github.com/quay/claircore/blob/88ccfbecee88d7b326b9a2fb3ab5b5f4cfa0b610/alpine/distributionscanner.go#L110-L113
 		case "alpine":
 			vID = d.Version
 		}

--- a/scanner/mappers/mappers_test.go
+++ b/scanner/mappers/mappers_test.go
@@ -916,3 +916,25 @@ func Test_getVulnName(t *testing.T) {
 	}
 
 }
+
+func Test_toClairCoreDistribution(t *testing.T) {
+	tests := map[string]struct {
+		d         *claircore.Distribution
+		versionID string
+	}{
+		"when version ID is empty and distribution is Alpine then use version": {
+			d:         &claircore.Distribution{Version: "sample alpine version ID", DID: "alpine"},
+			versionID: "sample alpine version ID",
+		},
+		"when version is not empty and distribution is Alpine then use version ID": {
+			d:         &claircore.Distribution{Version: "sample alpine version", DID: "alpine"},
+			versionID: "sample alpine version",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			versionID := versionID(tt.d)
+			assert.Equal(t, tt.versionID, versionID)
+		})
+	}
+}

--- a/scanner/mappers/mappers_test.go
+++ b/scanner/mappers/mappers_test.go
@@ -917,7 +917,7 @@ func Test_getVulnName(t *testing.T) {
 
 }
 
-func Test_toClairCoreDistribution(t *testing.T) {
+func Test_versionID(t *testing.T) {
 	tests := map[string]struct {
 		d         *claircore.Distribution
 		versionID string


### PR DESCRIPTION
## Description

`VersionId` is not populated for Alpine: https://github.com/quay/claircore/blob/v1.5.20/alpine/distributionscanner.go#L110

Using `Version` instead, see below:

```
# SELECT did, version_id, version FROM dist;
  did   | version_id |     version     
--------+------------+-----------------
 rhel   | 9          | 9
 rhel   | 8          | 8
 debian | 12         | 12 (bookworm)
 debian | 11         | 11 (bullseye)
 ubuntu | 22.04      | 22.04 (Jammy)
 alpine |            | 3.18
 alpine |            | 3.16
 alpine |            | 3.17
 alpine |            | 3.11
 alpine |            | 3.8
 alpine |            | 3.14
 debian | 9          | 9 (stretch)
 alpine |            | 3.10
 alpine |            | 3.9
 alpine |            | 3.12
 alpine |            | 3.15
 ubuntu | 20.04      | 20.04 (Focal)
 alpine |            | 3.19
 alpine |            | 3.13
 alpine |            | 3.2
 ubuntu | 18.04      | 18.04 (Bionic)
 debian | 10         | 10 (buster)
 ubuntu | 14.04      | 14.04 (Trusty)
 ubuntu | 16.04      | 16.04 (Xenial)
 rhel   | 7          | 7
 debian | 8          | 8 (jessie)
 ubuntu | 21.10      | 21.10 (Impish)
 debian | 7          | 7 (wheezy)
 ubuntu | 22.10      | 22.10 (Kinetic)
 amzn   | 2018.03    | 2018.03
 alpine |            | 3.7
 ubuntu | 23.10      | 23.10 (Mantic)
 ubuntu | 23.04      | 23.04 (Lunar)
(33 rows)
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

```
⮩  ./bin/scannerctl scan --certs certs/scannerctl https://docker.io/library/alpine:latest > /tmp/alpine.json
⮩  jq '.contents.distributions' /tmp/alpine.json                         
[
  {
    "id": "7",
    "did": "alpine",
    "name": "Alpine Linux",
    "version": "3.19",
    "version_id": "3.19",
    "cpe": "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*",
    "pretty_name": "Alpine Linux v3.19"
  }
]
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
