### PR TITLE
fix(test): Remove failing compatibility tests

### DIFF
--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -55,10 +55,6 @@ def main(argv):
     )
     logging.info(
         f"Helm chart versions for the latest {num_releases} releases:")
-    # Specifically remove 400.1.6 which is affected by a max message size bug, but is no longer supported.
-    if "400.1.6" in helm_versions:
-        print('Removed version 400.1.6')
-        helm_versions.remove("400.1.6")
 
     print("\n".join(helm_versions))
     helm_version_specific = get_latest_helm_chart_version_for_specific_release(
@@ -102,8 +98,8 @@ def __get_latest_helm_chart_versions(chart_name, num_releases):
     logging.debug(
         f"Identified these charts as {num_releases} latest: {latest_charts}")
 
-    return [c["version"] for c in latest_charts]
-
+    # Specifically remove 400.1.6 which is affected by a max message size bug, but is no longer supported.
+    return [c["version"] for c in latest_charts if c["version"] != "400.1.6"]
 
 def __get_latest_helm_chart_version_for_specific_release(chart_name, release):
     charts = read_charts()

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -101,6 +101,7 @@ def __get_latest_helm_chart_versions(chart_name, num_releases):
     # Specifically remove 400.1.6 which is affected by a max message size bug, but is no longer supported.
     return [c["version"] for c in latest_charts if c["version"] != "400.1.6"]
 
+
 def __get_latest_helm_chart_version_for_specific_release(chart_name, release):
     charts = read_charts()
     logging.info(f"Discovered total {len(charts)} charts")

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -55,6 +55,11 @@ def main(argv):
     )
     logging.info(
         f"Helm chart versions for the latest {num_releases} releases:")
+    # Specifically remove 400.1.6 which is affected by a max message size bug, but is no longer supported.
+    if "400.1.6" in helm_versions:
+        print('Removed version 400.1.6')
+        helm_versions.remove("400.1.6")
+
     print("\n".join(helm_versions))
     helm_version_specific = get_latest_helm_chart_version_for_specific_release(
         "stackrox-secured-cluster-services", sample_support_exception

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -18,7 +18,6 @@ from runners import ClusterTestSetsRunner
 from clusters import GKECluster
 from get_latest_helm_chart_versions import (
     get_latest_helm_chart_versions,
-    get_latest_helm_chart_version_for_specific_release,
 )
 
 Release = namedtuple("Release", ["major", "minor"])
@@ -64,6 +63,8 @@ test_tuples.extend(
         for central_chart_version in central_chart_versions
     ]
 )
+
+support_exceptions = []
 
 test_tuples.extend(
     support_exception

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -65,17 +65,6 @@ test_tuples.extend(
     ]
 )
 
-# Support exception for latest central and sensor 3.74 as per
-# https://issues.redhat.com/browse/ROX-18223
-support_exceptions = [
-    ChartVersions(
-        central_version=latest_tag,
-        sensor_version=get_latest_helm_chart_version_for_specific_release(
-            "stackrox-secured-cluster-services", Release(major=3, minor=74)
-        ),
-    )
-]
-
 test_tuples.extend(
     support_exception
     for support_exception in support_exceptions

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -65,6 +65,17 @@ test_tuples.extend(
 )
 
 support_exceptions = []
+# Support exception for latest central and sensor 3.74 as per
+# https://issues.redhat.com/browse/ROX-18223
+# Commented out until max message size fix has been backported
+# support_exceptions = [
+#     ChartVersions(
+#         central_version=latest_tag,
+#         sensor_version=get_latest_helm_chart_version_for_specific_release(
+#             "stackrox-secured-cluster-services", Release(major=3, minor=74)
+#         ),
+#     )
+# ]
 
 test_tuples.extend(
     support_exception


### PR DESCRIPTION
## Description

3.74 and 4.1 are both out of support and are both affected by the issue where network entities are too large so remove them from the version compatibility matrix.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Version compatibility test

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
