### PR TITLE
feat(scanner): Add readiness and liveness

### DIFF
--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -82,17 +82,13 @@ spec:
             drop: ["NET_RAW"]
           runAsNonRoot: true
           runAsUser: 65534
-# TODO(mclamei): Enable when the grpc healthcheck in indexer works.
-#
-# {{ if semverCompare ">= 1.24.0" ._rox._apiServer.version }}
-#         readinessProbe:
-#           grpc:
-#             port: 8443
-#           timeoutSeconds: 10
-#           periodSeconds: 10
-#           failureThreshold: 6
-#           successThreshold: 1
-# {{- end }}
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /health/readiness
+            port: 9443
+          periodSeconds: 5
+          timeoutSeconds: 1
         volumeMounts:
         - name: additional-ca-volume
           mountPath: /usr/local/share/ca-certificates/

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
@@ -82,17 +82,13 @@ spec:
             drop: ["NET_RAW"]
           runAsNonRoot: true
           runAsUser: 65534
-# TODO(mclamei): Enable when the grpc healthcheck in indexer works.
-#
-# {{ if semverCompare ">= 1.24.0" ._rox._apiServer.version }}
-#         readinessProbe:
-#           grpc:
-#             port: 8443
-#           timeoutSeconds: 10
-#           periodSeconds: 10
-#           failureThreshold: 6
-#           successThreshold: 1
-# {{- end }}
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /health/readiness
+            port: 9443
+          periodSeconds: 5
+          timeoutSeconds: 1
         volumeMounts:
         - name: additional-ca-volume
           mountPath: /usr/local/share/ca-certificates/

--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	golog "log"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -105,7 +106,7 @@ func main() {
 		os.Exit(1)
 	}
 	defer backends.Close(ctx)
-	zlog.Info(ctx).Msg("backends are ready")
+	zlog.Info(ctx).Msg("backends created")
 
 	// Initialize gRPC API service.
 	grpcSrv, err := createGRPCService(backends, cfg)
@@ -149,8 +150,9 @@ func createGRPCService(backends *Backends, cfg *config.Config) (grpc.API, error)
 		return nil, fmt.Errorf("identity extractor: %w", err)
 	}
 
-	// Create gRPC API service and debug routes.
-	customRoutes := make([]routes.CustomRoute, 0, len(routes.DebugRoutes))
+	// Custom routes: debugging.
+	customRoutes := make([]routes.CustomRoute, 0, len(routes.DebugRoutes)+
+		len(backends.HealthRoutes()))
 	for path, handler := range routes.DebugRoutes {
 		customRoutes = append(customRoutes, routes.CustomRoute{
 			Route:         path,
@@ -159,6 +161,11 @@ func createGRPCService(backends *Backends, cfg *config.Config) (grpc.API, error)
 			Compression:   true,
 		})
 	}
+
+	// Custom routes: health checking.
+	customRoutes = append(customRoutes, backends.HealthRoutes()...)
+
+	// Create gRPC API service.
 	grpcSrv := grpc.NewAPI(grpc.Config{
 		CustomRoutes:       customRoutes,
 		IdentityExtractors: []authn.IdentityExtractor{identityExtractor},
@@ -181,7 +188,7 @@ func createGRPCService(backends *Backends, cfg *config.Config) (grpc.API, error)
 	})
 
 	// Register API services.
-	grpcSrv.Register(getServices(backends)...)
+	grpcSrv.Register(backends.APIServices()...)
 
 	return grpcSrv, nil
 }
@@ -219,8 +226,8 @@ func createBackends(ctx context.Context, cfg *config.Config) (*Backends, error) 
 	return &b, nil
 }
 
