### PR TITLE
ROX-21956: compliance profiles use separate pipelines for V1 and V2

### DIFF
--- a/central/convert/internaltov2storage/compliance_operator_profile.go
+++ b/central/convert/internaltov2storage/compliance_operator_profile.go
@@ -1,4 +1,4 @@
-package internaltostorage
+package internaltov2storage
 
 import (
 	"fmt"
@@ -36,26 +36,5 @@ func ComplianceOperatorProfileV2(internalMsg *central.ComplianceOperatorProfileV
 		Product:        internalMsg.GetAnnotations()[v1alpha1.ProductAnnotation],
 		Title:          internalMsg.GetTitle(),
 		Values:         internalMsg.GetValues(),
-	}
-}
-
-// ComplianceOperatorProfileV1 converts V2 internal api profiles to V1 storage profiles
-func ComplianceOperatorProfileV1(internalMsg *central.ComplianceOperatorProfileV2, clusterID string) *storage.ComplianceOperatorProfile {
-	var rules []*storage.ComplianceOperatorProfile_Rule
-	for _, r := range internalMsg.GetRules() {
-		rules = append(rules, &storage.ComplianceOperatorProfile_Rule{
-			Name: r.GetRuleName(),
-		})
-	}
-
-	return &storage.ComplianceOperatorProfile{
-		Id:          internalMsg.GetId(),
-		ProfileId:   internalMsg.GetProfileId(),
-		Name:        internalMsg.GetName(),
-		ClusterId:   clusterID,
-		Labels:      internalMsg.GetLabels(),
-		Annotations: internalMsg.GetAnnotations(),
-		Description: internalMsg.GetDescription(),
-		Rules:       rules,
 	}
 }

--- a/central/sensor/service/connection/sensorevents.go
+++ b/central/sensor/service/connection/sensorevents.go
@@ -121,19 +121,6 @@ func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.Ms
 		// Node and NodeInventory dedupe on Node ID. We use a different dedupe key for
 		// NodeInventory because the two should not dedupe between themselves.
 		msg.DedupeKey = fmt.Sprintf("NodeInventory:%s", msg.GetDedupeKey())
-	case *central.SensorEvent_ComplianceOperatorProfileV2:
-		if !features.ComplianceEnhancements.Enabled() {
-			log.Warnf("Received next gen compliance event from cluster %s (%s). Next gen compliance is disabled on central.", s.cluster.GetName(), s.cluster.GetId())
-			return
-		}
-		// Due to needing both V1 and V2 compliance to run at the same time and due to how the
-		// reconciliation keys are used we need to use the V1 key for reconciliation.  This could
-		// have been avoided by sending both messages from sensor during the transition, but
-		// that seemed like a lot of extra traffic.
-		workerType = reflectutils.Type(&central.SensorEvent_ComplianceOperatorProfile{})
-		if !s.reconciliationMap.IsClosed() {
-			s.reconciliationMap.Add(&central.SensorEvent_ComplianceOperatorProfile{}, event.Id)
-		}
 	case *central.SensorEvent_ComplianceOperatorScanV2:
 		if !features.ComplianceEnhancements.Enabled() {
 			log.Warnf("Received next gen compliance event from cluster %s (%s). Next gen compliance is disabled on central.", s.cluster.GetName(), s.cluster.GetId())

--- a/central/sensor/service/pipeline/all/factory.go
+++ b/central/sensor/service/pipeline/all/factory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/central/sensor/service/pipeline/clusterstatusupdate"
 	"github.com/stackrox/rox/central/sensor/service/pipeline/complianceoperator/complianceoperatorinfo"
 	"github.com/stackrox/rox/central/sensor/service/pipeline/complianceoperatorprofiles"
+	"github.com/stackrox/rox/central/sensor/service/pipeline/complianceoperatorprofilesv2"
 	"github.com/stackrox/rox/central/sensor/service/pipeline/complianceoperatorresults"
 	"github.com/stackrox/rox/central/sensor/service/pipeline/complianceoperatorresultsv2"
 	"github.com/stackrox/rox/central/sensor/service/pipeline/complianceoperatorrules"
@@ -84,6 +85,7 @@ func (s *factoryImpl) PipelineForCluster(ctx context.Context, clusterID string) 
 		complianceoperatorinfo.GetPipeline(),
 		complianceoperatorrulesv2.GetPipeline(),
 		complianceoperatorresultsv2.GetPipeline(),
+		complianceoperatorprofilesv2.GetPipeline(),
 	}
 
 	deduper := s.manager.GetDeduper(ctx, clusterID)

