### PR TITLE
fix(perf): Remove pods from compliance domain

### DIFF
--- a/central/compliance/checks/hipaa_164/check306e/check_test.go
+++ b/central/compliance/checks/hipaa_164/check306e/check_test.go
@@ -59,7 +59,7 @@ func (s *suiteImpl) TestFail() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -110,7 +110,7 @@ func (s *suiteImpl) TestPass() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 

--- a/central/compliance/checks/hipaa_164/check308a1iia/check_test.go
+++ b/central/compliance/checks/hipaa_164/check308a1iia/check_test.go
@@ -64,7 +64,7 @@ func (s *suiteImpl) TestFail() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -124,7 +124,7 @@ func (s *suiteImpl) TestPass() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 

--- a/central/compliance/checks/hipaa_164/check308a1iib/check_test.go
+++ b/central/compliance/checks/hipaa_164/check308a1iib/check_test.go
@@ -50,7 +50,7 @@ func (s *suiteImpl) TestFail() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -88,7 +88,7 @@ func (s *suiteImpl) TestPass() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 

--- a/central/compliance/checks/hipaa_164/check308a5iib/check_test.go
+++ b/central/compliance/checks/hipaa_164/check308a5iib/check_test.go
@@ -48,7 +48,7 @@ func (s *suiteImpl) TestFail() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -83,7 +83,7 @@ func (s *suiteImpl) TestPass() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 

--- a/central/compliance/checks/nist800-190/check411/check_test.go
+++ b/central/compliance/checks/nist800-190/check411/check_test.go
@@ -38,7 +38,7 @@ var (
 		},
 	}
 
-	domain = framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain = framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 
 	cvssPolicyEnabledAndEnforced = &storage.Policy{
 		Id:              uuid.NewV4().String(),

--- a/central/compliance/checks/nist800-190/check412/check_test.go
+++ b/central/compliance/checks/nist800-190/check412/check_test.go
@@ -49,7 +49,7 @@ var (
 		},
 	}
 
