### PR TITLE
ROX-19005: pull vulnerabilities from a configurable URL

### DIFF
--- a/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
@@ -24,9 +24,9 @@ matcher:
       client_encoding=UTF8
     password_file: /run/secrets/stackrox.io/secrets/password
   {{- if ._rox.env.centralServices }}
-  vulnerabilities_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version={{.Version}}
+  vulnerabilities_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version=ROX_VERSION
   {{- else }}
-  vulnerabilities_url: https://sensor.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version={{.Version}}
+  vulnerabilities_url: https://sensor.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version=ROX_VERSION
   {{- end }}
   indexer_addr: scanner-v4-indexer.{{ .Release.Namespace }}.svc:8443
 log_level: info

--- a/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
@@ -24,9 +24,9 @@ matcher:
       client_encoding=UTF8
     password_file: /run/secrets/stackrox.io/secrets/password
   {{- if ._rox.env.centralServices }}
-  vulnerabilities_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version=ROX_VERSION
+  vulnerabilities_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version={{.Version}}
   {{- else }}
-  vulnerabilities_url: https://sensor.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version=ROX_VERSION
+  vulnerabilities_url: https://sensor.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version={{.Version}}
   {{- end }}
   indexer_addr: scanner-v4-indexer.{{ .Release.Namespace }}.svc:8443
 log_level: info

--- a/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
@@ -23,6 +23,11 @@ matcher:
       {{ if not (kindIs "invalid" ._rox.scannerV4.db.source.maxConns) -}} pool_max_conns={{._rox.scannerV4.db.source.maxConns}} {{- end }}
       client_encoding=UTF8
     password_file: /run/secrets/stackrox.io/secrets/password
+  {{- if ._rox.env.centralServices }}
+  vulnerabilities_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions
+  {{- else }}
+  vulnerabilities_url: https://sensor.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions
+  {{- end }}
   indexer_addr: scanner-v4-indexer.{{ .Release.Namespace }}.svc:8443
 log_level: info
 grpc_listen_addr: 0.0.0.0:8443

--- a/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
@@ -24,9 +24,9 @@ matcher:
       client_encoding=UTF8
     password_file: /run/secrets/stackrox.io/secrets/password
   {{- if ._rox.env.centralServices }}
-  vulnerabilities_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions
+  vulnerabilities_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version=ROX_VERSION
   {{- else }}
-  vulnerabilities_url: https://sensor.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions
+  vulnerabilities_url: https://sensor.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version=ROX_VERSION
   {{- end }}
   indexer_addr: scanner-v4-indexer.{{ .Release.Namespace }}.svc:8443
 log_level: info

--- a/scanner/config.yaml.sample
+++ b/scanner/config.yaml.sample
@@ -13,6 +13,7 @@ matcher:
   database:
     conn_string: "host=/var/run/postgresql"
     password_file: ""
+  vulnerability_url: https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/dev/output.json.zst
 mtls:
   certs_dir: certs/scanner-v4
 log_level: info

--- a/scanner/config.yaml.sample
+++ b/scanner/config.yaml.sample
@@ -13,7 +13,7 @@ matcher:
   database:
     conn_string: "host=/var/run/postgresql"
     password_file: ""