--- a/central/sensor/service/pipeline/complianceoperatorprofiles/pipeline.go
+++ b/central/sensor/service/pipeline/complianceoperatorprofiles/pipeline.go
@@ -3,11 +3,8 @@ package complianceoperatorprofiles
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/complianceoperator/manager"
 	"github.com/stackrox/rox/central/complianceoperator/profiles/datastore"
-	v2Datastore "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
-	"github.com/stackrox/rox/central/convert/internaltostorage"
 	countMetrics "github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/sensor/service/common"
 	"github.com/stackrox/rox/central/sensor/service/pipeline"
@@ -15,7 +12,6 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/set"
@@ -27,25 +23,20 @@ var (
 
 // GetPipeline returns an instantiation of this particular pipeline
 func GetPipeline() pipeline.Fragment {
-	if features.ComplianceEnhancements.Enabled() {
-		return NewPipeline(datastore.Singleton(), manager.Singleton(), v2Datastore.Singleton())
-	}
-	return NewPipeline(datastore.Singleton(), manager.Singleton(), nil)
+	return NewPipeline(datastore.Singleton(), manager.Singleton())
 }
 
 // NewPipeline returns a new instance of Pipeline.
-func NewPipeline(datastore datastore.DataStore, manager manager.Manager, v2ProfileDatastore v2Datastore.DataStore) pipeline.Fragment {
+func NewPipeline(datastore datastore.DataStore, manager manager.Manager) pipeline.Fragment {
 	return &pipelineImpl{
-		datastore:          datastore,
-		manager:            manager,
-		v2ProfileDatastore: v2ProfileDatastore,
+		datastore: datastore,
+		manager:   manager,
 	}
 }
 
 type pipelineImpl struct {
-	datastore          datastore.DataStore
-	v2ProfileDatastore v2Datastore.DataStore
-	manager            manager.Manager
+	datastore datastore.DataStore
+	manager   manager.Manager
 }
 
 func (s *pipelineImpl) Capabilities() []centralsensor.CentralCapability {
@@ -66,63 +57,21 @@ func (s *pipelineImpl) Reconcile(ctx context.Context, clusterID string, storeMap
 	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
 		return err
 	}
-
-	// For now if nextgen compliance is enabled, we have to reconcile both versions of compliance.
-	if features.ComplianceEnhancements.Enabled() {
-		// For nextgen compliance, reconciliation means disassociating a profile with a cluster.
-		// The profile itself will still remain.
-		profileEdges, err := s.v2ProfileDatastore.GetProfileEdgesByCluster(ctx, clusterID)
-		if err != nil {
-			return err
-		}
-
-		for _, profileEdge := range profileEdges {
-			// The UID is used for reconciliation
-			existingIDs.Add(profileEdge.GetProfileUid())
-		}
-	}
-
 	store := storeMap.Get((*central.SensorEvent_ComplianceOperatorProfile)(nil))
 	return reconciliation.Perform(store, existingIDs, "complianceoperatorprofiles", func(id string) error {
-		if features.ComplianceEnhancements.Enabled() {
-			if err := s.v2ProfileDatastore.DeleteProfileForCluster(ctx, id, clusterID); err != nil {
-				return err
-			}
-		}
-
 		return s.datastore.Delete(ctx, id)
 	})
 }
 
 func (s *pipelineImpl) Match(msg *central.MsgFromSensor) bool {
-	if features.ComplianceEnhancements.Enabled() {
-		return msg.GetEvent().GetComplianceOperatorProfileV2() != nil || msg.GetEvent().GetComplianceOperatorProfile() != nil
-	}
-
 	return msg.GetEvent().GetComplianceOperatorProfile() != nil
 }
 
 // Run runs the pipeline template on the input and returns the output.
-func (s *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.MsgFromSensor, _ common.MessageInjector) error {
+func (s *pipelineImpl) Run(_ context.Context, clusterID string, msg *central.MsgFromSensor, _ common.MessageInjector) error {
 	defer countMetrics.IncrementResourceProcessedCounter(pipeline.ActionToOperation(msg.GetEvent().GetAction()), metrics.ComplianceOperatorProfile)
 
 	event := msg.GetEvent()
-	// If a sensor sends in a v1 compliance message we will still process it the v1 way in the event
-	// a sensor is not updated or does not have the flag on.
-	switch event.Resource.(type) {
-	case *central.SensorEvent_ComplianceOperatorProfile:
-		return s.processComplianceProfile(ctx, event, clusterID)
-	case *central.SensorEvent_ComplianceOperatorProfileV2:
-		if !features.ComplianceEnhancements.Enabled() {
-			return errors.New("Next gen compliance is disabled.  Message unexpected.")
-		}
-		return s.processComplianceProfileV2(ctx, event, clusterID)
-	}
-
-	return errors.Errorf("unexpected message %t.", event.Resource)
-}
-
-func (s *pipelineImpl) processComplianceProfile(_ context.Context, event *central.SensorEvent, clusterID string) error {
 	profile := event.GetComplianceOperatorProfile()
 	profile.ClusterId = clusterID
 
@@ -131,30 +80,6 @@ func (s *pipelineImpl) processComplianceProfile(_ context.Context, event *centra
 		return s.manager.DeleteProfile(profile)
 	default:
 		return s.manager.AddProfile(profile)
-	}
-}
-
-func (s *pipelineImpl) processComplianceProfileV2(ctx context.Context, event *central.SensorEvent, clusterID string) error {
-	if !features.ComplianceEnhancements.Enabled() {
-		return errors.New("Next gen compliance is disabled.  Message unexpected.")
-	}
-
-	profile := event.GetComplianceOperatorProfileV2()
-
-	switch event.GetAction() {
-	case central.ResourceAction_REMOVE_RESOURCE:
-		// For now, we need to process V1 profiles as well to ensure we retain the full capability of V1 compliance
-		if err := s.manager.DeleteProfile(internaltostorage.ComplianceOperatorProfileV1(profile, clusterID)); err != nil {
-			return err
-		}
-		// profiles may be used by other clusters, so only delete the reference to this cluster not the entire profile
-		return s.v2ProfileDatastore.DeleteProfileForCluster(ctx, profile.Id, clusterID)
-	default:
-		// For now, we need to process V1 profiles as well to ensure we retain the full capability of V1 compliance
-		if err := s.manager.AddProfile(internaltostorage.ComplianceOperatorProfileV1(profile, clusterID)); err != nil {
-			return err
-		}
-		return s.v2ProfileDatastore.UpsertProfile(ctx, internaltostorage.ComplianceOperatorProfileV2(profile), clusterID, profile.GetId())
 	}
 }
 

--- a/central/sensor/service/pipeline/complianceoperatorprofiles/pipeline_test.go
+++ b/central/sensor/service/pipeline/complianceoperatorprofiles/pipeline_test.go
@@ -6,14 +6,11 @@ import (
 
 	managerMocks "github.com/stackrox/rox/central/complianceoperator/manager/mocks"
 	v1ProfileMocks "github.com/stackrox/rox/central/complianceoperator/profiles/datastore/mocks"
-	v2ProfileMocks "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore/mocks"
 	"github.com/stackrox/rox/central/convert/testutils"
 	"github.com/stackrox/rox/central/sensor/service/pipeline/reconciliation"
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
-	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -27,7 +24,6 @@ type PipelineTestSuite struct {
 	pipeline    *pipelineImpl
 	manager     *managerMocks.MockManager
 	v1ProfileDS *v1ProfileMocks.MockDataStore
-	v2ProfileDS *v2ProfileMocks.MockDataStore
 	mockCtrl    *gomock.Controller
 }
 
@@ -44,64 +40,17 @@ func (s *PipelineTestSuite) SetupTest() {
 
 	s.manager = managerMocks.NewMockManager(s.mockCtrl)
 	s.v1ProfileDS = v1ProfileMocks.NewMockDataStore(s.mockCtrl)
-	s.v2ProfileDS = v2ProfileMocks.NewMockDataStore(s.mockCtrl)
-	s.pipeline = NewPipeline(s.v1ProfileDS, s.manager, s.v2ProfileDS).(*pipelineImpl)
+	s.pipeline = NewPipeline(s.v1ProfileDS, s.manager).(*pipelineImpl)
 }
 
 func (s *PipelineTestSuite) TearDownTest() {
 	s.mockCtrl.Finish()
 }
 
-func (s *PipelineTestSuite) TestRunCreate() {
-	ctx := context.Background()
-
-	pipeline := NewPipeline(s.v1ProfileDS, s.manager, s.v2ProfileDS)
-	s.manager.EXPECT().AddProfile(testutils.GetProfileV1SensorMsg(s.T())).Return(nil).Times(1)
-	s.v2ProfileDS.EXPECT().UpsertProfile(ctx, testutils.GetProfileV2Storage(s.T()), fixtureconsts.Cluster1, testutils.ProfileUID).Return(nil).Times(1)
-
-	msg := &central.MsgFromSensor{
-		Msg: &central.MsgFromSensor_Event{
-			Event: &central.SensorEvent{
-				Id:     testutils.ProfileUID,
-				Action: central.ResourceAction_CREATE_RESOURCE,
-				Resource: &central.SensorEvent_ComplianceOperatorProfileV2{
-					ComplianceOperatorProfileV2: testutils.GetProfileV2SensorMsg(s.T()),
-				},
-			},
-		},
-	}
-
-	err := pipeline.Run(ctx, fixtureconsts.Cluster1, msg, nil)
-	s.NoError(err)
-}
-
-func (s *PipelineTestSuite) TestRunDelete() {
-	ctx := context.Background()
-
-	pipeline := NewPipeline(s.v1ProfileDS, s.manager, s.v2ProfileDS)
-	s.manager.EXPECT().DeleteProfile(testutils.GetProfileV1SensorMsg(s.T())).Return(nil).Times(1)
-	s.v2ProfileDS.EXPECT().DeleteProfileForCluster(ctx, testutils.ProfileUID, fixtureconsts.Cluster1).Return(nil).Times(1)
-
-	msg := &central.MsgFromSensor{
-		Msg: &central.MsgFromSensor_Event{
-			Event: &central.SensorEvent{
-				Id:     testutils.ProfileUID,
-				Action: central.ResourceAction_REMOVE_RESOURCE,
-				Resource: &central.SensorEvent_ComplianceOperatorProfileV2{
-					ComplianceOperatorProfileV2: testutils.GetProfileV2SensorMsg(s.T()),
-				},
-			},
-		},
-	}
-
-	err := pipeline.Run(ctx, fixtureconsts.Cluster1, msg, nil)
-	s.NoError(err)
-}
-
 func (s *PipelineTestSuite) TestRunV1Create() {
 	ctx := context.Background()
 
-	pipeline := NewPipeline(s.v1ProfileDS, s.manager, s.v2ProfileDS)
+	pipeline := NewPipeline(s.v1ProfileDS, s.manager)
 	s.manager.EXPECT().AddProfile(testutils.GetProfileV1SensorMsg(s.T())).Return(nil).Times(1)
 
 	msg := &central.MsgFromSensor{
@@ -123,7 +72,7 @@ func (s *PipelineTestSuite) TestRunV1Create() {
 func (s *PipelineTestSuite) TestRunV1Delete() {
 	ctx := context.Background()
 
-	pipeline := NewPipeline(s.v1ProfileDS, s.manager, s.v2ProfileDS)
+	pipeline := NewPipeline(s.v1ProfileDS, s.manager)
 	s.manager.EXPECT().DeleteProfile(testutils.GetProfileV1SensorMsg(s.T())).Return(nil).Times(1)
 
 	msg := &central.MsgFromSensor{
@@ -145,33 +94,9 @@ func (s *PipelineTestSuite) TestRunV1Delete() {
 func (s *PipelineTestSuite) TestRunReconcileNoOp() {
 	ctx := context.Background()
 
-	pipeline := NewPipeline(s.v1ProfileDS, s.manager, s.v2ProfileDS)
+	pipeline := NewPipeline(s.v1ProfileDS, s.manager)
 
 	s.v1ProfileDS.EXPECT().Walk(ctx, gomock.Any()).Return(nil).Times(1)
-	s.v2ProfileDS.EXPECT().GetProfileEdgesByCluster(ctx, fixtureconsts.Cluster1).Return(nil, nil).Times(1)
-
-	err := pipeline.Reconcile(ctx, fixtureconsts.Cluster1, reconciliation.NewStoreMap())
-	s.NoError(err)
-}
-
-func (s *PipelineTestSuite) TestRunReconcile() {
-	ctx := context.Background()
-
-	edgeID := uuid.NewV4().String()
-	edgeRecs := []*storage.ComplianceOperatorProfileClusterEdge{
-		{
-			Id:         edgeID,
-			ProfileId:  "",
-			ProfileUid: testutils.ProfileUID,
-			ClusterId:  fixtureconsts.Cluster1,
-		},
-	}
-	pipeline := NewPipeline(s.v1ProfileDS, s.manager, s.v2ProfileDS)
-
-	s.v1ProfileDS.EXPECT().Walk(ctx, gomock.Any()).Return(nil).Times(1)
-	s.v1ProfileDS.EXPECT().Delete(ctx, testutils.ProfileUID).Return(nil).Times(1)
-	s.v2ProfileDS.EXPECT().GetProfileEdgesByCluster(ctx, fixtureconsts.Cluster1).Return(edgeRecs, nil).Times(1)
-	s.v2ProfileDS.EXPECT().DeleteProfileForCluster(ctx, testutils.ProfileUID, fixtureconsts.Cluster1).Return(nil).Times(1)
 
 	err := pipeline.Reconcile(ctx, fixtureconsts.Cluster1, reconciliation.NewStoreMap())
 	s.NoError(err)

--- a/central/sensor/service/pipeline/complianceoperatorprofilesv2/pipeline.go
+++ b/central/sensor/service/pipeline/complianceoperatorprofilesv2/pipeline.go
@@ -1,0 +1,92 @@
+package complianceoperatorprofilesv2
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	v2Datastore "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
+	"github.com/stackrox/rox/central/convert/internaltov2storage"
+	countMetrics "github.com/stackrox/rox/central/metrics"
+	"github.com/stackrox/rox/central/sensor/service/common"
+	"github.com/stackrox/rox/central/sensor/service/pipeline"
+	"github.com/stackrox/rox/central/sensor/service/pipeline/reconciliation"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/metrics"
+	"github.com/stackrox/rox/pkg/set"
+)
+
+var (
+	_ pipeline.Fragment = (*pipelineImpl)(nil)
+)
+
+// GetPipeline returns an instantiation of this particular pipeline
+func GetPipeline() pipeline.Fragment {
+	return NewPipeline(v2Datastore.Singleton())
+}
+
+// NewPipeline returns a new instance of Pipeline.
+func NewPipeline(v2ProfileDatastore v2Datastore.DataStore) pipeline.Fragment {
+	return &pipelineImpl{
+		v2ProfileDatastore: v2ProfileDatastore,
+	}
+}
+
+type pipelineImpl struct {
+	v2ProfileDatastore v2Datastore.DataStore
+}
+
+func (s *pipelineImpl) Capabilities() []centralsensor.CentralCapability {
+	return nil
+}
+
+func (s *pipelineImpl) Reconcile(ctx context.Context, clusterID string, storeMap *reconciliation.StoreMap) error {
+	if !features.ComplianceEnhancements.Enabled() {
+		return nil
+	}
+
+	existingIDs := set.NewStringSet()
+
+	// For nextgen compliance, reconciliation means disassociating a profile with a cluster.
+	// The profile itself will still remain.
+	profileEdges, err := s.v2ProfileDatastore.GetProfileEdgesByCluster(ctx, clusterID)
+	if err != nil {
+		return err
+	}
+
+	for _, profileEdge := range profileEdges {
+		// The UID is used for reconciliation
+		existingIDs.Add(profileEdge.GetProfileUid())
+	}
+
+	store := storeMap.Get((*central.SensorEvent_ComplianceOperatorProfileV2)(nil))
+	return reconciliation.Perform(store, existingIDs, "complianceoperatorprofilesv2", func(id string) error {
+		return s.v2ProfileDatastore.DeleteProfileForCluster(ctx, id, clusterID)
+	})
+}
+
+func (s *pipelineImpl) Match(msg *central.MsgFromSensor) bool {
+	return msg.GetEvent().GetComplianceOperatorProfileV2() != nil
+}
+
+// Run runs the pipeline template on the input and returns the output.
+func (s *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.MsgFromSensor, _ common.MessageInjector) error {
+	defer countMetrics.IncrementResourceProcessedCounter(pipeline.ActionToOperation(msg.GetEvent().GetAction()), metrics.ComplianceOperatorProfileV2)
+
+	if !features.ComplianceEnhancements.Enabled() {
+		return errors.New("Next gen compliance is disabled.  Message unexpected.")
+	}
+
+	event := msg.GetEvent()
+	profile := event.GetComplianceOperatorProfileV2()
+
+	switch event.GetAction() {
+	case central.ResourceAction_REMOVE_RESOURCE:
+		return s.v2ProfileDatastore.DeleteProfileForCluster(ctx, profile.Id, clusterID)
+	default:
+		return s.v2ProfileDatastore.UpsertProfile(ctx, internaltov2storage.ComplianceOperatorProfileV2(profile), clusterID, profile.GetId())
+	}
+}
+
+func (s *pipelineImpl) OnFinish(_ string) {}

--- a/central/sensor/service/pipeline/complianceoperatorprofilesv2/pipeline_test.go
+++ b/central/sensor/service/pipeline/complianceoperatorprofilesv2/pipeline_test.go
@@ -1,0 +1,123 @@
+package complianceoperatorprofilesv2
+
+import (
+	"context"
+	"testing"
+
+	v2ProfileMocks "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore/mocks"
+	"github.com/stackrox/rox/central/convert/testutils"
+	"github.com/stackrox/rox/central/sensor/service/pipeline/reconciliation"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+func TestPipeline(t *testing.T) {
+	suite.Run(t, new(PipelineTestSuite))
+}
+
+type PipelineTestSuite struct {
+	suite.Suite
+	pipeline    *pipelineImpl
+	v2ProfileDS *v2ProfileMocks.MockDataStore
+	mockCtrl    *gomock.Controller
+}
+
+func (s *PipelineTestSuite) SetupSuite() {
+	s.T().Setenv(features.ComplianceEnhancements.EnvVar(), "true")
+	if !features.ComplianceEnhancements.Enabled() {
+		s.T().Skip("Skip tests when ComplianceEnhancements disabled")
+		s.T().SkipNow()
+	}
+}
+
+func (s *PipelineTestSuite) SetupTest() {
+	s.mockCtrl = gomock.NewController(s.T())
+
+	s.v2ProfileDS = v2ProfileMocks.NewMockDataStore(s.mockCtrl)
+	s.pipeline = NewPipeline(s.v2ProfileDS).(*pipelineImpl)
+}
+
+func (s *PipelineTestSuite) TearDownTest() {
+	s.mockCtrl.Finish()
+}
+
+func (s *PipelineTestSuite) TestRunCreate() {
+	ctx := context.Background()
+
+	pipeline := NewPipeline(s.v2ProfileDS)
+	s.v2ProfileDS.EXPECT().UpsertProfile(ctx, testutils.GetProfileV2Storage(s.T()), fixtureconsts.Cluster1, testutils.ProfileUID).Return(nil).Times(1)
+
+	msg := &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     testutils.ProfileUID,
+				Action: central.ResourceAction_CREATE_RESOURCE,
+				Resource: &central.SensorEvent_ComplianceOperatorProfileV2{
+					ComplianceOperatorProfileV2: testutils.GetProfileV2SensorMsg(s.T()),
+				},
+			},
+		},
+	}
+
+	err := pipeline.Run(ctx, fixtureconsts.Cluster1, msg, nil)
+	s.NoError(err)
+}
+
+func (s *PipelineTestSuite) TestRunDelete() {
+	ctx := context.Background()
+
+	pipeline := NewPipeline(s.v2ProfileDS)
+	s.v2ProfileDS.EXPECT().DeleteProfileForCluster(ctx, testutils.ProfileUID, fixtureconsts.Cluster1).Return(nil).Times(1)
+
+	msg := &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     testutils.ProfileUID,
+				Action: central.ResourceAction_REMOVE_RESOURCE,
+				Resource: &central.SensorEvent_ComplianceOperatorProfileV2{
+					ComplianceOperatorProfileV2: testutils.GetProfileV2SensorMsg(s.T()),
+				},
+			},
+		},
+	}
+
+	err := pipeline.Run(ctx, fixtureconsts.Cluster1, msg, nil)
+	s.NoError(err)
+}
+
+func (s *PipelineTestSuite) TestRunReconcileNoOp() {
+	ctx := context.Background()
+
+	pipeline := NewPipeline(s.v2ProfileDS)
+
+	s.v2ProfileDS.EXPECT().GetProfileEdgesByCluster(ctx, fixtureconsts.Cluster1).Return(nil, nil).Times(1)
+
+	err := pipeline.Reconcile(ctx, fixtureconsts.Cluster1, reconciliation.NewStoreMap())
+	s.NoError(err)
+}
+
+func (s *PipelineTestSuite) TestRunReconcile() {
+	ctx := context.Background()
+
+	edgeID := uuid.NewV4().String()
+	edgeRecs := []*storage.ComplianceOperatorProfileClusterEdge{
+		{
+			Id:         edgeID,
+			ProfileId:  "",
+			ProfileUid: testutils.ProfileUID,
+			ClusterId:  fixtureconsts.Cluster1,
+		},
+	}
+	pipeline := NewPipeline(s.v2ProfileDS)
+
+	s.v2ProfileDS.EXPECT().GetProfileEdgesByCluster(ctx, fixtureconsts.Cluster1).Return(edgeRecs, nil).Times(1)
+	s.v2ProfileDS.EXPECT().DeleteProfileForCluster(ctx, testutils.ProfileUID, fixtureconsts.Cluster1).Return(nil).Times(1)
+
+	err := pipeline.Reconcile(ctx, fixtureconsts.Cluster1, reconciliation.NewStoreMap())
+	s.NoError(err)
+}

--- a/pkg/deduperkey/key.go
+++ b/pkg/deduperkey/key.go
@@ -33,6 +33,7 @@ var (
 		&central.SensorEvent_ComplianceOperatorResult{},
 		&central.SensorEvent_ComplianceOperatorResultV2{},
 		&central.SensorEvent_ComplianceOperatorProfile{},
+		&central.SensorEvent_ComplianceOperatorProfileV2{},
 		&central.SensorEvent_ComplianceOperatorRule{},
 		&central.SensorEvent_ComplianceOperatorRuleV2{},
 		&central.SensorEvent_ComplianceOperatorScanSettingBinding{},

--- a/pkg/metrics/resource_string.go
+++ b/pkg/metrics/resource_string.go
@@ -35,11 +35,12 @@ func _() {
 	_ = x[ComplianceOperatorInfo-24]
 	_ = x[ComplianceOperatorCheckResultV2-25]
 	_ = x[ComplianceOperatorRuleV2-26]
+	_ = x[ComplianceOperatorProfileV2-27]
 }
 
-const _Resource_name = "AlertDeploymentProcessIndicatorProcessListeningOnPortImageSecretNamespaceNetworkPolicyNodeNodeInventoryProviderMetadataComplianceReturnImageIntegrationServiceAccountPermissionSetRoleRoleBindingDeploymentReprocessPodComplianceOperatorCheckResultComplianceOperatorProfileComplianceOperatorScanSettingBindingComplianceOperatorRuleComplianceOperatorScanComplianceOperatorInfoComplianceOperatorCheckResultV2ComplianceOperatorRuleV2"
+const _Resource_name = "AlertDeploymentProcessIndicatorProcessListeningOnPortImageSecretNamespaceNetworkPolicyNodeNodeInventoryProviderMetadataComplianceReturnImageIntegrationServiceAccountPermissionSetRoleRoleBindingDeploymentReprocessPodComplianceOperatorCheckResultComplianceOperatorProfileComplianceOperatorScanSettingBindingComplianceOperatorRuleComplianceOperatorScanComplianceOperatorInfoComplianceOperatorCheckResultV2ComplianceOperatorRuleV2ComplianceOperatorProfileV2"
 
-var _Resource_index = [...]uint16{0, 5, 15, 31, 53, 58, 64, 73, 86, 90, 103, 119, 135, 151, 165, 178, 182, 193, 212, 215, 244, 269, 305, 327, 349, 371, 402, 426}
+var _Resource_index = [...]uint16{0, 5, 15, 31, 53, 58, 64, 73, 86, 90, 103, 119, 135, 151, 165, 178, 182, 193, 212, 215, 244, 269, 305, 327, 349, 371, 402, 426, 453}
 
 func (i Resource) String() string {
 	if i < 0 || i >= Resource(len(_Resource_index)-1) {

--- a/pkg/metrics/resources.go
+++ b/pkg/metrics/resources.go
@@ -34,4 +34,5 @@ const (
 	ComplianceOperatorInfo
 	ComplianceOperatorCheckResultV2
 	ComplianceOperatorRuleV2
+	ComplianceOperatorProfileV2
 )

--- a/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
@@ -39,6 +39,7 @@ class ReconciliationTest extends BaseSpecification {
         "*central.SensorEvent_Deployment": 1,
         "*central.SensorEvent_Node": 0,
         "*central.SensorEvent_ComplianceOperatorProfile": 0,
+        "*central.SensorEvent_ComplianceOperatorProfileV2": 0,
         "*central.SensorEvent_ComplianceOperatorResult": 0,
         "*central.SensorEvent_ComplianceOperatorRule": 0,
         "*central.SensorEvent_ComplianceOperatorRuleV2": 0,

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorprofiles.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorprofiles.go
@@ -44,44 +44,6 @@ func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.Reso
 	// useful for the deduping from sensor.
 	uid := string(complianceProfile.UID)
 
-	// We probably could have gotten away with re-using the storage proto here for the time being.
-	// But we have a new field coming on for profiles and using the storage object even in an internal api
-	// is a bad practice, so we will make that split now.  V1 and V2 compliance will both need to work for a period
-	// of time.  However, we should not need to send the same profile twice, the pipeline can convert the V2 sensor message
-	// so V1 and V2 objects can both be stored.
-	if centralcaps.Has(centralsensor.ComplianceV2Integrations) {
-		protoProfile := &central.ComplianceOperatorProfileV2{
-			Id:             uid,
-			ProfileId:      complianceProfile.ID,
-			Name:           complianceProfile.Name,
-			ProfileVersion: "", // TODO(ROX-20536)
-			Labels:         complianceProfile.Labels,
-			Annotations:    complianceProfile.Annotations,
-			Description:    complianceProfile.Description,
-		}
-
-		for _, r := range complianceProfile.Rules {
-			protoProfile.Rules = append(protoProfile.Rules, &central.ComplianceOperatorProfileV2_Rule{
-				RuleName: string(r),
-			})
-		}
-
-		for _, v := range complianceProfile.Values {
-			protoProfile.Values = append(protoProfile.Values, string(v))
-		}
-
-		events := []*central.SensorEvent{
-			{
-				Id:     uid,
-				Action: action,
-				Resource: &central.SensorEvent_ComplianceOperatorProfileV2{
-					ComplianceOperatorProfileV2: protoProfile,
-				},
-			}}
-
-		return component.NewEvent(events...)
-	}
-
 	protoProfile := &storage.ComplianceOperatorProfile{
 		Id:          uid,
 		ProfileId:   complianceProfile.ID,
@@ -104,6 +66,37 @@ func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.Reso
 				ComplianceOperatorProfile: protoProfile,
 			},
 		},
+	}
+
+	if centralcaps.Has(centralsensor.ComplianceV2Integrations) {
+		protoProfile := &central.ComplianceOperatorProfileV2{
+			Id:             uid,
+			ProfileId:      complianceProfile.ID,
+			Name:           complianceProfile.Name,
+			ProfileVersion: "", // TODO(ROX-20536)
+			Labels:         complianceProfile.Labels,
+			Annotations:    complianceProfile.Annotations,
+			Description:    complianceProfile.Description,
+			Title:          complianceProfile.Title,
+		}
+
+		for _, r := range complianceProfile.Rules {
+			protoProfile.Rules = append(protoProfile.Rules, &central.ComplianceOperatorProfileV2_Rule{
+				RuleName: string(r),
+			})
+		}
+
+		for _, v := range complianceProfile.Values {
+			protoProfile.Values = append(protoProfile.Values, string(v))
+		}
+
+		events = append(events, &central.SensorEvent{
+			Id:     uid,
+			Action: action,
+			Resource: &central.SensorEvent_ComplianceOperatorProfileV2{
+				ComplianceOperatorProfileV2: protoProfile,
+			},
+		})
 	}
 
 	return component.NewEvent(events...)


### PR DESCRIPTION
## Description

Moving V1 and V2 profiles to use separate pipelines

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

UT and spinning up a cluster to ensure objects populate as expected.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
