### PR TITLE
ROX-20271: Upgrade NP-Guard to v1: updates

### DIFF
--- a/roxctl/netpol/connectivity/diff/cta.go
+++ b/roxctl/netpol/connectivity/diff/cta.go
@@ -38,7 +38,7 @@ func getInfoObj(path string, failFast bool) ([]*resource.Info, error) {
 }
 
 func (cmd *diffNetpolCommand) analyzeConnectivityDiff(analyzer diffAnalyzer) error {
-	errHandler := netpolerrors.NewErrHandler(cmd.treatWarningsAsErrors)
+	errHandler := netpolerrors.NewErrHandler(cmd.treatWarningsAsErrors, cmd.env.Logger())
 	info1, err1 := getInfoObj(cmd.inputFolderPath1, cmd.stopOnFirstError)
 	info2, err2 := getInfoObj(cmd.inputFolderPath2, cmd.stopOnFirstError)
 	if err := errHandler.HandleErrorPair(err1, err2); err != nil {

--- a/roxctl/netpol/connectivity/map/cta.go
+++ b/roxctl/netpol/connectivity/map/cta.go
@@ -116,6 +116,9 @@ func getInfoObj(path string, failFast bool) ([]*resource.Info, error) {
 			&resource.FilenameOptions{Filenames: []string{path}, Recursive: true}).
 		Flatten()
 	if !failFast {
+		// TODO: most errors here are mapped to warnings for this cmd, thus it's not the same semantics.
+		// we define failFast as "fail on the first encountered error", but if all "errors" are actually warnings,
+		// we just end up with partial warnings (first one) in the output, and also partial output?
 		b.ContinueOnError()
 	}
 	//nolint:wrapcheck // we do wrap the errors later in `errHandler.HandleErrors`
@@ -123,7 +126,7 @@ func getInfoObj(path string, failFast bool) ([]*resource.Info, error) {
 }
 
 func (cmd *Cmd) analyzeNetpols(analyzer netpolAnalyzer) error {
-	errHandler := netpolerrors.NewErrHandler(cmd.treatWarningsAsErrors)
+	errHandler := netpolerrors.NewErrHandler(cmd.treatWarningsAsErrors, cmd.env.Logger())
 	infos, err := getInfoObj(cmd.inputFolderPath, cmd.stopOnFirstError)
 	if err := errHandler.HandleError(err); err != nil {
 		//nolint:wrapcheck // The package claimed to be external is local and shared by two related netpol-commands

--- a/roxctl/netpol/connectivity/map/cta.go
+++ b/roxctl/netpol/connectivity/map/cta.go
@@ -109,16 +109,15 @@ func (cmd *Cmd) AddFlags(c *cobra.Command) *cobra.Command {
 	return c
 }
 
-func getInfoObj(path string, failFast bool) ([]*resource.Info, error) {
+func getInfoObj(path string, failFast, treatWarningsAsErrors bool) ([]*resource.Info, error) {
 	b := resource.NewLocalBuilder().
 		Unstructured().
 		FilenameParam(false,
 			&resource.FilenameOptions{Filenames: []string{path}, Recursive: true}).
 		Flatten()
-	if !failFast {
-		// TODO: most errors here are mapped to warnings for this cmd, thus it's not the same semantics.
-		// we define failFast as "fail on the first encountered error", but if all "errors" are actually warnings,
-		// we just end up with partial warnings (first one) in the output, and also partial output?
+	// only for the combination of --fail & --strict, should not run with ContinueOnError, and stop on first warning.
+	// the only error which is not warning returned from this call is errox.NotFound, for which it already fails fast.
+	if !(failFast && treatWarningsAsErrors) {
 		b.ContinueOnError()
 	}
 	//nolint:wrapcheck // we do wrap the errors later in `errHandler.HandleErrors`
@@ -127,7 +126,7 @@ func getInfoObj(path string, failFast bool) ([]*resource.Info, error) {
 
 func (cmd *Cmd) analyzeNetpols(analyzer netpolAnalyzer) error {
 	errHandler := netpolerrors.NewErrHandler(cmd.treatWarningsAsErrors, cmd.env.Logger())
-	infos, err := getInfoObj(cmd.inputFolderPath, cmd.stopOnFirstError)
+	infos, err := getInfoObj(cmd.inputFolderPath, cmd.stopOnFirstError, cmd.treatWarningsAsErrors)
 	if err := errHandler.HandleError(err); err != nil {
 		//nolint:wrapcheck // The package claimed to be external is local and shared by two related netpol-commands
 		return err

--- a/tests/roxctl/bats-tests/local/roxctl-netpol-connectivity-map-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-connectivity-map-development.bats
@@ -23,12 +23,22 @@ teardown() {
 @test "roxctl-development netpol connectivity map should return error on empty or non-existing directory" {
   run roxctl-development netpol connectivity map "$out_dir"
   assert_failure
-  assert_line --partial "error in connectivity analysis"
-  assert_line --partial "no such file or directory"
+  assert_line --partial "building connectivity map: there were errors during execution"
+  assert_line --partial "does not exist"
+  assert_line --partial "not found"
 
   run roxctl-development netpol connectivity map
   assert_failure
   assert_line --partial "accepts 1 arg(s), received 0"
+}
+
+@test "roxctl-development netpol connectivity map should return error on directory with no files" {
+  mkdir -p "$out_dir"  
+  run roxctl-development netpol connectivity map "$out_dir"
+  assert_failure
+  assert_line --partial "no relevant Kubernetes workload resources found"
+  assert_line --partial "no relevant Kubernetes network policy resources found"
+  assert_line --partial "building connectivity map: there were errors during execution"
 }
 
 @test "roxctl-development netpol connectivity map generates connlist output" {
@@ -51,9 +61,57 @@ teardown() {
 
   run roxctl-development netpol connectivity map "$out_dir/" --remove --output-file=/dev/null --fail
   assert_failure
-  assert_line --index 0 --partial 'This is a Technology Preview feature'
-  assert_line --index 1 --partial 'YAML document is malformed'  # expect only one line with this error
-  assert_line --index 2 --partial 'there were errors during execution'  # last line
+  assert_output --partial 'there were warnings during execution'
+  assert_output --partial 'file1.yaml'
+  refute_output --partial 'file2.yaml'
+
+  run roxctl-development netpol connectivity map "$out_dir/" --remove --output-file=/dev/null
+  assert_failure
+  assert_output --partial 'there were warnings during execution'
+  assert_output --partial 'file1.yaml'
+  assert_output --partial 'file2.yaml'
+}
+
+# TODO: is this test as desired? 
+@test "roxctl-development netpol connectivity succedes and returns parital warnings when run with --fail" {
+  mkdir -p "$out_dir"
+  assert_file_exist "${test_data}/np-guard/netpols-analysis-example-minimal/backend.yaml"
+  assert_file_exist "${test_data}/np-guard/netpols-analysis-example-minimal/frontend.yaml"
+  assert_file_exist "${test_data}/np-guard/netpols-analysis-example-minimal/netpols.yaml"
+  cp "${test_data}/np-guard/netpols-analysis-example-minimal/backend.yaml" "$out_dir/backend.yaml"
+  cp "${test_data}/np-guard/netpols-analysis-example-minimal/frontend.yaml" "$out_dir/frontend.yaml"
+  cp "${test_data}/np-guard/netpols-analysis-example-minimal/netpols.yaml" "$out_dir/netpols.yaml"
+  write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-01-XXXXXX-file1.yaml")"
+  write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-02-XXXXXX-file2.yaml")"
+
+  run roxctl-development netpol connectivity map "$out_dir/" --fail
+  assert_success
+  assert_output --partial 'there were warnings during execution'
+  assert_output --partial 'file1.yaml'
+  refute_output --partial 'file2.yaml'
+
+  run roxctl-development netpol connectivity map "$out_dir/"
+  assert_success
+  assert_output --partial 'there were warnings during execution'
+  assert_output --partial 'file1.yaml'
+  assert_output --partial 'file2.yaml'
+}
+
+@test "roxctl-development netpol connectivity map fails on warnings when run with --strict" {
+  mkdir -p "$out_dir"
+  assert_file_exist "${test_data}/np-guard/netpols-analysis-example-minimal/backend.yaml"
+  assert_file_exist "${test_data}/np-guard/netpols-analysis-example-minimal/frontend.yaml"
+  assert_file_exist "${test_data}/np-guard/netpols-analysis-example-minimal/netpols.yaml"
+  cp "${test_data}/np-guard/netpols-analysis-example-minimal/backend.yaml" "$out_dir/backend.yaml"
+  cp "${test_data}/np-guard/netpols-analysis-example-minimal/frontend.yaml" "$out_dir/frontend.yaml"
+  cp "${test_data}/np-guard/netpols-analysis-example-minimal/netpols.yaml" "$out_dir/netpols.yaml"
+  write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-01-XXXXXX-file1.yaml")"
+  write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-02-XXXXXX-file2.yaml")"
+
+  run roxctl-development netpol connectivity map "$out_dir/" --strict
+  assert_failure
+  assert_output --partial 'YAML document is malformed'
+  assert_output --partial 'building connectivity map: there were warnings during execution'
 }
 
 @test "roxctl-development netpol connectivity map produces no output when all yamls are templated" {
@@ -63,11 +121,15 @@ teardown() {
   echo "Analyzing a corrupted yaml file '$templatedYaml'" >&3
   run roxctl-development netpol connectivity map "$out_dir/"
   assert_failure
+  assert_output --partial 'there were warnings during execution'
+  assert_output --partial 'error parsing'
   assert_output --partial 'YAML document is malformed'
-  assert_output --partial 'no relevant Kubernetes resources found'
+  assert_output --partial 'no relevant Kubernetes workload resources found'
+  assert_output --partial 'no relevant Kubernetes network policy resources found'
+  assert_output --partial 'building connectivity map: there were errors during execution'
 }
 
-@test "roxctl-development netpol connectivity map produces errors when some yamls are templated" {
+@test "roxctl-development netpol connectivity map produces warnings when some yamls are templated" {
   mkdir -p "$out_dir"
   write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-XXXXXX.yaml")"
 
@@ -78,12 +140,14 @@ teardown() {
 
   echo "Analyzing a directory where 1/3 of yaml files are templated '$out_dir/'" >&3
   run roxctl-development netpol connectivity map "$out_dir/" --remove --output-file=/dev/null
-  assert_failure
+  assert_success
+  assert_output --partial 'there were warnings during execution'
   assert_output --partial 'YAML document is malformed'
-  refute_output --partial 'no relevant Kubernetes resources found'
+  assert_output --partial 'no relevant Kubernetes network policy resources found'
+  assert_output --partial 'default/frontend[Deployment] => default/backend[Deployment] : All Connections'
 }
 
-@test "roxctl-development netpol connectivity map produces errors when yamls are not K8s resources" {
+@test "roxctl-development netpol connectivity map produces warnings when yamls are not K8s resources" {
   mkdir -p "$out_dir"
   assert_file_exist "${test_data}/np-guard/empty-yamls/empty.yaml"
   assert_file_exist "${test_data}/np-guard/empty-yamls/empty2.yaml"
@@ -92,10 +156,12 @@ teardown() {
 
   run roxctl-development netpol connectivity map "$out_dir/" --remove --output-file=/dev/null
   assert_failure
-  assert_output --partial 'Yaml document is not a K8s resource'
-  assert_output --partial 'no relevant Kubernetes resources found'
-  assert_output --partial 'ERROR:'
-  assert_output --partial 'there were errors during execution'
+  assert_output --partial 'there were warnings during execution'
+  assert_output --partial 'unable to decode'
+  assert_output --partial 'YAML document does not represent a K8s resource'
+  assert_output --partial 'no relevant Kubernetes workload resources found'
+  assert_output --partial 'no relevant Kubernetes network policy resources found'
+  assert_output --partial 'building connectivity map: there were errors during execution'
 }
 
 @test "roxctl-development netpol connectivity map should return error on invalid networkpolicy resource" {

--- a/tests/roxctl/bats-tests/local/roxctl-netpol-connectivity-map-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-connectivity-map-development.bats
@@ -54,7 +54,7 @@ teardown() {
   assert_output --partial 'default/frontend[Deployment] => default/backend[Deployment] : TCP 9090'
 }
 
-@test "roxctl-development netpol connectivity map stops on first error when run with --fail" {
+@test "roxctl-development netpol connectivity shows all warnings when run with --fail only" {
   mkdir -p "$out_dir"
   write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-01-XXXXXX-file1.yaml")"
   write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-02-XXXXXX-file2.yaml")"
@@ -63,7 +63,7 @@ teardown() {
   assert_failure
   assert_output --partial 'there were warnings during execution'
   assert_output --partial 'file1.yaml'
-  refute_output --partial 'file2.yaml'
+  assert_output --partial 'file2.yaml'
 
   run roxctl-development netpol connectivity map "$out_dir/" --remove --output-file=/dev/null
   assert_failure
@@ -72,8 +72,8 @@ teardown() {
   assert_output --partial 'file2.yaml'
 }
 
-# TODO: is this test as desired? 
-@test "roxctl-development netpol connectivity succedes and returns parital warnings when run with --fail" {
+
+@test "roxctl-development netpol connectivity fails on first warning when run with --fail and --strict" {
   mkdir -p "$out_dir"
   assert_file_exist "${test_data}/np-guard/netpols-analysis-example-minimal/backend.yaml"
   assert_file_exist "${test_data}/np-guard/netpols-analysis-example-minimal/frontend.yaml"
@@ -84,8 +84,8 @@ teardown() {
   write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-01-XXXXXX-file1.yaml")"
   write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-02-XXXXXX-file2.yaml")"
 
-  run roxctl-development netpol connectivity map "$out_dir/" --fail
-  assert_success
+  run roxctl-development netpol connectivity map "$out_dir/" --fail --strict
+  assert_failure
   assert_output --partial 'there were warnings during execution'
   assert_output --partial 'file1.yaml'
   refute_output --partial 'file2.yaml'
@@ -95,7 +95,44 @@ teardown() {
   assert_output --partial 'there were warnings during execution'
   assert_output --partial 'file1.yaml'
   assert_output --partial 'file2.yaml'
+
+  run roxctl-development netpol connectivity map "$out_dir/" --fail
+  assert_success
+  assert_output --partial 'there were warnings during execution'
+  assert_output --partial 'file1.yaml'
+  assert_output --partial 'file2.yaml'  
+
+  run roxctl-development netpol connectivity map "$out_dir/" --strict
+  assert_failure
+  assert_output --partial 'there were warnings during execution'
+  assert_output --partial 'file1.yaml'
+  assert_output --partial 'file2.yaml'    
 }
+
+# TODO: does this test represent a desired behavior? 
+# @test "roxctl-development netpol connectivity succedes and returns parital warnings when run with --fail" {
+#   mkdir -p "$out_dir"
+#   assert_file_exist "${test_data}/np-guard/netpols-analysis-example-minimal/backend.yaml"
+#   assert_file_exist "${test_data}/np-guard/netpols-analysis-example-minimal/frontend.yaml"
+#   assert_file_exist "${test_data}/np-guard/netpols-analysis-example-minimal/netpols.yaml"
+#   cp "${test_data}/np-guard/netpols-analysis-example-minimal/backend.yaml" "$out_dir/backend.yaml"
+#   cp "${test_data}/np-guard/netpols-analysis-example-minimal/frontend.yaml" "$out_dir/frontend.yaml"
+#   cp "${test_data}/np-guard/netpols-analysis-example-minimal/netpols.yaml" "$out_dir/netpols.yaml"
+#   write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-01-XXXXXX-file1.yaml")"
+#   write_yaml_to_file "$templated_fragment" "$(mktemp "$out_dir/templated-02-XXXXXX-file2.yaml")"
+
+#   run roxctl-development netpol connectivity map "$out_dir/" --fail
+#   assert_success
+#   assert_output --partial 'there were warnings during execution'
+#   assert_output --partial 'file1.yaml'
+#   refute_output --partial 'file2.yaml'
+
+#   run roxctl-development netpol connectivity map "$out_dir/"
+#   assert_success
+#   assert_output --partial 'there were warnings during execution'
+#   assert_output --partial 'file1.yaml'
+#   assert_output --partial 'file2.yaml'
+# }
 
 @test "roxctl-development netpol connectivity map fails on warnings when run with --strict" {
   mkdir -p "$out_dir"


### PR DESCRIPTION
Updates for `roxctl netpol connectivity` commands error handling and bats tests, for ROX_20271.

Includes:
- few suggested changes for error handling 
- few tests updates (bats tests)