### PR TITLE
ROX-21465: Fix empty CVE list for pending requests

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/utils.ts
@@ -8,5 +8,14 @@ export function getImageScopeSearchValue({ imageScope }: VulnerabilityExceptionS
     if (tag === '.*') {
         return `${registry}/${remote}`;
     }
+    if (tag === '') {
+        // TODO (dv 2024-01-17)
+        //      If tag is an empty string then the image is referenced directly by hash. This is currently not supported
+        //      by deferrals, and will be treated the same as passing a wildcard '.*' as tag. Leaving the tag empty and providing
+        //      an 'Image' search query ending with `:` will result in an empty response, so we strip that character off here.
+        //
+        //      See ROX-20929 to track the BE implementation of hash support and update this code accordingly.
+        return `${registry}/${remote}`;
+    }
     return `${registry}/${remote}:${tag}`;
 }


### PR DESCRIPTION
## Description

When a pending exception request exists at an exact tag scope for an image referenced by hash instead of tag, the CVE list on the exception details page will be empty.

This is due to the trailing `:` character in the search query when constructing the image search string. Since hash referenced images are not supported by deferrals at this time, a tag scope here is essentially the same as "all tags" for the exception. See convo [here](https://redhat-internal.slack.com/archives/C03JMGWJYMD/p1700238824051929) for more details and the Jira to track BE implementation.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Create an exception for a CVE that belongs to an image that is not referenced by tag. Visit the exception details page an ensure the CVE list is not empty and contains the correct CVE(s).
![image](https://github.com/stackrox/stackrox/assets/1292638/61bbdfdf-2dc8-4010-85c5-c3e6dbfb8469)
![image](https://github.com/stackrox/stackrox/assets/1292638/22bf445a-7313-4cd9-8941-d86c431f5c1c)
![image](https://github.com/stackrox/stackrox/assets/1292638/a704d9c8-ed6b-4e26-b126-426e2106fb15)
