### PR TITLE
ROX-21938: Keep track of active flows

### DIFF
--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -481,15 +481,15 @@ func (g *garbageCollectorImpl) removeOrphanedNetworkFlows(clusters set.FrozenStr
 				return
 			}
 
-			err = store.RemoveOrphanedFlows(pruningCtx, &orphanTime)
-			if err != nil {
-				log.Errorf("error removing orphaned flows for cluster %q: %v", c, err)
-			}
-
-			// Second remove stale network flows
 			err = store.RemoveStaleFlows(pruningCtx)
 			if err != nil {
 				log.Errorf("error removing stale flows for cluster %q: %v", c, err)
+			}
+
+			// Second remove orphaned network flows
+			err = store.RemoveOrphanedFlows(pruningCtx, &orphanTime)
+			if err != nil {
+				log.Errorf("error removing orphaned flows for cluster %q: %v", c, err)
 			}
 		}(c)
 	}

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -481,6 +481,9 @@ func (g *garbageCollectorImpl) removeOrphanedNetworkFlows(clusters set.FrozenStr
 				return
 			}
 
+			// The order here is important. We need to remove stale flows before orphaned otherwise we could leave
+			// orphaned flows in the DB.
+			// For more information see: https://github.com/stackrox/stackrox/pull/9514
 			err = store.RemoveStaleFlows(pruningCtx)
 			if err != nil {
 				log.Errorf("error removing stale flows for cluster %q: %v", c, err)

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -559,12 +559,14 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 			// hence update the timestamp only if we have a more recent connection than the one we have already enriched.
 			if oldTS, found := enrichedConnections[indicator]; !found || oldTS < status.lastSeen {
 				enrichedConnections[indicator] = status.lastSeen
-				if status.lastSeen == timestamp.InfiniteFuture {
-					m.activeConnections[*conn] = &indicator
-					flowMetrics.SetActiveFlowsTotalGauge(len(m.activeConnections))
-				} else {
-					delete(m.activeConnections, *conn)
-					flowMetrics.SetActiveFlowsTotalGauge(len(m.activeConnections))
+				if features.SensorCapturesIntermediateEvents.Enabled() {
+					if status.lastSeen == timestamp.InfiniteFuture {
+						m.activeConnections[*conn] = &indicator
+						flowMetrics.SetActiveFlowsTotalGauge(len(m.activeConnections))
+					} else {
+						delete(m.activeConnections, *conn)
+						flowMetrics.SetActiveFlowsTotalGauge(len(m.activeConnections))
+					}
 				}
 			}
 		}
@@ -608,12 +610,14 @@ func (m *networkFlowManager) enrichContainerEndpoint(ep *containerEndpoint, stat
 	// hence update the timestamp only if we have a more recent endpoint than the one we have already enriched.
 	if oldTS, found := enrichedEndpoints[indicator]; !found || oldTS < status.lastSeen {
 		enrichedEndpoints[indicator] = status.lastSeen
-		if status.lastSeen == timestamp.InfiniteFuture {
-			m.activeEndpoints[*ep] = &indicator
-			flowMetrics.SetActiveEndpointsTotalGauge(len(m.activeEndpoints))
-		} else {
-			delete(m.activeEndpoints, *ep)
-			flowMetrics.SetActiveEndpointsTotalGauge(len(m.activeEndpoints))
+		if features.SensorCapturesIntermediateEvents.Enabled() {
+			if status.lastSeen == timestamp.InfiniteFuture {
+				m.activeEndpoints[*ep] = &indicator
+				flowMetrics.SetActiveEndpointsTotalGauge(len(m.activeEndpoints))
+			} else {
+				delete(m.activeEndpoints, *ep)
+				flowMetrics.SetActiveEndpointsTotalGauge(len(m.activeEndpoints))
+			}
 		}
 	}
 }

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -456,7 +456,7 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 			if activeConn, found := m.activeConnections[*conn]; found {
 				enrichedConnections[*activeConn] = timestamp.Now()
 				delete(m.activeConnections, *conn)
-				flowMetrics.SetActiveFlowsTrackerSizeGauge(len(m.activeConnections))
+				flowMetrics.SetActiveFlowsTotalGauge(len(m.activeConnections))
 				return
 			}
 			status.rotten = true
@@ -559,10 +559,10 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 				enrichedConnections[indicator] = status.lastSeen
 				if status.lastSeen == timestamp.InfiniteFuture {
 					m.activeConnections[*conn] = &indicator
-					flowMetrics.SetActiveFlowsTrackerSizeGauge(len(m.activeConnections))
+					flowMetrics.SetActiveFlowsTotalGauge(len(m.activeConnections))
 				} else {
 					delete(m.activeConnections, *conn)
-					flowMetrics.SetActiveFlowsTrackerSizeGauge(len(m.activeConnections))
+					flowMetrics.SetActiveFlowsTotalGauge(len(m.activeConnections))
 				}
 			}
 		}

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -456,6 +456,7 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 			if activeConn, found := m.activeConnections[*conn]; found {
 				enrichedConnections[activeConn] = timestamp.Now()
 				delete(m.activeConnections, *conn)
+				flowMetrics.SetActiveFlowsTrackerSizeGauge(len(m.activeConnections))
 				return
 			}
 			status.rotten = true
