### PR TITLE
ROX-21630: Create scan config details page

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/ScanConfigDetailPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/ScanConfigDetailPage.tsx
@@ -1,0 +1,49 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React, { useCallback } from 'react';
+import { generatePath, Link, useParams } from 'react-router-dom';
+import { Button, Divider, PageSection } from '@patternfly/react-core';
+
+import { complianceEnhancedScanConfigDetailPath } from 'routePaths';
+import useRestQuery from 'hooks/useRestQuery';
+import { getScanConfig } from 'services/ComplianceEnhancedService';
+import ViewScanConfigDetail from './ViewScanConfigDetail';
+
+const EditScanConfigButton = (id) => {
+    return (
+        <Link
+            to={`${generatePath(complianceEnhancedScanConfigDetailPath, {
+                scanConfigId: id,
+            })}?action=edit`}
+        >
+            <Button variant="primary">Edit scan schedule</Button>
+        </Link>
+    );
+};
+
+type ScanConfigDetailPageProps = {
+    hasWriteAccessForCompliance: boolean;
+};
+
+function ScanConfigDetailPage({
+    hasWriteAccessForCompliance,
+}: ScanConfigDetailPageProps): React.ReactElement {
+    const { scanConfigId } = useParams();
+
+    const scanConfigFetcher = useCallback(() => {
+        const { request, cancel } = getScanConfig(scanConfigId);
+        return { request, cancel };
+    }, [scanConfigId]);
+
+    const { data, loading, error } = useRestQuery(scanConfigFetcher);
+
+    return (
+        <ViewScanConfigDetail
+            hasWriteAccessForCompliance={hasWriteAccessForCompliance}
+            scanConfig={data}
+            isLoading={loading}
+            error={error}
+        />
+    );
+}
+
+export default ScanConfigDetailPage;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/ScanConfigDetailPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/ScanConfigDetailPage.tsx
@@ -8,18 +8,6 @@ import useRestQuery from 'hooks/useRestQuery';
 import { getScanConfig } from 'services/ComplianceEnhancedService';
 import ViewScanConfigDetail from './ViewScanConfigDetail';
 
-const EditScanConfigButton = (id) => {
-    return (
-        <Link
-            to={`${generatePath(complianceEnhancedScanConfigDetailPath, {
-                scanConfigId: id,
-            })}?action=edit`}
-        >
-            <Button variant="primary">Edit scan schedule</Button>
-        </Link>
-    );
-};
-
 type ScanConfigDetailPageProps = {
     hasWriteAccessForCompliance: boolean;
 };

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/ScanConfigsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/ScanConfigsPage.tsx
@@ -3,10 +3,14 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 
 import usePageAction from 'hooks/usePageAction';
 import usePermissions from 'hooks/usePermissions';
-import { complianceEnhancedScanConfigsPath } from 'routePaths';
+import {
+    complianceEnhancedScanConfigsPath,
+    complianceEnhancedScanConfigDetailPath,
+} from 'routePaths';
 
 import ScanConfigsTablePage from './Table/ScanConfigsTablePage';
 import CreateScanConfigPage from './CreateScanConfigPage';
+import ScanConfigDetailPage from './ScanConfigDetailPage';
 
 type PageActions = 'create' | 'edit' | 'clone';
 
@@ -39,6 +43,17 @@ function ScanConfigsPage() {
                         );
                     }
                     return <Redirect to={complianceEnhancedScanConfigsPath} />;
+                }}
+            />
+            <Route
+                exact
+                path={complianceEnhancedScanConfigDetailPath}
+                render={() => {
+                    return (
+                        <ScanConfigDetailPage
+                            hasWriteAccessForCompliance={hasWriteAccessForCompliance}
+                        />
+                    );
                 }}
             />
         </Switch>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Table/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Table/ScanConfigsTablePage.tsx
@@ -29,7 +29,11 @@ import {
 } from '@patternfly/react-table';
 import { OutlinedClockIcon } from '@patternfly/react-icons';
 
-import { complianceEnhancedScanConfigsPath, complianceEnhancedCoveragePath } from 'routePaths';
+import {
+    complianceEnhancedScanConfigsPath,
+    complianceEnhancedScanConfigDetailPath,
+    complianceEnhancedCoveragePath,
+} from 'routePaths';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import TabNavHeader from 'Components/TabNav/TabNavHeader';
 import TabNavSubHeader from 'Components/TabNav/TabNavSubHeader';
