### PR TITLE
ROX-21943: Add discovered-clusters route in UI

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersEmptyState.tsx
@@ -1,0 +1,54 @@
+import React, { ReactElement } from 'react';
+import {
+    Bullseye,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateIcon,
+    Flex,
+    Text,
+    Title,
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+import { Tbody, Td, Tr } from '@patternfly/react-table';
+
+export type DiscoveredClustersEmptyStateProps = {
+    colSpan: number;
+    hasFilter: boolean;
+};
+
+function DiscoveredClustersEmptyState({
+    colSpan,
+    hasFilter,
+}: DiscoveredClustersEmptyStateProps): ReactElement {
+    return (
+        <Tbody>
+            <Tr>
+                <Td colSpan={colSpan}>
+                    <Bullseye>
+                        {hasFilter ? (
+                            <EmptyState>
+                                <EmptyStateIcon icon={SearchIcon} />
+                                <EmptyStateBody>
+                                    <Flex direction={{ default: 'column' }}>
+                                        <Title headingLevel="h2">
+                                            No discovered clusters found
+                                        </Title>
+                                        <Text>Modify filters and try again</Text>
+                                    </Flex>
+                                </EmptyStateBody>
+                            </EmptyState>
+                        ) : (
+                            <EmptyState>
+                                <EmptyStateBody>
+                                    <Title headingLevel="h2">No discovered clusters</Title>
+                                </EmptyStateBody>
+                            </EmptyState>
+                        )}
+                    </Bullseye>
+                </Td>
+            </Tr>
+        </Tbody>
+    );
+}
+
+export default DiscoveredClustersEmptyState;

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
@@ -1,0 +1,126 @@
+import React, { ReactElement, useEffect, useState } from 'react';
+import {
+    Alert,
+    Breadcrumb,
+    BreadcrumbItem,
+    Bullseye,
+    Flex,
+    PageSection,
+    Spinner,
+    Text,
+    Title,
+} from '@patternfly/react-core';
+
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import PageTitle from 'Components/PageTitle';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSearch from 'hooks/useURLSearch';
+import useURLSort from 'hooks/useURLSort';
+import {
+    DiscoveredCluster,
+    countDiscoveredClusters,
+    defaultSortOption,
+    listDiscoveredClusters,
+    sortFields,
+} from 'services/DiscoveredClustersService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { clustersBasePath } from 'routePaths';
+
+import DiscoveredClustersTable from './DiscoveredClustersTable';
+import DiscoveredClustersToolbar from './DiscoveredClustersToolbar';
+
+const title = 'Discovered clusters';
+
+function DiscoveredClustersPage(): ReactElement {
+    const { page, perPage, setPage, setPerPage } = useURLPagination(10);
+    const { searchFilter, setSearchFilter } = useURLSearch();
+    const { getSortParams, sortOption } = useURLSort({ defaultSortOption, sortFields });
+
+    const [count, setCount] = useState(0);
+    const [errorMessage, setErrorMessage] = useState('');
+    const [clusters, setClusters] = useState<DiscoveredCluster[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        setIsLoading(true);
+
+        // const listArg = getListDiscoveredClustersArg({ page, perPage, searchFilter, sortOption });
+        // const { filter } = listArg;
+
+        Promise.all([countDiscoveredClusters(/* filter */), listDiscoveredClusters(/* listArg */)])
+            .then(([countArg, clustersArg]) => {
+                setClusters(clustersArg);
+                setCount(countArg);
+                setErrorMessage('');
+            })
+            .catch((error) => {
+                setClusters([]);
+                setCount(0);
+                setErrorMessage(getAxiosErrorMessage(error));
+            })
+            .finally(() => {
+                setIsLoading(false);
+            });
+    }, [page, perPage, searchFilter, setIsLoading, sortOption]);
+
+    /* eslint-disable no-nested-ternary */
+    return (
+        <>
+            <PageSection component="div" variant="light">
+                <PageTitle title={title} />
+                <Flex direction={{ default: 'column' }}>
+                    <Breadcrumb>
+                        <BreadcrumbItemLink to={clustersBasePath}>Clusters</BreadcrumbItemLink>
+                        <BreadcrumbItem isActive>{title}</BreadcrumbItem>
+                    </Breadcrumb>
+                    <Flex
+                        direction={{ default: 'column' }}
+                        spaceItems={{ default: 'spaceItemsSm' }}
+                    >
+                        <Title headingLevel="h1">{title}</Title>
+                        <Text>
+                            Discovered clusters might not yet have secured cluster services.
+                        </Text>
+                    </Flex>
+                </Flex>
+            </PageSection>
+            <PageSection component="div">
+                {isLoading ? (
+                    <Bullseye>
+                        <Spinner isSVG />
+                    </Bullseye>
+                ) : errorMessage ? (
+                    <Alert
+                        variant="warning"
+                        title="Unable to fetch discovered clusters"
+                        component="div"
+                        isInline
+                    >
+                        {errorMessage}
+                    </Alert>
+                ) : (
+                    <>
+                        <DiscoveredClustersToolbar
+                            count={count}
+                            isDisabled={isLoading}
+                            page={page}
+                            perPage={perPage}
+                            setPage={setPage}
+                            setPerPage={setPerPage}
+                            searchFilter={searchFilter}
+                            setSearchFilter={setSearchFilter}
+                        />
+                        <DiscoveredClustersTable
+                            clusters={clusters}
+                            getSortParams={getSortParams}
+                            searchFilter={searchFilter}
+                        />
+                    </>
+                )}
+            </PageSection>
+        </>
+    );
+    /* eslint-enable no-nested-ternary */
+}
+
+export default DiscoveredClustersPage;

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
@@ -48,9 +48,9 @@ function DiscoveredClustersPage(): ReactElement {
         // const { filter } = listArg;
 
         Promise.all([countDiscoveredClusters(/* filter */), listDiscoveredClusters(/* listArg */)])
-            .then(([countArg, clustersArg]) => {
-                setClusters(clustersArg);
-                setCount(countArg);
+            .then(([countFromResponse, clustersFromResponse]) => {
+                setClusters(clustersFromResponse);
+                setCount(countFromResponse);
                 setErrorMessage('');
             })
             .catch((error) => {

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
@@ -7,7 +7,7 @@ import { SearchFilter } from 'types/search';
 
 import DiscoveredClustersEmptyState from './DiscoveredClustersEmptyState';
 
-const colSpan = 4; // TODO separate Provider from Region?
+const colSpan = 4; // TODO separate Provider from
 
 export type DiscoveredClustersTableProps = {
     clusters: DiscoveredCluster[];
@@ -24,10 +24,10 @@ function DiscoveredClustersTable({
         <TableComposable variant="compact" borders={false}>
             <Thead>
                 <Tr>
-                    <Th>Cluster</Th>
+                    <Th sort={getSortParams('TODO')}>Cluster</Th>
                     <Th>Type</Th>
                     <Th>Provider</Th>
-                    <Th sort={getSortParams('TODO')}>First discovered</Th>
+                    <Th>Region</Th>
                 </Tr>
             </Thead>
             {clusters.length === 0 ? (
@@ -43,12 +43,8 @@ function DiscoveredClustersTable({
                         <Tr key={id}>
                             <Td dataLabel="Cluster">{'TODO'}</Td>
                             <Td dataLabel="Type">{'TODO'}</Td>
-                            <Td dataLabel="Provider" modifier="nowrap">
-                                {'TODO'}
-                            </Td>
-                            <Td dataLabel="First discovered" modifier="nowrap">
-                                {'TODO'}
-                            </Td>
+                            <Td dataLabel="Provider">{'TODO'}</Td>
+                            <Td dataLabel="Region">{'TODO'}</Td>
                         </Tr>
                     );
                 })

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
@@ -1,0 +1,60 @@
+import React, { ReactElement } from 'react';
+import { TableComposable, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
+import { UseURLSortResult } from 'hooks/useURLSort';
+import { DiscoveredCluster, hasDiscoveredClustersFilter } from 'services/DiscoveredClustersService';
+import { SearchFilter } from 'types/search';
+
+import DiscoveredClustersEmptyState from './DiscoveredClustersEmptyState';
+
+const colSpan = 4; // TODO separate Provider from Region?
+
+export type DiscoveredClustersTableProps = {
+    clusters: DiscoveredCluster[];
+    getSortParams: UseURLSortResult['getSortParams'];
+    searchFilter: SearchFilter;
+};
+
+function DiscoveredClustersTable({
+    clusters,
+    getSortParams,
+    searchFilter,
+}: DiscoveredClustersTableProps): ReactElement {
+    return (
+        <TableComposable variant="compact" borders={false}>
+            <Thead>
+                <Tr>
+                    <Th>Cluster</Th>
+                    <Th>Type</Th>
+                    <Th>Provider</Th>
+                    <Th sort={getSortParams('TODO')}>First discovered</Th>
+                </Tr>
+            </Thead>
+            {clusters.length === 0 ? (
+                <DiscoveredClustersEmptyState
+                    colSpan={colSpan}
+                    hasFilter={hasDiscoveredClustersFilter(searchFilter)}
+                />
+            ) : (
+                clusters.map((cluster) => {
+                    const { id } = cluster;
+
+                    return (
+                        <Tr key={id}>
+                            <Td dataLabel="Cluster">{'TODO'}</Td>
+                            <Td dataLabel="Type">{'TODO'}</Td>
+                            <Td dataLabel="Provider" modifier="nowrap">
+                                {'TODO'}
+                            </Td>
+                            <Td dataLabel="First discovered" modifier="nowrap">
+                                {'TODO'}
+                            </Td>
+                        </Tr>
+                    );
+                })
+            )}
+        </TableComposable>
+    );
+}
+
+export default DiscoveredClustersTable;

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
@@ -1,0 +1,72 @@
+import React, { ReactElement } from 'react';
+import {
+    Pagination,
+    Toolbar,
+    ToolbarContent,
+    ToolbarGroup,
+    ToolbarItem,
+} from '@patternfly/react-core';
+
+import { SearchFilter } from 'types/search';
+
+import SearchFilterType from './SearchFilterType';
+
+export type DiscoveredClustersToolbarProps = {
+    count: number;
+    isDisabled: boolean;
+    page: number;
+    perPage: number;
+    setPage: (newPage: number) => void;
+    setPerPage: (newPerPage: number) => void;
+    searchFilter: SearchFilter;
+    setSearchFilter: (newFilter: SearchFilter) => void;
+};
+
+function DiscoveredClustersToolbar({
+    count,
+    isDisabled,
+    page,
+    perPage,
+    setPage,
+    setPerPage,
+    searchFilter,
+    setSearchFilter,
+}: DiscoveredClustersToolbarProps): ReactElement {
+    function setTypes(/* TODO */) {
+        setSearchFilter({ ...searchFilter }); // TODO
+    }
+
+    return (
+        <Toolbar>
+            <ToolbarContent>
+                <ToolbarGroup variant="filter-group">
+                    <ToolbarItem>
+                        <SearchFilterType
+                            types={['GKE']}
+                            isDisabled={isDisabled}
+                            setTypes={setTypes}
+                        />
+                    </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarGroup variant="button-group" alignment={{ default: 'alignRight' }}>
+                    <ToolbarItem variant="pagination">
+                        <Pagination
+                            isCompact
+                            isDisabled={isDisabled}
+                            itemCount={count}
+                            page={page}
+                            perPage={perPage}
+                            onSetPage={(_, newPage) => setPage(newPage)}
+                            onPerPageSelect={(_, newPerPage) => {
+                                setPage(1);
+                                setPerPage(newPerPage);
+                            }}
+                        />
+                    </ToolbarItem>
+                </ToolbarGroup>
+            </ToolbarContent>
+        </Toolbar>
+    );
+}
+
+export default DiscoveredClustersToolbar;

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterType.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterType.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { Divider, Select, SelectOption } from '@patternfly/react-core';
+
+const optionAll = 'All';
+
+type SearchFilterTypeProps = {
+    types: string[]; // TODO
+    isDisabled: boolean;
+    setTypes: (types: string[]) => void; // TODO
+};
+
+function SearchFilterType({ types, isDisabled, setTypes }: SearchFilterTypeProps) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    function onSelect(_event, selection) {
+        setTypes(selection === optionAll ? [] : [selection]); // TODO add versus remove
+        setIsOpen(false);
+    }
+
+    const options = types.map((typeArg) => (
+        <SelectOption key={typeArg} value={typeArg}>
+            {typeArg}
+        </SelectOption>
+    ));
+    options.push(
+        <Divider key="Divider" />,
+        <SelectOption key="All" value={optionAll} isPlaceholder>
+            All types
+        </SelectOption>
+    );
+
+    // TODO replace single with checkbox for multiple selections.
+    return (
+        <Select
+            variant="single"
+            aria-label="Type filter menu items"
+            toggleAriaLabel="Type filter menu toggle"
+            onToggle={setIsOpen}
+            onSelect={onSelect}
+            selections={types[0] ?? optionAll}
+            isDisabled={isDisabled}
+            isOpen={isOpen}
+        >
+            {options}
+        </Select>
+    );
+}
+
+export default SearchFilterType;

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -10,6 +10,7 @@ import {
     apidocsPath,
     apidocsPathV2,
     clustersDelegatedScanningPath,
+    clustersDiscoveredClustersPath,
     clustersInitBundlesPathWithParam,
     clustersPathWithParam,
     collectionsPath,
@@ -92,6 +93,13 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
             () => import('Containers/Clusters/DelegateScanning/DelegateScanningPage')
         ),
         path: clustersDelegatedScanningPath,
+    },
+    // Discovered clusters must precede generic Clusters.
+    'clusters/discovered-clusters': {
+        component: asyncComponent(
+            () => import('Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage')
+        ),
+        path: clustersDiscoveredClustersPath,
     },
     // Cluster init bundles must precede generic Clusters.
     'clusters/init-bundles': {

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -26,6 +26,7 @@ export const clustersBasePath = `${mainPath}/clusters`;
 export const clustersPathWithParam = `${clustersBasePath}/:clusterId?`;
 export const clustersListPath = `${mainPath}/clusters-pf`;
 export const clustersDelegatedScanningPath = `${clustersBasePath}/delegated-image-scanning`;
+export const clustersDiscoveredClustersPath = `${clustersBasePath}/discovered-clusters`;
 export const clustersInitBundlesPath = `${clustersBasePath}/init-bundles`;
 export const clustersInitBundlesPathWithParam = `${clustersInitBundlesPath}/:id?`;
 export const collectionsBasePath = `${mainPath}/collections`;
@@ -150,6 +151,8 @@ export type RouteKey =
     | 'apidocs-v2'
     // Delegated image scanning must precede generic Clusters in Body and so here for consistency.
     | 'clusters/delegated-image-scanning'
+    // Discovered clusters must precede generic Clusters in Body and so here for consistency.
+    | 'clusters/discovered-clusters'
     // Cluster init bundles must precede generic Clusters in Body and so here for consistency.
     | 'clusters/init-bundles'
     | 'clusters'
@@ -196,6 +199,11 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     },
     // Delegated image scanning must precede generic Clusters in Body and so here for consistency.
     'clusters/delegated-image-scanning': {
+        resourceAccessRequirements: everyResource(['Administration']),
+    },
+    // Discovered clusters must precede generic Clusters in Body and so here for consistency.
+    'clusters/discovered-clusters': {
+        featureFlagRequirements: allEnabled(['ROX_CLOUD_SOURCES']),
         resourceAccessRequirements: everyResource(['Administration']),
     },
     // Cluster init bundles must precede generic Clusters in Body and so here for consistency.

--- a/ui/apps/platform/src/services/DiscoveredClustersService.ts
+++ b/ui/apps/platform/src/services/DiscoveredClustersService.ts
@@ -1,0 +1,42 @@
+import { SearchFilter } from 'types/search';
+import { SortOption } from 'types/table';
+
+import { Pagination } from './types';
+
+export type DiscoveredCluster = {
+    id: string;
+};
+
+export function countDiscoveredClusters(/* filter */): Promise<number> {
+    return Promise.resolve(0);
+}
+
+export function listDiscoveredClusters(/* arg */): Promise<DiscoveredCluster[]> {
+    return Promise.resolve([]);
+}
+
+export function getListDiscoveredClustersArg({ page, perPage, searchFilter, sortOption }) {
+    const filter = getDiscoveredClustersFilter(searchFilter);
+    const pagination: Pagination = { limit: perPage, offset: page - 1, sortOption };
+    return { filter, pagination };
+}
+
+// Given searchFilter from useURLSearch hook, return validated filter argument.
+
+export function getDiscoveredClustersFilter(searchFilter: SearchFilter) {
+    return {
+        ...searchFilter, // TODO
+    };
+}
+
+export function hasDiscoveredClustersFilter(searchFilter: SearchFilter) {
+    return Object.keys(searchFilter).length !== 0; // TODO
+}
+
+// For useURLSort hook.
+
+export const sortFields = [];
+export const defaultSortOption: SortOption = {
+    field: 'TODO',
+    direction: 'desc', // descending for most recently discovered?
+};

--- a/ui/apps/platform/src/services/DiscoveredClustersService.ts
+++ b/ui/apps/platform/src/services/DiscoveredClustersService.ts
@@ -38,5 +38,5 @@ export function hasDiscoveredClustersFilter(searchFilter: SearchFilter) {
 export const sortFields = [];
 export const defaultSortOption: SortOption = {
     field: 'TODO',
-    direction: 'desc', // descending for most recently discovered?
+    direction: 'asc',
 };


### PR DESCRIPTION
## Description

Adapt from
https://github.com/stackrox/stackrox/tree/master/ui/apps/platform/src/Containers/Administration/Events

Follow procedure
https://github.com/stackrox/stackrox/tree/master/ui/apps/platform#add-a-route

1. Edit ui/apps/platform/src/routePaths.ts file.
    * Add a path **without** params for link from sidebar navigation ~and, if needed, path **with** params for the `Route` element~.
        Because table row displays all information about a discovered cluster, no separate page for MVP.
    * Add a string to `RouteKey` type.
    * Add a property to `routeRequirementsMap` object.
        Specify `ROX_CLOUD_SOURCES` feature flag during development of a new route.
        Specify `Administration` minimum resource requirements. Because **Discovered clusters** link is on clusters page, `Cluster` is an implicit requirement.
2. Edit ui/apps/platform/src/Containers/MainPage/Body.tsx file.
    * Import the path for the `Route` element.
    * Add a property to `routeComponentMap` object.
3. ~Edit ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx file, if the route has a link.~
4. Add a folder and root component file (see step 2).
    * Add src/Containers/Clusters/DiscoveredClusters folder and DiscoveredClustersPage.tsx file.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 461 = 3949941 - 3949480
        total 10445 = 10432581 - 10422136
    * `ls -al build/static/js/*.js | wc`
        files 1 = 92 - 91
3. `yarn start` in ui

### Manual testing

#### without feature flag

1. Visit /main/clusters/discovered-clusters
    Instead of 404 page, see error on clusters page because it interprets discovered-clusters as an id by mistake :(

#### with feature flag

Before you `yarn deploy` in ui folder:

```sh
export ROX_CLOUD_SOURCES=true
```

1. Visit /main/clusters/discovered-clusters
    See **Discovered clusters** page.

2. Click **Clusters** link in breadcrumbs
