### PR TITLE
ROX-21521: get EKS cluster metadata

### DIFF
--- a/pkg/cloudproviders/aws/metadata.go
+++ b/pkg/cloudproviders/aws/metadata.go
@@ -24,6 +24,7 @@ import (
 )
 
 const (
+	loggingRateLimiter  = "aws-metadata"
 	timeout             = 5 * time.Second
 	eksClusterNameLabel = "alpha.eksctl.io/cluster-name"
 	eksClusterNameTag   = "eks:cluster-name"
@@ -138,21 +139,21 @@ func getClusterMetadata(ctx context.Context,
 	if err == nil {
 		return clusterMetadataFromName(clusterName, doc)
 	}
-	log.Errorf("Failed to get EKS cluster metadata from instance tags: %v", err)
+	logging.GetRateLimitedLogger().ErrorL(loggingRateLimiter, "Failed to get EKS cluster metadata from instance tags: %s", err)
 
 	config, err := k8sutil.GetK8sInClusterConfig()
 	if err != nil {
-		log.Errorf("Failed to get EKS cluster metadata: Obtaining in-cluster Kubernetes config: %v", err)
+		logging.GetRateLimitedLogger().ErrorL(loggingRateLimiter, "Failed to get EKS cluster metadata: Obtaining in-cluster Kubernetes config: %s", err)
 		return nil
 	}
 	k8sClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.Errorf("Failed to get EKS cluster metadata: Creating Kubernetes clientset: %v", err)
+		logging.GetRateLimitedLogger().ErrorL(loggingRateLimiter, "Failed to get EKS cluster metadata: Creating Kubernetes clientset: %s", err)
 		return nil
 	}
 	clusterName, err = getClusterNameFromNodeLabels(ctx, k8sClient)
 	if err != nil {
-		log.Errorf("Failed to get EKS cluster metadata from node labels: %v", err)
+		logging.GetRateLimitedLogger().ErrorL(loggingRateLimiter, "Failed to get EKS cluster metadata from node labels: %s", err)
 		return nil
 	}
 	return clusterMetadataFromName(clusterName, doc)

--- a/pkg/cloudproviders/aws/metadata.go
+++ b/pkg/cloudproviders/aws/metadata.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -13,13 +14,18 @@ import (
 	"github.com/fullsailor/pkcs7"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/cloudproviders/utils"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
+	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/logging"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
-	timeout = 5 * time.Second
+	timeout             = 5 * time.Second
+	eksClusterNameLabel = "alpha.eksctl.io/cluster-name"
+	eksClusterNameTag   = "eks:cluster-name"
 )
 
 var (
@@ -62,6 +68,8 @@ func GetMetadata(ctx context.Context) (*storage.ProviderMetadata, error) {
 		return nil, errs.ToError()
 	}
 
+	clusterMetadata := getClusterMetadata(ctx, mdClient, doc)
+
 	return &storage.ProviderMetadata{
 		Region: doc.Region,
 		Zone:   doc.AvailabilityZone,
@@ -71,6 +79,7 @@ func GetMetadata(ctx context.Context) (*storage.ProviderMetadata, error) {
 			},
 		},
 		Verified: verified,
+		Cluster:  clusterMetadata,
 	}, nil
 }
 
@@ -113,4 +122,57 @@ func plaintextIdentityDoc(ctx context.Context, mdClient *ec2metadata.EC2Metadata
 	}
 
 	return doc, nil
