### PR TITLE
fix(netflow): Do not stop the ticker in offline v3

### DIFF
--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -206,7 +206,6 @@ func NewManager(
 	policyDetector detector.Detector,
 ) Manager {
 	enricherTicker := time.NewTicker(tickerTime)
-	enricherTicker.Stop()
 	mgr := &networkFlowManager{
 		done:              concurrency.NewSignal(),
 		connectionsByHost: make(map[string]*hostConnections),
@@ -221,6 +220,7 @@ func NewManager(
 	if features.SensorCapturesIntermediateEvents.Enabled() {
 		mgr.sensorUpdates = make(chan *message.ExpiringMessage, env.NetworkFlowBufferSize.IntegerSetting())
 	} else {
+		enricherTicker.Stop()
 		mgr.sensorUpdates = make(chan *message.ExpiringMessage)
 	}
 


### PR DESCRIPTION
## Description

The ticker for the enrichment should not be stopped on creation.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- [x] Manual
  - Deploy ACS with the FF enabled
  - Create a deployment A
  - Stop the connection between sensor and central
  - Generate a flow to/from deployment A
  - Observe the metric `rox_sensor_network_flow_buffer_size` increases after 30s
  - Re-start the connection between sensor and central
  - Observe the flow appears in the NG and the database

Example of deployments used for the manual test:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  namespace: test
  labels:
    app: nginx
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: nginx
  name: nginx-service
  namespace: test
spec:
  ports:
  - port: 80
    protocol: TCP
    targetPort: 80
    name: tcp
  selector:
    app: nginx
  type: ClusterIP
```
```bash
kubectl -n test run talk --rm -i --tty --image quay.io/rhacs-demo/netflow -- -connect nginx-service.test.svc.cluster.local:80
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
