### PR TITLE
fix(chart): Prefactoring: Fix the naming of global resources in chart

### DIFF
--- a/image/templates/helm/shared/templates/_metadata.tpl
+++ b/image/templates/helm/shared/templates/_metadata.tpl
@@ -169,7 +169,13 @@
   {{- $name -}}
 {{- else -}}
   {{- /* Add global prefix to resource name. */ -}}
-  {{- printf "%s-%s" $._rox.globalPrefix (trimPrefix "stackrox-" $name) -}}
+  {{- if hasPrefix "stackrox-" $name -}}
+    {{- printf "%s-%s" $._rox.globalPrefix (trimPrefix "stackrox-" $name) -}}
+  {{- else if hasPrefix "stackrox:" $name -}}
+    {{- printf "%s:%s" $._rox.globalPrefix (trimPrefix "stackrox:" $name) -}}
+  {{- else -}}
+    {{- include "srox.fail" (printf "Unknown naming convention for global resource %q." $name) -}}
+  {{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-rbac.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-rbac.yaml
@@ -19,7 +19,7 @@ imagePullSecrets:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox:view-cluster
+  name: {{ include "srox.globalResourceName" (list . "stackrox:view-cluster") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox:view-cluster") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -38,7 +38,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox:monitor-cluster
+  name: {{ include "srox.globalResourceName" (list . "stackrox:monitor-cluster") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:monitor-cluster") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -50,7 +50,7 @@ subjects:
   namespace: {{ ._rox._namespace }}
 roleRef:
   kind: ClusterRole
-  name: stackrox:view-cluster
+  name: {{ include "srox.globalResourceName" (list . "stackrox:view-cluster") }}
   apiGroup: rbac.authorization.k8s.io
 ---
 # Role edit has all verbs but 'use' to disallow using any SCCs (resources: *).
@@ -102,7 +102,7 @@ roleRef:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox:edit-workloads
+  name: {{ include "srox.globalResourceName" (list . "stackrox:edit-workloads") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox:edit-workloads") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -131,7 +131,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox:enforce-policies
+  name: {{ include "srox.globalResourceName" (list . "stackrox:enforce-policies") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:enforce-policies") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -143,13 +143,13 @@ subjects:
   namespace: {{ ._rox._namespace }}
 roleRef:
   kind: ClusterRole
-  name: stackrox:edit-workloads
+  name: {{ include "srox.globalResourceName" (list . "stackrox:edit-workloads") }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox:network-policies
+  name: {{ include "srox.globalResourceName" (list . "stackrox:network-policies") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox:network-policies") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -173,7 +173,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox:network-policies-binding
+  name: {{ include "srox.globalResourceName" (list . "stackrox:network-policies-binding") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:network-policies-binding") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -185,13 +185,13 @@ subjects:
   namespace: {{ ._rox._namespace }}
 roleRef:
   kind: ClusterRole
-  name: stackrox:network-policies
+  name: {{ include "srox.globalResourceName" (list . "stackrox:network-policies") }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox:update-namespaces
+  name: {{ include "srox.globalResourceName" (list . "stackrox:update-namespaces") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox:update-namespaces") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -207,7 +207,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox:update-namespaces-binding
+  name: {{ include "srox.globalResourceName" (list . "stackrox:update-namespaces-binding") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:update-namespaces-binding") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -219,13 +219,13 @@ subjects:
   namespace: {{ ._rox._namespace }}
 roleRef:
   kind: ClusterRole
-  name: stackrox:update-namespaces
+  name: {{ include "srox.globalResourceName" (list . "stackrox:update-namespaces") }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox:create-events
+  name: {{ include "srox.globalResourceName" (list . "stackrox:create-events") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox:create-events") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -243,7 +243,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox:create-events-binding
+  name: {{ include "srox.globalResourceName" (list . "stackrox:create-events-binding") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:create-events-binding") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -255,13 +255,13 @@ subjects:
   namespace: {{ ._rox._namespace }}
 roleRef:
   kind: ClusterRole
-  name: stackrox:create-events
+  name: {{ include "srox.globalResourceName" (list . "stackrox:create-events") }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox:review-tokens
+  name: {{ include "srox.globalResourceName" (list . "stackrox:review-tokens") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox:review-tokens") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -277,7 +277,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox:review-tokens-binding
+  name: {{ include "srox.globalResourceName" (list . "stackrox:review-tokens-binding") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:review-tokens-binding") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -289,5 +289,5 @@ subjects:
   namespace: {{ ._rox._namespace }}
 roleRef:
   kind: ClusterRole
-  name: stackrox:review-tokens
+  name: {{ include "srox.globalResourceName" (list . "stackrox:review-tokens") }}
   apiGroup: rbac.authorization.k8s.io

--- a/image/templates/helm/stackrox-secured-cluster/templates/upgrader-serviceaccount.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/upgrader-serviceaccount.yaml
@@ -19,7 +19,7 @@ imagePullSecrets:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox:upgrade-sensors
+  name: {{ include "srox.globalResourceName" (list . "stackrox:upgrade-sensors") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:upgrade-sensors") | nindent 4 }}
   annotations:


### PR DESCRIPTION
## Description

When our Helm charts create *global* resources these resources must be namespace-prefixed to prevent name clashes when deploying into different namespaces in parallel (or sequential when these resources are not properly cleaned up afterwards).

In the context of ACSCS where we deploy multiple centrals on the same cluster we had to make sure that all such global resources in the central chart were correctly handled (prefixed). For the secured-cluster chart we didn't have this requirement and it seems some of the global resources were simply overlooked.

This was noticed in the context of scanner v4 testing.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes~~

## Testing Performed

Just CI.

