### PR TITLE
Update exception management links to point to corresponding state tabs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -42,6 +42,7 @@ import RequestApprovalButtonModal from './components/RequestApprovalButtonModal'
 import RequestDenialButtonModal from './components/RequestDenialButtonModal';
 import RequestCancelButtonModal from './components/RequestCancelButtonModal';
 import RequestUpdateButtonModal from './components/RequestUpdateButtonModal';
+import { getVulnerabilityState } from './utils';
 
 import './ExceptionRequestDetailsPage.css';
 
@@ -162,6 +163,8 @@ function ExceptionRequestDetailsPage() {
     const relevantCVEs =
         selectedContext === 'CURRENT' ? cves : getCVEsForUpdatedRequest(vulnerabilityException);
 
+    const vulnerabilityState = getVulnerabilityState(vulnerabilityException);
+
     return (
         <>
             {successMessage && (
@@ -240,6 +243,7 @@ function ExceptionRequestDetailsPage() {
                         cves={relevantCVEs}
                         scope={scope}
                         expandedRowSet={expandedRowSet}
+                        vulnerabilityState={vulnerabilityState}
                     />
                 </PageSection>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -13,7 +13,6 @@ import { SearchIcon } from '@patternfly/react-icons';
 import { useQuery } from '@apollo/client';
 import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';
-import omitBy from 'lodash/omitBy';
 
 import { getEntityPagePath } from 'Containers/Vulnerabilities/WorkloadCves/searchUtils';
 import { VulnerabilitySeverityLabel } from 'Containers/Vulnerabilities/WorkloadCves/types';
@@ -33,7 +32,10 @@ import {
     getScoreVersionsForTopCVSS,
     sortCveDistroList,
 } from 'Containers/Vulnerabilities/WorkloadCves/sortUtils';
-import { VulnerabilityExceptionScope } from 'services/VulnerabilityExceptionService';
+import {
+    VulnerabilityExceptionScope,
+    VulnerabilityState,
+} from 'services/VulnerabilityExceptionService';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { getImageScopeSearchValue } from 'Containers/Vulnerabilities/ExceptionManagement/utils';
 
@@ -48,9 +50,15 @@ type RequestCVEsTableProps = {
     cves: string[];
     scope: VulnerabilityExceptionScope;
     expandedRowSet: SetResult<string>;
+    vulnerabilityState: VulnerabilityState;
 };
 
-function RequestCVEsTable({ cves, scope, expandedRowSet }: RequestCVEsTableProps) {
+function RequestCVEsTable({
+    cves,
+    scope,
+    expandedRowSet,
+    vulnerabilityState,
+}: RequestCVEsTableProps) {
     const { page, perPage, setPage } = useURLPagination(20);
     const { sortOption, getSortParams } = useURLSort({
         sortFields: defaultCVESortFields,
@@ -168,18 +176,12 @@ function RequestCVEsTable({ cves, scope, expandedRowSet }: RequestCVEsTableProps
                                     s: {
                                         IMAGE: queryObject.Image,
                                     },
-                                    vulnerabilityState: 'DEFERRED',
                                 };
-                                // @TODO: This needs to be tested more thoroughly. Once the deferred tab shows the correct data, we should add a test for this
                                 const cveURL = getEntityPagePath(
                                     'CVE',
                                     cve,
-                                    // TODO: (dv 2023-11-15)
-                                    //      We need to pass the appropriate request state here in order to link to the correct tab
-                                    //      This will change depending on what type of request we are looking at as well as
-                                    //      the state of the request
-                                    'OBSERVED',
-                                    omitBy(cveURLQueryOptions, (value) => value === '')
+                                    vulnerabilityState,
+                                    cveURLQueryOptions
                                 );
 
                                 return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/utils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/utils.test.ts
@@ -1,0 +1,109 @@
+import { ExceptionStatus, VulnerabilityException } from 'services/VulnerabilityExceptionService';
+import { getImageScopeSearchValue, getVulnerabilityState } from './utils';
+
+describe('ExceptionManagement utils', () => {
+    describe('imageScopeSearchValue', () => {
+        it('should return empty string for all .*', () => {
+            const imageScope = { registry: '.*', remote: '.*', tag: '.*' };
+            const searchValue = getImageScopeSearchValue({ imageScope });
+
+            expect(searchValue).toEqual('');
+        });
+
+        it('should return registry/remote for .* tag', () => {
+            const imageScope = { registry: 'registry', remote: 'remote', tag: '.*' };
+            const searchValue = getImageScopeSearchValue({ imageScope });
+
+            expect(searchValue).toEqual('registry/remote');
+        });
+
+        it('should return registry/remote:tag for non .* tag', () => {
+            const imageScope = { registry: 'registry', remote: 'remote', tag: 'tag' };
+            const searchValue = getImageScopeSearchValue({ imageScope });
+
+            expect(searchValue).toEqual('registry/remote:tag');
+        });
+    });
+
+    describe('getVulnerabilityState', () => {
+        function makeVulnerabilityException(
+            status: ExceptionStatus,
+            type: 'DEFERRAL' | 'FALSE_POSITIVE'
+        ): VulnerabilityException {
+            const exception = {
+                id: '123',
+                cves: ['CVE-123-456'],
+                comments: [],
+                status,
+                scope: {
+                    imageScope: {
+                        registry: 'registry',
+                        remote: 'remote',
+                        tag: 'tag',
+                    },
+                },
+                createdAt: '2021-01-01T00:00:00.000Z',
+                name: 'Exception Name',
+                expired: false,
+                requester: { id: '123', name: 'username' },
+                approvers: [{ id: '123', name: 'Alice' }],
+                lastUpdated: '2021-01-01T00:00:00.000Z',
+            };
+
+            if (type === 'DEFERRAL') {
+                return {
+                    ...exception,
+                    targetState: 'DEFERRED',
+                    deferralRequest: {
+                        expiry: {
+                            expiryType: 'TIME',
+                            expiresOn: '2021-01-01T00:00:00.000Z',
+                        },
+                    },
+                };
+            }
+
+            return {
+                ...exception,
+                targetState: 'FALSE_POSITIVE',
+                falsePositiveRequest: {},
+            };
+        }
+
+        it('should return "OBSERVED" for unapproved exceptions', () => {
+            const pendingDeferral = makeVulnerabilityException('PENDING', 'DEFERRAL');
+            const deniedDeferral = makeVulnerabilityException('DENIED', 'DEFERRAL');
+            const pendingFalsePositive = makeVulnerabilityException('PENDING', 'FALSE_POSITIVE');
+            const deniedFalsePositive = makeVulnerabilityException('DENIED', 'FALSE_POSITIVE');
+
+            expect(getVulnerabilityState(deniedDeferral)).toEqual('OBSERVED');
+            expect(getVulnerabilityState(pendingDeferral)).toEqual('OBSERVED');
+            expect(getVulnerabilityState(deniedFalsePositive)).toEqual('OBSERVED');
+            expect(getVulnerabilityState(pendingFalsePositive)).toEqual('OBSERVED');
+        });
+
+        it('should return "DEFERRED" for approved deferrals', () => {
+            const approvedDeferral = makeVulnerabilityException('APPROVED', 'DEFERRAL');
+            const approvedPendingUpdateDeferral = makeVulnerabilityException(
+                'APPROVED_PENDING_UPDATE',
+                'DEFERRAL'
+            );
+
+            expect(getVulnerabilityState(approvedDeferral)).toEqual('DEFERRED');
+            expect(getVulnerabilityState(approvedPendingUpdateDeferral)).toEqual('DEFERRED');
+        });
+
+        it('should return "FALSE_POSITIVE" for approved false positives', () => {
+            const approvedFalsePositive = makeVulnerabilityException('APPROVED', 'FALSE_POSITIVE');
+            const approvedPendingUpdateFalsePositive = makeVulnerabilityException(
+                'APPROVED_PENDING_UPDATE',
+                'FALSE_POSITIVE'
+            );
+
+            expect(getVulnerabilityState(approvedFalsePositive)).toEqual('FALSE_POSITIVE');
+            expect(getVulnerabilityState(approvedPendingUpdateFalsePositive)).toEqual(
+                'FALSE_POSITIVE'
+            );
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/utils.ts
@@ -1,4 +1,8 @@
-import { VulnerabilityExceptionScope } from 'services/VulnerabilityExceptionService';
+import {
+    VulnerabilityException,
+    VulnerabilityExceptionScope,
+    isDeferralException,
+} from 'services/VulnerabilityExceptionService';
 
 export function getImageScopeSearchValue({ imageScope }: VulnerabilityExceptionScope): string {
     const { registry, remote, tag } = imageScope;
@@ -9,4 +13,11 @@ export function getImageScopeSearchValue({ imageScope }: VulnerabilityExceptionS
         return `${registry}/${remote}`;
     }
     return `${registry}/${remote}:${tag}`;
+}
+
+export function getVulnerabilityState(exception: VulnerabilityException) {
+    if (exception.status === 'APPROVED' || exception.status === 'APPROVED_PENDING_UPDATE') {
+        return isDeferralException(exception) ? 'DEFERRED' : 'FALSE_POSITIVE';
+    }
+    return 'OBSERVED';
 }


### PR DESCRIPTION
## Description

Updates CVE links in exception management detail pages to point to the corresponding Workload CVE tab based on the exception status.

Unapproved => 'OBSERVED'
Approved or Approved Pending Update Deferrals => 'DEFERRED'
Approved or Approved Pending Update False Positives => 'FALSE_POSITIVE'

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

New unit tests.

Create a request of each type and verify the links in the CVE table:

Pending (either type)
![image](https://github.com/stackrox/stackrox/assets/1292638/0338216f-bbd3-432a-814e-2baa034d17f4)
![image](https://github.com/stackrox/stackrox/assets/1292638/7725d27e-26a0-4419-8ab0-be20d50a48d0)

Approved deferral
![image](https://github.com/stackrox/stackrox/assets/1292638/1929a0a1-08e4-4417-b09c-03012b810bd9)
![image](https://github.com/stackrox/stackrox/assets/1292638/9321c036-3673-4ecf-8455-f1a3391814d5)

Approved false positive
![image](https://github.com/stackrox/stackrox/assets/1292638/87740df0-8342-4d7f-aeaa-e805aaf912e1)
![image](https://github.com/stackrox/stackrox/assets/1292638/d35d0148-fb46-49e8-8c9c-a4fcb260b661)

Denied (either type)
![image](https://github.com/stackrox/stackrox/assets/1292638/bbb3a3eb-17e5-4f4a-8fcc-af06d80619ad)
![image](https://github.com/stackrox/stackrox/assets/1292638/b43d466f-3a2f-4142-bee8-e39b4a1463e0)


