### PR TITLE
fix: prepare proto to buf format

### DIFF
--- a/proto/storage/test.proto
+++ b/proto/storage/test.proto
@@ -169,7 +169,7 @@ message TestStruct {
   string string = 16 [(gogoproto.moretags) = 'search:"Test String"'];
 
   // repeated int64: currently unsupported
-  repeated int64 int_slice_deprecated = 17 [deprecated = true, (gogoproto.moretags) = 'sql:"-"'];
+  repeated int64 int_slice_deprecated = 17 [(gogoproto.moretags) = 'sql:"-"', deprecated = true];
 
   repeated int32 int32_slice = 18 [(gogoproto.moretags) = 'search:"Test Int32 Slice"'];
 

--- a/proto/storage/vuln_requests.proto
+++ b/proto/storage/vuln_requests.proto
@@ -111,8 +111,8 @@ message VulnerabilityRequest {
     // Indicates if this request is a historical request that is no longer in effect
     // due to deferral expiry, cancellation, or restarting cve observation.
     bool                             expired            = 4 [(gogoproto.moretags) = 'search:"Expired Request"'];
-    SlimUser                         requestor          = 5 [deprecated = true, (gogoproto.moretags) = 'sql:"ignore_labels(User ID)"'];
-    repeated SlimUser                approvers          = 6 [deprecated = true, (gogoproto.moretags) = 'sql:"ignore_labels(User ID)"'];
+    SlimUser                         requestor          = 5 [(gogoproto.moretags) = 'sql:"ignore_labels(User ID)"', deprecated = true];
+    repeated SlimUser                approvers          = 6 [(gogoproto.moretags) = 'sql:"ignore_labels(User ID)"', deprecated = true];
     google.protobuf.Timestamp        created_at         = 7 [(gogoproto.moretags) = 'search:"Created Time"'];
     google.protobuf.Timestamp        last_updated       = 8 [(gogoproto.moretags) = 'search:"Last Updated"'];
     repeated RequestComment          comments           = 9;
@@ -134,7 +134,7 @@ message VulnerabilityRequest {
 
     // 21 to 25 reserved for the updated request type oneof.
     oneof updated_req {
-        DeferralRequest              updated_deferral_req  = 21 [deprecated = true, (gogoproto.moretags) = 'search:"-"'];
+        DeferralRequest              updated_deferral_req  = 21 [(gogoproto.moretags) = 'search:"-"', deprecated = true];
         DeferralUpdate               deferral_update       = 22 [(gogoproto.moretags) = 'search:"-"'];
         FalsePositiveUpdate          false_positive_update = 23;
     }


### PR DESCRIPTION
## Description

When `buf format` the proto it splits tags into a separated lines. This breaks our script as it leave `deprecated = true,` while it's the only tag so `,` must be removed. Instead of fixing script let's reorder tags. 

https://github.com/stackrox/stackrox/blob/7c2309549eb0cdf3d19a818e87dd292308d0295b/qa-tests-backend/scripts/migrate_protos.sh#L15-L20

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
