### PR TITLE
chore(ui): Update yup 1.3.3 dependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -89,7 +89,7 @@
         "store": "^2.0.12",
         "styled-components": "^5.3.1",
         "use-deep-compare-effect": "^1.8.1",
-        "yup": "^1.2.0"
+        "yup": "^1.3.3"
     },
     "scripts": {
         "clean": "rm -rf ./cypress/test-results",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -18537,10 +18537,10 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-yup@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/yup/-/yup-1.2.0.tgz#9e51af0c63bdfc9be0fdc6c10aa0710899d8aff6"
-  integrity sha512-PPqYKSAXjpRCgLgLKVGPA33v5c/WgEx3wi6NFjIiegz90zSwyMpvTFp/uGcVnnbx6to28pgnzp/q8ih3QRjLMQ==
+yup@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.3.3.tgz#d2f6020ad1679754c5f8178a29243d5447dead04"
+  integrity sha512-v8QwZSsHH2K3/G9WSkp6mZKO+hugKT1EmnMqLNUcfu51HU9MDyhlETT/JgtzprnrnQHPWsjc6MUDMBp/l9fNnw==
   dependencies:
     property-expr "^2.0.5"
     tiny-case "^1.0.3"


### PR DESCRIPTION
## Description

Version 1.2.0 was published almost 8 months ago.

Update with 2 sprints before next release, especially before feature bashes.

https://github.com/jquense/yup/blob/master/CHANGELOG.md#133-2023-12-14

* 1.3.3: `addMethod`: allow Schema without making TypeScript upset
* 1.3.2: pick and omit with excluded edges
* 1.3.1: `ValidationError` extends `Error`
* 1.3.0: Allow schema metadata to be strongly typed

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed