### PR TITLE
ROX-21997: Guard enriching netpols behind cluster check

### DIFF
--- a/central/detection/service/service_impl.go
+++ b/central/detection/service/service_impl.go
@@ -228,11 +228,13 @@ func (s *serviceImpl) enrichAndDetect(ctx context.Context, enrichmentContext enr
 	}
 
 	var appliedNetpols *augmentedobjs.NetworkPoliciesApplied
-	appliedNetpols, err = s.getAppliedNetpolsForDeployment(ctx, enrichmentContext, deployment)
-	if err != nil {
-		log.Warnf("Could not find applied network policies for deployment %s. Continuing with deployment enrichment. Error: %s", deployment.GetName(), err)
-	} else {
-		log.Debugf("Found applied network policies for deployment %s: %+v", deployment.GetName(), appliedNetpols)
+	if enrichmentContext.ClusterID != "" {
+		appliedNetpols, err = s.getAppliedNetpolsForDeployment(ctx, enrichmentContext, deployment)
+		if err != nil {
+			log.Warnf("Could not find applied network policies for deployment %s. Continuing with deployment enrichment. Error: %s", deployment.GetName(), err)
+		} else {
+			log.Debugf("Found applied network policies for deployment %s: %+v", deployment.GetName(), appliedNetpols)
+		}
 	}
 
 	filter, getUnusedCategories := centralDetection.MakeCategoryFilter(policyCategories)
@@ -406,7 +408,6 @@ func (s *serviceImpl) DetectDeployTimeFromYAML(ctx context.Context, req *apiV1.D
 		log.Warnf("Deployment YAMLs failed to parse: %v", errs)
 	}
 
-	// TODO(ROX-21342): Ensure central doesn't crash if user doesn't provide cluster info
 	// If a cluster is provided and Sensor has the capability, enhance deployments with additional info from Sensor
 	if eCtx.ClusterID != "" && s.connManager.GetConnection(eCtx.ClusterID).HasCapability(centralsensor.SensorEnhancedDeploymentCheckCap) {
 		conn := s.connManager.GetConnection(eCtx.ClusterID)


### PR DESCRIPTION
## Description
This PR introduces a guard to ensure Central doesn't return applied Network Policies for `roxctl deployment check` if `--cluster` is not provided in the call. 
If no cluster is provided by the user, we cannot guarantee to return the correct Network Policies for any given deployment, as they are cluster-specific.


## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

I manually tested this by observing centrals debug output. We log Network Policies that central found to the Debug loglevel.
- Deploy locally
- Apply a deployment with a matching Network Policy (see attachment)
- Set central `LOGLEVEL` env to debug
- `roxctl deployment check --cluster remote --namespace stackrox --file ./nginx.yaml`
- Observe central generating debug output "Found applied network policies ..."
- `roxctl deployment check --namespace stackrox --file ./nginx.yaml`
- Observe central NOT generating above debug output

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
