### PR TITLE
ROX-21024: fetch metadata from infra CR on OpenShift

### DIFF
--- a/sensor/kubernetes/clusterstatus/openshift.go
+++ b/sensor/kubernetes/clusterstatus/openshift.go
@@ -1,0 +1,119 @@
+package clusterstatus
+
+import (
+	"context"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configVersioned "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// Each resource tag for different cloud providers will have this set in case special "flavors" for installing
+	// OpenShift were used (e.g. OSD, ARO, ROSA).
+	redHatClusterTypeTagKey = "red-hat-clustertype"
+)
+
+type providerMetadataFromOpenShift = func(ctx context.Context, p configVersioned.Interface) (*storage.ProviderMetadata, error)
+
+func getProviderMetadataFromOpenShiftConfig(ctx context.Context,
+	client configVersioned.Interface) (*storage.ProviderMetadata, error) {
+	infraCR, err := client.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "retrieving cluster infrastructure CR")
+	}
+
+	return infraCRToProviderMetadata(infraCR), nil
+}
+
+func infraCRToProviderMetadata(infra *configv1.Infrastructure) *storage.ProviderMetadata {
+	// The platform status is required to read out the provider specific information. If it is unset,
+	// we can short-circuit here.
+	if infra.Status.PlatformStatus == nil {
+		return nil
+	}
+
+	switch infra.Status.PlatformStatus.Type {
+	case configv1.AWSPlatformType:
+		return &storage.ProviderMetadata{
+			Region:   infra.Status.PlatformStatus.AWS.Region,
+			Provider: &storage.ProviderMetadata_Aws{Aws: &storage.AWSProviderMetadata{}},
+			Verified: true,
+			Cluster: &storage.ClusterMetadata{
+				Type: clusterTypeFromAWSResourceTags(infra.Status.PlatformStatus.AWS.ResourceTags),
+				Name: infra.Status.InfrastructureName,
+			},
+		}
+	case configv1.GCPPlatformType:
+		return &storage.ProviderMetadata{
+			Region: infra.Status.PlatformStatus.GCP.Region,
+			Provider: &storage.ProviderMetadata_Google{Google: &storage.GoogleProviderMetadata{
+				Project: infra.Status.PlatformStatus.GCP.ProjectID,
+			}},
+			Verified: true,
+			Cluster: &storage.ClusterMetadata{
+				Type: clusterTypeFromGCPResourceTags(infra.Status.PlatformStatus.GCP.ResourceTags),
+				Name: infra.Status.InfrastructureName,
+			},
+		}
+	case configv1.AzurePlatformType:
+		return &storage.ProviderMetadata{
+			Region:   "",
+			Provider: &storage.ProviderMetadata_Azure{Azure: &storage.AzureProviderMetadata{}},
+			Verified: true,
+			Cluster: &storage.ClusterMetadata{
+				Type: clusterTypeFromAzureResourceTags(infra.Status.PlatformStatus.Azure.ResourceTags),
+				Name: infra.Status.InfrastructureName,
+			},
+		}
+	default:
+		// In case of a non-supported cloud provider, we currently assume nil.
+		return nil
+	}
+}
+
+func clusterTypeFromAWSResourceTags(tags []configv1.AWSResourceTag) storage.ClusterMetadata_Type {
+	var clusterType string
+	for _, tag := range tags {
+		if tag.Key == redHatClusterTypeTagKey {
+			clusterType = tag.Value
+		}
+	}
+	return clusterMetadataTypeFromResourceTag(strings.ToLower(clusterType))
+}
+
+func clusterTypeFromGCPResourceTags(tags []configv1.GCPResourceTag) storage.ClusterMetadata_Type {
+	var clusterType string
+	for _, tag := range tags {
+		if tag.Key == redHatClusterTypeTagKey {
+			clusterType = tag.Value
+		}
+	}
+	return clusterMetadataTypeFromResourceTag(strings.ToLower(clusterType))
+}
+
+func clusterTypeFromAzureResourceTags(tags []configv1.AzureResourceTag) storage.ClusterMetadata_Type {
+	var clusterType string
+	for _, tag := range tags {
+		if tag.Key == redHatClusterTypeTagKey {
+			clusterType = tag.Value
+		}
+	}
+	return clusterMetadataTypeFromResourceTag(strings.ToLower(clusterType))
+}
+
+func clusterMetadataTypeFromResourceTag(tagValue string) storage.ClusterMetadata_Type {
+	switch tagValue {
+	case "osd":
+		return storage.ClusterMetadata_OSD
+	case "rosa":
+		return storage.ClusterMetadata_ROSA
+	case "aro":
+		return storage.ClusterMetadata_ARO
+	default:
+		return storage.ClusterMetadata_OCP
+	}
+}