-// getServices returns the list of the API services based on the backends provided.
-func getServices(b *Backends) []grpc.APIService {
+// APIServices returns the list of the gRPC API services based on the configured backends.
+func (b *Backends) APIServices() []grpc.APIService {
 	var srvs []grpc.APIService
 	if b.Indexer != nil {
 		srvs = append(srvs, services.NewIndexerService(b.Indexer))
@@ -238,7 +245,45 @@ func getServices(b *Backends) []grpc.APIService {
 	return srvs
 }
 
-// Close closes all the backends used by the scanner.
+// HealthCheck returns true if all configured backends are healthy and ready.
+func (b *Backends) HealthCheck(ctx context.Context) bool {
+	var checkList []func(context.Context) error
+	if b.Indexer != nil {
+		checkList = append(checkList, b.Indexer.Ready)
+	}
+	if b.Matcher != nil {
+		checkList = append(checkList, b.Matcher.Ready)
+	}
+	for _, check := range checkList {
+		if err := check(ctx); err != nil {
+			zlog.Error(ctx).Err(err).Msg("scanner is not ready")
+			return false
+		}
+	}
+	return true
+}
+
+// HealthRoutes returns HTTP routes for health checking the configured backends.
+func (b *Backends) HealthRoutes() (r []routes.CustomRoute) {
+	for n, h := range map[string]http.HandlerFunc{
+		"/health/readiness": func(w http.ResponseWriter, r *http.Request) {
+			st := http.StatusOK
+			if !b.HealthCheck(r.Context()) {
+				st = http.StatusServiceUnavailable
+			}
+			w.WriteHeader(st)
+		},
+	} {
+		r = append(r, routes.CustomRoute{
+			Route:         n,
+			Authorizer:    allow.Anonymous(),
+			ServerHandler: h,
+		})
+	}
+	return r
+}
+
+// Close closes all the backends used by scanner.
 func (b *Backends) Close(ctx context.Context) {
 	type Closeable interface {
 		Close(context.Context) error

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -88,6 +88,7 @@ type Indexer interface {
 	ReportGetter
 	IndexContainerImage(context.Context, string, string, ...Option) (*claircore.IndexReport, error)
 	Close(context.Context) error
+	Ready(context.Context) error
 }
 
 // localIndexer is the Indexer implementation that runs libindex locally.
@@ -220,6 +221,13 @@ func (i *localIndexer) Close(ctx context.Context) error {
 	err := errors.Join(i.libIndex.Close(ctx), os.RemoveAll(i.root))
 	i.pool.Close()
 	return err
+}
+
+func (i *localIndexer) Ready(ctx context.Context) error {
+	if err := i.pool.Ping(ctx); err != nil {
+		return fmt.Errorf("indexer DB ping failed: %w", err)
+	}
+	return nil
 }
 
 // IndexContainerImage creates a ClairCore index report for a given container

--- a/scanner/indexer/mocks/indexer.go
+++ b/scanner/indexer/mocks/indexer.go
@@ -129,3 +129,17 @@ func (mr *MockIndexerMockRecorder) IndexContainerImage(arg0, arg1, arg2 any, arg
 	varargs := append([]any{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexContainerImage", reflect.TypeOf((*MockIndexer)(nil).IndexContainerImage), varargs...)
 }
+
+// Ready mocks base method.
+func (m *MockIndexer) Ready(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ready", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Ready indicates an expected call of Ready.
+func (mr *MockIndexerMockRecorder) Ready(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ready", reflect.TypeOf((*MockIndexer)(nil).Ready), arg0)
+}

--- a/scanner/matcher/mocks/matcher.go
+++ b/scanner/matcher/mocks/matcher.go
@@ -98,3 +98,31 @@ func (mr *MockMatcherMockRecorder) GetVulnerabilities(ctx, ir any) *gomock.Call 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVulnerabilities", reflect.TypeOf((*MockMatcher)(nil).GetVulnerabilities), ctx, ir)
 }
+
+// Initialized mocks base method.
+func (m *MockMatcher) Initialized(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Initialized", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Initialized indicates an expected call of Initialized.
+func (mr *MockMatcherMockRecorder) Initialized(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialized", reflect.TypeOf((*MockMatcher)(nil).Initialized), ctx)
+}
+
+// Ready mocks base method.
+func (m *MockMatcher) Ready(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ready", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Ready indicates an expected call of Ready.
+func (mr *MockMatcherMockRecorder) Ready(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ready", reflect.TypeOf((*MockMatcher)(nil).Ready), ctx)
+}

--- a/scanner/services/matcher_test.go
+++ b/scanner/services/matcher_test.go
@@ -55,11 +55,30 @@ func (s *matcherServiceTestSuite) Test_matcherService_NewMatcherService() {
 func (s *matcherServiceTestSuite) Test_matcherService_GetVulnerabilities_empty_contents_disbled() {
 	// when empty content is disabled and empty contents then error
 	srv := NewMatcherService(s.matcherMock, nil)
+	s.matcherMock.
+		EXPECT().
+		Initialized(gomock.Any()).
+		Return(nil)
 	res, err := srv.GetVulnerabilities(s.ctx, &v4.GetVulnerabilitiesRequest{
 		HashId:   "/v4/containerimage/sample-hash-id",
 		Contents: nil,
 	})
 	s.ErrorContains(err, "empty contents is disabled")
+	s.Nil(res)
+}
+
+func (s *matcherServiceTestSuite) Test_matcherService_GetVulnerabilities_not_initialized() {
+	// when matcher is not initialized then error
+	srv := NewMatcherService(s.matcherMock, nil)
+	s.matcherMock.
+		EXPECT().
+		Initialized(gomock.Any()).
+		Return(errors.New("not initialized"))
+	res, err := srv.GetVulnerabilities(s.ctx, &v4.GetVulnerabilitiesRequest{
+		HashId:   "/v4/containerimage/sample-hash-id",
+		Contents: nil,
+	})
+	s.ErrorContains(err, "not initialized")
 	s.Nil(res)
 }
 
@@ -84,6 +103,10 @@ func (s *matcherServiceTestSuite) Test_matcherService_GetVulnerabilities_empty_c
 					"1": {ID: "1", Name: "Foobar"},
 				},
 			}, nil)
+		s.matcherMock.
+			EXPECT().
+			Initialized(gomock.Any()).
+			Return(nil)
 		srv := NewMatcherService(s.matcherMock, s.indexerMock)
 		res, err := srv.GetVulnerabilities(s.ctx, &v4.GetVulnerabilitiesRequest{
 			HashId:   hashID,
@@ -114,6 +137,10 @@ func (s *matcherServiceTestSuite) Test_matcherService_GetVulnerabilities_empty_c
 					"1": {ID: "1", Name: "Foobar", CPE: cpe.MustUnbind(emptyCPE)},
 				},
 			}, nil)
+		s.matcherMock.
+			EXPECT().
+			Initialized(gomock.Any()).
+			Return(nil)
 		srv := NewMatcherService(s.matcherMock, nil)
 		res, err := srv.GetVulnerabilities(s.ctx, &v4.GetVulnerabilitiesRequest{
 			HashId: hashID,


### PR DESCRIPTION
## Description

Introduce HTTP routes to probe Scanner (Matcher, Indexer, or Combo) readiness based on the status provided by each backend.

1. **Indexer**: Database connection is OK.
2. **Matcher**: Database connection is OK, and vulnerability store is initialized (i.e. there are some vulnerabilities).
3. ~**Remote Indexer**: gRPC connection is ready or idle. Please give your opinion on keeping or removing this since the `Matcher` can perform Secured Cluster scans even if the Remote Indexer is not up.~ Check was removed after discussion in the PR.

Adding a gRPC endpoint for Health might make the Remote Indexer check more robust. I can do that separately.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))


## Testing Performed

### Here I tell how I validated my change

#### Deploy to OCP

1. Build Helm charts using `roxctl`:
   ```
   	roxctl helm output $(notdir $(@D)) \
	    --image-defaults=development_build \
	    --debug \
	    --debug-path image \
	    --remove \
	    --output-dir $(@D)
   ```
2. Deploy using helm

#### Verify Readiness

1. Check readiness of Matcher and Indexer.
2. Set 0 replicas for the Indexer, observe Matcher readiness flip to false
3. Set 0 replicas for Scanner DB, observer Matcher readiness flip to false
5. Turn back the replica count in (2.) and (3.), observe readiness come back to true.

#### Local testing

1. Run `scanner` locally, ping the endoints manually using ``curl localhost:9884/health/liveness` or similar.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
