### PR TITLE
ROX-18375: Translate ebpf to core_bpf

### DIFF
--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -291,7 +291,12 @@ type CollectorContainerSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	ImageFlavor *CollectorImageFlavor `json:"imageFlavor,omitempty"`
 
+	// Set this to 'true' to prevent translation of the collection method, e.g. to enforce using EBPF as an exception.
+	//+kubebuilder:default=false
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=3
+	ForceCollection *bool `json:"forceCollection,omitempty"`
+
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=4
 	ContainerSpec `json:",inline"`
 }
 

--- a/operator/apis/platform/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/apis/platform/v1alpha1/zz_generated.deepcopy.go
@@ -425,6 +425,11 @@ func (in *CollectorContainerSpec) DeepCopyInto(out *CollectorContainerSpec) {
 		*out = new(CollectorImageFlavor)
 		**out = **in
 	}
+	if in.ForceCollection != nil {
+		in, out := &in.ForceCollection, &out.ForceCollection
+		*out = new(bool)
+		**out = **in
+	}
 	in.ContainerSpec.DeepCopyInto(&out.ContainerSpec)
 }
 

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -476,6 +476,12 @@ spec:
                         - NoCollection
                         - KernelModule
                         type: string
+                      forceCollection:
+                        default: false
+                        description: Set this to 'true' to prevent translation of
+                          the collection method, e.g. to enforce using EBPF as an
+                          exception.
+                        type: boolean
                       imageFlavor:
                         default: Regular
                         description: The image flavor to use for collector. "Regular"

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -746,6 +746,10 @@ spec:
           please refer to the documentation).
         displayName: Image Flavor
         path: perNode.collector.imageFlavor
+      - description: Set this to 'true' to prevent translation of the collection method,
+          e.g. to enforce using EBPF as an exception.
+        displayName: Force Collection
+        path: perNode.collector.forceCollection
       - description: Allows overriding the default resource settings for this component.
           Please consult the documentation for an overview of default resource requirements
           and a sizing guide.

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -476,6 +476,12 @@ spec:
                         - NoCollection
                         - KernelModule
                         type: string
+                      forceCollection:
+                        default: false
+                        description: Set this to 'true' to prevent translation of
+                          the collection method, e.g. to enforce using EBPF as an
+                          exception.
+                        type: boolean
                       imageFlavor:
                         default: Regular
                         description: The image flavor to use for collector. "Regular"

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -648,6 +648,10 @@ spec:
       - description: Name of resource.
         displayName: Name
         path: overlays[0].name
+      - description: Set this to 'true' to prevent translation of the collection method,
+          e.g. to enforce using EBPF as an exception.
+        displayName: Force Collection
+        path: perNode.collector.forceCollection
       - description: Settings for the Node-Inventory container, which is responsible
           for scanning the Nodes' filesystem.
         displayName: Node Scanning Settings

