### PR TITLE
chore(scanner): rename name2cpe to name2repos

### DIFF
--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -64,7 +64,7 @@ var (
 	log = logging.LoggerForModule()
 
 	v4FileMapping = map[string]string{
-		"name2cpe": "repomapping-tmp/container-name-repos-map.json",
+		"name2repos": "repomapping-tmp/container-name-repos-map.json",
 		"repo2cpe": "repomapping-tmp/repository-to-cpe.json",
 	}
 )

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -65,7 +65,7 @@ var (
 
 	v4FileMapping = map[string]string{
 		"name2repos": "repomapping-tmp/container-name-repos-map.json",
-		"repo2cpe": "repomapping-tmp/repository-to-cpe.json",
+		"repo2cpe":   "repomapping-tmp/repository-to-cpe.json",
 	}
 )
 

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -211,7 +211,7 @@ func (s *handlerTestSuite) TestServeHTTP_Online_Mappings_Get() {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	// Should get mapping json file from online update.
-	req = s.getRequestWithJSONFile(t, "name2cpe")
+	req = s.getRequestWithJSONFile(t, "name2repos")
 	w.Data.Reset()
 	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)

--- a/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
@@ -23,10 +23,10 @@ indexer:
   get_layer_timeout: 1m
   {{- if ._rox.env.centralServices }}
   repository_to_cpe_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?file=repo2cpe
-  name_to_repos_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?file=name2cpe
+  name_to_repos_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?file=name2repos
   {{- else }}
   repository_to_cpe_url: https://sensor.{{ .Release.Namespace }}.svc/scanner/definitions?file=repo2cpe
-  name_to_repos_url: https://sensor.{{ .Release.Namespace }}.svc/scanner/definitions?file=name2cpe
+  name_to_repos_url: https://sensor.{{ .Release.Namespace }}.svc/scanner/definitions?file=name2repos
   {{- end }}
   repository_to_cpe_file: /run/mappings/repository-to-cpe.json
   name_to_repos_file: /run/mappings/container-name-repos-map.json

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -241,7 +241,7 @@ tests:
     scannerV4.disable: false
   expect: |
     .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.repository_to_cpe_url | assertThat(. == "https://central.stackrox.svc/api/extensions/scannerdefinitions?file=repo2cpe")
-    .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.name_to_repos_url | assertThat(. == "https://central.stackrox.svc/api/extensions/scannerdefinitions?file=name2cpe")
+    .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.name_to_repos_url | assertThat(. == "https://central.stackrox.svc/api/extensions/scannerdefinitions?file=name2repos")
 
 - name: "Scanner V4 is installed by default"
   set:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -165,7 +165,7 @@ tests:
     scannerV4.disable: false
   expect: |
     .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.repository_to_cpe_url | assertThat(. == "https://sensor.stackrox.svc/scanner/definitions?file=repo2cpe")
-    .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.name_to_repos_url | assertThat(. == "https://sensor.stackrox.svc/scanner/definitions?file=name2cpe")
+    .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.name_to_repos_url | assertThat(. == "https://sensor.stackrox.svc/scanner/definitions?file=name2repos")
 
 - name: "indexer should not allow ingress from central and matcher when deployed as a secured-cluster-service"
   set:


### PR DESCRIPTION
## Description

The file maps container names to repos, not CPEs. Changing the name to reflect this.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
