### PR TITLE
ROX-21689: Link from button on clusters page to init bundles

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/Components/ManageTokensButton.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ManageTokensButton.tsx
@@ -1,15 +1,26 @@
-import React from 'react';
-import { integrationsPath } from 'routePaths';
+import React, { ReactElement } from 'react';
 import { HashLink } from 'react-router-hash-link';
 
-const ManageTokensButton = () => (
-    <HashLink
-        to={`${integrationsPath}#token-integrations`}
-        className="no-underline flex-shrink-0"
-        data-testid="manageTokens"
-    >
-        Manage Tokens
-    </HashLink>
-);
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import { clustersInitBundlesPath, integrationsPath } from 'routePaths';
+
+function ManageTokensButton(): ReactElement {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isMoveInitBundlesEnabled = isFeatureFlagEnabled('ROX_MOVE_INIT_BUNDLES_UI');
+
+    return (
+        <HashLink
+            to={
+                isMoveInitBundlesEnabled
+                    ? clustersInitBundlesPath
+                    : `${integrationsPath}#token-integrations`
+            }
+            className="no-underline flex-shrink-0"
+            data-testid="manageTokens"
+        >
+            {isMoveInitBundlesEnabled ? 'Manage init bundles' : 'Manage tokens'}
+        </HashLink>
+    );
+}
 
 export default ManageTokensButton;


### PR DESCRIPTION
## Description

Fixed by dropping the 2 commits: Ouch, by mistake this is based on #9348

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

For **with feature flag** below:

1. Before you `yarn deploy` in ui folder:

    ```sh
    export ROX_MOVE_INIT_BUNDLES_UI=true
    ```

### Manual testing

1. Visit /main/clusters

### without feature flag

See **Manage tokens** button
See link to /main/integrations#token-integrations
![to_iintegrations](https://github.com/stackrox/stackrox/assets/11862657/88034e3c-82e1-4aee-a797-f5b9ec6eef1c)

### with feature flag

See **Manage init bundles** button
See link to /main/clusters/init-bundles
![to_init-bundles](https://github.com/stackrox/stackrox/assets/11862657/a6f8feaa-bf49-4554-9659-f98907e2e2a3)