+}
+
+// getClusterMetadata attempts to get the EKS cluster name on a best effort basis.
+// First, it tries to get the cluster name from the EC2 instance tags. Access to
+// the tags must be explicitly enabled for the EC2 instance beforehand.
+// Second, it tries the node labels. The label is only set when the EKS cluster
+// was created via eksctl.
+func getClusterMetadata(ctx context.Context,
+	client *ec2metadata.EC2Metadata, doc *ec2metadata.EC2InstanceIdentityDocument,
+) *storage.ClusterMetadata {
+	clusterName, err := getClusterNameFromInstanceTags(ctx, client)
+	if err == nil {
+		return clusterMetadataFromName(clusterName, doc)
+	}
+	log.Errorf("Failed to get EKS cluster metadata from instance tags: %v", err)
+
+	config, err := k8sutil.GetK8sInClusterConfig()
+	if err != nil {
+		log.Errorf("Obtaining in-cluster Kubernetes config: %v", err)
+		return nil
+	}
+	k8sClient := k8sutil.MustCreateK8sClient(config)
+	clusterName, err = getClusterNameFromNodeLabels(ctx, k8sClient)
+	if err == nil {
+		return clusterMetadataFromName(clusterName, doc)
+	}
+	log.Errorf("Failed to get EKS cluster metadata from node labels: %v", err)
+	return nil
+}
+
+func getClusterNameFromInstanceTags(ctx context.Context, client *ec2metadata.EC2Metadata) (string, error) {
+	clusterName, err := client.GetMetadataWithContext(ctx, fmt.Sprintf("/tags/instance/%s", eksClusterNameTag))
+	if err != nil {
+		return "", errors.Wrap(err, "getting cluster name tag")
+	}
+	return clusterName, nil
+}
+
+func getClusterNameFromNodeLabels(ctx context.Context, k8sClient kubernetes.Interface) (string, error) {
+	nodeLabels, err := utils.GetAnyNodeLabels(ctx, k8sClient)
+	if err != nil {
+		return "", errors.Wrap(err, "getting node labels")
+	}
+	if clusterName := nodeLabels[eksClusterNameLabel]; clusterName != "" {
+		return clusterName, nil
+	}
+	return "", errors.Errorf("node label %q not found", eksClusterNameLabel)
+}
+
+func clusterMetadataFromName(clusterName string, doc *ec2metadata.EC2InstanceIdentityDocument,
+) *storage.ClusterMetadata {
+	clusterARN := fmt.Sprintf("arn:aws:eks:%s:%s:cluster/%s", doc.Region, doc.AccountID, clusterName)
+	return &storage.ClusterMetadata{Type: storage.ClusterMetadata_EKS, Name: clusterName, Id: clusterARN}
 }

--- a/pkg/cloudproviders/aws/metadata.go
+++ b/pkg/cloudproviders/aws/metadata.go
@@ -142,10 +142,14 @@ func getClusterMetadata(ctx context.Context,
 
 	config, err := k8sutil.GetK8sInClusterConfig()
 	if err != nil {
-		log.Errorf("Obtaining in-cluster Kubernetes config: %v", err)
+		log.Errorf("Failed to get EKS cluster metadata: Obtaining in-cluster Kubernetes config: %v", err)
 		return nil
 	}
-	k8sClient := k8sutil.MustCreateK8sClient(config)
+	k8sClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Errorf("Failed to get EKS cluster metadata: Creating Kubernetes clientset: %v", err)
+		return nil
+	}
 	clusterName, err = getClusterNameFromNodeLabels(ctx, k8sClient)
 	if err != nil {
 		log.Errorf("Failed to get EKS cluster metadata from node labels: %v", err)

--- a/pkg/cloudproviders/aws/metadata_test.go
+++ b/pkg/cloudproviders/aws/metadata_test.go
@@ -1,0 +1,42 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetClusterMetadataFromNodeLabels(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	k8sClient := fake.NewSimpleClientset()
+	expectedClusterName := "my-cluster"
+	expectedClusterID := "arn:aws:eks:us-east-1:1234:cluster/my-cluster"
+
+	_, err := k8sClient.CoreV1().Nodes().Create(ctx, &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "my-node",
+			Labels: map[string]string{eksClusterNameLabel: "my-cluster"},
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	doc := &ec2metadata.EC2InstanceIdentityDocument{
+		Region:    "us-east-1",
+		AccountID: "1234",
+	}
+	clusterName, err := getClusterNameFromNodeLabels(ctx, k8sClient)
+	require.NoError(t, err)
+	clusterMetadata := clusterMetadataFromName(clusterName, doc)
+	assert.Equal(t, storage.ClusterMetadata_EKS, clusterMetadata.GetType())
+	assert.Equal(t, expectedClusterName, clusterMetadata.GetName())
+	assert.Equal(t, expectedClusterID, clusterMetadata.GetId())
+}

--- a/pkg/cloudproviders/utils/utils.go
+++ b/pkg/cloudproviders/utils/utils.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GetAnyNodeLabels returns the labels of an arbitrary node. This is useful
+// to extract global labels such as the cluster name.
+func GetAnyNodeLabels(ctx context.Context, client kubernetes.Interface) (map[string]string, error) {
+	nodeList, err := client.CoreV1().Nodes().List(ctx, v1.ListOptions{Limit: 1})
+	if err != nil {
+		return nil, errors.Wrap(err, "listing nodes")
+	}
+	if nodeList.Size() == 0 {
+		return nil, errors.New("no nodes found")
+	}
+	return nodeList.Items[0].GetLabels(), nil
+}


### PR DESCRIPTION
## Description

Get EKS cluster metadata. Unfortunately there is no reliable way to get the cluster name, so we have to get it on a best effort basis. There are two possible sources:
* EC2 metadata instance tags. This works if access has been enabled for the EC2 instance.
* Node labels. This works if the cluster was created via eksctl.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Tested on EKS cluster.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
