### PR TITLE
ROX-21477: Update "scope" field to handle sha based image tags

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveListExceptionFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveListExceptionFlow.test.js
@@ -63,7 +63,6 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
                 fillAndSubmitExceptionForm({
                     comment: 'Test comment',
                     expiryLabel: '30 days',
-                    scopeLabel: `Only ${image}:${tag}`,
                 });
 
                 verifyExceptionConfirmationDetails({
@@ -96,7 +95,6 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
                 verifySelectedCvesInModal(cveNames);
                 fillAndSubmitExceptionForm({
                     comment: 'Test comment',
-                    scopeLabel: `Only ${image}:${tag}`,
                 });
                 verifyExceptionConfirmationDetails({
                     expectedAction: 'False positive',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
@@ -143,11 +143,16 @@ export type RequestScopeProps = {
 
 export function RequestScope({ scope }: RequestScopeProps) {
     const { registry, remote, tag } = scope.imageScope;
-    const text =
-        registry === '.*' && remote === '.*' && tag === '.*'
-            ? '.*'
-            : `${registry}/${remote}:${tag}`;
-    return <div>{text}</div>;
+
+    if (registry === '.*' && remote === '.*' && tag === '.*') {
+        return <div>.*</div>;
+    }
+    if (tag === '') {
+        // If tag is empty, the image is referenced by hash, which is unsupported by the backend. This
+        // is effectively the same as .*, so we adjust the text here for clarity.
+        return <div>{`${registry}/${remote}:.*`}</div>;
+    }
+    return <div>{`${registry}/${remote}:${tag}`}</div>;
 }
 
 export type RequestedItemsProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionScopeField.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionRequestModal/ExceptionScopeField.tsx
@@ -17,8 +17,19 @@ export type ExceptionScopeFieldProps = {
 function ExceptionScopeField({ fieldId, label, scopeContext, formik }: ExceptionScopeFieldProps) {
     const { values, setFieldValue } = formik;
 
+    const isImageWithoutTag = scopeContext !== 'GLOBAL' && scopeContext.imageName.tag === '';
+
     return (
-        <FormGroup fieldId={fieldId} label={label} isRequired>
+        <FormGroup
+            fieldId={fieldId}
+            label={label}
+            isRequired
+            helperText={
+                isImageWithoutTag
+                    ? `This image does not have a tag and the exception will apply to all tags within ${scopeContext.imageName.registry}/${scopeContext.imageName.remote}`
+                    : undefined
+            }
+        >
             {scopeContext === 'GLOBAL' && (
                 <Radio
                     id="scope-global"
@@ -33,39 +44,39 @@ function ExceptionScopeField({ fieldId, label, scopeContext, formik }: Exception
                 />
             )}
             {scopeContext !== 'GLOBAL' && (
-                <>
-                    <Radio
-                        id="scope-single-image"
-                        name="scope-single-image"
-                        isChecked={
-                            values.scope.imageScope.registry === scopeContext.imageName.registry &&
-                            values.scope.imageScope.remote === scopeContext.imageName.remote &&
-                            values.scope.imageScope.tag === ALL
-                        }
-                        onChange={() =>
-                            setFieldValue('scope.imageScope', {
-                                ...scopeContext.imageName,
-                                tag: ALL,
-                            })
-                        }
-                        label={`All tags within ${scopeContext.imageName.registry}/${scopeContext.imageName.remote}`}
-                    />
-                    <Radio
-                        id="scope-single-image-single-tag"
-                        name="scope-single-image-single-tag"
-                        isChecked={
-                            values.scope.imageScope.registry === scopeContext.imageName.registry &&
-                            values.scope.imageScope.remote === scopeContext.imageName.remote &&
-                            values.scope.imageScope.tag === scopeContext.imageName.tag
-                        }
-                        onChange={() =>
-                            setFieldValue('scope.imageScope', {
-                                ...scopeContext.imageName,
-                            })
-                        }
-                        label={`Only ${scopeContext.imageName.registry}/${scopeContext.imageName.remote}:${scopeContext.imageName.tag}`}
-                    />
-                </>
+                <Radio
+                    id="scope-single-image"
+                    name="scope-single-image"
+                    isChecked={
+                        values.scope.imageScope.registry === scopeContext.imageName.registry &&
+                        values.scope.imageScope.remote === scopeContext.imageName.remote &&
+                        values.scope.imageScope.tag === ALL
+                    }
+                    onChange={() =>
+                        setFieldValue('scope.imageScope', {
+                            ...scopeContext.imageName,
+                            tag: ALL,
+                        })
+                    }
+                    label={`All tags within ${scopeContext.imageName.registry}/${scopeContext.imageName.remote}`}
+                />
+            )}
+            {scopeContext !== 'GLOBAL' && !isImageWithoutTag && (
+                <Radio
+                    id="scope-single-image-single-tag"
+                    name="scope-single-image-single-tag"
+                    isChecked={
+                        values.scope.imageScope.registry === scopeContext.imageName.registry &&
+                        values.scope.imageScope.remote === scopeContext.imageName.remote &&
+                        values.scope.imageScope.tag === scopeContext.imageName.tag
+                    }
+                    onChange={() =>
+                        setFieldValue('scope.imageScope', {
+                            ...scopeContext.imageName,
+                        })
+                    }
+                    label={`Only ${scopeContext.imageName.registry}/${scopeContext.imageName.remote}:${scopeContext.imageName.tag}`}
+                />
             )}
         </FormGroup>
     );


### PR DESCRIPTION
## Description

Handles the display of exception scope field, when the "just for this image tag" option is selected for an image that does not have an explicit tag, but is referenced by hash.

This isn't fully supported by the backend, and is effectively the same as choosing "all tags", so this is displayed as a wildcard as well.

In addition, this removes the "just for this image tag" option from the form UI when the image in scope does not have a tag.

**Note** - this is easier to review with "hide whitespace" on.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Create an exception at:
- global scope
- image scope for an image with no tag (`gke.gcr.io/fluent-bit`)
- single tag scope for an image with no tag (`gke.gcr.io/fluent-bit`)
- image scope for an image with a tag
- single tag scope for an image with a tag

![image](https://github.com/stackrox/stackrox/assets/1292638/409f3c2d-832b-4f76-a211-34dd547ea4a2)

Visit an image with a tag and open the exception form:
![image](https://github.com/stackrox/stackrox/assets/1292638/d68c5e99-bf91-4362-81e4-f9f83686bfce)

Visit an image without a tag and open the exception form:
![image](https://github.com/stackrox/stackrox/assets/1292638/65eb2f2f-097b-4cdc-a8d2-b7ede56bc608)



