### PR TITLE
rox-18182: enable TestProcessorDoesntExpireOnceStopped

### DIFF
--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
@@ -289,9 +289,6 @@ func (s *VulnRequestManagerTestSuite) verifyImageCVESearchByCVEState(state stora
 }
 
 func (s *VulnRequestManagerTestSuite) TestProcessorDoesntExpireOnceStopped() {
-	// TODO: Renable once fixed ROX-18182
-	s.T().Skipf("This test is flaky on master builds for some reason. Skip until fixed: ROX-18182")
-
 	s.manager.Start()
 	time.Sleep(expiryLoopDurationForTest) // wait for it to run at least once
 


### PR DESCRIPTION
## Description

Enable the last remaining disabled test to collect logs when it fails. Other tests in the suite were fixed and enabled, which are passing in the CI.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes 

If any of these don't apply, please comment below.

## Testing Performed

