### PR TITLE
feat(scanv4): Enable Scanner v4 when Scanner v2 is enabled

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/70-scanner-v4.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/70-scanner-v4.yaml.htpl
@@ -1,6 +1,6 @@
 [<- if and .FeatureFlags.ROX_SCANNER_V4_SUPPORT (not .KubectlOutput) >]
 scannerV4:
-  disable: true [</* On secured-clusters local scanners (irregardless of the version) require explicit activation. */>]
+  [</* On secured-clusters local scanners (irregardless of the version) require explicit activation. */>]
   indexer:
     replicas: 3
     logLevel: INFO

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -268,7 +268,22 @@
 {{/*
    Local Scanner v4 Indexer setup.
   */}}
+
 {{ $scannerV4Cfg := $._rox.scannerV4 }}
+
+{{/* In order to establish a smooth and automated activation of Scanner v4 in situations where Scanner v2 is
+     already activated, we let `scanner.disable: false` have the implicit side-effect of
+    `scannerV4.disable: false` if the latter has not been explicitly set. */}}
+{{- if eq $.Chart.Name "stackrox-secured-cluster-services" -}}
+  {{- if kindIs "invalid" $scannerV4Cfg.disable -}}
+    {{- if not $._rox.scanner.disable -}}
+      {{- $_ = set $scannerV4Cfg "disable" false -}}
+    {{- else -}}
+      {{- $_ = set $scannerV4Cfg "disable" true -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 {{/* Disable scanner v4 always in kubectl outputs */}}
 
 {{ include "srox.scannerV4Init" (list $ $scannerV4Cfg) }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -271,16 +271,12 @@
 
 {{ $scannerV4Cfg := $._rox.scannerV4 }}
 
-{{/* In order to establish a smooth and automated activation of Scanner v4 in situations where Scanner v2 is
+{{/* To establish a smooth and automated activation of Scanner v4 in situations where Scanner v2 is
      already activated, we let `scanner.disable: false` have the implicit side-effect of
     `scannerV4.disable: false` if the latter has not been explicitly set. */}}
 {{- if eq $.Chart.Name "stackrox-secured-cluster-services" -}}
   {{- if kindIs "invalid" $scannerV4Cfg.disable -}}
-    {{- if not $._rox.scanner.disable -}}
-      {{- $_ = set $scannerV4Cfg "disable" false -}}
-    {{- else -}}
-      {{- $_ = set $scannerV4Cfg "disable" true -}}
-    {{- end -}}
+    {{- $_ = set $scannerV4Cfg "disable" $._rox.scanner.disable -}}
   {{- end -}}
 {{- end -}}
 

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-slim.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-slim.test.yaml
@@ -2,6 +2,8 @@ values:
   monitoring:
     openshift:
       enabled: false
+  scannerV4:
+    disable: true
 server:
   visibleSchemas:
   - openshift-4.1.0

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -32,7 +32,7 @@ tests:
 
 - name: "scanner V4 is disabled should not be installed by default"
   expect: |
-    .deployments["scanner-v4"] | assertThat(. == null)
+    .deployments["scanner-v4-indexer"] | assertThat(. == null)
     .deployments["scanner-v4-db"] | assertThat(. == null)
 
 - name: "scanner can override image config"
@@ -124,3 +124,19 @@ tests:
         FOO: bar
   expect: |
     envVars(.deployments["scanner-v4-indexer"]; "indexer")["FOO"] | assertThat(. == "bar")
+
+- name: "Enabling scanner v2 automatically enables scanner v4 as well"
+  values:
+    scanner:
+      disable: false
+  expect: |
+    .deployments["scanner-v4-indexer"] | assertThat(. != null)
+
+- name: "Enabling scanner v2 does not enable scanner v4 if it has been explicitly disabled"
+  values:
+    scannerV4:
+      disable: true
+    scanner:
+      disable: false
+  expect: |
+    .deployments["scanner-v4-indexer"] | assertThat(. == null)


### PR DESCRIPTION
## Description

Context for this PR is the activation of the local scanner feature within the secured-cluster services Helm chart.

So far the situation is that scanner (v2) is disabled by default within the secured-cluster chart. Setting `scanner.disable: false` activates the local scanner feature and the deployment of scanner (v2).

With the upcoming 4.4 Helm charts we are installing scanner v4 by default as part of the central chart, i.e. the user does not need to explicitly set `scannerV4.disable: false` for scanner v4 to be deployed.

Given these semantics for the central chart and for the sake of coherence and ergonomics it seems reasonable to adjust the secured-cluster chart in such a way that an activated scanner v2 implies scanner v4 being activated as well (unless `scannerV4.disable` has been explicitly set by the user).

This PR implements exactly that.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
