### PR TITLE
chore(scanner): stop making arm64 builds for now

### DIFF
--- a/.github/workflows/scanner-build.yml
+++ b/.github/workflows/scanner-build.yml
@@ -19,7 +19,8 @@ jobs:
     strategy:
       matrix:
         # If this is updated, be sure to update architectures in push-manifests below.
-        goarch: ['amd64', 'arm64', 'ppc64le', 's390x']
+        # TODO(ROX-21746): add arm64 back
+        goarch: ['amd64', 'ppc64le', 's390x']
         goos: ['linux']
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61
@@ -88,6 +89,7 @@ jobs:
         source ./scripts/ci/lib.sh
 
         # If this is updated, be sure to update goarch in build-and-push above.
-        architectures="amd64,arm64,ppc64le,s390x"
+        # TODO(ROX-21746): add arm64 back
+        architectures="amd64,ppc64le,s390x"
 
         push_scanner_image_manifest_lists "$architectures"


### PR DESCRIPTION
## Description

https://download.postgresql.org/pub/repos/yum/15/redhat/rhel-8-aarch64/ was cleared today for some reason. Just ignored arm64 for now

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
