### PR TITLE
chore(ui): Update prettier 3.2.2 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -161,7 +161,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^3.1.1",
+        "prettier": "^3.2.2",
         "randomstring": "^1.2.1",
         "react-app-rewired": "^2.2.1",
         "react-scripts": "^5.0.1",

--- a/ui/apps/platform/src/services/ClustersService.ts
+++ b/ui/apps/platform/src/services/ClustersService.ts
@@ -240,10 +240,11 @@ export function generateClusterInitBundle(data: { name: string }): Promise<{
     response: GenerateClusterInitBundleResponse;
 }> {
     return axios
-        .post<{ meta: ClusterInitBundle; helmValuesBundle: string; kubectlBundle: string }>(
-            `${clusterInitUrl}/init-bundles`,
-            data
-        )
+        .post<{
+            meta: ClusterInitBundle;
+            helmValuesBundle: string;
+            kubectlBundle: string;
+        }>(`${clusterInitUrl}/init-bundles`, data)
         .then((response) => {
             return {
                 response: response.data || {},

--- a/ui/apps/platform/src/services/ComplianceEnhancedService.ts
+++ b/ui/apps/platform/src/services/ComplianceEnhancedService.ts
@@ -195,9 +195,9 @@ export function getScanConfigs(
     };
     const params = qs.stringify({ query });
     return axios
-        .get<{ configurations: ComplianceScanConfigurationStatus[] }>(
-            `${scanScheduleUrl}?${params}`
-        )
+        .get<{
+            configurations: ComplianceScanConfigurationStatus[];
+        }>(`${scanScheduleUrl}?${params}`)
         .then((response) => {
             return response?.data?.configurations ?? [];
         });

--- a/ui/apps/platform/src/services/DeploymentsService.ts
+++ b/ui/apps/platform/src/services/DeploymentsService.ts
@@ -123,9 +123,9 @@ export function fetchDeploymentsWithProcessInfoLegacy(
     }
     const params = queryString.stringify(queryObject, { arrayFormat: 'repeat', allowDots: true });
     return axios
-        .get<{ deployments: ListDeploymentWithProcessInfo[] }>(
-            `${deploymentsWithProcessUrl}?${params}`
-        )
+        .get<{
+            deployments: ListDeploymentWithProcessInfo[];
+        }>(`${deploymentsWithProcessUrl}?${params}`)
         .then((response) => response?.data?.deployments ?? []);
 }
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -14089,10 +14089,10 @@ prettier@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
   integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
 
-prettier@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.1.1.tgz#6ba9f23165d690b6cbdaa88cb0807278f7019848"
-  integrity sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==
+prettier@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.2.tgz#96e580f7ca9c96090ad054616c0c4597e2844b65"
+  integrity sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A==
 
 pretty-bytes@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
## Description

https://prettier.io/blog/2024/01/12/3.2.0

> faster CLI is slated to be released as version 4.0.

Keep up with minor updates in case future major upgrade has breaking changes.

https://prettier.io/blog/2024/01/12/3.2.0#avoid-introducing-linebreaks-in-template-interpolations-15209httpsgithubcomprettierprettierpull15209-by-bakkothttpsgithubcombakkot

> In a template string avoid adding a linebreak when formatting the expression unless one is already present or it's unavoidable due to e.g. a nested function. Previously a linebreak could be introduced whenever some interpolation in the template was sufficiently "not simple".

> Now it will instead be left alone.

> If a linebreak is already present within the `${...}`, format as normal.

Prettier will add fewer linebreaks in new template literals, but will not remove linebreaks that earlier versions added.

Therefore, update promptly, because cherry pick of template literal with fewer linebreaks into release branch with earlier version of Prettier would fail lint.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` and then `yarn lint:fix` in ui/apps/platform
2. `yarn build` in ui/apps/platform
