### PR TITLE
chore(scanner): Replace interface{} with any

### DIFF
--- a/scanner/e2etests/image_test.go
+++ b/scanner/e2etests/image_test.go
@@ -20,12 +20,12 @@ import (
 
 // Vulnerability describes a vulnerability in a TestCase.
 type Vulnerability struct {
-	Name        string                 `json:"Name"`
-	Description string                 `json:"Description"`
-	Link        string                 `json:"Link"`
-	Severity    string                 `json:"Severity"`
-	Metadata    map[string]interface{} `json:"Metadata"`
-	FixedBy     string                 `json:"FixedBy"`
+	Name        string         `json:"Name"`
+	Description string         `json:"Description"`
+	Link        string         `json:"Link"`
+	Severity    string         `json:"Severity"`
+	Metadata    map[string]any `json:"Metadata"`
+	FixedBy     string         `json:"FixedBy"`
 }
 
 // Vulnerability describes a feature in a TestCase.

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -142,7 +142,7 @@ func NewIndexer(ctx context.Context, cfg config.IndexerConfig) (Indexer, error) 
 }
 
 func castToConfig[T any](f func(cfg T)) func(o any) error {
-	return func(o interface{}) error {
+	return func(o any) error {
 		cfg, ok := o.(T)
 		if !ok {
 			return errors.New("internal error: casting failed")
@@ -164,15 +164,15 @@ func newLibindex(ctx context.Context, indexerCfg config.IndexerConfig, root stri
 		LayerScanConcurrency: libindex.DefaultLayerScanConcurrency,
 		Ecosystems:           ecosystems(ctx),
 		ScannerConfig: struct {
-			Package, Dist, Repo, File map[string]func(interface{}) error
+			Package, Dist, Repo, File map[string]func(any) error
 		}{
-			Repo: map[string]func(interface{}) error{
+			Repo: map[string]func(any) error{
 				"rhel-repository-scanner": castToConfig(func(cfg *rhel.RepositoryScannerConfig) {
 					cfg.Repo2CPEMappingURL = indexerCfg.RepositoryToCPEURL
 					cfg.Repo2CPEMappingFile = indexerCfg.RepositoryToCPEFile
 				}),
 			},
-			Package: map[string]func(interface{}) error{
+			Package: map[string]func(any) error{
 				"rhel_containerscanner": castToConfig(func(cfg *rhcc.ScannerConfig) {
 					cfg.Name2ReposMappingURL = indexerCfg.NameToReposURL
 					cfg.Name2ReposMappingFile = indexerCfg.NameToReposFile

--- a/scanner/updater/rhel/fetch_test.go
+++ b/scanner/updater/rhel/fetch_test.go
@@ -25,7 +25,7 @@ func TestFetch(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := u.Configure(ctx, func(_ interface{}) error { return nil }, srv.Client()); err != nil {
+		if err := u.Configure(ctx, func(_ any) error { return nil }, srv.Client()); err != nil {
 			t.Fatal(err)
 		}
 		rd, hint, err := u.Fetch(ctx, driver.Fingerprint(""))
@@ -58,7 +58,7 @@ func TestFetch(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := u.Configure(ctx, func(_ interface{}) error { return nil }, srv.Client()); err != nil {
+		if err := u.Configure(ctx, func(_ any) error { return nil }, srv.Client()); err != nil {
 			t.Fatal(err)
 		}
 		rd, hint, err := u.Fetch(ctx, "")

--- a/scanner/updater/rhel/parse_test.go
+++ b/scanner/updater/rhel/parse_test.go
@@ -23,13 +23,13 @@ func TestCVEDefFromUnpatched(t *testing.T) {
 		{
 			name:              "default path",
 			fileName:          "testdata/rhel-8-rpm-unpatched.xml",
-			configFunc:        func(_ interface{}) error { return nil },
+			configFunc:        func(_ any) error { return nil },
 			expectedVulnCount: 192,
 		},
 		{
 			name:              "ignore unpatched path",
 			fileName:          "testdata/rhel-8-rpm-unpatched.xml",
-			configFunc:        func(c interface{}) error { return nil },
+			configFunc:        func(c any) error { return nil },
 			ignoreUnpatched:   true,
 			expectedVulnCount: 0,
 		},

--- a/scanner/updater/rhel/updaterset.go
+++ b/scanner/updater/rhel/updaterset.go
@@ -169,7 +169,7 @@ func Updaters(ctx context.Context, c *http.Client) ([]driver.Updater, error) {
 	if err != nil {
 		return nil, err
 	}
-	nilCfg := func(interface{}) error { return nil }
+	nilCfg := func(any) error { return nil }
 	f.Configure(ctx, nilCfg, c)
 	s, err := f.UpdaterSet(ctx)
 	if err != nil {


### PR DESCRIPTION
## Description

Following up on https://github.com/stackrox/stackrox/pull/9476#pullrequestreview-1839285758:

```
find scanner -name '*.go' | while read f; do grep 'interface{}' $f && sed -i 's/interface{}/any/' $f && go fmt $f; done
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

`make -C scanner build`

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
