### PR TITLE
fix(ci): Incresed sleep time for scan config test

### DIFF
--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -60,7 +60,7 @@ func TestComplianceV2CreateGetScanConfigurations(t *testing.T) {
 	clusters, err := serviceCluster.GetClusters(ctx, &v1.GetClustersRequest{})
 	assert.NoError(t, err)
 	clusterID := clusters.GetClusters()[0].GetId()
-	testName := fmt.Sprintf("test_%s", uuid.NewV4().String())
+	testName := fmt.Sprintf("test-%s", uuid.NewV4().String())
 	req := &v2.ComplianceScanConfiguration{
 		ScanName: testName,
 		Id:       "",
@@ -114,8 +114,8 @@ func TestComplianceV2CreateGetScanConfigurations(t *testing.T) {
 		}
 		return errors.New("scan result not found")
 	}, retry.BetweenAttempts(func(previousAttemptNumber int) {
-		time.Sleep(2 * time.Second)
-	}), retry.Tries(20))
+		time.Sleep(60 * time.Second)
+	}), retry.Tries(10))
 	assert.NoError(t, err)
 }
 
@@ -129,7 +129,7 @@ func TestComplianceV2DeleteComplianceScanConfigurations(t *testing.T) {
 	assert.NoError(t, err)
 
 	clusterID := clusters.GetClusters()[0].GetId()
-	testName := fmt.Sprintf("test_%s", uuid.NewV4().String())
+	testName := fmt.Sprintf("test-%s", uuid.NewV4().String())
 	req := &v2.ComplianceScanConfiguration{
 		ScanName: testName,
 		Id:       "",


### PR DESCRIPTION
Increased sleep time in TestComplianceV2CreateGetScanConfiguration to increase wait time to get compliance scan results.
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
