### PR TITLE
ROX-21203: Introduce Central Enhancement Timeout

### DIFF
--- a/central/detection/service/service_impl.go
+++ b/central/detection/service/service_impl.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/detection"
 	deploytimePkg "github.com/stackrox/rox/pkg/detection/deploytime"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/authz"
@@ -412,7 +413,7 @@ func (s *serviceImpl) DetectDeployTimeFromYAML(ctx context.Context, req *apiV1.D
 		if conn == nil {
 			return nil, errox.InvalidArgs.New("connection to cluster is not ready - try again later")
 		}
-		deployments, err = s.enhancementWatcher.SendAndWaitForEnhancedDeployments(ctx, conn, deployments, 30*time.Second)
+		deployments, err = s.enhancementWatcher.SendAndWaitForEnhancedDeployments(ctx, conn, deployments, env.CentralDeploymentEnhancementTimeout.DurationSetting())
 		if err != nil {
 			return nil, errors.Wrap(err, "failed waiting for augmented deployment response")
 		}

--- a/pkg/env/deployment_enhancement.go
+++ b/pkg/env/deployment_enhancement.go
@@ -1,0 +1,9 @@
+package env
+
+import "time"
+
+var (
+	// CentralDeploymentEnhancementTimeout allows to configure the time Central waits for Sensor to answer to a
+	// DeploymentEnhancementRequest.
+	CentralDeploymentEnhancementTimeout = registerDurationSetting("ROX_CENTRAL_DEPLOYMENT_ENHANCE_TIMEOUT", 30*time.Second)
+)


### PR DESCRIPTION
## Description

This PR introduces a configurable timeout for Central to wait for Sensor to answer a Deployment Enhancement Request.
For this, a new environment variable was introduced, `ROX_CENTRAL_DEPLOYMENT_ENHANCE_TIMEOUT`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
Manual testing, by deploying and setting the timeout very low and watching for timeout answers.

- Deploy locally
- Enable feature flag
	- `kubectl set env deployment/sensor ROX_CLUSTER_AWARE_DEPLOYMENT_CHECK=true -n stackrox`
- Set short timeout
	- `kubectl set env deployment/central ROX_CENTRAL_DEPLOYMENT_ENHANCE_TIMEOUT="10ms" -n stackrox`
- Start enhanced deployment check (see yaml at the bottom of this PR description)
	- `bin/linux_amd64/roxctl deployment check --file ~/Downloads/nginx.yaml --cluster remote --namespace stackrox`

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.


---
`nginx.yaml`:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  namespace: stackrox
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx # what happens if these are not provided? what happens if these differ from the deployment labels?
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80

---

apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: multi-port-egress
  namespace: stackrox
spec:
  podSelector:
    matchLabels:
      app: nginx
  policyTypes:
    - Ingress
  ingress:
    - from:
        - ipBlock:
            cidr: 10.0.0.0/24
      ports:
        - protocol: TCP
          port: 32000
          endPort: 32768

```