--- a/operator/pkg/securedcluster/values/translation/translation.go
+++ b/operator/pkg/securedcluster/values/translation/translation.go
@@ -283,15 +283,21 @@ func (t Translator) getCollectorContainerValues(collectorContainerSpec *platform
 	if c := collectorContainerSpec.Collection; c != nil {
 		switch *c {
 		case platform.CollectionEBPF:
-			cv.SetStringValue("collectionMethod", storage.CollectionMethod_EBPF.String())
+			// EBPF collection has been deprecated, translate it to CORE_BPF if it's not forced
+			if collectorContainerSpec.ForceCollection != nil &&
+				*collectorContainerSpec.ForceCollection {
+				cv.SetStringValue("collectionMethod", storage.CollectionMethod_EBPF.String())
+			} else {
+				cv.SetStringValue("collectionMethod", storage.CollectionMethod_CORE_BPF.String())
+			}
 		case platform.CollectionNone:
 			cv.SetStringValue("collectionMethod", storage.CollectionMethod_NO_COLLECTION.String())
 		case platform.CollectionCOREBPF:
 			cv.SetStringValue("collectionMethod", storage.CollectionMethod_CORE_BPF.String())
 		case legacyCollectionKernelModule:
 			// Kernel module collection has been removed, but for the
-			// purposes of upgrades, we translate it to EBPF
-			cv.SetStringValue("collectionMethod", storage.CollectionMethod_EBPF.String())
+			// purposes of upgrades, we translate it to CORE_BPF
+			cv.SetStringValue("collectionMethod", storage.CollectionMethod_CORE_BPF.String())
 		default:
 			return cv.SetError(fmt.Errorf("invalid spec.perNode.collection %q", *c))
 		}

--- a/operator/pkg/securedcluster/values/translation/translation_test.go
+++ b/operator/pkg/securedcluster/values/translation/translation_test.go
@@ -282,7 +282,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 						PerNode: &platform.PerNodeSpec{
 							Collector: &platform.CollectorContainerSpec{
 								ImageFlavor: platform.ImageFlavorRegular.Pointer(),
-								Collection:  platform.CollectionEBPF.Pointer(),
+								Collection:  platform.CollectionCOREBPF.Pointer(),
 							},
 							TaintToleration: platform.TaintTolerate.Pointer(),
 							Compliance: &platform.ContainerSpec{
@@ -526,7 +526,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 					},
 				},
 				"collector": map[string]interface{}{
-					"collectionMethod":        "EBPF",
+					"collectionMethod":        "CORE_BPF",
 					"disableTaintTolerations": false,
 					"slimMode":                false,
 					"complianceResources": map[string]interface{}{
@@ -545,6 +545,101 @@ func (s *TranslationTestSuite) TestTranslate() {
 					},
 				},
 				"registryOverride": "my.registry.override.com",
+			},
+		},
+		"translate EBPF to CORE_BPF": {
+			args: args{
+				client: newFakeClientWithInitBundle(t),
+				sc: platform.SecuredCluster{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "stackrox"},
+					Spec: platform.SecuredClusterSpec{
+						ClusterName: "test-cluster",
+						PerNode: &platform.PerNodeSpec{
+							Collector: &platform.CollectorContainerSpec{
+								ImageFlavor: platform.ImageFlavorRegular.Pointer(),
+								Collection:  platform.CollectionEBPF.Pointer(),
+							},
+						},
+					},
+				},
+			},
+			want: chartutil.Values{
+				"clusterName":   "test-cluster",
+				"ca":            map[string]string{"cert": "ca central content"},
+				"createSecrets": false,
+				"collector": map[string]interface{}{
+					"collectionMethod": "CORE_BPF",
+					"slimMode":         false,
+				},
+				"admissionControl": map[string]interface{}{
+					"dynamic": map[string]interface{}{
+						"enforceOnCreates": true,
+						"enforceOnUpdates": true,
+					},
+					"listenOnCreates": true,
+					"listenOnUpdates": true,
+				},
+				"scanner": map[string]interface{}{
+					"disable": false,
+				},
+				"sensor": map[string]interface{}{
+					"localImageScanning": map[string]string{
+						"enabled": "true",
+					},
+				},
+				"monitoring": map[string]interface{}{
+					"openshift": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+			},
+		},
+		"force EBPF": {
+			args: args{
+				client: newFakeClientWithInitBundle(t),
+				sc: platform.SecuredCluster{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "stackrox"},
+					Spec: platform.SecuredClusterSpec{
+						ClusterName: "test-cluster",
+						PerNode: &platform.PerNodeSpec{
+							Collector: &platform.CollectorContainerSpec{
+								ImageFlavor:     platform.ImageFlavorRegular.Pointer(),
+								Collection:      platform.CollectionEBPF.Pointer(),
+								ForceCollection: pointer.Bool(true),
+							},
+						},
+					},
+				},
+			},
+			want: chartutil.Values{
+				"clusterName":   "test-cluster",
+				"ca":            map[string]string{"cert": "ca central content"},
+				"createSecrets": false,
+				"collector": map[string]interface{}{
+					"collectionMethod": "EBPF",
+					"slimMode":         false,
+				},
+				"admissionControl": map[string]interface{}{
+					"dynamic": map[string]interface{}{
+						"enforceOnCreates": true,
+						"enforceOnUpdates": true,
+					},
+					"listenOnCreates": true,
+					"listenOnUpdates": true,
+				},
+				"scanner": map[string]interface{}{
+					"disable": false,
+				},
+				"sensor": map[string]interface{}{
+					"localImageScanning": map[string]string{
+						"enabled": "true",
+					},
+				},
+				"monitoring": map[string]interface{}{
+					"openshift": map[string]interface{}{
+						"enabled": true,
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Description

Introduce a new values translation in the operator to switch from ebpf collection method to core_bpf. It means at upgrade of an existing secured cluster, configured to use ebpf, it will be modified to use core_bpf.

The translation is happening on every sync, which means by itself it will prevent any attempts to override a secured cluster CR to temporary use ebpf. To still be able to use ebpf if needed, a new boolean configuration option is introduced `spec.perNode.Collector.forceCollection`. If the flag is set, no translation from ebpf to core_bpf would be applied, and ebpf value could be used.

The use case for the new option is temporary workarounds and troubleshooting, thus it doesn't have to be advertised in common scenarios in the documentation.

Part of https://github.com/stackrox/collector/issues/1470

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

Deployed a new secured cluster using the operator, modified secured cluster CR to enable different combination of the collection method and force collection flag [(ebpf, true), (ebpf, false), (core_bpf, true), (core_bpf, false)], confirming the expected resulting collection method.