### PR TITLE
fix: Ensure the loop is stopped

### DIFF
--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -542,6 +542,10 @@ func (m *managerImpl) revertPastDueDeferralExceptions() {
 		return
 	}
 
+	if m.stopper.Client().Stopped().IsDone() {
+		return
+	}
+
 	if err := m.expireDeferrals(deferrals); err != nil {
 		log.Errorf("Failed to retire expired deferral requests and re-observe associated vulnerabilities with error(s): %+v", err)
 	} else {
@@ -656,6 +660,10 @@ func (m *managerImpl) revertFixableCVEDeferralExceptions() {
 		return
 	}
 	if len(deferrals) == 0 {
+		return
+	}
+
+	if m.stopper.Client().Stopped().IsDone() {
 		return
 	}
 


### PR DESCRIPTION
## Description

The vulnerability exception revert loop seems to be racy. The routine checks if the loop is stopped only before reading the database. However, since it is a separate routine (async), the stop could be triggered after the database has been read.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed