### PR TITLE
fix(indexer): Add Matcher to API auth

### DIFF
--- a/scanner/services/indexer.go
+++ b/scanner/services/indexer.go
@@ -22,7 +22,7 @@ import (
 )
 
 var indexerAuth = perrpc.FromMap(map[authz.Authorizer][]string{
-	or.SensorOr(idcheck.CentralOnly()): {
+	or.Or(idcheck.CentralOnly(), idcheck.SensorsOnly(), idcheck.ScannerV4MatcherOnly()): {
 		"/scanner.v4.Indexer/CreateIndexReport",
 		"/scanner.v4.Indexer/GetIndexReport",
 		"/scanner.v4.Indexer/HasIndexReport",


### PR DESCRIPTION
## Description

Allows the Scanner V4 Matcher to talk to Indexer.

Should address [failure in CI](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-ocp-4-11-merge-qa-e2e-tests/1750174582217641984) when testing release builds

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TBD

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
