### PR TITLE
ROX-21615: Disable broken test in release-4.1 branch

### DIFF
--- a/sensor/common/centralclient/client_test.go
+++ b/sensor/common/centralclient/client_test.go
@@ -56,6 +56,7 @@ const (
 )
 
 func TestClient(t *testing.T) {
+	t.Skip("ROX-21615")
 	suite.Run(t, new(ClientTestSuite))
 }
 


### PR DESCRIPTION
## Description

This was fixed in master with #8885 but it's not worth backporting that for an end-of-life branch.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI should be sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
