### PR TITLE
fix(bug): Ensure future processing when error is unretryable

### DIFF
--- a/central/hash/manager/deduper.go
+++ b/central/hash/manager/deduper.go
@@ -24,6 +24,8 @@ type Deduper interface {
 	// MarkSuccessful marks the message if necessary as being successfully processed, so it can be committed to the database
 	// It will promote the message from the received map to the successfully processed map
 	MarkSuccessful(msg *central.MsgFromSensor)
+	// MarkUnsuccessful deletes the msg from the received map in order to allow future messages a chance to be successfully processed
+	MarkUnsuccessful(msg *central.MsgFromSensor)
 	// StartSync is called once a new Sensor connection is initialized
 	StartSync()
 	// ProcessSync processes the Sensor sync message and reconciles the successfully processed and received maps
@@ -128,6 +130,19 @@ func (d *deduperImpl) StartSync() {
 	for _, v := range d.successfullyProcessed {
 		v.processed = false
 	}
+}
+
+// MarkUnsuccessful marks a message as unsuccessfully processed and purges any values for it from the deduper.
+// This only applies when the message had an unretryable error such as context canceled
+func (d *deduperImpl) MarkUnsuccessful(msg *central.MsgFromSensor) {
+	if skipDedupe(msg) {
+		return
+	}
+	key := eventPkg.GetKeyFromMessage(msg)
+
+	concurrency.WithLock(&d.hashLock, func() {
+		delete(d.received, key)
+	})
 }
 
 // MarkSuccessful marks a message as successfully processed

--- a/central/hash/manager/deduper.go
+++ b/central/hash/manager/deduper.go
@@ -24,8 +24,8 @@ type Deduper interface {
 	// MarkSuccessful marks the message if necessary as being successfully processed, so it can be committed to the database
 	// It will promote the message from the received map to the successfully processed map
 	MarkSuccessful(msg *central.MsgFromSensor)
-	// MarkUnsuccessful deletes the msg from the received map in order to allow future messages a chance to be successfully processed
-	MarkUnsuccessful(msg *central.MsgFromSensor)
+	// RemoveMessage deletes the msg from the received map in order to allow future messages a chance to be successfully processed
+	RemoveMessage(msg *central.MsgFromSensor)
 	// StartSync is called once a new Sensor connection is initialized
 	StartSync()
 	// ProcessSync processes the Sensor sync message and reconciles the successfully processed and received maps
@@ -132,14 +132,13 @@ func (d *deduperImpl) StartSync() {
 	}
 }
 
-// MarkUnsuccessful marks a message as unsuccessfully processed and purges any values for it from the deduper.
+// RemoveMessage removes a message that was unsuccessfully processed and purges any values for it from the deduper.
 // This only applies when the message had an unretryable error such as context canceled
-func (d *deduperImpl) MarkUnsuccessful(msg *central.MsgFromSensor) {
+func (d *deduperImpl) RemoveMessage(msg *central.MsgFromSensor) {
 	if skipDedupe(msg) {
 		return
 	}
 	key := eventPkg.GetKeyFromMessage(msg)
-
 	concurrency.WithLock(&d.hashLock, func() {
 		delete(d.received, key)
 	})

--- a/central/hash/manager/mocks/deduper.go
+++ b/central/hash/manager/mocks/deduper.go
@@ -65,18 +65,6 @@ func (mr *MockDeduperMockRecorder) MarkSuccessful(msg any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkSuccessful", reflect.TypeOf((*MockDeduper)(nil).MarkSuccessful), msg)
 }
 
-// MarkUnsuccessful mocks base method.
-func (m *MockDeduper) MarkUnsuccessful(msg *central.MsgFromSensor) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "MarkUnsuccessful", msg)
-}
-
-// MarkUnsuccessful indicates an expected call of MarkUnsuccessful.
-func (mr *MockDeduperMockRecorder) MarkUnsuccessful(msg any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkUnsuccessful", reflect.TypeOf((*MockDeduper)(nil).MarkUnsuccessful), msg)
-}
-
 // ProcessSync mocks base method.
 func (m *MockDeduper) ProcessSync() {
 	m.ctrl.T.Helper()
@@ -87,6 +75,18 @@ func (m *MockDeduper) ProcessSync() {
 func (mr *MockDeduperMockRecorder) ProcessSync() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessSync", reflect.TypeOf((*MockDeduper)(nil).ProcessSync))
+}
+
+// RemoveMessage mocks base method.
+func (m *MockDeduper) RemoveMessage(msg *central.MsgFromSensor) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RemoveMessage", msg)
+}
+
+// RemoveMessage indicates an expected call of RemoveMessage.
+func (mr *MockDeduperMockRecorder) RemoveMessage(msg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveMessage", reflect.TypeOf((*MockDeduper)(nil).RemoveMessage), msg)
 }
 
 // ShouldProcess mocks base method.

--- a/central/hash/manager/mocks/deduper.go
+++ b/central/hash/manager/mocks/deduper.go
@@ -65,6 +65,18 @@ func (mr *MockDeduperMockRecorder) MarkSuccessful(msg any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkSuccessful", reflect.TypeOf((*MockDeduper)(nil).MarkSuccessful), msg)
 }
 
+// MarkUnsuccessful mocks base method.
+func (m *MockDeduper) MarkUnsuccessful(msg *central.MsgFromSensor) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "MarkUnsuccessful", msg)
+}
+
+// MarkUnsuccessful indicates an expected call of MarkUnsuccessful.
+func (mr *MockDeduperMockRecorder) MarkUnsuccessful(msg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkUnsuccessful", reflect.TypeOf((*MockDeduper)(nil).MarkUnsuccessful), msg)
+}
+
 // ProcessSync mocks base method.
 func (m *MockDeduper) ProcessSync() {
 	m.ctrl.T.Helper()

--- a/central/sensor/service/connection/sensorevents.go
+++ b/central/sensor/service/connection/sensorevents.go
@@ -192,7 +192,7 @@ func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.Ms
 			if queue == nil {
 				queue = newWorkerQueue(workerQueueSize, stripTypePrefix(workerType), s.injector)
 				s.workerQueues[workerType] = queue
-				go queue.run(ctx, s.stopSig, s.handleMessages)
+				go queue.run(ctx, s.stopSig, s.deduper, s.handleMessages)
 			}
 		})
 	}

