### PR TITLE
ROX-21620: publish opensource instead of stackrox.io helm charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - Configuration files now specify ROX_MEMLIMIT instead of GOMEMLIMIT.
   - ROX_MEMLIMIT is meant to capture the memory limit of the deployment, so it may adjust the GOMEMLIMIT accordingly.
   - ROX_MEMLIMIT is not as flexible as GOMEMLIMIT. It may only be set to an integer representing a number of bytes.
+- ROX-21620: publish opensource instead of stackrox.io helm charts
 
 ## [4.3.0]
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -590,10 +590,8 @@ push_helm_charts() {
     local secured_cluster_services_chart_dir
     central_services_chart_dir="$(mktemp -d)"
     secured_cluster_services_chart_dir="$(mktemp -d)"
-    roxctl helm output central-services --image-defaults=stackrox.io --output-dir "${central_services_chart_dir}/stackrox"
     roxctl helm output central-services --image-defaults=rhacs --output-dir "${central_services_chart_dir}/rhacs"
     roxctl helm output central-services --image-defaults=opensource --output-dir "${central_services_chart_dir}/opensource"
-    roxctl helm output secured-cluster-services --image-defaults=stackrox.io --output-dir "${secured_cluster_services_chart_dir}/stackrox"
     roxctl helm output secured-cluster-services --image-defaults=rhacs --output-dir "${secured_cluster_services_chart_dir}/rhacs"
     roxctl helm output secured-cluster-services --image-defaults=opensource --output-dir "${secured_cluster_services_chart_dir}/opensource"
     "${SCRIPTS_ROOT}/scripts/ci/publish-helm-charts.sh" "${tag}" "${central_services_chart_dir}" "${secured_cluster_services_chart_dir}"

--- a/scripts/ci/publish-helm-charts.sh
+++ b/scripts/ci/publish-helm-charts.sh
@@ -43,8 +43,8 @@ gitbot -C "$tmp_remote_repository" checkout -b "$branch_name"
 
 mkdir "${tmp_remote_repository}/${remote_subdirectory}/${version}"
 
-cp -a "${central_services_chart}/stackrox" "${tmp_remote_repository}/${remote_subdirectory}/${version}/central-services"
-cp -a "${secured_cluster_services_chart}/stackrox" "${tmp_remote_repository}/${remote_subdirectory}/${version}/secured-cluster-services"
+cp -a "${central_services_chart}/opensource" "${tmp_remote_repository}/${remote_subdirectory}/${version}/central-services"
+cp -a "${secured_cluster_services_chart}/opensource" "${tmp_remote_repository}/${remote_subdirectory}/${version}/secured-cluster-services"
 
 mkdir "${tmp_remote_repository}/${remote_subdirectory}/rhacs/${version}"
 


### PR DESCRIPTION
## Description

Stops generating and publishing stackrox.io based helmcharts.
Going forward, the opensource flavor is published to stackrox/helmcharts.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] <strike>Unit test and regression tests added</strike>
- [X] Evaluated and added CHANGELOG entry if required
- [ ] <strike>Determined and documented upgrade steps</strike>
- [ ] <strike>Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))</strike>

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Used a "dry run" of a release (curtesy of @tommartensen) to produce an [example release-artifacts PR](https://github.com/stackrox/release-artifacts/pull/122).
 
The interesting artifact is the [helm repo archive](https://github.com/stackrox/release-artifacts/blob/4276a90f8c55a0b07a7112fe0e46b957b5ab8f41/helm-charts/opensource/stackrox-central-services-400.3.0-817-g1588c87071.tgz
) produced. I verified this contains the opensource charts, by looking at the `internal/defaults.yaml`'s image repository and confirming it now points to quay.io.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
