### PR TITLE
chore(scanner): retry DB connection upon startup

### DIFF
--- a/scanner/datastore/postgres/connect.go
+++ b/scanner/datastore/postgres/connect.go
@@ -10,9 +10,10 @@ import (
 	"github.com/stackrox/rox/pkg/retry"
 )
 
-const connTries = 30
-
-var interval = 10 * time.Second
+const (
+	connTries = 30
+	interval  = 10 * time.Second
+)
 
 // Connect is a wrapper around ClairCore's postgres.Connect which retries the connection upon failure.
 //

--- a/scanner/datastore/postgres/connect.go
+++ b/scanner/datastore/postgres/connect.go
@@ -1,0 +1,34 @@
+package postgres
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/quay/claircore/datastore/postgres"
+	"github.com/quay/zlog"
+	"github.com/stackrox/rox/pkg/retry"
+)
+
+const connTries = 30
+
+var interval = 10 * time.Second
+
+// Connect is a wrapper around ClairCore's postgres.Connect which retries the connection upon failure.
+//
+// At this time, this function does 30 attempts with a 10-second interval between attempts.
+func Connect(ctx context.Context, connString string, applicationName string) (pool *pgxpool.Pool, err error) {
+	err = retry.WithRetry(func() error {
+		pool, err = postgres.Connect(ctx, connString, applicationName)
+		return err
+	}, retry.Tries(connTries), retry.OnFailedAttempts(func(err error) {
+		zlog.Error(ctx).Err(err).Msg("failed to connect to postgres database")
+	}), retry.BetweenAttempts(func(previousAttemptNumber int) {
+		zlog.Warn(ctx).Int("attempt", previousAttemptNumber+1).Msg("retrying connection to postgres database")
+		time.Sleep(interval)
+	}))
+	if err != nil {
+		return nil, err
+	}
+	return pool, nil
+}

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -20,7 +20,7 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/alpine"
-	"github.com/quay/claircore/datastore/postgres"
+	ccpostgres "github.com/quay/claircore/datastore/postgres"
 	"github.com/quay/claircore/dpkg"
 	"github.com/quay/claircore/gobin"
 	ccindexer "github.com/quay/claircore/indexer"
@@ -37,6 +37,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/scanner/config"
+	"github.com/stackrox/rox/scanner/datastore/postgres"
 	"github.com/stackrox/rox/scanner/internal/version"
 )
 
@@ -97,7 +98,7 @@ func NewIndexer(ctx context.Context, cfg config.IndexerConfig) (Indexer, error) 
 		}
 	}()
 
-	store, err := postgres.InitPostgresIndexerStore(ctx, pool, true)
+	store, err := ccpostgres.InitPostgresIndexerStore(ctx, pool, true)
 	if err != nil {
 		return nil, fmt.Errorf("initializing postgres indexer store: %w", err)
 	}

--- a/scanner/matcher/matcher.go
+++ b/scanner/matcher/matcher.go
@@ -62,7 +62,7 @@ func NewMatcher(ctx context.Context, cfg config.MatcherConfig) (Matcher, error) 
 
 	var success bool
 
-	pool, err := ccpostgres.Connect(ctx, cfg.Database.ConnString, "libvuln")
+	pool, err := postgres.Connect(ctx, cfg.Database.ConnString, "libvuln")
 	if err != nil {
 		return nil, fmt.Errorf("connecting to postgres for matcher: %w", err)
 	}

--- a/scripts/ci/logcheck/restart-ok-patterns.json
+++ b/scripts/ci/logcheck/restart-ok-patterns.json
@@ -46,17 +46,5 @@
         "job": "upgrade",
         "logfile": "sensor-previous",
         "logline": "checking central status failed after"
-    },
-    {
-        "comment": "Scanner V4 Indexer restart due to Scanner V4 DB not being ready",
-        "job": ".*",
-        "logfile": "indexer-previous",
-        "logline": "connecting to postgres for indexer: failed to create ConnPool: failed to connect to"
-    },
-    {
-        "comment": "Scanner V4 Matcher restart due to Scanner V4 DB not being ready",
-        "job": ".*",
-        "logfile": "matcher-previous",
-        "logline": "connecting to postgres for matcher: failed to create ConnPool: failed to connect to"
     }
 ]


### PR DESCRIPTION
## Description

This makes Scanner v4 Indexer and Matcher startup more robust and give the DB about 5 minutes to startup.

