### PR TITLE
fix(ui): Add progress indicator for async Compliance 1.0 scans

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
@@ -115,7 +115,6 @@ function scanCompliance() {
     interactAndWaitForResponses(
         () => {
             cy.get(scanButton).click();
-            cy.get(scanButton).should('have.attr', 'disabled');
         },
         routeMatcherMap,
         undefined,

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import { useApolloClient } from '@apollo/client';
+import { Alert } from '@patternfly/react-core';
 
 import Button from 'Components/Button';
 import ExportButton from 'Components/ExportButton';
@@ -22,6 +23,8 @@ import StandardsAcrossEntity from '../widgets/StandardsAcrossEntity';
 import ManageStandardsError from './ManageStandardsError';
 import ManageStandardsModal from './ManageStandardsModal';
 import ComplianceDashboardTile from './ComplianceDashboardTile';
+import ComplianceScanProgress from './ComplianceScanProgress';
+import { isCurrentScanIncomplete, useComplianceRunStatuses } from './useComplianceRunStatuses';
 
 function ComplianceDashboardPage(): ReactElement {
     const { hasReadWriteAccess } = usePermissions();
@@ -40,6 +43,8 @@ function ComplianceDashboardPage(): ReactElement {
     const darkModeClasses = `${
         isDarkMode ? 'text-base-600 hover:bg-primary-200' : 'text-base-100 hover:bg-primary-800'
     }`;
+
+    const { runs, error, restartPolling, inProgressScanDetected } = useComplianceRunStatuses();
 
     function clickManageStandardsButton() {
         setIsFetchingStandards(true);
@@ -95,6 +100,8 @@ function ComplianceDashboardPage(): ReactElement {
                                 textCondensed="Scan all"
                                 clusterId="*"
                                 standardId="*"
+                                onScanTriggered={restartPolling}
+                                scanInProgress={isCurrentScanIncomplete(runs)}
                             />
                         )}
                         {hasWriteAccessForCompliance && (
@@ -123,6 +130,21 @@ function ComplianceDashboardPage(): ReactElement {
                 </div>
             </PageHeader>
             <div className="flex-1 relative p-6 xxxl:p-8 bg-base-200" id="capture-dashboard">
+                {(inProgressScanDetected || error) && (
+                    <div className="pf-u-pb-lg">
+                        {error ? (
+                            <Alert
+                                variant="danger"
+                                title="There was an error fetching compliance scan status, data below may be out of date"
+                                component="p"
+                            >
+                                {getAxiosErrorMessage(error)}
+                            </Alert>
+                        ) : (
+                            <ComplianceScanProgress runs={runs} />
+                        )}
+                    </div>
+                )}
                 <div
                     className="grid grid-gap-6 xxxl:grid-gap-8 md:grid-auto-fit xxl:grid-auto-fit-wide md:grid-dense pf-u-pb-lg"
                     // style={{ '--min-tile-height': '160px' }}

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -24,7 +24,7 @@ import ManageStandardsError from './ManageStandardsError';
 import ManageStandardsModal from './ManageStandardsModal';
 import ComplianceDashboardTile from './ComplianceDashboardTile';
 import ComplianceScanProgress from './ComplianceScanProgress';
-import { isCurrentScanIncomplete, useComplianceRunStatuses } from './useComplianceRunStatuses';
+import { useComplianceRunStatuses } from './useComplianceRunStatuses';
 
 function ComplianceDashboardPage(): ReactElement {
     const { hasReadWriteAccess } = usePermissions();
@@ -44,7 +44,8 @@ function ComplianceDashboardPage(): ReactElement {
         isDarkMode ? 'text-base-600 hover:bg-primary-200' : 'text-base-100 hover:bg-primary-800'
     }`;
 
-    const { runs, error, restartPolling, inProgressScanDetected } = useComplianceRunStatuses();
+    const { runs, error, restartPolling, inProgressScanDetected, isCurrentScanIncomplete } =
+        useComplianceRunStatuses();
 
     function clickManageStandardsButton() {
         setIsFetchingStandards(true);
@@ -101,7 +102,7 @@ function ComplianceDashboardPage(): ReactElement {
                                 clusterId="*"
                                 standardId="*"
                                 onScanTriggered={restartPolling}
-                                scanInProgress={isCurrentScanIncomplete(runs)}
+                                scanInProgress={isCurrentScanIncomplete}
                             />
                         )}
                         {hasWriteAccessForCompliance && (

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardTile.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardTile.tsx
@@ -9,25 +9,25 @@ import {
     entityNounOrdinaryCasePlural,
 } from '../entitiesForCompliance';
 
-const CLUSTERS_COUNT = gql`
+export const CLUSTERS_COUNT = gql`
     query clustersCount {
         results: complianceClusterCount
     }
 `;
 
-const NODES_COUNT = gql`
+export const NODES_COUNT = gql`
     query nodesCount {
         results: complianceNodeCount
     }
 `;
 
-const NAMESPACES_COUNT = gql`
+export const NAMESPACES_COUNT = gql`
     query namespacesCount {
         results: complianceNamespaceCount
     }
 `;
 
-const DEPLOYMENTS_COUNT = gql`
+export const DEPLOYMENTS_COUNT = gql`
     query deploymentsCount {
         results: complianceDeploymentCount
     }

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceScanProgress.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceScanProgress.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-    Card,
-    CardBody,
-    CardTitle,
-    Progress,
-    ProgressMeasureLocation,
-} from '@patternfly/react-core';
+import { Card, CardBody, CardTitle, Progress } from '@patternfly/react-core';
 
 import { ComplianceRunStatusResponse } from './useComplianceRunStatuses';
 
@@ -33,7 +27,7 @@ function ComplianceScanProgress({ runs }: ComplianceDashboardCurrentProps) {
                     value={finishedRunCount}
                     min={0}
                     max={runs.length}
-                    measureLocation={ProgressMeasureLocation.outside}
+                    measureLocation={'outside'}
                     label={`${finishedRunCount} of ${runs.length} runs`}
                     valueText={`${finishedRunCount} of ${runs.length} runs`}
                 />

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceScanProgress.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceScanProgress.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {
+    Card,
+    CardBody,
+    CardTitle,
+    Progress,
+    ProgressMeasureLocation,
+} from '@patternfly/react-core';
+
+import { ComplianceRunStatusResponse } from './useComplianceRunStatuses';
+
+export type ComplianceDashboardCurrentProps = {
+    runs: ComplianceRunStatusResponse['complianceRunStatuses']['runs'];
+};
+
+function ComplianceScanProgress({ runs }: ComplianceDashboardCurrentProps) {
+    const unfinishedRunCount = runs.filter((run) => run.state !== 'FINISHED').length;
+    const finishedRunCount = runs.length - unfinishedRunCount;
+
+    const title =
+        unfinishedRunCount === 0
+            ? 'Compliance scanning complete'
+            : 'Compliance scanning in progress';
+
+    return (
+        <Card>
+            <CardTitle id="compliance-scan-progress-title">{title}</CardTitle>
+            <CardBody>
+                <Progress
+                    aria-labelledby="compliance-scan-progress-title"
+                    size="sm"
+                    variant={unfinishedRunCount === 0 ? 'success' : undefined}
+                    value={finishedRunCount}
+                    min={0}
+                    max={runs.length}
+                    measureLocation={ProgressMeasureLocation.outside}
+                    label={`${finishedRunCount} of ${runs.length} runs`}
+                    valueText={`${finishedRunCount} of ${runs.length} runs`}
+                />
+            </CardBody>
+        </Card>
+    );
+}
+
+export default ComplianceScanProgress;

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/useComplianceRunStatuses.ts
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/useComplianceRunStatuses.ts
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { gql, useApolloClient, useQuery } from '@apollo/client';
+
+import { resourceTypes } from 'constants/entityTypes';
+import {
+    AGGREGATED_RESULTS_ACROSS_ENTITY,
+    AGGREGATED_RESULTS_STANDARDS_BY_ENTITY,
+} from 'queries/controls';
+
+export type ComplianceRunStatusResponse = {
+    complianceRunStatuses: {
+        runs: { state: string }[];
+    };
+};
+
+export function isCurrentScanIncomplete(
+    runs: ComplianceRunStatusResponse['complianceRunStatuses']['runs']
+) {
+    return runs.some((run) => run.state !== 'FINISHED');
+}
+
+const queriesToRefetchOnPollingComplete = [
+    AGGREGATED_RESULTS_STANDARDS_BY_ENTITY(resourceTypes.CLUSTER),
+    AGGREGATED_RESULTS_ACROSS_ENTITY(resourceTypes.CLUSTER),
+    AGGREGATED_RESULTS_ACROSS_ENTITY(resourceTypes.NAMESPACE),
+    AGGREGATED_RESULTS_ACROSS_ENTITY(resourceTypes.NODE),
+];
+
+const complianceRunStatusesQuery = gql`
+    query runStatuses($latest: Boolean) {
+        complianceRunStatuses(latest: $latest) {
+            runs {
+                state
+            }
+        }
+    }
+`;
+
+const pollInterval = 10000;
+const variables = {
+    latest: true,
+};
+
+export type UseComplianceRunStatusesResponse = {
+    /* The latest compliance scan runs */
+    runs: ComplianceRunStatusResponse['complianceRunStatuses']['runs'];
+    error: unknown;
+    /* Fetches the latest compliance scan runs, and restarts polling, if necessary */
+    restartPolling: () => void;
+    /* Whether or not an in progress scan was detected during the lifetime of this hook */
+    inProgressScanDetected: boolean;
+};
+
+export function useComplianceRunStatuses(): UseComplianceRunStatusesResponse {
+    const [inProgressScanDetected, setInProgressScanDetected] = useState(false);
+
+    const client = useApolloClient();
+
+    const { startPolling, stopPolling, error, data, refetch } = useQuery<
+        ComplianceRunStatusResponse,
+        typeof variables
+    >(complianceRunStatusesQuery, {
+        variables,
+        pollInterval,
+        onCompleted,
+        onError,
+        errorPolicy: 'all',
+        notifyOnNetworkStatusChange: true,
+        fetchPolicy: 'no-cache',
+    });
+
+    function onCompleted(data: ComplianceRunStatusResponse) {
+        if (isCurrentScanIncomplete(data.complianceRunStatuses.runs)) {
+            setInProgressScanDetected(true);
+        } else {
+            stopPolling();
+        }
+
+        return client.refetchQueries({ include: queriesToRefetchOnPollingComplete });
+    }
+
+    function onError() {
+        stopPolling();
+    }
+
+    return {
+        error,
+        runs: data?.complianceRunStatuses.runs ?? [],
+        restartPolling: () =>
+            refetch().then(({ data }) => {
+                if (isCurrentScanIncomplete(data.complianceRunStatuses.runs)) {
+                    setInProgressScanDetected(true);
+                    startPolling(pollInterval);
+                }
+            }),
+        inProgressScanDetected,
+    };
+}

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/useComplianceRunStatuses.ts
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/useComplianceRunStatuses.ts
@@ -6,6 +6,12 @@ import {
     AGGREGATED_RESULTS_ACROSS_ENTITY,
     AGGREGATED_RESULTS_STANDARDS_BY_ENTITY,
 } from 'queries/controls';
+import {
+    CLUSTERS_COUNT,
+    DEPLOYMENTS_COUNT,
+    NAMESPACES_COUNT,
+    NODES_COUNT,
+} from './ComplianceDashboardTile';
 
 export type ComplianceRunStatusResponse = {
     complianceRunStatuses: {
@@ -20,6 +26,10 @@ export function isCurrentScanIncomplete(
 }
 
 const queriesToRefetchOnPollingComplete = [
+    CLUSTERS_COUNT,
+    NODES_COUNT,
+    NAMESPACES_COUNT,
+    DEPLOYMENTS_COUNT,
     AGGREGATED_RESULTS_STANDARDS_BY_ENTITY(resourceTypes.CLUSTER),
     AGGREGATED_RESULTS_ACROSS_ENTITY(resourceTypes.CLUSTER),
     AGGREGATED_RESULTS_ACROSS_ENTITY(resourceTypes.NAMESPACE),

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/useComplianceRunStatuses.ts
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/useComplianceRunStatuses.ts
@@ -19,7 +19,7 @@ export type ComplianceRunStatusResponse = {
     };
 };
 
-export function isCurrentScanIncomplete(
+function isCurrentScanIncomplete(
     runs: ComplianceRunStatusResponse['complianceRunStatuses']['runs']
 ) {
     return runs.some((run) => run.state !== 'FINISHED');
@@ -59,6 +59,8 @@ export type UseComplianceRunStatusesResponse = {
     restartPolling: () => void;
     /* Whether or not an in progress scan was detected during the lifetime of this hook */
     inProgressScanDetected: boolean;
+    /* Whether or not the latest scan is incomplete */
+    isCurrentScanIncomplete: boolean;
 };
 
 export function useComplianceRunStatuses(): UseComplianceRunStatusesResponse {
@@ -104,5 +106,6 @@ export function useComplianceRunStatuses(): UseComplianceRunStatusesResponse {
                 }
             }),
         inProgressScanDetected,
+        isCurrentScanIncomplete: isCurrentScanIncomplete(data?.complianceRunStatuses.runs ?? []),
     };
 }

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -135,6 +135,10 @@
     display: inline;
 }
 
+.pf-c-progress__status-icon svg {
+  display: inline-block;
+}
+
 /* overriding vertical align property for table sort icon */
 .pf-c-table__sort-indicator {
     align-self: center;

--- a/ui/apps/platform/src/queries/standard.js
+++ b/ui/apps/platform/src/queries/standard.js
@@ -153,21 +153,6 @@ export const TRIGGER_SCAN = gql`
     }
 `;
 
-export const RUN_STATUSES = gql`
-    query runStatuses($ids: [ID!]!) {
-        complianceRunStatuses(ids: $ids) {
-            invalidRunIds
-            runs {
-                id
-                standardId
-                clusterId
-                state
-                errorMessage
-            }
-        }
-    }
-`;
-
 export const STANDARDS_QUERY = gql`
     query getComplianceStandards {
         results: complianceStandards {


### PR DESCRIPTION
## Description

Adds a progress indicator to Compliance 1.0 that is displayed when there are scan runs in-progress. Will poll for updates every 10 seconds until all runs are complete.

The testing procedure below uses simulated API calls and a polling interval of 1 second to better demonstrate behavior.

Relies on API changes in https://github.com/stackrox/stackrox/pull/8957

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- On load of Compliance 1.0, if there are no runs in progress nothing will be shown
- If runs are in progress, or if a new scan is kicked off, a progress bar will be shown and poll for updates
- If the user navigates away, refreshes, etc, the polling will continue and the progress bar will still be visible
- When the runs complete, the “success” progress bar will remain on the page, but will disappear if the user navigates away/back. Chart data will be refreshed on completion as well.
- The scan button is always enabled, even when scans are in progress
- If no runs are in progress when the user loads the page, we will not poll for updates (relevant if a scan is started elsewhere by another user)

https://github.com/stackrox/stackrox/assets/1292638/da306037-e6ef-49dc-b5fe-ae165e722ccf

If an error occurs in the network request:
![image](https://github.com/stackrox/stackrox/assets/1292638/180000b3-a41e-4f72-a7f1-b6cb11ef1cd1)



