### PR TITLE
fix(scanner): nightly and prerelease builds

### DIFF
--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -30,12 +30,13 @@ jobs:
         source './scripts/ci/lib.sh'
 
         # If goarch is updated, be sure to update architectures in push-manifests below.
-        matrix='{ "build_and_push": { "name":["default"], "goos":["linux"], "goarch":["amd64", "arm64", "ppc64le", "s390x"] } }'
+        matrix='{ "build_and_push": { "name":["default"], "goos":["linux"], "goarch":["amd64", "arm64", "ppc64le", "s390x"] }, "push_manifests": { "name":["default"] } }'
 
         # Conditionally add a prerelease build (binaries built with GOTAGS=release)
         if ! is_tagged; then
           if ! is_in_PR_context || pr_has_label ci-build-prerelease; then
             matrix="$(jq '.build_and_push.name += ["prerelease"]' <<< "$matrix")"
+            matrix="$(jq '.push_manifests.name += ["prerelease"]' <<< "$matrix")"
           fi
         fi
 
@@ -87,6 +88,10 @@ jobs:
         matrix.name == 'prerelease'
       run: echo "GOTAGS=release" >> "$GITHUB_ENV"
 
+    - name: Set build tag for prerelease images
+      if: matrix.name == 'prerelease'
+      run: echo "BUILD_TAG=$(make -C scanner --quiet --no-print-directory tag)-prerelease" >> "$GITHUB_ENV"
+
     - name: Build Scanner and ScannerDB images
       run: make -C scanner GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} images
 
@@ -100,8 +105,15 @@ jobs:
 
   push-manifests:
     needs:
+    - define-job-matrix
     - build-and-push
     runs-on: ubuntu-latest
+    strategy:
+      # Supports two image builds:
+      # default
+      # prerelease
+      fail-fast: false
+      matrix: ${{ fromJson(needs.define-job-matrix.outputs.matrix).push_manifests }}
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61
       env:
@@ -120,6 +132,12 @@ jobs:
       run: |
         # Prevent fatal error "detected dubious ownership in repository" from recent git.
         git config --global --add safe.directory "$(pwd)"
+
+    - uses: ./.github/actions/handle-tagged-build
+
+    - name: Set build tag for prerelease images
+      if: matrix.name == 'prerelease'
+      run: echo "BUILD_TAG=$(make -C scanner --quiet --no-print-directory tag)-prerelease" >> "$GITHUB_ENV"
 
     - name: Push Scanner and ScannerDB image manifests
       # Skip for external contributions.


### PR DESCRIPTION
## Description

We were not pushing Scanner v4 manifest indexes (see https://github.com/stackrox/stackrox/actions/runs/7647853880/job/20839784400). This PR fixes that, and it also appends `-prelease` to the image/version tag for prerelease builds.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Added the `ci-build-prerelease` label. Not sure how to test tagging from here, though

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
