### PR TITLE
ROX-18124: Document eventual removal for permission workaround

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -376,6 +376,10 @@ install_the_compliance_operator() {
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/catalog-source.yaml"
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/operator-group.yaml"
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/subscription.yaml"
+        # The following role and role binding are a workaround until we have
+        # installation tooling that sets permissions accordingly for the
+        # service account to interact with the Compliance Operator -
+        # https://issues.redhat.com/browse/ROX-18124.
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/complianceRole.yaml"
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/complianceRoleBinding.yaml"
         wait_for_object_to_appear openshift-compliance deploy/compliance-operator

--- a/tests/e2e/yaml/compliance-operator/complianceRole.yaml
+++ b/tests/e2e/yaml/compliance-operator/complianceRole.yaml
@@ -12,9 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: stackrox
     app.kubernetes.io/part-of: stackrox-secured-cluster-services
-    app.kubernetes.io/version: 4.2.x-187-ga2148c149d
     auto-upgrade.stackrox.io/component: sensor
-    helm.sh/chart: stackrox-secured-cluster-services-400.2.0-187-ga2148c149d
   name: edit-compliance
   namespace: openshift-compliance
 rules:

--- a/tests/e2e/yaml/compliance-operator/complianceRoleBinding.yaml
+++ b/tests/e2e/yaml/compliance-operator/complianceRoleBinding.yaml
@@ -12,9 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: stackrox
     app.kubernetes.io/part-of: stackrox-secured-cluster-services
-    app.kubernetes.io/version: 4.2.x-187-ga2148c149d
     auto-upgrade.stackrox.io/component: sensor
-    helm.sh/chart: stackrox-secured-cluster-services-400.2.0-187-ga2148c149d
   name: manage-compliance
   namespace: openshift-compliance
 roleRef:


### PR DESCRIPTION
This commit just leaves a reference to the story that tracks the work to add permissions to the installation path, which should allow us to remove this workaround in the future. This commit also removes the some labels on the role and binding so they don't interfere with any of the install tools.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

This should be tested with the v2 compliance e2e tests, which require these permissions.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
