### PR TITLE
ROX-21432: Validate scan config does not contains duplicate profile

### DIFF
--- a/central/complianceoperator/v2/compliancemanager/manager_impl.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl.go
@@ -148,15 +148,28 @@ func (m *managerImpl) ProcessScanRequest(ctx context.Context, scanRequest *stora
 		// Use the created time from the DB
 		scanRequest.CreatedTime = scanConfig.GetCreatedTime()
 	}
-	err = m.scanSettingDS.UpsertScanConfiguration(ctx, scanRequest)
-	if err != nil {
-		log.Error(err)
-		return nil, errors.Errorf("Unable to save scan configuration named %q.", scanRequest.GetScanConfigName())
-	}
 
 	var profiles []string
 	for _, profile := range scanRequest.GetProfiles() {
 		profiles = append(profiles, profile.GetProfileName())
+	}
+
+	// Check if there any existing cluster that has the scan configuration with any of profiles being referenced by the scan request.
+	// If so, then we cannot create the scan configuration.
+	found, err := m.scanSettingDS.ScanConfigurationProfileExists(ctx, scanRequest.GetId(), profiles, clusters)
+
+	if err != nil {
+		log.Error(err)
+		return nil, errors.Wrapf(err, "Unable to create scan configuration named %q.", scanRequest.GetScanConfigName())
+	}
+	if found {
+		return nil, errors.Errorf("Duplicated profiles found in current or existing scan configurations: %q.", scanRequest.GetScanConfigName())
+	}
+
+	err = m.scanSettingDS.UpsertScanConfiguration(ctx, scanRequest)
+	if err != nil {
+		log.Error(err)
+		return nil, errors.Errorf("Unable to save scan configuration named %q.", scanRequest.GetScanConfigName())
 	}
 
 	for _, clusterID := range clusters {

--- a/central/complianceoperator/v2/compliancemanager/manager_impl.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl.go
@@ -162,6 +162,7 @@ func (m *managerImpl) ProcessScanRequest(ctx context.Context, scanRequest *stora
 		log.Error(err)
 		return nil, errors.Wrapf(err, "Unable to create scan configuration named %q.", scanRequest.GetScanConfigName())
 	}
+	// TODO (ROX-22187):  Include the name of the conflicting scan configuration in the error message.
 	if found {
 		return nil, errors.Errorf("Duplicated profiles found in current or existing scan configurations: %q.", scanRequest.GetScanConfigName())
 	}

--- a/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
@@ -184,6 +184,7 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			clusters:    []string{testconsts.Cluster1},
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().ScanConfigurationExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], mockScanName).Return(false, nil).Times(1)
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpdateClusterStatus(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), testconsts.Cluster1, "")
@@ -202,12 +203,25 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			expectedErr: errors.Errorf("Scan Configuration named %q already exists.", mockScanName),
 		},
 		{
+			desc:        "Scan configuration has duplicate profiles",
+			testRequest: getTestRecNoID(),
+			testContext: suite.testContexts[testutils.UnrestrictedReadWriteCtx],
+			clusters:    []string{testconsts.Cluster1},
+			setMocks: func() {
+				suite.scanConfigDS.EXPECT().ScanConfigurationExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], mockScanName).Return(false, nil).Times(1)
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+			},
+			isErrorTest: true,
+			expectedErr: errors.Errorf("Duplicated profiles found in current or existing scan configurations: %q.", mockScanName),
+		},
+		{
 			desc:        "Unable to store scan configuration",
 			testRequest: getTestRecNoID(),
 			testContext: suite.testContexts[testutils.UnrestrictedReadWriteCtx],
 			clusters:    []string{testconsts.Cluster1},
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().ScanConfigurationExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], mockScanName).Return(false, nil).Times(1)
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(errors.Errorf("Unable to save scan config named %q", mockScanName)).Times(1)
 			},
 			isErrorTest: true,
@@ -220,6 +234,7 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			clusters:    []string{testconsts.Cluster1},
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().ScanConfigurationExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], mockScanName).Return(false, nil).Times(1)
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(errors.New("Unable to process sensor message")).Times(1)
 				suite.scanConfigDS.EXPECT().UpdateClusterStatus(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), testconsts.Cluster1, "Unable to process sensor message")
