### PR TITLE
test(ui): Adding tests for the cancel request workflow

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/ExceptionManagement.helpers.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/ExceptionManagement.helpers.ts
@@ -1,7 +1,7 @@
 import { visit } from '../../../helpers/visit';
 
 const basePath = '/main/vulnerabilities/exception-management';
-const pendingRequestsPath = `${basePath}/pending-requests`;
+export const pendingRequestsPath = `${basePath}/pending-requests`;
 
 export function visitExceptionManagement() {
     visit(pendingRequestsPath);

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
@@ -1,0 +1,99 @@
+import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
+import {
+    cancelAllCveExceptions,
+    fillAndSubmitExceptionForm,
+    selectSingleCveForException,
+    verifyExceptionConfirmationDetails,
+    verifySelectedCvesInModal,
+    visitWorkloadCveOverview,
+} from '../workloadCves/WorkloadCves.helpers';
+import { selectors as workloadCVESelectors } from '../workloadCves/WorkloadCves.selectors';
+import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
+import { visit } from '../../../helpers/visit';
+import { pendingRequestsPath } from './ExceptionManagement.helpers';
+
+const deferralComment = 'Defer me';
+const deferralExpiry = 'When all CVEs are fixable';
+const deferralScope = 'All images';
+
+describe('Exception Management Request Details Page', () => {
+    withAuth();
+
+    before(function () {
+        if (
+            !hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES') ||
+            !hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL') ||
+            !hasFeatureFlag('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS')
+        ) {
+            this.skip();
+        }
+    });
+
+    beforeEach(() => {
+        if (
+            hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES') &&
+            hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL') &&
+            hasFeatureFlag('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS')
+        ) {
+            cancelAllCveExceptions();
+
+            visitWorkloadCveOverview();
+            cy.get(vulnSelectors.clearFiltersButton).click(); // Note: This is a workaround to prevent a lack of CVE data from causing the test to fail in CI
+
+            // defer a single cve
+            selectSingleCveForException('DEFERRAL').then((cveName) => {
+                verifySelectedCvesInModal([cveName]);
+                fillAndSubmitExceptionForm({
+                    comment: deferralComment,
+                    expiryLabel: deferralExpiry,
+                });
+                verifyExceptionConfirmationDetails({
+                    expectedAction: 'Deferral',
+                    cves: [cveName],
+                    scope: deferralScope,
+                    expiry: deferralExpiry,
+                });
+                cy.get(workloadCVESelectors.copyToClipboardButton).click();
+                cy.get(workloadCVESelectors.copyToClipboardTooltipText).contains('Copied');
+                // @TODO: Can make this into a custom cypress command (ie. getClipboardText)
+                cy.window()
+                    .then((win) => {
+                        return win.navigator.clipboard.readText();
+                    })
+                    .then((url) => {
+                        visit(url);
+                    });
+            });
+        }
+    });
+
+    after(() => {
+        if (
+            hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES') &&
+            hasFeatureFlag('ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL') &&
+            hasFeatureFlag('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS')
+        ) {
+            cancelAllCveExceptions();
+        }
+    });
+
+    it('should be able to cancel a request if the user is the requester', () => {
+        cy.get('button:contains("Cancel request")').click();
+        cy.get('div[role="dialog"]').should('exist');
+        cy.get('div[role="dialog"] button:contains("Cancel request")').click();
+        cy.get('div[role="dialog"]').should('not.exist');
+        cy.location().should((location) => {
+            expect(location.pathname).to.eq(pendingRequestsPath);
+        });
+    });
+
+    it('should be able to see how many CVEs will be affected by a cancel', () => {
+        cy.get('table tbody tr:not(".pf-c-table__expandable-row")').then((rows) => {
+            const numCVEs = rows.length;
+            cy.get('button:contains("Cancel request")').click();
+            cy.get('div[role="dialog"]').should('exist');
+            cy.get(`div:contains("CVE count: ${numCVEs}")`).should('exist');
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCancelButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCancelButtonModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Alert, AlertVariant, Button, Flex, Modal, Spinner, Text } from '@patternfly/react-core';
+import { Alert, AlertVariant, Button, Flex, Modal, Text } from '@patternfly/react-core';
 
 import {
     VulnerabilityException,
@@ -8,7 +8,6 @@ import {
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useModal from 'hooks/useModal';
 import useRestMutation from 'hooks/useRestMutation';
-import useRequestCVEsDetails from '../hooks/useRequestCVEsDetails';
 
 type RequestCancelButtonModalProps = {
     exception: VulnerabilityException;
@@ -17,8 +16,6 @@ type RequestCancelButtonModalProps = {
 
 function RequestCancelButtonModal({ exception, onSuccess }: RequestCancelButtonModalProps) {
     const cancelRequestMutation = useRestMutation(cancelVulnerabilityException);
-    const { isLoading: isRequestCVEsDetailsLoading, totalAffectedImageCount } =
-        useRequestCVEsDetails(exception);
 
     const { isModalOpen, openModal, closeModal } = useModal();
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -38,8 +35,6 @@ function RequestCancelButtonModal({ exception, onSuccess }: RequestCancelButtonM
         });
     }
 
-    const isCancelRequestDisabled = isRequestCVEsDetailsLoading || cancelRequestMutation.isLoading;
-
     return (
         <>
             <Button variant="secondary" onClick={openModal}>
@@ -55,7 +50,7 @@ function RequestCancelButtonModal({ exception, onSuccess }: RequestCancelButtonM
                         key="approve"
                         variant="primary"
                         isLoading={cancelRequestMutation.isLoading}
-                        isDisabled={isCancelRequestDisabled}
+                        isDisabled={cancelRequestMutation.isLoading}
                         onClick={cancelRequest}
                     >
                         Cancel request
@@ -76,18 +71,6 @@ function RequestCancelButtonModal({ exception, onSuccess }: RequestCancelButtonM
                         title="Cancelling the request will return the CVEs to the 'Observed' status."
                     >
                         <Text>CVE count: {exception.cves.length}</Text>
-                        <Text>
-                            Affected images:{' '}
-                            {isRequestCVEsDetailsLoading ? (
-                                <Spinner
-                                    isSVG
-                                    size="md"
-                                    aria-label="Loading affected images count"
-                                />
-                            ) : (
-                                totalAffectedImageCount
-                            )}
-                        </Text>
                     </Alert>
                 </Flex>
             </Modal>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestDenialButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestDenialButtonModal.tsx
@@ -6,7 +6,6 @@ import {
     Flex,
     Form,
     Modal,
-    Spinner,
     Text,
     TextArea,
 } from '@patternfly/react-core';
@@ -21,7 +20,6 @@ import {
 } from 'services/VulnerabilityExceptionService';
 import useRestMutation from 'hooks/useRestMutation';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import useRequestCVEsDetails from 'Containers/Vulnerabilities/ExceptionManagement/hooks/useRequestCVEsDetails';
 
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 
@@ -40,8 +38,6 @@ const validationSchema = yup.object().shape({
 
 function RequestDenialButtonModal({ exception, onSuccess }: RequestDenialButtonModalProps) {
     const denyRequestMutation = useRestMutation(denyVulnerabilityException);
-    const { isLoading: isRequestCVEsDetailsLoading, totalAffectedImageCount } =
-        useRequestCVEsDetails(exception);
 
     const { isModalOpen, openModal, closeModal } = useModal();
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -112,18 +108,6 @@ function RequestDenialButtonModal({ exception, onSuccess }: RequestDenialButtonM
                         title="Denying the request will return the CVEs to the 'Observed' status."
                     >
                         <Text>CVE count: {exception.cves.length}</Text>
-                        <Text>
-                            Affected images:{' '}
-                            {isRequestCVEsDetailsLoading ? (
-                                <Spinner
-                                    isSVG
-                                    size="md"
-                                    aria-label="Loading affected images count"
-                                />
-                            ) : (
-                                totalAffectedImageCount
-                            )}
-                        </Text>
                     </Alert>
                     <Form>
                         <FormLabelGroup

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/hooks/useRequestCVEsDetails.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/hooks/useRequestCVEsDetails.ts
@@ -41,7 +41,6 @@ type RequestCVEDetail = {
 
 type UseAffectedImagesCountResult = {
     isLoading: boolean;
-    totalAffectedImageCount: number;
     requestCVEsDetails: RequestCVEDetail[];
 };
 
@@ -71,14 +70,8 @@ function useRequestCVEsDetails(exception: VulnerabilityException): UseAffectedIm
             };
         }) || [];
 
-    const totalAffectedImageCount =
-        data?.imageCVEs.reduce((acc, curr) => {
-            return acc + curr.affectedImageCount;
-        }, 0) || 0;
-
     return {
         isLoading,
-        totalAffectedImageCount,
         requestCVEsDetails,
     };
 }


### PR DESCRIPTION
## Description

This PR adds some tests for the cancel request workflow

1. `should be able to cancel a request if the user is the requester`
2. `should be able to see how many CVEs will be affected by a cancel`


