### PR TITLE
test(scanv4): Slice 1: (Prefactoring) Fix global resource names [DONT MERGE]

### DIFF
--- a/image/templates/helm/shared/templates/_metadata.tpl
+++ b/image/templates/helm/shared/templates/_metadata.tpl
@@ -173,6 +173,9 @@
     {{- printf "%s-%s" $._rox.globalPrefix (trimPrefix "stackrox-" $name) -}}
   {{- else if hasPrefix "stackrox:" $name -}}
     {{- printf "%s:%s" $._rox.globalPrefix (trimPrefix "stackrox:" $name) -}}
+  {{- else if eq "stackrox" $name -}}
+    {{/* Edge-case: the resource name doesn't have a "stackrox[-:]" prefix, but it is only "stackrox". */}}
+    {{- printf "%s" $._rox.globalPrefix -}}
   {{- else -}}
     {{- include "srox.fail" (printf "Unknown naming convention for global resource %q." $name) -}}
   {{- end -}}

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller-pod-security.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller-pod-security.yaml
@@ -4,7 +4,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: stackrox-admission-control
+  name: {{ include "srox.globalResourceName" (list . "stackrox-admission-control") }}
   labels:
     {{- include "srox.labels" (list . "podsecuritypolicy" "stackrox-admission-control") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -39,7 +39,7 @@ spec:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox-admission-control-psp
+  name: {{ include "srox.globalResourceName" (list . "stackrox-admission-control-psp") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox-admission-control-psp") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller-pod-security.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller-pod-security.yaml
@@ -51,7 +51,7 @@ rules:
     resources:
       - podsecuritypolicies
     resourceNames:
-      - stackrox-admission-control
+      - {{ include "srox.globalResourceName" (list . "stackrox-admission-control") }}
     verbs:
       - use
 ---

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -159,7 +159,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 {{- end }}
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: stackrox
+  name: {{ include "srox.globalResourceName" (list . "stackrox") }}
   labels:
     {{- include "srox.labels" (list . "validatingwebhookconfiguration" "stackrox") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -206,7 +206,7 @@ webhooks:
       - key: namespace.metadata.stackrox.io/name
         operator: NotIn
         values:
-          - stackrox
+          - {{ ._rox._namespace }}
           - kube-system
           - kube-public
           - istio-system

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector-pod-security.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector-pod-security.yaml
@@ -4,7 +4,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox-collector-psp
+  name: {{ include "srox.globalResourceName" (list . "stackrox-collector-psp") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox-collector-psp") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -16,7 +16,7 @@ rules:
     resources:
       - podsecuritypolicies
     resourceNames:
-      - stackrox-collector
+      - {{ include "srox.globalResourceName" (list . "stackrox-collector") }}
     verbs:
       - use
 ---
@@ -33,7 +33,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: stackrox-collector-psp
+  name: {{ include "srox.globalResourceName" (list . "stackrox-collector-psp") }}
 subjects:
   - kind: ServiceAccount
     name: collector
@@ -42,7 +42,7 @@ subjects:
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: stackrox-collector
+  name: {{ include "srox.globalResourceName" (list . "stackrox-collector") }}
   labels:
     {{- include "srox.labels" (list . "podsecuritypolicy" "stackrox-collector") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-pod-security.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-pod-security.yaml
@@ -4,7 +4,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stackrox-sensor-psp
+  name: {{ include "srox.globalResourceName" (list . "stackrox-sensor-psp") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox-sensor-psp") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"
@@ -16,7 +16,7 @@ rules:
     resources:
       - podsecuritypolicies
     resourceNames:
-      - stackrox-sensor
+      - {{ include "srox.globalResourceName" (list . "stackrox-sensor") }}
     verbs:
       - use
 ---
@@ -33,7 +33,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: stackrox-sensor-psp
+  name: {{ include "srox.globalResourceName" (list . "stackrox-sensor-psp") }}
 subjects:
   - kind: ServiceAccount
     name: sensor
@@ -45,7 +45,7 @@ subjects:
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: stackrox-sensor
+  name: {{ include "srox.globalResourceName" (list . "stackrox-sensor") }}
   labels:
     {{- include "srox.labels" (list . "podsecuritypolicy" "stackrox-sensor") | nindent 4 }}
     auto-upgrade.stackrox.io/component: "sensor"

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -140,3 +140,17 @@ tests:
       disable: false
   expect: |
     .deployments["scanner-v4-indexer"] | assertThat(. == null)
+
+- name: "Global resource ValidatingWebHook"
+  tests:
+  - name: "is not renamed for standard namespace"
+    expect: |
+      .validatingwebhookconfigurations["stackrox"] | assertThat(. != null)
+  - name: "is adapted to custom namespaces"
+    release:
+      namespace: custom-ns
+    set:
+      allowNonstandardNamespace: true
+    expect: |
+      .validatingwebhookconfigurations["stackrox"] | assertThat(. == null)
+      .validatingwebhookconfigurations["stackrox-custom-ns"] | assertThat(. != null)


### PR DESCRIPTION
## Description

While working on the multi-namespace tests for Scanner V4 I had to fix a couple of issues along the way. This is the first chunk of such fixes, which makes sure that global resources in our Helm charts are namespace-prefixed in case a non-stackrox namespace has been configured. This is to avoid resource clashes during Helm installation.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
