### PR TITLE
fix(roxctl): fail fast in central login

### DIFF
--- a/roxctl/central/login/login.go
+++ b/roxctl/central/login/login.go
@@ -278,6 +278,8 @@ In case the access token is expired and cannot be refreshed, you have to run "ro
 }
 
 func (l *loginCommand) verifyLoginAuthProviders() error {
+	// Use the HTTP client with the anonymous auth method to force anonymous access.
+	// Note that this may still be done via HTTP/2 instead of HTTP/1, unless HTTP/1 is forced.
 	httpClient, err := l.env.HTTPClient(30*time.Second, auth.Anonymous())
 	if err != nil {
 		return errors.Wrap(err, "creating HTTP client")

--- a/roxctl/common/flags/endpoint.go
+++ b/roxctl/common/flags/endpoint.go
@@ -10,29 +10,30 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
+	"k8s.io/utils/pointer"
 )
 
 var (
 	endpoint        string
-	endpointChanged *bool
+	endpointChanged = pointer.Bool(false)
 
 	serverName    string
-	serverNameSet *bool
+	serverNameSet = pointer.Bool(false)
 	directGRPC    bool
-	directGRPCSet *bool
+	directGRPCSet = pointer.Bool(false)
 	forceHTTP1    bool
-	forceHTTP1Set *bool
+	forceHTTP1Set = pointer.Bool(false)
 
 	plaintext    bool
-	plaintextSet *bool
+	plaintextSet = pointer.Bool(false)
 	insecure     bool
-	insecureSet  *bool
+	insecureSet  = pointer.Bool(false)
 
 	insecureSkipTLSVerify    bool
-	insecureSkipTLSVerifySet *bool
+	insecureSkipTLSVerifySet = pointer.Bool(false)
 
 	caCertFile    string
-	caCertFileSet *bool
+	caCertFileSet = pointer.Bool(false)
 
 	useKubeContext bool
 )


### PR DESCRIPTION
## Description

The `roxctl central login` command can only be used with auth providers which are not of the type `basic`.

Currently, we open the local browser irrespective of whether only a single auth provider is configured or not.

Instead, we can fail fast in case the login auth providers contain only auth providers of the type basic. This can be done because the API is anonymous.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

N/A.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