@@ -253,6 +268,7 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			clusters:    []string{testconsts.Cluster1},
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().GetScanConfiguration(gomock.Any(), mockScanID).Return(getTestRec(), true, nil).Times(1)
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpdateClusterStatus(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), testconsts.Cluster1, "")

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore.go
@@ -24,6 +24,9 @@ type DataStore interface {
 	// ScanConfigurationExists retrieves the existence of scan configuration specified by name
 	ScanConfigurationExists(ctx context.Context, scanName string) (bool, error)
 
+	// ScanConfigurationProfileExists takes all the profiles being referenced by the scan configuration and checks if any cluster is using it in any existing scan configurations.
+	ScanConfigurationProfileExists(ctx context.Context, id string, profiles []string, clusters []string) (bool, error)
+
 	// GetScanConfigurations retrieves the scan configurations specified by query
 	GetScanConfigurations(ctx context.Context, query *v1.Query) ([]*storage.ComplianceOperatorScanConfigurationV2, error)
 

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -52,7 +52,7 @@ func (ds *datastoreImpl) ScanConfigurationExists(ctx context.Context, scanName s
 	return len(scanConfigs) > 0, nil
 }
 
-// ScanConfigurationProfileExists takes all the profiles being referenced by the scan configuration and checks if any cluster is using it in any existing scan configurations.
+// ScanConfigurationProfileExists takes all the profiles being referenced by the scan configuration and checks if any cluster in the configuration is using it in any existing scan configurations.
 func (ds *datastoreImpl) ScanConfigurationProfileExists(ctx context.Context, id string, profiles []string, clusters []string) (bool, error) {
 	// use AreProfilesEqual to check if there are any duplicate profiles in the scan request profiles
 	for i := 0; i < len(profiles); i++ {

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -54,10 +54,10 @@ func (ds *datastoreImpl) ScanConfigurationExists(ctx context.Context, scanName s
 
 // ScanConfigurationProfileExists takes all the profiles being referenced by the scan configuration and checks if any cluster in the configuration is using it in any existing scan configurations.
 func (ds *datastoreImpl) ScanConfigurationProfileExists(ctx context.Context, id string, profiles []string, clusters []string) (bool, error) {
-	// use AreProfilesEqual to check if there are any duplicate profiles in the scan request profiles
+	// use areProfilesEqual to check if there are any duplicate profiles in the scan request profiles
 	for i := 0; i < len(profiles); i++ {
 		for j := i + 1; j < len(profiles); j++ {
-			if AreProfilesEqual(profiles[i], profiles[j]) {
+			if areProfilesEqual(profiles[i], profiles[j]) {
 				return true, nil
 			}
 		}
@@ -85,7 +85,7 @@ func (ds *datastoreImpl) ScanConfigurationProfileExists(ctx context.Context, id 
 	// Check if any of the profiles are being used by any of the existing scan configurations.
 	for _, profile := range profiles {
 		for profileName := range profileMap {
-			if AreProfilesEqual(profile, profileName) {
+			if areProfilesEqual(profile, profileName) {
 				return true, nil
 			}
 		}
@@ -94,9 +94,9 @@ func (ds *datastoreImpl) ScanConfigurationProfileExists(ctx context.Context, id 
 	return false, nil
 }
 
-// AreProfilesEqual returns true if the two profiles are equal
-func AreProfilesEqual(ProfileNameA string, ProfileNameB string) bool {
-	// we use hasPrefix to handle the comparison of profiles with version string in the name
+// areProfilesEqual returns true if the two profiles are equal
+func areProfilesEqual(ProfileNameA string, ProfileNameB string) bool {
+	// we use hasPrefix to handle the comparesion of profiles with version string in the name
 	// first get the shorter profile name
 	var shorterProfileName string
 	var longerProfileName string

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -96,7 +96,7 @@ func (ds *datastoreImpl) ScanConfigurationProfileExists(ctx context.Context, id 
 
 // AreProfilesEqual returns true if the two profiles are equal
 func AreProfilesEqual(ProfileNameA string, ProfileNameB string) bool {
-	// we use hasPrefix to handle the comparesion of profiles with version string in the name
+	// we use hasPrefix to handle the comparison of profiles with version string in the name
 	// first get the shorter profile name
 	var shorterProfileName string
 	var longerProfileName string

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -52,6 +52,70 @@ func (ds *datastoreImpl) ScanConfigurationExists(ctx context.Context, scanName s
 	return len(scanConfigs) > 0, nil
 }
 
+// ScanConfigurationProfileExists takes all the profiles being referenced by the scan configuration and checks if any cluster is using it in any existing scan configurations.
+func (ds *datastoreImpl) ScanConfigurationProfileExists(ctx context.Context, id string, profiles []string, clusters []string) (bool, error) {
+	// use AreProfilesEqual to check if there are any duplicate profiles in the scan request profiles
+	for i := 0; i < len(profiles); i++ {
+		for j := i + 1; j < len(profiles); j++ {
+			if AreProfilesEqual(profiles[i], profiles[j]) {
+				return true, nil
+			}
+		}
+	}
+
+	// Retrieve all scan configurations for the specified clusters.
+	scanConfigs, err := ds.storage.GetByQuery(ctx, search.NewQueryBuilder().
+		AddExactMatches(search.ClusterID, clusters...).ProtoQuery())
+	if err != nil {
+		return false, err
+	}
+
+	// Create a map for quick lookup of profiles.
+	profileMap := make(map[string]bool)
+
+	for _, scanConfig := range scanConfigs {
+		if scanConfig.GetId() == id {
+			continue
+		}
+		for _, profile := range scanConfig.GetProfiles() {
+			profileMap[profile.GetProfileName()] = true
+		}
+	}
+
+	// Check if any of the profiles are being used by any of the existing scan configurations.
+	for _, profile := range profiles {
+		for profileName := range profileMap {
+			if AreProfilesEqual(profile, profileName) {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// AreProfilesEqual returns true if the two profiles are equal
+func AreProfilesEqual(ProfileNameA string, ProfileNameB string) bool {
+	// we use hasPrefix to handle the comparesion of profiles with version string in the name
+	// first get the shorter profile name
+	var shorterProfileName string
+	var longerProfileName string
+	if len(ProfileNameA) < len(ProfileNameB) {
+		shorterProfileName = ProfileNameA
+		longerProfileName = ProfileNameB
+	} else {
+		shorterProfileName = ProfileNameB
+		longerProfileName = ProfileNameA
+	}
+
+	// if the shorter profile name is a prefix of the longer profile name, and their substring are not equal to "node", then they are equal
+	if longerProfileName[:len(shorterProfileName)] == shorterProfileName && longerProfileName[len(shorterProfileName):] != "-node" {
+		return true
+	}
+
+	return false
+}
+
 // GetScanConfigurations retrieves the scan configurations specified by query
 func (ds *datastoreImpl) GetScanConfigurations(ctx context.Context, query *v1.Query) ([]*storage.ComplianceOperatorScanConfigurationV2, error) {
 	scanConfigs, err := ds.storage.GetByQuery(ctx, query)

--- a/central/complianceoperator/v2/scanconfigurations/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/mocks/datastore.go
@@ -132,6 +132,21 @@ func (mr *MockDataStoreMockRecorder) ScanConfigurationExists(ctx, scanName any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanConfigurationExists", reflect.TypeOf((*MockDataStore)(nil).ScanConfigurationExists), ctx, scanName)
 }
 
+// ScanConfigurationProfileExists mocks base method.
+func (m *MockDataStore) ScanConfigurationProfileExists(ctx context.Context, id string, profiles, clusters []string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ScanConfigurationProfileExists", ctx, id, profiles, clusters)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ScanConfigurationProfileExists indicates an expected call of ScanConfigurationProfileExists.
+func (mr *MockDataStoreMockRecorder) ScanConfigurationProfileExists(ctx, id, profiles, clusters any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanConfigurationProfileExists", reflect.TypeOf((*MockDataStore)(nil).ScanConfigurationProfileExists), ctx, id, profiles, clusters)
+}
+
 // UpdateClusterStatus mocks base method.
 func (m *MockDataStore) UpdateClusterStatus(ctx context.Context, scanConfigID, clusterID, clusterStatus string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Description

This PR adds checks when creating a new scan config, we check if the new scan config has referenced any profile that is in any existing scan configurations.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

* Added unit test in scanconfigurations datastore to test checking if there are duplicate profile scan
* Added unit test in compliancemanager implementation to test create duplicate profile scan 
* Addded e2e test to test create two scan with same profile

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
