### PR TITLE
ROX-21210: Adding image scan notes popover

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -6,6 +6,7 @@ import {
     ClipboardCopy,
     Divider,
     Flex,
+    FlexItem,
     PageSection,
     Skeleton,
     Tab,
@@ -13,10 +14,12 @@ import {
     TabsComponent,
     TabTitleText,
     Title,
+    Alert,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { useParams } from 'react-router-dom';
 import { gql, useQuery } from '@apollo/client';
+import isEmpty from 'lodash/isEmpty';
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import PageTitle from 'Components/PageTitle';
@@ -33,6 +36,7 @@ import ImageDetailBadges, {
     ImageDetails,
     imageDetailsFragment,
 } from '../components/ImageDetailBadges';
+import getImageScanMessage from '../utils/getImageScanMessage';
 
 const workloadCveOverviewImagePath = getOverviewCvesPath({
     vulnerabilityState: 'OBSERVED',
@@ -82,6 +86,7 @@ function ImagePage() {
     const imageName = imageData?.name
         ? `${imageData.name.registry}/${imageData.name.remote}:${imageData.name.tag}`
         : 'NAME UNKNOWN';
+    const scanMessage = getImageScanMessage(imageData?.notes || [], imageData?.scanNotes || []);
 
     let mainContent: ReactNode | null = null;
 
@@ -122,6 +127,22 @@ function ImagePage() {
                                 </ClipboardCopy>
                             )}
                             <ImageDetailBadges imageData={imageData} />
+                            {!isEmpty(scanMessage) && (
+                                <Alert
+                                    className="pf-u-w-100"
+                                    variant="warning"
+                                    isInline
+                                    title="CVE data may be inaccurate"
+                                >
+                                    <Flex
+                                        direction={{ default: 'column' }}
+                                        spaceItems={{ default: 'spaceItemsSm' }}
+                                    >
+                                        <FlexItem>{scanMessage.header}</FlexItem>
+                                        <FlexItem>{scanMessage.body}</FlexItem>
+                                    </Flex>
+                                </Alert>
+                            )}
                         </Flex>
                     ) : (
                         <Flex

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -13,6 +13,7 @@ import EmptyTableResults from '../components/EmptyTableResults';
 import DateDistanceTd from '../components/DatePhraseTd';
 import TooltipTh from '../components/TooltipTh';
 import { VulnerabilitySeverityLabel, WatchStatus } from '../types';
+import ImageScanningErrorLabelLayout from '../components/ImageScanningErrorLabelLayout';
 
 export const imageListQuery = gql`
     query getImageList($query: String, $pagination: Pagination) {
@@ -46,6 +47,8 @@ export const imageListQuery = gql`
                 }
             }
             scanTime
+            scanNotes
+            notes
         }
     }
 `;
@@ -72,6 +75,8 @@ type Image = {
         } | null;
     } | null;
     scanTime: string | null;
+    scanNotes: string[];
+    notes: string[];
 };
 
 export type ImagesTableProps = {
@@ -126,6 +131,8 @@ function ImagesTable({
                     metadata,
                     watchStatus,
                     scanTime,
+                    scanNotes,
+                    notes,
                 }) => {
                     const criticalCount = imageCVECountBySeverity.critical.total;
                     const importantCount = imageCVECountBySeverity.important.total;
@@ -146,19 +153,24 @@ function ImagesTable({
                             <Tr>
                                 <Td dataLabel="Image">
                                     {name ? (
-                                        <ImageNameTd name={name} id={id}>
-                                            {isWatchedImage && (
-                                                <Label
-                                                    isCompact
-                                                    variant="outline"
-                                                    color="grey"
-                                                    className="pf-u-mt-xs"
-                                                    icon={<EyeIcon />}
-                                                >
-                                                    Watched image
-                                                </Label>
-                                            )}
-                                        </ImageNameTd>
+                                        <ImageScanningErrorLabelLayout
+                                            imageNotes={notes}
+                                            scanNotes={scanNotes}
+                                        >
+                                            <ImageNameTd name={name} id={id}>
+                                                {isWatchedImage && (
+                                                    <Label
+                                                        isCompact
+                                                        variant="outline"
+                                                        color="grey"
+                                                        className="pf-u-mt-xs"
+                                                        icon={<EyeIcon />}
+                                                    >
+                                                        Watched image
+                                                    </Label>
+                                                )}
+                                            </ImageNameTd>
+                                        </ImageScanningErrorLabelLayout>
                                     ) : (
                                         'Image name not available'
                                     )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -13,7 +13,7 @@ import EmptyTableResults from '../components/EmptyTableResults';
 import DateDistanceTd from '../components/DatePhraseTd';
 import TooltipTh from '../components/TooltipTh';
 import { VulnerabilitySeverityLabel, WatchStatus } from '../types';
-import ImageScanningErrorLabelLayout from '../components/ImageScanningErrorLabelLayout';
+import ImageScanningErrorLabel from '../components/ImageScanningErrorLabelLayout';
 
 export const imageListQuery = gql`
     query getImageList($query: String, $pagination: Pagination) {
@@ -153,24 +153,25 @@ function ImagesTable({
                             <Tr>
                                 <Td dataLabel="Image">
                                     {name ? (
-                                        <ImageScanningErrorLabelLayout
-                                            imageNotes={notes}
-                                            scanNotes={scanNotes}
-                                        >
-                                            <ImageNameTd name={name} id={id}>
-                                                {isWatchedImage && (
-                                                    <Label
-                                                        isCompact
-                                                        variant="outline"
-                                                        color="grey"
-                                                        className="pf-u-mt-xs"
-                                                        icon={<EyeIcon />}
-                                                    >
-                                                        Watched image
-                                                    </Label>
-                                                )}
-                                            </ImageNameTd>
-                                        </ImageScanningErrorLabelLayout>
+                                        <ImageNameTd name={name} id={id}>
+                                            {isWatchedImage && (
+                                                <Label
+                                                    isCompact
+                                                    variant="outline"
+                                                    color="grey"
+                                                    className="pf-u-mt-xs"
+                                                    icon={<EyeIcon />}
+                                                >
+                                                    Watched image
+                                                </Label>
+                                            )}
+                                            {(notes.length !== 0 || scanNotes.length !== 0) && (
+                                                <ImageScanningErrorLabel
+                                                    imageNotes={notes}
+                                                    scanNotes={scanNotes}
+                                                />
+                                            )}
+                                        </ImageNameTd>
                                     ) : (
                                         'Image name not available'
                                     )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
@@ -14,6 +14,8 @@ export type ImageDetails = {
     } | null;
     dataSource: { name: string } | null;
     scanTime: string | null;
+    scanNotes: string[];
+    notes: string[];
 };
 
 export const imageDetailsFragment = gql`
@@ -29,6 +31,8 @@ export const imageDetailsFragment = gql`
             name
         }
         scanTime
+        scanNotes
+        notes
     }
 `;
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageScanningErrorLabelLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageScanningErrorLabelLayout.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Button, Flex, FlexItem, Label, Popover } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import isEmpty from 'lodash/isEmpty';
+
+import getImageScanMessage from '../utils/getImageScanMessage';
+
+export type ImageScanningErrorLabelLayoutProps = {
+    children: React.ReactNode;
+    imageNotes: string[];
+    scanNotes: string[];
+};
+
+/**
+ * ‘Image scanning error’ label layout for use in tables. Conditionally renders a label
+ * with a tooltip for information about image scanning errors.
+ *
+ * @param children - The table cell contents to render before the label
+ * @param imageNotes - The image notes
+ * @param scanNotes - The image scan notes
+ */
+function ImageScanningErrorLabelLayout({
+    children,
+    imageNotes,
+    scanNotes,
+}: ImageScanningErrorLabelLayoutProps) {
+    const scanMessage = getImageScanMessage(imageNotes, scanNotes);
+
+    return (
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXs' }}>
+            {children}
+            {!isEmpty(scanMessage) && (
+                <FlexItem>
+                    <Popover
+                        aria-label="Image scanning error label"
+                        headerContent={<div>CVE data may be inaccurate</div>}
+                        bodyContent={
+                            <Flex
+                                direction={{ default: 'column' }}
+                                spaceItems={{ default: 'spaceItemsSm' }}
+                            >
+                                <FlexItem>{scanMessage.header}</FlexItem>
+                                <FlexItem>{scanMessage.body}</FlexItem>
+                            </Flex>
+                        }
+                        enableFlip
+                        position="top"
+                    >
+                        <Button variant="plain" className="pf-u-p-0">
+                            <Label
+                                color="orange"
+                                isCompact
+                                icon={<ExclamationTriangleIcon />}
+                                variant="outline"
+                            >
+                                Image scanning error
+                            </Label>
+                        </Button>
+                    </Popover>
+                </FlexItem>
+            )}
+        </Flex>
+    );
+}
+
+export default ImageScanningErrorLabelLayout;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageScanningErrorLabelLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageScanningErrorLabelLayout.tsx
@@ -5,62 +5,48 @@ import isEmpty from 'lodash/isEmpty';
 
 import getImageScanMessage from '../utils/getImageScanMessage';
 
-export type ImageScanningErrorLabelLayoutProps = {
-    children: React.ReactNode;
+export type ImageScanningErrorLabelProps = {
     imageNotes: string[];
     scanNotes: string[];
 };
 
-/**
- * ‘Image scanning error’ label layout for use in tables. Conditionally renders a label
- * with a tooltip for information about image scanning errors.
- *
- * @param children - The table cell contents to render before the label
- * @param imageNotes - The image notes
- * @param scanNotes - The image scan notes
- */
-function ImageScanningErrorLabelLayout({
-    children,
-    imageNotes,
-    scanNotes,
-}: ImageScanningErrorLabelLayoutProps) {
+function ImageScanningErrorLabel({ imageNotes, scanNotes }: ImageScanningErrorLabelProps) {
     const scanMessage = getImageScanMessage(imageNotes, scanNotes);
 
+    if (isEmpty(scanMessage)) {
+        return null;
+    }
+
     return (
-        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXs' }}>
-            {children}
-            {!isEmpty(scanMessage) && (
-                <FlexItem>
-                    <Popover
-                        aria-label="Image scanning error label"
-                        headerContent={<div>CVE data may be inaccurate</div>}
-                        bodyContent={
-                            <Flex
-                                direction={{ default: 'column' }}
-                                spaceItems={{ default: 'spaceItemsSm' }}
-                            >
-                                <FlexItem>{scanMessage.header}</FlexItem>
-                                <FlexItem>{scanMessage.body}</FlexItem>
-                            </Flex>
-                        }
-                        enableFlip
-                        position="top"
+        <>
+            <Popover
+                aria-label="Image scanning error label"
+                headerContent={<div>CVE data may be inaccurate</div>}
+                bodyContent={
+                    <Flex
+                        direction={{ default: 'column' }}
+                        spaceItems={{ default: 'spaceItemsSm' }}
                     >
-                        <Button variant="plain" className="pf-u-p-0">
-                            <Label
-                                color="orange"
-                                isCompact
-                                icon={<ExclamationTriangleIcon />}
-                                variant="outline"
-                            >
-                                Image scanning error
-                            </Label>
-                        </Button>
-                    </Popover>
-                </FlexItem>
-            )}
-        </Flex>
+                        <FlexItem>{scanMessage.header}</FlexItem>
+                        <FlexItem>{scanMessage.body}</FlexItem>
+                    </Flex>
+                }
+                enableFlip
+                position="top"
+            >
+                <Button variant="plain" className="pf-u-p-0">
+                    <Label
+                        color="orange"
+                        isCompact
+                        icon={<ExclamationTriangleIcon />}
+                        variant="outline"
+                    >
+                        Image scanning error
+                    </Label>
+                </Button>
+            </Popover>
+        </>
     );
 }
 
-export default ImageScanningErrorLabelLayout;
+export default ImageScanningErrorLabel;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/utils/getImageScanMessage.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/utils/getImageScanMessage.test.ts
@@ -1,0 +1,76 @@
+import { imageScanMessages } from 'messages/vulnMgmt.messages';
+import getImageScanMessage from './getImageScanMessage';
+
+describe('getImageScanMessage', () => {
+    it('should return an empty object when there are no notes in the notes arrays', () => {
+        const imagesNotes = [];
+        const scanNotes = [];
+
+        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+
+        expect(messageObj).toEqual({});
+    });
+
+    it('should return an object for missingMetadata when image notes contain MISSING_METADATA', () => {
+        const imagesNotes = ['MISSING_METADATA'];
+        const scanNotes = [];
+
+        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+
+        expect(messageObj).toEqual(imageScanMessages.missingMetadata);
+    });
+
+    it('should return an object for missingScanData when image notes contain MISSING_SCAN_DATA', () => {
+        const imagesNotes = ['MISSING_SCAN_DATA'];
+        const scanNotes = [];
+
+        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+
+        expect(messageObj).toEqual(imageScanMessages.missingScanData);
+    });
+
+    it('should return an object for osUnavailable when scan notes contain OS_UNAVAILABLE', () => {
+        const imagesNotes = [];
+        const scanNotes = ['OS_UNAVAILABLE'];
+
+        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+
+        expect(messageObj).toEqual(imageScanMessages.osUnavailable);
+    });
+
+    it('should return an object for languageCvesUnavailable when scan notes contain PARTIAL_SCAN_DATA and LANGUAGE_CVES_UNAVAILABLE', () => {
+        const imagesNotes = [];
+        const scanNotes = ['PARTIAL_SCAN_DATA', 'LANGUAGE_CVES_UNAVAILABLE'];
+
+        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+
+        expect(messageObj).toEqual(imageScanMessages.languageCvesUnavailable);
+    });
+
+    it('should return an object for osCvesUnavailable when scan notes contain PARTIAL_SCAN_DATA and OS_CVES_UNAVAILABLE', () => {
+        const imagesNotes = [];
+        const scanNotes = ['PARTIAL_SCAN_DATA', 'OS_CVES_UNAVAILABLE'];
+
+        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+
+        expect(messageObj).toEqual(imageScanMessages.osCvesUnavailable);
+    });
+
+    it('should return an object for osCvesUnavailable when scan notes contain OS_CVES_STALE', () => {
+        const imagesNotes = [];
+        const scanNotes = ['OS_CVES_STALE'];
+
+        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+
+        expect(messageObj).toEqual(imageScanMessages.osCvesStale);
+    });
+
+    it('should return an object for certifiedRHELUnavailable when scan notes contain PARTIAL_SCAN_DATA and CERTIFIED_RHEL_SCAN_UNAVAILABLE', () => {
+        const imagesNotes = [];
+        const scanNotes = ['PARTIAL_SCAN_DATA', 'CERTIFIED_RHEL_SCAN_UNAVAILABLE'];
+
+        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+
+        expect(messageObj).toEqual(imageScanMessages.certifiedRHELUnavailable);
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/utils/getImageScanMessage.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/utils/getImageScanMessage.test.ts
@@ -1,76 +1,110 @@
+import Raven from 'raven-js';
+
 import { imageScanMessages } from 'messages/vulnMgmt.messages';
 import getImageScanMessage from './getImageScanMessage';
 
+jest.mock('raven-js', () => ({
+    captureException: jest.fn(),
+}));
+
 describe('getImageScanMessage', () => {
     it('should return an empty object when there are no notes in the notes arrays', () => {
-        const imagesNotes = [];
+        const imageNotes = [];
         const scanNotes = [];
 
-        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+        const messageObj = getImageScanMessage(imageNotes, scanNotes);
 
         expect(messageObj).toEqual({});
     });
 
     it('should return an object for missingMetadata when image notes contain MISSING_METADATA', () => {
-        const imagesNotes = ['MISSING_METADATA'];
+        const imageNotes = ['MISSING_METADATA'];
         const scanNotes = [];
 
-        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+        const messageObj = getImageScanMessage(imageNotes, scanNotes);
 
         expect(messageObj).toEqual(imageScanMessages.missingMetadata);
     });
 
     it('should return an object for missingScanData when image notes contain MISSING_SCAN_DATA', () => {
-        const imagesNotes = ['MISSING_SCAN_DATA'];
+        const imageNotes = ['MISSING_SCAN_DATA'];
         const scanNotes = [];
 
-        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+        const messageObj = getImageScanMessage(imageNotes, scanNotes);
 
         expect(messageObj).toEqual(imageScanMessages.missingScanData);
     });
 
     it('should return an object for osUnavailable when scan notes contain OS_UNAVAILABLE', () => {
-        const imagesNotes = [];
+        const imageNotes = [];
         const scanNotes = ['OS_UNAVAILABLE'];
 
-        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+        const messageObj = getImageScanMessage(imageNotes, scanNotes);
 
         expect(messageObj).toEqual(imageScanMessages.osUnavailable);
     });
 
     it('should return an object for languageCvesUnavailable when scan notes contain PARTIAL_SCAN_DATA and LANGUAGE_CVES_UNAVAILABLE', () => {
-        const imagesNotes = [];
+        const imageNotes = [];
         const scanNotes = ['PARTIAL_SCAN_DATA', 'LANGUAGE_CVES_UNAVAILABLE'];
 
-        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+        const messageObj = getImageScanMessage(imageNotes, scanNotes);
 
         expect(messageObj).toEqual(imageScanMessages.languageCvesUnavailable);
     });
 
     it('should return an object for osCvesUnavailable when scan notes contain PARTIAL_SCAN_DATA and OS_CVES_UNAVAILABLE', () => {
-        const imagesNotes = [];
+        const imageNotes = [];
         const scanNotes = ['PARTIAL_SCAN_DATA', 'OS_CVES_UNAVAILABLE'];
 
-        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+        const messageObj = getImageScanMessage(imageNotes, scanNotes);
 
         expect(messageObj).toEqual(imageScanMessages.osCvesUnavailable);
     });
 
     it('should return an object for osCvesUnavailable when scan notes contain OS_CVES_STALE', () => {
-        const imagesNotes = [];
+        const imageNotes = [];
         const scanNotes = ['OS_CVES_STALE'];
 
-        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+        const messageObj = getImageScanMessage(imageNotes, scanNotes);
 
         expect(messageObj).toEqual(imageScanMessages.osCvesStale);
     });
 
     it('should return an object for certifiedRHELUnavailable when scan notes contain PARTIAL_SCAN_DATA and CERTIFIED_RHEL_SCAN_UNAVAILABLE', () => {
-        const imagesNotes = [];
+        const imageNotes = [];
         const scanNotes = ['PARTIAL_SCAN_DATA', 'CERTIFIED_RHEL_SCAN_UNAVAILABLE'];
 
-        const messageObj = getImageScanMessage(imagesNotes, scanNotes);
+        const messageObj = getImageScanMessage(imageNotes, scanNotes);
 
         expect(messageObj).toEqual(imageScanMessages.certifiedRHELUnavailable);
+    });
+
+    it('should capture the error when an unknown state is encountered', () => {
+        // Spy on Raven.captureException
+        const spy = jest.spyOn(Raven, 'captureException');
+
+        const imageNotes = [];
+        const scanNotes = ['THIS_IS_NOT_OK'];
+
+        const messageObj = getImageScanMessage(imageNotes, scanNotes);
+
+        // Assert that captureException was called with proper extra values
+        expect(spy).toHaveBeenCalledWith(
+            expect.any(Error),
+            expect.objectContaining({
+                extra: { imageNotes, scanNotes },
+            })
+        );
+
+        // Assert that the error message is correct
+        const errorArg = spy.mock.calls[0][0] as Error;
+        expect(errorArg).toBeInstanceOf(Error);
+        expect(errorArg.message).toBe('Unknown State Detected');
+
+        expect(messageObj).toEqual({});
+
+        // Restore the original function
+        spy.mockRestore();
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/utils/getImageScanMessage.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/utils/getImageScanMessage.ts
@@ -1,0 +1,40 @@
+import { imageScanMessages, ScanMessage } from 'messages/vulnMgmt.messages';
+
+export default function getImageScanMessage(
+    imageNotes: string[],
+    scanNotes: string[]
+): ScanMessage {
+    const hasMissingMetadata = imageNotes?.includes('MISSING_METADATA');
+    const hasMissingScanData = imageNotes?.includes('MISSING_SCAN_DATA');
+
+    const hasOSUnavailable = scanNotes?.includes('OS_UNAVAILABLE');
+    const hasPartialScanData = scanNotes?.includes('PARTIAL_SCAN_DATA');
+    const hasLanguageCvesUnavailable = scanNotes?.includes('LANGUAGE_CVES_UNAVAILABLE');
+    const hasOSCvesUnavailable = scanNotes?.includes('OS_CVES_UNAVAILABLE');
+    const hasOSCvesStale = scanNotes?.includes('OS_CVES_STALE');
+    const hasCertifiedRHELCvesUnavailable = scanNotes?.includes('CERTIFIED_RHEL_SCAN_UNAVAILABLE');
+
+    if (hasMissingMetadata) {
+        return imageScanMessages.missingMetadata;
+    }
+    if (hasMissingScanData) {
+        return imageScanMessages.missingScanData;
+    }
+    if (hasOSUnavailable) {
+        return imageScanMessages.osUnavailable;
+    }
+    if (hasPartialScanData && hasLanguageCvesUnavailable) {
+        return imageScanMessages.languageCvesUnavailable;
+    }
+    if (hasPartialScanData && hasOSCvesUnavailable) {
+        return imageScanMessages.osCvesUnavailable;
+    }
+    if (hasPartialScanData && hasCertifiedRHELCvesUnavailable) {
+        return imageScanMessages.certifiedRHELUnavailable;
+    }
+    if (hasOSCvesStale) {
+        return imageScanMessages.osCvesStale;
+    }
+
+    return {};
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/utils/getImageScanMessage.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/utils/getImageScanMessage.ts
@@ -1,3 +1,6 @@
+import isEmpty from 'lodash/isEmpty';
+import Raven from 'raven-js';
+
 import { imageScanMessages, ScanMessage } from 'messages/vulnMgmt.messages';
 
 export default function getImageScanMessage(
@@ -34,6 +37,11 @@ export default function getImageScanMessage(
     }
     if (hasOSCvesStale) {
         return imageScanMessages.osCvesStale;
+    }
+    if (!isEmpty(imageNotes) || !isEmpty(scanNotes)) {
+        Raven.captureException(new Error('Unknown State Detected'), {
+            extra: { imageNotes, scanNotes },
+        });
     }
 
     return {};


### PR DESCRIPTION
## Description

This PR adds the image scan notes popover in the 'Images' tab (within Workload CVEs) and an alert in the 'Images' details page

## Screenshots

I was not able to test this out using real data, but I tried to simulate the different states and the messages we would see. Attached screenshots of the messages below

### Popover

When there are no `notes` or `scanNotes` then we won't display anything
<img width="358" alt="Screenshot 2024-01-18 at 6 37 48 PM" src="https://github.com/stackrox/stackrox/assets/4805485/908c3569-7756-4f76-8b10-c800545371d3">

Otherwise, we'll display the label and the proper message in the popover depending on the string values in `notes` and `scanNotes`.
<img width="348" alt="Screenshot 2024-01-19 at 9 43 20 AM" src="https://github.com/stackrox/stackrox/assets/4805485/721a8236-1d53-482f-9ec8-8cb96792e6e4">
<img width="358" alt="Screenshot 2024-01-19 at 9 43 40 AM" src="https://github.com/stackrox/stackrox/assets/4805485/60a27533-f1b7-4cc0-8121-2d6820f9200a">
<img width="329" alt="Screenshot 2024-01-18 at 6 36 05 PM" src="https://github.com/stackrox/stackrox/assets/4805485/d28e2124-ed06-4002-91ad-db28bd7e5c6c">
<img width="337" alt="Screenshot 2024-01-18 at 6 36 28 PM" src="https://github.com/stackrox/stackrox/assets/4805485/bfcf3b91-4fba-4b49-9bb8-bfc217dfd92e">
<img width="367" alt="Screenshot 2024-01-18 at 6 36 47 PM" src="https://github.com/stackrox/stackrox/assets/4805485/20f1a3b0-5b3d-4f37-a8f0-90fbb0ffb3e0">
<img width="342" alt="Screenshot 2024-01-18 at 6 37 05 PM" src="https://github.com/stackrox/stackrox/assets/4805485/6a8c6487-2359-4e76-80b1-5e8f375762ec">
<img width="342" alt="Screenshot 2024-01-18 at 6 37 23 PM" src="https://github.com/stackrox/stackrox/assets/4805485/ca479ffe-3fbe-480d-833d-24ef16719ec1">

### Alert

When there are no `notes` or `scanNotes` then we won't display anything
<img width="1440" alt="Screenshot 2024-01-19 at 9 44 33 AM" src="https://github.com/stackrox/stackrox/assets/4805485/84fa13f4-9a7c-400a-84cb-0a31f22fdcf9">

Otherwise, we'll display the proper message in an alert warning depending on the string values in `notes` and `scanNotes`.
<img width="1440" alt="Screenshot 2024-01-19 at 9 40 05 AM" src="https://github.com/stackrox/stackrox/assets/4805485/bbcb16bc-1bcc-452e-bd89-99754744e436">
<img width="1440" alt="Screenshot 2024-01-19 at 9 40 20 AM" src="https://github.com/stackrox/stackrox/assets/4805485/2e26d6d0-7159-41d2-95dd-c0d65affae10">
<img width="1438" alt="Screenshot 2024-01-19 at 9 40 52 AM" src="https://github.com/stackrox/stackrox/assets/4805485/33a2ed25-d7f5-407d-81ea-321b0fac5fba">
<img width="1440" alt="Screenshot 2024-01-19 at 9 41 27 AM" src="https://github.com/stackrox/stackrox/assets/4805485/ea3852eb-458d-442f-bfe8-28d7cfa33879">
<img width="1440" alt="Screenshot 2024-01-19 at 9 41 48 AM" src="https://github.com/stackrox/stackrox/assets/4805485/379d8b3e-6110-4726-9472-3ea5a29695ed">
<img width="1440" alt="Screenshot 2024-01-19 at 9 42 05 AM" src="https://github.com/stackrox/stackrox/assets/4805485/ca7fca89-7d86-40cc-a9cf-abb2eca34b1b">
<img width="1440" alt="Screenshot 2024-01-19 at 9 42 25 AM" src="https://github.com/stackrox/stackrox/assets/4805485/e33674ab-1fb0-4b2c-92ea-a1f6562306f1">



