### PR TITLE
ROX-21291: Introduce environment var for enhancement queue size

### DIFF
--- a/pkg/env/deployment_enhancement.go
+++ b/pkg/env/deployment_enhancement.go
@@ -7,7 +7,7 @@ var (
 	// DeploymentEnhancementRequest.
 	CentralDeploymentEnhancementTimeout = registerDurationSetting("ROX_CENTRAL_DEPLOYMENT_ENHANCE_TIMEOUT", 30*time.Second)
 
-	// SensorEnhancementQueueSize configures the size of the buffered channel that incoming
+	// SensorDeploymentEnhancementQueueSize configures the size of the buffered channel that incoming
 	// DeploymentEnhancementRequests are queued in
 	SensorDeploymentEnhancementQueueSize = RegisterIntegerSetting("ROX_SENSOR_DEPLOYMENT_ENHANCEMENT_QUEUE_SIZE", 50)
 )

--- a/pkg/env/deployment_enhancement.go
+++ b/pkg/env/deployment_enhancement.go
@@ -6,4 +6,8 @@ var (
 	// CentralDeploymentEnhancementTimeout allows to configure the time Central waits for Sensor to answer to a
 	// DeploymentEnhancementRequest.
 	CentralDeploymentEnhancementTimeout = registerDurationSetting("ROX_CENTRAL_DEPLOYMENT_ENHANCE_TIMEOUT", 30*time.Second)
+
+	// SensorEnhancementQueueSize configures the size of the buffered channel that incoming
+	// DeploymentEnhancementRequests are queued in
+	SensorEnhancementQueueSize = RegisterIntegerSetting("ROX_SENSOR_ENHANCEMENT_QUEUE_SIZE", 50)
 )

--- a/pkg/env/deployment_enhancement.go
+++ b/pkg/env/deployment_enhancement.go
@@ -9,5 +9,5 @@ var (
 
 	// SensorEnhancementQueueSize configures the size of the buffered channel that incoming
 	// DeploymentEnhancementRequests are queued in
-	SensorEnhancementQueueSize = RegisterIntegerSetting("ROX_SENSOR_ENHANCEMENT_QUEUE_SIZE", 50)
+	SensorDeploymentEnhancementQueueSize = RegisterIntegerSetting("ROX_SENSOR_DEPLOYMENT_ENHANCEMENT_QUEUE_SIZE", 50)
 )

--- a/sensor/common/deploymentenhancer/component.go
+++ b/sensor/common/deploymentenhancer/component.go
@@ -34,7 +34,7 @@ func CreateEnhancer(provider store.Provider) common.SensorComponent {
 
 	return &DeploymentEnhancer{
 		responsesC:       make(chan *message.ExpiringMessage),
-		deploymentsQueue: make(chan *central.DeploymentEnhancementRequest, env.SensorEnhancementQueueSize.IntegerSetting()),
+		deploymentsQueue: make(chan *central.DeploymentEnhancementRequest, env.SensorDeploymentEnhancementQueueSize.IntegerSetting()),
 		storeProvider:    provider,
 		ctx:              ctx,
 		ctxCancel:        ctxCancel,
@@ -56,7 +56,7 @@ func (d *DeploymentEnhancer) ProcessMessage(msg *central.MsgToSensor) error {
 	case d.deploymentsQueue <- toEnhance:
 		return nil
 	default:
-		return errox.ResourceExhausted.Newf("DeploymentEnhancer queue has reached its limit of %d", env.SensorEnhancementQueueSize.IntegerSetting())
+		return errox.ResourceExhausted.Newf("DeploymentEnhancer queue has reached its limit of %d", env.SensorDeploymentEnhancementQueueSize.IntegerSetting())
 	}
 }
 

--- a/sensor/common/deploymentenhancer/component.go
+++ b/sensor/common/deploymentenhancer/component.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
@@ -15,8 +16,7 @@ import (
 )
 
 var (
-	log                 = logging.LoggerForModule()
-	deploymentQueueSize = 50 // TODO(ROX-21291): Configurable via env var
+	log = logging.LoggerForModule()
 )
 
 // The DeploymentEnhancer takes a list of Deployments and enhances them with all available information
@@ -34,7 +34,7 @@ func CreateEnhancer(provider store.Provider) common.SensorComponent {
 
 	return &DeploymentEnhancer{
 		responsesC:       make(chan *message.ExpiringMessage),
-		deploymentsQueue: make(chan *central.DeploymentEnhancementRequest, deploymentQueueSize),
+		deploymentsQueue: make(chan *central.DeploymentEnhancementRequest, env.SensorEnhancementQueueSize.IntegerSetting()),
 		storeProvider:    provider,
 		ctx:              ctx,
 		ctxCancel:        ctxCancel,
@@ -56,7 +56,7 @@ func (d *DeploymentEnhancer) ProcessMessage(msg *central.MsgToSensor) error {
 	case d.deploymentsQueue <- toEnhance:
 		return nil
 	default:
-		return errox.ResourceExhausted.Newf("DeploymentEnhancer queue has reached its limit of %d", deploymentQueueSize)
+		return errox.ResourceExhausted.Newf("DeploymentEnhancer queue has reached its limit of %d", env.SensorEnhancementQueueSize.IntegerSetting())
 	}
 }
 


### PR DESCRIPTION
## Description

Introducing a configurable queue size for incoming `DeploymentEnhancementRequest` messages to Sensor.
Tuning this variable correctly might be not that easy, as a single enhancement request can contain an arbitrary number of deployments.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- Automated CI tests
- Manual testing

Manual testing was concluded by reducing the queue size to 1 or 0, then looking for `resource exhausted` error messages

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
