### PR TITLE
ROX-21838: Factor out reusable ExternalLink component

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/IconText/ExternalLink.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/ExternalLink.tsx
@@ -1,0 +1,28 @@
+import React, { ReactElement, ReactNode } from 'react';
+import { Flex } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+export type ExternalLinkProps = {
+    children: ReactNode;
+};
+
+/*
+ * Pure presentation component for links that open in a new tab:
+ * docs page
+ * product page (for example, collection)
+ * vulnerability description
+ */
+function ExternalLink({ children }: ExternalLinkProps): ReactElement {
+    return (
+        <Flex
+            alignItems={{ default: 'alignItemsCenter' }}
+            display={{ default: 'inlineFlex' }}
+            spaceItems={{ default: 'spaceItemsSm' }}
+        >
+            {children}
+            <ExternalLinkAltIcon color="var(--pf-global--link--Color)" />
+        </Flex>
+    );
+}
+
+export default ExternalLink;

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
@@ -1,10 +1,12 @@
 import React, { ReactElement } from 'react';
 import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
-import { ExclamationCircleIcon, ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons';
+import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons';
 
-import { healthStatusLabels } from 'messages/common';
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import useMetadata from 'hooks/useMetadata';
+import { healthStatusLabels } from 'messages/common';
 import { getVersionedDocs } from 'utils/versioning';
+
 import HealthStatus from './HealthStatus';
 import ClusterStatusPill from './ClusterStatusPill';
 import { healthStatusStyles } from '../cluster.helpers';
@@ -31,21 +33,18 @@ function ClusterStatus({ healthStatus, isList = false }: ClusterStatusProps): Re
 
     const unhealthyClusterDetailAvailable = overallHealthStatus === 'UNHEALTHY';
     const bodyContent = version ? (
-        <Button
-            component="a"
-            href={getVersionedDocs(
-                version,
-                'troubleshooting/retrieving-and-analyzing-the-collector-logs-and-pod-status.html'
-            )}
-            variant="link"
-            target="_blank"
-            rel="noopener noreferrer"
-            icon={<ExternalLinkAltIcon />}
-            iconPosition="right"
-            isSmall
-        >
-            Troubleshooting collector
-        </Button>
+        <ExternalLink>
+            <a
+                href={getVersionedDocs(
+                    version,
+                    'troubleshooting/retrieving-and-analyzing-the-collector-logs-and-pod-status.html'
+                )}
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                Troubleshooting collector
+            </a>
+        </ExternalLink>
     ) : (
         <span>Documentation not available; version missing</span>
     );

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
@@ -14,6 +14,7 @@ import {
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { useMediaQuery } from 'react-responsive';
 
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { collectionsBasePath } from 'routePaths';
 import { Collection } from 'services/CollectionsService';
@@ -130,17 +131,15 @@ function CollectionsFormModal({
         ) : (
             <>
                 {hasWriteAccessForCollections && modalAction.type === 'view' && (
-                    <Button
-                        variant="link"
-                        component="a"
-                        href={`${collectionsBasePath}/${modalAction.collectionId}?action=edit`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        icon={<ExternalLinkAltIcon />}
-                        iconPosition="right"
-                    >
-                        Edit collection
-                    </Button>
+                    <ExternalLink>
+                        <a
+                            href={`${collectionsBasePath}/${modalAction.collectionId}?action=edit`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Edit collection
+                        </a>
+                    </ExternalLink>
                 )}
                 {isDrawerOpen ? (
                     <Button variant="secondary" onClick={closeDrawer}>

--- a/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
@@ -9,8 +9,9 @@ import {
     Flex,
     FlexItem,
 } from '@patternfly/react-core';
-import { DownloadIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { DownloadIcon } from '@patternfly/react-icons';
 
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import useMetadata from 'hooks/useMetadata';
 import usePermissions from 'hooks/usePermissions';
 import { generateCertSecretForComponent } from 'services/CertGenerationService';
@@ -129,25 +130,18 @@ function CertificateCard({ component, pollingCount }: CertificateCardProps): Rea
                         </FlexItem>
                         {version && (
                             <FlexItem align={{ default: 'alignRight' }}>
-                                <Button
-                                    variant="link"
-                                    isInline
-                                    component="a"
-                                    href={getVersionedDocs(
-                                        version,
-                                        'configuration/reissue-internal-certificates.html'
-                                    )}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    <Flex
-                                        alignItems={{ default: 'alignItemsCenter' }}
-                                        spaceItems={{ default: 'spaceItemsSm' }}
+                                <ExternalLink>
+                                    <a
+                                        href={getVersionedDocs(
+                                            version,
+                                            'configuration/reissue-internal-certificates.html'
+                                        )}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
                                     >
-                                        <span>Reissuing internal certificates</span>
-                                        <ExternalLinkAltIcon color="var(--pf-global--link--Color)" />
-                                    </Flex>
-                                </Button>
+                                        Reissuing internal certificates
+                                    </a>
+                                </ExternalLink>
                             </FlexItem>
                         )}
                     </Flex>

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
@@ -1,17 +1,14 @@
 import React, { useState, ReactElement } from 'react';
 import { Button, ButtonVariant, Flex, Popover, PopoverPosition } from '@patternfly/react-core';
-import {
-    AngleDownIcon,
-    AngleUpIcon,
-    DownloadIcon,
-    ExternalLinkAltIcon,
-} from '@patternfly/react-icons';
+import { AngleDownIcon, AngleUpIcon, DownloadIcon } from '@patternfly/react-icons';
 import { useFormik } from 'formik';
 import { parse } from 'date-fns';
 
-import downloadDiagnostics, { DiagnosticBundleRequest } from 'services/DebugService';
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import useMetadata from 'hooks/useMetadata';
+import downloadDiagnostics, { DiagnosticBundleRequest } from 'services/DebugService';
 import { getVersionedDocs } from 'utils/versioning';
+
 import DiagnosticBundleForm from './DiagnosticBundleForm';
 import { getQueryString, startingTimeRegExp } from './diagnosticBundleUtils';
 
@@ -88,25 +85,18 @@ function GenerateDiagnosticBundle(): ReactElement {
                 Download diagnostic bundle
             </Button>
             {version && (
-                <Button
-                    variant="link"
-                    isInline
-                    component="a"
-                    href={getVersionedDocs(
-                        version,
-                        'configuration/generate-diagnostic-bundle.html'
-                    )}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                    <Flex
-                        alignItems={{ default: 'alignItemsCenter' }}
-                        spaceItems={{ default: 'spaceItemsSm' }}
+                <ExternalLink>
+                    <a
+                        href={getVersionedDocs(
+                            version,
+                            'configuration/generate-diagnostic-bundle.html'
+                        )}
+                        target="_blank"
+                        rel="noopener noreferrer"
                     >
-                        <span>Generate a diagnostic bundle</span>
-                        <ExternalLinkAltIcon color="var(--pf-global--link--Color)" />
-                    </Flex>
-                </Button>
+                        Generate a diagnostic bundle
+                    </a>
+                </ExternalLink>
             )}
         </Flex>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx
@@ -10,10 +10,12 @@ import {
     List,
     ListItem,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import uniqBy from 'lodash/uniqBy';
+
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import { getDateTime } from 'utils/dateUtils';
 import { ensureExhaustive } from 'utils/type.utils';
+
 import { Distro, sortCveDistroList } from '../sortUtils';
 
 export type ImageCveMetadata = {
@@ -85,15 +87,11 @@ function ImageCvePageHeader({ data }: ImageCvePageHeaderProps) {
                     <List isPlain>
                         {prioritizedDistros.map((distro) => (
                             <ListItem key={distro.operatingSystem}>
-                                <a
-                                    className="pf-u-pl-0"
-                                    href={distro.link}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    {getDistroLinkText(distro)}
-                                    <ExternalLinkAltIcon className="pf-u-display-inline pf-u-ml-sm" />
-                                </a>
+                                <ExternalLink>
+                                    <a href={distro.link} target="_blank" rel="noopener noreferrer">
+                                        {getDistroLinkText(distro)}
+                                    </a>
+                                </ExternalLink>
                             </ListItem>
                         ))}
                     </List>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/CveSelections.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/CveSelections.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Link, generatePath } from 'react-router-dom';
 import { Flex, List, ListItem, Text, pluralize } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 
 const vulnerabilitiesWorkloadCveSinglePath = `${vulnerabilitiesWorkloadCvesPath}/cves/:cve`;
@@ -18,14 +18,14 @@ function CveSelections({ cves }: CveSelectionsProps) {
                 <ListItem key={cve}>
                     <Flex direction={{ default: 'column' }}>
                         <Flex direction={{ default: 'row' }}>
-                            <Text>
+                            <ExternalLink>
                                 <Link
                                     target="_blank"
                                     to={generatePath(vulnerabilitiesWorkloadCveSinglePath, { cve })}
                                 >
-                                    {cve} <ExternalLinkAltIcon className="pf-u-display-inline" />
+                                    {cve}
                                 </Link>
-                            </Text>
+                            </ExternalLink>
                             <Text>Across {pluralize(numAffectedImages, 'image')}</Text>
                         </Flex>
                         <Text>{summary}</Text>


### PR DESCRIPTION
## Description

Adapt from `IconText` element:
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Components/PatternFly/IconText/IconText.tsx

Prevent additional duplication in cluster init bundles of similar rendering code elsewhere:
1. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx#L34-L48
2. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx#L46-L56
3. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx#L133-L143
4. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx#L132-L150
5. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx#L91-L109
6. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/CveSelections.tsx#L22-L27
7. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx#L88-L96

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed


### Manual testing

1. ClusterStatus link seems obscure and high cost to benefit for manual testing after I tried unsuccessfully for 10 minutes.

2. CollectionFormModal first occurrence remains the same because link icon preceded text.

3. CollectionFormModal second occurrence

    * Before change
        ![CollectionsFormModal2_baseline](https://github.com/stackrox/stackrox/assets/11862657/04bd3e27-dd5d-433e-972d-ac1afbb0f812)

    * After change
        ![CollectionsFormModal2_component](https://github.com/stackrox/stackrox/assets/11862657/a6db1d26-09c3-4f28-90e7-4a2a5445c98e)

4. CertificateCard

    * Before change
        ![CertificateCard_baseline](https://github.com/stackrox/stackrox/assets/11862657/02f59375-420a-44de-a6c0-cb0e859d0b40)

    * After change
        ![CertificateCard_component](https://github.com/stackrox/stackrox/assets/11862657/514c9522-1c31-4b7c-88cd-39a1d59d746a)

5. GenerateDiagnosticBundle

    * Before change
        ![GenerateDiagnosticBundle_baseline](https://github.com/stackrox/stackrox/assets/11862657/b5dba9e0-8ff3-4310-b5f6-f949696ff5d9)

    * After change
        ![GenerateDiagnosticBundle_component](https://github.com/stackrox/stackrox/assets/11862657/c7b43901-7731-4117-b4bc-ac70989952b1)

6. CveSelections

    * Before change
        ![CveSelections_baseline](https://github.com/stackrox/stackrox/assets/11862657/ba735074-5855-4488-aad9-98de6470e6aa)

    * After change
        ![CveSelections_component](https://github.com/stackrox/stackrox/assets/11862657/36edf324-e762-4cf8-a03c-0fdc4e603a32)

7. ImageCvePageHeader

    * Before change
        ![ImageCvePageHeader_baseline](https://github.com/stackrox/stackrox/assets/11862657/57b601e7-fe6f-4da6-98aa-436a8e598111)

    * After change
        ![ImageCvePageHeader_component](https://github.com/stackrox/stackrox/assets/11862657/88601f2b-1f83-41a4-89c8-e3e7c679dc17)
