### PR TITLE
ROX-21130: Adapt from classic confirmation modal to revoke bundle

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
@@ -3,11 +3,12 @@ import { useHistory } from 'react-router-dom';
 import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
 
 import useRestQuery from 'hooks/useRestQuery';
-import { fetchClusterInitBundles, revokeClusterInitBundles } from 'services/ClustersService';
+import { fetchClusterInitBundles } from 'services/ClustersService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import InitBundleDescription from './InitBundleDescription';
 import InitBundlesHeader from './InitBundlesHeader';
+import RevokeBundleModal from './RevokeBundleModal';
 
 export type InitBundlePageProps = {
     hasWriteAccessForInitBundles: boolean;
@@ -17,7 +18,6 @@ export type InitBundlePageProps = {
 function InitBundlePage({ hasWriteAccessForInitBundles, id }: InitBundlePageProps): ReactElement {
     const history = useHistory();
     const [isRevoking, setIsRevoking] = useState(false);
-    const [errorMessageForRevoke, setErrorMessageForRevoke] = useState('');
 
     const {
         data: dataForFetch,
@@ -31,17 +31,13 @@ function InitBundlePage({ hasWriteAccessForInitBundles, id }: InitBundlePageProp
 
     function onClickRevoke() {
         setIsRevoking(true);
-        // TODO investigate second argument and add confirmation modal.
-        revokeClusterInitBundles([id], [])
-            .then(() => {
-                setErrorMessageForRevoke('');
-                setIsRevoking(false);
-                history.goBack(); // to table
-            })
-            .catch((error) => {
-                setErrorMessageForRevoke(getAxiosErrorMessage(error));
-                setIsRevoking(false);
-            });
+    }
+
+    function onCloseModal(wasRevoked: boolean) {
+        setIsRevoking(false);
+        if (wasRevoked) {
+            history.goBack(); // to table
+        }
     }
 
     const headerActions =
@@ -76,17 +72,13 @@ function InitBundlePage({ hasWriteAccessForInitBundles, id }: InitBundlePageProp
                     </Alert>
                 ) : initBundle ? (
                     <>
-                        {errorMessageForRevoke && (
-                            <Alert
-                                variant="danger"
-                                title="Unable to revoke cluster init bundle"
-                                component="div"
-                                isInline
-                            >
-                                {errorMessageForRevoke}
-                            </Alert>
-                        )}
                         <InitBundleDescription initBundle={initBundle} />
+                        {isRevoking && (
+                            <RevokeBundleModal
+                                initBundle={initBundle}
+                                onCloseModal={onCloseModal}
+                            />
+                        )}
                     </>
                 ) : (
                     <Alert

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesTable.tsx
@@ -1,15 +1,21 @@
 import React, { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { ActionsColumn, TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { ClusterInitBundle } from 'services/ClustersService';
 import { clustersInitBundlesPath } from 'routePaths';
 
 export type InitBundlesTableProps = {
+    hasWriteAccessForInitBundles: boolean;
     initBundles: ClusterInitBundle[];
+    setInitBundleToRevoke: (initBundle: ClusterInitBundle) => void;
 };
 
-function InitBundlesTable({ initBundles }: InitBundlesTableProps): ReactElement {
+function InitBundlesTable({
+    hasWriteAccessForInitBundles,
+    initBundles,
+    setInitBundleToRevoke,
+}: InitBundlesTableProps): ReactElement {
     return (
         <TableComposable variant="compact">
             <Thead>
@@ -18,6 +24,7 @@ function InitBundlesTable({ initBundles }: InitBundlesTableProps): ReactElement 
                     <Th>Created by</Th>
                     <Th>Created at</Th>
                     <Th>Expires at</Th>
+                    {hasWriteAccessForInitBundles && <Td />}
                 </Tr>
             </Thead>
             <Tbody>
@@ -32,6 +39,21 @@ function InitBundlesTable({ initBundles }: InitBundlesTableProps): ReactElement 
                             <Td dataLabel="Created by">{createdBy.id}</Td>
                             <Td dataLabel="Created at">{createdAt}</Td>
                             <Td dataLabel="Expires at">{expiresAt}</Td>
+                            {hasWriteAccessForInitBundles && (
+                                <Td>
+                                    <ActionsColumn
+                                        menuAppendTo={() => document.body}
+                                        items={[
+                                            {
+                                                title: 'Revoke bundle',
+                                                onClick: () => {
+                                                    setInitBundleToRevoke(initBundle);
+                                                },
+                                            },
+                                        ]}
+                                    />
+                                </Td>
+                            )}
                         </Tr>
                     );
                 })}

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/RevokeBundleModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/RevokeBundleModal.tsx
@@ -1,0 +1,153 @@
+import React, { ReactElement, useState } from 'react';
+import {
+    Alert,
+    Button,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Flex,
+    List,
+    ListItem,
+    Modal,
+} from '@patternfly/react-core';
+
+import {
+    ClusterInitBundle,
+    ImpactedCluster,
+    revokeClusterInitBundles,
+} from 'services/ClustersService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+export type RevokeBundleModalProps = {
+    initBundle: ClusterInitBundle;
+    onCloseModal: (wasRevoked: boolean) => void;
+};
+
+function RevokeBundleModal({ initBundle, onCloseModal }: RevokeBundleModalProps): ReactElement {
+    const [errorMessage, setErrorMessage] = useState('');
+    const [impactedClusters, setImpactedClusters] = useState<ImpactedCluster[]>(
+        initBundle.impactedClusters
+    );
+    const [hasMoreClusters, setHasMoreClusters] = useState(false);
+    const [isRevokingBundle, setIsRevokingBundle] = useState(false);
+
+    function onRevokeBundle() {
+        setErrorMessage('');
+        setIsRevokingBundle(true);
+        revokeClusterInitBundles(
+            [initBundle.id],
+            impactedClusters.map(({ id }) => id)
+        )
+            .then(({ initBundleRevocationErrors }) => {
+                if (initBundleRevocationErrors.length === 0) {
+                    setHasMoreClusters(false);
+                    onCloseModal(true);
+                } else {
+                    // The bundle has more impacted clusters than the list already rendered.
+                    // Therefore, user needs to confirm revoke again.
+                    setHasMoreClusters(true);
+                    setImpactedClusters(initBundleRevocationErrors[0].impactedClusters);
+                }
+            })
+            .catch((error) => {
+                setErrorMessage(getAxiosErrorMessage(error));
+            })
+            .finally(() => {
+                setIsRevokingBundle(false);
+            });
+    }
+
+    function onCancel() {
+        setErrorMessage('');
+        setHasMoreClusters(false);
+        onCloseModal(false);
+    }
+
+    // showClose={false} to prevent clicking close while isRevokingBundle.
+    return (
+        <Modal
+            title="Revoke cluster init bundle"
+            variant="small"
+            isOpen
+            showClose={false}
+            actions={[
+                <Button
+                    key="Revoke bundle"
+                    variant={impactedClusters.length === 0 ? 'primary' : 'danger'}
+                    onClick={onRevokeBundle}
+                    isDisabled={isRevokingBundle}
+                >
+                    Revoke bundle
+                </Button>,
+                <Button
+                    key="Cancel"
+                    variant="secondary"
+                    onClick={onCancel}
+                    isDisabled={isRevokingBundle}
+                >
+                    Cancel
+                </Button>,
+            ]}
+        >
+            <Flex direction={{ default: 'column' }}>
+                <DescriptionList isHorizontal>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Bundle name</DescriptionListTerm>
+                        <DescriptionListDescription>{initBundle.name}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                </DescriptionList>
+                {impactedClusters.length === 0 ? (
+                    <Alert
+                        title="No secured clusters depend on this bundle"
+                        variant="info"
+                        isInline
+                        component="p"
+                    />
+                ) : (
+                    <>
+                        {hasMoreClusters ? (
+                            <Alert
+                                title="Additional secured clusters now depend on this initBundle"
+                                variant="warning"
+                                isInline
+                                component="p"
+                            >
+                                You must confirm <strong>again</strong> to delete this bundle.
+                            </Alert>
+                        ) : (
+                            <Alert
+                                title="Secured clusters depend on this bundle"
+                                variant="danger"
+                                isInline
+                                component="p"
+                            >
+                                <p>
+                                    In clusters that depend on this bundle, secured cluster services
+                                    like Sensor will lose connectivity to Central.
+                                </p>
+                                <p className="pf-u-mt-md">
+                                    We recommend that you <strong>replace</strong> this bundle in
+                                    the following secured clusters <strong>before</strong> you
+                                    revoke it.
+                                </p>
+                            </Alert>
+                        )}
+                        <List component="ol">
+                            {impactedClusters.map(({ name }) => (
+                                <ListItem key={name}>{name}</ListItem>
+                            ))}
+                        </List>
+                    </>
+                )}
+                {errorMessage && (
+                    <Alert title="Revoke bundle failed" variant="danger" isInline component="p">
+                        {errorMessage}
+                    </Alert>
+                )}
+            </Flex>
+        </Modal>
+    );
+}
+
+export default RevokeBundleModal;


### PR DESCRIPTION
## Description

Adapt from classic init bundles:
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/DeleteClusterInitBundleConfirmationModal.tsx

### Residue

1. Investigate why the following did not work. Maybe difference between React 17 and 18?

    ```tsx
    /*
        * Cancel button has initial focus so delete requires an intentional action,
        * like click button or press tab key, not just press return key.
        */
    if (typeof refCancelButton?.current?.focus === 'function') {
        refCancelButton.current.focus();
    }
    ```

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_MOVE_INIT_BUNDLES_UI=true
```

### Manual testing

1. Visit /main/clusters, click **Manage init bundles**, click **Create bundle** and then go back to the bundles page.

2. Click link to bundle page, and then click **Revoke bundle**.
    * See **Revoke cluster init bundle** modal.
    * See **No secured clusters depend on this bundle** info alert.
    ![No_secured_clusters_depend_on_this_bundle](https://github.com/stackrox/stackrox/assets/11862657/e8e4bebe-cb5a-4ba2-ae00-ae0360698d8e)

3. Click **Revoke bundle**
    * See PATCH /v1/cluster-init/init-bundles/revoke request.
    * See GET /v1/cluster-init/init-bundles request.
    * See **Cluster init bundles** page.
    ![Revoke_bundle](https://github.com/stackrox/stackrox/assets/11862657/a64d1a1d-a4b5-4d16-9188-70127032d78f)

4. Click kabob menu, and then click **Revoke bundle** for existing bundle.
    * See **Revoke cluster init bundle** modal.
    * See **Secured clusters depend on this bundle** info alert.
    ![Secured_clusters_depend_on_this_bundle](https://github.com/stackrox/stackrox/assets/11862657/f490daa1-662e-48f2-8b5a-0c457ba26124)

5. Click **Cancel**.