-	domain = framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain = framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 
 	cvssPolicyEnabledAndEnforced = &storage.Policy{
 		Id:                 uuid.NewV4().String(),

--- a/central/compliance/checks/nist800-190/check414/check_test.go
+++ b/central/compliance/checks/nist800-190/check414/check_test.go
@@ -136,7 +136,7 @@ func TestNIST414_Success(t *testing.T) {
 	data.EXPECT().Policies().AnyTimes().Return(policies)
 	data.EXPECT().Deployments().AnyTimes().Return(toMapDeployments(testDeployments))
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 
 	run, err := framework.NewComplianceRun(check)
 	require.NoError(t, err)
@@ -258,7 +258,7 @@ func TestNIST414_FAIL(t *testing.T) {
 	data.EXPECT().Policies().AnyTimes().Return(policies)
 	data.EXPECT().Deployments().AnyTimes().Return(toMapDeployments(testDeployments))
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 
 	run, err := framework.NewComplianceRun(check)
 	require.NoError(t, err)

--- a/central/compliance/checks/nist800-190/check422/check_test.go
+++ b/central/compliance/checks/nist800-190/check422/check_test.go
@@ -38,7 +38,7 @@ var (
 		},
 	}
 
-	domain = framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain = framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 
 	latestTagEnabledAndEnforced = &storage.Policy{
 		Id:   uuid.NewV4().String(),

--- a/central/compliance/checks/nist800-190/check433/check_test.go
+++ b/central/compliance/checks/nist800-190/check433/check_test.go
@@ -57,7 +57,7 @@ func (s *suiteImpl) TestHostNetwork() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -99,7 +99,7 @@ func (s *suiteImpl) TestMissingIngress() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -141,7 +141,7 @@ func (s *suiteImpl) TestMissingEgress() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -179,7 +179,7 @@ func (s *suiteImpl) TestSkipKubeSystem() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -227,7 +227,7 @@ func (s *suiteImpl) TestPass() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 

--- a/central/compliance/checks/nist800-190/check442/check_test.go
+++ b/central/compliance/checks/nist800-190/check442/check_test.go
@@ -57,7 +57,7 @@ func (s *suiteImpl) TestHostNetwork() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -99,7 +99,7 @@ func (s *suiteImpl) TestMissingIngress() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -141,7 +141,7 @@ func (s *suiteImpl) TestMissingEgress() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -179,7 +179,7 @@ func (s *suiteImpl) TestSkipKubeSystem() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -227,7 +227,7 @@ func (s *suiteImpl) TestPass() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 

--- a/central/compliance/checks/nist800-190/check443/check_test.go
+++ b/central/compliance/checks/nist800-190/check443/check_test.go
@@ -36,7 +36,7 @@ var (
 		},
 	}
 
-	domain = framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain = framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 )
 
 func TestNIST443_Success(t *testing.T) {

--- a/central/compliance/checks/nist800-190/check444/check_test.go
+++ b/central/compliance/checks/nist800-190/check444/check_test.go
@@ -75,7 +75,7 @@ func (s *suiteImpl) TestPass() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -138,7 +138,7 @@ func (s *suiteImpl) TestFail() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 

--- a/central/compliance/checks/nist800-190/check455/check_test.go
+++ b/central/compliance/checks/nist800-190/check455/check_test.go
@@ -106,7 +106,7 @@ func (s *suiteImpl) TestPass() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -201,7 +201,7 @@ func (s *suiteImpl) TestFail() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 

--- a/central/compliance/checks/pcidss32/check121/check_test.go
+++ b/central/compliance/checks/pcidss32/check121/check_test.go
@@ -57,7 +57,7 @@ func (s *suiteImpl) TestHostNetwork() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -99,7 +99,7 @@ func (s *suiteImpl) TestMissingIngress() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -141,7 +141,7 @@ func (s *suiteImpl) TestMissingEgress() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -179,7 +179,7 @@ func (s *suiteImpl) TestSkipKubeSystem() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -227,7 +227,7 @@ func (s *suiteImpl) TestPass() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, testNodes, testDeployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 

--- a/central/compliance/checks/pcidss32/check132/check_test.go
+++ b/central/compliance/checks/pcidss32/check132/check_test.go
@@ -175,7 +175,7 @@ func (s *suiteImpl) checkTestCase(tc *testCase) {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(tc.cluster, tc.nodes, tc.deployments, nil, nil)
+	domain := framework.NewComplianceDomain(tc.cluster, tc.nodes, tc.deployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 

--- a/central/compliance/checks/pcidss32/check134/check_test.go
+++ b/central/compliance/checks/pcidss32/check134/check_test.go
@@ -175,7 +175,7 @@ func (s *suiteImpl) checkTestCase(tc *testCase) {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(tc.cluster, tc.nodes, tc.deployments, nil, nil)
+	domain := framework.NewComplianceDomain(tc.cluster, tc.nodes, tc.deployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 

--- a/central/compliance/checks/pcidss32/check135/check_test.go
+++ b/central/compliance/checks/pcidss32/check135/check_test.go
@@ -40,7 +40,7 @@ func (s *suiteImpl) TestFail() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, nil, testDeployments[1:], nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, nil, testDeployments[1:], nil)
 	data := mocks.NewMockComplianceDataRepository(s.mockCtrl)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
@@ -66,7 +66,7 @@ func (s *suiteImpl) TestPass() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, nil, testDeployments[:1], nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, nil, testDeployments[:1], nil)
 	data := mocks.NewMockComplianceDataRepository(s.mockCtrl)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)

--- a/central/compliance/checks/pcidss32/check225/check_test.go
+++ b/central/compliance/checks/pcidss32/check225/check_test.go
@@ -77,7 +77,7 @@ func (s *suiteImpl) TestUnusedPorts() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, nil, deployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, nil, deployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -150,7 +150,7 @@ func (s *suiteImpl) TestPass() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, nil, deployments, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, nil, deployments, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 

--- a/central/compliance/checks/pcidss32/check61/check_test.go
+++ b/central/compliance/checks/pcidss32/check61/check_test.go
@@ -61,7 +61,7 @@ func (s *suiteImpl) TestPassFail() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 
@@ -112,7 +112,7 @@ func (s *suiteImpl) TestPass() {
 	run, err := framework.NewComplianceRun(check)
 	s.NoError(err)
 
-	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil, nil)
+	domain := framework.NewComplianceDomain(testCluster, nil, nil, nil)
 	err = run.Run(context.Background(), "standard", domain, data)
 	s.NoError(err)
 

--- a/central/compliance/framework/domain.go
+++ b/central/compliance/framework/domain.go
@@ -11,7 +11,6 @@ type ComplianceDomain interface {
 	Cluster() ComplianceTarget
 	Nodes() []ComplianceTarget
 	Deployments() []ComplianceTarget
-	Pods() []*storage.Pod
 	MachineConfigs() map[string][]ComplianceTarget
 }
 
@@ -20,7 +19,6 @@ type complianceDomain struct {
 	cluster        clusterTarget
 	nodes          []nodeTarget
 	deployments    []deploymentTarget
-	pods           []*storage.Pod
 	machineConfigs map[string][]machineConfigTarget
 }
 
@@ -46,7 +44,6 @@ func newComplianceDomain(cluster *storage.Cluster, nodes []*storage.Node, deploy
 		cluster:        clusterTarget,
 		nodes:          nodeTargets,
 		deployments:    deploymentTargets,
-		pods:           pods,
 		machineConfigs: machineConfigTargets,
 	}
 }
@@ -83,12 +80,6 @@ func (d *complianceDomain) MachineConfigs() map[string][]ComplianceTarget {
 		}
 	}
 	return results
-}
-
-func (d *complianceDomain) Pods() []*storage.Pod {
-	result := make([]*storage.Pod, len(d.pods))
-	copy(result, d.pods)
-	return result
 }
 
 // NewComplianceDomain creates a new compliance domain from the given cluster, list of nodes and list of deployments.

