### PR TITLE
ROX-21467: Cancelled requests should not show in tables

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/ExceptionManagement.helpers.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/ExceptionManagement.helpers.ts
@@ -56,3 +56,36 @@ export function deferAndVisitRequestDetails({
             });
     });
 }
+
+// @TODO: We could possibly just use a single function for deferral/false positive
+export function markFalsePositiveAndVisitRequestDetails({
+    comment,
+    scope,
+}: {
+    comment: string;
+    scope: string;
+}) {
+    visitWorkloadCveOverview();
+    cy.get(vulnSelectors.clearFiltersButton).click(); // Note: This is a workaround to prevent a lack of CVE data from causing the test to fail in CI
+
+    // mark a single cve as false positive
+    selectSingleCveForException('FALSE_POSITIVE').then((cveName) => {
+        verifySelectedCvesInModal([cveName]);
+        fillAndSubmitExceptionForm({ comment });
+        verifyExceptionConfirmationDetails({
+            expectedAction: 'False positive',
+            cves: [cveName],
+            scope,
+        });
+        cy.get(workloadCVESelectors.copyToClipboardButton).click();
+        cy.get(workloadCVESelectors.copyToClipboardTooltipText).contains('Copied');
+        // @TODO: Can make this into a custom cypress command (ie. getClipboardText)
+        cy.window()
+            .then((win) => {
+                return win.navigator.clipboard.readText();
+            })
+            .then((url) => {
+                visit(url);
+            });
+    });
+}

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approveRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approveRequestFlow.test.ts
@@ -8,6 +8,18 @@ const comment = 'Defer me';
 const expiry = 'When all CVEs are fixable';
 const scope = 'All images';
 
+export function approveRequest() {
+    cy.get('button:contains("Approve request")').click();
+    cy.get('div[role="dialog"]').should('exist');
+    getInputByLabel('Approval rationale').type('Approved');
+    cy.get('div[role="dialog"] button:contains("Approve")').click();
+    cy.get('div[role="dialog"]').should('not.exist');
+    cy.get('div[aria-label="Success Alert"]').should(
+        'contain',
+        'The vulnerability request was successfully approved.'
+    );
+}
+
 describe('Exception Management Request Details Page', () => {
     withAuth();
 
@@ -47,14 +59,6 @@ describe('Exception Management Request Details Page', () => {
     });
 
     it('should be able to approve a request if approval permissions are granted', () => {
-        cy.get('button:contains("Approve request")').click();
-        cy.get('div[role="dialog"]').should('exist');
-        getInputByLabel('Approval rationale').type('Approved');
-        cy.get('div[role="dialog"] button:contains("Approve")').click();
-        cy.get('div[role="dialog"]').should('not.exist');
-        cy.get('div[aria-label="Success Alert"]').should(
-            'contain',
-            'The vulnerability request was successfully approved.'
-        );
+        approveRequest();
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
@@ -1,7 +1,12 @@
 import withAuth from '../../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../../helpers/features';
 import { cancelAllCveExceptions } from '../workloadCves/WorkloadCves.helpers';
-import { deferAndVisitRequestDetails, pendingRequestsPath } from './ExceptionManagement.helpers';
+import {
+    deferAndVisitRequestDetails,
+    markFalsePositiveAndVisitRequestDetails,
+    pendingRequestsPath,
+} from './ExceptionManagement.helpers';
+import { approveRequest } from './approveRequestFlow.test';
 
 const comment = 'Defer me';
 const expiry = 'When all CVEs are fixable';
@@ -27,11 +32,6 @@ describe('Exception Management Request Details Page', () => {
             hasFeatureFlag('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS')
         ) {
             cancelAllCveExceptions();
-            deferAndVisitRequestDetails({
-                comment,
-                expiry,
-                scope,
-            });
         }
     });
 
@@ -46,6 +46,11 @@ describe('Exception Management Request Details Page', () => {
     });
 
     it('should be able to cancel a request if the user is the requester', () => {
+        deferAndVisitRequestDetails({
+            comment,
+            expiry,
+            scope,
+        });
         cy.get('button:contains("Cancel request")').click();
         cy.get('div[role="dialog"]').should('exist');
         cy.get('div[role="dialog"] button:contains("Cancel request")').click();
@@ -53,14 +58,49 @@ describe('Exception Management Request Details Page', () => {
         cy.location().should((location) => {
             expect(location.pathname).to.eq(pendingRequestsPath);
         });
+        cy.get('table tbody tr').should('not.exist');
     });
 
     it('should be able to see how many CVEs will be affected by a cancel', () => {
+        deferAndVisitRequestDetails({
+            comment,
+            expiry,
+            scope,
+        });
         cy.get('table tbody tr:not(".pf-c-table__expandable-row")').then((rows) => {
             const numCVEs = rows.length;
             cy.get('button:contains("Cancel request")').click();
             cy.get('div[role="dialog"]').should('exist');
             cy.get(`div:contains("CVE count: ${numCVEs}")`).should('exist');
         });
+    });
+
+    it('should not see a cancelled request in the approved deferrals table', () => {
+        deferAndVisitRequestDetails({
+            comment,
+            expiry,
+            scope,
+        });
+        approveRequest();
+        cy.get('button:contains("Cancel request")').click();
+        cy.get('div[role="dialog"]').should('exist');
+        cy.get('div[role="dialog"] button:contains("Cancel request")').click();
+        cy.get('div[role="dialog"]').should('not.exist');
+        cy.get('button[role="tab"]:contains("Approved deferrals")').click();
+        cy.get('table tbody tr').should('not.exist');
+    });
+
+    it('should not see a cancelled request in the approved false positives table', () => {
+        markFalsePositiveAndVisitRequestDetails({
+            comment,
+            scope,
+        });
+        approveRequest();
+        cy.get('button:contains("Cancel request")').click();
+        cy.get('div[role="dialog"]').should('exist');
+        cy.get('div[role="dialog"] button:contains("Cancel request")').click();
+        cy.get('div[role="dialog"]').should('not.exist');
+        cy.get('button[role="tab"]:contains("Approved false positives")').click();
+        cy.get('table tbody tr').should('not.exist');
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -74,6 +74,7 @@ function ApprovedDeferrals() {
                     ...searchFilter,
                     'Request Status': ['APPROVED', 'APPROVED_PENDING_UPDATE'],
                     'Requested Vulnerability State': 'DEFERRED',
+                    'Expired Request': 'false',
                 },
                 sortOption,
                 page - 1,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -67,6 +67,7 @@ function ApprovedFalsePositives() {
                     ...searchFilter,
                     'Request Status': ['APPROVED', 'APPROVED_PENDING_UPDATE'],
                     'Requested Vulnerability State': 'FALSE_POSITIVE',
+                    'Expired Request': 'false',
                 },
                 sortOption,
                 page - 1,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -73,6 +73,7 @@ function DeniedRequests() {
                 {
                     ...searchFilter,
                     'Request Status': ['DENIED'],
+                    'Expired Request': 'false',
                 },
                 sortOption,
                 page - 1,


### PR DESCRIPTION
## Description

This PR will filter out cancelled requests within the `Approved deferrals`, `Approved false positives`, and `Denied requests` tables.

## Screen Recording

https://github.com/stackrox/stackrox/assets/4805485/9ae8fe4b-fe93-4220-8722-efe1b8a49f95

## Tests

<img width="1552" alt="Screenshot 2024-01-24 at 4 47 40 PM" src="https://github.com/stackrox/stackrox/assets/4805485/df1f4bc1-e87f-49f7-8da8-fd63f19e65ab">

