### PR TITLE
chore(ui): Don't call parent Makefile if `ROX_PRODUCT_BRANDING` is set

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -11,7 +11,8 @@ SOURCES += $(shell find apps -type d \( -name node_modules \) -prune -o -print)
 # tracking package.json files of monorepo packages is the easiest way to discover such situations
 PACKAGE_JSON_FILES := $(shell find . -type d \( -name node_modules \) -prune -false -o -name package.json)
 
-export REACT_APP_ROX_PRODUCT_BRANDING := $(shell $(MAKE) --quiet --no-print-directory -C .. product-branding)
+ROX_PRODUCT_BRANDING ?= $(shell $(MAKE) --quiet --no-print-directory -C .. product-branding)
+export REACT_APP_ROX_PRODUCT_BRANDING := $(ROX_PRODUCT_BRANDING)
 
 deps: yarn.lock $(PACKAGE_JSON_FILES)
 	yarn install --frozen-lockfile --prefer-offline --network-timeout=$(YARN_NETWORK_TIMEOUT)


### PR DESCRIPTION
## Description

Before the change, `REACT_APP_ROX_PRODUCT_BRANDING` is obtained from the parent Makefile (the one in repository root) by invoking its `product-branding` target which returns a value of `ROX_PRODUCT_BRANDING` environment variable if set, or `STACKROX_BRANDING` as default.

A problem with that is that the parent Makefile imports bunch of stuff which at some point even uses `go` binary. In RHTAP/Konflux context I'm trying to use vanilla NodeJS image from Red Hat as a UI builder, and this image does not have `go` (unlike builders used upstream and downstream). Again, `go` is needed only for the parent Makefile to load, it does not participate in "solving" `ROX_PRODUCT_BRANDING` values.

This PR allows to drop a dependency on `go` by trying to use `ROX_PRODUCT_BRANDING` environment variable _directly_ in UI Makefile. If it is set, the `?=` assignment does nothing and we use environment variable's value. Otherwise, `?=` evaluates the right-hand side and we get the former behavior of asking the parent `Makefile` which provides the default value.

Similarly how we set branding in downstream Dockerfiles and how we set it in upstream CI, we **will** know which branding we build in Konflux and we'll set the corresponding environment variable.

This change is extracted out of https://github.com/stackrox/stackrox/pull/8689. Comment about it https://github.com/stackrox/stackrox/pull/8689#discussion_r1416228188

Here's a spot we set and use the `ROX_PRODUCT_BRANDING` variable in downstream UI build <https://gitlab.cee.redhat.com/stackrox/rhacs-midstream/-/blob/0e36f2799efc0164961d4509b9ffc83377e00383/distgit/containers/rhacs-main/Dockerfile.in#L54-59> (we don't do StackRox builds downstream, only RHACS). Nothing will need to be changed there.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ - I don't think testing here is easily possible, unfortunately.

These won't be done as internal scripts get modified but there must be no user-facing change:
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

- [x] Deployed stackrox-branded upstream-built images and verified UI says StackRox. (Used simply `deploy/ks8/deploy-local.sh` to deploy.)
- [x] Deployed rhacs-branced upstream-built images and verified UI says RHACS.

To deploy the latter one used
```bash
$ make -C operator stackrox-image-pull-secret
$ ROX_PRODUCT_BRANDING=RHACS_BRANDING deploy/k8s/deploy-local.sh
```

Downstream build needs to be verified similarly too but it's [not possible at the moment](https://redhat-internal.slack.com/archives/CFMQ5C2TT/p1706100758272919), therefore I created a task for myself to follow-up on this <https://issues.redhat.com/browse/ROX-22072>.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
