### PR TITLE
ROX-21264: Add the NVD enricher

### DIFF
--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -25,6 +25,9 @@ jobs:
       uses: google-github-actions/setup-gcloud@v2
 
     - name: Update vulnerabilities
+      env:
+        STACKROX_NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        STACKROX_NVD_API_CALL_INTERVAL: 6s
       continue-on-error: true
       run: |
         if [ ! -d "scanner" ]; then

--- a/.github/workflows/scanner-pr-vuln-update.yaml
+++ b/.github/workflows/scanner-pr-vuln-update.yaml
@@ -26,6 +26,9 @@ jobs:
       uses: google-github-actions/setup-gcloud@v2
 
     - name: Update vulnerabilities
+      env:
+        STACKROX_NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        STACKROX_NVD_API_CALL_INTERVAL: 6s
       continue-on-error: true
       run: |
         if [ ! -d "scanner" ]; then

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -43,6 +43,9 @@ jobs:
       uses: google-github-actions/setup-gcloud@v2
 
     - name: Update vulnerabilities
+      env:
+        STACKROX_NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        STACKROX_NVD_API_CALL_INTERVAL: 6s
       continue-on-error: true
       run: |
         DOWNLOAD_URL="https://github.com/stackrox/stackrox/archive/refs/tags/${{ env.ROX_PRODUCT_VERSION }}.zip"

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -40,6 +40,8 @@ var (
 				ConnString:   "host=/var/run/postgresql",
 				PasswordFile: "",
 			},
+			// TODO(ROX-19005): replace with a URL related to the desired version.
+			VulnerabilitiesURL: "https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/dev/output.json.zst",
 		},
 		// Default is empty.
 		MTLS: MTLSConfig{
@@ -161,6 +163,8 @@ type MatcherConfig struct {
 	// instance at the specified address, instead of the local indexer (when the
 	// indexer is enabled).
 	IndexerAddr string `yaml:"indexer_addr"`
+	// VulnerabilitiesURL sets the URL to pull vulnerability data bundles.
+	VulnerabilitiesURL string `yaml:"vulnerabilities_url"`
 	// RemoteIndexerEnabled internal and generated flag, true when the remote indexer is enabled.
 	RemoteIndexerEnabled bool
 }
@@ -181,7 +185,9 @@ func (c *MatcherConfig) validate() error {
 			return fmt.Errorf("indexer_addr: failed to parse address: %w", err)
 		}
 	}
-
+	if _, err := url.Parse(c.VulnerabilitiesURL); err != nil {
+		return fmt.Errorf("vulnerabilities_url: %w", err)
+	}
 	return nil
 }
 

--- a/scanner/enricher/nvd/nvd.go
+++ b/scanner/enricher/nvd/nvd.go
@@ -1,0 +1,421 @@
+// Package nvd provides a NVD enricher.
+package nvd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/facebookincubator/nvdtools/cveapi/nvd/schema"
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/zlog"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+var (
+	_ driver.Enricher          = (*Enricher)(nil)
+	_ driver.EnrichmentUpdater = (*Enricher)(nil)
+
+	defaultFeed *url.URL
+)
+
+const (
+	// Type is the type of data returned from the Enricher's Enrich method.
+	Type = `message/vnd.stackrox.scannerv4.vulnerability; enricher=nvd schema=https://csrc.nist.gov/schema/nvd/api/2.0/source_api_json_2.0.schema`
+
+	// DefaultFeeds is the default place to look for CVE feeds.
+	DefaultFeeds = `https://services.nvd.nist.gov/rest/json/cves/2.0/`
+
+	// This appears above and must be the same.
+	name = `nvd`
+
+	// First year for the yearly CVE feeds: https://nvd.nist.gov/vuln/data-feeds
+	firstYear = 2002
+)
+
+func init() {
+	var err error
+	defaultFeed, err = url.Parse(DefaultFeeds)
+	utils.CrashOnError(err)
+}
+
+// Enricher provides NVD CVE data as enrichments to a VulnerabilityReport.
+//
+// Configure must be called before any other methods.
+type Enricher struct {
+	driver.NoopUpdater
+	c            *http.Client
+	feed         *url.URL
+	apiKey       string
+	callInterval time.Duration
+}
+
+// Config is the configuration for Enricher.
+type Config struct {
+	FeedRoot     *string `json:"feed_root" yaml:"feed_root"`
+	APIKey       *string `json:"api_key" yaml:"api_key"`
+	CallInterval *string `json:"call_interval" yaml:"call_interval"`
+}
+
+// NewFactory creates a Factory for the NVD enricher.
+func NewFactory() driver.UpdaterSetFactory {
+	set := driver.NewUpdaterSet()
+	_ = set.Add(&Enricher{})
+	return driver.StaticSet(set)
+}
+
+// Configure implements driver.Configurable.
+func (e *Enricher) Configure(ctx context.Context, f driver.ConfigUnmarshaler, c *http.Client) error {
+	ctx = zlog.ContextWithValues(ctx, "component", "enricher/nvd/Enricher/Configure")
+	var cfg Config
+	e.c = c
+	if err := f(&cfg); err != nil {
+		return err
+	}
+	if cfg.APIKey != nil {
+		e.apiKey = *cfg.APIKey
+	}
+	// NVD limits users without an API key to roughly one call every 6 seconds.
+	// With an API key, it is roughly one call every 0.6 seconds.
+	// We'll play it safe and do one call every 3 seconds.
+	// As of writing there are ~216,000 vulnerabilities, so this whole process should take ~5.4 minutes.
+	e.callInterval = 3 * time.Second
+	if cfg.CallInterval != nil {
+		var err error
+		e.callInterval, err = time.ParseDuration(*cfg.CallInterval)
+		if err != nil {
+			return err
+		}
+	}
+	if cfg.FeedRoot != nil {
+		if !strings.HasSuffix(*cfg.FeedRoot, "/") {
+			return fmt.Errorf("URL missing trailing slash: %q", *cfg.FeedRoot)
+		}
+		u, err := url.Parse(*cfg.FeedRoot)
+		if err != nil {
+			return err
+		}
+		e.feed = u
+	} else {
+		var err error
+		e.feed, err = defaultFeed.Parse(".")
+		utils.CrashOnError(err)
+	}
+	e.feed.RawQuery = "noRejected"
+	zlog.Info(ctx).
+		Str("feed", e.feed.String()).
+		Bool("has_api_key", e.apiKey != "").
+		Dur("call_interval", e.callInterval).
+		Msg("enricher configured")
+	return nil
+}
+
+// Name implements driver.Enricher and driver.EnrichmentUpdater.
+func (*Enricher) Name() string {
+	return name
+}
+
+// FetchEnrichment implements driver.EnrichmentUpdater.
+func (e *Enricher) FetchEnrichment(ctx context.Context, hint driver.Fingerprint) (io.ReadCloser, driver.Fingerprint, error) {
+	ctx = zlog.ContextWithValues(ctx, "component", "enricher/nvd/Enricher/FetchEnrichment")
+	out, err := os.CreateTemp("", "enricher.nvd.")
+	if err != nil {
+		return nil, hint, err
+	}
+	utils.Should(os.Remove(out.Name()))
+	var success bool
+	defer func() {
+		if !success {
+			if err := out.Close(); err != nil {
+				zlog.Warn(ctx).Err(err).Msg("unable to close spool")
+			}
+		}
+	}()
+	// Doing this serially is slower, but much less complicated than using an
+	// ErrGroup or the like.
+	//
+	// It may become an issue in 25-30 years.
+	startDate := time.Date(firstYear, time.January, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
+	for startDate.Before(now) {
+		// The maximum allowable range when using any date range parameters is 120 consecutive days.
+		endDate := startDate.Add(120*24*time.Hour - time.Second)
+		if endDate.After(now) {
+			endDate = now
+		}
+		var apiResp *schema.CVEAPIJSON20
+		for startIdx := 0; ; startIdx += apiResp.TotalResults {
+			apiResp, err = e.query(ctx, startDate, endDate, startIdx)
+			if err != nil {
+				return nil, hint, err
+			}
+			if apiResp.ResultsPerPage == 0 {
+				break
+			}
+			// Parse vulnerabilities in the API response.
+			enc := json.NewEncoder(out)
+			for _, vuln := range apiResp.Vulnerabilities {
+				item := filterFields(vuln.CVE)
+				enrichment, err := json.Marshal(item)
+				if err != nil {
+					return nil, hint, fmt.Errorf("serializing CVE %s: %w", item.ID, err)
+				}
+				r := driver.EnrichmentRecord{
+					Tags:       []string{item.ID},
+					Enrichment: enrichment,
+				}
+				if err := enc.Encode(&r); err != nil {
+					return nil, hint, fmt.Errorf("encoding enrichment: %w", err)
+				}
+			}
+			zlog.Info(ctx).Int("count", len(apiResp.Vulnerabilities)).Msg("loaded vulnerabilities")
+			// Rudimentary rate-limiting.
+			time.Sleep(e.callInterval)
+		}
+		startDate = endDate.Add(time.Second)
+	}
+	// Reset so clients can read the items.
+	if _, err := out.Seek(0, io.SeekStart); err != nil {
+		return nil, hint, fmt.Errorf("unable to reset item feed: %w", err)
+	}
+	success = true
+	// Hint is currently ignored, and always the same.
+	return out, hint, nil
+}
+
+func filterFields(cve *schema.CVEAPIJSON20CVEItem) *schema.CVEAPIJSON20CVEItem {
+	var desc []*schema.CVEAPIJSON20LangString
+	for _, d := range cve.Descriptions {
+		if d.Lang == "en" {
+			desc = append(desc, d)
+			break
+		}
+	}
+	item := &schema.CVEAPIJSON20CVEItem{
+		ID:           cve.ID,
+		Descriptions: desc,
+		Metrics:      &schema.CVEAPIJSON20CVEItemMetrics{},
+		Published:    cve.Published,
+		LastModified: cve.LastModified,
+	}
+	for _, cvss := range cve.Metrics.CvssMetricV31 {
+		if cvss.Type != "Primary" && cvss.Type != "" {
+			continue
+		}
+		item.Metrics.CvssMetricV31 = append(item.Metrics.CvssMetricV31, &schema.CVEAPIJSON20CVSSV31{
+			CvssData: &schema.CVSSV31{
+				Version:      cvss.CvssData.Version,
+				VectorString: cvss.CvssData.VectorString,
+				BaseScore:    cvss.CvssData.BaseScore,
+			},
+		})
+	}
+	for _, cvss := range cve.Metrics.CvssMetricV30 {
+		if cvss.Type != "Primary" && cvss.Type != "" {
+			continue
+		}
+		item.Metrics.CvssMetricV30 = append(item.Metrics.CvssMetricV30, &schema.CVEAPIJSON20CVSSV30{
+			CvssData: &schema.CVSSV30{
+				Version:      cvss.CvssData.Version,
+				VectorString: cvss.CvssData.VectorString,
+				BaseScore:    cvss.CvssData.BaseScore,
+			},
+		})
+	}
+	for _, cvss := range cve.Metrics.CvssMetricV2 {
+		if cvss.Type != "Primary" && cvss.Type != "" {
+			continue
+		}
+		item.Metrics.CvssMetricV2 = append(item.Metrics.CvssMetricV2, &schema.CVEAPIJSON20CVSSV2{
+			CvssData: &schema.CVSSV20{
+				Version:      cvss.CvssData.Version,
+				VectorString: cvss.CvssData.VectorString,
+				BaseScore:    cvss.CvssData.BaseScore,
+			},
+		})
+	}
+	return item
+}
+
+func (e *Enricher) feedURL(start time.Time, end time.Time, startIdx int) string {
+	// Feed URL should be validated during enricher configuration, crashing on errors.
+	u, err := e.feed.Parse(".")
+	utils.CrashOnError(err)
+	v, err := url.ParseQuery(e.feed.RawQuery)
+	utils.CrashOnError(err)
+	v.Set("startIndex", fmt.Sprintf("%d", startIdx))
+	v.Set("pubStartDate", start.Format("2006-01-02T15:04:05Z"))
+	v.Set("pubEndDate", end.Format("2006-01-02T15:04:05Z"))
+	u.RawQuery = v.Encode()
+	return u.String()
+}
+
+func (e *Enricher) query(ctx context.Context, start, end time.Time, startIdx int) (*schema.CVEAPIJSON20, error) {
+	ctx = zlog.ContextWithValues(ctx, "start_index", fmt.Sprintf("%d", startIdx),
+		"start_time", start.String(),
+		"end_time", end.String())
+	u := e.feedURL(start, end, startIdx)
+	zlog.Debug(ctx).Str("url", u).Msgf("starting NVD request")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating HTTP request: %w", err)
+	}
+	if e.apiKey != "" {
+		req.Header.Set("apiKey", e.apiKey)
+	}
+	apiResp, err := e.queryWithBackoff(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return apiResp, nil
+}
+
+func (e *Enricher) queryWithBackoff(ctx context.Context, req *http.Request) (apiResp *schema.CVEAPIJSON20, err error) {
+	for i := 1; i <= 5; i++ {
+		var resp *http.Response
+		resp, err = e.tryQuery(ctx, req)
+		if err == nil {
+			apiResp, err = parseResponse(resp)
+			if err == nil {
+				break
+			}
+		}
+		zlog.Warn(ctx).
+			Int("attempt", i).
+			Err(err).
+			Msg("failed query attempt")
+		// Wait some multiple of 3 seconds before next attempt.
+		time.Sleep(time.Duration(3*i) * time.Second)
+	}
+	return apiResp, err
+}
+
+func (e *Enricher) tryQuery(ctx context.Context, req *http.Request) (*http.Response, error) {
+	resp, err := e.c.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching NVD API results: %w", err)
+	}
+	zlog.Debug(ctx).
+		Int("status", resp.StatusCode).
+		Str("nvd_message", req.Header.Get("message")).
+		Msg("NVD response")
+	if resp.StatusCode != 200 {
+		_ = resp.Body.Close
+		return nil, fmt.Errorf("unexpected status code when querying %s: %d", req.URL.String(), resp.StatusCode)
+	}
+	return resp, nil
+}
+
+func parseResponse(resp *http.Response) (*schema.CVEAPIJSON20, error) {
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	apiResp := new(schema.CVEAPIJSON20)
+	if err := json.NewDecoder(resp.Body).Decode(apiResp); err != nil {
+		return nil, fmt.Errorf("decoding API response: %w", err)
+	}
+	return apiResp, nil
+}
+
+// ParseEnrichment implements driver.EnrichmentUpdater.
+func (e *Enricher) ParseEnrichment(ctx context.Context, rc io.ReadCloser) ([]driver.EnrichmentRecord, error) {
+	ctx = zlog.ContextWithValues(ctx, "component", "enricher/nvd/Enricher/ParseEnrichment")
+	// Our Fetch method actually has all the smarts w/r/t to constructing the
+	// records, so this is just decoding in a loop.
+	defer func() {
+		_ = rc.Close()
+	}()
+	var err error
+	dec := json.NewDecoder(rc)
+	ret := make([]driver.EnrichmentRecord, 0, 1024) // Wild guess at initial capacity.
+	// This is going to allocate like mad, hold onto your butts.
+	for err == nil {
+		ret = append(ret, driver.EnrichmentRecord{})
+		err = dec.Decode(&ret[len(ret)-1])
+	}
+	zlog.Debug(ctx).
+		Int("count", len(ret)).
+		Msg("decoded enrichments")
+	if !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// This is a slightly more relaxed version of the validation pattern in the NVD
+// JSON schema: https://csrc.nist.gov/schema/nvd/api/2.0/source_api_json_2.0.schema
+//
+// It allows for "CVE" to be case-insensitive and for dashes and underscores
+// between the different segments.
+var cveRegexp = regexp.MustCompile(`(?i:cve)[-_][0-9]{4}[-_][0-9]{4,}`)
+
+// Enrich implements driver.Enricher.
+func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *claircore.VulnerabilityReport) (string, []json.RawMessage, error) {
+	ctx = zlog.ContextWithValues(ctx, "component", "enricher/nvd/Enricher/Enrich")
+
+	// We return any CVSS blobs for CVEs mentioned in the free-form parts of the
+	// vulnerability.
+	m := make(map[string][]json.RawMessage)
+
+	erCache := make(map[string][]driver.EnrichmentRecord)
+	for id, v := range r.Vulnerabilities {
+		t := make(map[string]struct{})
+		ctx := zlog.ContextWithValues(ctx,
+			"vuln", v.Name)
+		for _, elem := range []string{
+			v.Description,
+			v.Name,
+			v.Links,
+		} {
+			for _, m := range cveRegexp.FindAllString(elem, -1) {
+				t[m] = struct{}{}
+			}
+		}
+		if len(t) == 0 {
+			continue
+		}
+		ts := make([]string, 0, len(t))
+		for m := range t {
+			ts = append(ts, m)
+		}
+		zlog.Debug(ctx).
+			Strs("cve", ts).
+			Msg("found CVEs")
+
+		sort.Strings(ts)
+		cveKey := strings.Join(ts, "_")
+		rec, ok := erCache[cveKey]
+		if !ok {
+			var err error
+			rec, err = g.GetEnrichment(ctx, ts)
+			if err != nil {
+				return "", nil, err
+			}
+			erCache[cveKey] = rec
+		}
+		zlog.Debug(ctx).
+			Int("count", len(rec)).
+			Msg("found records")
+		for _, r := range rec {
+			m[id] = append(m[id], r.Enrichment)
+		}
+	}
+	if len(m) == 0 {
+		return Type, nil, nil
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return Type, nil, err
+	}
+	return Type, []json.RawMessage{b}, nil
+}

