### PR TITLE
ROX-22081: Update default max gRPC payload

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -46,7 +46,7 @@ import (
 )
 
 const (
-	defaultMaxMsgSize               = 12 * 1024 * 1024
+	defaultMaxMsgSize               = 24 * 1024 * 1024
 	defaultMaxResponseMsgSize       = 256 * 1024 * 1024 // 256MB
 	defaultMaxGrpcConcurrentStreams = 100               // HTTP/2 spec recommendation for minimum value
 )


### PR DESCRIPTION
## Description

The gRPC threshold of 12MB has been reached by a few users, rather than constantly asking them to raise the environment variable, this PR bumpts the default to 24MB. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

No need.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
