### PR TITLE
ROX-21949: Add flow to edit existing Scan Config

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/EditScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/EditScanConfigDetail.tsx
@@ -1,15 +1,11 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react';
-import { generatePath } from 'react-router-dom';
 import {
     Alert,
     Breadcrumb,
     BreadcrumbItem,
     Bullseye,
-    Button,
     Divider,
-    Grid,
-    GridItem,
     Flex,
     FlexItem,
     PageSection,
@@ -17,42 +13,40 @@ import {
     Title,
 } from '@patternfly/react-core';
 
-import {
-    complianceEnhancedScanConfigsPath,
-    complianceEnhancedScanConfigDetailPath,
-} from 'routePaths';
+import { complianceEnhancedScanConfigsPath } from 'routePaths';
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-import LinkShim from 'Components/PatternFly/LinkShim';
 import { ComplianceScanConfigurationStatus } from 'services/ComplianceEnhancedService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import ScanConfigParameterView from './components/ScanConfigParameterView';
-import ScanConfigProfiles from './components/ScanConfigProfiles';
-import ScanConfigClustersTable from './components/ScanConfigClustersTable';
+import ScanConfigWizardForm from './Wizard/ScanConfigWizardForm';
+import { defaultScanConfigFormValues } from './Wizard/useFormikScanConfig';
+import { convertScanConfigToFormik } from './compliance.scanConfigs.utils';
 
-type ViewScanConfigDetailProps = {
-    hasWriteAccessForCompliance: boolean;
+type EditScanConfigDetailProps = {
     scanConfig?: ComplianceScanConfigurationStatus;
     isLoading: boolean;
     error?: Error | string | null;
 };
 
-function ViewScanConfigDetail({
-    hasWriteAccessForCompliance,
+function EditScanConfigDetail({
     scanConfig,
     isLoading,
     error = null,
-}: ViewScanConfigDetailProps): React.ReactElement {
+}: EditScanConfigDetailProps): React.ReactElement {
+    const parsedScanConfig = scanConfig
+        ? convertScanConfigToFormik(scanConfig)
+        : defaultScanConfigFormValues;
+
     return (
         <>
-            <PageTitle title="Compliance Scan Schedule Details" />
+            <PageTitle title="Edit Compliance Scan Schedule Details" />
             <PageSection variant="light" className="pf-u-py-md">
                 <Breadcrumb>
                     <BreadcrumbItemLink to={complianceEnhancedScanConfigsPath}>
                         Scan schedules
                     </BreadcrumbItemLink>
                     {!isLoading && !error && scanConfig && (
-                        <BreadcrumbItem isActive>{scanConfig.scanName}</BreadcrumbItem>
+                        <BreadcrumbItem isActive>Edit {scanConfig.scanName}</BreadcrumbItem>
                     )}
                 </Breadcrumb>
             </PageSection>
@@ -66,19 +60,6 @@ function ViewScanConfigDetail({
                         <FlexItem flex={{ default: 'flex_1' }}>
                             <Title headingLevel="h1">{scanConfig.scanName}</Title>
                         </FlexItem>
-                        {hasWriteAccessForCompliance && (
-                            <FlexItem align={{ default: 'alignRight' }}>
-                                <Button
-                                    variant="primary"
-                                    component={LinkShim}
-                                    href={`${generatePath(complianceEnhancedScanConfigDetailPath, {
-                                        scanConfigId: scanConfig.id,
-                                    })}?action=edit`}
-                                >
-                                    Edit scan schedule
-                                </Button>
-                            </FlexItem>
-                        )}
                     </Flex>
                 )}
             </PageSection>
@@ -101,23 +82,13 @@ function ViewScanConfigDetail({
                     )
                 )}
                 {!isLoading && scanConfig && (
-                    <Grid hasGutter>
-                        <GridItem sm={12} md={6}>
-                            <ScanConfigParameterView scanConfig={scanConfig} />
-                        </GridItem>
-                        <GridItem sm={12} md={6}>
-                            <ScanConfigProfiles profiles={scanConfig.scanConfig.profiles} />
-                        </GridItem>
-                        <GridItem sm={12}>
-                            <ScanConfigClustersTable
-                                clusterScanStatuses={scanConfig.clusterStatus}
-                            />
-                        </GridItem>
-                    </Grid>
+                    <PageSection padding={{ default: 'noPadding' }} isCenterAligned>
+                        <ScanConfigWizardForm initialFormValues={parsedScanConfig} />
+                    </PageSection>
                 )}
             </PageSection>
         </>
     );
 }
 
-export default ViewScanConfigDetail;
+export default EditScanConfigDetail;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/EditScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/EditScanConfigDetail.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React from 'react';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/ScanConfigDetailPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/ScanConfigDetailPage.tsx
@@ -3,10 +3,12 @@ import React, { useCallback } from 'react';
 import { generatePath, Link, useParams } from 'react-router-dom';
 import { Button, Divider, PageSection } from '@patternfly/react-core';
 
-import { complianceEnhancedScanConfigDetailPath } from 'routePaths';
+import usePageAction from 'hooks/usePageAction';
 import useRestQuery from 'hooks/useRestQuery';
 import { getScanConfig } from 'services/ComplianceEnhancedService';
+import EditScanConfigDetail from './EditScanConfigDetail';
 import ViewScanConfigDetail from './ViewScanConfigDetail';
+import { PageActions } from './compliance.scanConfigs.utils';
 
 type ScanConfigDetailPageProps = {
     hasWriteAccessForCompliance: boolean;
@@ -16,6 +18,7 @@ function ScanConfigDetailPage({
     hasWriteAccessForCompliance,
 }: ScanConfigDetailPageProps): React.ReactElement {
     const { scanConfigId } = useParams();
+    const { pageAction } = usePageAction<PageActions>();
 
     const scanConfigFetcher = useCallback(() => {
         const { request, cancel } = getScanConfig(scanConfigId);
@@ -23,6 +26,10 @@ function ScanConfigDetailPage({
     }, [scanConfigId]);
 
     const { data, loading, error } = useRestQuery(scanConfigFetcher);
+
+    if (pageAction === 'edit' && hasWriteAccessForCompliance) {
+        return <EditScanConfigDetail scanConfig={data} isLoading={loading} error={error} />;
+    }
 
     return (
         <ViewScanConfigDetail

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/ScanConfigsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/ScanConfigsPage.tsx
@@ -11,8 +11,7 @@ import {
 import ScanConfigsTablePage from './Table/ScanConfigsTablePage';
 import CreateScanConfigPage from './CreateScanConfigPage';
 import ScanConfigDetailPage from './ScanConfigDetailPage';
-
-type PageActions = 'create' | 'edit' | 'clone';
+import { PageActions } from './compliance.scanConfigs.utils';
 
 function ScanConfigsPage() {
     /*

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ClusterSelection.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ClusterSelection.tsx
@@ -21,7 +21,7 @@ import useTableSelection from 'hooks/useTableSelection';
 import { clustersBasePath } from 'routePaths';
 import { ComplianceIntegration } from 'services/ComplianceEnhancedService';
 
-import { ScanConfigFormValues } from './useFormikScanConfig';
+import { ScanConfigFormValues } from '../compliance.scanConfigs.utils';
 
 export type ClusterSelectionProps = {
     clusters: ComplianceIntegration[];

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ProfileSelection.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ProfileSelection.tsx
@@ -17,7 +17,7 @@ import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import useTableSelection from 'hooks/useTableSelection';
 import { ComplianceProfile } from 'services/ComplianceEnhancedService';
 
-import { ScanConfigFormValues } from './useFormikScanConfig';
+import { ScanConfigFormValues } from '../compliance.scanConfigs.utils';
 
 export type ProfileSelectionProps = {
     profiles: ComplianceProfile[];

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ReviewConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ReviewConfig.tsx
@@ -17,10 +17,10 @@ import {
 
 import { ComplianceProfile, ComplianceIntegration } from 'services/ComplianceEnhancedService';
 
-import { ScanConfigFormValues } from './useFormikScanConfig';
 import {
     convertFormikParametersToSchedule,
     formatScanSchedule,
+    ScanConfigFormValues,
 } from '../compliance.scanConfigs.utils';
 
 export type ProfileSelectionProps = {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ScanConfigOptions.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ScanConfigOptions.tsx
@@ -19,7 +19,7 @@ import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import RepeatScheduleDropdown from 'Components/PatternFly/RepeatScheduleDropdown';
 import { getTimeHoursMinutes } from 'utils/dateUtils';
 
-import { ScanConfigFormValues } from './useFormikScanConfig';
+import { ScanConfigFormValues } from '../compliance.scanConfigs.utils';
 
 function ScanConfigOptions(): ReactElement {
     const formik: FormikContextType<ScanConfigFormValues> = useFormikContext();

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ScanConfigWizardFooter.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ScanConfigWizardFooter.tsx
@@ -8,9 +8,10 @@ import {
 } from '@patternfly/react-core';
 import useModal from 'hooks/useModal';
 
-export type ScanConfigWizardStepsProps = {
+export type ScanConfigWizardFooterProps = {
     wizardSteps: WizardStep[];
     onSave: () => void;
+    isEditing: boolean;
     isSaving: boolean;
     proceedToNextStepIfValid: (nextFunction: () => void, stepId: string) => void;
 };
@@ -18,9 +19,10 @@ export type ScanConfigWizardStepsProps = {
 function ScanConfigWizardFooter({
     wizardSteps,
     onSave,
+    isEditing,
     isSaving,
     proceedToNextStepIfValid,
-}: ScanConfigWizardStepsProps) {
+}: ScanConfigWizardFooterProps) {
     const { isModalOpen, openModal, closeModal } = useModal();
     const firstStepId = wizardSteps[0].id;
     const lastStepId = wizardSteps[wizardSteps.length - 1].id;
@@ -44,7 +46,7 @@ function ScanConfigWizardFooter({
                         onClick={onSave}
                         isLoading={isSaving}
                     >
-                        Create
+                        {isEditing ? 'Save' : 'Create'}
                     </Button>
                 )}
                 <Button

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/useFormikScanConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/useFormikScanConfig.tsx
@@ -1,22 +1,7 @@
 import { FormikProps, useFormik } from 'formik';
 import * as yup from 'yup';
 
-import { DayOfMonth, DayOfWeek } from 'Components/PatternFly/DayPickerDropdown';
-
-export type ScanConfigParameters = {
-    name: string;
-    description: string;
-    intervalType: 'DAILY' | 'WEEKLY' | 'MONTHLY' | null;
-    time: string;
-    daysOfWeek: DayOfWeek[];
-    daysOfMonth: DayOfMonth[];
-};
-
-export type ScanConfigFormValues = {
-    parameters: ScanConfigParameters;
-    clusters: string[];
-    profiles: string[];
-};
+import { ScanConfigFormValues } from '../compliance.scanConfigs.utils';
 
 export const defaultScanConfigFormValues: ScanConfigFormValues = {
     parameters: {
@@ -60,9 +45,9 @@ const validationSchema = yup.object().shape({
     }),
 });
 
-function useFormikScanConfig(): FormikProps<ScanConfigFormValues> {
+function useFormikScanConfig(initialFormValues): FormikProps<ScanConfigFormValues> {
     const formik = useFormik<ScanConfigFormValues>({
-        initialValues: defaultScanConfigFormValues,
+        initialValues: initialFormValues || defaultScanConfigFormValues,
         validationSchema,
         onSubmit: () => {},
         validateOnMount: true,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/useFormikScanConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/useFormikScanConfig.tsx
@@ -7,7 +7,7 @@ export const defaultScanConfigFormValues: ScanConfigFormValues = {
     parameters: {
         name: '',
         description: '',
-        intervalType: null,
+        intervalType: 'DAILY',
         time: '',
         daysOfWeek: [],
         daysOfMonth: [],

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/compliance.scanConfigs.utils.test.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/compliance.scanConfigs.utils.test.ts
@@ -1,0 +1,135 @@
+import { Schedule } from 'services/ComplianceEnhancedService';
+import {
+    convertFormikParametersToSchedule,
+    convertScheduleToFormikParameters,
+    ScanConfigParameters,
+} from './compliance.scanConfigs.utils';
+
+// @TODO: Consider making a more unique name for general utils file under Vulnerability Reporting
+describe('compliance.scanConfigs.utils', () => {
+    describe('convertFormikParametersToSchedule', () => {
+        it('should return the correct Daily Scan Schedule for the given daily formik values', () => {
+            const formValues: ScanConfigParameters = {
+                name: 'ok-ok.ok',
+                description: 'Needles and Pins',
+                intervalType: 'DAILY',
+                time: '3:00 AM',
+                daysOfWeek: [],
+                daysOfMonth: [],
+            };
+
+            const scanConfig = convertFormikParametersToSchedule(formValues);
+
+            expect(scanConfig).toEqual({
+                hour: 3,
+                minute: 0,
+                intervalType: 'DAILY',
+            });
+        });
+
+        it('should return the correct Weekly Scan Schedule for the given weekly formik values', () => {
+            const formValues: ScanConfigParameters = {
+                name: 'once-a-week',
+                description:
+                    'Several Species of Small Furry Animals Gathered Together in a Cave and Grooving with a Pict',
+                intervalType: 'WEEKLY',
+                time: '13:00 PM',
+                daysOfWeek: ['1'],
+                daysOfMonth: [],
+            };
+
+            const scanConfig = convertFormikParametersToSchedule(formValues);
+
+            expect(scanConfig).toEqual({
+                hour: 13,
+                minute: 0,
+                intervalType: 'WEEKLY',
+                daysOfWeek: {
+                    days: [1],
+                },
+            });
+        });
+
+        it('should return the correct Monthly Scan Schedule for the given monthly formik values', () => {
+            const formValues: ScanConfigParameters = {
+                name: 'once-a-week',
+                description:
+                    'Several Species of Small Furry Animals Gathered Together in a Cave and Grooving with a Pict',
+                intervalType: 'MONTHLY',
+                time: '11:00 PM',
+                daysOfWeek: [],
+                daysOfMonth: ['1', '15'],
+            };
+
+            const scanConfig = convertFormikParametersToSchedule(formValues);
+
+            expect(scanConfig).toEqual({
+                hour: 23,
+                minute: 0,
+                intervalType: 'MONTHLY',
+                daysOfMonth: {
+                    days: [1, 15],
+                },
+            });
+        });
+    });
+
+    describe('convertScheduleToFormikParameters', () => {
+        it('should return the correct daily formik values for the given Daily Scan Schedule', () => {
+            const scanSchedule: Schedule = {
+                hour: 22,
+                minute: 0,
+                intervalType: 'DAILY',
+            };
+
+            const formValues = convertScheduleToFormikParameters(scanSchedule);
+
+            expect(formValues).toEqual({
+                intervalType: 'DAILY',
+                time: '10:00 PM',
+                daysOfWeek: [],
+                daysOfMonth: [],
+            });
+        });
+
+        it('should return the correct weekly formik values for the given Weekly Scan Schedule', () => {
+            const scanSchedule: Schedule = {
+                hour: 15,
+                minute: 0,
+                intervalType: 'WEEKLY',
+                daysOfWeek: {
+                    days: [1],
+                },
+            };
+
+            const formValues = convertScheduleToFormikParameters(scanSchedule);
+
+            expect(formValues).toEqual({
+                intervalType: 'WEEKLY',
+                time: '3:00 PM',
+                daysOfWeek: ['1'],
+                daysOfMonth: [],
+            });
+        });
+
+        it('should return the correct monthly formik values for the given Monthly Scan Schedule', () => {
+            const scanSchedule: Schedule = {
+                hour: 5,
+                minute: 0,
+                intervalType: 'MONTHLY',
+                daysOfMonth: {
+                    days: [15],
+                },
+            };
+
+            const formValues = convertScheduleToFormikParameters(scanSchedule);
+
+            expect(formValues).toEqual({
+                intervalType: 'MONTHLY',
+                time: '5:00 AM',
+                daysOfWeek: [],
+                daysOfMonth: ['15'],
+            });
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigParameterView.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigParameterView.tsx
@@ -13,11 +13,11 @@ import {
 import { ComplianceScanConfigurationStatus } from 'services/ComplianceEnhancedService';
 import { formatScanSchedule } from '../compliance.scanConfigs.utils';
 
-type ScanConfigParametersProps = {
+type ScanConfigParameterViewProps = {
     scanConfig: ComplianceScanConfigurationStatus;
 };
 
-function ScanConfigParameters({ scanConfig }: ScanConfigParametersProps): React.ReactElement {
+function ScanConfigParameterView({ scanConfig }: ScanConfigParameterViewProps): React.ReactElement {
     return (
         <Card className="pf-u-h-100">
             <CardTitle component="h2">Parameters</CardTitle>
@@ -63,4 +63,4 @@ function ScanConfigParameters({ scanConfig }: ScanConfigParametersProps): React.
     );
 }
 
-export default ScanConfigParameters;
+export default ScanConfigParameterView;

--- a/ui/apps/platform/src/services/ComplianceEnhancedService.ts
+++ b/ui/apps/platform/src/services/ComplianceEnhancedService.ts
@@ -306,12 +306,17 @@ export function getScanConfig(
 /*
  * Create a Scan Schedule.
  */
-export function createScanConfig(
+export function saveScanConfig(
     complianceScanConfiguration: ComplianceScanConfiguration
 ): Promise<ComplianceScanConfiguration> {
-    return axios
-        .post<ComplianceScanConfiguration>(`${scanScheduleUrl}`, complianceScanConfiguration)
-        .then((response) => response.data);
+    const promise = complianceScanConfiguration.id
+        ? axios.put<ComplianceScanConfiguration>(
+              `${scanScheduleUrl}/${complianceScanConfiguration.id}`,
+              complianceScanConfiguration
+          )
+        : axios.post<ComplianceScanConfiguration>(scanScheduleUrl, complianceScanConfiguration);
+
+    return promise.then((response) => response.data);
 }
 
 /*


### PR DESCRIPTION
## Description

These code changes add an edit flow to the scan configurations in Compliance 2.0.
(I would have included the delete flow, but the changes were already extensive, so I added a TODO comment for that.)

This builds on the wizard/form of the create flow, with some minor changes to make that flow conditional on whether an ID is already present for the scan configuration. (An ID sends the user down the edit flow path.)

**Important note:** 
To make the data structure of the form work with the Wizard component, we were already converting the form structure to the shape the API needed for a create action. Rather than try to change that pattern, I simply added converter functions to go the other other, from a scan configuration retrieved through the API into the data structure expected by the form.

An unfortunate side effect of this are the types for the daysOfWeek and daysOfMonth list of constants. After investigating the complex TypeScript functions just to type those succinctly, I decided to instead write some pretty rudimentary but easy-to-understand type guard functions. Tomato, tuh-mah-toe

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit tests added for the schedule conversion funcctions


## Testing Performed

### Here I tell how I validated my change

Extensive testing to make 3 new Scan Schedules in the UI, and edit each of them in different ways.

**Screenshots of just one of those editing sessions, for brevity:**

Three created scan schedules list in their table, with one about to be edited
![Screenshot 2024-01-26 at 4 02 42 PM](https://github.com/stackrox/stackrox/assets/715729/89c88f44-cf0d-43d9-bf1f-5b627d01cbca)

The unedited Scan Schedule
![Screenshot 2024-01-26 at 4 02 50 PM](https://github.com/stackrox/stackrox/assets/715729/4a8af9b4-b4f6-4e17-946e-460226ceda30)

Changing the name of the Scan Schedule
![Screenshot 2024-01-26 at 4 02 56 PM](https://github.com/stackrox/stackrox/assets/715729/8b6f86a7-4cd3-4c24-81ec-e830c1cc4292)

The unedited list of profiles for the Scan Schedule
![Screenshot 2024-01-26 at 4 03 12 PM](https://github.com/stackrox/stackrox/assets/715729/eab2e48d-8147-40bd-9433-66f41de47a51)

The edited list of profiles for the Scan Schedule
![Screenshot 2024-01-26 at 4 03 20 PM](https://github.com/stackrox/stackrox/assets/715729/b2ba815c-2c98-4cc5-8a52-c5938035fd6b)

Reviewing the changes to the Scan Schedule--note the action button read "Save", instead of "Create"
![Screenshot 2024-01-26 at 4 03 23 PM](https://github.com/stackrox/stackrox/assets/715729/008df01e-0d98-42ca-8139-074b616d0683)

The edited change schedule in the table, with the changes highlighted by my cursor
![Screenshot 2024-01-26 at 4 04 06 PM](https://github.com/stackrox/stackrox/assets/715729/2a057d91-dddd-421a-b796-071bfaaa804c)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