--- a/scanner/enricher/nvd/nvd_test.go
+++ b/scanner/enricher/nvd/nvd_test.go
@@ -1,0 +1,381 @@
+package nvd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/facebookincubator/nvdtools/cveapi/nvd/schema"
+	"github.com/google/go-cmp/cmp"
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/zlog"
+)
+
+func TestConfigure(t *testing.T) {
+	t.Parallel()
+	ctx := zlog.Test(context.Background(), t)
+	tt := []configTestcase{
+		{
+			Name: "None",
+		},
+		{
+			Name: "OK",
+			Config: func(i interface{}) error {
+				cfg := i.(*Config)
+				s := "http://example.com/"
+				cfg.FeedRoot = &s
+				return nil
+			},
+		},
+		{
+			Name:   "UnmarshalError",
+			Config: func(_ interface{}) error { return errors.New("expected error") },
+			Check: func(t *testing.T, err error) {
+				if err == nil {
+					t.Error("expected unmarshal error")
+				}
+			},
+		},
+		{
+			Name: "TrailingSlash",
+			Config: func(i interface{}) error {
+				cfg := i.(*Config)
+				s := "http://example.com"
+				cfg.FeedRoot = &s
+				return nil
+			},
+			Check: func(t *testing.T, err error) {
+				if err == nil {
+					t.Error("expected trailing slash error")
+				}
+			},
+		},
+		{
+			Name: "BadURL",
+			Config: func(i interface{}) error {
+				cfg := i.(*Config)
+				s := "http://[notaurl:/"
+				cfg.FeedRoot = &s
+				return nil
+			},
+			Check: func(t *testing.T, err error) {
+				if err == nil {
+					t.Error("expected URL parse error")
+				}
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.Name, tc.Run(ctx))
+	}
+}
+
+type configTestcase struct {
+	Config func(interface{}) error
+	Check  func(*testing.T, error)
+	Name   string
+}
+
+func (tc configTestcase) Run(ctx context.Context) func(*testing.T) {
+	e := &Enricher{}
+	return func(t *testing.T) {
+		ctx := zlog.Test(ctx, t)
+		f := tc.Config
+		if f == nil {
+			f = noopConfig
+		}
+		err := e.Configure(ctx, f, nil)
+		if tc.Check == nil {
+			if err != nil {
+				t.Errorf("unexpected err: %v", err)
+			}
+			return
+		}
+		tc.Check(t, err)
+	}
+}
+
+func noopConfig(_ interface{}) error { return nil }
+
+func TestFetch(t *testing.T) {
+	t.Parallel()
+	ctx := zlog.Test(context.Background(), t)
+	srv := mockServer(t)
+	tt := []fetchTestcase{
+		{
+			Name: "Happy Case",
+			Hint: "sample hint",
+			Check: func(t *testing.T, rc io.ReadCloser, fp driver.Fingerprint, err error) {
+				if rc == nil {
+					t.Error("wanted non-nil ReadCloser")
+				}
+				if got, want := driver.Fingerprint("sample hint"), fp; got != want {
+					t.Errorf("bad fingerprint: got: %q, want: %q", got, want)
+				}
+				t.Logf("got error: %v", err)
+				if err != nil {
+					t.Error("wanted nil error")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, tc.Run(ctx, srv))
+	}
+}
+
+type fetchTestcase struct {
+	Check func(*testing.T, io.ReadCloser, driver.Fingerprint, error)
+	Name  string
+	Hint  string
+}
+
+func (tc fetchTestcase) Run(ctx context.Context, srv *httptest.Server) func(*testing.T) {
+	e := &Enricher{}
+	return func(t *testing.T) {
+		ctx := zlog.Test(ctx, t)
+		f := func(i interface{}) error {
+			cfg, ok := i.(*Config)
+			if !ok {
+				t.Fatal("assertion failed")
+			}
+			u := srv.URL + "/"
+			cfg.FeedRoot = &u
+			ci := "0"
+			// Speed up the test.
+			cfg.CallInterval = &ci
+			return nil
+		}
+		if err := e.Configure(ctx, f, srv.Client()); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		rc, fp, err := e.FetchEnrichment(ctx, driver.Fingerprint(tc.Hint))
+		if rc != nil {
+			defer func() {
+				_ = rc.Close()
+			}()
+		}
+		if tc.Check == nil {
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			return
+		}
+		tc.Check(t, rc, fp, err)
+	}
+}
+
+func mockServer(t *testing.T) *httptest.Server {
+	const root = `testdata/`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return only the first page in the testdata, otherwise all empty.
+		if !strings.HasPrefix(r.FormValue("pubStartDate"), "2002-") || r.FormValue("startIndex") != "0" {
+			_, _ = fmt.Fprint(w, `{"resultsPerPage": 0, "totalResults": 0}`)
+			return
+		}
+		f, err := os.Open(filepath.Join(root, "feed.json"))
+		if err != nil {
+			t.Errorf("open failed: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		defer func() {
+			_ = f.Close()
+		}()
+		if _, err := io.Copy(w, f); err != nil {
+			t.Errorf("write error: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+	ctx := zlog.Test(context.Background(), t)
+	srv := mockServer(t)
+	tt := []parseTestcase{
+		{
+			Name: "OK",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.Name, tc.Run(ctx, srv))
+	}
+}
+
+type parseTestcase struct {
+	Check func(*testing.T, []driver.EnrichmentRecord, error)
+	Name  string
+}
+
+func (tc parseTestcase) Run(ctx context.Context, srv *httptest.Server) func(*testing.T) {
+	e := &Enricher{}
+	return func(t *testing.T) {
+		ctx := zlog.Test(ctx, t)
+		f := func(i interface{}) error {
+			cfg, ok := i.(*Config)
+			if !ok {
+				t.Fatal("assertion failed")
+			}
+			u := srv.URL + "/"
+			cfg.FeedRoot = &u
+			// Speed up the test.
+			ci := "0"
+			cfg.CallInterval = &ci
+			return nil
+		}
+		if err := e.Configure(ctx, f, srv.Client()); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		rc, _, err := e.FetchEnrichment(ctx, "")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		defer func() {
+			_ = rc.Close()
+		}()
+		rs, err := e.ParseEnrichment(ctx, rc)
+		if tc.Check == nil {
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			return
+		}
+		tc.Check(t, rs, err)
+	}
+}
+
+func TestEnrich(t *testing.T) {
+	t.Parallel()
+	ctx := zlog.Test(context.Background(), t)
+	g := newFakeGetter(t, "testdata/feed.json")
+	r := &claircore.VulnerabilityReport{
+		Vulnerabilities: map[string]*claircore.Vulnerability{
+			"-1": {
+				Description: "This is a fake vulnerability that doesn't have a CVE.",
+			},
+			"1": {
+				Description: "This is a fake vulnerability that looks like CVE-2023-50612.",
+			},
+			"6004": {
+				Description: "CVE-2020-6004 was unassigned",
+			},
+			"6005": {
+				Description: "CVE-2023-50612 duplicate",
+			},
+		},
+	}
+	e := &Enricher{}
+	kind, es, err := e.Enrich(ctx, g, r)
+	if err != nil {
+		t.Error(err)
+	}
+	if got, want := kind, Type; got != want {
+		t.Errorf("got: %q, want: %q", got, want)
+	}
+	want := map[string][]map[string]interface{}{
+		"1": {{
+			"descriptions": []any{
+				map[string]any{"lang": string("en"), "value": "Insecure Permissions vulnerability in fit2cloud Cloud Explorer Lite version 1.4.1, allow local attackers to escalate privileges and obtain sensitive information via the cloud accounts parameter."},
+			},
+			"id":           "CVE-2023-50612",
+			"lastModified": "2024-01-11T15:02:43.727",
+			"published":    "2024-01-06T03:15:43.990",
+			"metrics": map[string]any{
+				"cvssMetricV31": []any{
+					map[string]any{
+						"cvssData": map[string]any{
+							"baseScore":    float64(7.8),
+							"baseSeverity": "",
+							"vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+							"version":      "3.1",
+						},
+						"source": "",
+						"type":   "",
+					}}},
+			"references": nil,
+		}},
+		"6005": {{
+			"descriptions": []any{
+				map[string]any{"lang": string("en"), "value": "Insecure Permissions vulnerability in fit2cloud Cloud Explorer Lite version 1.4.1, allow local attackers to escalate privileges and obtain sensitive information via the cloud accounts parameter."},
+			},
+			"id":           "CVE-2023-50612",
+			"lastModified": "2024-01-11T15:02:43.727",
+			"published":    "2024-01-06T03:15:43.990",
+			"metrics": map[string]any{
+				"cvssMetricV31": []any{
+					map[string]any{
+						"cvssData": map[string]any{
+							"baseScore":    float64(7.8),
+							"baseSeverity": "",
+							"vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+							"version":      "3.1",
+						},
+						"source": "",
+						"type":   "",
+					}}},
+			"references": nil,
+		}},
+	}
+	got := map[string][]map[string]interface{}{}
+	if err := json.Unmarshal(es[0], &got); err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(got, want) {
+		t.Error(cmp.Diff(got, want))
+	}
+}
+
+func newFakeGetter(t *testing.T, path string) driver.EnrichmentGetter {
+	feedIn, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = feedIn.Close()
+	}()
+	var data *schema.CVEAPIJSON20
+	err = json.NewDecoder(feedIn).Decode(&data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := &fakeGetter{items: map[string]json.RawMessage{}}
+	for _, v := range data.Vulnerabilities {
+		en, err := json.Marshal(filterFields(v.CVE))
+		if err != nil {
+			t.Fatal(err)
+		}
+		g.items[v.CVE.ID] = en
+	}
+	return g
+}
+
+type fakeGetter struct {
+	res   []driver.EnrichmentRecord
+	items map[string]json.RawMessage
+}
+
+func (f *fakeGetter) GetEnrichment(_ context.Context, tags []string) ([]driver.EnrichmentRecord, error) {
+	id := tags[0]
+	if e, ok := f.items[id]; ok {
+		r := []driver.EnrichmentRecord{
+			{Tags: tags, Enrichment: e},
+		}
+		f.res = r
+		return r, nil
+	}
+	return nil, nil
+}

--- a/scanner/enricher/nvd/testdata/feed.json
+++ b/scanner/enricher/nvd/testdata/feed.json
@@ -1,0 +1,14623 @@
+{
+  "resultsPerPage": 100,
+  "startIndex": 0,
+  "totalResults": 100,
+  "format": "NVD_CVE",
+  "version": "2.0",
+  "timestamp": "2024-01-17T19:33:28.677",
+  "vulnerabilities": [
+    {
+      "cve": {
+        "id": "CVE-2023-50612",
+        "sourceIdentifier": "cve@mitre.org",
+        "published": "2024-01-06T03:15:43.990",
+        "lastModified": "2024-01-11T15:02:43.727",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Insecure Permissions vulnerability in fit2cloud Cloud Explorer Lite version 1.4.1, allow local attackers to escalate privileges and obtain sensitive information via the cloud accounts parameter."
+          },
+          {
+            "lang": "es",
+            "value": "La vulnerabilidad de permisos inseguros en fit2cloud Cloud Explorer Lite versión 1.4.1 permite a atacantes locales escalar privilegios y obtener información confidencial a través del parámetro de cuentas en la nube."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-276"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:fit2cloud:cloudexplorer_lite:1.4.1:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "D1A5AC77-6B76-41A9-8EFF-B5CA089313D4"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/yaowenxiao721/CloudExplorer-Lite-v1.4.1-vulnerability-BOPLA",
+            "source": "cve@mitre.org",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-39853",
+        "sourceIdentifier": "cve@mitre.org",
+        "published": "2024-01-06T04:15:08.863",
+        "lastModified": "2024-01-11T14:47:18.230",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "SQL Injection vulnerability in Dzzoffice version 2.01, allows remote attackers to obtain sensitive information via the doobj and doevent parameters in the Network Disk backend module."
+          },
+          {
+            "lang": "es",
+            "value": "Vulnerabilidad de inyección SQL en Dzzoffice versión 2.01, permite a atacantes remotos obtener información confidencial a través de los parámetros doobj y doevent en el módulo backend de Network Disk."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.6
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:dzzoffice:dzzoffice:2.01:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "D2D4D8E0-87E3-437D-9F20-6E2292F3B41E"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/EternalGemini/dzz",
+            "source": "cve@mitre.org",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-50609",
+        "sourceIdentifier": "cve@mitre.org",
+        "published": "2024-01-06T04:15:08.930",
+        "lastModified": "2024-01-11T14:54:52.880",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Cross Site Scripting (XSS) vulnerability in AVA teaching video application service platform version 3.1, allows remote attackers to execute arbitrary code via a crafted script to ajax.aspx."
+          },
+          {
+            "lang": "es",
+            "value": "Vulnerabilidad de Cross Site Scripting (XSS) en la plataforma de servicios de aplicaciones de vídeo de enseñanza AVA versión 3.1, permite a atacantes remotos ejecutar código arbitrario a través de un script manipulado en ajax.aspx."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.1,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 2.7
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:ava:teaching_video_application_service_platform:3.1:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "B3E9111B-3DF7-4902-BF66-06546EB80C15"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://gist.github.com/zhishituboshu/f8f07e9df411b1ee3d8212a166b2034e",
+            "source": "cve@mitre.org",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-46953",
+        "sourceIdentifier": "cve@mitre.org",
+        "published": "2024-01-06T05:15:09.427",
+        "lastModified": "2024-01-11T17:06:37.437",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "SQL Injection vulnerability in ABO.CMS v.5.9.3, allows remote attackers to execute arbitrary code via the d parameter in the Documents module."
+          },
+          {
+            "lang": "es",
+            "value": "Vulnerabilidad de inyección SQL en ABO.CMS v.5.9.3, permite a atacantes remotos ejecutar código arbitrario a través del parámetro d en el módulo Documentos."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:abocms:abo.cms:5.9.3:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "68CBBD26-B5CE-4911-A44E-1025CC510418"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://cxsecurity.com/issue/WLB-2023120036",
+            "source": "cve@mitre.org",
+            "tags": [
+              "Issue Tracking",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-50121",
+        "sourceIdentifier": "cve@mitre.org",
+        "published": "2024-01-06T05:15:09.610",
+        "lastModified": "2024-01-12T18:47:56.143",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Autel EVO NANO drone flight control firmware version 1.6.5 is vulnerable to denial of service (DoS)."
+          },
+          {
+            "lang": "es",
+            "value": "La versión 1.6.5 del firmware de control de vuelo del dron Autel EVO NANO es vulnerable a la denegación de servicio (DoS)."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+                "attackVector": "ADJACENT_NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "HIGH",
+                "baseScore": 5.7,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.1,
+              "impactScore": 3.6
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "NVD-CWE-noinfo"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:autelrobotics:evo_nano_drone_firmware:1.6.5:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "91BAABA5-17FA-4FA7-A788-6B9AE411517C"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:autelrobotics:evo_nano_drone:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "FAD21CF8-41CB-4B63-B33C-F55DA30809E0"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/Drone-Lab/Reports-of-AUTEL-drones-losing-control-at-the-edge-of-the-no-fly-zone/tree/main",
+            "source": "cve@mitre.org",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-6798",
+        "sourceIdentifier": "security@wordfence.com",
+        "published": "2024-01-06T10:15:45.840",
+        "lastModified": "2024-01-12T18:47:11.793",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "The RSS Aggregator by Feedzy – Feed to Post, Autoblogging, News & YouTube Video Feeds Aggregator plugin for WordPress is vulnerable to unauthorized settings update due to a missing capability check when updating settings in all versions up to, and including, 4.3.2. This makes it possible for authenticated attackers, with author-level access or above to change the plugin's settings including proxy settings, which are also exposed to authors."
+          },
+          {
+            "lang": "es",
+            "value": "El complemento RSS Aggregator by Feedzy – Feed to Post, Autoblogging, News &amp; YouTube Video Feeds Aggregator para WordPress es vulnerable a actualizaciones de configuración no autorizadas debido a una falta de verificación de capacidad al actualizar la configuración en todas las versiones hasta la 4.3.2 incluida. Esto hace posible que atacantes autenticados, con acceso de nivel de autor o superior, cambien la configuración del complemento, incluida la configuración del proxy, que también está expuesta a los autores."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.4,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 2.5
+            },
+            {
+              "source": "security@wordfence.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.4,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 2.5
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-862"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:themeisle:rss_aggregator_by_feedzy:*:*:*:*:*:wordpress:*:*",
+                    "versionEndExcluding": "4.3.3",
+                    "matchCriteriaId": "F0D415BA-7AFD-494E-9DBC-AFB3AAFA1915"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&new=3012392%40feedzy-rss-feeds%2Ftrunk&old=2991547%40feedzy-rss-feeds%2Ftrunk&sfp_email=&sfph_mail=",
+            "source": "security@wordfence.com",
+            "tags": [
+              "Patch"
+            ]
+          },
+          {
+            "url": "https://www.wordfence.com/threat-intel/vulnerabilities/id/c2cdf4e5-0a40-42ca-b5ac-78511fdd2b77?source=cve",
+            "source": "security@wordfence.com",
+            "tags": [
+              "Patch",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-6801",
+        "sourceIdentifier": "security@wordfence.com",
+        "published": "2024-01-06T10:15:46.133",
+        "lastModified": "2024-01-12T21:05:21.497",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "The RSS Aggregator by Feedzy – Feed to Post, Autoblogging, News & YouTube Video Feeds Aggregator plugin for WordPress is vulnerable to Stored Cross-Site Scripting via admin settings in all versions up to, and including, 4.3.2 due to insufficient input sanitization and output escaping. This makes it possible for authenticated attackers, with author-level permissions and above, to inject arbitrary web scripts in pages that will execute whenever a user accesses an injected page."
+          },
+          {
+            "lang": "es",
+            "value": "El complemento RSS Aggregator by Feedzy – Feed to Post, Autoblogging, News &amp; YouTube Video Feeds Aggregator para WordPress es vulnerable a Cross-Site Scripting Almacenado a través de la configuración de administrador en todas las versiones hasta la 4.3.2 incluida debido a una sanitización de entrada insuficiente y salida que se escapa. Esto hace posible que atacantes autenticados, con permisos de nivel de autor y superiores, inyecten scripts web arbitrarios en páginas que se ejecutarán cada vez que un usuario acceda a una página inyectada."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.4,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.3,
+              "impactScore": 2.7
+            },
+            {
+              "source": "security@wordfence.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.4,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 3.1,
+              "impactScore": 2.7
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:themeisle:rss_aggregator_by_feedzy:*:*:*:*:*:wordpress:*:*",
+                    "versionEndExcluding": "4.3.3",
+                    "matchCriteriaId": "F0D415BA-7AFD-494E-9DBC-AFB3AAFA1915"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://plugins.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&new=3012392%40feedzy-rss-feeds%2Ftrunk&old=2991547%40feedzy-rss-feeds%2Ftrunk&sfp_email=&sfph_mail=",
+            "source": "security@wordfence.com",
+            "tags": [
+              "Patch"
+            ]
+          },
+          {
+            "url": "https://www.wordfence.com/threat-intel/vulnerabilities/id/a713d897-c549-4e0d-9cb3-7002ef2b127f?source=cve",
+            "source": "security@wordfence.com",
+            "tags": [
+              "Patch",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-51441",
+        "sourceIdentifier": "security@apache.org",
+        "published": "2024-01-06T12:15:42.997",
+        "lastModified": "2024-01-12T21:04:54.340",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "** UNSUPPORTED WHEN ASSIGNED ** Improper Input Validation vulnerability in Apache Axis allowed users with access to the admin service to perform possible SSRF\nThis issue affects Apache Axis: through 1.3.\n\nAs Axis 1 has been EOL we recommend you migrate to a different SOAP engine, such as Apache Axis 2/Java. Alternatively you could use a build of Axis with the patch from  https://github.com/apache/axis-axis1-java/commit/685c309febc64aa393b2d64a05f90e7eb9f73e06  applied. The Apache Axis project does not expect to create an Axis 1.x release \nfixing this problem, though contributors that would like to work towards\n this are welcome.\n\n"
+          },
+          {
+            "lang": "es",
+            "value": "** NO SOPORTADO CUANDO SE ASIGNÓ ** La vulnerabilidad de validación de entrada incorrecta en Apache Axis permitió a los usuarios con acceso al servicio de administración realizar posibles SSRF. Este problema afecta a Apache Axis: hasta 1.3. Como Axis 1 ha estado en EOL, le recomendamos migrar a un motor SOAP diferente, como Apache Axis 2/Java. Alternativamente, puede usar una compilación de Axis con el parche de https://github.com/apache/axis-axis1-java/commit/685c309febc64aa393b2d64a05f90e7eb9f73e06 aplicado. El proyecto Apache Axis no espera crear una versión Axis 1.x que solucione este problema, aunque los contribuyentes que deseen trabajar para lograrlo son bienvenidos."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "HIGH",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.2,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.2,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-918"
+              }
+            ]
+          },
+          {
+            "source": "security@apache.org",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-20"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:apache:axis:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.3",
+                    "matchCriteriaId": "D6E42C7C-08ED-4328-AAB8-FA052541C15B"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/apache/axis-axis1-java/commit/685c309febc64aa393b2d64a05f90e7eb9f73e06",
+            "source": "security@apache.org",
+            "tags": [
+              "Patch"
+            ]
+          },
+          {
+            "url": "https://lists.apache.org/thread/8nrm5thop8f82pglx4o0jg8wmvy6d9yd",
+            "source": "security@apache.org",
+            "tags": [
+              "Patch",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0260",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T00:15:42.550",
+        "lastModified": "2024-01-10T20:53:51.637",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability, which was classified as problematic, was found in SourceCodester Engineers Online Portal 1.0. Affected is an unknown function of the file change_password_teacher.php of the component Password Change. The manipulation leads to session expiration. It is possible to launch the attack remotely. The exploit has been disclosed to the public and may be used. The identifier of this vulnerability is VDB-249816."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en SourceCodester Engineers Online Portal 1.0 y clasificada como problemática. Una función desconocida del archivo change_password_teacher.php del componente Password Change es afectada por esta vulnerabilidad. La manipulación provoca la caducidad de la sesión. Es posible lanzar el ataque de forma remota. El exploit ha sido divulgado al público y puede utilizarse. El identificador de esta vulnerabilidad es VDB-249816."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "NONE",
+                "baseScore": 7.5,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 4.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 1.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:N/I:P/A:N",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "NONE",
+                "baseScore": 4.0
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 2.9,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-613"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:engineers_online_portal_project:engineers_online_portal:1.0:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "EE2C0236-1BC6-45DD-B5A5-1FE81BD75296"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://mega.nz/file/yEsSwK6D#--ygVt0NtzhZdqVxvjaPLCYfnIeBSyf76KaRozOxfVo",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249816",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249816",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0261",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T02:15:44.380",
+        "lastModified": "2024-01-10T20:49:43.997",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability has been found in Sentex FTPDMIN 0.96 and classified as problematic. Affected by this vulnerability is an unknown functionality of the component RNFR Command Handler. The manipulation leads to denial of service. The attack can be launched remotely. The exploit has been disclosed to the public and may be used. The identifier VDB-249817 was assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad ha sido encontrada en Sentex FTPDMIN 0.96 y clasificada como problemática. Una función desconocida del componente RNFR Command Handler es afectada por esta vulnerabilidad. La manipulación conduce a la denegación del servicio. El ataque se puede lanzar de forma remota. El exploit ha sido divulgado al público y puede utilizarse. A esta vulnerabilidad se le asignó el identificador VDB-249817."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.5,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "LOW",
+                "baseScore": 5.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 1.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 5.0
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 10.0,
+              "impactScore": 2.9,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-404"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:ftpdmin_project:ftpdmin:0.96:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "CD7B7D62-61DE-46E7-877E-F70D3F89B1C3"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://packetstormsecurity.com/files/176342/FTPDMIN-0.96-Denial-Of-Service.html",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249817",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249817",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=q-CVJfYdd-g",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0262",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T02:15:44.623",
+        "lastModified": "2024-01-10T20:24:53.017",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Online Job Portal 1.0 and classified as problematic. Affected by this issue is some unknown functionality of the file /Admin/News.php of the component Create News Page. The manipulation of the argument News with the input </title><scRipt>alert(0x00C57D)</scRipt> leads to cross site scripting. The attack may be launched remotely. The exploit has been disclosed to the public and may be used. VDB-249818 is the identifier assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Online Job Portal 1.0 y clasificada como problemática. Una función desconocida del archivo /Admin/News.php del componente Create News Page es afectada por esta vulnerabilidad. La manipulación del argumento News con la entrada  conduce a cross site scripting. El ataque puede lanzarse de forma remota. El exploit ha sido divulgado al público y puede utilizarse. VDB-249818 es el identificador asignado a esta vulnerabilidad."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "HIGH",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 4.8,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 1.7,
+              "impactScore": 2.7
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:U/C:N/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "HIGH",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 2.4,
+                "baseSeverity": "LOW"
+              },
+              "exploitabilityScore": 0.9,
+              "impactScore": 1.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:M/C:N/I:P/A:N",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "MULTIPLE",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "NONE",
+                "baseScore": 3.3
+              },
+              "baseSeverity": "LOW",
+              "exploitabilityScore": 6.4,
+              "impactScore": 2.9,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:projectworlds:online_job_portal:1.0:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "B22E69CD-056A-4C41-B3FC-7047D31465E8"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://mega.nz/file/zEsxyIYQ#re6pHT-2OGX9SNk1OpygDCQYu1RpBiOrQ_2QS6beRos",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249818",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249818",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0263",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T04:15:08.563",
+        "lastModified": "2024-01-10T20:43:55.220",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in ACME Ultra Mini HTTPd 1.21. It has been classified as problematic. This affects an unknown part of the component HTTP GET Request Handler. The manipulation leads to denial of service. It is possible to initiate the attack remotely. The exploit has been disclosed to the public and may be used. It is recommended to apply a patch to fix this issue. The associated identifier of this vulnerability is VDB-249819."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en ACME Ultra Mini HTTPd 1.21. Ha sido clasificada como problemática. Una parte desconocida del componente HTTP GET Request Handler afecta a una parte desconocida. La manipulación conduce a la denegación del servicio. Es posible iniciar el ataque de forma remota. El exploit ha sido divulgado al público y puede utilizarse. Se recomienda aplicar un parche para solucionar este problema. El identificador asociado de esta vulnerabilidad es VDB-249819."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.5,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "LOW",
+                "baseScore": 5.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 1.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 5.0
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 10.0,
+              "impactScore": 2.9,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-404"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:acme:ultra_mini_httpd:1.21:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "7785BB65-78ED-4BB9-B21B-8773EE528EF6"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://0day.today/exploit/description/39212",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://packetstormsecurity.com/files/176333/Ultra-Mini-HTTPd-1.21-Denial-Of-Service.html",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249819",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249819",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://www.youtube.com/watch?v=HWOGeg3e5As",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0264",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T05:15:09.143",
+        "lastModified": "2024-01-10T20:57:12.603",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in SourceCodester Clinic Queuing System 1.0. It has been declared as critical. This vulnerability affects unknown code of the file /LoginRegistration.php. The manipulation of the argument formToken leads to authorization bypass. The attack can be initiated remotely. The exploit has been disclosed to the public and may be used. The identifier of this vulnerability is VDB-249820."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en SourceCodester Clinic Queuing System 1.0. Ha sido declarada crítica. Esta vulnerabilidad afecta a un código desconocido del archivo /LoginRegistration.php. La manipulación del argumento formToken conduce a la omisión de autorización. El ataque se puede iniciar de forma remota. El exploit ha sido divulgado al público y puede utilizarse. El identificador de esta vulnerabilidad es VDB-249820."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 7.3,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 7.5
+              },
+              "baseSeverity": "HIGH",
+              "exploitabilityScore": 10.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-639"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:oretnom23:clinic_queuing_system:1.0:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "959FD20D-FEFB-455F-9689-7C16934B6290"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/jmrcsnchz/ClinicQueueingSystem_RCE/",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://github.com/jmrcsnchz/ClinicQueueingSystem_RCE/blob/main/clinicx.py",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249820",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249820",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0265",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T05:15:09.977",
+        "lastModified": "2024-01-11T16:42:37.937",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in SourceCodester Clinic Queuing System 1.0. It has been rated as critical. This issue affects some unknown processing of the file /index.php of the component GET Parameter Handler. The manipulation of the argument page leads to file inclusion. The attack may be initiated remotely. The exploit has been disclosed to the public and may be used. The identifier VDB-249821 was assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en SourceCodester Clinic Queuing System 1.0. Ha sido calificada como crítica. Este problema afecta un procesamiento desconocido del archivo /index.php del componente GET Parameter Handler. La manipulación de la página de argumentos conduce a la inclusión del archivo. El ataque puede iniciarse de forma remota. El exploit ha sido divulgado al público y puede utilizarse. A esta vulnerabilidad se le asignó el identificador VDB-249821."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 8.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-73"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:oretnom23:clinic_queuing_system:1.0:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "959FD20D-FEFB-455F-9689-7C16934B6290"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/jmrcsnchz/ClinicQueueingSystem_RCE",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://github.com/jmrcsnchz/ClinicQueueingSystem_RCE/blob/main/clinicx.py",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249821",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249821",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0266",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T06:15:47.507",
+        "lastModified": "2024-01-11T16:41:04.007",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability classified as problematic has been found in Project Worlds Online Lawyer Management System 1.0. Affected is an unknown function of the component User Registration. The manipulation of the argument First Name leads to cross site scripting. It is possible to launch the attack remotely. The exploit has been disclosed to the public and may be used. VDB-249822 is the identifier assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad ha sido encontrada en Project Worlds Online Lawyer Management System 1.0 y clasificada como problemática. Una función desconocida del componente User Registration es afectada por esta vulnerabilidad. La manipulación del argumento First Name conduce a cross site scripting. Es posible lanzar el ataque de forma remota. El exploit ha sido divulgado al público y puede utilizarse. VDB-249822 es el identificador asignado a esta vulnerabilidad."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.4,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.3,
+              "impactScore": 2.7
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 4.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 1.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.0
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 10.0,
+              "impactScore": 2.9,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          },
+          {
+            "source": "cna@vuldb.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:yugeshverma:online_lawyer_management_system:1.0:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "9D50A11E-4B14-4439-8347-1D18A36D2406"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://drive.google.com/file/d/1U60z1xzBzJjalbmwBmPD5NjJ4pPaDevF/view?usp=sharing",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249822",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249822",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0267",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T06:15:47.863",
+        "lastModified": "2024-01-11T16:40:24.620",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability classified as critical was found in Kashipara Hospital Management System up to 1.0. Affected by this vulnerability is an unknown functionality of the file login.php of the component Parameter Handler. The manipulation of the argument email/password leads to sql injection. The attack can be launched remotely. The exploit has been disclosed to the public and may be used. The associated identifier of this vulnerability is VDB-249823."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Kashipara Hospital Management System hasta 1.0 y clasificada como crítica. Una función desconocida del archivo login.php del componente Parameter Handler es afectada por esta vulnerabilidad. La manipulación del argumento email/password conduce a la inyección de SQL. El ataque se puede lanzar de forma remota. El exploit ha sido divulgado al público y puede utilizarse. El identificador asociado de esta vulnerabilidad es VDB-249823."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 7.3,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 7.5
+              },
+              "baseSeverity": "HIGH",
+              "exploitabilityScore": 10.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:surajghosh:hospital_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "833B5FD2-E06E-411D-9130-588E3221E701"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Hospital%20Managment%20System/Hospital%20Managment%20System%20-%20vuln%201.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249823",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249823",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-7208",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T07:15:07.777",
+        "lastModified": "2024-01-11T16:39:58.583",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability classified as critical was found in Totolink X2000R_V2 2.0.0-B20230727.10434. This vulnerability affects the function formTmultiAP of the file /bin/boa. The manipulation leads to buffer overflow. VDB-249742 is the identifier assigned to this vulnerability. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Totolink X2000R_V2 2.0.0-B20230727.10434 y clasificada como crítica. Esta vulnerabilidad afecta a la función formTmultiAP del archivo /bin/boa. La manipulación provoca un desbordamiento de búfer. VDB-249742 es el identificador asignado a esta vulnerabilidad. NOTA: Se contactó primeramente con el proveedor sobre esta divulgación, pero no respondió de ninguna manera."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "ADJACENT_NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 8.0,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.1,
+              "impactScore": 5.9
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:A/AC:L/Au:S/C:C/I:C/A:C",
+                "accessVector": "ADJACENT_NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "COMPLETE",
+                "integrityImpact": "COMPLETE",
+                "availabilityImpact": "COMPLETE",
+                "baseScore": 7.7
+              },
+              "baseSeverity": "HIGH",
+              "exploitabilityScore": 5.1,
+              "impactScore": 10.0,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-787"
+              }
+            ]
+          },
+          {
+            "source": "cna@vuldb.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-120"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:totolink:x2000r_firmware:2.0.0-b20230727.10434:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "2DC1EF3D-D4D0-4793-9418-0C12884718CC"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:totolink:x2000r:v2:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "E04390BE-A47B-4821-8552-42035775A2FB"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/unpWn4bL3/iot-security/blob/main/13.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249742",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249742",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0268",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T08:15:07.393",
+        "lastModified": "2024-01-11T16:39:21.907",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability, which was classified as critical, has been found in Kashipara Hospital Management System up to 1.0. Affected by this issue is some unknown functionality of the file registration.php. The manipulation of the argument name/email/pass/gender/age/city leads to sql injection. The attack may be launched remotely. The exploit has been disclosed to the public and may be used. The identifier of this vulnerability is VDB-249824."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Kashipara Hospital Management System hasta 1.0 y clasificada como crítica. Una función desconocida del archivo registration.php es afectada por esta vulnerabilidad. La manipulación del argumento name/email/pass/gender/age/city conduce a la inyección de SQL. El ataque puede lanzarse de forma remota. El exploit ha sido divulgado al público y puede utilizarse. El identificador de esta vulnerabilidad es VDB-249824."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 7.3,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 7.5
+              },
+              "baseSeverity": "HIGH",
+              "exploitabilityScore": 10.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:surajghosh:hospital_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "833B5FD2-E06E-411D-9130-588E3221E701"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Hospital%20Managment%20System/Hospital%20Managment%20System%20-%20vuln%202.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249824",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249824",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0270",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T08:15:07.840",
+        "lastModified": "2024-01-08T19:04:24.233",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability, which was classified as critical, was found in Kashipara Food Management System up to 1.0. This affects an unknown part of the file item_list_submit.php. The manipulation of the argument item_name leads to sql injection. It is possible to initiate the attack remotely. The exploit has been disclosed to the public and may be used. The identifier VDB-249825 was assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Kashipara Food Management System hasta 1.0 y clasificada como crítica. Esto afecta a una parte desconocida del archivo item_list_submit.php. La manipulación del argumento item_name conduce a la inyección de SQL. Es posible iniciar el ataque de forma remota. El exploit ha sido divulgado al público y puede utilizarse. A esta vulnerabilidad se le asignó el identificador VDB-249825."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "BBBECC06-F3D5-4B63-8EB2-8E44A64624C5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%201.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249825",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249825",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-7209",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T09:15:08.853",
+        "lastModified": "2024-01-11T16:39:04.073",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Uniway Router up to 2.0. It has been rated as critical. Affected by this issue is some unknown functionality of the file /boaform/device_reset.cgi of the component Device Reset Handler. The manipulation leads to denial of service. The attack may be launched remotely. The exploit has been disclosed to the public and may be used. VDB-249758 is the identifier assigned to this vulnerability. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Uniway Router hasta 2.0. Ha sido calificada como crítica. Una función desconocida del archivo /boaform/device_reset.cgi del componente Device Reset Handler es afectada por esta vulnerabilidad. La manipulación conduce a la denegación del servicio. El ataque puede lanzarse de forma remota. El exploit ha sido divulgado al público y puede utilizarse. VDB-249758 es el identificador asignado a esta vulnerabilidad. NOTA: Se contactó primeramente con el proveedor sobre esta divulgación, pero no respondió de ninguna manera."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.5,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.5,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:N/I:N/A:C",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "COMPLETE",
+                "baseScore": 7.8
+              },
+              "baseSeverity": "HIGH",
+              "exploitabilityScore": 10.0,
+              "impactScore": 6.9,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-404"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:uniwayinfo:uw-302vp_firmware:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "2.0",
+                    "matchCriteriaId": "18BBE0D0-FB50-4A06-BF01-0E0AF36D818A"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:uniwayinfo:uw-302vp:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "BEB01B31-0127-430F-8683-4A90FE8BA490"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:uniwayinfo:uw-301vpw_firmware:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "2.0",
+                    "matchCriteriaId": "53622468-2B03-4FCF-B276-10BD7B358C1E"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:uniwayinfo:uw-301vpw:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "B402537E-B61D-4AF8-B296-AA5BC436647E"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:uniwayinfo:uw-311vpw_firmware:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "2.0",
+                    "matchCriteriaId": "ED8449AE-75A2-4E6E-9292-EBD65E51DDB2"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:uniwayinfo:uw-311vpw:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "BB6600B5-7B6E-4724-BE96-F35AFD245F9C"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:uniwayinfo:uw-101x_firmware:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "2.0",
+                    "matchCriteriaId": "60EF06FF-C812-45C0-8FD0-804756C153FB"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:uniwayinfo:uw-101x:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3E158FFE-DC0B-4E9E-9326-D25C600F22E0"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:uniwayinfo:uw-323dac_firmware:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "2.0",
+                    "matchCriteriaId": "C48E72D2-7641-40B9-8FE1-961EE903FFA9"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:uniwayinfo:uw-323dac:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "14CDD53C-E865-4E70-876F-5587BE57F102"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://drive.google.com/file/d/1XDZA4ibiYNcxTwq60vYCr03_6M_cvJ_2/view?usp=sharing",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249758",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249758",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0271",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T09:15:09.140",
+        "lastModified": "2024-01-08T18:21:11.393",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability has been found in Kashipara Food Management System up to 1.0 and classified as critical. This vulnerability affects unknown code of the file addmaterial_edit.php. The manipulation of the argument id leads to sql injection. The attack can be initiated remotely. The exploit has been disclosed to the public and may be used. VDB-249826 is the identifier assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Kashipara Food Management System hasta 1.0 y clasificada como crítica. Esta vulnerabilidad afecta a un código desconocido del archivo addmaterial_edit.php. La manipulación del argumento id conduce a la inyección de SQL. El ataque se puede iniciar de forma remota. El exploit ha sido divulgado al público y puede utilizarse. VDB-249826 es el identificador asignado a esta vulnerabilidad."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "BBBECC06-F3D5-4B63-8EB2-8E44A64624C5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%206.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249826",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249826",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-7210",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T10:15:08.660",
+        "lastModified": "2024-01-11T16:38:36.473",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in OneNav up to 0.9.33. It has been classified as critical. This affects an unknown part of the file /index.php?c=api of the component API. The manipulation of the argument X-Token leads to improper authentication. It is possible to initiate the attack remotely. The exploit has been disclosed to the public and may be used. The identifier VDB-249765 was assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en OneNav hasta 0.9.33. Ha sido clasificada como crítica. Esto afecta a una parte desconocida del archivo /index.php?c=api del componente API. La manipulación del argumento X-Token conduce a una autenticación incorrecta. Es posible iniciar el ataque de forma remota. El exploit ha sido divulgado al público y puede utilizarse. A esta vulnerabilidad se le asignó el identificador VDB-249765."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 7.3,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 7.5
+              },
+              "baseSeverity": "HIGH",
+              "exploitabilityScore": 10.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-287"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:onenav:onenav:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "0.9.33",
+                    "matchCriteriaId": "46E372A6-DEDE-43F1-AE48-5C31138485DB"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/advisories/GHSA-353q-7h99-hf4x",
+            "source": "nvd@nist.gov",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://note.zhaoj.in/share/eRbUygGMiJcp",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Broken Link"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249765",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249765",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-7211",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T10:15:08.907",
+        "lastModified": "2024-01-11T16:38:09.450",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Uniway Router 2.0. It has been declared as critical. This vulnerability affects unknown code of the component Administrative Web Interface. The manipulation leads to reliance on ip address for authentication. The attack can be initiated remotely. The complexity of an attack is rather high. The exploitation appears to be difficult. The exploit has been disclosed to the public and may be used. VDB-249766 is the identifier assigned to this vulnerability. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Uniway Router 2.0. Ha sido declarada crítica. Esta vulnerabilidad afecta a código desconocido del componente Administrative Web Interface. La manipulación lleva a depender de la dirección IP para la autenticación. El ataque se puede iniciar de forma remota. La complejidad de un ataque es bastante alta. La explotación parece difícil. El exploit ha sido divulgado al público y puede utilizarse. VDB-249766 es el identificador asignado a esta vulnerabilidad. NOTA: Se contactó primeramente con el proveedor sobre esta divulgación, pero no respondió de ninguna manera."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "HIGH",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 8.1,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.2,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "HIGH",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 5.6,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.2,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:H/Au:N/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "HIGH",
+                "authentication": "NONE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 5.1
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 4.9,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-287"
+              }
+            ]
+          },
+          {
+            "source": "cna@vuldb.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-291"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:uniwayinfo:uw-302vp_firmware:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "2.0",
+                    "matchCriteriaId": "18BBE0D0-FB50-4A06-BF01-0E0AF36D818A"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:uniwayinfo:uw-302vp:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "BEB01B31-0127-430F-8683-4A90FE8BA490"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:uniwayinfo:uw-301vpw_firmware:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "2.0",
+                    "matchCriteriaId": "53622468-2B03-4FCF-B276-10BD7B358C1E"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:uniwayinfo:uw-301vpw:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "B402537E-B61D-4AF8-B296-AA5BC436647E"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:uniwayinfo:uw-311vpw_firmware:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "2.0",
+                    "matchCriteriaId": "ED8449AE-75A2-4E6E-9292-EBD65E51DDB2"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:uniwayinfo:uw-311vpw:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "BB6600B5-7B6E-4724-BE96-F35AFD245F9C"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:uniwayinfo:uw-101x_firmware:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "2.0",
+                    "matchCriteriaId": "60EF06FF-C812-45C0-8FD0-804756C153FB"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:uniwayinfo:uw-101x:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3E158FFE-DC0B-4E9E-9326-D25C600F22E0"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:uniwayinfo:uw-323dac_firmware:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "2.0",
+                    "matchCriteriaId": "C48E72D2-7641-40B9-8FE1-961EE903FFA9"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:uniwayinfo:uw-323dac:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "14CDD53C-E865-4E70-876F-5587BE57F102"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://drive.google.com/file/d/11thSuALGcn0C_9tbmYu8_QzTXtBnCoNS/view?usp=sharing",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249766",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249766",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0272",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T11:15:16.537",
+        "lastModified": "2024-01-08T18:21:25.347",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Kashipara Food Management System up to 1.0 and classified as critical. This issue affects some unknown processing of the file addmaterialsubmit.php. The manipulation of the argument material_name leads to sql injection. The attack may be initiated remotely. The exploit has been disclosed to the public and may be used. The associated identifier of this vulnerability is VDB-249827."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Kashipara Food Management System hasta 1.0 y se clasificó como crítica. Este problema afecta un procesamiento desconocido del archivo addmaterialsubmit.php. La manipulación del argumento material_name conduce a la inyección SQL. El ataque puede iniciarse de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador asociado de esta vulnerabilidad es VDB-249827."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          },
+          {
+            "source": "cna@vuldb.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "BBBECC06-F3D5-4B63-8EB2-8E44A64624C5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%208.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249827",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249827",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0273",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T11:15:16.987",
+        "lastModified": "2024-01-08T18:19:08.660",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Kashipara Food Management System up to 1.0. It has been classified as critical. Affected is an unknown function of the file addwaste_entry.php. The manipulation of the argument item_name leads to sql injection. It is possible to launch the attack remotely. The exploit has been disclosed to the public and may be used. The identifier of this vulnerability is VDB-249828."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Kashipara Food Management System hasta la versión 1.0. Ha sido clasificada como crítica. Una función desconocida del archivo addwaste_entry.php es afectada por esta vulnerabilidad. La manipulación del argumento item_name conduce a la inyección de SQL. Es posible lanzar el ataque de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador de esta vulnerabilidad es VDB-249828."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "BBBECC06-F3D5-4B63-8EB2-8E44A64624C5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%203.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249828",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249828",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0274",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T12:15:14.580",
+        "lastModified": "2024-01-08T18:19:13.867",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Kashipara Food Management System up to 1.0. It has been declared as critical. Affected by this vulnerability is an unknown functionality of the file billAjax.php. The manipulation of the argument item_name leads to sql injection. The attack can be launched remotely. The exploit has been disclosed to the public and may be used. The identifier VDB-249829 was assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Kashipara Food Management System hasta la versión 1.0. Ha sido declarada crítica. Una función desconocida del archivo billAjax.php es afectada por esta vulnerabilidad. La manipulación del argumento item_name conduce a la inyección de SQL. El ataque se puede lanzar de forma remota. La explotación ha sido divulgada al público y puede utilizarse. A esta vulnerabilidad se le asignó el identificador VDB-249829."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "BBBECC06-F3D5-4B63-8EB2-8E44A64624C5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%202.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249829",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249829",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0275",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T12:15:14.820",
+        "lastModified": "2024-01-08T18:19:20.420",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Kashipara Food Management System up to 1.0. It has been rated as critical. Affected by this issue is some unknown functionality of the file item_edit_submit.php. The manipulation of the argument id leads to sql injection. The attack may be launched remotely. The exploit has been disclosed to the public and may be used. VDB-249830 is the identifier assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Kashipara Food Management System hasta la versión 1.0. Ha sido calificada como crítica. Una función desconocida del archivo item_edit_submit.php es afectada por esta vulnerabilidad. La manipulación del argumento id conduce a la inyección de SQL. El ataque puede lanzarse de forma remota. La explotación ha sido divulgada al público y puede utilizarse. VDB-249830 es el identificador asignado a esta vulnerabilidad."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "BBBECC06-F3D5-4B63-8EB2-8E44A64624C5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%204.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249830",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249830",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0276",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T13:15:08.293",
+        "lastModified": "2024-01-08T18:18:13.730",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability classified as critical has been found in Kashipara Food Management System up to 1.0. This affects an unknown part of the file rawstock_used_damaged_smt.php. The manipulation of the argument product_name leads to sql injection. It is possible to initiate the attack remotely. The exploit has been disclosed to the public and may be used. The associated identifier of this vulnerability is VDB-249831."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Kashipara Food Management System hasta 1.0 y clasificada como crítica. Una parte desconocida del archivo afecta a rawstock_used_damged_smt.php. La manipulación del argumento product_name conduce a la inyección SQL. Es posible iniciar el ataque de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador asociado de esta vulnerabilidad es VDB-249831."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "BBBECC06-F3D5-4B63-8EB2-8E44A64624C5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%205.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249831",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249831",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0277",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T13:15:08.540",
+        "lastModified": "2024-01-08T18:18:21.587",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability classified as critical was found in Kashipara Food Management System up to 1.0. This vulnerability affects unknown code of the file party_submit.php. The manipulation of the argument party_name leads to sql injection. The attack can be initiated remotely. The exploit has been disclosed to the public and may be used. The identifier of this vulnerability is VDB-249832."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Kashipara Food Management System hasta 1.0 y clasificada como crítica. Esta vulnerabilidad afecta a un código desconocido del archivo party_submit.php. La manipulación del argumento party_name conduce a la inyección de SQL. El ataque se puede iniciar de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador de esta vulnerabilidad es VDB-249832."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "BBBECC06-F3D5-4B63-8EB2-8E44A64624C5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%209.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249832",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249832",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0278",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T14:15:43.297",
+        "lastModified": "2024-01-08T18:18:29.317",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability, which was classified as critical, has been found in Kashipara Food Management System up to 1.0. This issue affects some unknown processing of the file partylist_edit_submit.php. The manipulation of the argument id leads to sql injection. The attack may be initiated remotely. The exploit has been disclosed to the public and may be used. The identifier VDB-249833 was assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Kashipara Food Management System hasta 1.0 y clasificada como crítica. Este problema afecta un procesamiento desconocido del archivo partylist_edit_submit.php. La manipulación del argumento id conduce a la inyección de SQL. El ataque puede iniciarse de forma remota. La explotación ha sido divulgada al público y puede utilizarse. A esta vulnerabilidad se le asignó el identificador VDB-249833."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "BBBECC06-F3D5-4B63-8EB2-8E44A64624C5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%2010.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249833",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249833",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0279",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T14:15:43.543",
+        "lastModified": "2024-01-08T18:18:37.673",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability, which was classified as critical, was found in Kashipara Food Management System up to 1.0. Affected is an unknown function of the file item_list_edit.php. The manipulation of the argument id leads to sql injection. It is possible to launch the attack remotely. The exploit has been disclosed to the public and may be used. VDB-249834 is the identifier assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Kashipara Food Management System hasta 1.0 y clasificada como crítica. Una función desconocida del archivo item_list_edit.php es afectada por esta vulnerabilidad. La manipulación del argumento id conduce a la inyección de SQL. Es posible lanzar el ataque de forma remota. La explotación ha sido divulgada al público y puede utilizarse. VDB-249834 es el identificador asignado a esta vulnerabilidad."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          },
+          {
+            "source": "cna@vuldb.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "BBBECC06-F3D5-4B63-8EB2-8E44A64624C5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%2011.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249834",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249834",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0280",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T15:15:08.917",
+        "lastModified": "2024-01-08T18:04:43.933",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability has been found in Kashipara Food Management System up to 1.0 and classified as critical. Affected by this vulnerability is an unknown functionality of the file item_type_submit.php. The manipulation of the argument type_name leads to sql injection. The attack can be launched remotely. The exploit has been disclosed to the public and may be used. The associated identifier of this vulnerability is VDB-249835."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Kashipara Food Management System hasta 1.0 y clasificada como crítica. Una función desconocida del archivo item_type_submit.php es afectada por esta vulnerabilidad. La manipulación del argumento type_name conduce a la inyección de SQL. El ataque se puede lanzar de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador asociado de esta vulnerabilidad es VDB-249835."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "BBBECC06-F3D5-4B63-8EB2-8E44A64624C5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%2012.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249835",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249835",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0281",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T15:15:09.157",
+        "lastModified": "2024-01-08T18:04:28.407",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Kashipara Food Management System up to 1.0 and classified as critical. Affected by this issue is some unknown functionality of the file loginCheck.php. The manipulation of the argument password leads to sql injection. The attack may be launched remotely. The exploit has been disclosed to the public and may be used. The identifier of this vulnerability is VDB-249836."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Kashipara Food Management System hasta 1.0 y se clasificó como crítica. Una función desconocida del archivo loginCheck.php es afectada por esta vulnerabilidad. La manipulación del argumento password conduce a la inyección de SQL. El ataque puede lanzarse de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador de esta vulnerabilidad es VDB-249836."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "BBBECC06-F3D5-4B63-8EB2-8E44A64624C5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%2013.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249836",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249836",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0282",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T16:15:44.133",
+        "lastModified": "2024-01-08T17:55:46.990",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Kashipara Food Management System up to 1.0. It has been classified as problematic. This affects an unknown part of the file addmaterialsubmit.php. The manipulation of the argument tin leads to cross site scripting. It is possible to initiate the attack remotely. The exploit has been disclosed to the public and may be used. The identifier VDB-249837 was assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Kashipara Food Management System hasta la versión 1.0. Ha sido clasificada como problemática. Una parte desconocida del archivo addmaterialsubmit.php afecta a esta vulnerabilidad. La manipulación del argumento tin puede conducir a cross site scripting. Es posible iniciar el ataque de forma remota. La explotación ha sido divulgada al público y puede utilizarse. A esta vulnerabilidad se le asignó el identificador VDB-249837."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.1,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 2.7
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:N/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 3.5,
+                "baseSeverity": "LOW"
+              },
+              "exploitabilityScore": 2.1,
+              "impactScore": 1.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:N/I:P/A:N",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "NONE",
+                "baseScore": 4.0
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 2.9,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "BBBECC06-F3D5-4B63-8EB2-8E44A64624C5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%2014.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249837",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249837",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0283",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T16:15:44.380",
+        "lastModified": "2024-01-08T17:55:40.947",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Kashipara Food Management System up to 1.0. It has been declared as problematic. This vulnerability affects unknown code of the file party_details.php. The manipulation of the argument party_name leads to cross site scripting. The attack can be initiated remotely. The exploit has been disclosed to the public and may be used. VDB-249838 is the identifier assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Kashipara Food Management System hasta la versión 1.0. Ha sido declarada problemática. Esta vulnerabilidad afecta a un código desconocido del archivo party_details.php. La manipulación del argumento party_name conduce a cross site scripting. El ataque se puede iniciar de forma remota. La explotación ha sido divulgada al público y puede utilizarse. VDB-249838 es el identificador asignado a esta vulnerabilidad."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.1,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 2.7
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:N/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 3.5,
+                "baseSeverity": "LOW"
+              },
+              "exploitabilityScore": 2.1,
+              "impactScore": 1.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:N/I:P/A:N",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "NONE",
+                "baseScore": 4.0
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 2.9,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:wordpress:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "E98CB91D-E1CA-417D-93AB-CB57FED7496C"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%2015.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249838",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249838",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-7212",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T17:15:08.180",
+        "lastModified": "2024-01-11T18:13:57.037",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability classified as critical has been found in DeDeCMS up to 5.7.112. Affected is an unknown function of the file file_class.php of the component Backend. The manipulation leads to unrestricted upload. It is possible to launch the attack remotely. The exploit has been disclosed to the public and may be used. The identifier of this vulnerability is VDB-249768. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad ha sido encontrada en DeDeCMS hasta 5.7.112 y clasificada como crítica. Una función desconocida del archivo file_class.php del componente Backend es afectada por esta vulnerabilidad. La manipulación conduce a una carga sin restricciones. Es posible lanzar el ataque de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador de esta vulnerabilidad es VDB-249768. NOTA: Se contactó primeramente al proveedor sobre esta divulgación, pero no respondió de ninguna forma."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "HIGH",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 4.7,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 1.2,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:M/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "MULTIPLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 5.8
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 6.4,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-434"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:dedecms:dedecms:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "5.7.112",
+                    "matchCriteriaId": "631E4A1A-04EF-45CF-8948-E0701CF12B8A"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://hmxwjm7x03.feishu.cn/docx/FPjhdYcQvocR4gxy34Rc0pmon5e?from=from_copylink",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Not Applicable"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249768",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249768",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0284",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T17:15:08.427",
+        "lastModified": "2024-01-08T17:50:23.470",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Kashipara Food Management System up to 1.0. It has been rated as problematic. This issue affects some unknown processing of the file party_submit.php. The manipulation of the argument party_address leads to cross site scripting. The attack may be initiated remotely. The exploit has been disclosed to the public and may be used. The associated identifier of this vulnerability is VDB-249839."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Kashipara Food Management System hasta la versión 1.0. Ha sido calificada como problemática. Este problema afecta un procesamiento desconocido del archivo party_submit.php. La manipulación del argumento party_address conduce a cross site scripting. El ataque puede iniciarse de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador asociado de esta vulnerabilidad es VDB-249839."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.1,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 2.7
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:N/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 3.5,
+                "baseSeverity": "LOW"
+              },
+              "exploitabilityScore": 2.1,
+              "impactScore": 1.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:N/I:P/A:N",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "NONE",
+                "baseScore": 4.0
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 2.9,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "BBBECC06-F3D5-4B63-8EB2-8E44A64624C5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Food%20Management%20System/Food%20Management%20System%20-%20vuln%2016.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249839",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249839",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0286",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T18:15:16.383",
+        "lastModified": "2024-01-11T16:35:40.620",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability, which was classified as problematic, was found in PHPGurukul Hospital Management System 1.0. This affects an unknown part of the file index.php#contact_us of the component Contact Form. The manipulation of the argument Name/Email/Message leads to cross site scripting. It is possible to initiate the attack remotely. The exploit has been disclosed to the public and may be used. The associated identifier of this vulnerability is VDB-249843."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en PHPGurukul Hospital Management System 1.0 y clasificada como problemática. Esto afecta a una parte desconocida del archivo index.php#contact_us del componente Contact Form. La manipulación del argumento Name/Email/Message conduce a cross site scripting. Es posible iniciar el ataque de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador asociado de esta vulnerabilidad es VDB-249843."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.1,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 2.7
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 4.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 1.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.0
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 10.0,
+              "impactScore": 2.9,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:phpgurukul:hospital_management_system:1.0:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "0D7CB92F-609E-4807-A613-7AA413460314"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://drive.google.com/file/d/1MkVtMe63h5TlZvcC_Hc1fn6dn-jwNR8l/view?usp=sharing",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249843",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249843",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-47145",
+        "sourceIdentifier": "psirt@us.ibm.com",
+        "published": "2024-01-07T19:15:08.017",
+        "lastModified": "2024-01-11T16:01:42.240",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "IBM Db2 for Windows (includes Db2 Connect Server) 10.5, 11.1, and 11.5 could allow a local user to escalate their privileges to the SYSTEM user using the MSI repair functionality.  IBM X-Force ID:  270402."
+          },
+          {
+            "lang": "es",
+            "value": "IBM Db2 para Windows (incluye Db2 Connect Server) 10.5, 11.1 y 11.5 podría permitir a un usuario local escalar sus privilegios al usuario de SYSTEM mediante la funcionalidad de reparación de MSI ID de IBM X-Force: 270402."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "psirt@us.ibm.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 8.4,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.5,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "NVD-CWE-noinfo"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:ibm:db2:*:*:*:*:*:*:*:*",
+                    "versionStartIncluding": "10.5",
+                    "versionEndExcluding": "10.5.0.11",
+                    "matchCriteriaId": "2E5A16E6-977D-4085-BACC-5508E460FC88"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:ibm:db2:*:*:*:*:*:*:*:*",
+                    "versionStartIncluding": "11.1",
+                    "versionEndExcluding": "11.1.4.7",
+                    "matchCriteriaId": "59C1181B-4576-4572-9162-A70BAB52FF9A"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:ibm:db2:*:*:*:*:*:*:*:*",
+                    "versionStartIncluding": "11.5",
+                    "versionEndExcluding": "11.5.8",
+                    "matchCriteriaId": "65161064-A4A3-48E5-AC0A-388429FF2F53"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "A2572D17-1DE6-457B-99CC-64AFD54487EA"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/270402",
+            "source": "psirt@us.ibm.com",
+            "tags": [
+              "VDB Entry",
+              "Vendor Advisory"
+            ]
+          },
+          {
+            "url": "https://www.ibm.com/support/pages/node/7105500",
+            "source": "psirt@us.ibm.com",
+            "tags": [
+              "Vendor Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-7213",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T19:15:08.230",
+        "lastModified": "2024-01-11T15:59:41.537",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability classified as critical was found in Totolink N350RT 9.3.5u.6139_B20201216. Affected by this vulnerability is the function main of the file /cgi-bin/cstecgi.cgi?action=login&flag=1 of the component HTTP POST Request Handler. The manipulation of the argument v33 leads to stack-based buffer overflow. The attack can be launched remotely. The exploit has been disclosed to the public and may be used. The identifier VDB-249769 was assigned to this vulnerability. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Totolink N350RT 9.3.5u.6139_B20201216 y clasificada como crítica. La función main del archivo /cgi-bin/cstecgi.cgi?action=login&amp;flag=1 del componente HTTP POST Request Handler es afectada por esta vulnerabilidad. La manipulación del argumento v33 provoca un desbordamiento de búfer en la región stack de la memoria. El ataque se puede lanzar de forma remota. La explotación ha sido divulgada al público y puede utilizarse. A esta vulnerabilidad se le asignó el identificador VDB-249769. NOTA: Se contactó primeramente al proveedor sobre esta divulgación, pero no respondió de ninguna forma."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 8.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-787"
+              }
+            ]
+          },
+          {
+            "source": "cna@vuldb.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-121"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:totolink:n350rt_firmware:9.3.5u.6139_b20201216:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "1E783757-7B3B-426D-A7CB-0FEE15BA7EA7"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:totolink:n350rt:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "4B88D1F1-F7A6-43D5-8DF7-E9425823C7B6"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/jylsec/vuldb/blob/main/TOTOLINK/N350RT/2/README.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249769",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249769",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-7214",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T20:15:47.560",
+        "lastModified": "2024-01-11T15:59:23.280",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability, which was classified as critical, has been found in Totolink N350RT 9.3.5u.6139_B20201216. Affected by this issue is the function main of the file /cgi-bin/cstecgi.cgi?action=login of the component HTTP POST Request Handler. The manipulation of the argument v8 leads to stack-based buffer overflow. The attack may be launched remotely. The exploit has been disclosed to the public and may be used. VDB-249770 is the identifier assigned to this vulnerability. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Totolink N350RT 9.3.5u.6139_B20201216 y clasificada como crítica. La función main del archivo /cgi-bin/cstecgi.cgi?action=login del componente HTTP POST Request Handler es afectada por esta vulnerabilidad. La manipulación del argumento v8 provoca un desbordamiento de búfer en la región stack de la memoria. El ataque puede lanzarse de forma remota. La explotación ha sido divulgada al público y puede utilizarse. VDB-249770 es el identificador asignado a esta vulnerabilidad. NOTA: Se contactó primeramente al proveedor sobre esta divulgación, pero no respondió de ninguna forma."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 8.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-787"
+              }
+            ]
+          },
+          {
+            "source": "cna@vuldb.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-121"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:totolink:n350rt_firmware:9.3.5u.6139_b20201216:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "1E783757-7B3B-426D-A7CB-0FEE15BA7EA7"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:totolink:n350rt:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "4B88D1F1-F7A6-43D5-8DF7-E9425823C7B6"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/jylsec/vuldb/blob/main/TOTOLINK/N350RT/3/README.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249770",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249770",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0287",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-07T23:15:43.607",
+        "lastModified": "2024-01-08T17:51:58.093",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Kashipara Food Management System 1.0. It has been rated as critical. Affected by this issue is some unknown functionality of the file itemBillPdf.php. The manipulation of the argument printid leads to sql injection. The attack may be launched remotely. The exploit has been disclosed to the public and may be used. The identifier of this vulnerability is VDB-249848."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Kashipara Food Management System 1.0. Ha sido calificada como crítica. Una función desconocida del archivo itemBillPdf.php es afectada por esta vulnerabilidad. La manipulación del argumento printid conduce a la inyección de SQL. El ataque puede lanzarse de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador de esta vulnerabilidad es VDB-249848."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:1.0:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "162932BA-98AD-4F73-AE9D-29FDFD4CA3AE"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/laoquanshi/heishou/blob/main/Food%20Management%20System%20SQL%20Injection%20Vulnerability5.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249848",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249848",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0288",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T00:15:43.947",
+        "lastModified": "2024-01-08T17:52:18.343",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability classified as critical has been found in Kashipara Food Management System 1.0. This affects an unknown part of the file rawstock_used_damaged_submit.php. The manipulation of the argument product_name leads to sql injection. It is possible to initiate the attack remotely. The exploit has been disclosed to the public and may be used. The identifier VDB-249849 was assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Kashipara Food Management System 1.0 y clasificada como crítica. Esto afecta a una parte desconocida del archivo rawstock_used_damged_submit.php. La manipulación del argumento product_name conduce a la inyección SQL. Es posible iniciar el ataque de forma remota. La explotación ha sido divulgada al público y puede utilizarse. A esta vulnerabilidad se le asignó el identificador VDB-249849."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:1.0:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "162932BA-98AD-4F73-AE9D-29FDFD4CA3AE"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/laoquanshi/heishou/blob/main/Food%20Management%20System%20SQL%20Injection%20Vulnerability12.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249849",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249849",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0289",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T00:15:44.190",
+        "lastModified": "2024-01-08T17:52:33.037",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability classified as critical was found in Kashipara Food Management System 1.0. This vulnerability affects unknown code of the file stock_entry_submit.php. The manipulation of the argument itemype leads to sql injection. The attack can be initiated remotely. The exploit has been disclosed to the public and may be used. VDB-249850 is the identifier assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Kashipara Food Management System 1.0 y clasificada como crítica. Esta vulnerabilidad afecta a un código desconocido del archivo stock_entry_submit.php. La manipulación del argumento itemype conduce a la inyección de SQL. El ataque se puede iniciar de forma remota. La explotación ha sido divulgada al público y puede utilizarse. VDB-249850 es el identificador asignado a esta vulnerabilidad."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:1.0:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "162932BA-98AD-4F73-AE9D-29FDFD4CA3AE"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/laoquanshi/heishou/blob/main/Food%20Management%20System%20SQL%20Injection%20Vulnerability14.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Vendor Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249850",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249850",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0290",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T01:15:10.607",
+        "lastModified": "2024-01-08T17:52:47.720",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability, which was classified as critical, has been found in Kashipara Food Management System 1.0. This issue affects some unknown processing of the file stock_edit.php. The manipulation of the argument item_type leads to sql injection. The attack may be initiated remotely. The exploit has been disclosed to the public and may be used. The associated identifier of this vulnerability is VDB-249851."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Kashipara Food Management System 1.0 y clasificada como crítica. Este problema afecta un procesamiento desconocido del archivo stock_edit.php. La manipulación del argumento item_type conduce a la inyección SQL. El ataque puede iniciarse de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador asociado de esta vulnerabilidad es VDB-249851."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:kashipara:food_management_system:1.0:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "162932BA-98AD-4F73-AE9D-29FDFD4CA3AE"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/laoquanshi/heishou/blob/main/Food%20Management%20System%20SQL%20Injection%20Vulnerability15.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249851",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249851",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0291",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T01:15:10.850",
+        "lastModified": "2024-01-11T15:58:47.450",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Totolink LR1200GB 9.1.0u.6619_B20230130. It has been rated as critical. This issue affects the function UploadFirmwareFile of the file /cgi-bin/cstecgi.cgi. The manipulation of the argument FileName leads to command injection. The attack may be initiated remotely. The exploit has been disclosed to the public and may be used. The identifier VDB-249857 was assigned to this vulnerability. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Totolink LR1200GB 9.1.0u.6619_B20230130. Ha sido calificado como crítico. Este problema afecta la función UploadFirmwareFile del archivo /cgi-bin/cstecgi.cgi. La manipulación del argumento FileName conduce a la inyección de comandos. El ataque puede iniciarse de forma remota. La explotación ha sido divulgada al público y puede utilizarse. A esta vulnerabilidad se le asignó el identificador VDB-249857. NOTA: Se contactó primeramente al proveedor sobre esta divulgación, pero no respondió de ninguna forma."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 8.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-77"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:totolink:lr1200gb_firmware:9.1.0u.6619_b20230130:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "00F36DE9-D043-4C8B-9EF9-8DA669589E85"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:totolink:lr1200gb:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "8442849E-5B06-41A1-8DA8-827FBD7A34E5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/jylsec/vuldb/blob/main/TOTOLINK/LR1200GB/UploadFirmwareFile/README.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249857",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249857",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-50948",
+        "sourceIdentifier": "psirt@us.ibm.com",
+        "published": "2024-01-08T02:15:13.793",
+        "lastModified": "2024-01-11T17:00:50.077",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "IBM Storage Fusion HCI 2.1.0 through 2.6.1 contains hard-coded credentials, such as a password or cryptographic key, which it uses for its own inbound authentication, outbound communication to external components, or encryption of internal data.  IBM X-Force ID:  275671."
+          },
+          {
+            "lang": "es",
+            "value": "IBM Storage Fusion HCI 2.1.0 a 2.6.1 contiene credenciales codificadas, como una contraseña o clave criptográfica, que utiliza para su propia autenticación entrante, comunicación saliente con componentes externos o cifrado de datos internos. ID de IBM X-Force: 275671."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "psirt@us.ibm.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "ADJACENT_NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.6
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-798"
+              }
+            ]
+          },
+          {
+            "source": "psirt@us.ibm.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-259"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:ibm:storage_fusion_hci:*:*:*:*:*:*:*:*",
+                    "versionStartIncluding": "2.1.0",
+                    "versionEndExcluding": "2.7.1",
+                    "matchCriteriaId": "84A20FBA-EA8F-403E-A89C-7441B0D68FFD"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/275671",
+            "source": "psirt@us.ibm.com",
+            "tags": [
+              "VDB Entry",
+              "Vendor Advisory"
+            ]
+          },
+          {
+            "url": "https://www.ibm.com/support/pages/node/7105509",
+            "source": "psirt@us.ibm.com",
+            "tags": [
+              "Vendor Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-7215",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T02:15:14.027",
+        "lastModified": "2024-01-11T16:59:42.420",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability, which was classified as problematic, has been found in Chanzhaoyu chatgpt-web 2.11.1. This issue affects some unknown processing. The manipulation of the argument Description with the input <image src onerror=prompt(document.domain)> leads to cross site scripting. The attack may be initiated remotely. The exploit has been disclosed to the public and may be used. The associated identifier of this vulnerability is VDB-249779."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Chanzhaoyu chatgpt-web 2.11.1 y clasificada como problemática. Este problema afecta algún procesamiento desconocido. La manipulación del argumento Description con la entrada  conduce a cross site scripting. El ataque puede iniciarse de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador asociado de esta vulnerabilidad es VDB-249779."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.1,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 2.7
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:N/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 3.5,
+                "baseSeverity": "LOW"
+              },
+              "exploitabilityScore": 2.1,
+              "impactScore": 1.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:N/I:P/A:N",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "NONE",
+                "baseScore": 4.0
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 2.9,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:chanzhaoyu:chatgpt_web:2.11.1:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "743F26DA-3A55-47CD-8FA3-F22DF98A9EFC"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/Chanzhaoyu/chatgpt-web/issues/2001",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Issue Tracking"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249779",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249779",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0292",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T02:15:14.367",
+        "lastModified": "2024-01-11T16:59:08.770",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability classified as critical has been found in Totolink LR1200GB 9.1.0u.6619_B20230130. Affected is the function setOpModeCfg of the file /cgi-bin/cstecgi.cgi. The manipulation of the argument hostName leads to os command injection. It is possible to launch the attack remotely. The exploit has been disclosed to the public and may be used. VDB-249858 is the identifier assigned to this vulnerability. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad ha sido encontrada en Totolink LR1200GB 9.1.0u.6619_B20230130 y clasificada como crítica. La función setOpModeCfg del fichero /cgi-bin/cstecgi.cgi es afectada por la vulnerabilidad. La manipulación del argumento hostName conduce a la inyección de comandos del sistema operativo. Es posible lanzar el ataque de forma remota. La explotación ha sido divulgada al público y puede utilizarse. VDB-249858 es el identificador asignado a esta vulnerabilidad. NOTA: Se contactó primeramente al proveedor sobre esta divulgación, pero no respondió de ninguna forma."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          },
+          {
+            "source": "cna@vuldb.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:totolink:lr1200gb_firmware:9.1.0u.6619_b20230130:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "00F36DE9-D043-4C8B-9EF9-8DA669589E85"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:totolink:lr1200gb:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "8442849E-5B06-41A1-8DA8-827FBD7A34E5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/jylsec/vuldb/blob/main/TOTOLINK/LR1200GB/setOpModeCfg/README.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249858",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249858",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-47140",
+        "sourceIdentifier": "psirt@us.ibm.com",
+        "published": "2024-01-08T03:15:13.283",
+        "lastModified": "2024-01-11T16:58:30.733",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "IBM CICS Transaction Gateway 9.3 could allow a user to transfer or view files due to improper access controls.  IBM X-Force ID:  270259."
+          },
+          {
+            "lang": "es",
+            "value": "IBM CICS Transaction Gateway 9.3 podría permitir a un usuario transferir o ver archivos debido a controles de acceso inadecuados. ID de IBM X-Force: 270259."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "NONE",
+                "baseScore": 8.1,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 5.2
+            },
+            {
+              "source": "psirt@us.ibm.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N",
+                "attackVector": "LOCAL",
+                "attackComplexity": "HIGH",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 4.0,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 1.4,
+              "impactScore": 2.5
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "NVD-CWE-Other"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:ibm:cics_transaction_gateway:9.3:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "1C357E81-5A3B-4583-A5CC-36B35054BB0D"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/270259",
+            "source": "psirt@us.ibm.com",
+            "tags": [
+              "VDB Entry",
+              "Vendor Advisory"
+            ]
+          },
+          {
+            "url": "https://https://www.ibm.com/support/pages/node/7105094",
+            "source": "psirt@us.ibm.com",
+            "tags": [
+              "Broken Link"
+            ]
+          },
+          {
+            "url": "https://www.ibm.com/support/pages/node/7105094",
+            "source": "nvd@nist.gov",
+            "tags": [
+              "Vendor Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0293",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T03:15:13.820",
+        "lastModified": "2024-01-11T16:58:37.920",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability classified as critical was found in Totolink LR1200GB 9.1.0u.6619_B20230130. Affected by this vulnerability is the function setUploadSetting of the file /cgi-bin/cstecgi.cgi. The manipulation of the argument FileName leads to os command injection. The attack can be launched remotely. The exploit has been disclosed to the public and may be used. The associated identifier of this vulnerability is VDB-249859. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Totolink LR1200GB 9.1.0u.6619_B20230130 y clasificada como crítica. La función setUploadSetting del archivo /cgi-bin/cstecgi.cgi es afectada por esta vulnerabilidad. La manipulación del argumento FileName conduce a la inyección de comandos del sistema operativo. El ataque se puede lanzar de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador asociado de esta vulnerabilidad es VDB-249859. NOTA: Se contactó primeramente al proveedor sobre esta divulgación, pero no respondió de ninguna forma."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:totolink:lr1200gb_firmware:9.1.0u.6619_b20230130:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "00F36DE9-D043-4C8B-9EF9-8DA669589E85"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:totolink:lr1200gb:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "8442849E-5B06-41A1-8DA8-827FBD7A34E5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/jylsec/vuldb/blob/main/TOTOLINK/LR1200GB/setUploadSetting/README.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249859",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249859",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0294",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T03:15:14.050",
+        "lastModified": "2024-01-11T16:56:53.397",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability, which was classified as critical, has been found in Totolink LR1200GB 9.1.0u.6619_B20230130. Affected by this issue is the function setUssd of the file /cgi-bin/cstecgi.cgi. The manipulation of the argument ussd leads to os command injection. The attack may be launched remotely. The exploit has been disclosed to the public and may be used. The identifier of this vulnerability is VDB-249860. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Totolink LR1200GB 9.1.0u.6619_B20230130 y clasificada como crítica. La función setUssd del archivo /cgi-bin/cstecgi.cgi es afectada por esta vulnerabilidad. La manipulación del argumento ussd conduce a la inyección de comandos del sistema operativo. El ataque puede lanzarse de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador de esta vulnerabilidad es VDB-249860. NOTA: Se contactó primeramente al proveedor sobre esta divulgación, pero no respondió de ninguna forma."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 7.3,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 7.5
+              },
+              "baseSeverity": "HIGH",
+              "exploitabilityScore": 10.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:totolink:lr1200gb_firmware:9.1.0u.6619_b20230130:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "00F36DE9-D043-4C8B-9EF9-8DA669589E85"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:totolink:lr1200gb:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "8442849E-5B06-41A1-8DA8-827FBD7A34E5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/jylsec/vuldb/blob/main/TOTOLINK/LR1200GB/setUssd/README.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249860",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249860",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0295",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T04:15:08.287",
+        "lastModified": "2024-01-11T16:56:41.500",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability, which was classified as critical, was found in Totolink LR1200GB 9.1.0u.6619_B20230130. This affects the function setWanCfg of the file /cgi-bin/cstecgi.cgi. The manipulation of the argument hostName leads to os command injection. It is possible to initiate the attack remotely. The exploit has been disclosed to the public and may be used. The identifier VDB-249861 was assigned to this vulnerability. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Totolink LR1200GB 9.1.0u.6619_B20230130 y clasificada como crítica. Esto afecta a la función setWanCfg del archivo /cgi-bin/cstecgi.cgi. La manipulación del argumento hostName conduce a la inyección de comandos del sistema operativo. Es posible iniciar el ataque de forma remota. La explotación ha sido divulgada al público y puede utilizarse. A esta vulnerabilidad se le asignó el identificador VDB-249861. NOTA: Se contactó primeramente al proveedor sobre esta divulgación, pero no respondió de ninguna forma."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 7.3,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 7.5
+              },
+              "baseSeverity": "HIGH",
+              "exploitabilityScore": 10.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:totolink:lr1200gb_firmware:9.1.0u.6619_b20230130:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "00F36DE9-D043-4C8B-9EF9-8DA669589E85"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:totolink:lr1200gb:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "8442849E-5B06-41A1-8DA8-827FBD7A34E5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/jylsec/vuldb/blob/main/TOTOLINK/LR1200GB/setWanCfg/README.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249861",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249861",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0296",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T04:15:08.540",
+        "lastModified": "2024-01-11T16:56:28.763",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability has been found in Totolink N200RE 9.3.5u.6139_B20201216 and classified as critical. This vulnerability affects the function NTPSyncWithHost of the file /cgi-bin/cstecgi.cgi. The manipulation of the argument host_time leads to os command injection. The attack can be initiated remotely. The exploit has been disclosed to the public and may be used. VDB-249862 is the identifier assigned to this vulnerability. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad ha sido encontrada en Totolink N200RE 9.3.5u.6139_B20201216 y clasificada como crítica. Esta vulnerabilidad afecta a la función NTPSyncWithHost del archivo /cgi-bin/cstecgi.cgi. La manipulación del argumento host_time conduce a la inyección de comandos del sistema operativo. El ataque se puede iniciar de forma remota. La explotación ha sido divulgada al público y puede utilizarse. VDB-249862 es el identificador asignado a esta vulnerabilidad. NOTA: Se contactó primeramente al proveedor sobre esta divulgación, pero no respondió de ninguna forma."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 7.3,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 7.5
+              },
+              "baseSeverity": "HIGH",
+              "exploitabilityScore": 10.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:totolink:n200re_firmware:9.3.5u.6139_b20201216:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "053F2B0B-9AD2-404B-9135-080AF3D3FC20"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:totolink:n200re:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "9FF7FF59-DB13-4FEA-A81C-124048BF1676"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/jylsec/vuldb/blob/main/TOTOLINK/N200RE/NTPSyncWithHost/README.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249862",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249862",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0297",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T05:15:09.393",
+        "lastModified": "2024-01-11T16:56:14.950",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Totolink N200RE 9.3.5u.6139_B20201216 and classified as critical. This issue affects the function UploadFirmwareFile of the file /cgi-bin/cstecgi.cgi. The manipulation of the argument FileName leads to os command injection. The attack may be initiated remotely. The exploit has been disclosed to the public and may be used. The associated identifier of this vulnerability is VDB-249863. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Totolink N200RE 9.3.5u.6139_B20201216 y clasificada como crítica. Este problema afecta la función UploadFirmwareFile del archivo /cgi-bin/cstecgi.cgi. La manipulación del argumento FileName conduce a la inyección de comandos del sistema operativo. El ataque puede iniciarse de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador asociado de esta vulnerabilidad es VDB-249863. NOTA: Se contactó primeramente al proveedor sobre esta divulgación, pero no respondió de ninguna forma."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 7.3,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 7.5
+              },
+              "baseSeverity": "HIGH",
+              "exploitabilityScore": 10.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:totolink:n200re_firmware:9.3.5u.6139_b20201216:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "053F2B0B-9AD2-404B-9135-080AF3D3FC20"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:totolink:n200re:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "9FF7FF59-DB13-4FEA-A81C-124048BF1676"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/jylsec/vuldb/blob/main/TOTOLINK/N200RE/UploadFirmwareFile/README.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249863",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249863",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0298",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T05:15:09.770",
+        "lastModified": "2024-01-11T16:55:37.693",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Totolink N200RE 9.3.5u.6139_B20201216. It has been classified as critical. Affected is the function setDiagnosisCfg of the file /cgi-bin/cstecgi.cgi. The manipulation of the argument ip leads to os command injection. It is possible to launch the attack remotely. The exploit has been disclosed to the public and may be used. The identifier of this vulnerability is VDB-249864. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Totolink N200RE 9.3.5u.6139_B20201216. Ha sido clasificada como crítica. La función setDiagnosisCfg del fichero /cgi-bin/cstecgi.cgi es afectada por la vulnerabilidad. La manipulación del argumento ip conduce a la inyección de comandos del sistema operativo. Es posible lanzar el ataque de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador de esta vulnerabilidad es VDB-249864. NOTA: Se contactó primeramente al proveedor sobre esta divulgación, pero no respondió de ninguna forma."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 7.3,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 7.5
+              },
+              "baseSeverity": "HIGH",
+              "exploitabilityScore": 10.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          },
+          {
+            "source": "cna@vuldb.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:totolink:n200re_firmware:9.3.5u.6139_b20201216:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "053F2B0B-9AD2-404B-9135-080AF3D3FC20"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:totolink:n200re:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "9FF7FF59-DB13-4FEA-A81C-124048BF1676"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/jylsec/vuldb/blob/main/TOTOLINK/N200RE/setDiagnosisCfg/README.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249864",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249864",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0299",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T06:15:44.593",
+        "lastModified": "2024-01-11T16:55:13.367",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Totolink N200RE 9.3.5u.6139_B20201216. It has been declared as critical. Affected by this vulnerability is the function setTracerouteCfg of the file /cgi-bin/cstecgi.cgi. The manipulation of the argument command leads to os command injection. The attack can be launched remotely. The exploit has been disclosed to the public and may be used. The identifier VDB-249865 was assigned to this vulnerability. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Totolink N200RE 9.3.5u.6139_B20201216. Ha sido declarada crítica. La función setTracerouteCfg del archivo /cgi-bin/cstecgi.cgi es afectada por esta vulnerabilidad. La manipulación del argumento command conduce a la inyección de comandos del sistema operativo. El ataque se puede lanzar de forma remota. La explotación ha sido divulgada al público y puede utilizarse. A esta vulnerabilidad se le asignó el identificador VDB-249865. NOTA: Se contactó primeramente al proveedor sobre esta divulgación, pero no respondió de ninguna forma."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 7.3,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 7.5
+              },
+              "baseSeverity": "HIGH",
+              "exploitabilityScore": 10.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:totolink:n200re_firmware:9.3.5u.6139_b20201216:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "053F2B0B-9AD2-404B-9135-080AF3D3FC20"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:totolink:n200re:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "9FF7FF59-DB13-4FEA-A81C-124048BF1676"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/jylsec/vuldb/blob/main/TOTOLINK/N200RE/setTracerouteCfg/README.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249865",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249865",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0300",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T06:15:45.047",
+        "lastModified": "2024-01-11T16:54:51.317",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Beijing Baichuo Smart S150 Management Platform up to 20240101. It has been rated as critical. Affected by this issue is some unknown functionality of the file /useratte/userattestation.php of the component HTTP POST Request Handler. The manipulation of the argument web_img leads to unrestricted upload. The attack may be launched remotely. The exploit has been disclosed to the public and may be used. VDB-249866 is the identifier assigned to this vulnerability. NOTE: The vendor was contacted early about this disclosure but did not respond in any way."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Beijing Baichuo Smart S150 Management Platform hasta 20240101 y fue calificada como crítica. Una función desconocida del archivo /useratte/userattestation.php del componente HTTP POST Request Handler es afectada por esta vulnerabilidad. La manipulación del argumento web_img conduce a una carga sin restricciones. El ataque puede lanzarse de forma remota. La explotación ha sido divulgada al público y puede utilizarse. VDB-249866 es el identificador asignado a esta vulnerabilidad. NOTA: Se contactó primeramente al proveedor sobre esta divulgación, pero no respondió de ninguna forma."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-434"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:o:byzoro:smart_s150_firmware:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "2024-01-01",
+                    "matchCriteriaId": "4E4613FF-B68E-4F98-8DB5-7E66422731E7"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:h:byzoro:smart_s150:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "8933946D-BF4C-4F40-8752-D4D6A371BE6E"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/tolkent/cve/blob/main/upload.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249866",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249866",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0301",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T07:15:08.767",
+        "lastModified": "2024-01-11T18:50:32.310",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability classified as critical was found in fhs-opensource iparking 1.5.22.RELEASE. This vulnerability affects the function getData of the file src/main/java/com/xhb/pay/action/PayTempOrderAction.java. The manipulation leads to sql injection. The attack can be initiated remotely. The exploit has been disclosed to the public and may be used. The identifier of this vulnerability is VDB-249868."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en fhs-opensource iparking 1.5.22.RELEASE y clasificada como crítica. Esta vulnerabilidad afecta a la función getData del archivo src/main/java/com/xhb/pay/action/PayTempOrderAction.java. La manipulación conduce a la inyección de SQL. El ataque se puede iniciar de forma remota. La explotación ha sido divulgada al público y puede utilizarse. El identificador de esta vulnerabilidad es VDB-249868."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:fhs-opensource:iparking:1.5.22:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "1D6A2A9B-E632-4DF9-986F-616A1DAD9C3C"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/laoquanshi/heishou/blob/main/iparking-SQL.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249868",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249868",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0302",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T07:15:10.597",
+        "lastModified": "2024-01-11T18:52:04.270",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability, which was classified as critical, has been found in fhs-opensource iparking 1.5.22.RELEASE. This issue affects some unknown processing of the file /vueLogin. The manipulation leads to deserialization. The attack may be initiated remotely. The exploit has been disclosed to the public and may be used. The identifier VDB-249869 was assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en fhs-opensource iparking 1.5.22.RELEASE y clasificada como crítica. Este problema afecta algún procesamiento desconocido del archivo /vueLogin. La manipulación conduce a la deserialización. El ataque puede iniciarse de forma remota. La explotación ha sido divulgada al público y puede utilizarse. A esta vulnerabilidad se le asignó el identificador VDB-249869."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-502"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:fhs-opensource:iparking:1.5.22:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "1D6A2A9B-E632-4DF9-986F-616A1DAD9C3C"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/laoquanshi/heishou/blob/main/Iparking%20rce.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249869",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249869",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-22216",
+        "sourceIdentifier": "cve@mitre.org",
+        "published": "2024-01-08T07:15:11.547",
+        "lastModified": "2024-01-11T16:44:03.750",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "In default installations of Microchip maxView Storage Manager (for Adaptec Smart Storage Controllers) where Redfish server is configured for remote system management, unauthorized access can occur, with data modification and information disclosure. This affects 3.00.23484 through 4.14.00.26064 (except for the patched versions 3.07.23980 and 4.07.00.25339)."
+          },
+          {
+            "lang": "es",
+            "value": "En las instalaciones predeterminadas de Microchip maxView Storage Manager (para Adaptec Smart Storage Controllers) donde el servidor Redfish está configurado para la administración remota del sistema, puede ocurrir acceso no autorizado, con modificación de datos y divulgación de información. Esto afecta desde 3.00.23484 hasta 4.14.00.26064 (excepto las versiones parcheadas 3.07.23980 y 4.07.00.25339)."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "NONE",
+                "baseScore": 9.1,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.2
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "NVD-CWE-noinfo"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:microchip:maxview_storage_manager:*:*:*:*:*:-:*:*",
+                    "versionStartIncluding": "3.00.23484",
+                    "versionEndIncluding": "4.14.00.26064",
+                    "matchCriteriaId": "11777E9D-2BAF-4988-8A4E-C1EDF022EA79"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://www.microchip.com/en-us/solutions/embedded-security/how-to-report-potential-product-security-vulnerabilities/maxview-storage-manager-redfish-server-vulnerability",
+            "source": "cve@mitre.org",
+            "tags": [
+              "Vendor Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0303",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T08:15:36.400",
+        "lastModified": "2024-01-11T18:58:18.753",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability, which was classified as critical, was found in Youke365 up to 1.5.3. Affected is an unknown function of the file /app/api/controller/caiji.php of the component Parameter Handler. The manipulation of the argument url leads to server-side request forgery. It is possible to launch the attack remotely. The exploit has been disclosed to the public and may be used. VDB-249870 is the identifier assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad fue encontrada en Youke365 hasta 1.5.3 y clasificada como crítica. Una función desconocida del archivo /app/api/controller/caiji.php del componente Parameter Handler es afectada por esta vulnerabilidad. La manipulación del argumento URL conduce a server-side request forgery. Es posible lanzar el ataque de forma remota. El exploit ha sido divulgado al público y puede utilizarse. VDB-249870 es el identificador asignado a esta vulnerabilidad. "
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-918"
+              }
+            ]
+          },
+          {
+            "source": "cna@vuldb.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-918"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:youke365:youke_365:*:*:*:*:*:*:*:*",
+                    "versionStartIncluding": "1.5.0",
+                    "versionEndIncluding": "1.5.3",
+                    "matchCriteriaId": "E62F0C74-2DD0-40F6-9C99-3169D96C5D45"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://note.zhaoj.in/share/fssH60eQkvSl",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Broken Link"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249870",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249870",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0304",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T08:15:36.737",
+        "lastModified": "2024-01-11T18:53:13.737",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability has been found in Youke365 up to 1.5.3 and classified as critical. Affected by this vulnerability is an unknown functionality of the file /app/api/controller/collect.php. The manipulation of the argument url leads to server-side request forgery. The attack can be launched remotely. The exploit has been disclosed to the public and may be used. The associated identifier of this vulnerability is VDB-249871."
+          },
+          {
+            "lang": "es",
+            "value": "Una vulnerabilidad ha sido encontrada en Youke365 hasta 1.5.3 y clasificada como crítica. Una función desconocida del archivo /app/api/controller/collect.php es afectada por esta vulnerabilidad. La manipulación del argumento URL conduce a server-side request forgery. El ataque se puede lanzar de forma remota. El exploit ha sido divulgado al público y puede utilizarse. El identificador asociado de esta vulnerabilidad es VDB-249871."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-918"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:youke365:youke_365:*:*:*:*:*:*:*:*",
+                    "versionStartIncluding": "1.5.0",
+                    "versionEndIncluding": "1.5.3",
+                    "matchCriteriaId": "E62F0C74-2DD0-40F6-9C99-3169D96C5D45"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://note.zhaoj.in/share/3jF3Xpl3ttlZ",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Broken Link"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249871",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249871",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-29048",
+        "sourceIdentifier": "security@open-xchange.com",
+        "published": "2024-01-08T09:15:19.893",
+        "lastModified": "2024-01-12T14:09:06.640",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A component for parsing OXMF templates could be abused to execute arbitrary system commands that would be executed as the non-privileged runtime user. Users and attackers could run system commands with limited privilege to gain unauthorized access to confidential information and potentially violate integrity by modifying resources. The template engine has been reconfigured to deny execution of harmful commands on a system level. No publicly available exploits are known.\n\n"
+          },
+          {
+            "lang": "es",
+            "value": "Se podría abusar de un componente para analizar plantillas OXMF para ejecutar comandos arbitrarios del sistema que se ejecutarían como usuario de tiempo de ejecución sin privilegios. Los usuarios y atacantes podrían ejecutar comandos del sistema con privilegios limitados para obtener acceso no autorizado a información confidencial y potencialmente violar la integridad al modificar recursos. El motor de plantillas se ha reconfigurado para denegar la ejecución de comandos dañinos a nivel del sistema. No se conocen exploits disponibles públicamente."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 8.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "security@open-xchange.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 8.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          },
+          {
+            "source": "security@open-xchange.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:*:*:*:*:*:*:*:*",
+                    "versionEndExcluding": "7.10.6",
+                    "matchCriteriaId": "5BBF1862-B6FF-4F32-A3C1-59D28BA25F81"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:-:*:*:*:*:*:*",
+                    "matchCriteriaId": "3A4EAD2E-C3C3-4C79-8C42-375FFE638486"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev01:*:*:*:*:*:*",
+                    "matchCriteriaId": "39198733-D227-4935-9A60-1026040D262F"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev02:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C86EE81-8CD4-4131-969A-BDA24B9B48E8"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev03:*:*:*:*:*:*",
+                    "matchCriteriaId": "F9E9C869-7DA9-4EFA-B613-82BA127F6CE5"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev04:*:*:*:*:*:*",
+                    "matchCriteriaId": "F8FAA329-5893-412B-8349-4DA3023CC76E"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev05:*:*:*:*:*:*",
+                    "matchCriteriaId": "BB6A57A4-B18D-498D-9A8C-406797A6255C"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev06:*:*:*:*:*:*",
+                    "matchCriteriaId": "7F0977F0-90B4-48B4-BED6-C218B5CA5E03"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev07:*:*:*:*:*:*",
+                    "matchCriteriaId": "4D55DE67-8F93-48F3-BE54-D3A065479281"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev08:*:*:*:*:*:*",
+                    "matchCriteriaId": "D27980B4-B71B-4DA8-B130-F0B5929F8E65"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev09:*:*:*:*:*:*",
+                    "matchCriteriaId": "DD1709BC-7DEB-4508-B3C3-B20F5FD001A3"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev10:*:*:*:*:*:*",
+                    "matchCriteriaId": "08A6BDD5-259E-4DC3-A548-00CD0D459749"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev11:*:*:*:*:*:*",
+                    "matchCriteriaId": "B8166FF4-77D8-4A12-92E5-615B3DA2E602"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev12:*:*:*:*:*:*",
+                    "matchCriteriaId": "999F057B-7918-461A-B60C-3BE72E92CDC9"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev13:*:*:*:*:*:*",
+                    "matchCriteriaId": "88FD1550-3715-493E-B674-9ECF3DD7A813"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev14:*:*:*:*:*:*",
+                    "matchCriteriaId": "F31A4949-397F-4D1B-8AEA-AC7B335722F8"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev15:*:*:*:*:*:*",
+                    "matchCriteriaId": "D33A91D4-CE21-486D-9469-B09060B8C637"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev16:*:*:*:*:*:*",
+                    "matchCriteriaId": "5E3E5CD2-7631-4DBE-AB4D-669E82BCCAD4"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev17:*:*:*:*:*:*",
+                    "matchCriteriaId": "2BEE0AF0-3D22-4DE7-9E71-A4469D9CA2EB"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev18:*:*:*:*:*:*",
+                    "matchCriteriaId": "AAFB199C-1D66-442D-AD7E-414DD339E1D3"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev19:*:*:*:*:*:*",
+                    "matchCriteriaId": "26322561-2491-4DC7-B974-0B92B61A5BDA"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev20:*:*:*:*:*:*",
+                    "matchCriteriaId": "A6BA6C2B-F2D5-4FF7-B316-C8E99C2B464B"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev21:*:*:*:*:*:*",
+                    "matchCriteriaId": "733E4A65-821B-4187-AA3A-1ACD3E882C07"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev22:*:*:*:*:*:*",
+                    "matchCriteriaId": "6B0A0043-33E8-4440-92AC-DDD70EA39535"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev23:*:*:*:*:*:*",
+                    "matchCriteriaId": "303205CC-8BDE-47EE-A675-9BA19983139A"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev24:*:*:*:*:*:*",
+                    "matchCriteriaId": "8C088014-47D6-4632-9FB5-2C7B1085B762"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev25:*:*:*:*:*:*",
+                    "matchCriteriaId": "42CF6057-EB40-4208-9F1E-83213E97987C"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev26:*:*:*:*:*:*",
+                    "matchCriteriaId": "966BC23E-B8CE-4F98-B3A6-4B620E8808BE"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev27:*:*:*:*:*:*",
+                    "matchCriteriaId": "7409CE19-ACC1-4AF4-8C8A-AE2CDBB63D3D"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev28:*:*:*:*:*:*",
+                    "matchCriteriaId": "17D71CDE-3111-459B-8520-F62E0D5D2972"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev29:*:*:*:*:*:*",
+                    "matchCriteriaId": "6D808ED6-F819-4014-BD24-4537D52DDFB0"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev30:*:*:*:*:*:*",
+                    "matchCriteriaId": "B3792A91-10E9-42D9-B852-37D369D8364E"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev31:*:*:*:*:*:*",
+                    "matchCriteriaId": "6F0BFEEF-8B19-4F71-B7F1-2CC94969616F"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev32:*:*:*:*:*:*",
+                    "matchCriteriaId": "52003F06-9351-49B6-A3C5-A2B6FC0B9F4D"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev33:*:*:*:*:*:*",
+                    "matchCriteriaId": "C8786112-32AE-4BA5-8D66-D4E2429D3228"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev34:*:*:*:*:*:*",
+                    "matchCriteriaId": "3A67F528-0248-4E24-A5AB-2995ED7D2600"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev35:*:*:*:*:*:*",
+                    "matchCriteriaId": "AE090C73-E093-4BD9-BEFE-634179500A78"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev36:*:*:*:*:*:*",
+                    "matchCriteriaId": "0A7CF0F7-5DF5-4749-A777-0F9EDCD14EA6"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev37:*:*:*:*:*:*",
+                    "matchCriteriaId": "EBE620A7-F071-4412-B0CE-7BCBF3BD7311"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev50:*:*:*:*:*:*",
+                    "matchCriteriaId": "1D7A5899-0795-452E-8B43-75C266AE6B88"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "http://packetstormsecurity.com/files/176421/OX-App-Suite-7.10.6-XSS-Command-Execution-LDAP-Injection.html",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "http://seclists.org/fulldisclosure/2024/Jan/3",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Mailing List",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://documentation.open-xchange.com/appsuite/security/advisories/csaf/2023/oxas-adv-2023-0005.json",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Issue Tracking"
+            ]
+          },
+          {
+            "url": "https://software.open-xchange.com/products/appsuite/doc/Release_Notes_for_Patch_Release_6248_7.10.6_2023-09-19.pdf",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Release Notes"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-29049",
+        "sourceIdentifier": "security@open-xchange.com",
+        "published": "2024-01-08T09:15:20.120",
+        "lastModified": "2024-01-12T14:16:38.190",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "The \"upsell\" widget at the portal page could be abused to inject arbitrary script code. Attackers that manage to lure users to a compromised account, or gain temporary access to a legitimate account, could inject script code to gain persistent code execution capabilities under a trusted domain. User input for this widget is now sanitized to avoid malicious content the be processed. No publicly available exploits are known.\n\n"
+          },
+          {
+            "lang": "es",
+            "value": "Se podría abusar del widget \"upsell\" en la página del portal para inyectar código de script arbitrario. Los atacantes que logran atraer a los usuarios a una cuenta comprometida u obtener acceso temporal a una cuenta legítima, podrían inyectar código de secuencia de comandos para obtener capacidades de ejecución de código persistente en un dominio confiable. La entrada del usuario para este widget ahora se sanitiza para evitar que se procese contenido malicioso. No se conocen exploits disponibles públicamente."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.1,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 2.7
+            },
+            {
+              "source": "security@open-xchange.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.4,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.3,
+              "impactScore": 2.7
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          },
+          {
+            "source": "security@open-xchange.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:*:*:*:*:*:*:*:*",
+                    "versionEndExcluding": "7.10.6",
+                    "matchCriteriaId": "5BBF1862-B6FF-4F32-A3C1-59D28BA25F81"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:-:*:*:*:*:*:*",
+                    "matchCriteriaId": "3A4EAD2E-C3C3-4C79-8C42-375FFE638486"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev01:*:*:*:*:*:*",
+                    "matchCriteriaId": "39198733-D227-4935-9A60-1026040D262F"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev02:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C86EE81-8CD4-4131-969A-BDA24B9B48E8"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev03:*:*:*:*:*:*",
+                    "matchCriteriaId": "F9E9C869-7DA9-4EFA-B613-82BA127F6CE5"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev04:*:*:*:*:*:*",
+                    "matchCriteriaId": "F8FAA329-5893-412B-8349-4DA3023CC76E"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev05:*:*:*:*:*:*",
+                    "matchCriteriaId": "BB6A57A4-B18D-498D-9A8C-406797A6255C"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev06:*:*:*:*:*:*",
+                    "matchCriteriaId": "7F0977F0-90B4-48B4-BED6-C218B5CA5E03"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev07:*:*:*:*:*:*",
+                    "matchCriteriaId": "4D55DE67-8F93-48F3-BE54-D3A065479281"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev08:*:*:*:*:*:*",
+                    "matchCriteriaId": "D27980B4-B71B-4DA8-B130-F0B5929F8E65"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev09:*:*:*:*:*:*",
+                    "matchCriteriaId": "DD1709BC-7DEB-4508-B3C3-B20F5FD001A3"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev10:*:*:*:*:*:*",
+                    "matchCriteriaId": "08A6BDD5-259E-4DC3-A548-00CD0D459749"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev11:*:*:*:*:*:*",
+                    "matchCriteriaId": "B8166FF4-77D8-4A12-92E5-615B3DA2E602"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev12:*:*:*:*:*:*",
+                    "matchCriteriaId": "999F057B-7918-461A-B60C-3BE72E92CDC9"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev13:*:*:*:*:*:*",
+                    "matchCriteriaId": "88FD1550-3715-493E-B674-9ECF3DD7A813"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev14:*:*:*:*:*:*",
+                    "matchCriteriaId": "F31A4949-397F-4D1B-8AEA-AC7B335722F8"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev15:*:*:*:*:*:*",
+                    "matchCriteriaId": "D33A91D4-CE21-486D-9469-B09060B8C637"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev16:*:*:*:*:*:*",
+                    "matchCriteriaId": "5E3E5CD2-7631-4DBE-AB4D-669E82BCCAD4"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev17:*:*:*:*:*:*",
+                    "matchCriteriaId": "2BEE0AF0-3D22-4DE7-9E71-A4469D9CA2EB"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev18:*:*:*:*:*:*",
+                    "matchCriteriaId": "AAFB199C-1D66-442D-AD7E-414DD339E1D3"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev19:*:*:*:*:*:*",
+                    "matchCriteriaId": "26322561-2491-4DC7-B974-0B92B61A5BDA"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev20:*:*:*:*:*:*",
+                    "matchCriteriaId": "A6BA6C2B-F2D5-4FF7-B316-C8E99C2B464B"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev21:*:*:*:*:*:*",
+                    "matchCriteriaId": "733E4A65-821B-4187-AA3A-1ACD3E882C07"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev22:*:*:*:*:*:*",
+                    "matchCriteriaId": "6B0A0043-33E8-4440-92AC-DDD70EA39535"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev23:*:*:*:*:*:*",
+                    "matchCriteriaId": "303205CC-8BDE-47EE-A675-9BA19983139A"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev24:*:*:*:*:*:*",
+                    "matchCriteriaId": "8C088014-47D6-4632-9FB5-2C7B1085B762"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev25:*:*:*:*:*:*",
+                    "matchCriteriaId": "42CF6057-EB40-4208-9F1E-83213E97987C"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev26:*:*:*:*:*:*",
+                    "matchCriteriaId": "966BC23E-B8CE-4F98-B3A6-4B620E8808BE"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev27:*:*:*:*:*:*",
+                    "matchCriteriaId": "7409CE19-ACC1-4AF4-8C8A-AE2CDBB63D3D"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev28:*:*:*:*:*:*",
+                    "matchCriteriaId": "17D71CDE-3111-459B-8520-F62E0D5D2972"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev29:*:*:*:*:*:*",
+                    "matchCriteriaId": "6D808ED6-F819-4014-BD24-4537D52DDFB0"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev30:*:*:*:*:*:*",
+                    "matchCriteriaId": "B3792A91-10E9-42D9-B852-37D369D8364E"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev31:*:*:*:*:*:*",
+                    "matchCriteriaId": "6F0BFEEF-8B19-4F71-B7F1-2CC94969616F"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev32:*:*:*:*:*:*",
+                    "matchCriteriaId": "52003F06-9351-49B6-A3C5-A2B6FC0B9F4D"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev33:*:*:*:*:*:*",
+                    "matchCriteriaId": "C8786112-32AE-4BA5-8D66-D4E2429D3228"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "http://packetstormsecurity.com/files/176421/OX-App-Suite-7.10.6-XSS-Command-Execution-LDAP-Injection.html",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "http://seclists.org/fulldisclosure/2024/Jan/3",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Mailing List",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://documentation.open-xchange.com/appsuite/security/advisories/csaf/2023/oxas-adv-2023-0005.json",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Issue Tracking"
+            ]
+          },
+          {
+            "url": "https://software.open-xchange.com/products/appsuite/doc/Release_Notes_for_Patch_Release_6248_7.10.6_2023-09-19.pdf",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Release Notes"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-29050",
+        "sourceIdentifier": "security@open-xchange.com",
+        "published": "2024-01-08T09:15:20.300",
+        "lastModified": "2024-01-12T14:24:21.330",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "The optional \"LDAP contacts provider\" could be abused by privileged users to inject LDAP filter strings that allow to access content outside of the intended hierarchy. Unauthorized users could break confidentiality of information in the directory and potentially cause high load on the directory server, leading to denial of service. Encoding has been added for user-provided fragments that are used when constructing the LDAP query. No publicly available exploits are known.\n\n"
+          },
+          {
+            "lang": "es",
+            "value": "Los usuarios privilegiados podrían abusar del \"proveedor de contactos LDAP\" opcional para inyectar cadenas de filtro LDAP que permitan acceder a contenido fuera de la jerarquía prevista. Los usuarios no autorizados podrían romper la confidencialidad de la información en el directorio y potencialmente causar una gran carga en el servidor del directorio, lo que llevaría a la denegación de servicio. Se ha agregado codificación para los fragmentos proporcionados por el usuario que se utilizan al construir la consulta LDAP. No se conocen exploits disponibles públicamente."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "CHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.6,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.1,
+              "impactScore": 5.8
+            },
+            {
+              "source": "security@open-xchange.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:N/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "HIGH",
+                "userInteraction": "NONE",
+                "scope": "CHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "LOW",
+                "baseScore": 7.6,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.3,
+              "impactScore": 4.7
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-74"
+              }
+            ]
+          },
+          {
+            "source": "security@open-xchange.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-90"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:*:*:*:*:*:*:*:*",
+                    "versionEndExcluding": "7.10.6",
+                    "matchCriteriaId": "5BBF1862-B6FF-4F32-A3C1-59D28BA25F81"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:-:*:*:*:*:*:*",
+                    "matchCriteriaId": "3A4EAD2E-C3C3-4C79-8C42-375FFE638486"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev01:*:*:*:*:*:*",
+                    "matchCriteriaId": "39198733-D227-4935-9A60-1026040D262F"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev02:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C86EE81-8CD4-4131-969A-BDA24B9B48E8"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev03:*:*:*:*:*:*",
+                    "matchCriteriaId": "F9E9C869-7DA9-4EFA-B613-82BA127F6CE5"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev04:*:*:*:*:*:*",
+                    "matchCriteriaId": "F8FAA329-5893-412B-8349-4DA3023CC76E"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev05:*:*:*:*:*:*",
+                    "matchCriteriaId": "BB6A57A4-B18D-498D-9A8C-406797A6255C"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev06:*:*:*:*:*:*",
+                    "matchCriteriaId": "7F0977F0-90B4-48B4-BED6-C218B5CA5E03"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev07:*:*:*:*:*:*",
+                    "matchCriteriaId": "4D55DE67-8F93-48F3-BE54-D3A065479281"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev08:*:*:*:*:*:*",
+                    "matchCriteriaId": "D27980B4-B71B-4DA8-B130-F0B5929F8E65"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev09:*:*:*:*:*:*",
+                    "matchCriteriaId": "DD1709BC-7DEB-4508-B3C3-B20F5FD001A3"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev10:*:*:*:*:*:*",
+                    "matchCriteriaId": "08A6BDD5-259E-4DC3-A548-00CD0D459749"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev11:*:*:*:*:*:*",
+                    "matchCriteriaId": "B8166FF4-77D8-4A12-92E5-615B3DA2E602"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev12:*:*:*:*:*:*",
+                    "matchCriteriaId": "999F057B-7918-461A-B60C-3BE72E92CDC9"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev13:*:*:*:*:*:*",
+                    "matchCriteriaId": "88FD1550-3715-493E-B674-9ECF3DD7A813"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev14:*:*:*:*:*:*",
+                    "matchCriteriaId": "F31A4949-397F-4D1B-8AEA-AC7B335722F8"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev15:*:*:*:*:*:*",
+                    "matchCriteriaId": "D33A91D4-CE21-486D-9469-B09060B8C637"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev16:*:*:*:*:*:*",
+                    "matchCriteriaId": "5E3E5CD2-7631-4DBE-AB4D-669E82BCCAD4"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev17:*:*:*:*:*:*",
+                    "matchCriteriaId": "2BEE0AF0-3D22-4DE7-9E71-A4469D9CA2EB"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev18:*:*:*:*:*:*",
+                    "matchCriteriaId": "AAFB199C-1D66-442D-AD7E-414DD339E1D3"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev19:*:*:*:*:*:*",
+                    "matchCriteriaId": "26322561-2491-4DC7-B974-0B92B61A5BDA"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev20:*:*:*:*:*:*",
+                    "matchCriteriaId": "A6BA6C2B-F2D5-4FF7-B316-C8E99C2B464B"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev21:*:*:*:*:*:*",
+                    "matchCriteriaId": "733E4A65-821B-4187-AA3A-1ACD3E882C07"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev22:*:*:*:*:*:*",
+                    "matchCriteriaId": "6B0A0043-33E8-4440-92AC-DDD70EA39535"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev23:*:*:*:*:*:*",
+                    "matchCriteriaId": "303205CC-8BDE-47EE-A675-9BA19983139A"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev24:*:*:*:*:*:*",
+                    "matchCriteriaId": "8C088014-47D6-4632-9FB5-2C7B1085B762"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev25:*:*:*:*:*:*",
+                    "matchCriteriaId": "42CF6057-EB40-4208-9F1E-83213E97987C"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev26:*:*:*:*:*:*",
+                    "matchCriteriaId": "966BC23E-B8CE-4F98-B3A6-4B620E8808BE"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev27:*:*:*:*:*:*",
+                    "matchCriteriaId": "7409CE19-ACC1-4AF4-8C8A-AE2CDBB63D3D"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev28:*:*:*:*:*:*",
+                    "matchCriteriaId": "17D71CDE-3111-459B-8520-F62E0D5D2972"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev29:*:*:*:*:*:*",
+                    "matchCriteriaId": "6D808ED6-F819-4014-BD24-4537D52DDFB0"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev30:*:*:*:*:*:*",
+                    "matchCriteriaId": "B3792A91-10E9-42D9-B852-37D369D8364E"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev31:*:*:*:*:*:*",
+                    "matchCriteriaId": "6F0BFEEF-8B19-4F71-B7F1-2CC94969616F"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev32:*:*:*:*:*:*",
+                    "matchCriteriaId": "52003F06-9351-49B6-A3C5-A2B6FC0B9F4D"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev33:*:*:*:*:*:*",
+                    "matchCriteriaId": "C8786112-32AE-4BA5-8D66-D4E2429D3228"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev34:*:*:*:*:*:*",
+                    "matchCriteriaId": "3A67F528-0248-4E24-A5AB-2995ED7D2600"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev35:*:*:*:*:*:*",
+                    "matchCriteriaId": "AE090C73-E093-4BD9-BEFE-634179500A78"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev36:*:*:*:*:*:*",
+                    "matchCriteriaId": "0A7CF0F7-5DF5-4749-A777-0F9EDCD14EA6"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev37:*:*:*:*:*:*",
+                    "matchCriteriaId": "EBE620A7-F071-4412-B0CE-7BCBF3BD7311"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev50:*:*:*:*:*:*",
+                    "matchCriteriaId": "1D7A5899-0795-452E-8B43-75C266AE6B88"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:8.16:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "D2F1CDFA-09DF-40ED-8E60-835032C89924"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "http://packetstormsecurity.com/files/176421/OX-App-Suite-7.10.6-XSS-Command-Execution-LDAP-Injection.html",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "http://seclists.org/fulldisclosure/2024/Jan/3",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Mailing List",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://documentation.open-xchange.com/appsuite/security/advisories/csaf/2023/oxas-adv-2023-0005.json",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Issue Tracking"
+            ]
+          },
+          {
+            "url": "https://software.open-xchange.com/products/appsuite/doc/Release_Notes_for_Patch_Release_6248_7.10.6_2023-09-19.pdf",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Release Notes"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-29051",
+        "sourceIdentifier": "security@open-xchange.com",
+        "published": "2024-01-08T09:15:20.480",
+        "lastModified": "2024-01-12T15:05:05.143",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "User-defined OXMF templates could be used to access a limited part of the internal OX App Suite Java API. The existing switch to disable the feature by default was not effective in this case. Unauthorized users could discover and modify application state, including objects related to other users and contexts. We now make sure that the switch to disable user-generated templates by default works as intended and will remove the feature in future generations of the product. No publicly available exploits are known.\n\n"
+          },
+          {
+            "lang": "es",
+            "value": "Se pueden utilizar plantillas OXMF definidas por el usuario para acceder a una parte limitada de la API Java interna de OX App Suite. El interruptor existente para desactivar la función de forma predeterminada no fue efectivo en este caso. Los usuarios no autorizados podrían descubrir y modificar el estado de la aplicación, incluidos objetos relacionados con otros usuarios y contextos. Ahora nos aseguramos de que el cambio para deshabilitar las plantillas generadas por el usuario de forma predeterminada funcione según lo previsto y eliminará la función en generaciones futuras del producto. No se conocen exploits disponibles públicamente."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "NONE",
+                "baseScore": 8.1,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 5.2
+            },
+            {
+              "source": "security@open-xchange.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "NONE",
+                "baseScore": 8.1,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 5.2
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "NVD-CWE-Other"
+              }
+            ]
+          },
+          {
+            "source": "security@open-xchange.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-284"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:*:*:*:*:*:*:*:*",
+                    "versionEndExcluding": "7.10.6",
+                    "matchCriteriaId": "5BBF1862-B6FF-4F32-A3C1-59D28BA25F81"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:-:*:*:*:*:*:*",
+                    "matchCriteriaId": "3A4EAD2E-C3C3-4C79-8C42-375FFE638486"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev01:*:*:*:*:*:*",
+                    "matchCriteriaId": "39198733-D227-4935-9A60-1026040D262F"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev02:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C86EE81-8CD4-4131-969A-BDA24B9B48E8"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev03:*:*:*:*:*:*",
+                    "matchCriteriaId": "F9E9C869-7DA9-4EFA-B613-82BA127F6CE5"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev04:*:*:*:*:*:*",
+                    "matchCriteriaId": "F8FAA329-5893-412B-8349-4DA3023CC76E"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev05:*:*:*:*:*:*",
+                    "matchCriteriaId": "BB6A57A4-B18D-498D-9A8C-406797A6255C"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev06:*:*:*:*:*:*",
+                    "matchCriteriaId": "7F0977F0-90B4-48B4-BED6-C218B5CA5E03"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev07:*:*:*:*:*:*",
+                    "matchCriteriaId": "4D55DE67-8F93-48F3-BE54-D3A065479281"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev08:*:*:*:*:*:*",
+                    "matchCriteriaId": "D27980B4-B71B-4DA8-B130-F0B5929F8E65"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev09:*:*:*:*:*:*",
+                    "matchCriteriaId": "DD1709BC-7DEB-4508-B3C3-B20F5FD001A3"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev10:*:*:*:*:*:*",
+                    "matchCriteriaId": "08A6BDD5-259E-4DC3-A548-00CD0D459749"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev11:*:*:*:*:*:*",
+                    "matchCriteriaId": "B8166FF4-77D8-4A12-92E5-615B3DA2E602"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev12:*:*:*:*:*:*",
+                    "matchCriteriaId": "999F057B-7918-461A-B60C-3BE72E92CDC9"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev13:*:*:*:*:*:*",
+                    "matchCriteriaId": "88FD1550-3715-493E-B674-9ECF3DD7A813"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev14:*:*:*:*:*:*",
+                    "matchCriteriaId": "F31A4949-397F-4D1B-8AEA-AC7B335722F8"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev15:*:*:*:*:*:*",
+                    "matchCriteriaId": "D33A91D4-CE21-486D-9469-B09060B8C637"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev16:*:*:*:*:*:*",
+                    "matchCriteriaId": "5E3E5CD2-7631-4DBE-AB4D-669E82BCCAD4"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev17:*:*:*:*:*:*",
+                    "matchCriteriaId": "2BEE0AF0-3D22-4DE7-9E71-A4469D9CA2EB"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev18:*:*:*:*:*:*",
+                    "matchCriteriaId": "AAFB199C-1D66-442D-AD7E-414DD339E1D3"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev19:*:*:*:*:*:*",
+                    "matchCriteriaId": "26322561-2491-4DC7-B974-0B92B61A5BDA"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev20:*:*:*:*:*:*",
+                    "matchCriteriaId": "A6BA6C2B-F2D5-4FF7-B316-C8E99C2B464B"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev21:*:*:*:*:*:*",
+                    "matchCriteriaId": "733E4A65-821B-4187-AA3A-1ACD3E882C07"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev22:*:*:*:*:*:*",
+                    "matchCriteriaId": "6B0A0043-33E8-4440-92AC-DDD70EA39535"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev23:*:*:*:*:*:*",
+                    "matchCriteriaId": "303205CC-8BDE-47EE-A675-9BA19983139A"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev24:*:*:*:*:*:*",
+                    "matchCriteriaId": "8C088014-47D6-4632-9FB5-2C7B1085B762"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev25:*:*:*:*:*:*",
+                    "matchCriteriaId": "42CF6057-EB40-4208-9F1E-83213E97987C"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev26:*:*:*:*:*:*",
+                    "matchCriteriaId": "966BC23E-B8CE-4F98-B3A6-4B620E8808BE"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev27:*:*:*:*:*:*",
+                    "matchCriteriaId": "7409CE19-ACC1-4AF4-8C8A-AE2CDBB63D3D"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev28:*:*:*:*:*:*",
+                    "matchCriteriaId": "17D71CDE-3111-459B-8520-F62E0D5D2972"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev29:*:*:*:*:*:*",
+                    "matchCriteriaId": "6D808ED6-F819-4014-BD24-4537D52DDFB0"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev30:*:*:*:*:*:*",
+                    "matchCriteriaId": "B3792A91-10E9-42D9-B852-37D369D8364E"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev31:*:*:*:*:*:*",
+                    "matchCriteriaId": "6F0BFEEF-8B19-4F71-B7F1-2CC94969616F"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev32:*:*:*:*:*:*",
+                    "matchCriteriaId": "52003F06-9351-49B6-A3C5-A2B6FC0B9F4D"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev33:*:*:*:*:*:*",
+                    "matchCriteriaId": "C8786112-32AE-4BA5-8D66-D4E2429D3228"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev34:*:*:*:*:*:*",
+                    "matchCriteriaId": "3A67F528-0248-4E24-A5AB-2995ED7D2600"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev35:*:*:*:*:*:*",
+                    "matchCriteriaId": "AE090C73-E093-4BD9-BEFE-634179500A78"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev36:*:*:*:*:*:*",
+                    "matchCriteriaId": "0A7CF0F7-5DF5-4749-A777-0F9EDCD14EA6"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev37:*:*:*:*:*:*",
+                    "matchCriteriaId": "EBE620A7-F071-4412-B0CE-7BCBF3BD7311"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev50:*:*:*:*:*:*",
+                    "matchCriteriaId": "1D7A5899-0795-452E-8B43-75C266AE6B88"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:8.17:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "BA5FBFC9-4542-4C5E-BCC1-52AA83EF5F09"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "http://packetstormsecurity.com/files/176422/OX-App-Suite-7.10.6-Access-Control-Cross-Site-Scripting.html",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "http://seclists.org/fulldisclosure/2024/Jan/4",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Mailing List",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://documentation.open-xchange.com/appsuite/security/advisories/csaf/2023/oxas-adv-2023-0006.json",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Issue Tracking"
+            ]
+          },
+          {
+            "url": "https://software.open-xchange.com/products/appsuite/doc/Release_Notes_for_Patch_Release_6251_7.10.6_2023-09-25.pdf",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Release Notes"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-29052",
+        "sourceIdentifier": "security@open-xchange.com",
+        "published": "2024-01-08T09:15:20.680",
+        "lastModified": "2024-01-12T14:27:55.633",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Users were able to define disclaimer texts for an upsell shop dialog that would contain script code that was not sanitized correctly. Attackers could lure victims to user accounts with malicious script code and make them execute it in the context of a trusted domain. We added sanitization for this content. No publicly available exploits are known.\n\n"
+          },
+          {
+            "lang": "es",
+            "value": "Los usuarios pudieron definir textos de exención de responsabilidad para un cuadro de diálogo de tienda de ventas adicionales que contendría código de script que no se sanitizó correctamente. Los atacantes podrían atraer a las víctimas a cuentas de usuario con código de script malicioso y obligarlas a ejecutarlo en el contexto de un dominio confiable. Agregamos sanitización para este contenido. No se conocen exploits disponibles públicamente."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.4,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.3,
+              "impactScore": 2.7
+            },
+            {
+              "source": "security@open-xchange.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.4,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.3,
+              "impactScore": 2.7
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          },
+          {
+            "source": "security@open-xchange.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:-:*:*:*:*:*:*",
+                    "matchCriteriaId": "3A4EAD2E-C3C3-4C79-8C42-375FFE638486"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev01:*:*:*:*:*:*",
+                    "matchCriteriaId": "39198733-D227-4935-9A60-1026040D262F"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev02:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C86EE81-8CD4-4131-969A-BDA24B9B48E8"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev03:*:*:*:*:*:*",
+                    "matchCriteriaId": "F9E9C869-7DA9-4EFA-B613-82BA127F6CE5"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev04:*:*:*:*:*:*",
+                    "matchCriteriaId": "F8FAA329-5893-412B-8349-4DA3023CC76E"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev05:*:*:*:*:*:*",
+                    "matchCriteriaId": "BB6A57A4-B18D-498D-9A8C-406797A6255C"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev06:*:*:*:*:*:*",
+                    "matchCriteriaId": "7F0977F0-90B4-48B4-BED6-C218B5CA5E03"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev07:*:*:*:*:*:*",
+                    "matchCriteriaId": "4D55DE67-8F93-48F3-BE54-D3A065479281"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev08:*:*:*:*:*:*",
+                    "matchCriteriaId": "D27980B4-B71B-4DA8-B130-F0B5929F8E65"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev09:*:*:*:*:*:*",
+                    "matchCriteriaId": "DD1709BC-7DEB-4508-B3C3-B20F5FD001A3"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev10:*:*:*:*:*:*",
+                    "matchCriteriaId": "08A6BDD5-259E-4DC3-A548-00CD0D459749"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev11:*:*:*:*:*:*",
+                    "matchCriteriaId": "B8166FF4-77D8-4A12-92E5-615B3DA2E602"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev12:*:*:*:*:*:*",
+                    "matchCriteriaId": "999F057B-7918-461A-B60C-3BE72E92CDC9"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev13:*:*:*:*:*:*",
+                    "matchCriteriaId": "88FD1550-3715-493E-B674-9ECF3DD7A813"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev14:*:*:*:*:*:*",
+                    "matchCriteriaId": "F31A4949-397F-4D1B-8AEA-AC7B335722F8"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev15:*:*:*:*:*:*",
+                    "matchCriteriaId": "D33A91D4-CE21-486D-9469-B09060B8C637"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev16:*:*:*:*:*:*",
+                    "matchCriteriaId": "5E3E5CD2-7631-4DBE-AB4D-669E82BCCAD4"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev17:*:*:*:*:*:*",
+                    "matchCriteriaId": "2BEE0AF0-3D22-4DE7-9E71-A4469D9CA2EB"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev18:*:*:*:*:*:*",
+                    "matchCriteriaId": "AAFB199C-1D66-442D-AD7E-414DD339E1D3"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev19:*:*:*:*:*:*",
+                    "matchCriteriaId": "26322561-2491-4DC7-B974-0B92B61A5BDA"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev20:*:*:*:*:*:*",
+                    "matchCriteriaId": "A6BA6C2B-F2D5-4FF7-B316-C8E99C2B464B"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev21:*:*:*:*:*:*",
+                    "matchCriteriaId": "733E4A65-821B-4187-AA3A-1ACD3E882C07"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev22:*:*:*:*:*:*",
+                    "matchCriteriaId": "6B0A0043-33E8-4440-92AC-DDD70EA39535"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev23:*:*:*:*:*:*",
+                    "matchCriteriaId": "303205CC-8BDE-47EE-A675-9BA19983139A"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev24:*:*:*:*:*:*",
+                    "matchCriteriaId": "8C088014-47D6-4632-9FB5-2C7B1085B762"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev25:*:*:*:*:*:*",
+                    "matchCriteriaId": "42CF6057-EB40-4208-9F1E-83213E97987C"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev26:*:*:*:*:*:*",
+                    "matchCriteriaId": "966BC23E-B8CE-4F98-B3A6-4B620E8808BE"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev27:*:*:*:*:*:*",
+                    "matchCriteriaId": "7409CE19-ACC1-4AF4-8C8A-AE2CDBB63D3D"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev28:*:*:*:*:*:*",
+                    "matchCriteriaId": "17D71CDE-3111-459B-8520-F62E0D5D2972"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev29:*:*:*:*:*:*",
+                    "matchCriteriaId": "6D808ED6-F819-4014-BD24-4537D52DDFB0"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev30:*:*:*:*:*:*",
+                    "matchCriteriaId": "B3792A91-10E9-42D9-B852-37D369D8364E"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev31:*:*:*:*:*:*",
+                    "matchCriteriaId": "6F0BFEEF-8B19-4F71-B7F1-2CC94969616F"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev32:*:*:*:*:*:*",
+                    "matchCriteriaId": "52003F06-9351-49B6-A3C5-A2B6FC0B9F4D"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev33:*:*:*:*:*:*",
+                    "matchCriteriaId": "C8786112-32AE-4BA5-8D66-D4E2429D3228"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev34:*:*:*:*:*:*",
+                    "matchCriteriaId": "3A67F528-0248-4E24-A5AB-2995ED7D2600"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "http://packetstormsecurity.com/files/176422/OX-App-Suite-7.10.6-Access-Control-Cross-Site-Scripting.html",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "http://seclists.org/fulldisclosure/2024/Jan/4",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Mailing List",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://documentation.open-xchange.com/appsuite/security/advisories/csaf/2023/oxas-adv-2023-0006.json",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Issue Tracking"
+            ]
+          },
+          {
+            "url": "https://software.open-xchange.com/products/appsuite/doc/Release_Notes_for_Patch_Release_6251_7.10.6_2023-09-25.pdf",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Release Notes"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-41710",
+        "sourceIdentifier": "security@open-xchange.com",
+        "published": "2024-01-08T09:15:20.883",
+        "lastModified": "2024-01-12T13:56:25.453",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "User-defined script code could be stored for a upsell related shop URL. This code was not correctly sanitized when adding it to DOM. Attackers could lure victims to user accounts with malicious script code and make them execute it in the context of a trusted domain. We added sanitization for this content. No publicly available exploits are known.\n\n"
+          },
+          {
+            "lang": "es",
+            "value": "Se podría almacenar un código de secuencia de comandos definido por el usuario para una URL de la tienda relacionada con ventas adicionales. Este código no se sanitizó correctamente al agregarlo al DOM. Los atacantes podrían atraer a las víctimas a cuentas de usuario con código de script malicioso y obligarlas a ejecutarlo en el contexto de un dominio confiable. Agregamos sanitización para este contenido. No se conocen exploits disponibles públicamente."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.4,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.3,
+              "impactScore": 2.7
+            },
+            {
+              "source": "security@open-xchange.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.4,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.3,
+              "impactScore": 2.7
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          },
+          {
+            "source": "security@open-xchange.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-79"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:*:*:*:*:*:*:*:*",
+                    "versionEndExcluding": "7.10.6",
+                    "matchCriteriaId": "5BBF1862-B6FF-4F32-A3C1-59D28BA25F81"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:-:*:*:*:*:*:*",
+                    "matchCriteriaId": "3A4EAD2E-C3C3-4C79-8C42-375FFE638486"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev01:*:*:*:*:*:*",
+                    "matchCriteriaId": "39198733-D227-4935-9A60-1026040D262F"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev02:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C86EE81-8CD4-4131-969A-BDA24B9B48E8"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev03:*:*:*:*:*:*",
+                    "matchCriteriaId": "F9E9C869-7DA9-4EFA-B613-82BA127F6CE5"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev04:*:*:*:*:*:*",
+                    "matchCriteriaId": "F8FAA329-5893-412B-8349-4DA3023CC76E"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev05:*:*:*:*:*:*",
+                    "matchCriteriaId": "BB6A57A4-B18D-498D-9A8C-406797A6255C"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev06:*:*:*:*:*:*",
+                    "matchCriteriaId": "7F0977F0-90B4-48B4-BED6-C218B5CA5E03"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev07:*:*:*:*:*:*",
+                    "matchCriteriaId": "4D55DE67-8F93-48F3-BE54-D3A065479281"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev08:*:*:*:*:*:*",
+                    "matchCriteriaId": "D27980B4-B71B-4DA8-B130-F0B5929F8E65"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev09:*:*:*:*:*:*",
+                    "matchCriteriaId": "DD1709BC-7DEB-4508-B3C3-B20F5FD001A3"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev10:*:*:*:*:*:*",
+                    "matchCriteriaId": "08A6BDD5-259E-4DC3-A548-00CD0D459749"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev11:*:*:*:*:*:*",
+                    "matchCriteriaId": "B8166FF4-77D8-4A12-92E5-615B3DA2E602"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev12:*:*:*:*:*:*",
+                    "matchCriteriaId": "999F057B-7918-461A-B60C-3BE72E92CDC9"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev13:*:*:*:*:*:*",
+                    "matchCriteriaId": "88FD1550-3715-493E-B674-9ECF3DD7A813"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev14:*:*:*:*:*:*",
+                    "matchCriteriaId": "F31A4949-397F-4D1B-8AEA-AC7B335722F8"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev15:*:*:*:*:*:*",
+                    "matchCriteriaId": "D33A91D4-CE21-486D-9469-B09060B8C637"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev16:*:*:*:*:*:*",
+                    "matchCriteriaId": "5E3E5CD2-7631-4DBE-AB4D-669E82BCCAD4"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev17:*:*:*:*:*:*",
+                    "matchCriteriaId": "2BEE0AF0-3D22-4DE7-9E71-A4469D9CA2EB"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev18:*:*:*:*:*:*",
+                    "matchCriteriaId": "AAFB199C-1D66-442D-AD7E-414DD339E1D3"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev19:*:*:*:*:*:*",
+                    "matchCriteriaId": "26322561-2491-4DC7-B974-0B92B61A5BDA"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev20:*:*:*:*:*:*",
+                    "matchCriteriaId": "A6BA6C2B-F2D5-4FF7-B316-C8E99C2B464B"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev21:*:*:*:*:*:*",
+                    "matchCriteriaId": "733E4A65-821B-4187-AA3A-1ACD3E882C07"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev22:*:*:*:*:*:*",
+                    "matchCriteriaId": "6B0A0043-33E8-4440-92AC-DDD70EA39535"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev23:*:*:*:*:*:*",
+                    "matchCriteriaId": "303205CC-8BDE-47EE-A675-9BA19983139A"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev24:*:*:*:*:*:*",
+                    "matchCriteriaId": "8C088014-47D6-4632-9FB5-2C7B1085B762"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev25:*:*:*:*:*:*",
+                    "matchCriteriaId": "42CF6057-EB40-4208-9F1E-83213E97987C"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev26:*:*:*:*:*:*",
+                    "matchCriteriaId": "966BC23E-B8CE-4F98-B3A6-4B620E8808BE"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev27:*:*:*:*:*:*",
+                    "matchCriteriaId": "7409CE19-ACC1-4AF4-8C8A-AE2CDBB63D3D"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev28:*:*:*:*:*:*",
+                    "matchCriteriaId": "17D71CDE-3111-459B-8520-F62E0D5D2972"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev29:*:*:*:*:*:*",
+                    "matchCriteriaId": "6D808ED6-F819-4014-BD24-4537D52DDFB0"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev30:*:*:*:*:*:*",
+                    "matchCriteriaId": "B3792A91-10E9-42D9-B852-37D369D8364E"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev31:*:*:*:*:*:*",
+                    "matchCriteriaId": "6F0BFEEF-8B19-4F71-B7F1-2CC94969616F"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev32:*:*:*:*:*:*",
+                    "matchCriteriaId": "52003F06-9351-49B6-A3C5-A2B6FC0B9F4D"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev33:*:*:*:*:*:*",
+                    "matchCriteriaId": "C8786112-32AE-4BA5-8D66-D4E2429D3228"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:open-xchange:ox_app_suite:7.10.6:rev34:*:*:*:*:*:*",
+                    "matchCriteriaId": "3A67F528-0248-4E24-A5AB-2995ED7D2600"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "http://packetstormsecurity.com/files/176422/OX-App-Suite-7.10.6-Access-Control-Cross-Site-Scripting.html",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Third Party Advisory",
+              "VDB Entry"
+            ]
+          },
+          {
+            "url": "http://seclists.org/fulldisclosure/2024/Jan/4",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Mailing List",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://documentation.open-xchange.com/appsuite/security/advisories/csaf/2023/oxas-adv-2023-0006.json",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Issue Tracking"
+            ]
+          },
+          {
+            "url": "https://software.open-xchange.com/products/appsuite/doc/Release_Notes_for_Patch_Release_6251_7.10.6_2023-09-25.pdf",
+            "source": "security@open-xchange.com",
+            "tags": [
+              "Release Notes"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0305",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T09:15:21.240",
+        "lastModified": "2024-01-11T21:18:08.867",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Guangzhou Yingke Electronic Technology Ncast up to 2017 and classified as problematic. Affected by this issue is some unknown functionality of the file /manage/IPSetup.php of the component Guest Login. The manipulation leads to information disclosure. The attack may be launched remotely. The exploit has been disclosed to the public and may be used. The identifier of this vulnerability is VDB-249872."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Guangzhou Yingke Electronic Technology Ncast hasta 2017 y se clasificó como problemática. Una función desconocida del archivo /manage/IPSetup.php del componente Guest Login es afectada por esta vulnerabilidad. La manipulación conduce a la divulgación de información. El ataque puede lanzarse de forma remota. El exploit ha sido divulgado al público y puede utilizarse. El identificador de esta vulnerabilidad es VDB-249872."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 7.5,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 1.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.0
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 10.0,
+              "impactScore": 2.9,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "NVD-CWE-noinfo"
+              }
+            ]
+          },
+          {
+            "source": "cna@vuldb.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-200"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:ncast_project:ncast:*:*:*:*:*:*:*:*",
+                    "versionStartIncluding": "2007",
+                    "versionEndIncluding": "2017",
+                    "matchCriteriaId": "1148BE5A-A3CF-4C86-8131-AD3D0E649541"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/2267787739/cve/blob/main/logic.md",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249872",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249872",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0306",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T09:15:21.497",
+        "lastModified": "2024-01-11T21:22:22.937",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Kashipara Dynamic Lab Management System up to 1.0. It has been classified as critical. This affects an unknown part of the file /admin/admin_login_process.php. The manipulation of the argument admin_password leads to sql injection. It is possible to initiate the attack remotely. The exploit has been disclosed to the public and may be used. The identifier VDB-249873 was assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Kashipara Dynamic Lab Management System hasta la versión 1.0. Ha sido clasificada como crítica. Esto afecta a una parte desconocida del archivo /admin/admin_login_process.php. La manipulación del argumento admin_password conduce a la inyección de SQL. Es posible iniciar el ataque de forma remota. El exploit ha sido divulgado al público y puede utilizarse. A esta vulnerabilidad se le asignó el identificador VDB-249873."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 7.5,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 7.3,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 7.5
+              },
+              "baseSeverity": "HIGH",
+              "exploitabilityScore": 10.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:lopalopa:dynamic_lab_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "0BB1B1C8-9985-40B2-B9CD-1C4896E526C0"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/E1CHO/cve_hub/blob/main/Dynamic%20Lab%20Management%20System%20-%20vuln%201.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249873",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249873",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-5091",
+        "sourceIdentifier": "arm-security@arm.com",
+        "published": "2024-01-08T10:15:11.233",
+        "lastModified": "2024-01-12T13:39:11.443",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Use After Free vulnerability in Arm Ltd Valhall GPU Kernel Driver allows a local non-privileged user to make improper GPU processing operations to gain access to already freed memory. This issue affects Valhall GPU Kernel Driver: from r37p0 through r40p0.\n\n"
+          },
+          {
+            "lang": "es",
+            "value": "Vulnerabilidad de Use After Free en Arm Ltd Valhall GPU Kernel Driver permite a un usuario local sin privilegios realizar operaciones de procesamiento de GPU incorrectas para obtener acceso a la memoria ya liberada. Este problema afecta al controlador del kernel de GPU de Valhall: desde r37p0 hasta r40p0."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.5,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 3.6
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-416"
+              }
+            ]
+          },
+          {
+            "source": "arm-security@arm.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-416"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:arm:valhall_gpu_kernel_driver:*:*:*:*:*:*:*:*",
+                    "versionStartIncluding": "r37p0",
+                    "versionEndIncluding": "r40p0",
+                    "matchCriteriaId": "06079983-073D-4714-9C72-1E0FA60213A0"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://developer.arm.com/Arm%20Security%20Center/Mali%20GPU%20Driver%20Vulnerabilities",
+            "source": "arm-security@arm.com",
+            "tags": [
+              "Vendor Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0307",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T10:15:11.343",
+        "lastModified": "2024-01-11T21:08:45.333",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Kashipara Dynamic Lab Management System up to 1.0. It has been declared as critical. This vulnerability affects unknown code of the file login_process.php. The manipulation of the argument password leads to sql injection. The attack can be initiated remotely. The exploit has been disclosed to the public and may be used. VDB-249874 is the identifier assigned to this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Kashipara Dynamic Lab Management System hasta la versión 1.0. Ha sido declarada crítica. Esta vulnerabilidad afecta a un código desconocido del archivo login_process.php. La manipulación del argumento password conduce a la inyección de SQL. El ataque se puede iniciar de forma remota. El exploit ha sido divulgado al público y puede utilizarse. VDB-249874 es el identificador asignado a esta vulnerabilidad."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 7.5,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 7.3,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "NONE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 7.5
+              },
+              "baseSeverity": "HIGH",
+              "exploitabilityScore": 10.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:lopalopa:dynamic_lab_management_system:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "1.0",
+                    "matchCriteriaId": "0BB1B1C8-9985-40B2-B9CD-1C4896E526C0"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/VistaAX/vulnerablility/blob/main/Dynamic%20Lab%20Management%20System%20-%20vuln%202.pdf",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249874",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249874",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0308",
+        "sourceIdentifier": "cna@vuldb.com",
+        "published": "2024-01-08T10:15:11.560",
+        "lastModified": "2024-01-12T13:24:38.147",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A vulnerability was found in Inis up to 2.0.1. It has been rated as critical. This issue affects some unknown processing of the file app/api/controller/default/Proxy.php. The manipulation of the argument p_url leads to server-side request forgery. The attack may be initiated remotely. The exploit has been disclosed to the public and may be used. The associated identifier of this vulnerability is VDB-249875."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una vulnerabilidad en Inis hasta 2.0.1. Ha sido calificada como crítica. Este problema afecta un procesamiento desconocido del archivo app/api/controller/default/Proxy.php. La manipulación del argumento p_url conduce a server-side request forgery. El ataque puede iniciarse de forma remota. El exploit ha sido divulgado al público y puede utilizarse. El identificador asociado de esta vulnerabilidad es VDB-249875."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 8.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "LOW",
+                "baseScore": 6.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 3.4
+            }
+          ],
+          "cvssMetricV2": [
+            {
+              "source": "cna@vuldb.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "2.0",
+                "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+                "accessVector": "NETWORK",
+                "accessComplexity": "LOW",
+                "authentication": "SINGLE",
+                "confidentialityImpact": "PARTIAL",
+                "integrityImpact": "PARTIAL",
+                "availabilityImpact": "PARTIAL",
+                "baseScore": 6.5
+              },
+              "baseSeverity": "MEDIUM",
+              "exploitabilityScore": 8.0,
+              "impactScore": 6.4,
+              "acInsufInfo": false,
+              "obtainAllPrivilege": false,
+              "obtainUserPrivilege": false,
+              "obtainOtherPrivilege": false,
+              "userInteractionRequired": false
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "cna@vuldb.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-918"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:inis_project:inis:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "2.0.1",
+                    "matchCriteriaId": "BF3BA3A1-37C8-4CA7-824D-43F337B28185"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://note.zhaoj.in/share/2E2JG2PClHGF",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Broken Link"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?ctiid.249875",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://vuldb.com/?id.249875",
+            "source": "cna@vuldb.com",
+            "tags": [
+              "Permissions Required",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-6921",
+        "sourceIdentifier": "cvd@cert.pl",
+        "published": "2024-01-08T12:15:46.513",
+        "lastModified": "2024-01-11T20:57:37.320",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Blind SQL Injection vulnerability in PrestaShow Google Integrator (PrestaShop addon) allows for data extraction and modification. This attack is possible via command insertion in one of the cookies.\n"
+          },
+          {
+            "lang": "es",
+            "value": "Vulnerabilidad de inyección SQL ciega en PrestaShow Google Integrator (complemento PrestaShop) permite la extracción y modificación de datos. Este ataque es posible mediante la inserción de un comando en una de las cookies."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "NONE",
+                "baseScore": 9.1,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.2
+            },
+            {
+              "source": "cvd@cert.pl",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          },
+          {
+            "source": "cvd@cert.pl",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-89"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:prestashow:google_integrator:*:*:*:*:*:prestashop:*:*",
+                    "versionEndExcluding": "2.1.4",
+                    "matchCriteriaId": "6C4DFC6A-D90C-4E43-980E-2404E45E7983"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://cert.pl/en/posts/2024/01/CVE-2023-6921/",
+            "source": "cvd@cert.pl",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://cert.pl/posts/2024/01/CVE-2023-6921/",
+            "source": "cvd@cert.pl",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://prestashow.pl/pl/moduly-prestashop/28-prestashop-google-integrator-ga4-gtm-ads-remarketing.html",
+            "source": "cvd@cert.pl",
+            "tags": [
+              "Product"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-6552",
+        "sourceIdentifier": "cvd@cert.pl",
+        "published": "2024-01-08T13:15:09.257",
+        "lastModified": "2024-01-11T21:13:09.007",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Lack of \"current\" GET parameter validation during the action of changing a language leads to an open redirect vulnerability.\n"
+          },
+          {
+            "lang": "es",
+            "value": "La falta de validación del parámetro GET \"actual\" durante la acción de cambiar un idioma conduce a una vulnerabilidad de redireccionamiento abierto."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "CHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 6.1,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.8,
+              "impactScore": 2.7
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-601"
+              }
+            ]
+          },
+          {
+            "source": "cvd@cert.pl",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-601"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tasmoadmin:tasmoadmin:*:*:*:*:*:*:*:*",
+                    "versionEndExcluding": "3.3.0",
+                    "matchCriteriaId": "35397843-FA5B-4258-8C48-14C6366FE292"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://cert.pl/en/posts/2024/01/CVE-2023-6552/",
+            "source": "cvd@cert.pl",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://cert.pl/posts/2024/01/CVE-2023-6552/",
+            "source": "cvd@cert.pl",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://github.com/TasmoAdmin/TasmoAdmin/pull/1039",
+            "source": "cvd@cert.pl",
+            "tags": [
+              "Patch"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0321",
+        "sourceIdentifier": "security@huntr.dev",
+        "published": "2024-01-08T13:15:09.347",
+        "lastModified": "2024-01-11T20:50:46.433",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Stack-based Buffer Overflow in GitHub repository gpac/gpac prior to 2.3-DEV."
+          },
+          {
+            "lang": "es",
+            "value": "desbordamiento de búfer en la región stack de la memoria en el repositorio de GitHub gpac/gpac anterior a 2.3-DEV."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            }
+          ],
+          "cvssMetricV30": [
+            {
+              "source": "security@huntr.dev",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.0",
+                "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "LOW",
+                "baseScore": 4.0,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.5,
+              "impactScore": 1.4
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-787"
+              }
+            ]
+          },
+          {
+            "source": "security@huntr.dev",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-121"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:gpac:gpac:*:*:*:*:*:*:*:*",
+                    "versionEndExcluding": "2.3.0-dev",
+                    "matchCriteriaId": "F3A1B96B-3E09-4DB5-B15E-249D5E6EDEDC"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/gpac/gpac/commit/d0ced41651b279bb054eb6390751e2d4eb84819a",
+            "source": "security@huntr.dev",
+            "tags": [
+              "Patch"
+            ]
+          },
+          {
+            "url": "https://huntr.com/bounties/4c027b94-8e9c-4c31-a169-893b25047769",
+            "source": "security@huntr.dev",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-0322",
+        "sourceIdentifier": "security@huntr.dev",
+        "published": "2024-01-08T13:15:09.557",
+        "lastModified": "2024-01-11T17:36:34.290",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Out-of-bounds Read in GitHub repository gpac/gpac prior to 2.3-DEV."
+          },
+          {
+            "lang": "es",
+            "value": "Fuera de los límites Read en el repositorio de GitHub gpac/gpac anterior a 2.3-DEV."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "HIGH",
+                "baseScore": 9.1,
+                "baseSeverity": "CRITICAL"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.2
+            }
+          ],
+          "cvssMetricV30": [
+            {
+              "source": "security@huntr.dev",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.0",
+                "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:L",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "LOW",
+                "baseScore": 4.4,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 2.5
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "security@huntr.dev",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-125"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:gpac:gpac:*:*:*:*:*:*:*:*",
+                    "versionEndExcluding": "2.3.0",
+                    "matchCriteriaId": "8427BDFE-346D-45C9-B0BD-1F06E8825368"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:gpac:gpac:2.3.0:dev:*:*:*:*:*:*",
+                    "matchCriteriaId": "92DC0391-41BE-4FD8-BA6A-C90EE8659840"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/gpac/gpac/commit/092904b80edbc4dce315684a59cc3184c45c1b70",
+            "source": "security@huntr.dev",
+            "tags": [
+              "Patch"
+            ]
+          },
+          {
+            "url": "https://huntr.com/bounties/87611fc9-ed7c-43e9-8e52-d83cd270bbec",
+            "source": "security@huntr.dev",
+            "tags": [
+              "Exploit"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-51701",
+        "sourceIdentifier": "security-advisories@github.com",
+        "published": "2024-01-08T14:15:46.677",
+        "lastModified": "2024-01-11T17:33:45.077",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "fastify-reply-from is a Fastify plugin to forward the current HTTP request to another server. A reverse proxy server built with `@fastify/reply-from` could misinterpret the incoming body by passing an header `ContentType: application/json ; charset=utf-8`. This can lead to bypass of security checks. This vulnerability has been patched in '@fastify/reply-from` version 9.6.0. \n"
+          },
+          {
+            "lang": "es",
+            "value": "fastify-reply-from es un complemento de Fastify para reenviar la solicitud HTTP actual a otro servidor. Un servidor proxy inverso creado con `@fastify/reply-from` podría malinterpretar el cuerpo entrante al pasar un encabezado `ContentType: application/json; charset=utf-8`. Esto puede provocar que se eludan los controles de seguridad. Esta vulnerabilidad ha sido parcheada en '@fastify/reply-from` versión 9.6.0."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "NONE",
+                "baseScore": 7.5,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            },
+            {
+              "source": "security-advisories@github.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "LOW",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 1.4
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-444"
+              }
+            ]
+          },
+          {
+            "source": "security-advisories@github.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-444"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:fastify:reply-from:*:*:*:*:*:node.js:*:*",
+                    "versionEndExcluding": "9.6.0",
+                    "matchCriteriaId": "156AAC0C-39BA-44A0-81BD-B9190ED48E8F"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/fastify/fastify-reply-from/releases/tag/v9.6.0",
+            "source": "security-advisories@github.com",
+            "tags": [
+              "Release Notes"
+            ]
+          },
+          {
+            "url": "https://github.com/fastify/fastify-reply-from/security/advisories/GHSA-v2v2-hph8-q5xp",
+            "source": "security-advisories@github.com",
+            "tags": [
+              "Vendor Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-7224",
+        "sourceIdentifier": "security@openvpn.net",
+        "published": "2024-01-08T14:15:47.130",
+        "lastModified": "2024-01-11T17:33:31.310",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "OpenVPN Connect version 3.0 through 3.4.6 on macOS allows local users to execute code in external third party libraries using the DYLD_INSERT_LIBRARIES environment variable"
+          },
+          {
+            "lang": "es",
+            "value": "OpenVPN Connect versión 3.0 a 3.4.6 en macOS permite a los usuarios locales ejecutar código en librerías externas de terceros utilizando la variable de entorno DYLD_INSERT_LIBRARIES"
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-94"
+              }
+            ]
+          },
+          {
+            "source": "security@openvpn.net",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-95"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:openvpn:connect:*:*:*:*:*:macos:*:*",
+                    "versionStartIncluding": "3.0.0",
+                    "versionEndIncluding": "3.4.6",
+                    "matchCriteriaId": "E933ACE1-DCEF-4AE5-AF74-075DD0E38ACC"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://openvpn.net/vpn-server-resources/openvpn-connect-for-macos-change-log/",
+            "source": "security@openvpn.net",
+            "tags": [
+              "Release Notes"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-21644",
+        "sourceIdentifier": "security-advisories@github.com",
+        "published": "2024-01-08T14:15:47.217",
+        "lastModified": "2024-01-11T17:33:09.870",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "pyLoad is the free and open-source Download Manager written in pure Python. Any unauthenticated user can browse to a specific URL to expose the Flask config, including the `SECRET_KEY` variable. This issue has been patched in version 0.5.0b3.dev77."
+          },
+          {
+            "lang": "es",
+            "value": "pyLoad es el administrador de descargas gratuito y de código abierto escrito en Python puro. Cualquier usuario no autenticado puede navegar a una URL específica para exponer la configuración de Flask, incluida la variable `SECRET_KEY`. Este problema se solucionó en la versión 0.5.0b3.dev77."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 7.5,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            },
+            {
+              "source": "security-advisories@github.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "NONE",
+                "baseScore": 7.5,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "NVD-CWE-noinfo"
+              }
+            ]
+          },
+          {
+            "source": "security-advisories@github.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-284"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:pyload:pyload:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "0.4.9",
+                    "matchCriteriaId": "71C7D7BA-743B-4C43-B77C-E6C1A6ACFE7E"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:pyload:pyload:0.5.0:beta1:*:*:*:*:*:*",
+                    "matchCriteriaId": "3040B5C9-171B-40D9-83CB-CD529DC046ED"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:pyload:pyload:0.5.0:beta2:*:*:*:*:*:*",
+                    "matchCriteriaId": "78FA70FC-0CFE-4E89-9274-1670E1204B61"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/pyload/pyload/commit/bb22063a875ffeca357aaf6e2edcd09705688c40",
+            "source": "security-advisories@github.com",
+            "tags": [
+              "Patch"
+            ]
+          },
+          {
+            "url": "https://github.com/pyload/pyload/security/advisories/GHSA-mqpq-2p68-46fv",
+            "source": "security-advisories@github.com",
+            "tags": [
+              "Exploit",
+              "Vendor Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-21645",
+        "sourceIdentifier": "security-advisories@github.com",
+        "published": "2024-01-08T14:15:47.420",
+        "lastModified": "2024-01-11T17:32:30.503",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "pyLoad is the free and open-source Download Manager written in pure Python. A log injection vulnerability was identified in `pyload` allowing any unauthenticated actor to inject arbitrary messages into the logs gathered by `pyload`. Forged or otherwise, corrupted log files can be used to cover an attacker’s tracks or even to implicate another party in the commission of a malicious act. This vulnerability has been patched in version 0.5.0b3.dev77.\n"
+          },
+          {
+            "lang": "es",
+            "value": "pyLoad es el administrador de descargas gratuito y de código abierto escrito en Python puro. Se identificó una vulnerabilidad de inyección de registros en \"pyload\" que permite a cualquier actor no autenticado inyectar mensajes arbitrarios en los registros recopilados por \"pyload\". Los archivos de registro corruptos, falsificados o no, se pueden utilizar para cubrir las huellas de un atacante o incluso para implicar a otra parte en la comisión de un acto malicioso. Esta vulnerabilidad ha sido parcheada en la versión 0.5.0b3.dev77."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 1.4
+            },
+            {
+              "source": "security-advisories@github.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "LOW",
+                "availabilityImpact": "NONE",
+                "baseScore": 5.3,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 1.4
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "security-advisories@github.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-74"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:pyload:pyload:*:*:*:*:*:*:*:*",
+                    "versionEndIncluding": "0.4.9",
+                    "matchCriteriaId": "71C7D7BA-743B-4C43-B77C-E6C1A6ACFE7E"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:pyload:pyload:0.5.0:beta1:*:*:*:*:*:*",
+                    "matchCriteriaId": "3040B5C9-171B-40D9-83CB-CD529DC046ED"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:pyload:pyload:0.5.0:beta2:*:*:*:*:*:*",
+                    "matchCriteriaId": "78FA70FC-0CFE-4E89-9274-1670E1204B61"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/pyload/pyload/commit/4159a1191ec4fe6d927e57a9c4bb8f54e16c381d",
+            "source": "security-advisories@github.com",
+            "tags": [
+              "Patch"
+            ]
+          },
+          {
+            "url": "https://github.com/pyload/pyload/security/advisories/GHSA-ghmw-rwh8-6qmr",
+            "source": "security-advisories@github.com",
+            "tags": [
+              "Exploit",
+              "Vendor Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2024-21647",
+        "sourceIdentifier": "security-advisories@github.com",
+        "published": "2024-01-08T14:15:47.640",
+        "lastModified": "2024-01-11T17:31:54.497",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Puma is a web server for Ruby/Rack applications built for parallelism. Prior to version 6.4.2, puma exhibited incorrect behavior when parsing chunked transfer encoding bodies in a way that allowed HTTP request smuggling. Fixed versions limits the size of chunk extensions. Without this limit, an attacker could cause unbounded resource (CPU, network bandwidth) consumption. This vulnerability has been fixed in versions 6.4.2 and 5.6.8.\n\n"
+          },
+          {
+            "lang": "es",
+            "value": "Puma es un servidor web para aplicaciones Ruby/Rack creado para el paralelismo. Antes de la versión 6.4.2, Puma exhibía un comportamiento incorrecto al analizar cuerpos de codificación de transferencia fragmentados de una manera que permitía el contrabando de solicitudes HTTP. Las versiones fijas limitan el tamaño de las extensiones de fragmentos. Sin este límite, un atacante podría provocar un consumo ilimitado de recursos (CPU, ancho de banda de red). Esta vulnerabilidad se ha solucionado en las versiones 6.4.2 y 5.6.8."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.5,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            },
+            {
+              "source": "security-advisories@github.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                "attackVector": "NETWORK",
+                "attackComplexity": "HIGH",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "HIGH",
+                "baseScore": 5.9,
+                "baseSeverity": "MEDIUM"
+              },
+              "exploitabilityScore": 2.2,
+              "impactScore": 3.6
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "security-advisories@github.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-444"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:puma:puma:*:*:*:*:*:ruby:*:*",
+                    "versionEndExcluding": "5.6.8",
+                    "matchCriteriaId": "A4C4E799-9F02-4DF4-A3C3-8A7DA1B86BFE"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:puma:puma:*:*:*:*:*:ruby:*:*",
+                    "versionStartIncluding": "6.0.0",
+                    "versionEndExcluding": "6.4.2",
+                    "matchCriteriaId": "9729F4C2-7642-400E-B88A-154E29A8CA2C"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://github.com/puma/puma/commit/5fc43d73b6ff193325e657a24ed76dec79133e93",
+            "source": "security-advisories@github.com",
+            "tags": [
+              "Patch"
+            ]
+          },
+          {
+            "url": "https://github.com/puma/puma/security/advisories/GHSA-c2f4-cvqm-65w2",
+            "source": "security-advisories@github.com",
+            "tags": [
+              "Vendor Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-32650",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:08.543",
+        "lastModified": "2024-01-16T16:29:57.263",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "An integer overflow vulnerability exists in the FST_BL_GEOM parsing maxhandle functionality of GTKWave 3.3.115, when compiled as a 32-bit binary. A specially crafted .fst file can lead to memory corruption. A victim would need to open a malicious file to trigger this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Existe una vulnerabilidad de desbordamiento de enteros en la funcionalidad de análisis maxhandle FST_BL_GEOM de GTKWave 3.3.115, cuando se compila como un binario de 32 bits. Un archivo .fst especialmente manipulado puede provocar daños en la memoria. Una víctima necesitaría abrir un archivo malicioso para activar esta vulnerabilidad."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "HIGH",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.0,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.0,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-190"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-190"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1777",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-34087",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:08.783",
+        "lastModified": "2024-01-16T16:29:57.263",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "An improper array index validation vulnerability exists in the EVCD var len parsing functionality of GTKWave 3.3.115. A specially crafted .evcd file can lead to arbitrary code execution. A victim would need to open a malicious file to trigger this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Existe una vulnerabilidad de validación de índice de matriz incorrecta en la funcionalidad de análisis EVCD var len de GTKWave 3.3.115. Un archivo .evcd especialmente manipulado puede provocar la ejecución de código arbitrario. Una víctima necesitaría abrir un archivo malicioso para activar esta vulnerabilidad."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-119"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-119"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1803",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-34436",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:08.990",
+        "lastModified": "2024-01-16T16:29:57.263",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "An out-of-bounds write vulnerability exists in the LXT2 num_time_table_entries functionality of GTKWave 3.3.115. A specially crafted .lxt2 file can lead to arbitrary code execution. A victim would need to open a malicious file to trigger this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Existe una vulnerabilidad de escritura fuera de los límites en la funcionalidad LXT2 num_time_table_entries de GTKWave 3.3.115. Un archivo .lxt2 especialmente manipulado puede provocar la ejecución de código arbitrario. Una víctima necesitaría abrir un archivo malicioso para activar esta vulnerabilidad."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-787"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-119"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1819",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-35004",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:09.210",
+        "lastModified": "2024-01-16T16:29:57.263",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "An integer overflow vulnerability exists in the VZT longest_len value allocation functionality of GTKWave 3.3.115. A specially crafted .vzt file can lead to arbitrary code execution. A victim would need to open a malicious file to trigger this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Existe una vulnerabilidad de desbordamiento de enteros en la funcionalidad de asignación de valores VZT long_len de GTKWave 3.3.115. Un archivo .vzt especialmente manipulado puede provocar la ejecución de código arbitrario. Una víctima necesitaría abrir un archivo malicioso para activar esta vulnerabilidad."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-190"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-190"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1816",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-35057",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:09.407",
+        "lastModified": "2024-01-16T16:29:57.263",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "An integer overflow vulnerability exists in the LXT2 lxt2_rd_trace value elements allocation functionality of GTKWave 3.3.115. A specially crafted .lxt2 file can lead to memory corruption. A victim would need to open a malicious file to trigger this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Existe una vulnerabilidad de desbordamiento de enteros en la funcionalidad de asignación de elementos de valor LXT2 lxt2_rd_trace de GTKWave 3.3.115. Un archivo .lxt2 especialmente manipulado puede provocar daños en la memoria. Una víctima necesitaría abrir un archivo malicioso para activar esta vulnerabilidad."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-190"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-190"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1821",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-35128",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:09.600",
+        "lastModified": "2024-01-16T16:29:57.263",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "An integer overflow vulnerability exists in the fstReaderIterBlocks2 time_table tsec_nitems functionality of GTKWave 3.3.115. A specially crafted .fst file can lead to memory corruption. A victim would need to open a malicious file to trigger this vulnerability."
+          },
+          {
+            "lang": "es",
+            "value": "Existe una vulnerabilidad de desbordamiento de enteros en la funcionalidad fstReaderIterBlocks2 time_table tsec_nitems de GTKWave 3.3.115. Un archivo .fst especialmente manipulado puede provocar daños en la memoria. Una víctima necesitaría abrir un archivo malicioso para activar esta vulnerabilidad."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "HIGH",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.0,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.0,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-190"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-190"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1792",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-35702",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:09.793",
+        "lastModified": "2024-01-16T17:33:44.477",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Multiple stack-based buffer overflow vulnerabilities exist in the FST LEB128 varint functionality of GTKWave 3.3.115. A specially crafted .fst file can lead to arbitrary code execution. A victim would need to open a malicious file to trigger these vulnerabilities.This vulnerability concerns the fstReaderVarint32 function."
+          },
+          {
+            "lang": "es",
+            "value": "Existen múltiples vulnerabilidades de desbordamiento de búfer en la región stack de la memoria en la funcionalidad variante FST LEB128 de GTKWave 3.3.115. Un archivo .fst especialmente manipulado puede provocar la ejecución de código arbitrario. Una víctima necesitaría abrir un archivo malicioso para activar estas vulnerabilidades. Esta vulnerabilidad afecta a la función fstReaderVarint32."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-787"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-121"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1783",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-35703",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:09.987",
+        "lastModified": "2024-01-16T17:34:14.000",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Multiple stack-based buffer overflow vulnerabilities exist in the FST LEB128 varint functionality of GTKWave 3.3.115. A specially crafted .fst file can lead to arbitrary code execution. A victim would need to open a malicious file to trigger these vulnerabilities.This vulnerability concerns the fstReaderVarint64 function."
+          },
+          {
+            "lang": "es",
+            "value": "Existen múltiples vulnerabilidades de desbordamiento de búfer en la región stack de la memoria en la funcionalidad variante FST LEB128 de GTKWave 3.3.115. Un archivo .fst especialmente manipulado puede provocar la ejecución de código arbitrario. Una víctima necesitaría abrir un archivo malicioso para activar estas vulnerabilidades. Esta vulnerabilidad afecta a la función fstReaderVarint64."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-787"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-121"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1783",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-35704",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:10.180",
+        "lastModified": "2024-01-16T17:34:22.723",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Multiple stack-based buffer overflow vulnerabilities exist in the FST LEB128 varint functionality of GTKWave 3.3.115. A specially crafted .fst file can lead to arbitrary code execution. A victim would need to open a malicious file to trigger these vulnerabilities.This vulnerability concerns the fstReaderVarint32WithSkip function."
+          },
+          {
+            "lang": "es",
+            "value": "Existen múltiples vulnerabilidades de desbordamiento de búfer en la región stack de la memoria en la funcionalidad variante FST LEB128 de GTKWave 3.3.115. Un archivo .fst especialmente manipulado puede provocar la ejecución de código arbitrario. Una víctima necesitaría abrir un archivo malicioso para activar estas vulnerabilidades. Esta vulnerabilidad afecta a la función fstReaderVarint32WithSkip."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-787"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-121"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1783",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-35955",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:10.380",
+        "lastModified": "2024-01-11T17:31:20.087",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Multiple heap-based buffer overflow vulnerabilities exist in the fstReaderIterBlocks2 VCDATA parsing functionality of GTKWave 3.3.115. A specially-crafted .fst file can lead to arbitrary code execution. A victim would need to open a malicious file to trigger these vulnerabilities.This vulnerability concerns the decompression function `LZ4_decompress_safe_partial`."
+          },
+          {
+            "lang": "es",
+            "value": "Existen múltiples vulnerabilidades de desbordamiento de búfer de almacenamiento dinámico en la funcionalidad de análisis VCDATA fstReaderIterBlocks2 de GTKWave 3.3.115. Un archivo .fst especialmente manipulado puede provocar la ejecución de código arbitrario. Una víctima necesitaría abrir un archivo malicioso para activar estas vulnerabilidades. Esta vulnerabilidad se refiere a la función de descompresión `LZ4_decompress_safe_partial`."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-119"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-119"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1785",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-35956",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:10.620",
+        "lastModified": "2024-01-11T17:31:13.103",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Multiple heap-based buffer overflow vulnerabilities exist in the fstReaderIterBlocks2 VCDATA parsing functionality of GTKWave 3.3.115. A specially-crafted .fst file can lead to arbitrary code execution. A victim would need to open a malicious file to trigger these vulnerabilities.This vulnerability concerns the decompression function `fastlz_decompress`."
+          },
+          {
+            "lang": "es",
+            "value": "Existen múltiples vulnerabilidades de desbordamiento del búfer en la región Heap de la memoria en la funcionalidad de análisis VCDATA fstReaderIterBlocks2 de GTKWave 3.3.115. Un archivo .fst especialmente manipulado puede provocar la ejecución de código arbitrario. Una víctima necesitaría abrir un archivo malicioso para activar estas vulnerabilidades. Esta vulnerabilidad se refiere a la función de descompresión `fastlz_decompress`."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-119"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-119"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1785",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-35957",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:10.903",
+        "lastModified": "2024-01-11T17:30:12.243",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Multiple heap-based buffer overflow vulnerabilities exist in the fstReaderIterBlocks2 VCDATA parsing functionality of GTKWave 3.3.115. A specially-crafted .fst file can lead to arbitrary code execution. A victim would need to open a malicious file to trigger these vulnerabilities.This vulnerability concerns the decompression function `uncompress`."
+          },
+          {
+            "lang": "es",
+            "value": "Existen múltiples vulnerabilidades de desbordamiento de búfer de almacenamiento dinámico en la funcionalidad de análisis VCDATA fstReaderIterBlocks2 de GTKWave 3.3.115. Un archivo .fst especialmente manipulado puede provocar la ejecución de código arbitrario. Una víctima necesitaría abrir un archivo malicioso para activar estas vulnerabilidades. Esta vulnerabilidad se refiere a la función de descompresión \"descomprimir\"."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-119"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-119"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1785",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-35958",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:11.090",
+        "lastModified": "2024-01-11T17:30:03.740",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Multiple heap-based buffer overflow vulnerabilities exist in the fstReaderIterBlocks2 VCDATA parsing functionality of GTKWave 3.3.115. A specially-crafted .fst file can lead to arbitrary code execution. A victim would need to open a malicious file to trigger these vulnerabilities.This vulnerability concerns the copy function `fstFread`."
+          },
+          {
+            "lang": "es",
+            "value": "Existen múltiples vulnerabilidades de desbordamiento de búfer de almacenamiento dinámico en la funcionalidad de análisis VCDATA fstReaderIterBlocks2 de GTKWave 3.3.115. Un archivo .fst especialmente manipulado puede provocar la ejecución de código arbitrario. Una víctima necesitaría abrir un archivo malicioso para activar estas vulnerabilidades. Esta vulnerabilidad se refiere a la función de copia \"fstFread\"."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-119"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-119"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1785",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-35959",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:11.280",
+        "lastModified": "2024-01-11T17:29:39.203",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Multiple OS command injection vulnerabilities exist in the decompression functionality of GTKWave 3.3.115. A specially crafted wave file can lead to arbitrary command execution. A victim would need to open a malicious file to trigger these vulnerabilities.This vulnerability concerns `.ghw` decompression."
+          },
+          {
+            "lang": "es",
+            "value": "Existen múltiples vulnerabilidades de inyección de comandos del sistema operativo en la funcionalidad de descompresión de GTKWave 3.3.115. Un archivo wave especialmente manipulado puede provocar la ejecución de comandos arbitrarios. Una víctima necesitaría abrir un archivo malicioso para activar estas vulnerabilidades. Esta vulnerabilidad se refiere a la descompresión `.ghw`."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1786",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-35960",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:11.460",
+        "lastModified": "2024-01-11T17:29:28.713",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Multiple OS command injection vulnerabilities exist in the decompression functionality of GTKWave 3.3.115. A specially crafted wave file can lead to arbitrary command execution. A victim would need to open a malicious file to trigger these vulnerabilities.This vulnerability concerns legacy decompression in `vcd_main`."
+          },
+          {
+            "lang": "es",
+            "value": "Existen múltiples vulnerabilidades de inyección de comandos del sistema operativo en la funcionalidad de descompresión de GTKWave 3.3.115. Un archivo wave especialmente manipulado puede provocar la ejecución de comandos arbitrarios. Una víctima necesitaría abrir un archivo malicioso para activar estas vulnerabilidades. Esta vulnerabilidad se refiere a la descompresión heredada en `vcd_main`."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1786",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-35961",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:11.667",
+        "lastModified": "2024-01-11T17:29:19.650",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Multiple OS command injection vulnerabilities exist in the decompression functionality of GTKWave 3.3.115. A specially crafted wave file can lead to arbitrary command execution. A victim would need to open a malicious file to trigger these vulnerabilities.This vulnerability concerns decompression in `vcd_recorder_main`."
+          },
+          {
+            "lang": "es",
+            "value": "Existen múltiples vulnerabilidades de inyección de comandos del sistema operativo en la funcionalidad de descompresión de GTKWave 3.3.115. Un archivo wave especialmente manipulado puede provocar la ejecución de comandos arbitrarios. Una víctima necesitaría abrir un archivo malicioso para activar estas vulnerabilidades. Esta vulnerabilidad se refiere a la descompresión en `vcd_recorder_main`."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1786",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "cve": {
+        "id": "CVE-2023-35962",
+        "sourceIdentifier": "talos-cna@cisco.com",
+        "published": "2024-01-08T15:15:11.877",
+        "lastModified": "2024-01-11T17:29:09.627",
+        "vulnStatus": "Analyzed",
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Multiple OS command injection vulnerabilities exist in the decompression functionality of GTKWave 3.3.115. A specially crafted wave file can lead to arbitrary command execution. A victim would need to open a malicious file to trigger these vulnerabilities.This vulnerability concerns decompression in the `vcd2vzt` utility."
+          },
+          {
+            "lang": "es",
+            "value": "Existen múltiples vulnerabilidades de inyección de comandos del sistema operativo en la funcionalidad de descompresión de GTKWave 3.3.115. Un archivo wave especialmente manipulado puede provocar la ejecución de comandos arbitrarios. Una víctima necesitaría abrir un archivo malicioso para activar estas vulnerabilidades. Esta vulnerabilidad se refiere a la descompresión en la utilidad `vcd2vzt`."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            },
+            {
+              "source": "talos-cna@cisco.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "REQUIRED",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH",
+                "baseScore": 7.8,
+                "baseSeverity": "HIGH"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 5.9
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          },
+          {
+            "source": "talos-cna@cisco.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tonybybell:gtkwave:3.3.115:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "3C619471-C2FB-4A2C-894C-2562A6BA76DF"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://talosintelligence.com/vulnerability_reports/TALOS-2023-1786",
+            "source": "talos-cna@cisco.com",
+            "tags": [
+              "Exploit",
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -10,16 +10,16 @@ import (
 	"strconv"
 	"strings"
 
-	nvdschema "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
+	nvdschema "github.com/facebookincubator/nvdtools/cveapi/nvd/schema"
 	"github.com/facebookincubator/nvdtools/cvss2"
 	"github.com/facebookincubator/nvdtools/cvss3"
 	"github.com/gogo/protobuf/types"
 	"github.com/quay/claircore"
-	"github.com/quay/claircore/enricher/cvss"
 	"github.com/quay/claircore/pkg/cpe"
 	"github.com/quay/zlog"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/scanner/enricher/nvd"
 )
 
 var (
@@ -65,11 +65,11 @@ func ToProtoV4VulnerabilityReport(ctx context.Context, r *claircore.Vulnerabilit
 	if r == nil {
 		return nil, nil
 	}
-	scores, err := nvdScoresMap(r.Enrichments)
+	nvdVulns, err := nvdVulnerabilities(r.Enrichments)
 	if err != nil {
-		return nil, fmt.Errorf("internal error: parsing nvd scores: %w", err)
+		return nil, fmt.Errorf("internal error: parsing nvd vulns: %w", err)
 	}
-	vulnerabilities, err := toProtoV4VulnerabilitiesMap(ctx, r.Vulnerabilities, scores)
+	vulnerabilities, err := toProtoV4VulnerabilitiesMap(ctx, r.Vulnerabilities, nvdVulns)
 	if err != nil {
 		return nil, fmt.Errorf("internal error: %w", err)
 	}
@@ -272,15 +272,12 @@ func toProtoV4PackageVulnerabilitiesMap(ccPkgVulnerabilities map[string][]string
 func toProtoV4VulnerabilitiesMap(
 	ctx context.Context,
 	vulns map[string]*claircore.Vulnerability,
-	nvdScores map[string]nvdschema.CVSSV30,
+	nvdVulns map[string]*nvdschema.CVEAPIJSON20CVEItem,
 ) (map[string]*v4.VulnerabilityReport_Vulnerability, error) {
 	if vulns == nil {
 		return nil, nil
 	}
 	var vulnerabilities map[string]*v4.VulnerabilityReport_Vulnerability
-	if len(vulns) > 0 {
-		vulnerabilities = make(map[string]*v4.VulnerabilityReport_Vulnerability, len(vulns))
-	}
 	for k, v := range vulns {
 		if v == nil {
 			continue
@@ -302,9 +299,13 @@ func toProtoV4VulnerabilitiesMap(
 			repoID = v.Repo.ID
 		}
 		normalizedSeverity := toProtoV4VulnerabilitySeverity(ctx, v.NormalizedSeverity)
-		sev, err := severityAndScores(v, nvdScores)
+		sev, err := severityAndScores(v, nvdVulns)
 		if err != nil {
-			return nil, err
+			zlog.Warn(ctx).
+				Str("vulnerability", v.ID).
+				Err(err).
+				Msg("ignoring invalid severity and CVSS scores")
+			continue
 		}
 		// Look for CVSS scores in the severity field, then set the
 		// scores only if at least one is found.
@@ -325,10 +326,22 @@ func toProtoV4VulnerabilitiesMap(
 				Vector:    sev.v3Vector,
 			}
 		}
+		// Using the NVD description if not provided.
+		description := v.Description
+		if description == "" {
+			if v, ok := nvdVulns[v.ID]; ok {
+				if len(v.Descriptions) > 0 {
+					description = v.Descriptions[0].Value
+				}
+			}
+		}
+		if vulnerabilities == nil {
+			vulnerabilities = make(map[string]*v4.VulnerabilityReport_Vulnerability, len(vulns))
+		}
 		vulnerabilities[k] = &v4.VulnerabilityReport_Vulnerability{
 			Id:                 v.ID,
 			Name:               vulnerabilityName(v),
-			Description:        v.Description,
+			Description:        description,
 			Issued:             issued,
 			Link:               v.Links,
 			Severity:           sev.severity,
@@ -509,29 +522,28 @@ func fixedInVersion(v *claircore.Vulnerability) string {
 	return fixedIn
 }
 
-// nvdScoresMap look for NVD CVSS in the vulnerability report enrichments and
-// returns a mapping of vulnerability IDs to CVSS Scores V3.
-func nvdScoresMap(enrichments map[string][]json.RawMessage) (map[string]nvdschema.CVSSV30, error) {
-	cvss := enrichments[cvss.Type]
-	if len(cvss) == 0 {
+// nvdVulnerabilities look for NVD CVSS in the vulnerability report enrichments and
+// returns a map of CVEs.
+func nvdVulnerabilities(enrichments map[string][]json.RawMessage) (map[string]*nvdschema.CVEAPIJSON20CVEItem, error) {
+	enrichmentsList := enrichments[nvd.Type]
+	if len(enrichmentsList) == 0 {
 		return nil, nil
 	}
-	// TODO(ROX-21264): ClairCore only supports CVSS v3.1, so we assume CVSSV30 --
-	//                  need to update this when we start using our own CVSS score enricher.
-	var scores map[string][]nvdschema.CVSSV30
+	var items map[string][]nvdschema.CVEAPIJSON20CVEItem
 	// The CVSS enrichment always contains only one element.
-	err := json.Unmarshal(cvss[0], &scores)
+	err := json.Unmarshal(enrichmentsList[0], &items)
 	if err != nil {
 		return nil, err
 	}
-	if len(scores) == 0 {
+	if len(items) == 0 {
 		return nil, nil
 	}
-	ret := make(map[string]nvdschema.CVSSV30)
-	for id, l := range scores {
+	ret := make(map[string]*nvdschema.CVEAPIJSON20CVEItem)
+	for id, list := range items {
 		// There is no criteria for selecting more than one enrichment record, assume the
 		// first is the right one.
-		ret[id] = l[0]
+		i := list[0]
+		ret[id] = &i
 	}
 	return ret, nil
 }
@@ -555,14 +567,13 @@ var (
 // ClairCore vulnerability. The returned information is dependent on the
 // underlying updater. If errors are found in the encoded information, partial
 // values might be returned with an error.
-func severityAndScores(vuln *claircore.Vulnerability, nvdScores map[string]nvdschema.CVSSV30) (severityValues, error) {
+func severityAndScores(vuln *claircore.Vulnerability, nvdVulns map[string]*nvdschema.CVEAPIJSON20CVEItem) (severityValues, error) {
 	var values severityValues
-	errList := errorhelpers.NewErrorList("parsing severity and CVSS scores")
+	errList := errorhelpers.NewErrorList(fmt.Sprintf("%s: parsing severity and CVSS scores", vuln.Updater))
 	switch {
 	case osvUpdaterPattern.MatchString(vuln.Updater):
 		if vuln.Severity == "" {
 			errList.AddStrings("severity is empty")
-			break
 		}
 		// ClairCore has no CVSS version indicator for OSV data, assuming CVSS V2 if
 		// not prefixed with a V3 version.
@@ -580,7 +591,6 @@ func severityAndScores(vuln *claircore.Vulnerability, nvdScores map[string]nvdsc
 	case rhelUpdaterPattern.MatchString(vuln.Updater):
 		if vuln.Severity == "" {
 			errList.AddStrings("severity is empty")
-			break
 		}
 		q, err := url.ParseQuery(vuln.Severity)
 		if err != nil {
@@ -588,8 +598,6 @@ func severityAndScores(vuln *claircore.Vulnerability, nvdScores map[string]nvdsc
 			break
 		}
 		values.severity = q.Get("severity")
-		// Look for CVSS fields. When at least one vector is found, we consider that the
-		// CVSS information exists, but return partial results in the case of failures.
 		if v := q.Get("cvss2_vector"); v != "" {
 			s := q.Get("cvss2_score")
 			if _, err := cvss2.VectorFromString(v); err != nil {
@@ -615,16 +623,21 @@ func severityAndScores(vuln *claircore.Vulnerability, nvdScores map[string]nvdsc
 	default:
 		// Everything else uses NVD.
 		values.severity = vuln.Severity
-		if nvd, ok := nvdScores[vuln.ID]; ok {
-			switch {
-			case strings.HasPrefix(nvd.Version, "2"):
-				values.v2Score = float32(nvd.BaseScore)
-				values.v2Vector = nvd.VectorString
-			case strings.HasPrefix(nvd.Version, "3"):
-				values.v3Score = float32(nvd.BaseScore)
-				values.v3Vector = nvd.VectorString
-			default:
-				errList.AddError(fmt.Errorf("unsupported CVSS score version: %s", nvd.Version))
+		if v, ok := nvdVulns[vuln.ID]; ok {
+			if len(v.Metrics.CvssMetricV31) > 0 {
+				cvssv31 := v.Metrics.CvssMetricV31[0]
+				values.v3Score = float32(cvssv31.CvssData.BaseScore)
+				values.v3Vector = cvssv31.CvssData.VectorString
+			}
+			if len(v.Metrics.CvssMetricV30) > 0 {
+				cvssv30 := v.Metrics.CvssMetricV30[0]
+				values.v3Score = float32(cvssv30.CvssData.BaseScore)
+				values.v3Vector = cvssv30.CvssData.VectorString
+			}
+			if len(v.Metrics.CvssMetricV2) > 0 {
+				cvssv2 := v.Metrics.CvssMetricV2[0]
+				values.v2Score = float32(cvssv2.CvssData.BaseScore)
+				values.v2Vector = cvssv2.CvssData.VectorString
 			}
 		}
 	}

--- a/tools/allowed-large-files
+++ b/tools/allowed-large-files
@@ -41,6 +41,7 @@ scale/image/fixtures/scrape.json
 scanner/cmd/scannerctl/fixtures/images.json
 scanner/e2etests/testdata/image_tests.json
 scanner/e2etests/testdata/image_tests.orig.json
+scanner/enricher/nvd/testdata/feed.json
 scanner/updater/rhel/testdata/Red_Hat_Enterprise_Linux_3.xml
 scanner/updater/rhel/testdata/rhel-report.json
 scripts/ci/lib.sh


### PR DESCRIPTION
## Description

The NVD enricher can:

1. Pull CVE items from NVD, and populate (a.) the enrichment table , and (b.) the vulnerability bundle with the items keyed by CVE tags.
2. Retrieve those enrichments from the DB during vulnerability matcher and populate the VR.

We use the NVD data to:

1. Populate CVSS scores that were not provided by the related security source.
2. Populate description of vulns when not provided by the security source.

The updaters were modified to run the NVD enricher so the vulnerability definitions file will contain enrichments. Basically, the enricher reaches out to the NVD V2 API to grab only the information we need. This information is then combined with other vulnerabilities and sent to the Scanner tool in the same bundle as the other. It's all handled seamlessly and consumed just like any other data.

Once approved, the prior NVD CVSS pipeline can be decommissioned.
 
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

#### Step 1: Run the updater locally. I actually commented out the other updaters to make the process faster:

```diff
diff --git a/scanner/updater/export.go b/scanner/updater/export.go
index fd15f7aecd..4bdd9161ae 100644
--- a/scanner/updater/export.go
+++ b/scanner/updater/export.go
@@ -14,8 +14,6 @@ import (
 	"github.com/quay/claircore/libvuln/updates"
 	"github.com/quay/zlog"
 	"github.com/stackrox/rox/scanner/enricher/nvd"
-	"github.com/stackrox/rox/scanner/updater/manual"
-	"github.com/stackrox/rox/scanner/updater/rhel"
 	"golang.org/x/time/rate"
 
 	// default updaters
@@ -61,25 +59,6 @@ func Export(ctx context.Context, outputDir string) error {
 
 	var opts [][]updates.ManagerOption
 
-	// Manual CVEs.
-	manualSet, err := manual.UpdaterSet(ctx, nil)
-	if err != nil {
-		return err
-	}
-	outOfTree := append([]driver.Updater{}, manualSet.Updaters()...)
-	opts = append(opts, []updates.ManagerOption{updates.WithOutOfTree(outOfTree)})
-
-	// RHEL custom: Forked from ClairCore.
-	fac, err := rhel.NewFactory(ctx, rhel.DefaultManifest)
-	if err != nil {
-		return err
-	}
-	opts = append(opts, []updates.ManagerOption{
-		updates.WithFactories(map[string]driver.UpdaterSetFactory{
-			"rhel-custom": fac,
-		}),
-	})
-
 	// NVD enricher.
 	opts = append(opts, []updates.ManagerOption{
 		updates.WithFactories(map[string]driver.UpdaterSetFactory{
@@ -105,17 +84,7 @@ func Export(ctx context.Context, outputDir string) error {
 	})
 
 	// ClairCore updaters.
-	for _, uSet := range [][]string{
-		{"oracle"},
-		{"photon"},
-		{"suse"},
-		{"aws"},
-		{"alpine"},
-		{"debian"},
-		{"rhcc"},
-		{"ubuntu"},
-		{"osv"},
-	} {
+	for _, uSet := range [][]string{} {
 		opts = append(opts, []updates.ManagerOption{updates.WithEnabled(uSet)})
 	}
```

Command used:

```
⮩ make certs
⮩ make bin/updater
⮩ bin/updater -output-dir dir
...
⮩ ls -lh dir
-rw-r--r-- 1 jvdm jvdm 16M Jan 17 18:11 output.json.zst
```

#### Step 2: Local vulnerabilities

Set scanner to run locally and pull vulns from a local endpoint.

```yaml
http_listen_addr: 127.0.0.1:9443
grpc_listen_addr: 127.0.0.1:8443
indexer:
  enable: true
  database:
    conn_string: "host=/var/run/postgresql"
    password_file: ""
  get_layer_timeout: 1m
matcher:
  enable: true
  database:
    conn_string: "host=/var/run/postgresql"
    password_file: ""
  vulnerabilities_url: "http://localhost:9876"
mtls:
  certs_dir: "certs/scanner-v4"
log_level: debug
```

Then run a HTTP server, I used python:

```python
import http.server
import socketserver
import sys


class CustomHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
    def do_GET(self):
        self.path = sys.argv[1]
        return http.server.SimpleHTTPRequestHandler.do_GET(self)


if len(sys.argv) != 2:
    print("Usage: python3 serve_file.py <file_to_serve>")
    sys.exit(1)

PORT = 9876

handler = CustomHTTPRequestHandler
with socketserver.TCPServer(("", PORT), handler) as httpd:
    print(f"Serving file {sys.argv[1]} at http://localhost:{PORT}")
    httpd.serve_forever()
```

Then run in one terminal:

```sh
⮩ python server.py dir/output.json.zst
Serving file output.json.zst at http://localhost:9876
127.0.0.1 - - [17/Jan/2024 18:32:36] "GET / HTTP/1.1" 200 -
```

IN another:

```
⮩ make ./bin/scanner
```

Scanner should pull in the enrichments from the bundle into the DB:

```
⮩  psql
psql (99.1 (X 99.1-1), server 99.4 (X 99.4-3))
Type "help" for help.

jvdm=> \pset tuples_only 
Tuples only is on.
jvdm=> \pset pager
Pager usage is off.
jvdm=> select * from enrichment limit 1;
  1 | md5       | \x0b6ccef5489c270baa053bb5ba138802 | nvd     | {CVE-2002-1594} | {"id": "CVE-2002-1594", "metrics": {"cvssMetricV2": [{"type": "", "source": "", "cvssData": {"version": "2.0", "baseScore": 7.2, "vectorString": "AV:L/AC:L/Au:N/C:C/I:C/A:C"}}]}, "published": "2002-01-02T05:00:00.000", "references": null, "descriptions": [{"lang": "en", "value": "Buffer overflow in (1) grpck and (2) pwck, if installed setuid on a system as recommended in some AIX documentation, may allow local users to gain privileges via a long command line argument."}], "lastModified": "2017-07-11T01:29:15.710"}

jvdm=> 
```

#### Step 3: Matching

Run a scan using `scannerctl`:

```sh
⮩  make bin/scannerctl
⮩  ./bin/scannerctl scan --certs certs/scannerctl https://docker.io/library/alpine:latest >/tmp/vr.json
```

And verify scores and descriptions.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
