### PR TITLE
ROX-21762: Cleanups

### DIFF
--- a/central/localscanner/certificates_test.go
+++ b/central/localscanner/certificates_test.go
@@ -70,7 +70,7 @@ func (s *localScannerSuite) TestValidateServiceCertificate() {
 			s.Require().NoError(err)
 			validatingCA, err := mtls.LoadCAForValidation(certMap["ca.pem"])
 			s.Require().NoError(err)
-			s.NoError(certgen.VerifyServiceCert(certMap, validatingCA, serviceType, ""))
+			s.NoError(certgen.VerifyServiceCertAndKey(certMap, "", validatingCA, serviceType))
 		})
 	}
 }

--- a/pkg/certgen/certgen.go
+++ b/pkg/certgen/certgen.go
@@ -3,6 +3,7 @@ package certgen
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/pkg/errors"
@@ -40,34 +41,37 @@ func IssueOtherServiceCerts(fileMap map[string][]byte, ca mtls.CA, subjs []mtls.
 	return nil
 }
 
-// VerifyServiceCert verifies that the service certificate (stored with the given fileNamePrefix in the file
+// VerifyServiceCertAndKey verifies that the service certificate (stored with the given fileNamePrefix in the file
 // map) is a valid service certificate for the given serviceType, relative to the given CA.
-func VerifyServiceCert(fileMap map[string][]byte, ca mtls.CA, serviceType storage.ServiceType, fileNamePrefix string) error {
-	return VerifyCert(fileMap, fileNamePrefix, GetValidateServiceCertFunc(ca, serviceType))
-}
-
-// ValidateCertFunc is a function which validates the passed certificate and returns error, if any.
-type ValidateCertFunc func(certificate *x509.Certificate) error
-
-// VerifyCert verifies that the certificate (stored with the given fileNamePrefix in the file
-// map) is a valid certificate by using a given validate function.
-func VerifyCert(fileMap map[string][]byte, fileNamePrefix string, validate ValidateCertFunc) error {
+// It also verifies that the associated private key in the file map also matches the certificate.
+func VerifyServiceCertAndKey(fileMap map[string][]byte, fileNamePrefix string, ca mtls.CA, serviceType storage.ServiceType,
+	extraValidations ...func(certificate *x509.Certificate) error) error {
 	certPEM := fileMap[fileNamePrefix+mtls.ServiceCertFileName]
 	if len(certPEM) == 0 {
-		return errors.New("no service certificate in file map")
+		return fmt.Errorf("no service certificate for %s in file map", serviceType.String())
 	}
 	cert, err := helpers.ParseCertificatePEM(certPEM)
 	if err != nil {
 		return errors.New("unparseable certificate in file map")
 	}
 
-	if err := validate(cert); err != nil {
-		return errors.Wrap(err, "failed to validate certificate")
+	subjFromCert, err := ca.ValidateAndExtractSubject(cert)
+	if err != nil {
+		return errors.Wrap(err, "failed to validate certificate and extract subject")
+	}
+	if subjFromCert.ServiceType != serviceType {
+		return errors.Errorf("unexpected certificate service type: got %s, expected %s", subjFromCert.ServiceType, serviceType)
+	}
+
+	for _, validation := range extraValidations {
+		if err := validation(cert); err != nil {
+			return errors.Wrap(err, "failed to validate certificate")
+		}
 	}
 
 	keyPEM := fileMap[fileNamePrefix+mtls.ServiceKeyFileName]
 	if len(keyPEM) == 0 {
-		return errors.New("no service private key in file map")
+		return fmt.Errorf("no service private key for %s in file map", serviceType.String())
 	}
 
 	if _, err := tls.X509KeyPair(certPEM, keyPEM); err != nil {
@@ -75,18 +79,4 @@ func VerifyCert(fileMap map[string][]byte, fileNamePrefix string, validate Valid
 	}
 
 	return nil
-}
-
-// GetValidateServiceCertFunc returns a function which checks whether the service certificate for the given serviceType is valid.
-func GetValidateServiceCertFunc(ca mtls.CA, serviceType storage.ServiceType) ValidateCertFunc {
-	return func(cert *x509.Certificate) error {
-		subjFromCert, err := ca.ValidateAndExtractSubject(cert)
-		if err != nil {
-			return errors.Wrap(err, "failed to validate certificate and extract subject")
-		}
-		if subjFromCert.ServiceType != serviceType {
-			return errors.Errorf("unexpected certificate service type: got %s, expected %s", subjFromCert.ServiceType, serviceType)
-		}
-		return nil
-	}
 }


### PR DESCRIPTION
## Description

Refactoring after chages related to ROX-21533:

1. Replace `VerifyServiceCert` and `VerifyCert` in `certgen` package with `VerifyServiceCertAndKey` that takes optional extra verification functions
2. Merge `TestRenewInitBundle` and `Test_checkCertRenewal` tests which were testing the same function in slightly different ways
3. Mention the expected subject of cert/key in error messages and adjust tests to match

No user-visible changes, apart from the last item.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI should be sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
