### PR TITLE
fix(perf): Only fetch node metadata in compliance domain

### DIFF
--- a/central/compliance/manager/manager_impl.go
+++ b/central/compliance/manager/manager_impl.go
@@ -98,13 +98,17 @@ func (m *manager) createDomain(ctx context.Context, clusterID string) (framework
 		return nil, errors.Wrapf(err, "could not get cluster with ID %q", clusterID)
 	}
 
-	nodes, err := m.nodeStore.SearchRawNodes(ctx, search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterID).ProtoQuery())
+	clusterQuery := search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterID).ProtoQuery()
+	results, err := m.nodeStore.Search(ctx, clusterQuery)
+	if err != nil {
+		return nil, errors.Wrapf(err, "retrieving nodes for cluster %s", clusterID)
+	}
+	nodes, err := m.nodeStore.GetManyNodeMetadata(ctx, search.ResultsToIDs(results))
 	if err != nil {
 		return nil, errors.Wrapf(err, "retrieving nodes for cluster %s", clusterID)
 	}
 
-	query := search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterID).ProtoQuery()
-	deployments, err := m.deploymentStore.SearchRawDeployments(ctx, query)
+	deployments, err := m.deploymentStore.SearchRawDeployments(ctx, clusterQuery)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get deployments for cluster %s", clusterID)
 	}


### PR DESCRIPTION
## Description

Node vulnerabilities are not used in compliance. At scale, it was taking 2-3s per cluster to get the nodes for the domain which are pulled serially. Now, it takes on avg 27 milliseconds per cluster at scale.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Ran scale tests

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
