### PR TITLE
ROX-21040: return last updated timestamp from Scanner v4

### DIFF
--- a/pkg/scanners/scannerv4/scannerv4.go
+++ b/pkg/scanners/scannerv4/scannerv4.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -136,8 +137,15 @@ func (s *scannerv4) GetScan(image *storage.Image) (*storage.ImageScan, error) {
 }
 
 func (s *scannerv4) GetVulnDefinitionsInfo() (*v1.VulnDefinitionsInfo, error) {
-	// TODO(ROX-21040): Implementation dependent on the API existing.
-	return nil, errors.New("ScannerV4 - GetVulnDefinitionsInfo NOT Implemented")
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	m, err := s.scannerClient.GetMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &v1.VulnDefinitionsInfo{
+		LastUpdatedTimestamp: m.GetLastVulnerabilityUpdate(),
+	}, nil
 }
 
 func (s *scannerv4) Match(image *storage.ImageName) bool {

--- a/pkg/scannerv4/client/mocks/client.go
+++ b/pkg/scannerv4/client/mocks/client.go
@@ -56,6 +56,21 @@ func (mr *MockScannerMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockScanner)(nil).Close))
 }
 
+// GetMetadata mocks base method.
+func (m *MockScanner) GetMetadata(ctx context.Context) (*v4.Metadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMetadata", ctx)
+	ret0, _ := ret[0].(*v4.Metadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMetadata indicates an expected call of GetMetadata.
+func (mr *MockScannerMockRecorder) GetMetadata(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockScanner)(nil).GetMetadata), ctx)
+}
+
 // GetOrCreateImageIndex mocks base method.
 func (m *MockScanner) GetOrCreateImageIndex(ctx context.Context, ref name.Digest, auth authn.Authenticator) (*v4.IndexReport, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Description

Utilize the `GetMetadata` endpoint in Scanner v4 matcher and return the last vuln update time

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

trivial

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