--- a/central/sensor/service/connection/worker_queue.go
+++ b/central/sensor/service/connection/worker_queue.go
@@ -86,7 +86,7 @@ func (w *workerQueue) runWorker(ctx context.Context, idx int, stopSig *concurren
 				}
 				log.Errorf("Unretryable error found while handling sensor message %T permanently: %v", msg.GetEvent().GetResource(), err)
 			}
-			deduper.MarkUnsuccessful(msg)
+			deduper.RemoveMessage(msg)
 		}
 	}
 	w.waitGroup.Add(-1)

--- a/central/sensor/service/connection/worker_queue.go
+++ b/central/sensor/service/connection/worker_queue.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	hashManager "github.com/stackrox/rox/central/hash/manager"
 	"github.com/stackrox/rox/central/sensor/service/common"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -63,7 +64,7 @@ func (w *workerQueue) push(msg *central.MsgFromSensor) {
 	w.queues[idx].push(msg)
 }
 
-func (w *workerQueue) runWorker(ctx context.Context, idx int, stopSig *concurrency.ErrorSignal, handler func(context.Context, *central.MsgFromSensor) error) {
+func (w *workerQueue) runWorker(ctx context.Context, idx int, stopSig *concurrency.ErrorSignal, deduper hashManager.Deduper, handler func(context.Context, *central.MsgFromSensor) error) {
 	queue := w.queues[idx]
 	for msg := queue.pullBlocking(stopSig); msg != nil; msg = queue.pullBlocking(stopSig) {
 		err := handler(ctx, msg)
@@ -82,16 +83,17 @@ func (w *workerQueue) runWorker(ctx context.Context, idx int, stopSig *concurren
 				}, stopSig)
 				continue
 			}
+			deduper.MarkUnsuccessful(msg)
 			log.Errorf("Unretryable error found while handling sensor message %T permanently: %v", msg.GetEvent().GetResource(), err)
 		}
 	}
 	w.waitGroup.Add(-1)
 }
 
-func (w *workerQueue) run(ctx context.Context, stopSig *concurrency.ErrorSignal, handler func(context.Context, *central.MsgFromSensor) error) {
+func (w *workerQueue) run(ctx context.Context, stopSig *concurrency.ErrorSignal, deduper hashManager.Deduper, handler func(context.Context, *central.MsgFromSensor) error) {
 	w.waitGroup.Add(w.totalSize)
 	for i := 0; i < w.totalSize; i++ {
-		go w.runWorker(ctx, i, stopSig, handler)
+		go w.runWorker(ctx, i, stopSig, deduper, handler)
 	}
 
 	w.waitGroup.Wait()

--- a/pkg/deduperkey/key.go
+++ b/pkg/deduperkey/key.go
@@ -36,10 +36,6 @@ var (
 		&central.SensorEvent_ComplianceOperatorRuleV2{},
 		&central.SensorEvent_ComplianceOperatorScanSettingBinding{},
 		&central.SensorEvent_ComplianceOperatorScan{},
-		&central.SensorEvent_ComplianceOperatorResultV2{},
-		&central.SensorEvent_ComplianceOperatorProfileV2{},
-		&central.SensorEvent_ComplianceOperatorRuleV2{},
-		&central.SensorEvent_ComplianceOperatorScanV2{},
 		&central.SensorEvent_AlertResults{},
 	}
 )

--- a/pkg/deduperkey/key.go
+++ b/pkg/deduperkey/key.go
@@ -36,6 +36,10 @@ var (
 		&central.SensorEvent_ComplianceOperatorRuleV2{},
 		&central.SensorEvent_ComplianceOperatorScanSettingBinding{},
 		&central.SensorEvent_ComplianceOperatorScan{},
+		&central.SensorEvent_ComplianceOperatorResultV2{},
+		&central.SensorEvent_ComplianceOperatorProfileV2{},
+		&central.SensorEvent_ComplianceOperatorRuleV2{},
+		&central.SensorEvent_ComplianceOperatorScanV2{},
 		&central.SensorEvent_AlertResults{},
 	}
 )


### PR DESCRIPTION
## Description

When an object is being processed and hits an unretryable error, the object is dropped and is not reinserted back into the queue to be processed. However, the received map still has the reference to that object so if the Sensor comes back up and resends an event then it will be deduped by the received map even though the object was never successfully processed. This will remain until Central is bounced and then the received map will be reset because it is simply in-memory. Therefore, on an unretryable failure purge the received map of the reference to the object in order to allow future events to successfully be processed

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
