### PR TITLE
ROX-21479: Remove ability to cancel a denied request

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/denyRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/denyRequestFlow.test.ts
@@ -56,6 +56,8 @@ describe('Exception Management Request Details Page', () => {
             'contain',
             'The vulnerability request was successfully denied.'
         );
+        // should not be able to cancel a denied request
+        cy.get('button:contains("Cancel request")').should('not.exist');
     });
 
     it('should be able to see how many CVEs will be affected by a denial', () => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -155,7 +155,7 @@ function ExceptionRequestDetailsPage() {
     const showApproveDenyButtons =
         hasWriteAccessForApproving &&
         (status === 'PENDING' || status === 'APPROVED_PENDING_UPDATE');
-    const showCancelButton = currentUser.userId === requester.id;
+    const showCancelButton = currentUser.userId === requester.id && status !== 'DENIED';
     const showUpdateButton =
         currentUser.userId === requester.id &&
         (status === 'APPROVED' || status === 'APPROVED_PENDING_UPDATE');


### PR DESCRIPTION
## Description

This little PR removes the ability to cancel a denied request. Since it's already denied, there is no reason to cancel it

## Screenshots

<img width="721" alt="Screenshot 2024-01-22 at 11 22 07 AM" src="https://github.com/stackrox/stackrox/assets/4805485/216a0ad2-979c-4621-923b-14f64eabdf2e">


## Tests

I updated the test to include a check for the `Cancel request` button. Ideally, I should probably check for that in a separate test. I didn't want to go through a whole deferral flow again just to check that, so I tacked it onto the first test. We can also revisit some of these tests to make sure we're doing things optimally. For example, having a test to check for the button that follows right after a previous test that does the denial. Maybe that's worth a discussion. I think there are always pros and cons to doing something like that.

