### PR TITLE
ROX-21770: compliance populate all result fields

### DIFF
--- a/central/convert/storagetov2/compliance_results_service.go
+++ b/central/convert/storagetov2/compliance_results_service.go
@@ -20,13 +20,18 @@ type scanResultKey struct {
 // ComplianceV2CheckResult converts a storage check result to a v2 check result
 func ComplianceV2CheckResult(incoming *storage.ComplianceOperatorCheckResultV2) *v2.ComplianceCheckResult {
 	converted := &v2.ComplianceCheckResult{
-		CheckId:      incoming.GetCheckId(),
-		CheckName:    incoming.GetCheckName(),
-		Description:  incoming.GetDescription(),
-		Instructions: incoming.GetInstructions(),
+		CheckId:   incoming.GetCheckId(),
+		CheckName: incoming.GetCheckName(),
 		Clusters: []*v2.ComplianceCheckResult_ClusterCheckStatus{
 			clusterStatus(incoming),
 		},
+		Description:  incoming.GetDescription(),
+		Instructions: incoming.GetInstructions(),
+		Standard:     incoming.GetStandard(),
+		Control:      incoming.GetControl(),
+		Rationale:    incoming.GetRationale(),
+		ValuesUsed:   incoming.GetValuesUsed(),
+		Warnings:     incoming.GetWarnings(),
 	}
 
 	return converted


### PR DESCRIPTION
## Description

When building the API object originally a few fields such as `rationale`, `warnings`, etc were not included in the response.  

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Created an openshift cluster with compliance operator installed.  Ran some scans and used to the API to retrieve the results.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