--- a/central/compliance/framework/domain.go
+++ b/central/compliance/framework/domain.go
@@ -22,7 +22,7 @@ type complianceDomain struct {
 	machineConfigs map[string][]machineConfigTarget
 }
 
-func newComplianceDomain(cluster *storage.Cluster, nodes []*storage.Node, deployments []*storage.Deployment, pods []*storage.Pod, machineConfigs map[string][]string) *complianceDomain {
+func newComplianceDomain(cluster *storage.Cluster, nodes []*storage.Node, deployments []*storage.Deployment, machineConfigs map[string][]string) *complianceDomain {
 	clusterTarget := targetForCluster(cluster)
 	nodeTargets := make([]nodeTarget, len(nodes))
 	for i, node := range nodes {
@@ -83,6 +83,6 @@ func (d *complianceDomain) MachineConfigs() map[string][]ComplianceTarget {
 }
 
 // NewComplianceDomain creates a new compliance domain from the given cluster, list of nodes and list of deployments.
-func NewComplianceDomain(cluster *storage.Cluster, nodes []*storage.Node, deployments []*storage.Deployment, pods []*storage.Pod, machineConfigs map[string][]string) ComplianceDomain {
-	return newComplianceDomain(cluster, nodes, deployments, pods, machineConfigs)
+func NewComplianceDomain(cluster *storage.Cluster, nodes []*storage.Node, deployments []*storage.Deployment, machineConfigs map[string][]string) ComplianceDomain {
+	return newComplianceDomain(cluster, nodes, deployments, machineConfigs)
 }

--- a/central/compliance/framework/run_test.go
+++ b/central/compliance/framework/run_test.go
@@ -38,15 +38,6 @@ var (
 		},
 	}
 
-	testPods = []*storage.Pod{
-		{
-			Id: uuid.NewV4().String(),
-		},
-		{
-			Id: uuid.NewV4().String(),
-		},
-	}
-
 	testMachineConfigs = map[string][]string{
 		"standard": {
 			"config1",
@@ -54,7 +45,7 @@ var (
 		},
 	}
 
-	testDomain = newComplianceDomain(testCluster, testNodes, testDeployments, testPods, testMachineConfigs)
+	testDomain = newComplianceDomain(testCluster, testNodes, testDeployments, testMachineConfigs)
 )
 
 func TestEmptyRun(t *testing.T) {

--- a/central/compliance/manager/manager_impl.go
+++ b/central/compliance/manager/manager_impl.go
@@ -109,17 +109,11 @@ func (m *manager) createDomain(ctx context.Context, clusterID string) (framework
 		return nil, errors.Wrapf(err, "could not get deployments for cluster %s", clusterID)
 	}
 
-	query = search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterID).ProtoQuery()
-	pods, err := m.podStore.SearchRawPods(ctx, query)
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not get pods for cluster %s", clusterID)
-	}
-
 	machineConfigs, err := m.complianceOperatorManager.GetMachineConfigs(clusterID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting machine configs for cluster %s", clusterID)
 	}
-	return framework.NewComplianceDomain(cluster, nodes, deployments, pods, machineConfigs), nil
+	return framework.NewComplianceDomain(cluster, nodes, deployments, machineConfigs), nil
 }
 
 func (m *manager) createRun(domain framework.ComplianceDomain, standard *standards.Standard) *runInstance {

--- a/central/compliance/manager/run_bench_test.go
+++ b/central/compliance/manager/run_bench_test.go
@@ -25,7 +25,7 @@ func BenchmarkFold(b *testing.B) {
 			Name: "test",
 		},
 	}
-	domain := framework.NewComplianceDomain(nil, nodes, nil, nil, nil)
+	domain := framework.NewComplianceDomain(nil, nodes, nil, nil)
 
 	nodeResults := map[string]map[string]*compliance.ComplianceStandardResult{
 		"test": data,

--- a/central/compliance/manager/run_test.go
+++ b/central/compliance/manager/run_test.go
@@ -33,7 +33,6 @@ func makeTestRun(testRunID, testStandardID, testStandardName string, testNodes [
 		testNodes,
 		nil,
 		nil,
-		nil,
 	)
 	return createRun(testRunID, testDomain, testStandard)
 }


### PR DESCRIPTION
## Description

Pods are unused so no need to load them into the domain

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Just code removal

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
