### PR TITLE
ROX-21129: Add cluster init bundles wizard step 2

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep2.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep2.tsx
@@ -2,6 +2,10 @@ import React, { ReactElement } from 'react';
 import { Alert, Flex, Title } from '@patternfly/react-core';
 
 import { InitBundleWizardFormikProps } from './InitBundleWizard.utils';
+import SecureClusterUsingHelmChart from './SecureClusterUsingHelmChart';
+import SecureClusterUsingOperator from './SecureClusterUsingOperator';
+
+const headingLevel = 'h3';
 
 export type InitBundleWizardStep2Props = {
     errorMessage: string;
@@ -10,20 +14,26 @@ export type InitBundleWizardStep2Props = {
 
 function InitBundleWizardStep2({ errorMessage, formik }: InitBundleWizardStep2Props): ReactElement {
     const { values } = formik;
+    const { installation } = values;
 
     /* eslint-disable no-nested-ternary */
     return (
         <Flex direction={{ default: 'column' }}>
-            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
-                <Title headingLevel="h2">Download bundle</Title>
-                <p>
-                    {values.installation === 'Operator'
-                        ? 'Use this bundle to install secured cluster services on OpenShift with an Operator.'
-                        : values.platform === 'OpenShift'
-                          ? 'Use this bundle to install secured cluster services on OpenShift with a Helm chart.'
-                          : 'Use this bundle to install secured cluster services on xKS with a Helm chart.'}
-                </p>
-            </Flex>
+            <Title headingLevel="h2">Download bundle</Title>
+            <Alert
+                variant="info"
+                isInline
+                title="A cluster init bundle can only be downloaded once"
+                component="p"
+            >
+                Store this bundle securely because it contains secrets. You can use the same bundle
+                to secure multiple clusters.
+            </Alert>
+            {installation === 'Operator' ? (
+                <SecureClusterUsingOperator headingLevel={headingLevel} />
+            ) : (
+                <SecureClusterUsingHelmChart headingLevel={headingLevel} />
+            )}
             {errorMessage && (
                 <Alert
                     variant="danger"

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
@@ -1,0 +1,74 @@
+import React, { ReactElement } from 'react';
+import { useLocation } from 'react-router-dom';
+import qs from 'qs';
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    Divider,
+    Flex,
+    FlexItem,
+    PageSection,
+    Title,
+} from '@patternfly/react-core';
+
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import PageTitle from 'Components/PageTitle';
+import TabNav from 'Components/TabNav/TabNav';
+import { clustersBasePath, clustersSecureClusterPath } from 'routePaths';
+
+import SecureClusterUsingHelmChart from './SecureClusterUsingHelmChart';
+import SecureClusterUsingOperator from './SecureClusterUsingOperator';
+
+const title = 'Secure a cluster with an init bundle';
+const headingLevel = 'h2';
+
+const tabHelmChart = 'Helm-chart';
+const titleOperator = 'Operator';
+const titleHelmChart = 'Helm chart';
+const tabLinks = [
+    {
+        href: `${clustersSecureClusterPath}?tab=Operator`,
+        title: titleOperator,
+    },
+    {
+        href: `${clustersSecureClusterPath}?tab=${tabHelmChart}`,
+        title: titleHelmChart,
+    },
+];
+
+function SecureClusterPage(): ReactElement {
+    const { search } = useLocation();
+    const { tab } = qs.parse(search, { ignoreQueryPrefix: true });
+    const isOperator = tab !== tabHelmChart;
+
+    return (
+        <>
+            <PageSection component="div" variant="light">
+                <PageTitle title="Secure a cluster" />
+                <Flex direction={{ default: 'column' }}>
+                    <Flex direction={{ default: 'column' }}>
+                        <Breadcrumb>
+                            <BreadcrumbItemLink to={clustersBasePath}>Clusters</BreadcrumbItemLink>
+                            <BreadcrumbItem isActive>{title}</BreadcrumbItem>
+                        </Breadcrumb>
+                        <Title headingLevel="h1">Secure a cluster with an init bundle</Title>
+                    </Flex>
+                    <FlexItem>
+                        <TabNav
+                            currentTabTitle={isOperator ? titleOperator : titleHelmChart}
+                            tabLinks={tabLinks}
+                        />
+                        <Divider component="div" />
+                    </FlexItem>
+                    {isOperator ? (
+                        <SecureClusterUsingOperator headingLevel={headingLevel} />
+                    ) : (
+                        <SecureClusterUsingHelmChart headingLevel={headingLevel} />
+                    )}
+                </Flex>
+            </PageSection>
+        </>
+    );
+}
+
+export default SecureClusterPage;

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
@@ -1,0 +1,25 @@
+import React, { ReactElement } from 'react';
+import { Flex, List, ListItem, Title } from '@patternfly/react-core';
+
+export type SecureClusterUsingHelmChartProps = {
+    headingLevel: 'h2' | 'h3';
+};
+
+function SecureClusterUsingHelmChart({
+    headingLevel,
+}: SecureClusterUsingHelmChartProps): ReactElement {
+    return (
+        <Flex direction={{ default: 'column' }}>
+            <Title headingLevel={headingLevel}>
+                Secure a cluster using Helm chart installation method
+            </Title>
+            <List component="ol">
+                <ListItem>Do something.</ListItem>
+                <ListItem>Do something.</ListItem>
+                <ListItem>Do something.</ListItem>
+            </List>
+        </Flex>
+    );
+}
+
+export default SecureClusterUsingHelmChart;

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
@@ -1,0 +1,25 @@
+import React, { ReactElement } from 'react';
+import { Flex, List, ListItem, Title } from '@patternfly/react-core';
+
+export type SecureClusterUsingOperatorProps = {
+    headingLevel: 'h2' | 'h3';
+};
+
+function SecureClusterUsingOperator({
+    headingLevel,
+}: SecureClusterUsingOperatorProps): ReactElement {
+    return (
+        <Flex direction={{ default: 'column' }}>
+            <Title headingLevel={headingLevel}>
+                Secure a cluster using Operator installation method
+            </Title>
+            <List component="ol">
+                <ListItem>Do something.</ListItem>
+                <ListItem>Do something.</ListItem>
+                <ListItem>Do something.</ListItem>
+            </List>
+        </Flex>
+    );
+}
+
+export default SecureClusterUsingOperator;

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -13,6 +13,7 @@ import {
     clustersDiscoveredClustersPath,
     clustersInitBundlesPathWithParam,
     clustersPathWithParam,
+    clustersSecureClusterPath,
     collectionsPath,
     complianceEnhancedBasePath,
     compliancePath,
@@ -105,6 +106,13 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
     'clusters/init-bundles': {
         component: asyncComponent(() => import('Containers/Clusters/InitBundles/InitBundlesRoute')),
         path: clustersInitBundlesPathWithParam,
+    },
+    // Cluster secure-a-cluster must precede generic Clusters.
+    'clusters/secure-a-cluster': {
+        component: asyncComponent(
+            () => import('Containers/Clusters/InitBundles/SecureClusterPage')
+        ),
+        path: clustersSecureClusterPath,
     },
     clusters: {
         component: asyncComponent(() => import('Containers/Clusters/ClustersPage')),

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -29,6 +29,7 @@ export const clustersDelegatedScanningPath = `${clustersBasePath}/delegated-imag
 export const clustersDiscoveredClustersPath = `${clustersBasePath}/discovered-clusters`;
 export const clustersInitBundlesPath = `${clustersBasePath}/init-bundles`;
 export const clustersInitBundlesPathWithParam = `${clustersInitBundlesPath}/:id?`;
+export const clustersSecureClusterPath = `${clustersBasePath}/secure-a-cluster`;
 export const collectionsBasePath = `${mainPath}/collections`;
 export const collectionsPath = `${mainPath}/collections/:collectionId?`;
 export const complianceBasePath = `${mainPath}/compliance`;
@@ -155,6 +156,8 @@ export type RouteKey =
     | 'clusters/discovered-clusters'
     // Cluster init bundles must precede generic Clusters in Body and so here for consistency.
     | 'clusters/init-bundles'
+    // Cluster secure-a-cluster must precede generic Clusters in Body and so here for consistency.
+    | 'clusters/secure-a-cluster'
     | 'clusters'
     | 'collections'
     | 'compliance'
@@ -210,6 +213,11 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     'clusters/init-bundles': {
         featureFlagRequirements: allEnabled(['ROX_MOVE_INIT_BUNDLES_UI']),
         resourceAccessRequirements: everyResource(['Administration', 'Integration']),
+    },
+    // Clusters secure-a-cluster must precede generic Clusters in Body and so here for consistency.
+    'clusters/secure-a-cluster': {
+        featureFlagRequirements: allEnabled(['ROX_MOVE_INIT_BUNDLES_UI']),
+        resourceAccessRequirements: everyResource([]),
     },
     clusters: {
         resourceAccessRequirements: everyResource(['Cluster']),


### PR DESCRIPTION
## Description

1. Add reusable content components for **Operator** or **Helm chart** installation method.
    * `InitBundleWizardStep2` renders either/or depending on selection in wizard step 1.
    * `SecureClusterPage` renders either/or via tabs. Add `secure-a-cluster` route for this page.
2. Rename **Install cluster** button as **Secure a cluster** wording from Cloud Sources mocks of clusters page.
    * Replace **View instructions** link with **Init bundle installation methods** link to **Secure a cluster with an init bundle** page.
    * Replace **New cluster** with **Legacy installation method**.

### Residue

After we merge this, move forward in parallel:
* Add content of the 2 components to focus the attention of reviewers:
    * Kerry: clear wording and consistency with docs.
    * Mansur: usability and visual design.
    * Simon: correct and complete for the context.
* Rename AddClusterPrompt component and add content for no clusters and conditional rendering:
    * no init bundles: **Create bundle** as call to action.
    * init bundles after return from wizard: **Review instructions** link to open **Secure a cluster with an init bundle** page in a new tab.
        That is, primary tab is still /main/clusters so user sees change from no clusters state to ordinary clusters list as soon as there is a secured clusters.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_MOVE_INIT_BUNDLES_UI=true
```

1. `yarn lint` in ui/apps/platform
2. `yarn build` in ui/apps/platform
3. `yarn start` in ui

### Manual testing

1. Visit /main/clusters, and then click **Secure a cluster**: see 2 links (residue investigate inconsistent style).
    ![1_Secure_a_cluster](https://github.com/stackrox/stackrox/assets/11862657/ee81b9f7-7dc5-4377-a1d3-699c23577da0)

2. Click **Init bundle installation methods**: see /main/clusters/secure-a-cluster page with placeholder content for Operator.
    ![2_page_Operator](https://github.com/stackrox/stackrox/assets/11862657/d8f66f37-8a0f-4107-bd23-c2068c33914a)

3. Click **Helm chart** tab: see placeholder content for Helm chart.
    ![3_page_Helm_chart](https://github.com/stackrox/stackrox/assets/11862657/9b5b6bad-9ab4-4e62-92b0-6107da487f5e)

4. Click **Clusters** breadcrumb link, click **Manage init bundles**, and then click **Create bundle**: see wizard step 1.
    ![4_wizard_step_1](https://github.com/stackrox/stackrox/assets/11862657/e8d6617e-1589-44ac-94d7-94de8c0a015c)

5. Enter a name, and then click **Next**: see step 2 with placeholder content for Operator.
    ![5_wizard_step_2_Operator](https://github.com/stackrox/stackrox/assets/11862657/af4d999f-d89c-47fa-be43-a13bdccc5d63)

6. Click **Back**, select **GKE**, and then click **Next**: see step 2 with placeholder content for Helm chart.
    ![6_wizard_step_2_Helm_chart](https://github.com/stackrox/stackrox/assets/11862657/a6a03a27-75a1-46d5-b108-a16e67bfbfa9)
