### PR TITLE
chore(ui): Add popover when cluster-compliance error in scan config

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedScanConfigs.test.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedScanConfigs.test.js
@@ -74,7 +74,6 @@ describe('Compliance Dashboard', () => {
             .blur();
 
         getHelperElementByLabel('Name').contains('Scan name is required');
-        getHelperElementByLabel('Frequency').contains('Frequency is required');
         getHelperElementByLabel('Time').contains('Time is required');
 
         getInputByLabel('Frequency').click();
@@ -85,7 +84,7 @@ describe('Compliance Dashboard', () => {
         getHelperElementByLabel('On day(s)').contains('Selection is required');
 
         // Step 2, check valid form and save
-        getInputByLabel('Name').clear().type('Scooby');
+        getInputByLabel('Name').clear().type('scooby-doo');
         getInputByLabel('On day(s)').click();
         cy.get('.pf-c-select.pf-m-expanded .pf-c-check__label:contains("Tuesday")').click();
         cy.get('input[aria-label="Time picker"]').click(); // PF Datepicker doesn't follow pattern used by helper function

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/useFormikScanConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/useFormikScanConfig.tsx
@@ -20,6 +20,7 @@ const validationSchema = yup.object().shape({
     parameters: yup.object().shape({
         name: yup
             .string()
+            .trim()
             .required('Scan name is required')
             .matches(
                 /^[a-z0-9][a-z0-9.-]{0,251}[a-z0-9]$/,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/components/ScanConfigClustersTable.tsx
@@ -2,12 +2,14 @@
 // eslint-disable @typescript-eslint/ban-ts-comment
 import React, { useState } from 'react';
 import {
+    Button,
     Card,
     CardActions,
     CardBody,
     CardHeader,
     CardTitle,
     Pagination,
+    Popover,
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, ThProps, Thead, Tr } from '@patternfly/react-table';
 
@@ -130,10 +132,31 @@ function ScanConfigClustersTable({ clusterScanStatuses }: ScanConfigClustersTabl
                                 <Tr key={cluster.clusterId}>
                                     <Td dataLabel="Cluster">{cluster.clusterName}</Td>
                                     <Td dataLabel="Operator status">
-                                        <IconText
-                                            icon={statusObj.icon}
-                                            text={statusObj.statusText}
-                                        />
+                                        {statusObj.statusText === 'Healthy' ? (
+                                            <IconText
+                                                icon={statusObj.icon}
+                                                text={statusObj.statusText}
+                                            />
+                                        ) : (
+                                            <Popover
+                                                aria-label="Reveal errors"
+                                                headerContent={
+                                                    <div>
+                                                        {cluster.errors.length === 1
+                                                            ? 'Error'
+                                                            : 'Errors'}
+                                                    </div>
+                                                }
+                                                bodyContent={<div>{cluster.errors}</div>}
+                                            >
+                                                <Button variant="link">
+                                                    <IconText
+                                                        icon={statusObj.icon}
+                                                        text={statusObj.statusText}
+                                                    />
+                                                </Button>
+                                            </Popover>
+                                        )}
                                     </Td>
                                 </Tr>
                             );


### PR DESCRIPTION
## Description

UX enhancement to make troubleshooting easier

## Checklist
- [x] Investigated and inspected CI test results (ui-e2e-test failures are infrastructure failures)


## Testing Performed

### Here I tell how I validated my change

Manual testing with a scan config that has an error in a cluster
<img width="1680" alt="Screenshot 2024-01-29 at 9 29 28 PM" src="https://github.com/stackrox/stackrox/assets/715729/b8e1e6a0-1ec5-4eae-a7e0-57b846438a01">


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
