### PR TITLE
ROX-21729: Enhance collection delete error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-21620: publish opensource instead of stackrox.io helm charts
 - ROX-20163: Sensor captures runtime events even if it is disconnected from Central.
 - ROX-20280: Fixed bug that prevented user from editing the endpoint from an unauthenticated email notifier. The credentials are still required to change the endpoint if it's not unauthenticated.
-- ROX-21729: When deleting a collection is blocked by a referenced objects the names of the respective report configurations and collection are being displayed in the error message.
+- ROX-21729: - ROX-21729: When deleting a collection that is referenced by other objects such as report configurations, the error message now includes the names of the collection being deleted and its referencing object (report configuration).
 
 ## [4.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-21620: publish opensource instead of stackrox.io helm charts
 - ROX-20163: Sensor captures runtime events even if it is disconnected from Central.
 - ROX-20280: Fixed bug that prevented user from editing the endpoint from an unauthenticated email notifier. The credentials are still required to change the endpoint if it's not unauthenticated.
+- ROX-21729: When deleting a collection is blocked by a referenced objects the names of the respective report configurations and collection are being displayed in the error message.
 
 ## [4.3.0]
 

--- a/central/resourcecollection/service/service_impl.go
+++ b/central/resourcecollection/service/service_impl.go
@@ -190,7 +190,7 @@ func (s *serviceImpl) checkVulnerabilityReportReferences(ctx context.Context, re
 		for _, reportConfigurations := range reportConfigurations {
 			names = append(names, reportConfigurations.GetName())
 		}
-		return errors.Wrapf(errox.ReferencedByAnotherObject, "Collection is in use by the following report configuratios: %q", strings.Join(names, ", "))
+		return errors.Wrapf(errox.ReferencedByAnotherObject, "Collection is in use by the following report configuratios: %q.", strings.Join(names, ", "))
 	}
 	return nil
 }

--- a/central/resourcecollection/service/service_impl.go
+++ b/central/resourcecollection/service/service_impl.go
@@ -171,7 +171,7 @@ func (s *serviceImpl) checkCollectionReferences(ctx context.Context, request *v1
 		for _, referencedCollection := range referencedCollections {
 			names = append(names, referencedCollection.GetName())
 		}
-		return errors.Wrapf(errox.ReferencedByAnotherObject, "Collection is in use by one or more other collections by following collections: %q", strings.Join(names, ", "))
+		return errors.Wrapf(errox.ReferencedByAnotherObject, "Collection is in use by the following collections: %q.", strings.Join(names, ", "))
 	}
 	return nil
 }
@@ -190,7 +190,7 @@ func (s *serviceImpl) checkVulnerabilityReportReferences(ctx context.Context, re
 		for _, reportConfigurations := range reportConfigurations {
 			names = append(names, reportConfigurations.GetName())
 		}
-		return errors.Wrapf(errox.ReferencedByAnotherObject, "Collection is in use by one or more report configurations by following reports: %q", strings.Join(names, ", "))
+		return errors.Wrapf(errox.ReferencedByAnotherObject, "Collection is in use by the following report configuratios: %q", strings.Join(names, ", "))
 	}
 	return nil
 }

--- a/central/resourcecollection/service/service_impl.go
+++ b/central/resourcecollection/service/service_impl.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/or"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
@@ -56,8 +55,6 @@ var (
 		Reversed: false,
 	}
 )
-
-var log = logging.LoggerForModule()
 
 type collectionRequest interface {
 	GetName() string


### PR DESCRIPTION
## Description

This PR adds the capability to show the names of references objects and which type they have.
The errors appear not in the same windows because of formatting problems. 
The error message before only mentioned that something referenced the collection, but lacked any information about the source of the reference.

**✅ Report configuration:**
![Screenshot from 2024-01-23 14-47-17](https://github.com/stackrox/stackrox/assets/9550466/1890681e-9de5-4a00-a0e4-a231c2378642)

**✅ Collections:**
![Screenshot from 2024-01-23 14-46-53](https://github.com/stackrox/stackrox/assets/9550466/4c1e87e1-1337-4791-a927-285f0e909971)


## Abandoned / Not implemented

**❌🗑️ Combined error output, but abandoned because of lack of readability: ❌**
![Screenshot from 2024-01-23 14-57-20](https://github.com/stackrox/stackrox/assets/9550466/f1636a3b-e258-49ff-b6f1-bdc6d86d81cb)


## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [ ] ~~Determined and documented upgrade steps~~
- [ ]~~ Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

 - Added and adjusted unit tests
 - Deletion blocked by report config should display report config name
   1. Create a collection
   2. Configure report configuration, add the created collection to it. 
   3. Try to delete the collection
   4. **Expected:** Error message should contain the report configuration which references the collection ID.
- Deletion blocked by collection ID should display collection name
   1. Create a collection A
   2. Create a second collection, embed collection A in it
   3. Try to delete collection A
   4. **Expected** Error message should contain the collection name referencing the collection A.
 