### PR TITLE
test(helmtest): Prepare image pull secret tests for upcoming change.

### DIFF
--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets-legacy.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets-legacy.test.yaml
@@ -1,0 +1,118 @@
+defs: |
+  def authForCentral:
+      (container(.deployments.central; "central") | .image | sub("/.*$"; "")) as $mainRegistry |
+        .secrets["stackrox"].data[".dockerconfigjson"] | @base64d | fromjson | .auths
+          | .["https://" + (if ($mainRegistry == "docker.io") then "index.docker.io/v1/" else $mainRegistry end)]
+          | .auth | @base64d;
+
+  # Please keep the defs here in sync with the ones in the secured cluster sibling of this test.
+
+  # Separate function, to make error messages helpful.
+  def containsAll(needles):
+      . as $hay | all(needles[]; . as $needle | any($hay[]; . == $needle));
+
+  def saRefersTo(pullSecretNames):
+      (.imagePullSecrets // []) | [.[] | .name] | assertThat(. | containsAll(pullSecretNames));
+
+  # This treats the lists as multisets.
+  def saOnlyRefersTo(pullSecretNames):
+      [.imagePullSecrets[] | .name] | sort | assertThat(. == (pullSecretNames | sort));
+
+values:
+  central:
+    persistence:
+      none: true
+
+expect: |
+  # Ensure that default service accounts are always referenced in the correct fashion in the non-error case
+  assumeThat(.error == null) | .serviceaccounts["central"] | saRefersTo(["stackrox", "stackrox-scanner"])
+  assumeThat(.error == null) | .serviceaccounts["central-db"] | saRefersTo(["stackrox", "stackrox-scanner"])
+  assumeThat(.error == null) | .serviceaccounts["scanner"] | saRefersTo(["stackrox", "stackrox-scanner"])
+
+tests:
+- name: "with no image pull secret creation"
+  expect: |
+    .secrets?["stackrox"]? | assertThat(. == null)
+  tests:
+  - name: "works with allowNone=true, and only default image pull secrets are referenced in service accounts"
+    set:
+      imagePullSecrets.allowNone: true
+    expect: |
+      .serviceaccounts["central"] | saOnlyRefersTo(["stackrox", "stackrox-scanner"])
+      .serviceaccounts["central-db"] | saOnlyRefersTo(["stackrox", "stackrox-scanner"])
+      .serviceaccounts["scanner"] | saOnlyRefersTo(["stackrox", "stackrox-scanner"])
+  - name: "with default setting of allowNone=false"
+    tests:
+    - name: "should fail with no extra secrets"
+      expectError: true
+    - name: "should succeed with pull secrets referenced in default SA"
+      server:
+        objects:
+        - apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: default
+            namespace: stackrox
+          imagePullSecrets:
+          - name: from-default-1
+          - name: from-default-2
+      expect: |
+        .serviceaccounts[] | saRefersTo(["from-default-1", "from-default-2"])
+    - name: "should succeed with useExisting"
+      expect: |
+        .serviceaccounts[] | saRefersTo(["extra-secret1", "extra-secret2"])
+      tests:
+      - name: as JSON list
+        set:
+          imagePullSecrets.useExisting: ["extra-secret1", "extra-secret2"]
+
+      - name: as semicolon-delimited list string
+        set:
+          imagePullSecrets.useExisting: "extra-secret1; extra-secret2 "
+
+- name: "with image pull secret creation (username specified)"
+  values:
+    imagePullSecrets:
+      username: foo
+  expect: |
+    .secrets["stackrox"] | assertThat(. != null)
+    .serviceaccounts[] | saRefersTo(["stackrox"])
+  tests:
+  - name: "with password specified too"
+    values:
+      imagePullSecrets:
+        password: bar
+    expect: |
+      authForCentral | assertThat(. == "foo:bar")
+    tests:
+    - name: "with default registry"
+    - name: "with custom central registry"
+      set:
+        central.image.registry: my.registry.io
+    - name: "with docker registry"
+      set:
+        central.image.registry: docker.io/stackrox
+  - name: "with empty password"
+    values:
+      imagePullSecrets:
+        password: ""
+    expect: |
+      authForCentral | assertThat(. == "foo:")
+  - name: "secrets from default SA are referenced, if present"
+    server:
+      objects:
+      - apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: default
+          namespace: stackrox
+        imagePullSecrets:
+        - name: from-default-1
+        - name: from-default-2
+    expect: |
+      .serviceaccounts[] | saRefersTo(["from-default-1", "from-default-2"])
+  - name: "useExisting secrets are referenced, if specified"
+    set:
+      imagePullSecrets.useExisting: ["extra-secret1", "extra-secret2"]
+    expect: |
+      .serviceaccounts[] | saRefersTo(["extra-secret1", "extra-secret2"])

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets-legacy.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets-legacy.test.yaml
@@ -1,0 +1,125 @@
+defs: |
+  def authForCollector:
+    (container(.daemonsets.collector; "collector") | .image | sub("/.*$"; "")) as $collectorRegistry |
+      .secrets["secured-cluster-services-collector"].data[".dockerconfigjson"] | @base64d | fromjson | .auths
+        | .["https://" + (if ($collectorRegistry == "docker.io") then "index.docker.io/v1/" else $collectorRegistry end)]
+        | .auth | @base64d;
+
+  def authForMain:
+      (container(.deployments.sensor; "sensor") | .image | sub("/.*$"; "")) as $mainRegistry |
+        .secrets["secured-cluster-services-main"].data[".dockerconfigjson"] | @base64d | fromjson | .auths
+          | .["https://" + (if ($mainRegistry == "docker.io") then "index.docker.io/v1/" else $mainRegistry end)]
+          | .auth | @base64d;
+
+expect: |
+  # Ensure that default/legacy service accounts are always referenced in the correct fashion in the non-error case
+
+  assumeThat(.error == null) | .serviceaccounts["collector"] | saRefersTo(["stackrox", "collector-stackrox"])
+  assumeThat(.error == null) | .serviceaccounts["sensor"] | saRefersTo(["stackrox"])
+  assumeThat(.error == null) | .serviceaccounts["sensor"] | saNotRefersTo(["collector-stackrox"])
+  assumeThat(.error == null) | .serviceaccounts["admission-control"] | saRefersTo(["stackrox"])
+  assumeThat(.error == null) | .serviceaccounts["admission-control"] | saNotRefersTo(["collector-stackrox"])
+
+  # Ensure that newly created secrets are always referenced in the correct fashion in the non-error case.
+
+  assumeThat(.error == null) | .serviceaccounts["collector"]
+    | saRefersTo(["secured-cluster-services-main", "secured-cluster-services-collector"])
+  assumeThat(.error == null) | .serviceaccounts["sensor"] | saRefersTo(["secured-cluster-services-main"])
+  assumeThat(.error == null) | .serviceaccounts["sensor"] | saNotRefersTo(["secured-cluster-services-collector", "collector-stackrox"])
+  assumeThat(.error == null) | .serviceaccounts["admission-control"] | saRefersTo(["secured-cluster-services-main"])
+  assumeThat(.error == null) | .serviceaccounts["admission-control"] | saNotRefersTo(["secured-cluster-services-collector", "collector-stackrox"])
+
+tests:
+- name: "with no image pull secret creation"
+  expect: |
+    .secrets?["secured-cluster-services-main"]? | assertThat(. == null)
+    .secrets?["secured-cluster-services-collector"]? | assertThat(. == null)
+  tests:
+  - name: "works with allowNone=true"
+    set:
+      imagePullSecrets.allowNone: true
+  - name: "with default setting of allowNone=false"
+    tests:
+    - name: "should fail with no extra secrets"
+      expectError: true
+    - name: "should succeed with pull secrets referenced in default SA"
+      server:
+        objects:
+        - apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: default
+            namespace: stackrox
+          imagePullSecrets:
+          - name: from-default-1
+          - name: from-default-2
+      expect: |
+        .serviceaccounts[] | saRefersTo(["from-default-1", "from-default-2"])
+    - name: "should succeed with useExisting"
+      expect: |
+        .serviceaccounts[] | saRefersTo(["extra-secret1", "extra-secret2"])
+      tests:
+      - name: as JSON list
+        set:
+          imagePullSecrets.useExisting: ["extra-secret1", "extra-secret2"]
+
+      - name: as semicolon-delimited list string
+        set:
+          imagePullSecrets.useExisting: "extra-secret1; extra-secret2 "
+
+- name: "with image pull secret creation (username specified)"
+  values:
+    imagePullSecrets:
+      username: foo
+  expect: |
+    .secrets["secured-cluster-services-main"] | assertThat(. != null)
+    .secrets["secured-cluster-services-collector"] | assertThat(. != null)
+    .serviceaccounts[] | saRefersTo(["secured-cluster-services-main"])
+    .serviceaccounts["collector"] | saRefersTo(["secured-cluster-services-collector"])
+  tests:
+  - name: "with password specified too"
+    values:
+      imagePullSecrets:
+        password: bar
+    expect: |
+      authForMain | assertThat(. == "foo:bar")
+      authForCollector | assertThat(. == "foo:bar")
+    tests:
+    - name: "with default registry"
+    - name: "with custom default registry"
+      set:
+        image.registry: my.registry.io
+    - name: "with custom main registry"
+      set:
+        image.main.registry: my.registry.io
+    - name: "with custom collector registry"
+      set:
+        image.collector.registry: my.collector-registry.io
+    - name: "with docker registry"
+      set:
+        image.registry: docker.io/stackrox
+  - name: "with empty password"
+    values:
+      imagePullSecrets:
+        password: ""
+    expect: |
+      authForMain | assertThat(. == "foo:")
+      authForCollector | assertThat(. == "foo:")
+  - name: "secrets from default SA are referenced, if present"
+    server:
+      objects:
+      - apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: default
+          namespace: stackrox
+        imagePullSecrets:
+        - name: from-default-1
+        - name: from-default-2
+    expect: |
+      .serviceaccounts[] | saRefersTo(["from-default-1", "from-default-2"])
+  - name: "useExisting secrets are referenced, if specified"
+    set:
+      imagePullSecrets.useExisting: ["extra-secret1", "extra-secret2"]
+    expect: |
+      .serviceaccounts[] | saRefersTo(["extra-secret1", "extra-secret2"])


### PR DESCRIPTION
## Description

This creates clones of a couple of helmtest files related to image pull secrets.

Sadly GitHub does not show this, but they are identical:

```
$ diff -u pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets-legacy.test.yaml pkg/helm/charts/tests/centralservices/testdata/helmtest/image-pull-secrets.test.yaml
$ diff -u pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets-legacy.test.yaml pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/image-pull-secrets.test.yaml
$ 
```

The `-legacy` in the name means they will be testing support for the soon-to-be-legacy use case. I.e. automatically referring to a few image pull secrets whose names are considered special.

These are created in this separet PR purely in order to make the next PR (actual fix to ROX-9156) easier to review.
The next PR will change the test cases in the original files to cover the new use case where no specially-named secrets exist.

The alternative of just keeping both new and legacy cases in a single file is certainly possible, but would be very tedious to review, since a big bunch of test cases that are very similar (but not identical) to the existing ones would seemingly appear. This way makes it obvious what changes are being made.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
