### PR TITLE
ROX-21690: embed initial mapping files

### DIFF
--- a/scanner/image/scanner/Dockerfile
+++ b/scanner/image/scanner/Dockerfile
@@ -1,6 +1,14 @@
+ARG MAPPINGS_REGISTRY=registry.access.redhat.com
+ARG MAPPINGS_BASE_IMAGE=ubi8
+ARG MAPPINGS_BASE_TAG=latest
 ARG BASE_REGISTRY=registry.access.redhat.com
 ARG BASE_IMAGE=ubi8-minimal
 ARG BASE_TAG=latest
+
+FROM ${MAPPINGS_REGISTRY}/${MAPPINGS_BASE_IMAGE}:${MAPPINGS_BASE_TAG} AS mappings
+
+COPY download-mappings.sh /download-mappings.sh
+RUN /download-mappings.sh
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
@@ -18,6 +26,7 @@ COPY scripts/entrypoint.sh \
      scripts/save-dir-contents /usr/local/bin/
 COPY bin/scanner /usr/local/bin/
 COPY THIRD_PARTY_NOTICES/ /THIRD_PARTY_NOTICES/
+COPY --from=mappings /mappings/repository-to-cpe.json /mappings/container-name-repos-map.json /run/mappings/
 
 RUN microdnf upgrade --nobest && \
     microdnf clean all && \

--- a/scanner/image/scanner/download-mappings.sh
+++ b/scanner/image/scanner/download-mappings.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+output_dir="/mappings"
+mkdir $output_dir
+
+curl --retry 3 -sS --fail -o "${output_dir}/repository-to-cpe.json" https://access.redhat.com/security/data/metrics/repository-to-cpe.json
+curl --retry 3 -sS --fail -o "${output_dir}/container-name-repos-map.json" https://access.redhat.com/security/data/metrics/container-name-repos-map.json


### PR DESCRIPTION
## Description

Embed the latest version of the RHEL-related mapping files into each Scanner image. This is required to ensure indexing can occur when Scanner v4 starts up before Central

This adds 2.1MB to the image:

```
$ ls -lh /run/mappings/
total 2.1M
-rw-r--r-- 1 root root 100K Jan 12 20:40 container-name-repos-map.json
-rw-r--r-- 1 root root 2.0M Jan 12 20:40 repository-to-cpe.json
```

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Pull the image to find the files in the image

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
