### PR TITLE
fix: roxctl validate endpoint for port

### DIFF
--- a/roxctl/common/flags/endpoint.go
+++ b/roxctl/common/flags/endpoint.go
@@ -85,7 +85,8 @@ func AddConnectionFlags(c *cobra.Command) {
 }
 
 // EndpointAndPlaintextSetting returns the Central endpoint to connect to, as well as a bool indicating whether to
-// connect in plaintext mode.
+// connect in plaintext mode. As connection requires a port it deduces it from provided schema. If schema is not provided
+// the givenEndpoint must contain port or error is returned.
 func EndpointAndPlaintextSetting() (string, bool, error) {
 	endpoint = flagOrSettingValue(endpoint, *endpointChanged, env.EndpointEnv)
 	if !strings.Contains(endpoint, "://") {

--- a/roxctl/common/flags/endpoint.go
+++ b/roxctl/common/flags/endpoint.go
@@ -90,14 +90,14 @@ func EndpointAndPlaintextSetting() (string, bool, error) {
 	endpoint = flagOrSettingValue(endpoint, *endpointChanged, env.EndpointEnv)
 	if !strings.Contains(endpoint, "://") {
 		if _, _, err := net.SplitHostPort(endpoint); err != nil {
-			return "", false, errox.InvalidArgs.Newf("invalid endpoint: %s, the scheme should be: http(s)://<endpoint>:<port>", err.Error())
+			return "", false, errox.InvalidArgs.CausedBy(err)
 		}
 		return endpoint, plaintext, nil
 	}
 
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return "", false, errors.Wrap(err, "malformed endpoint URL")
+		return "", false, errox.InvalidArgs.CausedBy(err)
 	}
 
 	if u.Path != "" && u.Path != "/" {

--- a/roxctl/common/flags/endpoint.go
+++ b/roxctl/common/flags/endpoint.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"net"
 	"net/url"
 	"strings"
 
@@ -114,6 +115,10 @@ func EndpointAndPlaintextSetting() (string, bool, error) {
 		if booleanFlagOrSettingValue(plaintext, *plaintextSet, env.PlaintextEnv) != usePlaintext {
 			return "", false, errox.InvalidArgs.Newf("endpoint URL scheme %q is incompatible with --plaintext=%v setting", u.Scheme, plaintext)
 		}
+	}
+
+	if _, _, err := net.SplitHostPort(u.Host); err != nil {
+		return "", false, errox.InvalidArgs.Newf("invalid endpoint: %s, the scheme should be: http(s)://<endpoint>:<port>", err.Error())
 	}
 
 	return u.Host, usePlaintext, nil

--- a/roxctl/common/flags/endpoint.go
+++ b/roxctl/common/flags/endpoint.go
@@ -114,7 +114,7 @@ func EndpointAndPlaintextSetting() (string, bool, error) {
 		defaultPort = 443
 		usePlaintext = false
 	default:
-		return "", false, errox.InvalidArgs.Newf("invalid scheme %q in endpoint URL, the scheme should be: http(s)://<endpoint>:<port>", u.Scheme)
+		return "", false, errox.InvalidArgs.Newf("invalid scheme %q in endpoint URL, use either 'http' or 'https'", u.Scheme)
 	}
 
 	if *plaintextSet ||

--- a/roxctl/common/flags/endpoint_test.go
+++ b/roxctl/common/flags/endpoint_test.go
@@ -24,8 +24,8 @@ func TestEndpointAndPlaintextSetting(t *testing.T) {
 			host:     "localhost:8443",
 		},
 		{
-			endpoint: "localhost",
-			host:     "localhost",
+			endpoint: "https://localhost",
+			host:     "localhost:443",
 		},
 		{
 			endpoint: "https://example.com:443",
@@ -38,15 +38,33 @@ func TestEndpointAndPlaintextSetting(t *testing.T) {
 		},
 		{
 			endpoint: "https://example.com",
-			err:      "invalid endpoint: address example.com: missing port in address, the scheme should be: http(s)://<endpoint>:<port>",
+			host:     "example.com:443",
 		},
 		{
-			endpoint: "http://example.com",
-			err:      "invalid endpoint: address example.com: missing port in address, the scheme should be: http(s)://<endpoint>:<port>",
+			endpoint:     "http://example.com",
+			host:         "example.com:80",
+			usePlaintext: true,
+		},
+		{
+			endpoint:     "http://128.66.0.1",
+			host:         "128.66.0.1:80",
+			usePlaintext: true,
 		},
 		{
 			endpoint: "128.66.0.1",
-			host:     "128.66.0.1",
+			err:      "invalid endpoint: address 128.66.0.1: missing port in address, the scheme should be: http(s)://<endpoint>:<port>",
+		},
+		{
+			endpoint: "example.com",
+			err:      "invalid endpoint: address example.com: missing port in address, the scheme should be: http(s)://<endpoint>:<port>",
+		},
+		{
+			endpoint: "example.com:80:80",
+			err:      "invalid endpoint: address example.com:80:80: too many colons in address, the scheme should be: http(s)://<endpoint>:<port>",
+		},
+		{
+			endpoint: "host:port",
+			host:     "host:port",
 		},
 	}
 
@@ -64,5 +82,4 @@ func TestEndpointAndPlaintextSetting(t *testing.T) {
 			assert.Equal(t, tc.usePlaintext, usePlaintext)
 		})
 	}
-
 }

