### PR TITLE
docs(operator): replace hardcoded operator-sdk path

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -193,7 +193,7 @@ $ kubectl -n bundle-test patch serviceaccount default -p '{"imagePullSecrets": [
 # Use one-liner above.
 
 # 4. Run bundle.
-$ .gotools/bin/operator-sdk run bundle \
+$ `make which-operator-sdk` run bundle \
   quay.io/rhacs-eng/stackrox-operator-bundle:v$(make --quiet --no-print-directory tag) \
   --pull-secret-name my-opm-image-pull-secrets \
   --service-account default \
@@ -208,7 +208,7 @@ $ kubectl -n bundle-test patch serviceaccount rhacs-operator-controller-manager 
 # You may need to bounce operator pods after this if they can't pull images for a while.
 $ kubectl -n bundle-test delete pod -l app=rhacs-operator
 
-# 6. operator-sdk run bundle command should complete successfully.
+# 6. The above operator-sdk run bundle command should complete successfully.
 # If it does not, watch pod statuses and check pod logs.
 $ kubectl -n bundle-test get pods
 # ... and dive deep from there into the ones that are not healthy.


### PR DESCRIPTION
## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Doc-only change, tested manually:

```
$ `make which-operator-sdk` run
make[1]: Entering directory '/home/mowsiany/go/src/github.com/stackrox/stackrox/operator'
make[1]: '/home/mowsiany/go/src/github.com/stackrox/stackrox/operator/.gotools/bin/operator-sdk' is up to date.
make[1]: Leaving directory '/home/mowsiany/go/src/github.com/stackrox/stackrox/operator'
This command has subcommands that will deploy your Operator with OLM.

Usage:
  operator-sdk run [command]

Available Commands:
  bundle           Deploy an Operator in the bundle format with OLM
  bundle-upgrade   Upgrade an Operator previously installed in the bundle format with OLM

Flags:
  -h, --help   help for run

Global Flags:
      --plugins strings   plugin keys to be used for this subcommand execution
      --verbose           Enable verbose logging

Use "operator-sdk run [command] --help" for more information about a command.
$ 
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
