### PR TITLE
chore: Enable tagging Michael Heß in Slack notifications

### DIFF
--- a/scripts/ci/get-slack-user-id.sh
+++ b/scripts/ci/get-slack-user-id.sh
@@ -20,6 +20,7 @@ slack_user=''
 case "$github_login" in
 '0x656b694d')       slack_user='U02MJ72K1B5' ;;
 'BradLugo')         slack_user='U042Z3TSZU3' ;;
+'GrimmiMeloni')     slack_user='U048VH2JZ1C' ;;
 'JoukoVirtanen')    slack_user='U033Y28GYN4' ;;
 'Maddosaurus')      slack_user='U01Q5L5R0GJ' ;;
 'Molter73')         slack_user='U02A292NPV2' ;;
@@ -43,7 +44,6 @@ case "$github_login" in
 'fredrb')           slack_user='U02H0SPRHC0' ;;
 'gaurav-nelson')    slack_user='U01P6PMFGKF' ;;
 'gavin-stackrox')   slack_user='U01QJF2LM9D' ;;
-'grimmimeloni')     slack_user='U048VH2JZ1C' ;;
 'house-d')          slack_user='U03H69TFKH9' ;;
 'ivan-degtiarenko') slack_user='U01U2UKP7D4' ;;
 'janisz')           slack_user='U0218FUVDMJ' ;;

--- a/scripts/ci/get-slack-user-id.sh
+++ b/scripts/ci/get-slack-user-id.sh
@@ -43,6 +43,7 @@ case "$github_login" in
 'fredrb')           slack_user='U02H0SPRHC0' ;;
 'gaurav-nelson')    slack_user='U01P6PMFGKF' ;;
 'gavin-stackrox')   slack_user='U01QJF2LM9D' ;;
+'grimmimeloni')     slack_user='U048VH2JZ1C' ;;
 'house-d')          slack_user='U03H69TFKH9' ;;
 'ivan-degtiarenko') slack_user='U01U2UKP7D4' ;;
 'janisz')           slack_user='U0218FUVDMJ' ;;


### PR DESCRIPTION
## Description

Per title.

See how @-tagging does not work currently in https://redhat-internal.slack.com/archives/CLUNQEEMA/p1705995812469439

## Checklist

These aren't needed and won't be done:

- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

Visually/manually double-checked that

- [x] GitHub login is correct.
- [x] Slack ID is correct.