### PR TITLE
chore(scanner): make mapping seed files configurable

### DIFF
--- a/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
@@ -23,11 +23,13 @@ indexer:
   get_layer_timeout: 1m
   {{- if ._rox.env.centralServices }}
   repository_to_cpe_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?file=repo2cpe
-  name_to_cpe_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?file=name2cpe
+  name_to_repos_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?file=name2cpe
   {{- else }}
   repository_to_cpe_url: https://sensor.{{ .Release.Namespace }}.svc/scanner/definitions?file=repo2cpe
-  name_to_cpe_url: https://sensor.{{ .Release.Namespace }}.svc/scanner/definitions?file=name2cpe
+  name_to_repos_url: https://sensor.{{ .Release.Namespace }}.svc/scanner/definitions?file=name2cpe
   {{- end }}
+  repository_to_cpe_file: /run/mappings/repository-to-cpe.json
+  name_to_repos_file: /run/mappings/container-name-repos-map.json
 matcher:
   enable: false
 log_level: info

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -230,4 +230,4 @@ tests:
     scannerV4.disable: false
   expect: |
     .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.repository_to_cpe_url | assertThat(contains("https://central.stackrox.svc/api/extensions/scannerdefinitions"))
-    .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.name_to_cpe_url | assertThat(contains("https://central.stackrox.svc/api/extensions/scannerdefinitions"))
+    .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.name_to_repos_url | assertThat(contains("https://central.stackrox.svc/api/extensions/scannerdefinitions"))

--- a/scanner/config.yaml.sample
+++ b/scanner/config.yaml.sample
@@ -7,7 +7,7 @@ indexer:
     password_file: ""
   get_layer_timeout: 1m
   repository_to_cpe_url: https://access.redhat.com/security/data/metrics/repository-to-cpe.json
-  name_to_cpe_url: https://access.redhat.com/security/data/metrics/container-name-repos-map.json
+  name_to_repos_url: https://access.redhat.com/security/data/metrics/container-name-repos-map.json
 matcher:
   enable: true
   database:

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -129,11 +129,17 @@ func newLibindex(ctx context.Context, indexerCfg config.IndexerConfig, store cci
 		Ecosystems:           ecosystems(ctx),
 	}
 	opts.ScannerConfig.Repo = map[string]func(interface{}) error{
-		"rhel-repository-scanner": deserializeFunc([]byte(fmt.Sprintf(` {"repo2cpe_mapping_url": "%s",
-  "repo2cpe_mapping_file": "/run/mappings/repository-to-cpe.json"}`, indexerCfg.RepositoryToCPEURL)))}
+		"rhel-repository-scanner": deserializeFunc([]byte(fmt.Sprintf(`
+{
+  "repo2cpe_mapping_url": "%s",
+  "repo2cpe_mapping_file": "%s"
+}`, indexerCfg.RepositoryToCPEURL, indexerCfg.RepositoryToCPEFile)))}
 	opts.ScannerConfig.Package = map[string]func(interface{}) error{
-		"rhel_containerscanner": deserializeFunc([]byte(fmt.Sprintf(` {"name2repos_mapping_url": "%s",
-  "name2repos_mapping_file": "/run/mappings/container-name-repos-map.json"}`, indexerCfg.NameToCPEURL)))}
+		"rhel_containerscanner": deserializeFunc([]byte(fmt.Sprintf(`
+{
+  "name2repos_mapping_url": "%s",
+  "name2repos_mapping_file": "%s"
+}`, indexerCfg.NameToReposURL, indexerCfg.NameToReposFile)))}
 
 	indexer, err := libindex.New(ctx, &opts, c)
 	if err != nil {

--- a/scanner/indexer/indexer_test.go
+++ b/scanner/indexer/indexer_test.go
@@ -82,7 +82,7 @@ indexer:
     password_file: ""
   get_layer_timeout: 1m
   repository_to_cpe_url: https://storage.googleapis.com/scanner-v4-test/redhat-repository-mappings/repository-to-cpe.json
-  name_to_cpe_url: https://storage.googleapis.com/scanner-v4-test/redhat-repository-mappings/container-name-repos-map.json
+  name_to_repos_url: https://storage.googleapis.com/scanner-v4-test/redhat-repository-mappings/container-name-repos-map.json
 matcher:
   enable: true
   database:


### PR DESCRIPTION
## Description

This makes the seed files configurable, so we can still run outside the container image. This also renames `name_to_cpe_url ` to `name_to_repos_url` to be more accurate

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
