### PR TITLE
ROX-21710: Simplify structure of clusters page

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/Clusters.helpers.js
+++ b/ui/apps/platform/cypress/integration/clusters/Clusters.helpers.js
@@ -20,16 +20,20 @@ const routeMatcherMapForClusterDefaults = {
     },
 };
 
+// With conditional rendering of side panel,
+// commented requests only when it opens.
 const routeMatcherMapForClusters = {
+    /*
     [sensorUpgradesConfigAlias]: {
         method: 'GET',
         url: '/v1/sensorupgrades/config',
     },
+    */
     [clustersAlias]: {
         method: 'GET',
         url: 'v1/clusters',
     },
-    ...routeMatcherMapForClusterDefaults,
+    // ...routeMatcherMapForClusterDefaults,
 };
 const routeMatcherMapForDelegateScanning = {
     [delegatedRegistryConfigAlias]: {
@@ -68,7 +72,6 @@ export function interactAndVisitClusters(interactionCallback, staticResponseMap)
     interactionCallback();
 
     cy.location('pathname').should('eq', clustersPath);
-    cy.get(`h1:contains("${title}")`);
 
     waitForResponses(routeMatcherMapForClusters);
 }

--- a/ui/apps/platform/src/Containers/Clusters/AddClusterPrompt.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/AddClusterPrompt.tsx
@@ -1,25 +1,25 @@
 import React from 'react';
 import {
-    Alert,
-    AlertVariant,
     Button,
     ButtonVariant,
+    EmptyState,
+    EmptyStateIcon,
     Flex,
     FlexItem,
     Text,
     TextContent,
     TextVariants,
 } from '@patternfly/react-core';
+import { CheckCircleIcon } from '@patternfly/react-icons';
 
 function AddClusterPrompt() {
     return (
-        <>
-            <Alert isInline variant={AlertVariant.success} title="You are ready to go!">
-                <p className="pf-u-font-weight-normal">
-                    You have successfully deployed a Red Hat Advanced Cluster Security platform. Now
-                    you can configure the clusters you want to secure.
-                </p>
-            </Alert>
+        <EmptyState>
+            <EmptyStateIcon icon={CheckCircleIcon} color="var(--pf-global--success-color--100)" />
+            <p className="pf-u-font-weight-normal">
+                You have successfully deployed a Red Hat Advanced Cluster Security platform. Now you
+                can configure the clusters you want to secure.
+            </p>
             <Flex
                 alignItems={{ default: 'alignItemsCenter' }}
                 justifyContent={{ default: 'justifyContentCenter' }}
@@ -50,7 +50,7 @@ function AddClusterPrompt() {
                     </Button>
                 </FlexItem>
             </Flex>
-        </>
+        </EmptyState>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
@@ -1,50 +1,15 @@
-import React, { ReactElement, useCallback } from 'react';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
+import React, { ReactElement } from 'react';
+import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
-import { Button } from '@patternfly/react-core';
 
-import PageHeader from 'Components/PageHeader';
-import LinkShim from 'Components/PatternFly/LinkShim';
-import SearchFilterInput from 'Components/SearchFilterInput';
-import entityTypes, { searchCategories } from 'constants/entityTypes';
-import workflowStateContext from 'Containers/workflowStateContext';
+import { searchCategories } from 'constants/entityTypes';
 import { SEARCH_OPTIONS_QUERY } from 'queries/search';
-import usePermissions from 'hooks/usePermissions';
-import useURLSearch from 'hooks/useURLSearch';
-import { clustersDelegatedScanningPath } from 'routePaths';
-import { Cluster } from 'services/ClustersService';
-import parseURL from 'utils/URLParser';
 
 import ClustersTablePanel from './ClustersTablePanel';
 import ClustersSidePanel from './ClustersSidePanel';
-import ManageTokensButton from './Components/ManageTokensButton';
 
 function ClustersPage(): ReactElement {
-    const { hasReadAccess, hasReadWriteAccess } = usePermissions();
-    const hasReadAccessForDelegatedScanning = hasReadAccess('Administration');
-    const hasWriteAccessForIntegration = hasReadWriteAccess('Integration');
-
-    const history = useHistory();
-    const { pathname, search } = useLocation();
-    const { clusterId: selectedClusterId } = useParams(); // see routePaths for parameter
-
-    const { searchFilter, setSearchFilter } = useURLSearch();
-    const workflowState = parseURL({ pathname, search });
-
-    // Handle changes to the currently selected deployment.
-    const setSelectedClusterId = useCallback(
-        (newCluster: string | Cluster) => {
-            const newClusterId = typeof newCluster === 'string' ? newCluster : newCluster?.id ?? '';
-            const newWorkflowState = newClusterId
-                ? workflowState.pushRelatedEntity(entityTypes.CLUSTER, newClusterId)
-                : workflowState.pop();
-
-            const newUrl = newWorkflowState.toUrl();
-
-            history.push(newUrl);
-        },
-        [workflowState, history]
-    );
+    const { clusterId } = useParams(); // see routePaths for parameter
 
     const searchQueryOptions = {
         variables: {
@@ -54,61 +19,13 @@ function ClustersPage(): ReactElement {
     const { data: searchData } = useQuery(SEARCH_OPTIONS_QUERY, searchQueryOptions);
     const searchOptions = (searchData && searchData.searchOptions) || [];
 
-    const headerText = 'Clusters';
-    const subHeaderText = 'Resource list';
-
-    const pageHeader = (
-        <PageHeader header={headerText} subHeader={subHeaderText}>
-            <div className="flex flex-1 items-center justify-end">
-                <SearchFilterInput
-                    className="w-full"
-                    searchFilter={searchFilter}
-                    searchOptions={searchOptions}
-                    searchCategory="CLUSTERS"
-                    placeholder="Filter clusters"
-                    handleChangeSearchFilter={setSearchFilter}
-                />
-                {hasReadAccessForDelegatedScanning && (
-                    <div className="flex items-center ml-4 mr-1">
-                        <Button
-                            variant="secondary"
-                            component={LinkShim}
-                            href={clustersDelegatedScanningPath}
-                        >
-                            Manage delegated scanning
-                        </Button>
-                    </div>
-                )}
-                {hasWriteAccessForIntegration && (
-                    <div className="flex items-center ml-1">
-                        <Button variant="tertiary">
-                            <ManageTokensButton />
-                        </Button>
-                    </div>
-                )}
-            </div>
-        </PageHeader>
-    );
-
     return (
-        <workflowStateContext.Provider value={workflowState}>
-            <section className="flex flex-1 flex-col h-full">
-                <div className="flex flex-1 flex-col">
-                    {pageHeader}
-                    <div className="flex flex-1 relative">
-                        <ClustersTablePanel
-                            selectedClusterId={selectedClusterId}
-                            setSelectedClusterId={setSelectedClusterId}
-                            searchOptions={searchOptions}
-                        />
-                        <ClustersSidePanel
-                            selectedClusterId={selectedClusterId}
-                            setSelectedClusterId={setSelectedClusterId}
-                        />
-                    </div>
-                </div>
-            </section>
-        </workflowStateContext.Provider>
+        <section className="flex flex-1 flex-col h-full">
+            <div className="flex flex-1 relative">
+                <ClustersTablePanel selectedClusterId={clusterId} searchOptions={searchOptions} />
+                {clusterId && <ClustersSidePanel selectedClusterId={clusterId} />}
+            </div>
+        </section>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
+import React, { ReactElement, useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { Alert, Button } from '@patternfly/react-core';
 import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
@@ -22,6 +22,7 @@ import { Cluster, ClusterManagerType } from 'types/cluster.proto';
 import { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useAnalytics, { CLUSTER_CREATED } from 'hooks/useAnalytics';
+import { clustersBasePath } from 'routePaths';
 
 import ClusterEditForm from './ClusterEditForm';
 import ClusterDeployment from './ClusterDeployment';
@@ -60,7 +61,12 @@ type MessageState = {
     text: string;
 };
 
-function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
+export type ClustersSidePanelProps = {
+    selectedClusterId: string;
+};
+
+function ClustersSidePanel({ selectedClusterId }: ClustersSidePanelProps): ReactElement {
+    const history = useHistory();
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForCluster = hasReadWriteAccess('Cluster');
 
@@ -86,12 +92,12 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
 
     function unselectCluster() {
         setSubmissionError(null);
-        setSelectedClusterId('');
         setSelectedCluster(defaultCluster);
         setMessageState(null);
         setIsBlocked(false);
         setWizardStep('FORM');
         setPollingDelay(null);
+        history.push(clustersBasePath);
     }
 
     function managerType(cluster: Partial<Cluster> | null): ClusterManagerType {
@@ -285,13 +291,6 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
         }
     }
 
-    /**
-     * rendering section
-     */
-    if (!selectedClusterId) {
-        return null;
-    }
-
     const selectedClusterName = (selectedCluster && selectedCluster.name) || '';
 
     // @TODO: improve error handling when adding support for new clusters
@@ -386,14 +385,5 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
         </SidePanelAnimatedArea>
     );
 }
-
-ClustersSidePanel.propTypes = {
-    setSelectedClusterId: PropTypes.func.isRequired,
-    selectedClusterId: PropTypes.string,
-};
-
-ClustersSidePanel.defaultProps = {
-    selectedClusterId: '',
-};
 
 export default ClustersSidePanel;

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -1,20 +1,25 @@
 import React, { ReactElement, useState, useReducer } from 'react';
-import PropTypes from 'prop-types';
+import { useHistory } from 'react-router-dom';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import {
+    Bullseye,
     Button,
     Dropdown,
     DropdownItem,
     DropdownPosition,
     DropdownToggle,
+    PageSection,
 } from '@patternfly/react-core';
 
 import CheckboxTable from 'Components/CheckboxTable';
 import CloseButton from 'Components/CloseButton';
 import Dialog from 'Components/Dialog';
+import PageHeader from 'Components/PageHeader';
+import { PanelNew, PanelBody, PanelHead, PanelHeadEnd } from 'Components/Panel';
+import LinkShim from 'Components/PatternFly/LinkShim';
+import SearchFilterInput from 'Components/SearchFilterInput';
 import { DEFAULT_PAGE_SIZE } from 'Components/Table';
 import TableHeader from 'Components/TableHeader';
-import { PanelNew, PanelBody, PanelHead, PanelHeadEnd } from 'Components/Panel';
 import useInterval from 'hooks/useInterval';
 import useMetadata from 'hooks/useMetadata';
 import usePermissions from 'hooks/usePermissions';
@@ -33,26 +38,31 @@ import { toggleRow, toggleSelectAll } from 'utils/checkboxUtils';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { filterAllowedSearch, convertToRestSearch, getHasSearchApplied } from 'utils/searchUtils';
 import { getVersionedDocs } from 'utils/versioning';
+import { clustersBasePath, clustersDelegatedScanningPath } from 'routePaths';
 
 import AutoUpgradeToggle from './Components/AutoUpgradeToggle';
+import ManageTokensButton from './Components/ManageTokensButton';
 import { clusterTablePollingInterval, getUpgradeableClusters } from './cluster.helpers';
 import { getColumnsForClusters } from './clustersTableColumnDescriptors';
 import AddClusterPrompt from './AddClusterPrompt';
 
 export type ClustersTablePanelProps = {
     selectedClusterId: string;
-    setSelectedClusterId: (clusterId: string) => void;
     searchOptions: SearchCategory[];
 };
 
 function ClustersTablePanel({
     selectedClusterId,
-    setSelectedClusterId,
     searchOptions,
 }: ClustersTablePanelProps): ReactElement {
-    const { hasReadWriteAccess } = usePermissions();
+    const history = useHistory();
+
+    const { hasReadAccess, hasReadWriteAccess } = usePermissions();
+    const hasReadAccessForDelegatedScanning = hasReadAccess('Administration');
+    const hasWriteAccessForIntegration = hasReadWriteAccess('Integration');
     const hasWriteAccessForAdministration = hasReadWriteAccess('Administration');
     const hasWriteAccessForCluster = hasReadWriteAccess('Cluster');
+
     const [isInstallMenuOpen, setIsInstallMenuOpen] = useState(false);
 
     function onToggleInstallMenu(newIsInstallMenuOpen) {
@@ -73,7 +83,7 @@ function ClustersTablePanel({
 
     const metadata = useMetadata();
 
-    const { searchFilter: pageSearch } = useURLSearch();
+    const { searchFilter, setSearchFilter } = useURLSearch();
 
     const [checkedClusterIds, setCheckedClusterIds] = useState<string[]>([]);
     const [upgradableClusters, setUpgradableClusters] = useState<Cluster[]>([]);
@@ -126,6 +136,39 @@ function ClustersTablePanel({
 
     const { version } = metadata;
 
+    const pageHeader = (
+        <PageHeader header="Clusters" subHeader="Resource list">
+            <div className="flex flex-1 items-center justify-end">
+                <SearchFilterInput
+                    className="w-full"
+                    searchFilter={searchFilter}
+                    searchOptions={searchOptions}
+                    searchCategory="CLUSTERS"
+                    placeholder="Filter clusters"
+                    handleChangeSearchFilter={setSearchFilter}
+                />
+                {hasReadAccessForDelegatedScanning && (
+                    <div className="flex items-center ml-4 mr-1">
+                        <Button
+                            variant="secondary"
+                            component={LinkShim}
+                            href={clustersDelegatedScanningPath}
+                        >
+                            Manage delegated scanning
+                        </Button>
+                    </div>
+                )}
+                {hasWriteAccessForIntegration && (
+                    <div className="flex items-center ml-1">
+                        <Button variant="tertiary">
+                            <ManageTokensButton />
+                        </Button>
+                    </div>
+                )}
+            </div>
+        </PageHeader>
+    );
+
     const installMenuOptions = [
         version ? (
             <DropdownItem
@@ -163,7 +206,7 @@ function ClustersTablePanel({
             });
     }
 
-    const filteredSearch = filterAllowedSearch(searchOptions, pageSearch || {});
+    const filteredSearch = filterAllowedSearch(searchOptions, searchFilter || {});
     const restSearch = convertToRestSearch(filteredSearch || {});
     useDeepCompareEffect(() => {
         if (restSearch.length) {
@@ -181,7 +224,11 @@ function ClustersTablePanel({
     }, clusterTablePollingInterval);
 
     function onAddCluster() {
-        setSelectedClusterId('new');
+        history.push(`${clustersBasePath}/new`); // TODO we might replace pseudo-id with ?action=create
+    }
+
+    function setSelectedClusterId(cluster: Cluster) {
+        history.push(`${clustersBasePath}/${cluster.id}`);
     }
 
     function upgradeSingleCluster(id) {
@@ -338,8 +385,23 @@ function ClustersTablePanel({
 
     const hasSearchApplied = getHasSearchApplied(filteredSearch);
 
+    if (
+        (!fetchingClusters || pollingCount > 0) &&
+        currentClusters.length <= 0 &&
+        !hasSearchApplied
+    ) {
+        return (
+            <PageSection variant="light">
+                <Bullseye>
+                    <AddClusterPrompt />
+                </Bullseye>
+            </PageSection>
+        );
+    }
+
     return (
         <div className="overflow-hidden w-full">
+            {pageHeader}
             <PanelNew testid="panel">
                 <PanelHead>
                     {headerComponent}
@@ -351,9 +413,6 @@ function ClustersTablePanel({
                             {messages}
                         </div>
                     )}
-                    {(!fetchingClusters || pollingCount > 0) &&
-                        currentClusters.length <= 0 &&
-                        !hasSearchApplied && <AddClusterPrompt />}
                     {(!fetchingClusters || pollingCount > 0) &&
                         (currentClusters.length > 0 || hasSearchApplied) && (
                             <div data-testid="clusters-table" className="h-full w-full">
@@ -388,16 +447,5 @@ function ClustersTablePanel({
         </div>
     );
 }
-
-ClustersTablePanel.propTypes = {
-    selectedClusterId: PropTypes.string,
-    setSelectedClusterId: PropTypes.func.isRequired,
-    searchOptions: PropTypes.arrayOf(PropTypes.string),
-};
-
-ClustersTablePanel.defaultProps = {
-    selectedClusterId: null,
-    searchOptions: [],
-};
 
 export default ClustersTablePanel;


### PR DESCRIPTION
## Description

First of 2 refactoring steps as prerequisite to designs for init bundles and unsecured clusters.

### Problem

New design for **no clusters** page has nothing in common with **clusters table** page, but `ClusterTablePanel` renders `AddClusterPrompt` element with both headers.

### Analysis

Clusters components still have tightly coupled structure left over from original side-by-side table and panel.

### Solution

Depend on page address is source of truth for page state.

1. ClustersPage
    * Replace `setSelectedClusterId` with `history.push(…)` call in descendants.
    * Move `PageHeader` element to ClustersTablePanel component.
    * Delete `workflowStateContext` because no descendant has `useContext` hook.
    * Conditionally render `ClustersSidePanel` element.
2. ClustersTablePanel
    * Move `AddClusterPrompt` element up to become alternative to table page.
        Pending redesign and renaming, add `PageSection` and `Bullseye` to ClustersTablePanel so changed files is more readable for AddClusterPrompt.
    * Adjust integration test.
3. ClustersSidePanel
    * Delete early return because of conditional rendering in ClustersPage.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test helper

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_MOVE_INIT_BUNDLES_UI=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3948062 - 3948062
        total: -433 = 10399223 - 10399656
    * `ls -al build/static/js/*.js | wc -l`
        0 = 89 - 89 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/clusters
    ![clusters](https://github.com/stackrox/stackrox/assets/11862657/1ce86bf5-e42b-41d0-be12-2f69f36ee1fa)

2. Click a row to open the side panel
    * See /main/clusters/id as page address
    * See GET /v1/cluster-defaults
    * See GET /v1/clusters/id
    * See side panel covers page header. Next step will replace cluster side panel with separate cluster page  (with classic style unchanged).
        ![cluster](https://github.com/stackrox/stackrox/assets/11862657/5d451451-4b10-4416-9a6e-cfd4d714619d)

3. Click close button
    * See /main/clusters as page address

### Integration testing

* clusters/clusterDeletion.test.js
* clusters/clusters.test.js
* clusters/clustersCertificateExpiration.test.js
* clusters/clustersHealthStatus.test.js
* clusters/clustersManager.test.js
* clusters/delegatedScanning.test.js
* clusters/redirectFromDashboard.test.js

With page header before changes to simplify:
![AddClusterPrompt_with_headers](https://github.com/stackrox/stackrox/assets/11862657/5036ec97-beb1-40d8-a8dc-84251e9da67c)

Without page header after changes to simplify:
![AddClusterPrompt_without_headers](https://github.com/stackrox/stackrox/assets/11862657/ebf32ac2-c5a9-408b-904f-18b2f7446005)
