### PR TITLE
ROX-20624: Add (dummy) gRPC health endpoints

### DIFF
--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -82,17 +82,20 @@ spec:
             drop: ["NET_RAW"]
           runAsNonRoot: true
           runAsUser: 65534
-# TODO(mclamei): Enable when the grpc healthcheck in indexer works.
-#
-# {{ if semverCompare ">= 1.24.0" ._rox._apiServer.version }}
-#         readinessProbe:
-#           grpc:
-#             port: 8443
-#           timeoutSeconds: 10
-#           periodSeconds: 10
-#           failureThreshold: 6
-#           successThreshold: 1
-# {{- end }}
+        {{ if semverCompare ">= 1.24.0" ._rox._apiServer.version }}
+        readinessProbe:
+          grpc:
+            port: 8443
+          timeoutSeconds: 60
+          periodSeconds: 60
+          failureThreshold: 3
+        livenessProbe:
+          grpc:
+            port: 8443
+          timeoutSeconds: 15
+          periodSeconds: 15
+          failureThreshold: 3
+        {{- end }}
         volumeMounts:
         - name: additional-ca-volume
           mountPath: /usr/local/share/ca-certificates/

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
@@ -82,17 +82,20 @@ spec:
             drop: ["NET_RAW"]
           runAsNonRoot: true
           runAsUser: 65534
-# TODO(mclamei): Enable when the grpc healthcheck in indexer works.
-#
-# {{ if semverCompare ">= 1.24.0" ._rox._apiServer.version }}
-#         readinessProbe:
-#           grpc:
-#             port: 8443
-#           timeoutSeconds: 10
-#           periodSeconds: 10
-#           failureThreshold: 6
-#           successThreshold: 1
-# {{- end }}
+        {{ if semverCompare ">= 1.24.0" ._rox._apiServer.version }}
+        readinessProbe:
+          grpc:
+            port: 8443
+          timeoutSeconds: 60
+          periodSeconds: 60
+          failureThreshold: 3
+        livenessProbe:
+          grpc:
+            port: 8443
+          timeoutSeconds: 15
+          periodSeconds: 15
+          failureThreshold: 3
+        {{- end }}
         volumeMounts:
         - name: additional-ca-volume
           mountPath: /usr/local/share/ca-certificates/

