### PR TITLE
chore(errors): Hide sensitive errors from notifier tests

### DIFF
--- a/central/notifier/service/service_impl.go
+++ b/central/notifier/service/service_impl.go
@@ -228,6 +228,8 @@ func (s *serviceImpl) TestUpdatedNotifier(ctx context.Context, request *v1.Updat
 	}()
 
 	if err := notifier.Test(ctx); err != nil {
+		log.Warnf("test notifier %q of type %q failed: %s: %v", request.GetNotifier().GetId(), request.GetNotifier().GetType(), err.Error(), err.Unwrap())
+
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 	return &v1.Empty{}, nil

--- a/central/notifiers/awssh/notifier.go
+++ b/central/notifiers/awssh/notifier.go
@@ -417,9 +417,9 @@ func (n *notifier) ProtoNotifier() *storage.Notifier {
 //   - AWS SecurityHub is reachable
 //
 // If either of the checks fails, an error is returned.
-func (n *notifier) Test(ctx context.Context) error {
+func (n *notifier) Test(ctx context.Context) *notifiers.NotifierError {
 	if n.stoppedSig.IsDone() {
-		return errNotRunning
+		return notifiers.NewNotifierError(errNotRunning.Error(), nil)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, n.upstreamTimeout)
@@ -437,7 +437,7 @@ func (n *notifier) Test(ctx context.Context) error {
 		MaxResults: aws.Int64(1),
 	})
 	if err != nil {
-		return createError("error testing AWS Security Hub integration", err, n.descriptor.GetName())
+		return notifiers.NewNotifierError("get findings from AWS Security Hub failed", createError("error testing AWS Security Hub integration", err, n.descriptor.GetName()))
 	}
 
 	testAlert := &storage.Alert{
@@ -478,7 +478,7 @@ func (n *notifier) Test(ctx context.Context) error {
 	})
 
 	if err != nil {
-		return createError("error testing AWS Security Hub integration", err, n.descriptor.GetName())
+		return notifiers.NewNotifierError("import test findings to AWS Security Hub failed", createError("error testing AWS Security Hub integration", err, n.descriptor.GetName()))
 	}
 	return nil
 }

--- a/central/notifiers/cscc/cscc.go
+++ b/central/notifiers/cscc/cscc.go
@@ -140,8 +140,8 @@ func (c *cscc) ProtoNotifier() *storage.Notifier {
 	return c.Notifier
 }
 
-func (c *cscc) Test(context.Context) error {
-	return errors.New("Test is not yet implemented for Cloud SCC")
+func (c *cscc) Test(context.Context) *notifiers.NotifierError {
+	return notifiers.NewNotifierError("Test is not yet implemented for Cloud SCC", nil)
 }
 
 func (c *cscc) getCluster(id string, clusterDatastore clusterDatastore.DataStore) (*storage.Cluster, error) {

--- a/central/notifiers/email/email.go
+++ b/central/notifiers/email/email.go
@@ -365,11 +365,14 @@ func (e *email) NetworkPolicyYAMLNotify(ctx context.Context, yaml string, cluste
 }
 
 // Test sends a test notification.
-func (e *email) Test(ctx context.Context) error {
+func (e *email) Test(ctx context.Context) *notifiers.NotifierError {
 	subject := "StackRox Test Email"
 	body := fmt.Sprintf("%v\r\n", "This is a test email created to test integration with StackRox.")
-	err := e.sendEmail(ctx, e.notifier.GetLabelDefault(), subject, body)
-	return err
+	if err := e.sendEmail(ctx, e.notifier.GetLabelDefault(), subject, body); err != nil {
+		return notifiers.NewNotifierError("send test email failed", err)
+	}
+
+	return nil
 }
 
 func (e *email) sendEmail(ctx context.Context, recipient, subject, body string) error {

--- a/central/notifiers/generic/generic.go
+++ b/central/notifiers/generic/generic.go
@@ -163,14 +163,19 @@ func (g *generic) ProtoNotifier() *storage.Notifier {
 	return g.Notifier
 }
 
-func (g *generic) Test(ctx context.Context) error {
+func (g *generic) Test(ctx context.Context) *notifiers.NotifierError {
 	alert := &storage.Alert{
 		Id: "testalert",
 		Policy: &storage.Policy{
 			Name: "This is a test message created to test integration with StackRox.",
 		},
 	}
-	return g.AlertNotify(ctx, alert)
+
+	if err := g.AlertNotify(ctx, alert); err != nil {
+		return notifiers.NewNotifierError("send test message failed", err)
+	}
+
+	return nil
 }
 
 func (g *generic) constructJSON(message proto.Message, msgKey string) (io.Reader, error) {

--- a/central/notifiers/jira/jira.go
+++ b/central/notifiers/jira/jira.go
@@ -392,7 +392,7 @@ func (j *jira) createIssue(_ context.Context, severity storage.Severity, i *jira
 	return err
 }
 
-func (j *jira) Test(ctx context.Context) error {
+func (j *jira) Test(ctx context.Context) *notifiers.NotifierError {
 	i := &jiraLib.Issue{
 		Fields: &jiraLib.IssueFields{
 			Description: "StackRox Test Issue",
@@ -405,7 +405,12 @@ func (j *jira) Test(ctx context.Context) error {
 			Summary: "This is a test issue created to test integration with StackRox.",
 		},
 	}
-	return j.createIssue(ctx, storage.Severity_LOW_SEVERITY, i)
+
+	if err := j.createIssue(ctx, storage.Severity_LOW_SEVERITY, i); err != nil {
+		return notifiers.NewNotifierError("create test Jira issue failed", err)
+	}
+
+	return nil
 }
 
 // Optimistically tries to match all of the Jira priorities with the known mapping defined in defaultPriorities

--- a/central/notifiers/pagerduty/pagerduty.go
+++ b/central/notifiers/pagerduty/pagerduty.go
@@ -100,8 +100,8 @@ func (p *pagerDuty) ProtoNotifier() *storage.Notifier {
 	return p.Notifier
 }
 
-func (p *pagerDuty) Test(_ context.Context) error {
-	return p.postAlert(&storage.Alert{
+func (p *pagerDuty) Test(_ context.Context) *notifiers.NotifierError {
+	err := p.postAlert(&storage.Alert{
 		Id: uuid.NewDummy().String(),
 		Policy: &storage.Policy{
 			Name:        "Test PagerDuty Policy",
@@ -119,6 +119,12 @@ func (p *pagerDuty) Test(_ context.Context) error {
 		},
 		Time: types.TimestampNow(),
 	}, newAlert)
+
+	if err != nil {
+		return notifiers.NewNotifierError("send PagerDuty alert failed", err)
+	}
+
+	return nil
 }
 
 func (p *pagerDuty) AckAlert(_ context.Context, alert *storage.Alert) error {

--- a/central/notifiers/sumologic/sumologic.go
+++ b/central/notifiers/sumologic/sumologic.go
@@ -121,16 +121,22 @@ type testPayload struct {
 	TestMessage string `json:"testMessage"`
 }
 
-func (s *sumologic) Test(ctx context.Context) error {
+func (s *sumologic) Test(ctx context.Context) *notifiers.NotifierError {
 	payload := testPayload{
 		TestID:      "testalert",
 		TestMessage: "This is a test message created to test integration with StackRox.",
 	}
 	marshaledPayload, err := json.Marshal(payload)
 	if err != nil {
-		return err
+		return notifiers.NewNotifierError("create test alert failed", err)
 	}
-	return s.sendPayload(ctx, bytes.NewBuffer(marshaledPayload))
+
+	err = s.sendPayload(ctx, bytes.NewBuffer(marshaledPayload))
+	if err != nil {
+		return notifiers.NewNotifierError("send test alert failed", err)
+	}
+
+	return nil
 }
 
 func init() {

--- a/central/notifiers/syslog/syslog.go
+++ b/central/notifiers/syslog/syslog.go
@@ -291,9 +291,13 @@ func (s *syslog) ProtoNotifier() *storage.Notifier {
 	return s.Notifier
 }
 
-func (s *syslog) Test(context.Context) error {
+func (s *syslog) Test(context.Context) *notifiers.NotifierError {
 	data := s.getCEFHeaderWithExtension("Test", "Test", 0, "stackroxKubernetesSecurityPlatformTestMessage=test")
-	return s.sendSyslog(testMessageSeverity, time.Now(), "stackroxKubernetesSecurityPlatformIntegrationTest", data)
+	if err := s.sendSyslog(testMessageSeverity, time.Now(), "stackroxKubernetesSecurityPlatformIntegrationTest", data); err != nil {
+		return notifiers.NewNotifierError("send test syslog failed", err)
+	}
+
+	return nil
 }
 
 func (s *syslog) SendAuditMessage(_ context.Context, msg *v1.Audit_Message) error {

--- a/pkg/notifiers/error.go
+++ b/pkg/notifiers/error.go
@@ -1,0 +1,45 @@
+package notifiers
+
+// NotifierError represents an error that occurs in notifier calls.
+type NotifierError struct {
+	// msg provides additional information or context about the error.
+	msg string
+
+	// err holds the underlying error.
+	err error
+}
+
+// NewNotifierError creates and returns a new instance of NotifierError.
+//
+// Parameters:
+//   - msg: A string providing additional information or context about the error.
+//     This message will be visible by users, and it should not expose any
+//     sensitive information.
+//   - err: The underlying error that caused the extraction failure.
+//
+// Returns:
+//   - An initialized pointer to an NotifierError struct with the given parameters.
+func NewNotifierError(msg string, err error) *NotifierError {
+	return &NotifierError{
+		msg: msg,
+		err: err,
+	}
+}
+
+var _ error = (*NotifierError)(nil)
+
+func (e *NotifierError) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	return e.msg
+}
+
+func (e *NotifierError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	return e.err
+}

--- a/pkg/notifiers/mocks/alert_notifier.go
+++ b/pkg/notifiers/mocks/alert_notifier.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	storage "github.com/stackrox/rox/generated/storage"
+	notifiers "github.com/stackrox/rox/pkg/notifiers"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -83,10 +84,10 @@ func (mr *MockAlertNotifierMockRecorder) ProtoNotifier() *gomock.Call {
 }
 
 // Test mocks base method.
-func (m *MockAlertNotifier) Test(arg0 context.Context) error {
+func (m *MockAlertNotifier) Test(arg0 context.Context) *notifiers.NotifierError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Test", arg0)
-	ret0, _ := ret[0].(error)
+	ret0, _ := ret[0].(*notifiers.NotifierError)
 	return ret0
 }
 

--- a/pkg/notifiers/mocks/audit_notifier.go
+++ b/pkg/notifiers/mocks/audit_notifier.go
@@ -15,6 +15,7 @@ import (
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
+	notifiers "github.com/stackrox/rox/pkg/notifiers"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -98,10 +99,10 @@ func (mr *MockAuditNotifierMockRecorder) SendAuditMessage(arg0, arg1 any) *gomoc
 }
 
 // Test mocks base method.
-func (m *MockAuditNotifier) Test(arg0 context.Context) error {
+func (m *MockAuditNotifier) Test(arg0 context.Context) *notifiers.NotifierError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Test", arg0)
-	ret0, _ := ret[0].(error)
+	ret0, _ := ret[0].(*notifiers.NotifierError)
 	return ret0
 }
 

--- a/pkg/notifiers/mocks/notifier.go
+++ b/pkg/notifiers/mocks/notifier.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	storage "github.com/stackrox/rox/generated/storage"
+	notifiers "github.com/stackrox/rox/pkg/notifiers"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -69,10 +70,10 @@ func (mr *MockNotifierMockRecorder) ProtoNotifier() *gomock.Call {
 }
 
 // Test mocks base method.
-func (m *MockNotifier) Test(arg0 context.Context) error {
+func (m *MockNotifier) Test(arg0 context.Context) *notifiers.NotifierError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Test", arg0)
-	ret0, _ := ret[0].(error)
+	ret0, _ := ret[0].(*notifiers.NotifierError)
 	return ret0
 }
 

--- a/pkg/notifiers/mocks/report_notifier.go
+++ b/pkg/notifiers/mocks/report_notifier.go
@@ -15,6 +15,7 @@ import (
 	reflect "reflect"
 
 	storage "github.com/stackrox/rox/generated/storage"
+	notifiers "github.com/stackrox/rox/pkg/notifiers"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -84,10 +85,10 @@ func (mr *MockReportNotifierMockRecorder) ReportNotify(arg0, arg1, arg2, arg3, a
 }
 
 // Test mocks base method.
-func (m *MockReportNotifier) Test(arg0 context.Context) error {
+func (m *MockReportNotifier) Test(arg0 context.Context) *notifiers.NotifierError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Test", arg0)
-	ret0, _ := ret[0].(error)
+	ret0, _ := ret[0].(*notifiers.NotifierError)
 	return ret0
 }
 

--- a/pkg/notifiers/mocks/resolvable_alert_notifier.go
+++ b/pkg/notifiers/mocks/resolvable_alert_notifier.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	storage "github.com/stackrox/rox/generated/storage"
+	notifiers "github.com/stackrox/rox/pkg/notifiers"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -111,10 +112,10 @@ func (mr *MockResolvableAlertNotifierMockRecorder) ResolveAlert(arg0, arg1 any) 
 }
 
 // Test mocks base method.
-func (m *MockResolvableAlertNotifier) Test(arg0 context.Context) error {
+func (m *MockResolvableAlertNotifier) Test(arg0 context.Context) *notifiers.NotifierError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Test", arg0)
-	ret0, _ := ret[0].(error)
+	ret0, _ := ret[0].(*notifiers.NotifierError)
 	return ret0
 }
 

--- a/pkg/notifiers/notifier.go
+++ b/pkg/notifiers/notifier.go
@@ -15,5 +15,5 @@ type Notifier interface {
 	// ProtoNotifier gets the proto version of the notifier
 	ProtoNotifier() *storage.Notifier
 	// Test sends a test message
-	Test(context.Context) error
+	Test(context.Context) *NotifierError
 }


### PR DESCRIPTION
## Description

When we run tests on notifiers it is possible to see internal IPs of services. To improve security, we should not expose internal IPs or other sensitive information in returned results.

This PR changes notifier error handling in a way that returns only defined messages and no internal library messages. But it logs a full error message with all the details.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

1. Added Tests
2. **TODO:** Manual testing of image build from CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