--- a/roxctl/common/flags/endpoint_test.go
+++ b/roxctl/common/flags/endpoint_test.go
@@ -1,0 +1,68 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpointAndPlaintextSetting(t *testing.T) {
+	truth := false
+	endpointChanged = &truth
+	plaintextSet = &truth
+
+	testCases := []struct {
+		endpoint     string
+		host         string
+		usePlaintext bool
+		err          string
+	}{
+		{
+			endpoint: "localhost:8443",
+			host:     "localhost:8443",
+		},
+		{
+			endpoint: "localhost",
+			host:     "localhost",
+		},
+		{
+			endpoint: "https://example.com:443",
+			host:     "example.com:443",
+		},
+		{
+			endpoint:     "http://example.com:80",
+			host:         "example.com:80",
+			usePlaintext: true,
+		},
+		{
+			endpoint: "https://example.com",
+			err:      "invalid endpoint: address example.com: missing port in address, the scheme should be: http(s)://<endpoint>:<port>",
+		},
+		{
+			endpoint: "http://example.com",
+			err:      "invalid endpoint: address example.com: missing port in address, the scheme should be: http(s)://<endpoint>:<port>",
+		},
+		{
+			endpoint: "128.66.0.1",
+			host:     "128.66.0.1",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.endpoint, func(t *testing.T) {
+			t.Setenv(env.EndpointEnv.EnvVar(), tc.endpoint)
+			host, usePlaintext, err := EndpointAndPlaintextSetting()
+			if tc.err == "" {
+				require.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.err)
+			}
+			assert.Equal(t, tc.host, host)
+			assert.Equal(t, tc.usePlaintext, usePlaintext)
+		})
+	}
+
+}