-  vulnerability_url: https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/dev/output.json.zst
+  vulnerability_url: https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/dev/vulns.json.zst
 mtls:
   certs_dir: certs/scanner-v4
 log_level: info

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -168,6 +168,7 @@ type MatcherConfig struct {
 	VulnerabilitiesURL string `yaml:"vulnerabilities_url"`
 	// RemoteIndexerEnabled internal and generated flag, true when the remote indexer is enabled.
 	RemoteIndexerEnabled bool
+	VulnerabilityVersion string `yaml:"vulnerability_version"`
 }
 
 func (c *MatcherConfig) validate() error {
@@ -193,11 +194,15 @@ func (c *MatcherConfig) validate() error {
 	if _, err := url.Parse(c.VulnerabilitiesURL); err != nil {
 		return fmt.Errorf("vulnerabilities_url: invalid URL: %w", err)
 	}
+
 	v := "dev"
 	if buildinfo.ReleaseBuild {
 		v = version.Version
 	}
-	c.VulnerabilitiesURL = strings.ReplaceAll(c.VulnerabilitiesURL, "{{.Version}}", v)
+	if c.VulnerabilityVersion != "" {
+		v = c.VulnerabilityVersion
+	}
+	c.VulnerabilitiesURL = strings.ReplaceAll(c.VulnerabilitiesURL, "ROX_VERSION", v)
 	return nil
 }
 

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/scanner/internal/version"
+	yaml "gopkg.in/yaml.v3"
 )
 
 var (

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -66,10 +65,6 @@ type Config struct {
 	MTLS             MTLSConfig    `yaml:"mtls"`
 	Proxy            ProxyConfig   `yaml:"proxy"`
 	LogLevel         LogLevel      `yaml:"log_level"`
-}
-
-type MatcherConfigData struct {
-	Version string
 }
 
 func (c *Config) validate() error {
@@ -201,19 +196,7 @@ func (c *MatcherConfig) validate() error {
 	if buildinfo.ReleaseBuild {
 		v = version.Version
 	}
-	cfgV := MatcherConfigData{Version: v}
-	// Parse and execute the template
-	tmpl, err := template.New("vulnUrl").Parse(strings.ReplaceAll(c.VulnerabilitiesURL, "ROX_VERSION", "{{.Version}}"))
-	if err != nil {
-		return fmt.Errorf("vulnerabilities_url: unable to parse URL: %w", err)
-	}
-	var urlBuilder strings.Builder
-	err = tmpl.Execute(&urlBuilder, cfgV)
-	if err != nil {
-		return fmt.Errorf("vulnerabilities_url: fail to config version: %w", err)
-	}
-
-	c.VulnerabilitiesURL = urlBuilder.String()
+	c.VulnerabilitiesURL = strings.ReplaceAll(c.VulnerabilitiesURL, "{{.Version}}", v)
 	return nil
 }
 

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -41,7 +41,7 @@ var (
 				ConnString:   "host=/var/run/postgresql",
 				PasswordFile: "",
 			},
-			VulnerabilitiesURL: "https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/dev/output.json.zst",
+			VulnerabilitiesURL: "https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/dev/vulns.json.zst",
 		},
 		// Default is empty.
 		MTLS: MTLSConfig{

--- a/scanner/config/config_test.go
+++ b/scanner/config/config_test.go
@@ -161,7 +161,7 @@ func Test_MatcherConfig_validate(t *testing.T) {
 		assert.False(t, c.RemoteIndexerEnabled)
 	})
 	t.Run("when URL is replaceable, replace it", func(t *testing.T) {
-		c := MatcherConfig{Enable: true, Database: Database{ConnString: "host=foobar"}, VulnerabilitiesURL: "https://central.stackrox.svc/api/extensions/scannerdefinitions?version=ROX_VERSION"}
+		c := MatcherConfig{Enable: true, Database: Database{ConnString: "host=foobar"}, VulnerabilitiesURL: "https://central.stackrox.svc/api/extensions/scannerdefinitions?version={{.Version}}"}
 		err := c.validate()
 		assert.NoError(t, err)
 		v := "dev"

--- a/scanner/config/config_test.go
+++ b/scanner/config/config_test.go
@@ -161,7 +161,7 @@ func Test_MatcherConfig_validate(t *testing.T) {
 		assert.False(t, c.RemoteIndexerEnabled)
 	})
 	t.Run("when URL is replaceable, replace it", func(t *testing.T) {
-		c := MatcherConfig{Enable: true, Database: Database{ConnString: "host=foobar"}, VulnerabilitiesURL: "https://central.stackrox.svc/api/extensions/scannerdefinitions?version={{.Version}}"}
+		c := MatcherConfig{Enable: true, Database: Database{ConnString: "host=foobar"}, VulnerabilitiesURL: "https://central.stackrox.svc/api/extensions/scannerdefinitions?version=ROX_VERSION"}
 		err := c.validate()
 		assert.NoError(t, err)
 		v := "dev"

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -371,7 +371,6 @@ func (u *Updater) fetch(ctx context.Context, prevTimestamp time.Time) (*os.File,
 			// For other errors, do not retry
 			closeResponse(resp)
 			return nil, time.Time{}, err
-
 		}
 		break // no error, no retry
 	}

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -75,6 +75,8 @@ func TestUpdate(t *testing.T) {
 		importVulns: func(_ context.Context, _ io.Reader) error {
 			return nil
 		},
+		retryDelay: 1 * time.Second,
+		retryMax:   1,
 	}
 
 	// Skip update when locking fails.

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -107,9 +107,11 @@ func TestFetch(t *testing.T) {
 	srv, now := testHTTPServer(t)
 
 	u := &Updater{
-		client: srv.Client(),
-		url:    srv.URL,
-		root:   t.TempDir(),
+		client:     srv.Client(),
+		url:        srv.URL,
+		root:       t.TempDir(),
+		retryDelay: 1 * time.Second,
+		retryMax:   1,
 	}
 
 	// Fetch file, as it's modified after the given time.


### PR DESCRIPTION
## Description

We want to be able to support running Scanner v4 as a StackRox service and separate from the rest of the services. To do that, the `vulnerabilities_url` must be configurable. Unfortunately, not all endpoints are created equally, and it's hard to determine the correct URL.

This approach attempts to make this simple for users. Scanner v4 vuln data is versioned, and requiring every user to update the configured version, themselves, is not feasible. Hence, this PR introduces `ROX_VERSION`, which, if added to the `vulnerabiltiies_url` will be replaced with the version of Scanner v4. This also allows for queries to Central to look like `https://central.stackrox.svc/api/extensions/scannerdefinitions?version=ROX_VERSION` and direct queries to GCP to look like `https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/ROX_VERSION/output.json.zst`

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

1. 
```
make cli-darwin_amd64

./bin/darwin_amd64/roxctl helm output central-services --image-defaults=development_build --debug-path=./image --debug --remove

export KUBECONFIG=<kubeconfig path from downloaded infra artifacts>

vals_dir=<path to dir holding helm values files>

```
    
2. Use customized central image with vuln endpoint and matcher image from this PR:
```
enablePodSecurityPolicies: false
allowNonstandardNamespace: true
customize:
  envVars:
    LOGLEVEL: "Debug"
image:
  registry: "quay.io"
central:
  image:
    tag: "4.3.x-1004-g345338267a"
    name: "rhacs-eng/main"
  db:
    enabled: true
    image:
      tag: "4.3.x-1029-g28a30b69d0"
      name: "rhacs-eng/central-db"
    resources:
      requests:
        cpu: 2
        memory: "4Gi"
      limits:
        cpu: 2
        memory: "4Gi"
  persistence:
    none: true
  exposure:
    loadBalancer:
      enabled: true
  telemetry:
    enabled: false
scanner:
  disable: false
  replicas: 1
  autoscaling:
    minReplicas: 1
    maxReplicas: 1
  image:
    tag: "4.3.x-1029-g28a30b69d0"
    name: "rhacs-eng/scanner"
  dbImage:
    tag: "4.3.x-1029-g28a30b69d0"
    name: "rhacs-eng/scanner-db"
scannerV4:
  disable: false
  indexer:
    image:
      tag: "4.3.x-1029-g28a30b69d0"
      name: "rhacs-eng/scanner-v4"
    replicas: 1
    autoscaling:
      minReplicas: 1
      maxReplicas: 1
  matcher:
    image:
      tag: "4.3.x-1029-g28a30b69d0"
      name: "rhacs-eng/scanner-v4"
    replicas: 1
    autoscaling:
      minReplicas: 1
      maxReplicas: 1
    resources:
      requests:
        cpu: "1"
        memory: "1500Mi"
      limits:
        cpu: "2"
        memory: "8Gi"
  db:
    image:
      tag: "4.3.x-1029-g28a30b69d0"
      name: "rhacs-eng/scanner-v4-db"
    persistence:
      persistentVolumeClaim:
        storageClass: "ssd-csi"
        size: "50Gi"
    resources:
      requests:
        cpu: "200m"
        memory: "200Mi"
      limits:
        cpu: "4"
        memory: "6Gi"
```
3. 
```
helm upgrade --install -n stackrox stackrox-central-services --create-namespace ./stackrox-central-services-chart \
        -f "$vals_dir/central_values.yaml" -f "$vals_dir/secret_values.yaml"
```
4.
```
{"level":"info","host":"scanner-v4-matcher-6fbb8f9c7f-86t2l","component":"matcher/updater/vuln/Updater.fetch","url":"https://central.stackrox.svc/api/extensions/scannerdefinitions?version=dev","time":"2024-02-06T16:37:19Z","message":"fetching vuln update"}
grpc_internal: 2024/02/06 16:37:20.296099 logging.go:43: Debug: [core][Channel #3 SubChannel #4] Subchannel Connectivity change to IDLE, last error: connection error: desc = "transport: Error while dialing: dial tcp :8443: connect: connection refused"
grpc_internal: 2024/02/06 16:37:20.296221 logging.go:43: Debug: [core][Channel #3 SubChannel #4] Subchannel Connectivity change to CONNECTING
grpc_internal: 2024/02/06 16:37:20.296240 logging.go:43: Debug: [core][Channel #3 SubChannel #4] Subchannel picks a new address ":8443" to connect
grpc_internal: 2024/02/06 16:37:20.305040 logging.go:43: Debug: [core][Channel #3 SubChannel #4] Subchannel Connectivity change to READY
grpc_internal: 2024/02/06 16:37:20.305182 logging.go:43: Debug: [core][Channel #3] Channel Connectivity change to READY
{"level":"info","host":"scanner-v4-matcher-6fbb8f9c7f-86t2l","component":"libvuln/OfflineImporter","updater":"RHEL6-jboss-ws-3-including-unpatched","ref":"c9c97b92-7c4b-4d87-905d-ef65accf96e2","count":3184,"time":"2024-02-06T16:37:21Z","message":"update imported"}
{"level":"info","host":"scanner-v4-matcher-6fbb8f9c7f-86t2l","component":"libvuln/OfflineImporter","updater":"RHEL8-rhsso-including-unpatched","ref":"99dbb5b1-f049-4c64-bbe1-93f02ebb8118","count":684,"time":"2024-02-06T16:37:21Z","message":"update imported"}
{"level":"info","host":"scanner-v4-matcher-6fbb8f9c7f-86t2l","component":"libvuln/OfflineImporter","updater":"RHEL7-dotnet-3.1","ref":"4cf9ac2a-8d13-4a56-b012-3a816f70c697","count":438,"time":"2024-02-06T16:37:21Z","message":"update imported"}
{"level":"info","host":"scanner-v4-matcher-6fbb8f9c7f-86t2l","component":"libvuln/OfflineImporter","updater":"RHEL7-dotnet-3.0-including-unpatched","ref":"084e1a23-b0a1-4cd8-9d6e-edd9ad0bc9f0","count":22,"time":"2024-02-06T16:37:21Z","message":"update imported"}
{"level":"info","host":"scanner-v4-matcher-6fbb8f9c7f-86t2l","component":"libvuln/OfflineImporter","updater":"RHEL7-dotnet-2.1-including-unpatched","ref":"cc4e12d8-96ba-48d7-a20d-5552d3762b01","count":408,"time":"2024-02-06T16:37:21Z","message":"update imported"}
{"level":"info","host":"scanner-v4-matcher-6fbb8f9c7f-86t2l","component":"libvuln/OfflineImporter","updater":"RHEL8-openstack-16.2","ref":"9534854b-e548-467f-940e-4a9d7eaae8c1","count":328,"time":"2024-02-06T16:37:21Z","message":"update imported"}
{"level":"info","host":"scanner-v4-matcher-6fbb8f9c7f-86t2l","component":"libvuln/OfflineImporter","updater":"RHEL8-openshift-4.9","ref":"c7844a73-5d0f-4a04-8d30-de04f162626b","count":84,"time":"2024-02-06T16:37:21Z","message":"update imported"}
{"level":"info","host":"scanner-v4-matcher-6fbb8f9c7f-86t2l","component":"libvuln/OfflineImporter","updater":"RHEL7-dotnet-6.0-including-unpatched","ref":"cfbe1843-eefb-480c-9917-5d4e3843acb1","count":510,"time":"2024-02-06T16:37:22Z","message":"update imported"}
{"level":"info","host":"scanner-v4-matcher-6fbb8f9c7f-86t2l","component":"libvuln/OfflineImporter","updater":"RHEL8-openshift-4.5","ref":"4b6a23b2-8e31-4933-aa59-dbbce0dab0ec","count":56,"time":"2024-02-06T16:37:22Z","message":"update imported"}
{"level":"info","host":"scanner-v4-matcher-6fbb8f9c7f-86t2l","component":"libvuln/OfflineImporter","updater":"RHEL7-cfme-5.8","ref":"f4b5d4d3-9f6a-4a72-94d8-adae80826bbc","count":300,"time":"2024-02-06T16:37:22Z","message":"update imported"}
{"level":"info","host":"scanner-v4-matcher-6fbb8f9c7f-86t2l","component":"libvuln/OfflineImporter","updater":"RHEL9-storage-ceph-6-including-unpatched","ref":"5b4e18ea-997c-46f5-ad15-a8ceedf67380","count":668,"time":"2024-02-06T16:37:22Z","message":"update imported"}
{"level":"info","host":"scanner-v4-matcher-6fbb8f9c7f-86t2l","component":"libvuln/OfflineImporter","updater":"RHEL7-openshift-3.8-including-unpatched","ref":"490dff43-ad43-44e0-a133-5eb5676d6d35","count":72,"time":"2024-02-06T16:37:22Z","message":"update imported"}
```


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
