### PR TITLE
ROX-22029: Scope CVE queries to exact match only

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -372,7 +372,7 @@ function ImageCvePage() {
                         <WorkloadTableToolbar
                             searchOptions={searchOptions}
                             autocompleteSearchContext={{
-                                'CVE ID': exactCveIdSearchRegex,
+                                CVE: exactCveIdSearchRegex,
                             }}
                             onFilterChange={() => setPage(1)}
                         />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -175,13 +175,14 @@ function ImageCvePage() {
     const currentVulnerabilityState = useVulnerabilityState();
 
     const urlParams = useParams();
-    const cveId: string = urlParams.cveId ?? '';
+    const cveId = urlParams.cveId ?? '';
+    const exactCveIdSearchRegex = `^${cveId}$`;
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const query = getVulnStateScopedQueryString(
         {
             ...querySearchFilter,
-            CVE: [cveId],
+            CVE: [exactCveIdSearchRegex],
         },
         currentVulnerabilityState
     );
@@ -239,7 +240,7 @@ function ImageCvePage() {
     });
 
     function getDeploymentSearchQuery(severity?: VulnerabilitySeverity) {
-        const filters = { ...querySearchFilter, CVE: [cveId] };
+        const filters = { ...querySearchFilter, CVE: [exactCveIdSearchRegex] };
         if (severity) {
             filters.SEVERITY = [severity];
         }
@@ -371,7 +372,7 @@ function ImageCvePage() {
                         <WorkloadTableToolbar
                             searchOptions={searchOptions}
                             autocompleteSearchContext={{
-                                'CVE ID': cveId,
+                                'CVE ID': exactCveIdSearchRegex,
                             }}
                             onFilterChange={() => setPage(1)}
                         />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/FilterAutocomplete.tsx
@@ -41,7 +41,7 @@ export type FilterAutocompleteSelectProps = {
     autocompleteSearchContext?:
         | { 'Image SHA': string }
         | { 'Deployment ID': string }
-        | { 'CVE ID': string }
+        | { CVE: string }
         | Record<string, never>;
 };
 
@@ -58,12 +58,12 @@ function FilterAutocompleteSelect({
     const [isTyping, setIsTyping] = useState(false);
     const { isOpen, onToggle } = useSelectToggle();
 
-    // Autocomplete requests for "Cluster" never return results if there is a 'CVE ID', 'Severity', or 'Fixable' search filter
+    // Autocomplete requests for "Cluster" never return results if there is a 'CVE', 'Severity', or 'Fixable' search filter
     // included in the query. In this case we don't include the additional filters at all which leaves the cluster results
     // unfiltered. Not ideal, but better than no results.
     const useSearchContextForAutocomplete =
         searchOption.value !== 'CLUSTER' ||
-        (!autocompleteSearchContext['CVE ID'] && !searchFilter.SEVERITY && !searchFilter.FIXABLE);
+        (!('CVE' in autocompleteSearchContext) && !searchFilter.SEVERITY && !searchFilter.FIXABLE);
 
     const autocompleteSearchFilterBase = useSearchContextForAutocomplete
         ? { ...autocompleteSearchContext, ...searchFilter }


### PR DESCRIPTION
## Description

Scopes queries on the Workload CVE single page to use the exact CVE name as the search filter.

Previously, the query was sent with a bare string e.g. `"CVE-2020-123"`, which would match any CVE that _starts_ with `CVE-2020-123`. There are no examples in my local environment where this would be a problem, but if there were overlapping substrings in any environment this would lead to incorrect data. (A page would show data for the combination of `"CVE-2020-123"` and `"CVE-2020-12345"`, if they existed.)

This bug was not caused by the move to regex filter values, but in theory could have triggered the issue more often.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Since there is no data that matches in my test system, verify that `query` parameter based CVE ID values are contained within regex boundary characters, while `id` and `cve` parameters are left as a plain string.

CVE page metadata:
![image](https://github.com/stackrox/stackrox/assets/1292638/6e41d672-69b3-406c-8354-cd9a1cb18a48)

CVE page summary data:
![image](https://github.com/stackrox/stackrox/assets/1292638/29220726-82ef-43bb-a0ff-923b6f89527a)

CVE page image list:
![image](https://github.com/stackrox/stackrox/assets/1292638/f60897cc-2a40-47db-b413-3e9ff0fa5d96)


