### PR TITLE
ROX-22078: Add link for legacy installation to NoClustersPage

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
@@ -18,7 +18,7 @@ describe('Delegated Image Scanning', () => {
     it(`should have a link on the clusters main page`, () => {
         visitClusters();
 
-        cy.get('a:contains("Manage delegated scanning")').click();
+        cy.get('a:contains("Delegated scanning")').click();
 
         cy.location('pathname').should('eq', '/main/clusters/delegated-image-scanning');
     });
@@ -113,7 +113,7 @@ describe('Delegated Image Scanning', () => {
                 visitWithStaticResponseForPermissions(clustersPath, staticResponseForPermissions);
 
                 // make sure link is not present
-                cy.get('a:contains("Manage delegated scanning")').should('not.exist');
+                cy.get('a:contains("Delegated scanning")').should('not.exist');
             });
         });
     });

--- a/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
@@ -31,7 +31,7 @@ describe('Clusters', () => {
             // Replace h1 with h2 if we factor out a minimal Clusters page.
             cy.get('h1:contains("Secure clusters with a reusable init bundle")');
             // Assert link instead of button, because init bundles exist.
-            cy.get('a:contains("Review installation methods")');
+            cy.get('a:contains("Review init bundle installation methods")');
         } else {
             cy.get('h2:contains("Configure the clusters you want to secure.")');
             cy.get('a:contains("View instructions")');

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -166,7 +166,7 @@ function ClustersTablePanel({
                             component={LinkShim}
                             href={clustersDelegatedScanningPath}
                         >
-                            Manage delegated scanning
+                            Delegated scanning
                         </Button>
                     </div>
                 )}
@@ -184,9 +184,12 @@ function ClustersTablePanel({
     /* eslint-disable no-nested-ternary */
     const installMenuOptions = [
         isMoveInitBundlesEnabled ? (
-            <DropdownItem key="init-bundle">
-                <Link to={clustersSecureClusterPath}>Init bundle installation methods</Link>
-            </DropdownItem>
+            <DropdownItem
+                key="init-bundle"
+                component={
+                    <Link to={clustersSecureClusterPath}>Init bundle installation methods</Link>
+                }
+            />
         ) : version ? (
             <DropdownItem
                 key="link"
@@ -202,9 +205,14 @@ function ClustersTablePanel({
                 Instructions unavailable; version missing
             </DropdownItem>
         ),
-        <DropdownItem key="add" onClick={onAddCluster}>
-            {isMoveInitBundlesEnabled ? 'Legacy installation method' : 'New cluster'}
-        </DropdownItem>,
+        <DropdownItem
+            key="legacy"
+            component={
+                <Link to={`${clustersBasePath}/new`}>
+                    {isMoveInitBundlesEnabled ? 'Legacy installation method' : 'New cluster'}
+                </Link>
+            }
+        />,
     ];
     /* eslint-enable no-nested-ternary */
 
@@ -281,10 +289,6 @@ function ClustersTablePanel({
                 </Bullseye>
             </PageSection>
         );
-    }
-
-    function onAddCluster() {
-        history.push(`${clustersBasePath}/new`); // TODO we might replace pseudo-id with ?action=create
     }
 
     function setSelectedClusterId(cluster: Cluster) {

--- a/ui/apps/platform/src/Containers/Clusters/Components/ManageTokensButton.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ManageTokensButton.tsx
@@ -18,7 +18,7 @@ function ManageTokensButton(): ReactElement {
             className="no-underline flex-shrink-0"
             data-testid="manageTokens"
         >
-            {isMoveInitBundlesEnabled ? 'Manage init bundles' : 'Manage tokens'}
+            {isMoveInitBundlesEnabled ? 'Init bundles' : 'Manage tokens'}
         </HashLink>
     );
 }

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import {
     Alert,
     Bullseye,
@@ -20,7 +21,7 @@ import LinkShim from 'Components/PatternFly/LinkShim';
 import { fetchClusterInitBundles } from 'services/ClustersService';
 import { getProductBranding } from 'constants/productBranding';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { clustersInitBundlesPath, clustersSecureClusterPath } from 'routePaths';
+import { clustersBasePath, clustersInitBundlesPath, clustersSecureClusterPath } from 'routePaths';
 
 /*
  * Comments about data flow:
@@ -113,7 +114,7 @@ function NoClustersPage(): ReactElement {
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                             >
-                                                Review installation methods
+                                                Review init bundle installation methods
                                             </a>
                                         </ExternalLink>
                                     </FlexItem>
@@ -130,6 +131,9 @@ function NoClustersPage(): ReactElement {
                                 Create bundle
                             </Button>
                         )}
+                        <div className="pf-u-mt-xl">
+                            <Link to={`${clustersBasePath}/new`}>Legacy installation method</Link>
+                        </div>
                     </EmptyState>
                 )}
             </PageSection>


### PR DESCRIPTION
## Description

### Problem

Marcin reported:
1. Lack of a link on NoClustersPage for legacy method to install secured cluster services.
2. After entering /main/clusters/new in address bar, redirect back to /main/clusters and NoClustersPage.

### Analysis

1. Unintended side effect of https://github.com/stackrox/stackrox/pull/9365
    * Positive change: separated no clusters from clusters per mocks
    * Negative change: my bad to forget to replace irrelevant link with **Legacy installation method** link which had been on **Install cluster** dropdown in clusters heading.
2. Redirect to /main/clusters
    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/MainPage/MainPage.tsx#L50-L67
    * does prevent entering /main/clusters/new in address bar directly as a work around.
    * does not prevent React Router links to init bundles or legacy installation methods.

### Solution

Please pardon adding a few changes as prerequisite to discovered clusters while I am editing ClustersTablePanel for more realistic sprint demo.

1. delegatedScanningTest
    * Adjust wording of assertion.
2. redirectFromDashboard
    * Adjust wording of assertion.
3. ManageTokensButton
    * Delete **Manage** as a prerequisite to discovered clusters.
4. ClustersTablePanel
    * Delete **Manage** as a prerequisite to discovered clusters.
    * Add `component` prop according to PatternFly docs to solve accessibility problem with double `a` elements.
5. NoClustersPage
    * Adjust wording of link to contrast with new link.
    * Add missing **Legacy installation method** link.
    * Deleted unneeded `onClick` prop.

### Residue

1. When click **Review init bundle installation methods** link in testing step 2, it opens /main/clusters/secure-a-cluster **in a new tab**, therefore MainPage redirect to /main/clusters is a problem to solve. Possible solution:
    * Move from MainPage to Body where route is already available.
    * Do **not** redirect for any /main/clusters/… route.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_MOVE_INIT_BUNDLES_UI=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3950606 - 3950606
        total: 129 = 10471486 - 10471357
    * `ls -al build/static/js/*.js | wc -l`
        0 = 90 - 90 files
3. `yarn start` in ui

### Manual testing

Temporarily edit code.

1. Visit /main/clusters with simulated no clusters and no bundles.
    * **Create bundle** button
    * **Legacy installation method** link
    ![NoClustersPage_without_bundles](https://github.com/stackrox/stackrox/assets/11862657/aaf5cc29-ef16-4b45-bd2d-c4a9c68072c2)

2. Visit /main/clusters with simulated no clusters but with bundles.
    * **Review init bundle installation methods** link
    * **Legacy installation method** link
    ![NoClustersPage_with_bundles](https://github.com/stackrox/stackrox/assets/11862657/4baddb58-0d0e-4c7d-a1b2-07a5068fc26b)

3. Visit /main/clusters with clusters and init bundles, and then click **Secure a cluster**
    * **Init bundle installation methods**
    * **Legacy installation method**
    ![Dropdown](https://github.com/stackrox/stackrox/assets/11862657/7cd18b75-e23f-4b3a-93ca-c48b1d6a3730)

### Integration testing

Before you `yarn cypress-open` in ui/apps/platform folder:

```sh
export CYPRESS_ROX_MOVE_INIT_BUNDLES_UI=true
```

* clusters/delegatedScanningTest.test.js
* clusters/redirectFromDashboard.test.js