### PR TITLE
ROX-21711: Render cluster side panel as cluster page instead

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/Clusters.helpers.js
+++ b/ui/apps/platform/cypress/integration/clusters/Clusters.helpers.js
@@ -54,7 +54,7 @@ const title = 'Clusters';
 // assert
 
 export function assertClusterNameInSidePanel(clusterName) {
-    cy.get(`[data-testid="clusters-side-panel-header"]:contains("${clusterName}")`);
+    cy.get(`h1:contains("${clusterName}")`);
 }
 
 // visit
@@ -113,8 +113,6 @@ export function visitClusterById(clusterId, staticResponseMap) {
         },
     };
     visit(`${clustersPath}/${clusterId}`, routeMatcherMapForClusterById, staticResponseMap);
-
-    cy.get(`h1:contains("${title}")`);
 }
 
 export function visitClustersWithFixtureMetadataDatetime(fixturePath, metadata, datetimeISOString) {

--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
@@ -6,7 +6,7 @@ import { searchCategories } from 'constants/entityTypes';
 import { SEARCH_OPTIONS_QUERY } from 'queries/search';
 
 import ClustersTablePanel from './ClustersTablePanel';
-import ClustersSidePanel from './ClustersSidePanel';
+import ClusterPage from './ClusterPage';
 
 function ClustersPage(): ReactElement {
     const { clusterId } = useParams(); // see routePaths for parameter
@@ -19,12 +19,13 @@ function ClustersPage(): ReactElement {
     const { data: searchData } = useQuery(SEARCH_OPTIONS_QUERY, searchQueryOptions);
     const searchOptions = (searchData && searchData.searchOptions) || [];
 
+    if (clusterId) {
+        return <ClusterPage clusterId={clusterId} />;
+    }
+
     return (
         <section className="flex flex-1 flex-col h-full">
-            <div className="flex flex-1 relative">
-                <ClustersTablePanel selectedClusterId={clusterId} searchOptions={searchOptions} />
-                {clusterId && <ClustersSidePanel selectedClusterId={clusterId} />}
-            </div>
+            <ClustersTablePanel selectedClusterId={clusterId} searchOptions={searchOptions} />
         </section>
     );
 }


### PR DESCRIPTION
## Description

Second of 2 refactoring steps as prerequisite to designs for init bundles and unsecured clusters.

### Clusters.helpers.js

1. Replace `data-testid` attribute with `h1` element in selector.
2. Delete asssetion about **Clusters** `h1` element in `visitClusterById` function.

### ClusterPage.tsx

1. Rename ClusterSidePanel.tsx as ClusterPage.tsx file.
2. Rename `selectedClusterId` as `clusterId` prop.
3. Delete `isDarkMode` and `useTheme` hook.
4. Replace `SidePanelAnimatedArea` element with `section` element.
5. Replace `PanelHead` and `PanelTitle` with `PageHeader` element for consistency with ClustersTablePanel.
6. Delete `CloseButton` element.
7. Replace `unselectCluster()` with `history.push(clustersBasePath)` call for **Finish** button.

### ClustersPage.tsx

1. Rewrite conditional rendering as `if` statement.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited integration test helper

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_MOVE_INIT_BUNDLES_UI=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3948107 - 3948107
        total: -894 = 10404721 - 10405615
    * `ls -al build/static/js/*.js | wc -l`
        0 = 89 - 89 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/clusters

2. Click a row to open the side panel
    * See /main/clusters/id as page address
    * See GET /v1/cluster-defaults
    * See GET /v1/clusters/id

    Before changes: see side panel covers page header.
    ![ClustersSidePanel](https://github.com/stackrox/stackrox/assets/11862657/2f67cf74-9cdc-477c-af09-1b179e115deb)

    After changes: see separate cluster page  (with classic style unchanged).
    See absence of close button.
    ![ClusterPage](https://github.com/stackrox/stackrox/assets/11862657/1218ffe0-19bd-4f06-b36c-9204bb5fcd9d)

3. Click **Next** button.
    * See PUT /v1/clusters/id
    ![Finish](https://github.com/stackrox/stackrox/assets/11862657/b872b731-d1ab-40b4-bf72-171b47a0ea5d)

4. Click **Finish** button.
    * Go back to clusters page.

### Integration testing

* clusters/clusterDeletion.test.js one test failed locally
* clusters/clusters.test.js
* clusters/clustersCertificateExpiration.test.js
* clusters/clustersHealthStatus.test.js
* clusters/clustersManager.test.js
* clusters/delegatedScanning.test.js
* clusters/redirectFromDashboard.test.js
