### PR TITLE
ROX-20411: Adding Scanner V4 Certificate Expiration Status

### DIFF
--- a/ui/apps/platform/src/Containers/SystemHealth/DashboardPage.js
+++ b/ui/apps/platform/src/Containers/SystemHealth/DashboardPage.js
@@ -110,6 +110,14 @@ const SystemHealthDashboardPage = () => {
                     <GridItem span={12}>
                         <CertificateCard component="SCANNER" pollingCount={pollingCountSlower} />
                     </GridItem>
+                    {hasAccessForScannerV4 && (
+                        <GridItem span={12}>
+                            <CertificateCard
+                                component="SCANNER_V4"
+                                pollingCount={pollingCountSlower}
+                            />
+                        </GridItem>
+                    )}
                 </Grid>
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/SystemHealth/DashboardPage.js
+++ b/ui/apps/platform/src/Containers/SystemHealth/DashboardPage.js
@@ -110,7 +110,7 @@ const SystemHealthDashboardPage = () => {
                     <GridItem span={12}>
                         <CertificateCard component="SCANNER" pollingCount={pollingCountSlower} />
                     </GridItem>
-                    {hasAccessForScannerV4 && (
+                    {isScannerV4Enabled && (
                         <GridItem span={12}>
                             <CertificateCard
                                 component="SCANNER_V4"

--- a/ui/apps/platform/src/services/CertGenerationService.ts
+++ b/ui/apps/platform/src/services/CertGenerationService.ts
@@ -7,6 +7,7 @@ const certGenBaseURL = '/api/extensions/certgen';
 const pathSegmentForComponent: Record<CertExpiryComponent, string> = {
     CENTRAL: 'central',
     SCANNER: 'scanner',
+    SCANNER_V4: 'scanner?v=4',
 };
 
 export function generateCertSecretForComponent(component: CertExpiryComponent) {

--- a/ui/apps/platform/src/types/credentialExpiryService.proto.ts
+++ b/ui/apps/platform/src/types/credentialExpiryService.proto.ts
@@ -1,1 +1,1 @@
-export type CertExpiryComponent = 'CENTRAL' | 'SCANNER'; // omit 'UNKNOWN'
+export type CertExpiryComponent = 'CENTRAL' | 'SCANNER' | 'SCANNER_V4'; // omit 'UNKNOWN'

--- a/ui/apps/platform/src/utils/credentialExpiry.ts
+++ b/ui/apps/platform/src/utils/credentialExpiry.ts
@@ -31,5 +31,6 @@ export function getCredentialExpiryVariant(
 
 export const nameOfComponent: Record<CertExpiryComponent, string> = {
     CENTRAL: 'Central',
-    SCANNER: 'Scanner',
+    SCANNER: 'StackRox Scanner',
+    SCANNER_V4: 'Scanner V4',
 };


### PR DESCRIPTION
## Description

This PR includes these main changes:
1. Rename the `Scanner certificate` card to `StackRox Scanner certificate`
2. Add another card for `Scanner V4 certificate` for the new scanner
3. Modify the API service function to explicitly state which component we need to query for

## Screenshots

<img width="1440" alt="Screenshot 2024-01-24 at 12 34 49 PM" src="https://github.com/stackrox/stackrox/assets/4805485/6ee30280-37c0-4ce7-9fd6-1b4f99e00530">
