### PR TITLE
fix(ui): Update workload cve telemetry to track fewer filter values

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -391,11 +391,9 @@ const VulnMgmtCves = ({
             return;
         }
 
-        cveNames.forEach((cve) => {
-            analyticsTrack({
-                event: GLOBAL_SNOOZE_CVE,
-                properties: { type, cve, duration },
-            });
+        analyticsTrack({
+            event: GLOBAL_SNOOZE_CVE,
+            properties: { type, duration },
         });
     }
 

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -30,18 +30,18 @@ export const GLOBAL_SNOOZE_CVE = 'Global Snooze CVE';
 type AnalyticsBoolean = 0 | 1;
 
 // search categories and type guards for tracking search filters on the Workload CVE pages
-export const searchCategoriesWithFilter = [
-    'CVE',
-    'IMAGE',
-    'COMPONENT',
-    'COMPONENT SOURCE',
-    'SEVERITY',
-    'FIXABLE',
-] as const;
+export const searchCategoriesWithFilter = ['COMPONENT SOURCE', 'SEVERITY', 'FIXABLE'] as const;
 export const isSearchCategoryWithFilter = tupleTypeGuard(searchCategoriesWithFilter);
 export type SearchCategoryWithFilter = UnionFrom<typeof searchCategoriesWithFilter>;
 
-export const searchCategoriesWithoutFilter = ['DEPLOYMENT', 'NAMESPACE', 'CLUSTER'] as const;
+export const searchCategoriesWithoutFilter = [
+    'CVE',
+    'IMAGE',
+    'COMPONENT',
+    'DEPLOYMENT',
+    'NAMESPACE',
+    'CLUSTER',
+] as const;
 export const isSearchCategoryWithoutFilter = tupleTypeGuard(searchCategoriesWithoutFilter);
 export type SearchCategoryWithoutFilter = UnionFrom<typeof searchCategoriesWithoutFilter>;
 
@@ -137,7 +137,6 @@ type AnalyticsEvent =
           event: typeof GLOBAL_SNOOZE_CVE;
           properties: {
               type: 'NODE' | 'PLATFORM';
-              cve: string;
               duration: string;
           };
       };


### PR DESCRIPTION
## Description

Updates VM telemetry to not track values for "CVE", "Image", or "Component" in Workload CVE filters, nor track "CVE" when a legacy global snooze is applied.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Apply CVE, Image, and Component filters, and verify that the filter value is not sent via telemetry API calls. _Note that only "category" appears in the properties when viewing the network request._
![image](https://github.com/stackrox/stackrox/assets/1292638/6ff54f8a-4aa0-44f0-bb62-fbf0e900db89)


Repeat for legacy snooze:

![image](https://github.com/stackrox/stackrox/assets/1292638/7dc73e5c-d885-4886-bcb5-2b5b5226ff5a)