--- a/sensor/kubernetes/clusterstatus/openshift.go
+++ b/sensor/kubernetes/clusterstatus/openshift.go
@@ -70,8 +70,12 @@ func infraCRToProviderMetadata(infra *configv1.Infrastructure) *storage.Provider
 			},
 		}
 	default:
-		// In case of a non-supported cloud provider, we currently assume nil.
-		return nil
+		return &storage.ProviderMetadata{
+			Cluster: &storage.ClusterMetadata{
+				Type: storage.ClusterMetadata_OCP,
+				Name: infra.Status.InfrastructureName,
+			},
+		}
 	}
 }
 

--- a/sensor/kubernetes/clusterstatus/updater.go
+++ b/sensor/kubernetes/clusterstatus/updater.go
@@ -312,7 +312,7 @@ func (u *updaterImpl) getCloudProviderMetadata(ctx context.Context) *storage.Pro
 		}
 	}
 
-	log.Info("No Cloud Provider metadata is found")
+	log.Info("No cloud provider metadata was found")
 	return nil
 }
 

--- a/sensor/kubernetes/clusterstatus/updater.go
+++ b/sensor/kubernetes/clusterstatus/updater.go
@@ -49,7 +49,8 @@ type updaterImpl struct {
 	contextMtx    sync.Mutex
 	cancelContext context.CancelFunc
 	// This function is needed to be able to mock in test
-	getProviders func(context.Context) *storage.ProviderMetadata
+	getProviders                     func(context.Context) *storage.ProviderMetadata
+	getProviderMetadataFromOpenShift providerMetadataFromOpenShift
 }
 
 func (u *updaterImpl) Start() error {
@@ -302,7 +303,7 @@ func (u *updaterImpl) getCloudProviderMetadata(ctx context.Context) *storage.Pro
 	// In the case of OpenShift _and_ not having collected metadata previously through cloud providers metadata service,
 	// we can read out the Infrastructure CR for provider specific information.
 	if env.OpenshiftAPI.BooleanSetting() {
-		m, err := u.getMetadataFromInfrastructureCR(ctx)
+		m, err := u.getProviderMetadataFromOpenShift(ctx, u.client.OpenshiftConfig())
 		if err != nil {
 			log.Error("Failed to obtain provider metadata from config.openshift.io/v1/Infrastructure: ", err)
 		}
@@ -320,67 +321,12 @@ func NewUpdater(client client.Interface) common.SensorComponent {
 	offlineMode := &atomic.Bool{}
 	offlineMode.Store(true)
 	return &updaterImpl{
-		client:       client,
-		kubeClient:   client.Kubernetes(),
-		updates:      make(chan *message.ExpiringMessage),
-		stopSig:      concurrency.NewSignal(),
-		offlineMode:  offlineMode,
-		getProviders: providers.GetMetadata,
-	}
-}
-
-func (u *updaterImpl) getMetadataFromInfrastructureCR(ctx context.Context) (*storage.ProviderMetadata, error) {
-	clusterInfraCR, err := u.client.OpenshiftConfig().ConfigV1().
-		Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return providerMetadataFromInfraCR(clusterInfraCR), nil
-}
-
-func providerMetadataFromInfraCR(infra *configv1.Infrastructure) *storage.ProviderMetadata {
-	// The platform status is required to read out the provider specific information. If it is unset,
-	// we can short-circuit here.
-	if infra.Status.PlatformStatus == nil {
-		return nil
-	}
-
-	switch infra.Status.PlatformStatus.Type {
-	case configv1.AWSPlatformType:
-		return &storage.ProviderMetadata{
-			Region:   infra.Status.PlatformStatus.AWS.Region,
-			Provider: &storage.ProviderMetadata_Aws{Aws: &storage.AWSProviderMetadata{}},
-			Verified: true,
-			Cluster: &storage.ClusterMetadata{
-				Type: storage.ClusterMetadata_OCP,
-				Name: infra.Status.InfrastructureName,
-			},
-		}
-	case configv1.GCPPlatformType:
-		return &storage.ProviderMetadata{
-			Region: infra.Status.PlatformStatus.GCP.Region,
-			Provider: &storage.ProviderMetadata_Google{Google: &storage.GoogleProviderMetadata{
-				Project: infra.Status.PlatformStatus.GCP.ProjectID,
-			}},
-			Verified: true,
-			Cluster: &storage.ClusterMetadata{
-				Type: storage.ClusterMetadata_OCP,
-				Name: infra.Status.InfrastructureName,
-			},
-		}
-	case configv1.AzurePlatformType:
-		return &storage.ProviderMetadata{
-			Region:   "",
-			Provider: &storage.ProviderMetadata_Azure{Azure: &storage.AzureProviderMetadata{}},
-			Verified: true,
-			Cluster: &storage.ClusterMetadata{
-				Type: storage.ClusterMetadata_OCP,
-				Name: infra.Status.InfrastructureName,
-			},
-		}
-	default:
-		// In case of a non-supported cloud provider, we currently assume nil.
-		return nil
+		client:                           client,
+		kubeClient:                       client.Kubernetes(),
+		updates:                          make(chan *message.ExpiringMessage),
+		stopSig:                          concurrency.NewSignal(),
+		offlineMode:                      offlineMode,
+		getProviders:                     providers.GetMetadata,
+		getProviderMetadataFromOpenShift: getProviderMetadataFromOpenShiftConfig,
 	}
 }

--- a/sensor/kubernetes/clusterstatus/updater_test.go
+++ b/sensor/kubernetes/clusterstatus/updater_test.go
@@ -273,7 +273,7 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 				},
 			},
 		},
