### PR TITLE
feat(roxctl): generate docs for roxctl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -191,6 +191,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.15.1 // indirect
 	github.com/containers/storage v1.51.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20231011164504-785e29786b46 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/go.sum
+++ b/go.sum
@@ -850,6 +850,7 @@ github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/roxctl/doc/generate.go
+++ b/roxctl/doc/generate.go
@@ -1,0 +1,53 @@
+package doc
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/roxctl/common"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
+)
+
+// Command provides the doc generation command.
+func Command(_ environment.Environment) *cobra.Command {
+	var dir string
+	cmd := &cobra.Command{
+		Use:   "doc [man|md|yaml|rest]",
+		Short: "Generate docs for roxctl",
+		Long: `Generate docs for roxctl in the given format.
+
+The following formats are supported:
+- man generates man page like docs
+- md generates markdown pages
+- rest generates reStructured text docs
+`,
+		Args: common.ExactArgsWithCustomErrMessage(1,
+			"Missing argument. Use one of the following: [man|md|yaml|rest]"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch args[0] {
+			case "man":
+				return errors.Wrap(doc.GenManTree(cmd.Root(), &doc.GenManHeader{
+					Title:  "roxctl",
+					Source: "roxctl",
+				}, dir), "generating man page docs")
+			case "md":
+				return errors.Wrap(doc.GenMarkdownTree(cmd.Root(), dir), "generating markdown docs")
+			case "yaml":
+				return errors.Wrap(doc.GenYamlTree(cmd.Root(), dir), "generating YAML docs")
+			case "rest":
+				return errors.Wrap(doc.GenReSTTree(cmd.Root(), dir), "generating reStructured docs")
+			default:
+				return common.ErrInvalidCommandOption.CausedByf("invalid option %q used; use one of the following: [man|md|yaml|rest]", args[0])
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&dir, "output", "o", "",
+		"directory where the docs should be written to")
+	utils.Must(cmd.MarkFlagRequired("output"))
+	flags.HideInheritedFlags(cmd)
+
+	return cmd
+}

--- a/roxctl/doc/generate.go
+++ b/roxctl/doc/generate.go
@@ -26,6 +26,8 @@ The following formats are supported:
 		Args: common.ExactArgsWithCustomErrMessage(1,
 			"Missing argument. Use one of the following: [man|md|yaml|rest]"),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Current caveat: in case the command is not within PATH, cmd.CommandPath will be appended to the
+			// given directory. This may result in errors during writing the docs to the specified output.
 			switch args[0] {
 			case "man":
 				return errors.Wrap(doc.GenManTree(cmd.Root(), &doc.GenManHeader{

--- a/roxctl/maincommand/command.go
+++ b/roxctl/maincommand/command.go
@@ -19,6 +19,7 @@ import (
 	connectivitymapDeprecated "github.com/stackrox/rox/roxctl/connectivity-map"
 	"github.com/stackrox/rox/roxctl/declarativeconfig"
 	"github.com/stackrox/rox/roxctl/deployment"
+	"github.com/stackrox/rox/roxctl/doc"
 	"github.com/stackrox/rox/roxctl/generate"
 	"github.com/stackrox/rox/roxctl/helm"
 	"github.com/stackrox/rox/roxctl/image"
@@ -89,6 +90,9 @@ func Command() *cobra.Command {
 	}
 	if env.DeclarativeConfiguration.BooleanSetting() {
 		c.AddCommand(declarativeconfig.Command(cliEnvironment))
+	}
+	if !buildinfo.ReleaseBuild {
+		c.AddCommand(doc.Command(cliEnvironment))
 	}
 
 	return c


### PR DESCRIPTION
## Description

This PR introduces a new `docs` command with which doc pages can be generated for all roxctl commands.

The doc page generation works using [spf13/cobra/doc](https://pkg.go.dev/github.com/spf13/cobra/doc) package and the currently supported formats of man, markdown, reST, YAML.

Note that this currently is only used by the doc team as input for extending the docs, and not necessarily used as-is.

For the time being, decided to guard this functionality behind the buildinfo (i.e. disable this for release builds), we may want to switch to an environment variable if desired as well (this way we could theoretically generate the docs later on in the upstream release pipeline as artifacts as well).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

N/A

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