This should hopefully make CI happier, too.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

Indexer logs:

```
$ oc logs -f deploy/scanner-v4-indexer
No certificates found in /usr/local/share/ca-certificates
'/etc/pki/injected-ca-trust/tls-ca-bundle.pem' -> '/etc/pki/ca-trust/source/anchors/tls-ca-bundle.pem'
pkg/memlimit: 2024/01/25 23:56:21.047904 memlimit.go:43: Info: ROX_MEMLIMIT set to 3.80Gi
{"level":"info","host":"scanner-v4-indexer-64595dcf57-scbpj","component":"main","version":"4.3.x-865-g5630b7635e","time":"2024-01-25T23:56:21Z","message":"starting scanner"}
pkg/metrics: 2024/01/25 23:56:21.049341 server.go:142: Warn: Secure metrics server is disabled
pkg/metrics: 2024/01/25 23:56:21.049500 server.go:142: Warn: Secure metrics server is disabled
pkg/env: 2024/01/25 23:56:21.049652 metrics.go:47: Debug: ROX_METRICS_PORT=:9090, resolved to :9090
pkg/metrics: 2024/01/25 23:56:21.049719 server.go:142: Warn: Secure metrics server is disabled
{"level":"info","host":"scanner-v4-indexer-64595dcf57-scbpj","component":"main","time":"2024-01-25T23:56:21Z","message":"indexer is enabled"}
pkg/metrics: 2024/01/25 23:56:21.050582 throttle.go:90: Info: gathering CPU throttle metrics from sys/fs/cgroup/cpu.stat
{"level":"error","host":"scanner-v4-indexer-64595dcf57-scbpj","component":"scanner/backend/indexer.NewIndexer","error":"failed to create ConnPool: failed to connect to `host=scanner-v4-db.stackrox.svc user=postgres database=`: dial error (dial tcp 172.30.242.98:5432: connect: connection refused)","time":"2024-01-25T23:56:21Z","message":"failed to connect to postgres database"}
{"level":"warn","host":"scanner-v4-indexer-64595dcf57-scbpj","component":"scanner/backend/indexer.NewIndexer","attempt":2,"time":"2024-01-25T23:56:21Z","message":"retrying connection to postgres database"}
{"level":"error","host":"scanner-v4-indexer-64595dcf57-scbpj","component":"scanner/backend/indexer.NewIndexer","error":"failed to create ConnPool: failed to connect to `host=scanner-v4-db.stackrox.svc user=postgres database=`: dial error (dial tcp 172.30.242.98:5432: connect: connection refused)","time":"2024-01-25T23:56:31Z","message":"failed to connect to postgres database"}
{"level":"warn","host":"scanner-v4-indexer-64595dcf57-scbpj","component":"scanner/backend/indexer.NewIndexer","attempt":3,"time":"2024-01-25T23:56:31Z","message":"retrying connection to postgres database"}
{"level":"error","host":"scanner-v4-indexer-64595dcf57-scbpj","component":"scanner/backend/indexer.NewIndexer","error":"failed to create ConnPool: failed to connect to `host=scanner-v4-db.stackrox.svc user=postgres database=`: dial error (dial tcp 172.30.242.98:5432: connect: connection refused)","time":"2024-01-25T23:56:41Z","message":"failed to connect to postgres database"}
{"level":"warn","host":"scanner-v4-indexer-64595dcf57-scbpj","component":"scanner/backend/indexer.NewIndexer","attempt":4,"time":"2024-01-25T23:56:41Z","message":"retrying connection to postgres database"}
{"level":"info","host":"scanner-v4-indexer-64595dcf57-scbpj","component":"libindex/New","time":"2024-01-25T23:56:51Z","message":"registered configured scanners"}
{"level":"info","host":"scanner-v4-indexer-64595dcf57-scbpj","component":"indexer.NewLayerScanner","time":"2024-01-25T23:56:51Z","message":"NewLayerScanner: constructing a new layer-scanner"}
{"level":"info","host":"scanner-v4-indexer-64595dcf57-scbpj","component":"main","time":"2024-01-25T23:56:51Z","message":"matcher is disabled"}
{"level":"info","host":"scanner-v4-indexer-64595dcf57-scbpj","component":"main","time":"2024-01-25T23:56:51Z","message":"backends are ready"}
```

Matcher logs have a lot more noise, but the same idea

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
