### PR TITLE
ROX-21868: fix update skip condition in mark_collector_release

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -631,7 +631,7 @@ mark_collector_release() {
 
     # We need to make sure the file ends with a newline so as not to corrupt it when appending.
     [[ ! -f RELEASED_VERSIONS ]] || sed --in-place -e '$a'\\ RELEASED_VERSIONS
-    if grep -q "${tag}" RELEASED_VERSIONS; then
+    if grep -q "\s${tag}\s\s" RELEASED_VERSIONS; then
         echo "Skip RELEASED_VERSIONS file change, already up to date ..." >> "${GITHUB_STEP_SUMMARY}"
     else
         echo "Update RELEASED_VERSIONS file ..." >> "${GITHUB_STEP_SUMMARY}"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -631,7 +631,7 @@ mark_collector_release() {
 
     # We need to make sure the file ends with a newline so as not to corrupt it when appending.
     [[ ! -f RELEASED_VERSIONS ]] || sed --in-place -e '$a'\\ RELEASED_VERSIONS
-    if grep -q "\s${tag}\s\s" RELEASED_VERSIONS; then
+    if grep -qF "${tag}" RELEASED_VERSIONS; then
         echo "Skip RELEASED_VERSIONS file change, already up to date ..." >> "${GITHUB_STEP_SUMMARY}"
     else
         echo "Update RELEASED_VERSIONS file ..." >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Description

Marking the collector release failed for 
- 4.3.4: https://github.com/stackrox/stackrox/actions/runs/7609473566
- 4.2.4: https://github.com/stackrox/stackrox/actions/runs/7587950405

According to step summary no commit was added because:

`Skip RELEASED_VERSIONS file change, already up to date ...`

Closer investigation showed that this matched: 

```
$ grep 4.2.4 RELEASED_VERSIONS
3.14.2 4.0.2  # Rox release 4.0.2 by roxbot at Tue May 30 19:49:04 UTC 2023 
```

... because `grep` treated the dot like any char. 
To avoid this issue, this PR introduces spaces around the tag regex.
The format of the file specifies that the Stackrox version is surrounded by one space before and two spaces after. 

The RELEASED_VERSIONS file shall be updated manually.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

```
grep "\s${tag}\s\s" RELEASED_VERSIONS
```

where `tag = 4.2.4` and `tag = 4.3.4` did not show any matches in the file. `tag = 4.2.3` (when the update still worked), showed the expected one match in the file. 