--- a/scanner/services/health/health.go
+++ b/scanner/services/health/health.go
@@ -1,0 +1,109 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/stackrox/rox/pkg/grpc/authz/allow"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+// Provider is any object that can provide health checking information.
+type Provider interface {
+	// Ready is true when the service can handle traffic.
+	Ready() bool
+	// Live is true when the service is not stuck.
+	Live() bool
+	// Name returns the health provider name.
+	Name() string
+}
+
+// Service is scanner's gRPC API for Health service. It dynamically checks named
+// health providers by matching them against service names in the health check
+// calls.
+type Service struct {
+	grpc_health_v1.UnimplementedHealthServer
+	providers map[string]Provider
+}
+
+// NewService creates a new health gRPC service.
+func NewService(list []Provider) *Service {
+	providers := make(map[string]Provider, len(list))
+	for _, p := range list {
+		providers[p.Name()] = p
+	}
+	return &Service{
+		providers: providers,
+	}
+}
+
+// Check implements grpc_health_v1.HealthCheckRequest.Check
+func (s *Service) Check(_ context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	healthy, err := s.check(req.GetService())
+	if err != nil {
+		return nil, err
+	}
+	st := grpc_health_v1.HealthCheckResponse_NOT_SERVING
+	if healthy {
+		st = grpc_health_v1.HealthCheckResponse_SERVING
+	}
+	return &grpc_health_v1.HealthCheckResponse{Status: st}, nil
+}
+
+func (s *Service) check(srv string) (bool, error) {
+	var checks []func() bool
+	name, probe, _ := strings.Cut(srv, "-")
+	if p, ok := s.providers[name]; ok {
+		switch probe {
+		case "readiness":
+			checks = append(checks, p.Ready)
+		case "liveness":
+			checks = append(checks, p.Live)
+		case "":
+			checks = append(checks, p.Live, p.Ready)
+		default:
+			return false, status.Errorf(codes.NotFound, fmt.Sprintf("unknown service: %s", srv))
+		}
+	} else if name == "" {
+		// If the caller does not specify a service name, the server should respond with
+		// its overall health status.
+		for _, p := range s.providers {
+			checks = append(checks, p.Live, p.Ready)
+		}
+	} else {
+		return false, status.Errorf(codes.NotFound, fmt.Sprintf("unknown service: %s", srv))
+	}
+	// Call all health checks, healthy if all true.
+	st := true
+	for _, c := range checks {
+		st = c() && st
+	}
+	return st, nil
+}
+
+// Watch implements grpc_health_v1.HealthCheckRequest.Watch, which is not supported in Scanner.
+func (s *Service) Watch(_ *grpc_health_v1.HealthCheckRequest, _ grpc_health_v1.Health_WatchServer) error {
+	return status.Errorf(codes.Unimplemented, "method Watch not implemented")
+}
+
+// RegisterServiceServer registers this service with the given gRPC Server.
+func (s *Service) RegisterServiceServer(grpcServer *grpc.Server) {
+	grpc_health_v1.RegisterHealthServer(grpcServer, s)
+}
+
+// RegisterServiceHandler registers this service with the given gRPC Gateway endpoint.
+func (s *Service) RegisterServiceHandler(_ context.Context, _ *runtime.ServeMux, _ *grpc.ClientConn) error {
+	// Currently we do not set up gRPC gateway for this endpoint.
+	return nil
+}
+
+// AuthFuncOverride specifies the auth criteria for this API.
+func (s *Service) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
+	// Auth is disabled for health checking endpoints.
+	return ctx, allow.Anonymous().Authorized(ctx, fullMethodName)
+}

