### PR TITLE
ROX-21681: Adapt Helm charts to use central-encryption-key-chain

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -180,8 +180,8 @@ spec:
         {{- end }}
         {{- if ._rox.central.notifierSecretsEncryption }}
         {{- if ._rox.central.notifierSecretsEncryption.enabled }}
-        - name: central-encryption-key
-          mountPath: /run/secrets/stackrox.io/central-encryption-key
+        - name: central-encryption-key-chain
+          mountPath: /run/secrets/stackrox.io/central-encryption-key-chain
         {{- end }}
         {{- end }}
         {{- if ._rox.monitoring.openshift.enabled }}
@@ -268,9 +268,9 @@ spec:
       {{- end }}
       {{- if ._rox.central.notifierSecretsEncryption }}
       {{- if ._rox.central.notifierSecretsEncryption.enabled }}
-      - name: central-encryption-key
+      - name: central-encryption-key-chain
         secret:
-          secretName: central-encryption-key
+          secretName: central-encryption-key-chain
       {{- end }}
       {{- end }}
       - name: stackrox-db

--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -206,9 +206,7 @@ type DeclarativeConfiguration struct {
 
 // NotifierSecretsEncryption defines settings for encrypting notifier secrets in the Central DB.
 type NotifierSecretsEncryption struct {
-	// Enables the encryption of notifier secrets stored in the Central DB. An encryption key must be
-	// provided in a secret called `central-encryption-key` in the Central namespace, with the key stored in
-	// the `encryption-key` data field.
+	// Enables the encryption of notifier secrets stored in the Central DB.
 	//+kubebuilder:default=false
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	Enabled *bool `json:"enabled,omitempty"`

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -366,10 +366,7 @@ spec:
                       enabled:
                         default: false
                         description: Enables the encryption of notifier secrets stored
-                          in the Central DB. An encryption key must be provided in
-                          a secret called `central-encryption-key` in the Central
-                          namespace, with the key stored in the `encryption-key` data
-                          field.
+                          in the Central DB.
                         type: boolean
                     type: object
                   persistence:

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -321,9 +321,7 @@ spec:
         displayName: Expose Endpoint
         path: central.monitoring.exposeEndpoint
       - description: Enables the encryption of notifier secrets stored in the Central
-          DB. An encryption key must be provided in a secret called `central-encryption-key`
-          in the Central namespace, with the key stored in the `encryption-key` data
-          field.
+          DB.
         displayName: Enabled
         path: central.notifierSecretsEncryption.enabled
       - description: Uses a Kubernetes persistent volume claim (PVC) to manage the

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -366,10 +366,7 @@ spec:
                       enabled:
                         default: false
                         description: Enables the encryption of notifier secrets stored
-                          in the Central DB. An encryption key must be provided in
-                          a secret called `central-encryption-key` in the Central
-                          namespace, with the key stored in the `encryption-key` data
-                          field.
+                          in the Central DB.
                         type: boolean
                     type: object
                   persistence:

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -79,9 +79,7 @@ spec:
         displayName: Expose Endpoint
         path: central.monitoring.exposeEndpoint
       - description: Enables the encryption of notifier secrets stored in the Central
-          DB. An encryption key must be provided in a secret called `central-encryption-key`
-          in the Central namespace, with the key stored in the `encryption-key` data
-          field.
+          DB.
         displayName: Enabled
         path: central.notifierSecretsEncryption.enabled
       - description: Uses a Kubernetes persistent volume claim (PVC) to manage the


### PR DESCRIPTION
## Description

The expected location of the key secret has changed (see [here](https://github.com/stackrox/stackrox/blob/master/central/notifiers/utils/encryption.go#L15) ) and this PR adapts the Helm charts.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

#### Helm upgrade
1. Install 4.3.2:
```bash
kubectl create ns stackrox
deploy/common/pull-secret.sh stackrox quay.io | kubectl -n stackrox apply -f -

helm install -n stackrox stackrox-central-services rhacs/central-services --set central.exposure.route.enabled=true --set central.persistence.none=true --set central.notifierSecretsEncryption.enabled=true
```
2. Create the `central-encryption-key` secret (for 4.3.2) and `central-encryption-key-chain` secret (in preparation for 4.4) with the the following contents:
```yaml
kind: Secret
apiVersion: v1
metadata:
  name: central-encryption-key
  namespace: stackrox
data:
  encryption-key: WS9WRmhWYU1wMXRhaEl5NUhrS2Z3a1FRL1RoNnRoeE5NeUFlV0VNUldoaz0=
type: Opaque
---
kind: Secret
apiVersion: v1
metadata:
  name: central-encryption-key-chain
  namespace: stackrox
stringData:
  key-chain.yaml: |
    keyMap:
      0: Y/VFhVaMp1tahIy5HkKfwkQQ/Th6thxNMyAeWEMRWhk=
    activeKeyIndex: 0
type: Opaque
```

The two secrets are equivalent as they provide the exact same key.

3. Create an e-mail integration in the Central UI, test it and save it

4. Update Central Services to the version built by CI for this PR
```bash
make cli
roxctl helm output central-services --image-defaults=development_build --debug
helm upgrade --install -n stackrox stackrox-central-services ./stackrox-central-services-chart
```

5. Verify that the e-mail integration still works

#### Fresh install with OLM
1. Install via OLM
```bash
kubectl create ns stackrox
deploy/common/pull-secret.sh stackrox quay.io | kubectl -n stackrox apply -f -
make -C operator deploy-via-olm
```
3. Create the `central-encryption-key-chain` as described above
4.  Create an e-mail integration in the Central UI, test it and save it

#### OLM upgrade
I was not able to test the OLM operator upgrade as described [here](https://docs.engineering.redhat.com/pages/viewpage.action?spaceKey=StackRox&title=How+to+test+upstream+OLM+operator+upgrade) because that would perform an upgrade from 4.2.0 -> current_tag, but we need an upgrade from 4.3.0 (the first version that included the feature)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
