### PR TITLE
ROX-21848: Fix compliance e2e tests to pass backend validation

### DIFF
--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -60,7 +60,7 @@ func TestComplianceV2CreateGetScanConfigurations(t *testing.T) {
 	clusters, err := serviceCluster.GetClusters(ctx, &v1.GetClustersRequest{})
 	assert.NoError(t, err)
 	clusterID := clusters.GetClusters()[0].GetId()
-	testName := fmt.Sprintf("test_%s", uuid.NewV4().String())
+	testName := fmt.Sprintf("test-%s", uuid.NewV4().String())
 	req := &v2.ComplianceScanConfiguration{
 		ScanName: testName,
 		Id:       "",
@@ -129,7 +129,7 @@ func TestComplianceV2DeleteComplianceScanConfigurations(t *testing.T) {
 	assert.NoError(t, err)
 
 	clusterID := clusters.GetClusters()[0].GetId()
-	testName := fmt.Sprintf("test_%s", uuid.NewV4().String())
+	testName := fmt.Sprintf("test-%s", uuid.NewV4().String())
 	req := &v2.ComplianceScanConfiguration{
 		ScanName: testName,
 		Id:       "",


### PR DESCRIPTION
The compliance e2e tests are failing with traces like the following:

    compliance_operator_v2_test.go:119:
        	Error Trace:	/go/src/github.com/stackrox/stackrox/tests/compliance_operator_v2_test.go:119
        	Error:      	Received unexpected error:
        	            	scan result not found
        	Test:       	TestComplianceV2CreateGetScanConfigurations
    --- FAIL: TestComplianceV2CreateGetScanConfigurations (39.17s)

This is because the scan configuration name contains an underscore instead of a dash and fails the backend validation.

This commit updates the tests to use a dash instead of an underscore, but there should probably be a follow up to determine why the assertions aren't preventing the test from failing immediately after the scan config is created.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

The compliance e2e tests should pass with this change. If they don't then this PR needs more work.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
