### PR TITLE
chore(info): Add build flavor to Scanner V4 startup log

### DIFF
--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/quay/zlog"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/grpc/authn/service"
@@ -64,7 +65,7 @@ func main() {
 		golog.Fatalf("failed to initialize logging: %v", err)
 	}
 	ctx = zlog.ContextWithValues(ctx, "component", "main")
-	zlog.Info(ctx).Str("version", version.Version).Msg("starting scanner")
+	zlog.Info(ctx).Str("version", version.Version).Str("build_flavor", buildinfo.BuildFlavor).Msg("starting scanner")
 
 	// If certs was specified, configure the identity environment.
 	if p := cfg.MTLS.CertsDir; p != "" {


### PR DESCRIPTION
## Description

Adds `build flavor` to the indexer/matcher startup logs. Since logic (such as auth) is dependant on the type of build, this will help determine if testing a release/development/etc. build.

## Checklist
- [x] ~Investigated and inspected CI test results~
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Inspected logs:

Release build:
```
{"level":"info","host":"scanner-v4-matcher-5849f7cf8c-lcp6f","component":"main","version":"4.3.x-883-geaa3ee1bbe-dirty","build_flavor":"release","time":"2024-01-26T20:27:33Z","message":"starting scanner"}

{"level":"info","host":"scanner-v4-indexer-7d65dbc85-4npts","component":"main","version":"4.3.x-883-geaa3ee1bbe-dirty","build_flavor":"release","time":"2024-01-26T20:27:44Z","message":"starting scanner"}
```

Non-Release build:
```
{"level":"info","host":"scanner-v4-indexer-7d65dbc85-rmxfd","component":"main","version":"4.3.x-883-geaa3ee1bbe-dirty","build_flavor":"development","time":"2024-01-26T20:33:17Z","message":"starting scanner"}

{"level":"info","host":"scanner-v4-matcher-5849f7cf8c-gdwv2","component":"main","version":"4.3.x-883-geaa3ee1bbe-dirty","build_flavor":"development","time":"2024-01-26T20:33:58Z","message":"starting scanner"}
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