--- a/roxctl/common/flags/endpoint_test.go
+++ b/roxctl/common/flags/endpoint_test.go
@@ -4,81 +4,86 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/pointers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestEndpointAndPlaintextSetting(t *testing.T) {
-	truth := false
-	endpointChanged = &truth
-	plaintextSet = &truth
+	endpointChanged = pointers.Bool(false)
+	plaintextSet = pointers.Bool(false)
 
 	testCases := []struct {
-		endpoint     string
-		host         string
-		usePlaintext bool
-		err          string
+		givenEndpoint    string
+		expectedEndpoint string
+		usePlaintext     bool
+		err              string
 	}{
 		{
-			endpoint: "localhost:8443",
-			host:     "localhost:8443",
+			givenEndpoint:    "localhost:8443",
+			expectedEndpoint: "localhost:8443",
 		},
 		{
-			endpoint: "https://localhost",
-			host:     "localhost:443",
+			givenEndpoint:    "https://localhost",
+			expectedEndpoint: "localhost:443",
 		},
 		{
-			endpoint: "https://example.com:443",
-			host:     "example.com:443",
+			givenEndpoint:    "https://example.com:443",
+			expectedEndpoint: "example.com:443",
 		},
 		{
-			endpoint:     "http://example.com:80",
-			host:         "example.com:80",
-			usePlaintext: true,
+			givenEndpoint:    "http://example.com:80",
+			expectedEndpoint: "example.com:80",
+			usePlaintext:     true,
 		},
 		{
-			endpoint: "https://example.com",
-			host:     "example.com:443",
+			givenEndpoint:    "https://example.com",
+			expectedEndpoint: "example.com:443",
 		},
 		{
-			endpoint:     "http://example.com",
-			host:         "example.com:80",
-			usePlaintext: true,
+			givenEndpoint:    "http://example.com",
+			expectedEndpoint: "example.com:80",
+			usePlaintext:     true,
 		},
 		{
-			endpoint:     "http://128.66.0.1",
-			host:         "128.66.0.1:80",
-			usePlaintext: true,
+			givenEndpoint:    "http://128.66.0.1",
+			expectedEndpoint: "128.66.0.1:80",
+			usePlaintext:     true,
 		},
 		{
-			endpoint: "128.66.0.1",
-			err:      "invalid endpoint: address 128.66.0.1: missing port in address",
+			givenEndpoint: "128.66.0.1",
+			err:           "invalid arguments: address 128.66.0.1: missing port in address",
 		},
 		{
-			endpoint: "example.com",
-			err:      "invalid endpoint: address example.com: missing port in address, the scheme should be: http(s)://<endpoint>:<port>",
+			givenEndpoint: "example.com",
+			err:           "invalid arguments: address example.com: missing port in address",
 		},
 		{
-			endpoint: "example.com:80:80",
-			err:      "invalid endpoint: address example.com:80:80: too many colons in address, the scheme should be: http(s)://<endpoint>:<port>",
+			givenEndpoint: "example.com:80:80",
+			err:           "invalid arguments: address example.com:80:80: too many colons in address",
 		},
 		{
-			endpoint: "host:port",
-			host:     "host:port",
+			givenEndpoint: "https://host:port",
+			err:           `invalid arguments: parse "https://host:port": invalid port ":port" after host`,
+		},
+		{
+			// SplitHostPort does not verify if port is numeric (but url.Parse does).
+			givenEndpoint:    "host:port",
+			expectedEndpoint: "host:port",
 		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
-		t.Run(tc.endpoint, func(t *testing.T) {
-			t.Setenv(env.EndpointEnv.EnvVar(), tc.endpoint)
+		t.Run(tc.givenEndpoint, func(t *testing.T) {
+			t.Setenv(env.EndpointEnv.EnvVar(), tc.givenEndpoint)
 			host, usePlaintext, err := EndpointAndPlaintextSetting()
 			if tc.err == "" {
 				require.NoError(t, err)
 			} else {
 				assert.EqualError(t, err, tc.err)
 			}
-			assert.Equal(t, tc.host, host)
+			assert.Equal(t, tc.expectedEndpoint, host)
 			assert.Equal(t, tc.usePlaintext, usePlaintext)
 		})
 	}

--- a/roxctl/common/flags/endpoint_test.go
+++ b/roxctl/common/flags/endpoint_test.go
@@ -52,7 +52,7 @@ func TestEndpointAndPlaintextSetting(t *testing.T) {
 		},
 		{
 			endpoint: "128.66.0.1",
-			err:      "invalid endpoint: address 128.66.0.1: missing port in address, the scheme should be: http(s)://<endpoint>:<port>",
+			err:      "invalid endpoint: address 128.66.0.1: missing port in address",
 		},
 		{
 			endpoint: "example.com",


### PR DESCRIPTION
## Description

When the port is missing we will get an error from `Dial` that is retried so for 60s user gets nothing and at the end configuration error is thrown. This PR adds roxctl validation for host:port

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

