### PR TITLE
fix(ui): Update ConfigMgmt for async compliance scans

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
@@ -110,8 +110,6 @@ function scanCompliance() {
 
     const scanButton = '[data-testid="scan-button"]';
 
-    cy.get(scanButton).should('not.have.attr', 'disabled');
-
     interactAndWaitForResponses(
         () => {
             cy.get(scanButton).click();
@@ -121,7 +119,11 @@ function scanCompliance() {
         { timeout: 20000 }
     );
 
-    cy.get(scanButton).should('not.have.attr', 'disabled');
+    // Note: scan results are polled for every 10 seconds, this should give us plenty of time
+    // to await completion of the scan.
+    cy.get('div:contains("Compliance scanning complete")', {
+        timeout: 30000,
+    });
 }
 
 /*

--- a/ui/apps/platform/cypress/integration/configmanagement/ConfigurationManagement.helpers.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/ConfigurationManagement.helpers.js
@@ -153,13 +153,7 @@ function opnameForPrimaryAndSecondaryEntities(entitiesKey1, entitiesKey2) {
 }
 
 const routeMatcherMapForConfigurationManagementDashboard = getRouteMatcherMapForGraphQL([
-    'numPolicies',
-    'numCISControls',
-    'policyViolationsBySeverity',
-    'runStatuses',
     'complianceByControls',
-    'usersWithClusterAdminRoles',
-    'secrets',
 ]);
 
 export function visitConfigurationManagementDashboard() {
@@ -254,6 +248,10 @@ export function interactAndWaitForConfigurationManagementScan(interactionCallbac
         interactionCallback,
         routeMatcherMapForConfigurationManagementDashboard
     );
+
+    cy.get('div:contains("Compliance scanning in progress")', {
+        timeout: 30000,
+    }).should('not.exist');
 }
 
 export function navigateToSingleEntityPage(entitiesKey) {

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -16,15 +16,35 @@ import {
 } from 'services/ComplianceService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
+import {
+    AGGREGATED_RESULTS_ACROSS_ENTITY,
+    AGGREGATED_RESULTS_STANDARDS_BY_ENTITY,
+} from 'queries/controls';
 import ScanButton from '../ScanButton';
 import StandardsByEntity from '../widgets/StandardsByEntity';
 import StandardsAcrossEntity from '../widgets/StandardsAcrossEntity';
 
 import ManageStandardsError from './ManageStandardsError';
 import ManageStandardsModal from './ManageStandardsModal';
-import ComplianceDashboardTile from './ComplianceDashboardTile';
+import ComplianceDashboardTile, {
+    CLUSTERS_COUNT,
+    DEPLOYMENTS_COUNT,
+    NAMESPACES_COUNT,
+    NODES_COUNT,
+} from './ComplianceDashboardTile';
 import ComplianceScanProgress from './ComplianceScanProgress';
 import { useComplianceRunStatuses } from './useComplianceRunStatuses';
+
+const queriesToRefetchOnPollingComplete = [
+    CLUSTERS_COUNT,
+    NODES_COUNT,
+    NAMESPACES_COUNT,
+    DEPLOYMENTS_COUNT,
+    AGGREGATED_RESULTS_STANDARDS_BY_ENTITY(resourceTypes.CLUSTER),
+    AGGREGATED_RESULTS_ACROSS_ENTITY(resourceTypes.CLUSTER),
+    AGGREGATED_RESULTS_ACROSS_ENTITY(resourceTypes.NAMESPACE),
+    AGGREGATED_RESULTS_ACROSS_ENTITY(resourceTypes.NODE),
+];
 
 function ComplianceDashboardPage(): ReactElement {
     const { hasReadWriteAccess } = usePermissions();
@@ -45,7 +65,7 @@ function ComplianceDashboardPage(): ReactElement {
     }`;
 
     const { runs, error, restartPolling, inProgressScanDetected, isCurrentScanIncomplete } =
-        useComplianceRunStatuses();
+        useComplianceRunStatuses(queriesToRefetchOnPollingComplete);
 
     function clickManageStandardsButton() {
         setIsFetchingStandards(true);

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceScanProgress.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceScanProgress.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { Card, CardBody, CardTitle, Progress } from '@patternfly/react-core';
+import { Card, CardBody, CardProps, CardTitle, Progress } from '@patternfly/react-core';
 
 import { ComplianceRunStatusResponse } from './useComplianceRunStatuses';
 
 export type ComplianceDashboardCurrentProps = {
     runs: ComplianceRunStatusResponse['complianceRunStatuses']['runs'];
-};
+} & CardProps;
 
-function ComplianceScanProgress({ runs }: ComplianceDashboardCurrentProps) {
+function ComplianceScanProgress({ runs, ...props }: ComplianceDashboardCurrentProps) {
     const unfinishedRunCount = runs.filter((run) => run.state !== 'FINISHED').length;
     const finishedRunCount = runs.length - unfinishedRunCount;
 
@@ -17,7 +17,7 @@ function ComplianceScanProgress({ runs }: ComplianceDashboardCurrentProps) {
             : 'Compliance scanning in progress';
 
     return (
-        <Card>
+        <Card {...props}>
             <CardTitle id="compliance-scan-progress-title">{title}</CardTitle>
             <CardBody>
                 <Progress

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/useComplianceRunStatuses.ts
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/useComplianceRunStatuses.ts
@@ -1,17 +1,5 @@
 import { useState } from 'react';
-import { gql, useApolloClient, useQuery } from '@apollo/client';
-
-import { resourceTypes } from 'constants/entityTypes';
-import {
-    AGGREGATED_RESULTS_ACROSS_ENTITY,
-    AGGREGATED_RESULTS_STANDARDS_BY_ENTITY,
-} from 'queries/controls';
-import {
-    CLUSTERS_COUNT,
-    DEPLOYMENTS_COUNT,
-    NAMESPACES_COUNT,
-    NODES_COUNT,
-} from './ComplianceDashboardTile';
+import { DocumentNode, gql, useApolloClient, useQuery } from '@apollo/client';
 
 export type ComplianceRunStatusResponse = {
     complianceRunStatuses: {
@@ -24,17 +12,6 @@ function isCurrentScanIncomplete(
 ) {
     return runs.some((run) => run.state !== 'FINISHED');
 }
-
-const queriesToRefetchOnPollingComplete = [
-    CLUSTERS_COUNT,
-    NODES_COUNT,
-    NAMESPACES_COUNT,
-    DEPLOYMENTS_COUNT,
-    AGGREGATED_RESULTS_STANDARDS_BY_ENTITY(resourceTypes.CLUSTER),
-    AGGREGATED_RESULTS_ACROSS_ENTITY(resourceTypes.CLUSTER),
-    AGGREGATED_RESULTS_ACROSS_ENTITY(resourceTypes.NAMESPACE),
-    AGGREGATED_RESULTS_ACROSS_ENTITY(resourceTypes.NODE),
-];
 
 const complianceRunStatusesQuery = gql`
     query runStatuses($latest: Boolean) {
@@ -63,7 +40,9 @@ export type UseComplianceRunStatusesResponse = {
     isCurrentScanIncomplete: boolean;
 };
 
-export function useComplianceRunStatuses(): UseComplianceRunStatusesResponse {
+export function useComplianceRunStatuses(
+    queriesToRefetchOnPollingComplete: DocumentNode[]
+): UseComplianceRunStatusesResponse {
     const [inProgressScanDetected, setInProgressScanDetected] = useState(false);
 
     const client = useApolloClient();
@@ -78,7 +57,6 @@ export function useComplianceRunStatuses(): UseComplianceRunStatusesResponse {
         onError,
         errorPolicy: 'all',
         notifyOnNetworkStatusChange: true,
-        fetchPolicy: 'no-cache',
     });
 
     function onCompleted(data: ComplianceRunStatusResponse) {


### PR DESCRIPTION
## Description

Updates the Scan button in **Config Management** that was missed (doh) when updating the Compliance page to async scans. I chose to add the progress indicator to the widget instead of the top of the page due to that widget being the only context on this page that was dependent on the compliance scan.

This also fixes the tests to await the correct requests and assert on the presense/absence of the scan progress indicator where necessary.

![image](https://github.com/stackrox/stackrox/assets/1292638/75afce23-05e6-442e-af60-de78423ae210)
![image](https://github.com/stackrox/stackrox/assets/1292638/31b24fdc-a8a5-4ea4-8abb-dfef196e296d)


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

e2e CI

Triggering the compliance scan via ConfigMgmt will display the in progress indicator within the widget on that page. The state will sync between this page and Compliance 1.0 if the user visits either before the scan is complete.

Triggering a scan via ConfigMgmt does not disable the button, allowing the user to restart an in-progress scan. This functionality is the same as the scan button on the Compliance 1.0 page.

https://github.com/stackrox/stackrox/assets/1292638/1a61c5ed-236e-4df0-a995-583151668f22