-		"on openshift running on a provider not supported should return nil": {
+		"on openshift running on a provider not supported should return basic information": {
 			getProviders: nilGetProviders,
 			openshift:    true,
 			infra: &configv1.Infrastructure{
@@ -285,6 +285,12 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 						AlibabaCloud: &configv1.AlibabaCloudPlatformStatus{},
 					},
 					InfrastructureName: "cluster-1",
+				},
+			},
+			metadata: &storage.ProviderMetadata{
+				Cluster: &storage.ClusterMetadata{
+					Type: storage.ClusterMetadata_OCP,
+					Name: "cluster-1",
 				},
 			},
 		},


### PR DESCRIPTION
## Description

OpenShift blocks access to the metadataservice of cloud providers. In case OpenShift is deployed using GCP / Azure / AWS, it currently is not possible to correctly attribute the clusters since the metadata call will fail.

The PR will now read metadata, in case none can be identified from metadata services of cloud providers, from the `config.openshift.io/v1/Infrastructure` CR. The CR contains basic information about the underlying provider that was used as well as the cluster name.

While there may be some issues (i.e. cloud provider specific things like subscription ID & region for Azure, account ID for AWS, zone for all) aren't available, this is definitely an improvement. Additionally, the fields that were left unset are not used
by any code part other than the CSCC notifier and telemetry. Adding those fields back in might be possible, depending on the labels set for nodes, but it might be non-trivial to do so.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

<img width="862" alt="Screenshot 2024-01-31 at 22 20 29" src="https://github.com/stackrox/stackrox/assets/89904305/e7b77c07-a625-4d3d-b9c4-c41b6236a3e6">

<img width="469" alt="Screenshot 2024-01-31 at 22 23 36" src="https://github.com/stackrox/stackrox/assets/89904305/e6904958-987d-40f1-bbff-7090a5e3e4dc">

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