@@ -558,8 +559,10 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 				enrichedConnections[indicator] = status.lastSeen
 				if status.lastSeen == timestamp.InfiniteFuture {
 					m.activeConnections[*conn] = indicator
+					flowMetrics.SetActiveFlowsTrackerSizeGauge(len(m.activeConnections))
 				} else {
 					delete(m.activeConnections, *conn)
+					flowMetrics.SetActiveFlowsTrackerSizeGauge(len(m.activeConnections))
 				}
 			}
 		}

--- a/sensor/common/networkflow/manager/testing_test.go
+++ b/sensor/common/networkflow/manager/testing_test.go
@@ -93,6 +93,11 @@ func createConnectionPair() *connectionPair {
 	}
 }
 
+func (c *connectionPair) lastSeen(lastSeen timestamp.MicroTS) *connectionPair {
+	c.status.lastSeen = lastSeen
+	return c
+}
+
 func (c *connectionPair) containerID(id string) *connectionPair {
 	c.conn.containerID = id
 	return c

--- a/sensor/common/networkflow/manager/testing_test.go
+++ b/sensor/common/networkflow/manager/testing_test.go
@@ -34,7 +34,7 @@ func createManager(mockCtrl *gomock.Controller) (*networkFlowManager, *mocksMana
 		centralReady:      concurrency.NewSignal(),
 		enricherTicker:    ticker,
 		finished:          &sync.WaitGroup{},
-		activeConnections: make(map[connection]networkConnIndicator),
+		activeConnections: make(map[connection]*networkConnIndicator),
 	}
 	return mgr, mockEntityStore, mockExternalStore, mockDetector
 }

--- a/sensor/common/networkflow/manager/testing_test.go
+++ b/sensor/common/networkflow/manager/testing_test.go
@@ -35,6 +35,7 @@ func createManager(mockCtrl *gomock.Controller) (*networkFlowManager, *mocksMana
 		enricherTicker:    ticker,
 		finished:          &sync.WaitGroup{},
 		activeConnections: make(map[connection]*networkConnIndicator),
+		activeEndpoints:   make(map[containerEndpoint]*containerEndpointIndicator),
 	}
 	return mgr, mockEntityStore, mockExternalStore, mockDetector
 }
@@ -151,6 +152,11 @@ func createEndpointPair(firstSeen timestamp.MicroTS) *endpointPair {
 
 func (ep *endpointPair) containerID(id string) *endpointPair {
 	ep.endpoint.containerID = id
+	return ep
+}
+
+func (ep *endpointPair) lastSeen(lastSeen timestamp.MicroTS) *endpointPair {
+	ep.status.lastSeen = lastSeen
 	return ep
 }
 

--- a/sensor/common/networkflow/manager/testing_test.go
+++ b/sensor/common/networkflow/manager/testing_test.go
@@ -34,6 +34,7 @@ func createManager(mockCtrl *gomock.Controller) (*networkFlowManager, *mocksMana
 		centralReady:      concurrency.NewSignal(),
 		enricherTicker:    ticker,
 		finished:          &sync.WaitGroup{},
+		activeConnections: make(map[connection]networkConnIndicator),
 	}
 	return mgr, mockEntityStore, mockExternalStore, mockDetector
 }

--- a/sensor/common/networkflow/metrics/metrics.go
+++ b/sensor/common/networkflow/metrics/metrics.go
@@ -16,6 +16,7 @@ func init() {
 		HostConnectionsRemoved,
 		HostEndpointsAdded,
 		HostEndpointsRemoved,
+		activeFlowsTrackerSize,
 	)
 }
 
@@ -82,4 +83,15 @@ var (
 		Name:      "processes_listening_on_port_removed",
 		Help:      "Total number of processes listening on ports",
 	})
+	activeFlowsTrackerSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "active_network_flow_tracker_size",
+		Help:      "A gauge that tracks the size of the active network flow tracker",
+	})
 )
+
+// SetActiveFlowsTrackerSizeGauge set the active flows tracker size gauge.
+func SetActiveFlowsTrackerSizeGauge(number int) {
+	activeFlowsTrackerSize.Set(float64(number))
+}

