### PR TITLE
ROX-19058: add scannerV4 to kuttl tests for central

### DIFF
--- a/operator/tests/common/central-cr-assert.yaml
+++ b/operator/tests/common/central-cr-assert.yaml
@@ -103,3 +103,4 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
+  

--- a/operator/tests/common/central-cr-assert.yaml
+++ b/operator/tests/common/central-cr-assert.yaml
@@ -64,6 +64,27 @@ metadata:
 status:
   availableReplicas: 1
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scanner-v4-indexer
+status:
+  availableReplicas: 2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scanner-v4-matcher
+status:
+  availableReplicas: 2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scanner-v4-db
+status:
+  availableReplicas: 1
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -74,3 +95,11 @@ spec:
   resources:
     requests:
       storage: 100Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: scanner-v4-db
+spec:
+  accessModes:
+  - ReadWriteOnce

--- a/operator/tests/common/central-cr-assert.yaml
+++ b/operator/tests/common/central-cr-assert.yaml
@@ -69,14 +69,14 @@ kind: Deployment
 metadata:
   name: scanner-v4-indexer
 status:
-  availableReplicas: 2
+  availableReplicas: 1
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: scanner-v4-matcher
 status:
-  availableReplicas: 2
+  availableReplicas: 1
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/operator/tests/common/central-cr-assert.yaml
+++ b/operator/tests/common/central-cr-assert.yaml
@@ -103,4 +103,3 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
-  

--- a/operator/tests/common/central-cr-pre-scanner-v4-assert.yaml
+++ b/operator/tests/common/central-cr-pre-scanner-v4-assert.yaml
@@ -1,0 +1,76 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app=central
+  tail: -1
+- type: pod
+  selector: app=central-db
+  tail: -1
+- type: pod
+  selector: app=scanner
+  tail: -1
+- type: pod
+  selector: app=scanner-db
+  tail: -1
+- command: kubectl describe pod -n $NAMESPACE -l app=central
+- command: kubectl describe pod -n $NAMESPACE -l app=central-db
+- command: kubectl describe pod -n $NAMESPACE -l app=scanner
+- command: kubectl describe pod -n $NAMESPACE -l app=scanner-db
+timeout: 1500
+---
+apiVersion: platform.stackrox.io/v1alpha1
+kind: Central
+metadata:
+  name: stackrox-central-services
+status:
+  conditions:
+  - status: "True"
+    type: Deployed
+  - status: "True"
+    type: Initialized
+  - status: "False"
+    type: Irreconcilable
+  - status: "False"
+    type: ProxyConfigFailed
+  - status: "False"
+    type: ReleaseFailed
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central-db
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scanner
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scanner-db
+status:
+  availableReplicas: 1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: central-db
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi

--- a/operator/tests/common/central-cr.yaml
+++ b/operator/tests/common/central-cr.yaml
@@ -68,7 +68,7 @@ spec:
           memory: 1Gi
         limits:
           cpu: 1
-          memory: 2Gi
+          memory: 3Gi
     db:
       resources:
         requests:

--- a/operator/tests/common/delete-central-errors-openshift.yaml
+++ b/operator/tests/common/delete-central-errors-openshift.yaml
@@ -9,6 +9,21 @@ testRunSelector:
 apiVersion: authorization.openshift.io/v1
 kind: RoleBinding
 metadata:
+  name: central-db-use-scc
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: central-prometheus-k8s
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: central-sts-config-reader
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
   name: central-use-scc
 ---
 apiVersion: authorization.openshift.io/v1
@@ -19,22 +34,32 @@ metadata:
 apiVersion: authorization.openshift.io/v1
 kind: RoleBinding
 metadata:
+  name: scanner-v4-use-scc
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
   name: stackrox-central-diagnostics
 ---
 apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
+kind: Role
 metadata:
-  name: stackrox-central-psp
+  name: central-prometheus-k8s
 ---
 apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
+kind: Role
 metadata:
-  name: stackrox-scanner-psp
+  name: central-sts-config-reader
 ---
 apiVersion: authorization.openshift.io/v1
 kind: Role
 metadata:
   name: stackrox-central-diagnostics
+---
+apiVersion: authorization.openshift.io/v1
+kind: Role
+metadata:
+  name: use-central-db-scc
 ---
 apiVersion: authorization.openshift.io/v1
 kind: Role
@@ -45,6 +70,11 @@ apiVersion: authorization.openshift.io/v1
 kind: Role
 metadata:
   name: use-scanner-scc
