### PR TITLE
ROX-21131: Add conditional rendering for no clusters page

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
 import { visitMainDashboardWithStaticResponseForClustersForPermission } from '../../helpers/main';
 
 import { clustersAlias, interactAndVisitClusters } from './Clusters.helpers';
@@ -26,12 +27,14 @@ describe('Clusters', () => {
             );
         }, staticResponseMapForClusters);
 
-        cy.get(
-            'p:contains("You have successfully deployed a Red Hat Advanced Cluster Security platform.")'
-        );
-
-        cy.get('h2:contains("Configure the clusters you want to secure.")');
-
-        cy.get('a:contains("View instructions")');
+        if (hasFeatureFlag('ROX_MOVE_INIT_BUNDLES_UI')) {
+            // Replace h1 with h2 if we factor out a minimal Clusters page.
+            cy.get('h1:contains("Secure clusters with a reusable init bundle")');
+            // Assert link instead of button, because init bundles exist.
+            cy.get('a:contains("Review installation methods")');
+        } else {
+            cy.get('h2:contains("Configure the clusters you want to secure.")');
+            cy.get('a:contains("View instructions")');
+        }
     });
 });

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, useState, useReducer } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import {
+    Alert,
     Bullseye,
     Button,
     Dropdown,
@@ -9,6 +10,7 @@ import {
     DropdownPosition,
     DropdownToggle,
     PageSection,
+    Spinner,
 } from '@patternfly/react-core';
 
 import CheckboxTable from 'Components/CheckboxTable';
@@ -50,6 +52,7 @@ import ManageTokensButton from './Components/ManageTokensButton';
 import { clusterTablePollingInterval, getUpgradeableClusters } from './cluster.helpers';
 import { getColumnsForClusters } from './clustersTableColumnDescriptors';
 import AddClusterPrompt from './AddClusterPrompt';
+import NoClustersPage from './NoClustersPage';
 
 export type ClustersTablePanelProps = {
     selectedClusterId: string;
@@ -98,7 +101,8 @@ function ClustersTablePanel({
     const [pollingCount, setPollingCount] = useState(0);
     const [tableRef, setTableRef] = useState<CheckboxTable | null>(null);
     const [showDialog, setShowDialog] = useState(false);
-    const [fetchingClusters, setFetchingClusters] = useState(false);
+    const [errorMessage, setErrorMessage] = useState('');
+    const [hasFetchedClusters, setHasFetchedClusters] = useState(false);
 
     // Handle changes to applied search options.
     const [isViewFiltered, setIsViewFiltered] = useState(false);
@@ -205,7 +209,6 @@ function ClustersTablePanel({
     /* eslint-enable no-nested-ternary */
 
     function refreshClusterList(restSearch?: RestSearchOption[]) {
-        setFetchingClusters(true);
         // Although return works around typescript-eslint/no-floating-promises error elsewhere,
         // removed here because it caused the error for callers.
         // Anyway, catch block would be better.
@@ -213,10 +216,11 @@ function ClustersTablePanel({
             .then((clustersResponse) => {
                 setCurrentClusters(clustersResponse.clusters);
                 setClusterIdToRetentionInfo(clustersResponse.clusterIdToRetentionInfo);
-                setFetchingClusters(false);
+                setErrorMessage('');
+                setHasFetchedClusters(true);
             })
-            .catch(() => {
-                setFetchingClusters(false);
+            .catch((error) => {
+                setErrorMessage(getAxiosErrorMessage(error));
             });
     }
 
@@ -236,6 +240,48 @@ function ClustersTablePanel({
     useInterval(() => {
         setPollingCount(pollingCount + 1);
     }, clusterTablePollingInterval);
+
+    // Do not render page heading now because of current NoClustersPage design (rendered below).
+    // PatternFly clusters page: reconsider whether to factor out minimal common heading.
+    //
+    // Before there is a response:
+    if (!hasFetchedClusters) {
+        return (
+            <PageSection variant="light">
+                <Bullseye>
+                    {errorMessage ? (
+                        <Alert
+                            variant="warning"
+                            isInline
+                            title="Unable to fetch clusters"
+                            component="p"
+                        >
+                            {errorMessage}
+                        </Alert>
+                    ) : (
+                        <Spinner isSVG />
+                    )}
+                </Bullseye>
+            </PageSection>
+        );
+    }
+
+    const hasSearchApplied = getHasSearchApplied(filteredSearch);
+
+    // PatternFly clusters page: reconsider whether to factor out minimal common heading.
+    //
+    // After there is a response, if there are no clusters nor search filter:
+    if (currentClusters.length === 0 && !hasSearchApplied) {
+        return isMoveInitBundlesEnabled ? (
+            <NoClustersPage />
+        ) : (
+            <PageSection variant="light">
+                <Bullseye>
+                    <AddClusterPrompt />
+                </Bullseye>
+            </PageSection>
+        );
+    }
 
     function onAddCluster() {
         history.push(`${clustersBasePath}/new`); // TODO we might replace pseudo-id with ?action=create
@@ -397,22 +443,8 @@ function ClustersTablePanel({
     const pageSize =
         currentClusters.length <= DEFAULT_PAGE_SIZE ? DEFAULT_PAGE_SIZE : currentClusters.length;
 
-    const hasSearchApplied = getHasSearchApplied(filteredSearch);
-
-    if (
-        (!fetchingClusters || pollingCount > 0) &&
-        currentClusters.length <= 0 &&
-        !hasSearchApplied
-    ) {
-        return (
-            <PageSection variant="light">
-                <Bullseye>
-                    <AddClusterPrompt />
-                </Bullseye>
-            </PageSection>
-        );
-    }
-
+    // After there is a response, if there are clusters or search filter.
+    // Conditionally render a subsequent error in addition to most recent successful respnse.
     return (
         <div className="overflow-hidden w-full">
             {pageHeader}
@@ -422,31 +454,38 @@ function ClustersTablePanel({
                     <PanelHeadEnd>{headerActions}</PanelHeadEnd>
                 </PanelHead>
                 <PanelBody>
+                    {errorMessage && (
+                        <Alert
+                            variant="warning"
+                            isInline
+                            title="Unable to fetch clusters"
+                            component="p"
+                        >
+                            {errorMessage}
+                        </Alert>
+                    )}
                     {messages.length > 0 && (
                         <div className="flex flex-col w-full items-center bg-warning-200 text-warning-8000 justify-center font-700 text-center">
                             {messages}
                         </div>
                     )}
-                    {(!fetchingClusters || pollingCount > 0) &&
-                        (currentClusters.length > 0 || hasSearchApplied) && (
-                            <div data-testid="clusters-table" className="h-full w-full">
-                                <CheckboxTable
-                                    ref={(table) => {
-                                        setTableRef(table);
-                                    }}
-                                    rows={currentClusters}
-                                    columns={clusterColumns}
-                                    onRowClick={setSelectedClusterId}
-                                    toggleRow={toggleCluster}
-                                    toggleSelectAll={toggleAllClusters}
-                                    selection={checkedClusterIds}
-                                    selectedRowId={selectedClusterId}
-                                    noDataText="No clusters to show."
-                                    minRows={20}
-                                    pageSize={pageSize}
-                                />
-                            </div>
-                        )}
+                    <div data-testid="clusters-table" className="h-full w-full">
+                        <CheckboxTable
+                            ref={(table) => {
+                                setTableRef(table);
+                            }}
+                            rows={currentClusters}
+                            columns={clusterColumns}
+                            onRowClick={setSelectedClusterId}
+                            toggleRow={toggleCluster}
+                            toggleSelectAll={toggleAllClusters}
+                            selection={checkedClusterIds}
+                            selectedRowId={selectedClusterId}
+                            noDataText="No clusters to show."
+                            minRows={20}
+                            pageSize={pageSize}
+                        />
+                    </div>
                 </PanelBody>
             </PanelNew>
             <Dialog

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -1,0 +1,140 @@
+import React, { ReactElement, useEffect, useState } from 'react';
+import {
+    Alert,
+    Bullseye,
+    Button,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateIcon,
+    Flex,
+    FlexItem,
+    PageSection,
+    Spinner,
+    Title,
+    Text,
+} from '@patternfly/react-core';
+import { CloudSecurityIcon } from '@patternfly/react-icons';
+
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import LinkShim from 'Components/PatternFly/LinkShim';
+import { fetchClusterInitBundles } from 'services/ClustersService';
+import { getProductBranding } from 'constants/productBranding';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { clustersInitBundlesPath, clustersSecureClusterPath } from 'routePaths';
+
+/*
+ * Comments about data flow:
+ * 1. It is important that /main/clusters NoClustersPage **Create bundle**
+ *    goes to /main/clusters/init-bundles InitBundlesWizard in the same tab,
+ *    so when **Download** goes back, NoClustersPage makes a new GET /v1/init-bundles request
+ *    and therefore renders the link instead of the button.
+ *
+ * 2. It is important that /main/clusters NoClustersPage **Review installation instructions**
+ *    opens /main/clusters/secure-a-cluster SecureCluster in new tab,
+ *    so polling loop in original tab will cause conditional rendering of table
+ *    whenever there is a secured cluster.
+ *    That is, if it opens the page in the same tab,
+ *    then it suggests the need for a back button outside of a wizard.
+ */
+
+function NoClustersPage(): ReactElement {
+    // Use promise instead of useRestQuery hook because of role-based access control.
+    const [errorMessage, setErrorMessage] = useState('');
+    const [initBundlesCount, setInitBundlesCount] = useState(0);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const { basePageTitle } = getProductBranding();
+    const textForSuccessAlert = `You have successfully deployed a ${basePageTitle} platform. Now you can configure the clusters you want to secure.`;
+
+    useEffect(() => {
+        setIsLoading(true);
+        fetchClusterInitBundles()
+            .then(({ response }) => {
+                setErrorMessage('');
+                setInitBundlesCount(response.items.length);
+            })
+            .catch((error) => {
+                setErrorMessage(getAxiosErrorMessage(error));
+            })
+            .finally(() => {
+                setIsLoading(false);
+            });
+    }, []);
+
+    /* eslint-disable no-nested-ternary */
+    return (
+        <>
+            <PageSection variant="light" component="div" padding={{ default: 'noPadding' }}>
+                <Alert isInline variant="success" title="You are ready to go!">
+                    {textForSuccessAlert}
+                </Alert>
+            </PageSection>
+            <PageSection variant="light">
+                {isLoading ? (
+                    <Bullseye>
+                        <Spinner isSVG />
+                    </Bullseye>
+                ) : errorMessage ? (
+                    <Alert
+                        variant="warning"
+                        title="Unable to fetch cluster init bundles"
+                        component="div"
+                        isInline
+                    >
+                        {errorMessage}
+                    </Alert>
+                ) : (
+                    <EmptyState variant="large">
+                        <EmptyStateIcon icon={CloudSecurityIcon} />
+                        <Title headingLevel="h1">Secure clusters with a reusable init bundle</Title>
+                        <EmptyStateBody>
+                            <Flex
+                                direction={{ default: 'column' }}
+                                spaceItems={{ default: 'spaceItemsLg' }}
+                            >
+                                <FlexItem>
+                                    <Text component="p">
+                                        Follow the instructions to install secured cluster services.
+                                    </Text>
+                                    <Text component="p">
+                                        Upon successful installation, secured clusters are listed
+                                        here.
+                                    </Text>
+                                </FlexItem>
+                                {initBundlesCount !== 0 && (
+                                    <FlexItem>
+                                        <Text component="p">
+                                            You have successfully created cluster init bundles.
+                                        </Text>
+                                        <ExternalLink>
+                                            <a
+                                                href={clustersSecureClusterPath}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                            >
+                                                Review installation methods
+                                            </a>
+                                        </ExternalLink>
+                                    </FlexItem>
+                                )}
+                            </Flex>
+                        </EmptyStateBody>
+                        {initBundlesCount === 0 && (
+                            <Button
+                                variant="primary"
+                                isLarge
+                                component={LinkShim}
+                                href={`${clustersInitBundlesPath}?action=create`}
+                            >
+                                Create bundle
+                            </Button>
+                        )}
+                    </EmptyState>
+                )}
+            </PageSection>
+        </>
+    );
+    /* eslint-enable no-nested-ternary */
+}
+
+export default NoClustersPage;

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -24,6 +24,7 @@ import { clustersInitBundlesPath, clustersSecureClusterPath } from 'routePaths';
 
 /*
  * Comments about data flow:
+ *
  * 1. It is important that /main/clusters NoClustersPage **Create bundle**
  *    goes to /main/clusters/init-bundles InitBundlesWizard in the same tab,
  *    so when **Download** goes back, NoClustersPage makes a new GET /v1/init-bundles request


### PR DESCRIPTION
## Description

A few more changes than I had intended because during manual testing, an unexpected GET /v1/init-bundles request directed attention at a loophole in complicated conditional rendering because
* `fetchingClusters` has initial value `false`
* `pollingCount` has initial value `0`
* `currentClusters.length` has initial value `0`

Which rendered NoClustersPage **before** first successful response.

### Updates to data flow

1. Visit or redirect to /main clusters which makes GET /v1/clusters request every 5 seconds.
2. Before first successful response, render either error message or spinner.
3. After first successful response:
    * If no clusters and not filtered, render NoClustersPage.
    * If clusters or filtered, render clusters table and so on.

### Changes for data flow

1. Replace `fetchingClusters` with opposite `hasFetchedClusters` to simplify conditional rendering of spinner during initial request. We might restore `isFilteringClusters` if the team develops a reusable component as recently discussed. However, it does not apply to ordinary polled requests.
2. Simplify and lift up conditional rendering with early return:
    * Before there is a response.
    * After there is a response, if there are no clusters nor search filter.
    * After there is a response, if there are clusters or search filter.

### Comments about data flow

1. It is important that /main/clusters NoClustersPage **Create bundle** goes to /main/clusters/init-bundles InitBundlesWizard in the same tab, so when **Download** goes back, NoClustersPage makes a new GET /v1/init-bundles request and therefore renders the link instead of the button.
2. It is important that /main/clusters NoClustersPage **Review installation instructions** opens /main/clusters/secure-a-cluster SecureCluster in new tab, so polling loop in original tab will cause conditional rendering of table whenever there is a secured cluster. That is, if it opens the page in the same tab, then it suggests the need for a back button outside of a wizard.

### Residue

1. After we merge this, move forward in parallel:
    * Add analytics.
    * Add integration tests.
2. As comments document, reconsider whether to factor out a minimal **Clusters** page heading so NoClustersPage (and therefore Spinner for initial fetch) has something in common with ordinary clusters page.
3. Factor out the clusters request and conditional rendering?
    * Rename ClustersPage as ClustersRoute like AdministrationEventsRoute.
    * Factor out the above as ClustersPage.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_MOVE_INIT_BUNDLES_UI=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3950304 - 3950304
        total: 4298 = 10450113 - 10445815
    * `ls -al build/static/js/*.js | wc -l`
        0 = 90 - 90 files
3. `yarn start` in ui

### Manual testing

By the way, I noticed an inconsistency and added conditional rendering for **StackRox** in success alert if product branding is **StackRox** at upper left of page (see pictures).

1. Visit /main/clusters: see table
    ![StackRox_ClustersTablePanel](https://github.com/stackrox/stackrox/assets/11862657/a14340df-1274-4e43-a235-b932994b1b67)

2. Visit /main/clusters with simulated no clusters nor init bundles.

    * See **Create bundle** button.
        ![StackRox_NoClustersPage_nor_bundles](https://github.com/stackrox/stackrox/assets/11862657/b08a117e-d51c-47a5-b8ff-d22ee5d391c8)

    * Click to open init bundle wizard.

3. Click **Download** in wizard with simulated no clusters but init bundles.

    * See **Review installation instructions** link.
        ![StackRox_NoClustersPage_but_bundles](https://github.com/stackrox/stackrox/assets/11862657/6c0f9d5f-913c-4082-b696-b63a04c10b5f)

    * Click to open /main/clusters/secure-a-cluster page in a new tab so that the original tab displays clusters table whenever a cluster is secured.
