### PR TITLE
ROX-21879: Scan results by cluster card selector

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsContent.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsContent.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { Alert, Divider, Flex, FlexItem, Gallery, GalleryItem } from '@patternfly/react-core';
+
+import useURLStringUnion from 'hooks/useURLStringUnion';
+import { ComplianceClusterScanStats } from 'services/ComplianceEnhancedService';
+
+import RadioButtonWithStats from '../Components/RadioButtonWithStats';
+
+export type ClusterDetailsContentProps = {
+    scanRecords: ComplianceClusterScanStats[];
+};
+
+function ClusterDetailsContent({ scanRecords }: ClusterDetailsContentProps) {
+    const scanNames = scanRecords.map((item) => item.scanStats.scanName) as [string, ...string[]];
+    const [urlSelectedScan, setUrlSelectedScan] = useURLStringUnion('selectedScan', scanNames);
+    const [selectedScan, setSelectedScan] = useState('');
+
+    useEffect(() => {
+        if (
+            urlSelectedScan &&
+            scanRecords.some((record) => record.scanStats.scanName === urlSelectedScan)
+        ) {
+            setSelectedScan(urlSelectedScan);
+        } else if (scanRecords.length > 0) {
+            setSelectedScan(scanRecords[0].scanStats.scanName);
+        }
+    }, [urlSelectedScan, scanRecords]);
+
+    const handleSelectedScan = (scan) => {
+        setUrlSelectedScan(scan);
+        setSelectedScan(scan);
+    };
+
+    return (
+        <Flex
+            direction={{ default: 'column' }}
+            className="pf-u-background-color-100 pf-u-p-lg"
+            spaceItems={{ default: 'spaceItemsLg' }}
+            flexWrap={{ default: 'nowrap' }}
+        >
+            <FlexItem>
+                <Alert
+                    variant="info"
+                    title="View results by scan schedule today. Support for viewing compliance results by profiles is coming soon."
+                    component="div"
+                    isInline
+                />
+            </FlexItem>
+            <FlexItem>
+                <Gallery hasGutter>
+                    {scanRecords.map(({ scanStats }) => (
+                        <GalleryItem key={scanStats.scanName}>
+                            <RadioButtonWithStats
+                                key={scanStats.scanName}
+                                scanStats={scanStats}
+                                isSelected={scanStats.scanName === selectedScan}
+                                onSelected={handleSelectedScan}
+                            />
+                        </GalleryItem>
+                    ))}
+                </Gallery>
+            </FlexItem>
+            <FlexItem>
+                <Divider component="div" />
+            </FlexItem>
+        </Flex>
+    );
+}
+
+export default ClusterDetailsContent;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsHeader.tsx
@@ -4,22 +4,23 @@ import { Flex, Label, LabelGroup, Skeleton, Title } from '@patternfly/react-core
 import { ComplianceClusterOverallStats } from 'services/ComplianceEnhancedService';
 
 import {
-    getPassAndTotalCount,
+    getStatusCounts,
     calculateCompliancePercentage,
     getComplianceLabelGroupColor,
 } from '../compliance.coverage.utils';
 
 export type ClusterDetailsHeaderProps = {
     clusterStats: ComplianceClusterOverallStats | undefined;
+    isLoading: boolean;
 };
 
