### PR TITLE
fix(pipeline): compliance info pipeline

### DIFF
--- a/central/sensor/service/pipeline/all/factory.go
+++ b/central/sensor/service/pipeline/all/factory.go
@@ -32,7 +32,6 @@ import (
 	"github.com/stackrox/rox/central/sensor/service/pipeline/roles"
 	"github.com/stackrox/rox/central/sensor/service/pipeline/secrets"
 	"github.com/stackrox/rox/central/sensor/service/pipeline/serviceaccounts"
-	"github.com/stackrox/rox/pkg/features"
 )
 
 // NewFactory returns a new instance of a Factory that produces a pipeline handling all message types.
@@ -80,11 +79,9 @@ func (s *factoryImpl) PipelineForCluster(ctx context.Context, clusterID string) 
 		complianceoperatorscans.GetPipeline(),
 		nodeinventory.GetPipeline(),
 		enhancements.GetPipeline(),
+		complianceoperatorinfo.GetPipeline(),
 	}
 
-	if features.ComplianceEnhancements.Enabled() {
-		pipelines = append(pipelines, complianceoperatorinfo.GetPipeline())
-	}
 	deduper := s.manager.GetDeduper(ctx, clusterID)
 	return NewClusterPipeline(clusterID, deduper, pipelines...), nil
 }


### PR DESCRIPTION
## Description

The pipeline for receiving information about the compliance operator installation was only created if the feature flag was enabled.  The feature flag is no longer used in sensor so there is a scenario where sensor can send the message if it sends it before the central capabilities are sync'ed with sensor.  The pipeline should always exist and simply do nothing if the feature flag is not enabled.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Started clusters with feature flag on and off and compliance operator not installed to ensure that the existence of the pipeline behaved appropriately when the flag was off.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
