### PR TITLE
ROX-22068: Add scanner-v4 setup script to manifest-based install

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -483,6 +483,7 @@ function launch_central {
           if [[ "${ROX_SCANNER_V4:-}" != "false" ]]; then
             echo "Deploying ScannerV4..."
             if [[ -d "${unzip_dir}/scanner-v4" ]]; then
+              "${unzip_dir}/scanner-v4/scripts/setup.sh"
               launch_service "${unzip_dir}" scanner-v4
             else
               echo >&2 "WARNING: Deployment bundle does not seem to contain support for Scanner V4."

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -481,8 +481,8 @@ function launch_central {
           fi
           launch_service "${unzip_dir}" scanner
           if [[ "${ROX_SCANNER_V4:-}" != "false" ]]; then
-            echo "Deploying ScannerV4..."
             if [[ -d "${unzip_dir}/scanner-v4" ]]; then
+              echo "Deploying ScannerV4..."
               "${unzip_dir}/scanner-v4/scripts/setup.sh"
               launch_service "${unzip_dir}" scanner-v4
             else

--- a/image/templates/common/setup-scanner-v4.sh
+++ b/image/templates/common/setup-scanner-v4.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 
-# Sets up Central to use Scanner-v4. Note that deploying Scanner is a prerequisite to deploying Scanner-v4.
+# Sets up the Central deployment to use Scanner V4
 
+# shellcheck disable=SC1083
 KUBE_COMMAND=${KUBE_COMMAND:-{{.K8sConfig.Command}}}
 NAMESPACE="${ROX_NAMESPACE:-stackrox}"
 
-${KUBE_COMMAND} -n "$NAMESPACE" patch deploy/central -p '{"spec":{"template":{"spec":{"containers":[{"name":"central","env":[{"name": "ROX_SCANNER_V4", "value": "true"}]}]}}}}'
+${KUBE_COMMAND} -n "$NAMESPACE" patch deploy/central --patch-file <(cat <<EOF
+spec:
+  template:
+    spec:
+      containers:
+      - name: central
+        env:
+        - name: "ROX_SCANNER_V4"
+          value: "true"
+EOF
+)

--- a/image/templates/common/setup-scanner-v4.sh
+++ b/image/templates/common/setup-scanner-v4.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Sets up Central to use Scanner-v4. Note that deploying Scanner is a prerequisite to deploying Scanner-v4.
+
+KUBE_COMMAND=${KUBE_COMMAND:-{{.K8sConfig.Command}}}
+NAMESPACE="${ROX_NAMESPACE:-stackrox}"
+
+${KUBE_COMMAND} -n "$NAMESPACE" patch deploy/central -p '{"spec":{"template":{"spec":{"containers":[{"name":"central","env":[{"name": "ROX_SCANNER_V4", "value": "true"}]}]}}}}'

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -125,7 +125,7 @@ spec:
         {{- end }}
         - name: ROX_INSTALL_METHOD
           value: {{ ._rox.env.installMethod | quote }}
-        [<- if .FeatureFlags.ROX_SCANNER_V4_SUPPORT >]
+        [<- if and (not .KubectlOutput) .FeatureFlags.ROX_SCANNER_V4_SUPPORT >]
         {{- if ._rox._scannerV4Enabled }}
         - name: ROX_SCANNER_V4
           value: "true"

--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -276,7 +276,7 @@
   {{ include "srox.scannerInit" (list $ $scannerCfg) }}
 {{ end }}
 
-[< if and .FeatureFlags.ROX_SCANNER_V4_SUPPORT ->]
+[< if .FeatureFlags.ROX_SCANNER_V4_SUPPORT ->]
 
 {{/*
    ScannerV4 setup.

--- a/pkg/renderer/readme.go
+++ b/pkg/renderer/readme.go
@@ -48,6 +48,7 @@ the login page, and log in with username "admin" and the password found in the
      If you want to run the StackRox Scanner:
      - Run scanner/scripts/setup.sh
      - Run {{.K8sConfig.Command}} create -R -f scanner
+     - Run scanner-v4/scripts/setup.sh
      - Run {{.K8sConfig.Command}} create -R -f scanner-v4
 `
 	kubectlCentralDBTemplate = `

--- a/pkg/renderer/readme.go
+++ b/pkg/renderer/readme.go
@@ -44,8 +44,7 @@ the login page, and log in with username "admin" and the password found in the
 `
 
 	kubectlScannerTemplate = `
-  - Deploy Scanner
-     If you want to run the StackRox Scanner:
+  - Deploy Scanner components
      - Run scanner/scripts/setup.sh
      - Run {{.K8sConfig.Command}} create -R -f scanner
      - Run scanner-v4/scripts/setup.sh

--- a/pkg/renderer/readme.go
+++ b/pkg/renderer/readme.go
@@ -45,10 +45,10 @@ the login page, and log in with username "admin" and the password found in the
 
 	kubectlScannerTemplate = `
   - Deploy Scanner components
-     - Run scanner/scripts/setup.sh
-     - Run {{.K8sConfig.Command}} create -R -f scanner
-     - Run scanner-v4/scripts/setup.sh
-     - Run {{.K8sConfig.Command}} create -R -f scanner-v4
+    - Run scanner/scripts/setup.sh
+    - Run {{.K8sConfig.Command}} create -R -f scanner
+    - Run scanner-v4/scripts/setup.sh
+    - Run {{.K8sConfig.Command}} create -R -f scanner-v4
 `
 	kubectlCentralDBTemplate = `
   - Deploy Central DB

--- a/pkg/renderer/render_new.go
+++ b/pkg/renderer/render_new.go
@@ -22,7 +22,8 @@ var (
 	}
 
 	kubectlScannerScriptMap = FileNameMap{
-		"common/setup-scanner.sh": "scanner/scripts/setup.sh",
+		"common/setup-scanner.sh":    "scanner/scripts/setup.sh",
+		"common/setup-scanner-v4.sh": "scanner-v4/scripts/setup.sh",
 	}
 
 	centralDBScriptMap = FileNameMap{

--- a/scripts/style/shellcheck_skip.txt
+++ b/scripts/style/shellcheck_skip.txt
@@ -9,6 +9,7 @@ image/templates/common/ca-setup.sh
 image/templates/common/delete-ca.sh
 image/templates/common/port-forward.sh
 image/templates/common/setup-central.sh
+image/templates/common/setup-scanner-v4.sh
 image/templates/common/setup-scanner.sh
 image/templates/common/setup.sh
 image/templates/sensor/kubernetes/sensor.sh

--- a/scripts/style/shellcheck_skip.txt
+++ b/scripts/style/shellcheck_skip.txt
@@ -9,7 +9,6 @@ image/templates/common/ca-setup.sh
 image/templates/common/delete-ca.sh
 image/templates/common/port-forward.sh
 image/templates/common/setup-central.sh
-image/templates/common/setup-scanner-v4.sh
 image/templates/common/setup-scanner.sh
 image/templates/common/setup.sh
 image/templates/sensor/kubernetes/sensor.sh


### PR DESCRIPTION
## Description

Deploying Stackrox using manifest bundles is done in 3 independent steps, where steps (2) and (3) are optional:
1. install Central
2. install Scanner
3. install Scanner-v4

However, when installing Central in step (1), the deployment will have `ROX_SCANNER_V4=true`, even though there is no Scanner v4 installed.

This PR skips setting `ROX_SCANNER_V4=true` when generating the manifest bundles. Instead, the env var will be set via the `scanner-v4/scripts/setup.sh` which is executed during step (3) above.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

I generated a manifest bundle using `roxctl` and deployed it to an infra cluster, and verified that:
* the README file is generated correctly
* `ROX_SCANNER_V4=true` is not enabled until the Scanner-v4 installation step
* the deployment is successful

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