+---
+apiVersion: authorization.openshift.io/v1
+kind: Role
+metadata:
+  name: use-scanner-v4-scc
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/operator/tests/common/delete-central-errors.yaml
+++ b/operator/tests/common/delete-central-errors.yaml
@@ -367,3 +367,4 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: use-scanner-v4-scc
+  

--- a/operator/tests/common/delete-central-errors.yaml
+++ b/operator/tests/common/delete-central-errors.yaml
@@ -367,4 +367,3 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: use-scanner-v4-scc
-  

--- a/operator/tests/common/delete-central-errors.yaml
+++ b/operator/tests/common/delete-central-errors.yaml
@@ -21,7 +21,17 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: central-db-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: central-endpoints
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: central-external-db
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -34,9 +44,29 @@ metadata:
   name: scanner-config
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scanner-v4-db-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scanner-v4-indexer-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scanner-v4-matcher-config
+---
+apiVersion: v1
 kind: Endpoints
 metadata:
   name: central
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: central-db
 ---
 apiVersion: v1
 kind: Endpoints
@@ -49,9 +79,44 @@ metadata:
   name: scanner-db
 ---
 apiVersion: v1
+kind: Endpoints
+metadata:
+  name: scanner-v4-db
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: scanner-v4-indexer
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: scanner-v4-matcher
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: admin-pass
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: central-db-password
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: central-db-tls
+---
+apiVersion: v1
 kind: Secret
 metadata:
   name: central-htpasswd
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: central-monitoring-tls
 ---
 apiVersion: v1
 kind: Secret
@@ -76,6 +141,26 @@ metadata:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: scanner-v4-db-password
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scanner-v4-db-tls
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scanner-v4-indexer-tls
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scanner-v4-matcher-tls
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: sh.helm.release.v1.stackrox-central-services.v1
 ---
 apiVersion: v1
@@ -86,12 +171,27 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: central-db
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
   name: scanner
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scanner-v4
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: central
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: central-db
 ---
 apiVersion: v1
 kind: Service
@@ -103,10 +203,30 @@ kind: Service
 metadata:
   name: scanner-db
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: scanner-v4-db
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: scanner-v4-indexer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: scanner-v4-matcher
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: central
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central-db
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -118,10 +238,20 @@ kind: Deployment
 metadata:
   name: scanner-db
 ---
-apiVersion: autoscaling/v1
-kind: HorizontalPodAutoscaler
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: scanner
+  name: scanner-v4-db
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scanner-v4-indexer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scanner-v4-matcher
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -131,6 +261,16 @@ metadata:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: central-db
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: central-monitoring-tls
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
   name: scanner
 ---
 apiVersion: networking.k8s.io/v1
@@ -138,10 +278,40 @@ kind: NetworkPolicy
 metadata:
   name: scanner-db
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: scanner-v4-db
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: scanner-v4-indexer
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: scanner-v4-matcher
+---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: Central
 metadata:
   name: stackrox-central-services
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: central-db-use-scc
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: central-prometheus-k8s
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: central-sts-config-reader
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -156,22 +326,32 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: scanner-v4-use-scc
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: stackrox-central-diagnostics
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: Role
 metadata:
-  name: stackrox-central-psp
+  name: central-prometheus-k8s
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: Role
 metadata:
-  name: stackrox-scanner-psp
+  name: central-sts-config-reader
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: stackrox-central-diagnostics
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: use-central-db-scc
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -186,9 +366,4 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: central-prometheus-k8s
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: central-prometheus-k8s
+  name: use-scanner-v4-scc

--- a/operator/tests/common/delete-central-errors.yaml
+++ b/operator/tests/common/delete-central-errors.yaml
@@ -96,11 +96,6 @@ metadata:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: admin-pass
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: central-db-password
 ---
 apiVersion: v1

--- a/operator/tests/upgrade/upgrade/05-assert.yaml
+++ b/operator/tests/upgrade/upgrade/05-assert.yaml
@@ -1,1 +1,1 @@
-../../common/central-cr-assert.yaml
+../../common/central-cr-pre-scanner-v4-assert.yaml

--- a/operator/tests/upgrade/upgrade/30-central-cr.yaml
+++ b/operator/tests/upgrade/upgrade/30-central-cr.yaml
@@ -1,0 +1,1 @@
+../../common/central-cr.yaml


### PR DESCRIPTION
## Description

Adding Scanner V4 resource to assertions of kuttl tests.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
