### PR TITLE
ROX-21471: Request details for canceled request should look different

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
@@ -4,6 +4,7 @@ import { cancelAllCveExceptions } from '../workloadCves/WorkloadCves.helpers';
 import {
     deferAndVisitRequestDetails,
     markFalsePositiveAndVisitRequestDetails,
+    visitExceptionManagement,
 } from './ExceptionManagement.helpers';
 import { approveRequest } from './approveRequestFlow.test';
 
@@ -89,6 +90,7 @@ describe('Exception Management Request Details Page', () => {
         cy.get('div[role="dialog"]').should('exist');
         cy.get('div[role="dialog"] button:contains("Cancel request")').click();
         cy.get('div[role="dialog"]').should('not.exist');
+        visitExceptionManagement();
         cy.get('button[role="tab"]:contains("Approved deferrals")').click();
         cy.get('table tbody tr').should('not.exist');
     });
@@ -103,6 +105,7 @@ describe('Exception Management Request Details Page', () => {
         cy.get('div[role="dialog"]').should('exist');
         cy.get('div[role="dialog"] button:contains("Cancel request")').click();
         cy.get('div[role="dialog"]').should('not.exist');
+        visitExceptionManagement();
         cy.get('button[role="tab"]:contains("Approved false positives")').click();
         cy.get('table tbody tr').should('not.exist');
     });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
@@ -4,7 +4,6 @@ import { cancelAllCveExceptions } from '../workloadCves/WorkloadCves.helpers';
 import {
     deferAndVisitRequestDetails,
     markFalsePositiveAndVisitRequestDetails,
-    pendingRequestsPath,
 } from './ExceptionManagement.helpers';
 import { approveRequest } from './approveRequestFlow.test';
 
@@ -55,10 +54,14 @@ describe('Exception Management Request Details Page', () => {
         cy.get('div[role="dialog"]').should('exist');
         cy.get('div[role="dialog"] button:contains("Cancel request")').click();
         cy.get('div[role="dialog"]').should('not.exist');
-        cy.location().should((location) => {
-            expect(location.pathname).to.eq(pendingRequestsPath);
-        });
-        cy.get('table tbody tr').should('not.exist');
+        cy.get('div[aria-label="Success Alert"]').should(
+            'contain',
+            'The vulnerability request was successfully canceled.'
+        );
+        cy.get('div[aria-label="Warning Alert"]').should(
+            'contain',
+            'You are viewing a canceled request. If this cancelation was not intended, please submit a new request'
+        );
     });
 
     it('should be able to see how many CVEs will be affected by a cancel', () => {


### PR DESCRIPTION
## Description

This PR should display the request details a little differently when a request is canceled. You should see an alert at the top now.

## Screenshot


https://github.com/stackrox/stackrox/assets/4805485/046487fe-e4c3-41ab-85d5-4f15189b56bc

<img width="1440" alt="Screenshot 2024-01-26 at 4 29 06 PM" src="https://github.com/stackrox/stackrox/assets/4805485/3d30b776-b265-4324-b781-75d4239159ad">