--- a/scanner/services/health/health_test.go
+++ b/scanner/services/health/health_test.go
@@ -1,0 +1,134 @@
+package health
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockProvider struct {
+	ready, live                         bool
+	name                                string
+	nameCalled, readyCalled, liveCalled bool
+}
+
+func (m *mockProvider) Name() string {
+	m.nameCalled = true
+	return m.name
+}
+
+func (m *mockProvider) Ready() bool {
+	m.readyCalled = true
+	return m.ready
+}
+
+func (m *mockProvider) Live() bool {
+	m.liveCalled = true
+	return m.live
+}
+
+func Test_service_check(t *testing.T) {
+	type fields struct {
+		matcher mockProvider
+		indexer mockProvider
+	}
+	type args struct {
+		srv string
+	}
+	tests := map[string]struct {
+		fields fields
+		args   args
+		check  func(*testing.T, *fields, bool, error)
+	}{
+		"when service is empty then check everything": {
+			args: args{srv: ""},
+			check: func(t *testing.T, f *fields, got bool, err error) {
+				assert.NoError(t, err)
+				assert.True(t, f.indexer.liveCalled || f.indexer.readyCalled || f.matcher.liveCalled || f.matcher.readyCalled)
+				assert.False(t, got)
+			},
+		},
+		"when service is matcher then check matcher but not indexer": {
+			args: args{srv: "matcher"},
+			fields: fields{
+				indexer: mockProvider{name: "indexer"},
+				matcher: mockProvider{name: "matcher", live: true, ready: true},
+			},
+			check: func(t *testing.T, f *fields, got bool, err error) {
+				assert.NoError(t, err)
+				assert.False(t, f.indexer.liveCalled)
+				assert.False(t, f.indexer.readyCalled)
+				assert.True(t, f.matcher.liveCalled)
+				assert.True(t, f.matcher.readyCalled)
+				assert.True(t, got)
+			},
+		},
+		"when service is indexer then check indexer but not matcher": {
+			args: args{srv: "indexer"},
+			fields: fields{
+				indexer: mockProvider{name: "indexer", live: true, ready: true},
+				matcher: mockProvider{name: "matcher"},
+			},
+			check: func(t *testing.T, f *fields, got bool, err error) {
+				assert.NoError(t, err)
+				assert.True(t, f.indexer.liveCalled)
+				assert.True(t, f.indexer.readyCalled)
+				assert.False(t, f.matcher.liveCalled)
+				assert.False(t, f.matcher.readyCalled)
+				assert.True(t, got)
+			},
+		},
+		"when service is indexer-liveness then check indexer liveness but not matcher": {
+			args: args{srv: "indexer-liveness"},
+			fields: fields{
+				indexer: mockProvider{name: "indexer", live: true},
+				matcher: mockProvider{name: "matcher"},
+			},
+			check: func(t *testing.T, f *fields, got bool, err error) {
+				assert.NoError(t, err)
+				assert.True(t, f.indexer.liveCalled)
+				assert.False(t, f.indexer.readyCalled)
+				assert.False(t, f.matcher.liveCalled)
+				assert.False(t, f.matcher.readyCalled)
+				assert.True(t, got)
+			},
+		},
+		"when service is indexer-readiness then check indexer readiness but not matcher": {
+			args: args{srv: "indexer-readiness"},
+			fields: fields{
+				indexer: mockProvider{name: "indexer", ready: true},
+				matcher: mockProvider{name: "matcher"},
+			},
+			check: func(t *testing.T, f *fields, got bool, err error) {
+				assert.NoError(t, err)
+				assert.False(t, f.indexer.liveCalled)
+				assert.True(t, f.indexer.readyCalled)
+				assert.False(t, f.matcher.liveCalled)
+				assert.False(t, f.matcher.readyCalled)
+				assert.True(t, got)
+			},
+		},
+		"when unknown service then error": {
+			args: args{srv: "something-unknown"},
+			fields: fields{
+				indexer: mockProvider{name: "indexer"},
+				matcher: mockProvider{name: "matcher"},
+			},
+			check: func(t *testing.T, f *fields, got bool, err error) {
+				assert.ErrorContains(t, err, "unknown service")
+				assert.False(t, f.indexer.liveCalled)
+				assert.False(t, f.indexer.readyCalled)
+				assert.False(t, f.matcher.liveCalled)
+				assert.False(t, f.matcher.readyCalled)
+				assert.False(t, got)
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := NewService(&tt.fields.matcher, &tt.fields.indexer)
+			got, err := s.check(tt.args.srv)
+			tt.check(t, &tt.fields, got, err)
+		})
+	}
+}

--- a/scanner/services/indexer_test.go
+++ b/scanner/services/indexer_test.go
@@ -22,7 +22,7 @@ type indexerServiceTestSuite struct {
 	suite.Suite
 	ctx         context.Context
 	indexerMock *mocks.MockIndexer
-	service     *indexerService
+	service     *IndexerService
 	mockCtrl    *gomock.Controller
 }
 
@@ -61,7 +61,7 @@ func (s *indexerServiceTestSuite) setupMock(hashID string, optCount int, report 
 }
 
 func (s *indexerServiceTestSuite) TestAuthz() {
-	testutils.AssertAuthzWorks(s.T(), &indexerService{})
+	testutils.AssertAuthzWorks(s.T(), &IndexerService{})
 }
 
 func (s *indexerServiceTestSuite) Test_CreateIndexReport_whenUsername_thenAuthEnabled() {

--- a/scanner/services/matcher_test.go
+++ b/scanner/services/matcher_test.go
@@ -40,7 +40,7 @@ func (s *matcherServiceTestSuite) TearDownTest() {
 }
 
 func (s *matcherServiceTestSuite) TestAuthz() {
-	testutils.AssertAuthzWorks(s.T(), &matcherService{})
+	testutils.AssertAuthzWorks(s.T(), &MatcherService{})
 }
 
 func (s *matcherServiceTestSuite) Test_matcherService_NewMatcherService() {


### PR DESCRIPTION
## Description

Add interfaces to Matcher and Indexer services to support the initial implementation of a [grpc_health_v1 health Service](https://google.golang.org/grpc/health/grpc_health_v1). The initial implementation does not perform any actual health checks.

**PR originally stacked over #9476**

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

WIP

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
