### PR TITLE
test(ui): Adding tests for the deny request workflow

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/ExceptionManagement.helpers.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/ExceptionManagement.helpers.ts
@@ -1,4 +1,13 @@
 import { visit } from '../../../helpers/visit';
+import {
+    fillAndSubmitExceptionForm,
+    selectSingleCveForException,
+    verifyExceptionConfirmationDetails,
+    verifySelectedCvesInModal,
+    visitWorkloadCveOverview,
+} from '../workloadCves/WorkloadCves.helpers';
+import { selectors as workloadCVESelectors } from '../workloadCves/WorkloadCves.selectors';
+import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
 
 const basePath = '/main/vulnerabilities/exception-management';
 export const pendingRequestsPath = `${basePath}/pending-requests`;
@@ -8,4 +17,42 @@ export function visitExceptionManagement() {
 
     cy.get('h1:contains("Exception management")');
     cy.location('pathname').should('eq', pendingRequestsPath);
+}
+
+export function deferAndVisitRequestDetails({
+    comment,
+    expiry,
+    scope,
+}: {
+    comment: string;
+    expiry: string;
+    scope: string;
+}) {
+    visitWorkloadCveOverview();
+    cy.get(vulnSelectors.clearFiltersButton).click(); // Note: This is a workaround to prevent a lack of CVE data from causing the test to fail in CI
+
+    // defer a single cve
+    selectSingleCveForException('DEFERRAL').then((cveName) => {
+        verifySelectedCvesInModal([cveName]);
+        fillAndSubmitExceptionForm({
+            comment,
+            expiryLabel: expiry,
+        });
+        verifyExceptionConfirmationDetails({
+            expectedAction: 'Deferral',
+            cves: [cveName],
+            scope,
+            expiry,
+        });
+        cy.get(workloadCVESelectors.copyToClipboardButton).click();
+        cy.get(workloadCVESelectors.copyToClipboardTooltipText).contains('Copied');
+        // @TODO: Can make this into a custom cypress command (ie. getClipboardText)
+        cy.window()
+            .then((win) => {
+                return win.navigator.clipboard.readText();
+            })
+            .then((url) => {
+                visit(url);
+            });
+    });
 }

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/denyRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/denyRequestFlow.test.ts
@@ -1,7 +1,8 @@
 import withAuth from '../../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../../helpers/features';
+import { getInputByLabel } from '../../../helpers/formHelpers';
 import { cancelAllCveExceptions } from '../workloadCves/WorkloadCves.helpers';
-import { deferAndVisitRequestDetails, pendingRequestsPath } from './ExceptionManagement.helpers';
+import { deferAndVisitRequestDetails } from './ExceptionManagement.helpers';
 
 const comment = 'Defer me';
 const expiry = 'When all CVEs are fixable';
@@ -45,20 +46,22 @@ describe('Exception Management Request Details Page', () => {
         }
     });
 
-    it('should be able to cancel a request if the user is the requester', () => {
-        cy.get('button:contains("Cancel request")').click();
+    it('should be able to deny a request if approval permissions are granted', () => {
+        cy.get('button:contains("Deny request")').click();
         cy.get('div[role="dialog"]').should('exist');
-        cy.get('div[role="dialog"] button:contains("Cancel request")').click();
+        getInputByLabel('Denial rationale').type('Denied');
+        cy.get('div[role="dialog"] button:contains("Deny")').click();
         cy.get('div[role="dialog"]').should('not.exist');
-        cy.location().should((location) => {
-            expect(location.pathname).to.eq(pendingRequestsPath);
-        });
+        cy.get('div[aria-label="Success Alert"]').should(
+            'contain',
+            'The vulnerability request was successfully denied.'
+        );
     });
 
-    it('should be able to see how many CVEs will be affected by a cancel', () => {
+    it('should be able to see how many CVEs will be affected by a denial', () => {
         cy.get('table tbody tr:not(".pf-c-table__expandable-row")').then((rows) => {
             const numCVEs = rows.length;
-            cy.get('button:contains("Cancel request")').click();
+            cy.get('button:contains("Deny request")').click();
             cy.get('div[role="dialog"]').should('exist');
             cy.get(`div:contains("CVE count: ${numCVEs}")`).should('exist');
         });


### PR DESCRIPTION
## Description

This PR adds some tests for the deny request workflow

1. `should be able to deny a request if approval permissions are granted`
2. `should be able to see how many CVEs will be affected by a denial`