--- a/sensor/common/networkflow/metrics/metrics.go
+++ b/sensor/common/networkflow/metrics/metrics.go
@@ -17,6 +17,7 @@ func init() {
 		HostEndpointsAdded,
 		HostEndpointsRemoved,
 		activeFlowsTotal,
+		activeEndpointsTotal,
 	)
 }
 
@@ -89,9 +90,20 @@ var (
 		Name:      "active_network_flows_total",
 		Help:      "A gauge that tracks the total active network flows in sensor",
 	})
+	activeEndpointsTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "active_endpoints_total",
+		Help:      "A gauge that tracks the total active endpoints in sensor",
+	})
 )
 
 // SetActiveFlowsTotalGauge set the active network flows total gauge.
 func SetActiveFlowsTotalGauge(number int) {
 	activeFlowsTotal.Set(float64(number))
+}
+
+// SetActiveEndpointsTotalGauge set the active endpoints total gauge.
+func SetActiveEndpointsTotalGauge(number int) {
+	activeEndpointsTotal.Set(float64(number))
 }

--- a/sensor/common/networkflow/metrics/metrics.go
+++ b/sensor/common/networkflow/metrics/metrics.go
@@ -16,7 +16,7 @@ func init() {
 		HostConnectionsRemoved,
 		HostEndpointsAdded,
 		HostEndpointsRemoved,
-		activeFlowsTrackerSize,
+		activeFlowsTotal,
 	)
 }
 
@@ -83,15 +83,15 @@ var (
 		Name:      "processes_listening_on_port_removed",
 		Help:      "Total number of processes listening on ports",
 	})
-	activeFlowsTrackerSize = prometheus.NewGauge(prometheus.GaugeOpts{
+	activeFlowsTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
-		Name:      "active_network_flow_tracker_size",
-		Help:      "A gauge that tracks the size of the active network flow tracker",
+		Name:      "active_network_flows_total",
+		Help:      "A gauge that tracks the total active network flows in sensor",
 	})
 )
 
-// SetActiveFlowsTrackerSizeGauge set the active flows tracker size gauge.
-func SetActiveFlowsTrackerSizeGauge(number int) {
-	activeFlowsTrackerSize.Set(float64(number))
+// SetActiveFlowsTotalGauge set the active network flows total gauge.
+func SetActiveFlowsTotalGauge(number int) {
+	activeFlowsTotal.Set(float64(number))
 }


### PR DESCRIPTION
## Description

This PR will enable sensor to track active connections. In-memory active connections will be deleted once `lastseen` is set to something other than `InfiiniteFuture` or if we failed the container lookup and the time elapsed since `firstseen` is greater than `maxContainerResolutionWaitPeriod`. In the second case sensor will send the last known active connection with `lastseen` set to `now`.

This is needed for offline v3 due to the following scenario:

1. Sensor goes offline
2. Pod A is created
3. Pod A connects to something
4. Collector reports active connection for Pod A
5. Pod A is deleted
6. Sensor goes back online (clears in-memory stores)
7. Active connection for Pod A gets reported to central
8. Collector reports close connection for Pod A
9. Sensor fails to find the Pod in the stores
10. Sensor marks the connection as rotten and does not send anything to central
11. The connection is orphaned in central as active so it will never be pruned

With these changes, the scenario is as follows:

1. Sensor goes offline
2. Pod A is created
3. Pod A connects to something
4. Collector reports active connection for Pod A
5. Pod A is deleted
6. Sensor goes back online (clears in-memory stores)
7. Active connection for Pod A gets reported to central
8. Collector reports close connection for Pod A
9. Sensor fails to find the Pod in the stores
10. Sensor finds the active connection in the `activeConnections` map
11. Sensor sends the last known connection from the map with `lastseen` set to `now`
12. The connection is orphaned in central as closed so it will be pruned by central's gc

Notes to reviewers: 

1. The order in the pruning of network flows needed to be switched since it is necessary to aggregate the network flows before deleting the orphaned flows. Otherwise the closed flows will be deleted leaving the active flows forever in the db.

2. As a follow up sensor could keep track of active connections only when it is offline. This will alleviate sensor's memory pressure if there are a lot of active network flows. I decided to keep track of them also when online since it's simpler and I did some testing in #9423 with 1 million faked active flows and sensor's total memory usage was ~1GB.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- [x] CI
- [x] Added unit tests
- [x] Manual test
  - Deploy ACS
  - Disconnect sensor from central
  - Create a pod that has an active connection
  - Delete the pod
  - Connect sensor to central
  - Observe that the connection gets reported as active and after a while is marked as closed in central's db

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
