### PR TITLE
feat(scanv4): Enable Scanner V4 by default in Central chart

### DIFF
--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -84,12 +84,14 @@
     {{- if kindIs "invalid" $._rox.scannerV4.indexer.serviceTLS.generate }}
       {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
       {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
-      {{- $lookupOut := dict -}}
-      {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-indexer-tls") -}}
-      {{- if not $lookupOut.result -}}
-        {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
-        {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
-        {{- $_ := set $._rox.scannerV4.indexer.serviceTLS "generate" true -}}
+      {{- if $.Release.IsUpgrade -}}
+        {{- $lookupOut := dict -}}
+        {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-indexer-tls") -}}
+        {{- if not $lookupOut.result -}}
+          {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
+          {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
+          {{- $_ := set $._rox.scannerV4.indexer.serviceTLS "generate" true -}}
+        {{- end -}}
       {{- end -}}
     {{- end }}
     {{ $cryptoSpec := dict "CN" "SCANNER_V4_INDEXER_SERVICE: Scanner V4 Indexer" "dnsBase" "scanner-v4-indexer" }}
@@ -104,13 +106,15 @@
     {{- if kindIs "invalid" $._rox.scannerV4.matcher.serviceTLS.generate }}
       {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
       {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
-      {{- $lookupOut := dict -}}
-      {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-matcher-tls") -}}
-      {{- if not $lookupOut.result -}}
-        {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
-        {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
-        {{- $_ := set $._rox.scannerV4.matcher.serviceTLS "generate" true -}}
-      {{- end -}}
+      {{- if $.Release.IsUpgrade -}}
+        {{- $lookupOut := dict -}}
+        {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-matcher-tls") -}}
+        {{- if not $lookupOut.result -}}
+          {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
+          {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
+          {{- $_ := set $._rox.scannerV4.matcher.serviceTLS "generate" true -}}
+        {{- end -}}
+      {{- end }}
     {{- end }}
     {{ $cryptoSpec := dict "CN" "SCANNER_V4_MATCHER_SERVICE: Scanner V4 Matcher" "dnsBase" "scanner-v4-matcher" }}
     {{ include "srox.configureCrypto" (list $ "scannerV4.matcher.serviceTLS" $cryptoSpec) }}
@@ -121,12 +125,14 @@
   {{- if kindIs "invalid" $._rox.scannerV4.db.serviceTLS.generate }}
     {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
     {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
-    {{- $lookupOut := dict -}}
-    {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-db-tls") -}}
-    {{- if not $lookupOut.result -}}
-      {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
-      {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
-      {{- $_ := set $._rox.scannerV4.db.serviceTLS "generate" true -}}
+    {{- if $.Release.IsUpgrade -}}
+      {{- $lookupOut := dict -}}
+      {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-db-tls") -}}
+      {{- if not $lookupOut.result -}}
+        {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
+        {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
+        {{- $_ := set $._rox.scannerV4.db.serviceTLS "generate" true -}}
+      {{- end -}}
     {{- end -}}
   {{- end }}
   {{- if kindIs "invalid" $._rox.scannerV4.db.password.generate }}

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -165,7 +165,7 @@ defaults:
 
 [<- if .FeatureFlags.ROX_SCANNER_V4_SUPPORT >]
   scannerV4:
-    disable: true
+    disable: false
     matcher:
       metricsPort: 9090
       autoscaling:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -231,3 +231,21 @@ tests:
   expect: |
     .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.repository_to_cpe_url | assertThat(contains("https://central.stackrox.svc/api/extensions/scannerdefinitions"))
     .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.name_to_repos_url | assertThat(contains("https://central.stackrox.svc/api/extensions/scannerdefinitions"))
+
+- name: "Scanner V4 is installed by default"
+  set:
+    scannerV4.disable: null
+  expect: |
+    .deployments["scanner-v4-indexer"] | assertThat(. != null)
+    .deployments["scanner-v4-matcher"] | assertThat(. != null)
+    .deployments["scanner-v4-db"] | assertThat(. != null)
+
+- name: "Scanner V4 can be disabled without impacting Scanner V2"
+  set:
+    scannerV4.disable: true
+  expect: |
+    .deployments["scanner-v4-indexer"] | assertThat(. == null)
+    .deployments["scanner-v4-matcher"] | assertThat(. == null)
+    .deployments["scanner-v4-db"] | assertThat(. == null)
+    .deployments["scanner"] | assertThat(. != null)
+    .deployments["scanner-db"] | assertThat(. != null)

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -80,7 +80,8 @@ tests:
 - name: "Install mode is reported by Helm chart installation notes"
   tests:
   - name: "when installing neither indexer nor matcher"
-    scannerV4.disable: true
+    set:
+      scannerV4.disable: true
     expect: |
       .notes | assertThat(match("Scanner V4 Installation Method: +none"))
   - name: "when installing indexer and matcher"


### PR DESCRIPTION
## Description

Actually we only wanted to merge this change: https://github.com/stackrox/stackrox/pull/9529/files#diff-d987dde6c0295b6166f8fc0b16b92ed97f68f96907aad8045fe5aef490a11488R168

So that *by default* Scanner V4 is installed with the central-services Helm chart. This comes as a requirement for the Scanner V4 initiative.

But this change alone caused `helm lint <central-services-chart>` to fail. Explanation for this behaviour can be found in a comment in the diff.

So this PR also modifies the behaviour of the Helm chart so that Helm linting works.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] Determined and documented upgrade steps
- [x] ~~Documented user facing changes~~

Regarding:

- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Documented user facing changes
> Updating the user-visible documentation for the Scanner V4 integration is tracked in separate tickets, hence doesn't need to be done here.

- [ ] Determined and documented upgrade steps

> Some upgrade tests exist already, others will be added as part of the remaining work for the Scanner V4 installation.

I believe the two remaining CI failures are due to flaky tests.

## Testing Performed

Local testing plus CI.

### Here I tell how I validated my change

* Execute unit tests.
* Specifically executed
```
roxctl helm output central-services --output-dir ./stackrox-central-services-chart --remove --debug && helm lint ./stackrox-central-services-chart
```

### Reminder for reviewers

Please resolve my comments in the diff.
