### PR TITLE
ROX-21683: Link from integration tile to cluster init bundles table

### DIFF
--- a/ui/apps/platform/cypress/integration/integrations/general.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/general.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
 import { getRegExpForTitleWithBranding } from '../../helpers/title';
 
 import {
@@ -80,6 +81,7 @@ describe('Integrations Dashboard', () => {
         assertIntegrationsTable(integrationSource, integrationType);
     });
 
+    // Cluster Init Bundle card will be removed in a future version.
     it('should go to the table for clusterInitBundle type of authProviders', () => {
         const integrationSource = 'authProviders';
         const integrationType = 'clusterInitBundle';
@@ -88,6 +90,10 @@ describe('Integrations Dashboard', () => {
 
         clickIntegrationTileOnDashboard(integrationSource, integrationType);
 
-        assertIntegrationsTable(integrationSource, integrationType);
+        if (hasFeatureFlag('ROX_MOVE_INIT_BUNDLES_UI')) {
+            cy.location('pathname').should('eq', '/main/clusters/init-bundles');
+        } else {
+            assertIntegrationsTable(integrationSource, integrationType);
+        }
     });
 });

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ClusterInitBundlesTile.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ClusterInitBundlesTile.tsx
@@ -1,6 +1,8 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import { fetchClusterInitBundles } from 'services/ClustersService';
+import { clustersInitBundlesPath } from 'routePaths';
 
 import {
     authenticationTokensSource as source,
@@ -13,6 +15,8 @@ const { image, label, type } = descriptor;
 
 function ClusterInitBundlesTile(): ReactElement {
     const [numIntegrations, setNumIntegrations] = useState(0);
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isMoveInitBundlesEnabled = isFeatureFlagEnabled('ROX_MOVE_INIT_BUNDLES_UI');
 
     useEffect(() => {
         fetchClusterInitBundles()
@@ -26,7 +30,11 @@ function ClusterInitBundlesTile(): ReactElement {
         <IntegrationTile
             image={image}
             label={label}
-            linkTo={getIntegrationsListPath(source, type)}
+            linkTo={
+                isMoveInitBundlesEnabled
+                    ? clustersInitBundlesPath
+                    : getIntegrationsListPath(source, type)
+            }
             numIntegrations={numIntegrations}
         />
     );


### PR DESCRIPTION
## Description

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

For **with feature flag** below:

1. Before you `yarn deploy` in ui folder:

    ```sh
    export ROX_MOVE_INIT_BUNDLES_UI=true
    ```

2. Before you `yarn cypress-open` in ui/apps/platform folder:

    ```sh
    export CYPRESS_ROX_MOVE_INIT_BUNDLES_UI=true
    ```

### Manual testing

1. Visit /main/integrations and then scroll down
    ![integrations](https://github.com/stackrox/stackrox/assets/11862657/9d6d8afe-36aa-48e5-9fb2-6f6168bb93c6)

2. Click **Cluster Init Bundle** card

### without feature flag

See /main/integrations/authProviders/clusterInitBundle
See absence of requests because of Redux and sagas for integrations route
![integrations_authProviders_clusterInitBundle](https://github.com/stackrox/stackrox/assets/11862657/a02b8645-08d7-4e40-b5b2-0cc32af08160)

### with feature flag

See GET /v1/cluster-init/init-bundles request
See /main/clusters/init-bundles page
![clusters_init-bundles](https://github.com/stackrox/stackrox/assets/11862657/bb258fe7-98b6-4920-91e5-5798ebbeb9bd)

### Integration testing

1. `yarn cypress-open` in ui/apps/platform
    * integrations/clusterInitBundles.test.js
        See test pass because it visits the path directly
    * integrations/general.test.js
        Oops, I forgot about this. Added conditional assertion.