@@ -88,8 +92,8 @@ function ScanConfigsTablePage({
                 <Tr key={id}>
                     <Td>
                         <Link
-                            to={generatePath(complianceEnhancedScanConfigsPath, {
-                                policyId: id,
+                            to={generatePath(complianceEnhancedScanConfigDetailPath, {
+                                scanConfigId: id,
                             })}
                         >
                             {scanName}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/ViewScanConfigDetail.tsx
@@ -1,0 +1,123 @@
+/* eslint-disable no-nested-ternary */
+import React from 'react';
+import { generatePath } from 'react-router-dom';
+import {
+    Alert,
+    Breadcrumb,
+    BreadcrumbItem,
+    Bullseye,
+    Button,
+    Divider,
+    Grid,
+    GridItem,
+    Flex,
+    FlexItem,
+    PageSection,
+    Spinner,
+    Title,
+} from '@patternfly/react-core';
+
+import {
+    complianceEnhancedScanConfigsPath,
+    complianceEnhancedScanConfigDetailPath,
+} from 'routePaths';
+import PageTitle from 'Components/PageTitle';
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import LinkShim from 'Components/PatternFly/LinkShim';
+import { ComplianceScanConfigurationStatus } from 'services/ComplianceEnhancedService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import ScanConfigParameters from './components/ScanConfigParameters';
+import ScanConfigProfiles from './components/ScanConfigProfiles';
+import ScanConfigClustersTable from './components/ScanConfigClustersTable';
+
+type ViewScanConfigDetailProps = {
+    hasWriteAccessForCompliance: boolean;
+    scanConfig?: ComplianceScanConfigurationStatus;
+    isLoading: boolean;
+    error?: Error | string | null;
+};
+
+function ViewScanConfigDetail({
+    hasWriteAccessForCompliance,
+    scanConfig,
+    isLoading,
+    error = null,
+}: ViewScanConfigDetailProps): React.ReactElement {
+    return (
+        <>
+            <PageTitle title="Compliance Scan Schedule Details" />
+            <PageSection variant="light" className="pf-u-py-md">
+                <Breadcrumb>
+                    <BreadcrumbItemLink to={complianceEnhancedScanConfigsPath}>
+                        Scan schedules
+                    </BreadcrumbItemLink>
+                    {!isLoading && !error && scanConfig && (
+                        <BreadcrumbItem isActive>{scanConfig.scanName}</BreadcrumbItem>
+                    )}
+                </Breadcrumb>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                {!isLoading && !error && scanConfig && (
+                    <Flex
+                        alignItems={{ default: 'alignItemsCenter' }}
+                        className="pf-u-py-lg pf-u-px-lg"
+                    >
+                        <FlexItem flex={{ default: 'flex_1' }}>
+                            <Title headingLevel="h1">{scanConfig.scanName}</Title>
+                        </FlexItem>
+                        {hasWriteAccessForCompliance && (
+                            <FlexItem align={{ default: 'alignRight' }}>
+                                <Button
+                                    variant="primary"
+                                    component={LinkShim}
+                                    href={`${generatePath(complianceEnhancedScanConfigDetailPath, {
+                                        scanConfigId: scanConfig.id,
+                                    })}?action=edit`}
+                                >
+                                    Edit scan schedule
+                                </Button>
+                            </FlexItem>
+                        )}
+                    </Flex>
+                )}
+            </PageSection>
+            <Divider component="div" />
+            <PageSection isCenterAligned>
+                {isLoading ? (
+                    <Bullseye>
+                        <Spinner isSVG />
+                    </Bullseye>
+                ) : (
+                    error && (
+                        <Alert
+                            variant="warning"
+                            title="Unable to fetch scan schedule"
+                            component="div"
+                            isInline
+                        >
+                            {getAxiosErrorMessage(error)}
+                        </Alert>
+                    )
+                )}
+                {!isLoading && scanConfig && (
+                    <Grid hasGutter>
+                        <GridItem sm={12} md={6}>
+                            <ScanConfigParameters scanConfig={scanConfig} />
+                        </GridItem>
+                        <GridItem sm={12} md={6}>
+                            <ScanConfigProfiles profiles={scanConfig.scanConfig.profiles} />
+                        </GridItem>
+                        <GridItem sm={12}>
+                            <ScanConfigClustersTable
+                                clusterScanStatuses={scanConfig.clusterStatus}
+                            />
+                        </GridItem>
+                    </Grid>
+                )}
+            </PageSection>
+        </>
+    );
+}
+
+export default ViewScanConfigDetail;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ScanConfigOptions.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ScanConfigOptions.tsx
@@ -73,6 +73,7 @@ function ScanConfigOptions(): ReactElement {
                                     fieldId="parameters.name"
                                     errors={formik.errors}
                                     touched={formik.touched}
+                                    helperText="Name can contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character."
                                 >
                                     <TextInput
                                         isRequired

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/useFormikScanConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/useFormikScanConfig.tsx
@@ -33,7 +33,13 @@ export const defaultScanConfigFormValues: ScanConfigFormValues = {
 
 const validationSchema = yup.object().shape({
     parameters: yup.object().shape({
-        name: yup.string().required('Scan name is required'),
+        name: yup
+            .string()
+            .required('Scan name is required')
+            .matches(
+                /(^((?!-)(?!\.)[a-z0-9-.]{0,253}$))/,
+                "Name can contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character."
+            ),
         description: yup.string(),
         intervalType: yup.string().required('Frequency is required'),
         time: yup.string().required('Time is required'),

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/useFormikScanConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/useFormikScanConfig.tsx
@@ -37,7 +37,7 @@ const validationSchema = yup.object().shape({
             .string()
             .required('Scan name is required')
             .matches(
-                /(^((?!-)(?!\.)[a-z0-9-.]{0,253}$))/,
+                /^[a-z0-9][a-z0-9.-]{0,251}[a-z0-9]$/,
                 "Name can contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character."
             ),
         description: yup.string(),

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/compliance.scanConfigs.utils.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/compliance.scanConfigs.utils.ts
@@ -71,13 +71,14 @@ export function convertFormikParametersToSchedule(parameters: ScanConfigParamete
 
 export function convertFormikToScanConfig(formikValues: ScanConfigFormValues) {
     const { parameters, clusters, profiles } = formikValues;
-    const { name } = parameters;
+    const { name, description } = parameters;
 
     const scanSchedule = convertFormikParametersToSchedule(parameters);
 
     return {
         scanName: name,
         scanConfig: {
+            description,
             oneTimeScan: false,
             profiles,
             scanSchedule,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/compliance.scanConfigs.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/compliance.scanConfigs.utils.tsx
@@ -1,3 +1,6 @@
+import React, { ReactElement } from 'react';
+import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+
 import {
     DailySchedule,
     MonthlySchedule,
@@ -9,6 +12,11 @@ import {
 import { getDayOfMonthWithOrdinal, getTimeHoursMinutes } from 'utils/dateUtils';
 
 import { ScanConfigFormValues, ScanConfigParameters } from './Wizard/useFormikScanConfig';
+
+type ClusterStatusObject = {
+    icon: ReactElement;
+    statusText: string;
+};
 
 export function convertFormikParametersToSchedule(parameters: ScanConfigParameters): Schedule {
     const { intervalType, time, daysOfWeek, daysOfMonth } = parameters;
@@ -118,4 +126,16 @@ export function formatScanSchedule(schedule: Schedule) {
         default:
             return 'Invalid Schedule';
     }
+}
+
+export function getClusterStatusObject(errors: string[]): ClusterStatusObject {
+    return errors && errors.length && errors[0] !== ''
+        ? {
+              icon: <ExclamationCircleIcon color="var(--pf-global--danger-color--100)" />,
+              statusText: 'Unhealthy',
+          }
+        : {
+              icon: <CheckCircleIcon color="var(--pf-global--success-color--100)" />,
+              statusText: 'Healthy',
+          };
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigClustersTable.tsx
@@ -11,7 +11,6 @@ import {
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, ThProps, Thead, Tr } from '@patternfly/react-table';
 
-import useURLPagination from 'hooks/useURLPagination';
 import { ClusterScanStatus } from 'services/ComplianceEnhancedService';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -129,6 +128,10 @@ function ScanConfigClustersTable({ clusterScanStatuses }: ScanConfigClustersTabl
         columnIndex,
     });
 
+    const startNumber = (page - 1) * perPage;
+    const endNumber = page * perPage;
+    const clustersWindow = sortedClusters.slice(startNumber, endNumber);
+
     return (
         <Card>
             <CardHeader>
@@ -154,7 +157,7 @@ function ScanConfigClustersTable({ clusterScanStatuses }: ScanConfigClustersTabl
                         </Tr>
                     </Thead>
                     <Tbody>
-                        {sortedClusters.map((cluster) => {
+                        {clustersWindow.map((cluster) => {
                             return (
                                 <Tr key={cluster.clusterId}>
                                     <Td>{cluster.clusterName}</Td>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigClustersTable.tsx
@@ -11,43 +11,9 @@ import {
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, ThProps, Thead, Tr } from '@patternfly/react-table';
 
+import IconText from 'Components/PatternFly/IconText/IconText';
 import { ClusterScanStatus } from 'services/ComplianceEnhancedService';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mockClusters = [
-    {
-        id: 'control-cluster',
-        name: 'control-cluster',
-        type: 'OCP',
-        provider: 'AWS',
-        region: 'us-east-1',
-        status: 'Healthy',
-    },
-    {
-        id: 'prod-cluster',
-        name: 'prod-cluster',
-        type: 'OSD',
-        provider: 'AWS',
-        region: 'us-east-1',
-        status: 'Healthy',
-    },
-    {
-        id: 'staging-cluster',
-        name: 'staging-cluster',
-        type: 'OCP',
-        provider: 'AWS',
-        region: 'us-west-1',
-        status: 'Healthy',
-    },
-    {
-        id: 'dev-cluster',
-        name: 'dev-cluster',
-        type: 'OCP',
-        provider: 'GCP',
-        region: 'us-central-1',
-        status: 'Healthy',
-    },
-];
+import { getClusterStatusObject } from '../compliance.scanConfigs.utils';
 
 type ScanConfigClustersTableProps = {
     clusterScanStatuses: ClusterScanStatus[];
@@ -151,24 +117,24 @@ function ScanConfigClustersTable({ clusterScanStatuses }: ScanConfigClustersTabl
                     <Thead noWrap>
                         <Tr>
                             <Th sort={getSortParams(0)}>Cluster</Th>
-                            <Th>Type</Th>
-                            <Th sort={getSortParams(2)}>Provider (Region)</Th>
-                            <Th sort={getSortParams(3)}>Operator status</Th>
+                            <Th sort={getSortParams(1)} width={20}>
+                                Operator status
+                            </Th>
                         </Tr>
                     </Thead>
                     <Tbody>
                         {clustersWindow.map((cluster) => {
+                            const statusObj = getClusterStatusObject(cluster.errors);
+
                             return (
                                 <Tr key={cluster.clusterId}>
-                                    <Td>{cluster.clusterName}</Td>
-                                    {/* @ts-expect-error api */}
-                                    <Td>{cluster.type || '-'}</Td>
-                                    <Td>
-                                        {/* @ts-expect-error api */}
-                                        {cluster.provider || '-'} ({cluster.region || '-'})
+                                    <Td dataLabel="Cluster">{cluster.clusterName}</Td>
+                                    <Td dataLabel="Operator status">
+                                        <IconText
+                                            icon={statusObj.icon}
+                                            text={statusObj.statusText}
+                                        />
                                     </Td>
-                                    {/* @ts-expect-error api */}
-                                    <Td>{cluster.status || '-'}</Td>
                                 </Tr>
                             );
                         })}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigClustersTable.tsx
@@ -52,9 +52,9 @@ function ScanConfigClustersTable({ clusterScanStatuses }: ScanConfigClustersTabl
     // this would be a place to return simplified string or number versions of each column to sort by.
     const getSortableRowValues = (cluster: ClusterScanStatus): (string | number | null)[] => {
         // @ts-expect-error api
-        const { clusterName, provider, status } = cluster;
+        const { clusterName, status } = cluster;
 
-        return [clusterName, null, provider, status] as (string | number | null)[];
+        return [clusterName, status] as (string | number | null)[];
     };
 
     // Note that we perform the sort as part of the component's render logic and not in onSort.
@@ -62,19 +62,19 @@ function ScanConfigClustersTable({ clusterScanStatuses }: ScanConfigClustersTabl
     const sortedClusters = clusterScanStatuses.sort((a, b) => {
         const aValue = getSortableRowValues(a)[activeSortIndex];
         const bValue = getSortableRowValues(b)[activeSortIndex];
-        if (typeof aValue === 'number') {
+        if (typeof aValue === 'number' && typeof bValue === 'number') {
             // Numeric sort
             if (activeSortDirection === 'asc') {
-                return aValue - (bValue as number);
+                return aValue - bValue;
             }
-            return (bValue as number) - aValue;
+            return bValue - aValue;
         }
-        if (typeof aValue === 'string') {
+        if (typeof aValue === 'string' && typeof bValue === 'string') {
             // String sort
             if (activeSortDirection === 'asc') {
-                return aValue.localeCompare(bValue as string);
+                return aValue.localeCompare(bValue);
             }
-            return (bValue as string).localeCompare(aValue);
+            return bValue.localeCompare(aValue);
         }
 
         // fallback, don't sort

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigClustersTable.tsx
@@ -1,0 +1,179 @@
+/* eslint-disable react/jsx-no-comment-textnodes */
+// eslint-disable @typescript-eslint/ban-ts-comment
+import React, { useState } from 'react';
+import {
+    Card,
+    CardActions,
+    CardBody,
+    CardHeader,
+    CardTitle,
+    Pagination,
+} from '@patternfly/react-core';
+import { TableComposable, Tbody, Td, Th, ThProps, Thead, Tr } from '@patternfly/react-table';
+
+import useURLPagination from 'hooks/useURLPagination';
+import { ClusterScanStatus } from 'services/ComplianceEnhancedService';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mockClusters = [
+    {
+        id: 'control-cluster',
+        name: 'control-cluster',
+        type: 'OCP',
+        provider: 'AWS',
+        region: 'us-east-1',
+        status: 'Healthy',
+    },
+    {
+        id: 'prod-cluster',
+        name: 'prod-cluster',
+        type: 'OSD',
+        provider: 'AWS',
+        region: 'us-east-1',
+        status: 'Healthy',
+    },
+    {
+        id: 'staging-cluster',
+        name: 'staging-cluster',
+        type: 'OCP',
+        provider: 'AWS',
+        region: 'us-west-1',
+        status: 'Healthy',
+    },
+    {
+        id: 'dev-cluster',
+        name: 'dev-cluster',
+        type: 'OCP',
+        provider: 'GCP',
+        region: 'us-central-1',
+        status: 'Healthy',
+    },
+];
+
+type ScanConfigClustersTableProps = {
+    clusterScanStatuses: ClusterScanStatus[];
+};
+
+function ScanConfigClustersTable({ clusterScanStatuses }: ScanConfigClustersTableProps) {
+    const [page, setPage] = useState(1);
+    const [perPage, setPerPage] = useState(20);
+
+    const onSetPage = (
+        _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+        newPage: number
+    ) => {
+        setPage(newPage);
+    };
+
+    const onPerPageSelect = (
+        _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+        newPerPage: number,
+        newPage: number
+    ) => {
+        setPerPage(newPerPage);
+        setPage(newPage);
+    };
+
+    // Index of the currently sorted column
+    // Note: if you intend to make columns reorderable, you may instead want to use a non-numeric key
+    // as the identifier of the sorted column. See the "Compound expandable" example.
+    const [activeSortIndex, setActiveSortIndex] = useState<number>(0);
+
+    // Sort direction of the currently sorted column
+    const [activeSortDirection, setActiveSortDirection] = useState<'asc' | 'desc'>('asc');
+
+    // Since OnSort specifies sorted columns by index, we need sortable values for our object by column index.
+    // This example is trivial since our data objects just contain strings, but if the data was more complex
+    // this would be a place to return simplified string or number versions of each column to sort by.
+    const getSortableRowValues = (cluster: ClusterScanStatus): (string | number | null)[] => {
+        // @ts-expect-error api
+        const { clusterName, provider, status } = cluster;
+
+        return [clusterName, null, provider, status] as (string | number | null)[];
+    };
+
+    // Note that we perform the sort as part of the component's render logic and not in onSort.
+    // We shouldn't store the list of data in state because we don't want to have to sync that with props.
+    const sortedClusters = clusterScanStatuses.sort((a, b) => {
+        const aValue = getSortableRowValues(a)[activeSortIndex];
+        const bValue = getSortableRowValues(b)[activeSortIndex];
+        if (typeof aValue === 'number') {
+            // Numeric sort
+            if (activeSortDirection === 'asc') {
+                return aValue - (bValue as number);
+            }
+            return (bValue as number) - aValue;
+        }
+        if (typeof aValue === 'string') {
+            // String sort
+            if (activeSortDirection === 'asc') {
+                return aValue.localeCompare(bValue as string);
+            }
+            return (bValue as string).localeCompare(aValue);
+        }
+
+        // fallback, don't sort
+        return 0;
+    });
+
+    const getSortParams = (columnIndex: number): ThProps['sort'] => ({
+        sortBy: {
+            index: activeSortIndex,
+            direction: activeSortDirection,
+            defaultDirection: 'asc', // starting sort direction when first sorting a column. Defaults to 'asc'
+        },
+        onSort: (_event, index, direction) => {
+            setActiveSortIndex(index);
+            setActiveSortDirection(direction);
+        },
+        columnIndex,
+    });
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardActions>
+                    <Pagination
+                        itemCount={clusterScanStatuses.length}
+                        page={page}
+                        onSetPage={onSetPage}
+                        perPage={perPage}
+                        onPerPageSelect={onPerPageSelect}
+                    />
+                </CardActions>
+                <CardTitle component="h2">Clusters</CardTitle>
+            </CardHeader>
+            <CardBody>
+                <TableComposable borders={false}>
+                    <Thead noWrap>
+                        <Tr>
+                            <Th sort={getSortParams(0)}>Cluster</Th>
+                            <Th>Type</Th>
+                            <Th sort={getSortParams(2)}>Provider (Region)</Th>
+                            <Th sort={getSortParams(3)}>Operator status</Th>
+                        </Tr>
+                    </Thead>
+                    <Tbody>
+                        {sortedClusters.map((cluster) => {
+                            return (
+                                <Tr key={cluster.clusterId}>
+                                    <Td>{cluster.clusterName}</Td>
+                                    {/* @ts-expect-error api */}
+                                    <Td>{cluster.type || '-'}</Td>
+                                    <Td>
+                                        {/* @ts-expect-error api */}
+                                        {cluster.provider || '-'} ({cluster.region || '-'})
+                                    </Td>
+                                    {/* @ts-expect-error api */}
+                                    <Td>{cluster.status || '-'}</Td>
+                                </Tr>
+                            );
+                        })}
+                    </Tbody>
+                </TableComposable>
+            </CardBody>
+        </Card>
+    );
+}
+
+export default ScanConfigClustersTable;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigParameters.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigParameters.tsx
@@ -1,0 +1,63 @@
+/* eslint-disable no-nested-ternary */
+import React from 'react';
+import {
+    Card,
+    CardBody,
+    CardTitle,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Timestamp,
+} from '@patternfly/react-core';
+
+import { ComplianceScanConfigurationStatus } from 'services/ComplianceEnhancedService';
+import { formatScanSchedule } from '../compliance.scanConfigs.utils';
+
+type ScanConfigParametersProps = {
+    scanConfig: ComplianceScanConfigurationStatus;
+};
+
+function ScanConfigParameters({ scanConfig }: ScanConfigParametersProps): React.ReactElement {
+    return (
+        <Card className="pf-u-h-100">
+            <CardTitle component="h2">Parameters</CardTitle>
+            <CardBody>
+                <DescriptionList>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Name</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {scanConfig.scanName}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Description</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {scanConfig.scanConfig.description || <em>No description</em>}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Schedule</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {formatScanSchedule(scanConfig.scanConfig.scanSchedule)}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Last run</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            <Timestamp
+                                date={new Date(scanConfig.lastUpdatedTime)}
+                                dateFormat="short"
+                                timeFormat="long"
+                                className="pf-u-color-100 pf-u-font-size-md"
+                            />
+                            <span className="pf-u-warning-color-100">(using lastUpdatedTime)</span>
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                </DescriptionList>
+            </CardBody>
+        </Card>
+    );
+}
+
+export default ScanConfigParameters;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigParameters.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigParameters.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React from 'react';
 import {
     Card,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigParameters.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigParameters.tsx
@@ -45,13 +45,17 @@ function ScanConfigParameters({ scanConfig }: ScanConfigParametersProps): React.
                     <DescriptionListGroup>
                         <DescriptionListTerm>Last run</DescriptionListTerm>
                         <DescriptionListDescription>
+                            {/* TODO: (vjw, 2024-01-16) using the `lastUpdatedTime` field
+                                      as a placeholder for now
+                                      There is a comment in GitHub that the correct field,
+                                      `lastRun` will be available soon.
+                            */}
                             <Timestamp
                                 date={new Date(scanConfig.lastUpdatedTime)}
                                 dateFormat="short"
                                 timeFormat="long"
                                 className="pf-u-color-100 pf-u-font-size-md"
                             />
-                            <span className="pf-u-warning-color-100">(using lastUpdatedTime)</span>
                         </DescriptionListDescription>
                     </DescriptionListGroup>
                 </DescriptionList>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigProfiles.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigProfiles.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React from 'react';
 import { Card, CardBody, CardTitle, List, ListItem } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigProfiles.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigProfiles.tsx
@@ -1,0 +1,24 @@
+/* eslint-disable no-nested-ternary */
+import React from 'react';
+import { Card, CardBody, CardTitle, List, ListItem } from '@patternfly/react-core';
+
+type ScanConfigProfilesProps = {
+    profiles: string[];
+};
+
+function ScanConfigProfiles({ profiles }: ScanConfigProfilesProps): React.ReactElement {
+    return (
+        <Card className="pf-u-h-100">
+            <CardTitle component="h2">Profiles</CardTitle>
+            <CardBody>
+                <List isPlain>
+                    {profiles.map((profile) => (
+                        <ListItem key={profile}>{profile}</ListItem>
+                    ))}
+                </List>
+            </CardBody>
+        </Card>
+    );
+}
+
+export default ScanConfigProfiles;

--- a/ui/apps/platform/src/hooks/useRestQuery.ts
+++ b/ui/apps/platform/src/hooks/useRestQuery.ts
@@ -35,7 +35,7 @@ export default function useRestQuery<ReturnType>(
             })
             .catch((err) => {
                 if (isMounted) {
-                    setLoading(true);
+                    setLoading(false);
                     setError(err);
                 }
             });

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -39,6 +39,7 @@ export const complianceEnhancedStatusProfilesPath = `${complianceEnhancedStatusP
 export const complianceEnhancedStatusScansPath = `${complianceEnhancedStatusPath}/scans/:id`;
 export const complianceEnhancedClusterComplianceBasePath = `${complianceEnhancedBasePath}/cluster-compliance`;
 export const complianceEnhancedScanConfigsPath = `${complianceEnhancedClusterComplianceBasePath}/scan-configs`;
+export const complianceEnhancedScanConfigDetailPath = `${complianceEnhancedScanConfigsPath}/:scanConfigId`;
 export const complianceEnhancedCoveragePath = `${complianceEnhancedClusterComplianceBasePath}/coverage`;
 export const configManagementPath = `${mainPath}/configmanagement`;
 export const dashboardPath = `${mainPath}/dashboard`;

--- a/ui/apps/platform/src/services/ComplianceEnhancedService.ts
+++ b/ui/apps/platform/src/services/ComplianceEnhancedService.ts
@@ -43,9 +43,10 @@ type BaseComplianceScanConfigurationSettings = {
     oneTimeScan: boolean;
     profiles: string[];
     scanSchedule: Schedule;
+    description?: string;
 };
 
-type ClusterScanStatus = {
+export type ClusterScanStatus = {
     clusterId: string;
     errors: string[];
     clusterName: string;
@@ -210,10 +211,16 @@ export function getComplianceClusterScanStats(
 /*
  * Get a Scan Schedule.
  */
-export function getScanConfig(scanConfigId: string): Promise<ComplianceScanConfigurationStatus> {
-    return axios
-        .get<ComplianceScanConfigurationStatus>(`${scanScheduleUrl}/${scanConfigId}`)
-        .then((response) => response.data);
+export function getScanConfig(
+    scanConfigId: string
+): CancellableRequest<ComplianceScanConfigurationStatus> {
+    return makeCancellableAxiosRequest((signal) =>
+        axios
+            .get<ComplianceScanConfigurationStatus>(`${scanScheduleUrl}/${scanConfigId}`, {
+                signal,
+            })
+            .then((response) => response.data)
+    );
 }
 
 /*


### PR DESCRIPTION
## Description

This PR implements the read-only view of a single Scan Schedule (`scanConfig` in the API).

Image of the mock from this page:
![scanConfig read-only view mock-Compliance 2 0 MVP and beyond](https://github.com/stackrox/stackrox/assets/715729/3cb542ff-0e43-4a52-9b70-e9284706614f)

The [API call](https://stagingdb.demo.stackrox.com/main/apidocs-v2#tag/ComplianceScanConfigurationService/operation/ComplianceScanConfigurationService_GetComplianceScanConfiguration) to get this data have, or need, updates, and for MVP the only thing we can get for the profiles are their names.

Notes:

1. `Name` field has to follow RFC 1123, so this PR also adds helper text to the form in the wizard, and a regex and error message for frontend validation.
2. `Description` leave wasn't being sent in POST request when creating Scan Schedules (scanConfigs), so I added that.
3. `Schedule` is using the helper function from the table.
4. `Last Run`: as you can see in the mocks, I added a visual note that this is using the `lastRun` field returned from the API, but I don't think this is correct, is it @dashrews78 ?  I am also using the <Timestamp> component from PatternFly, but this requires 2 CSS utility classes to override some unnecessary opinionated styling that is in that component, to match the other description list items.
5. Profiles widget: as discussed in various project meetings, we do not have data to link to profiles for MVP, and in fact the API response only returns a list of profile names as strings for now, so I am showing them just as a list of strings, instead of the links in the mock.
6. Clusters widget: The only data we are getting for the clusters associated with this scanConfig are:
6.a. `id`: I'm using that as a React key for each row
6.b. `name`: first column of each row
6.c. array of `errors`: not needed in this context?
6.d. There is no data for Type, Provider, Region, and Operator Status. (In a recently-concluded meeting, we said we would remove  Type, Provider, and Region in another context, so we may end up doing that here as well.)
6.e. Of special note, the nested `clusters` array in the scanConfig is not paginated by the API, so I adopted the frontend pagination and sorting for tables where all the data is available up from the PatternFly docs for [Pagination](https://v4-archive.patternfly.org/v4/components/pagination/) and [Table](https://v4-archive.patternfly.org/v4/components/table#composable-sortable--wrapping-headers). 


## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

### Here I tell how I validated my change

Examples
with description
![scanConfig with description](https://github.com/stackrox/stackrox/assets/715729/720fa051-e634-45bc-bceb-863a711effb9)

without description
![scanConfig example with 2 profiles](https://github.com/stackrox/stackrox/assets/715729/76e5764e-31a6-4825-9d91-3bb51c1e46a2)

To test pagination and sorting of the clusters table, I mocked an API response with 41 clusters.

Initial load shows first page
<img width="1575" alt="scanConfig-read-view-cluster-pagination" src="https://github.com/stackrox/stackrox/assets/715729/b8358596-a751-43ed-af91-ebb1fb78a870">

After clicking arrow on first column to reverse its sort
<img width="1575" alt="scanConfig-read-view-cluster-pagination-reversed" src="https://github.com/stackrox/stackrox/assets/715729/526379c8-ff99-4a48-a210-a1384b2aec42">

Advancing to the 2nd page of the current sort
<img width="1575" alt="scanConfig-read-view-cluster-pagination-2nd-page" src="https://github.com/stackrox/stackrox/assets/715729/1a16a313-914f-488d-a8fd-356bf131ef4c">

After changing the number displayed per page
<img width="1575" alt="scanConfig-read-view-cluster-pagination-changing-per-page" src="https://github.com/stackrox/stackrox/assets/715729/29f42ac9-937a-4951-a401-1de0b6841849">


Finally, for the new validation of the name field in the wizard form, here is the error state
![frontend validation for scanConfig name](https://github.com/stackrox/stackrox/assets/715729/c7b4a6ae-387e-44de-83ef-bbd02604313b)



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