-function ClusterDetailsHeader({ clusterStats }: ClusterDetailsHeaderProps) {
+function ClusterDetailsHeader({ clusterStats, isLoading }: ClusterDetailsHeaderProps) {
     let passCount;
     let totalCount;
     let compliancePercentage;
 
     if (clusterStats) {
-        ({ passCount, totalCount } = getPassAndTotalCount(clusterStats.checkStats));
+        ({ passCount, totalCount } = getStatusCounts(clusterStats.checkStats));
         compliancePercentage = calculateCompliancePercentage(passCount, totalCount);
     }
 
@@ -27,19 +28,19 @@ function ClusterDetailsHeader({ clusterStats }: ClusterDetailsHeaderProps) {
         <>
             <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsFlexStart' }}>
                 <Title headingLevel="h1">
-                    {!clusterStats ? (
+                    {isLoading ? (
                         <Skeleton
                             fontSize="2xl"
                             screenreaderText="Loading cluster name"
                             width="200px"
                         />
                     ) : (
-                        clusterStats.cluster.clusterName
+                        clusterStats?.cluster.clusterName
                     )}
                 </Title>
                 <LabelGroup numLabels={1}>
                     <Label color={getComplianceLabelGroupColor(compliancePercentage)}>
-                        {!clusterStats ? (
+                        {isLoading ? (
                             <Skeleton
                                 screenreaderText="Loading compliance percentage"
                                 width="110px"

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/ClustersCoverageTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/ClustersCoverageTable.tsx
@@ -28,7 +28,7 @@ import { getAllClustersCombinedStats } from 'services/ComplianceEnhancedService'
 import {
     calculateCompliancePercentage,
     getCompliancePfClassName,
-    getPassAndTotalCount,
+    getStatusCounts,
 } from './compliance.coverage.utils';
 
 function ClustersCoverageTable() {
@@ -43,7 +43,7 @@ function ClustersCoverageTable() {
 
     const renderTableContent = () => {
         return clusterScanStats?.map(({ cluster, checkStats }, index) => {
-            const { passCount, totalCount } = getPassAndTotalCount(checkStats);
+            const { passCount, totalCount } = getStatusCounts(checkStats);
             const passPercentage = calculateCompliancePercentage(passCount, totalCount);
 
             return (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Components/RadioButtonWithStats.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Components/RadioButtonWithStats.tsx
@@ -1,0 +1,96 @@
+import React, { useMemo } from 'react';
+import {
+    Card,
+    CardTitle,
+    CardBody,
+    Radio,
+    FlexItem,
+    Flex,
+    Label,
+    LabelGroup,
+} from '@patternfly/react-core';
+import { BarsIcon, CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+
+import { ComplianceScanStatsShim } from 'services/ComplianceEnhancedService';
+
+import { getStatusCounts } from '../compliance.coverage.utils';
+
+export type RadioButtonWithStatsProps = {
+    scanStats: ComplianceScanStatsShim;
+    isSelected: boolean;
+    onSelected: (scanName: string) => void;
+};
+
+function RadioButtonWithStats({ scanStats, isSelected, onSelected }: RadioButtonWithStatsProps) {
+    const { scanName } = scanStats;
+    const { passCount, failCount, otherCount } = useMemo(
+        () => getStatusCounts(scanStats.checkStats),
+        [scanStats]
+    );
+
+    const onKeyDown = (event: React.KeyboardEvent) => {
+        if ([' ', 'Enter'].includes(event.key)) {
+            event.preventDefault();
+            onSelected(scanName);
+        }
+    };
+
+    return (
+        <>
+            <Card
+                id={`selectable-card-${scanName}`}
+                onKeyDown={onKeyDown}
+                onClick={() => onSelected(scanName)}
+                hasSelectableInput
+                onSelectableInputChange={() => onSelected(scanName)}
+                isSelectableRaised
+                isSelected={isSelected}
+                isCompact
+                selectableInputAriaLabel={`results for scan: ${scanName}`}
+            >
+                <CardTitle className="pf-u-p-sm pf-u-pb-0">
+                    <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
+                        <FlexItem>
+                            <Radio
+                                id={`selectable-card-radio-${scanName}`}
+                                aria-label={`radio button for ${scanName} coverage`}
+                                name={`selectable-card-radio-${scanName}`}
+                                isChecked={isSelected}
+                            />
+                        </FlexItem>
+                    </Flex>
+                </CardTitle>
+                <CardTitle>{scanName}</CardTitle>
+                <CardBody>
+                    <LabelGroup aria-label={`check results for ${scanName}`}>
+                        <Label
+                            aria-label={`number of passing checks: ${passCount}`}
+                            className="pf-u-mr-xs"
+                            icon={<CheckCircleIcon />}
+                            color="green"
+                        >
+                            {passCount}
+                        </Label>
+                        <Label
+                            aria-label={`number of failing checks: ${failCount}`}
+                            className="pf-u-mr-xs"
+                            icon={<ExclamationCircleIcon />}
+                            color="red"
+                        >
+                            {failCount}
+                        </Label>
+                        <Label
+                            aria-label={`number of other checks: ${otherCount}`}
+                            icon={<BarsIcon />}
+                            color="grey"
+                        >
+                            {otherCount}
+                        </Label>
+                    </LabelGroup>
+                </CardBody>
+            </Card>
+        </>
+    );
+}
+
+export default RadioButtonWithStats;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/compliance.coverage.utils.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/compliance.coverage.utils.ts
@@ -19,21 +19,32 @@ export const ComplianceStatus = {
 
 export type ComplianceStatus = (typeof ComplianceStatus)[keyof typeof ComplianceStatus];
 
-export function getPassAndTotalCount(checkStats: ComplianceCheckStatusCount[]): {
+export function getStatusCounts(checkStats: ComplianceCheckStatusCount[]): {
     passCount: number;
+    failCount: number;
+    otherCount: number;
     totalCount: number;
 } {
-    let totalCount = 0;
     let passCount = 0;
+    let failCount = 0;
+    let otherCount = 0;
+    let totalCount = 0;
 
-    checkStats.forEach((stat) => {
-        totalCount += stat.count;
-        if (stat.status === ComplianceCheckStatus.PASS) {
-            passCount += stat.count;
+    checkStats.forEach((statusInfo) => {
+        totalCount += statusInfo.count;
+        switch (statusInfo.status) {
+            case ComplianceCheckStatus.PASS:
+                passCount += statusInfo.count;
+                break;
+            case ComplianceCheckStatus.FAIL:
+                failCount += statusInfo.count;
+                break;
+            default:
+                otherCount += statusInfo.count;
         }
     });
 
-    return { passCount, totalCount };
+    return { passCount, failCount, otherCount, totalCount };
 }
 
 export function calculateCompliancePercentage(passCount: number, totalCount: number): number {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Status/Dashboard/ScanResultsOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Status/Dashboard/ScanResultsOverviewTable.tsx
@@ -23,7 +23,7 @@ import { SortOption } from 'types/table';
 import { displayOnlyItemOrItemCount } from 'utils/textUtils';
 
 import ScanResultsToolbar from './ScanResultsToolbar';
-import { getPassAndTotalCount } from '../../ClusterCompliance/Coverage/compliance.coverage.utils';
+import { getStatusCounts } from '../../ClusterCompliance/Coverage/compliance.coverage.utils';
 
 const sortFields = ['Scan Name', 'Failing Controls', 'Last Scanned'];
 const defaultSortOption = { field: 'Scan Name', direction: 'asc' } as SortOption;
@@ -63,7 +63,7 @@ function ScanResultsOverviewTable() {
         }
 
         return scanResultsOverviewData?.map(({ scanStats, cluster, profileName }) => {
-            const { passCount, totalCount } = getPassAndTotalCount(scanStats.checkStats);
+            const { passCount, totalCount } = getStatusCounts(scanStats.checkStats);
             return (
                 <Tr key={scanStats.scanName}>
                     <Td>

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -193,6 +193,11 @@
     border-color: transparent;
 }
 
+/* fixes flattened radio buttons caused by tailwind appearance when using pf standalone radio button */
+.pf-c-radio.pf-m-standalone input[type="radio"] {
+    appearance: auto;
+}
+
 /* For classic components to equal or exceed z-index of PatternFly elements. */
 
 .z-xs-100 {


### PR DESCRIPTION
## Description

Create cards that allow users to toggle between cluster results according to the scan configurations.

* Calls to fetch both overall cluster results and cluster results by scan configuration will kick off at the same time
* A loading indicator will display below the cluster details header during the loading of scan overview card details. We'll need that scan info before we can fetch compliance check results.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

* Each scan configuration setup that includes the cluster in view should display as a card on this page
* Each card should display pass count, fail count, and other count
* The initial scan results card is automatically selected upon loading. When a user chooses a card, a URL query parameter is updated (`selectedScan`), ensuring that the selected card remains active even after refreshing the page

![Screenshot 2024-01-26 at 2 21 40 AM](https://github.com/stackrox/stackrox/assets/61400697/6d338582-3ffd-4655-a553-7aca11e52aca)
