### PR TITLE
ROX-21672: Clear stale NG data when the scope is zero deployments

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
@@ -6,6 +6,7 @@ import { useFetchClusterNamespacesForPermissions } from 'hooks/useFetchClusterNa
 import useFetchNamespaceDeployments from 'hooks/useFetchNamespaceDeployments';
 import { nonGlobalResourceNamesForNetworkGraph } from 'routePaths';
 
+import { SearchFilter } from 'types/search';
 import ClusterSelector, { ClusterSelectorProps } from './ClusterSelector';
 import NamespaceSelector from './NamespaceSelector';
 import DeploymentSelector from './DeploymentSelector';
@@ -15,6 +16,7 @@ export type NetworkBreadcrumbsProps = {
     selectedCluster: { name: string; id: string };
     selectedNamespaces: string[];
     selectedDeployments: string[];
+    onScopeChange: (newFilter: SearchFilter) => void;
 };
 
 function NetworkBreadcrumbs({
@@ -22,6 +24,7 @@ function NetworkBreadcrumbs({
     selectedCluster,
     selectedNamespaces,
     selectedDeployments,
+    onScopeChange,
 }: NetworkBreadcrumbsProps) {
     const { searchFilter, setSearchFilter } = useURLSearch();
 
@@ -34,6 +37,11 @@ function NetworkBreadcrumbs({
     }, []);
     const { deploymentsByNamespace } = useFetchNamespaceDeployments(selectedNamespaceIds);
 
+    const onChange = (newFilter: SearchFilter) => {
+        setSearchFilter(newFilter);
+        onScopeChange(newFilter);
+    };
+
     return (
         <>
             <Breadcrumb>
@@ -42,7 +50,7 @@ function NetworkBreadcrumbs({
                         clusters={clusters}
                         selectedClusterName={selectedCluster?.name ?? ''}
                         searchFilter={searchFilter}
-                        setSearchFilter={setSearchFilter}
+                        setSearchFilter={onChange}
                     />
                 </BreadcrumbItem>
                 <BreadcrumbItem isDropdown>
@@ -52,7 +60,7 @@ function NetworkBreadcrumbs({
                         selectedDeployments={selectedDeployments}
                         deploymentsByNamespace={deploymentsByNamespace}
                         searchFilter={searchFilter}
-                        setSearchFilter={setSearchFilter}
+                        setSearchFilter={onChange}
                     />
                 </BreadcrumbItem>
                 <BreadcrumbItem isDropdown>
@@ -60,7 +68,7 @@ function NetworkBreadcrumbs({
                         deploymentsByNamespace={deploymentsByNamespace}
                         selectedDeployments={selectedDeployments}
                         searchFilter={searchFilter}
-                        setSearchFilter={setSearchFilter}
+                        setSearchFilter={onChange}
                     />
                 </BreadcrumbItem>
             </Breadcrumb>

--- a/ui/apps/platform/src/hooks/useFetchDeploymentCount.ts
+++ b/ui/apps/platform/src/hooks/useFetchDeploymentCount.ts
@@ -1,10 +1,14 @@
-import { gql, useQuery, ApolloError } from '@apollo/client';
+import { gql, useQuery, ApolloError, QueryHookOptions } from '@apollo/client';
 
 import { SearchFilter } from 'types/search';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 type DeploymentCountResponse = {
     count: number;
+};
+
+type DeploymentCountParameters = {
+    query: string;
 };
 
 type UseFetchDeploymentCount = {
@@ -19,12 +23,15 @@ const DEPLOYMENT_COUNT_QUERY = gql`
     }
 `;
 
-function useFetchDeploymentCount(searchFilter: SearchFilter): UseFetchDeploymentCount {
+function useFetchDeploymentCount(
+    searchFilter: SearchFilter,
+    queryOptions: QueryHookOptions<DeploymentCountResponse, DeploymentCountParameters> = {}
+): UseFetchDeploymentCount {
     const query = getRequestQueryStringForSearchFilter(searchFilter);
-    const queryOptions = { variables: { query } };
+    const options = { ...queryOptions, variables: { query } };
     const { loading, error, data } = useQuery<DeploymentCountResponse, { query: string }>(
         DEPLOYMENT_COUNT_QUERY,
-        queryOptions
+        options
     );
 
     return {


### PR DESCRIPTION
## Description

Handles two edge cases in the Network Graph that lead to incorrect/stale data displayed in the visualization:

1. Selecting a namespace with deployments, deselecting it, and then selecting a namespace with zero deployments causes the old deployment data to be displayed
2. Selecting multiple namespaces (some with and some without deployments) and then deselecting all namespaces that contain deployments causes old deployment data to be displayed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit NG, select a cluster, select `stackrox`, then deselect `stackrox`, then select `default`:
![image](https://github.com/stackrox/stackrox/assets/1292638/ce566226-f41b-4717-b7c5-3b25782a737d)
![image](https://github.com/stackrox/stackrox/assets/1292638/178996e3-56fc-48a2-90ef-f879d1751ff9)
Before:
![image](https://github.com/stackrox/stackrox/assets/1292638/7e88d37b-6d3b-4735-99a3-49c996a0e49d)
After:
![image](https://github.com/stackrox/stackrox/assets/1292638/c9a939b9-4ec4-4ddd-a911-55118888851e)

Visit NG, select `stackrox`, then select `default`. Deselect `stackrox`.
![image](https://github.com/stackrox/stackrox/assets/1292638/0eb6c449-2259-43a7-8bdc-1cb52e6e5c23)
Before:
![image](https://github.com/stackrox/stackrox/assets/1292638/51287afb-435d-48d1-a22a-e54551a8724d)
After:
![image](https://github.com/stackrox/stackrox/assets/1292638/3890daaf-b44f-43a4-8013-d4e0555ff207)

