### PR TITLE
chore(ui): Turn off policy criteria modal for now

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -74,7 +74,7 @@ var (
 	AuthMachineToMachine = registerFeature("Enable Auth Machine to Machine functionalities", "ROX_AUTH_MACHINE_TO_MACHINE", false)
 
 	// PolicyCriteriaModal enables a modal for selecting policy criteria when editing a policy
-	PolicyCriteriaModal = registerFeature("Enable modal to select policy criteria when editing a policy", "ROX_POLICY_CRITERIA_MODAL", true)
+	PolicyCriteriaModal = registerFeature("Enable modal to select policy criteria when editing a policy", "ROX_POLICY_CRITERIA_MODAL", false)
 
 	// SensorDeploymentBuildOptimization enables a performance improvement by skipping deployments processing when no dependency or spec changed
 	SensorDeploymentBuildOptimization = registerFeature("Enables a performance improvement by skipping deployments processing when no dependency or spec changed", "ROX_DEPLOYMENT_BUILD_OPTIMIZATION", true)


### PR DESCRIPTION
## Description

While we await different UX

## Checklist
- [x] Investigated and inspected CI test results (non-groovy-tests failure was flake due to the infrastructure not coming up)

## Testing Performed

### Here I tell how I validated my change

Deploying the PR build image, then checking to ensure the Policy Criteria Modal is no longer available, and the old policy drag and drop fields still work.

1. No policy modal, but drag and drop is back and can be used in creating a policy
<img width="1467" alt="Screenshot 2024-01-19 at 3 10 55 PM" src="https://github.com/stackrox/stackrox/assets/715729/0560905d-529b-44bc-a9e0-24b4efe33657">


2. Policy created with drag and drop criteria works
<img width="1467" alt="Screenshot 2024-01-19 at 3 13 45 PM" src="https://github.com/stackrox/stackrox/assets/715729/3f1ff42e-ee9d-438f-bc91-9dab35bd9a78">


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
