### PR TITLE
fix(scanner): ignore non-existent proxy config

### DIFF
--- a/scanner/config/config_test.go
+++ b/scanner/config/config_test.go
@@ -237,9 +237,9 @@ func Test_ProxyConfig_validate(t *testing.T) {
 		err := c.validate()
 		assert.NoError(t, err)
 	})
-	t.Run("when config file does not exist then error", func(t *testing.T) {
+	t.Run("when config file does not exist then ok", func(t *testing.T) {
 		c := ProxyConfig{ConfigDir: tmp, ConfigFile: "does-not-exist.yaml"}
 		err := c.validate()
-		assert.Error(t, err)
+		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
## Description

This is causing CI failures. For example: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-master-merge-gke-upgrade-tests/1751358746904236032

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI. TODO verify this passes when the config secret is deleted and scanner v4 is restarted

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
