### PR TITLE
ROX-21992: Flip Feature Flag to on by default

### DIFF
--- a/central/detection/service/service_impl.go
+++ b/central/detection/service/service_impl.go
@@ -408,12 +408,14 @@ func (s *serviceImpl) DetectDeployTimeFromYAML(ctx context.Context, req *apiV1.D
 
 	// TODO(ROX-21342): Ensure central doesn't crash if user doesn't provide cluster info
 	// If a cluster is provided and Sensor has the capability, enhance deployments with additional info from Sensor
-	if eCtx.ClusterID != "" && s.connManager.GetConnection(eCtx.ClusterID).HasCapability(centralsensor.SensorEnhancedDeploymentCheckCap) {
+	if eCtx.ClusterID != "" {
 		conn := s.connManager.GetConnection(eCtx.ClusterID)
 		if conn == nil {
 			return nil, errox.InvalidArgs.New("connection to cluster is not ready - try again later")
 		}
-		deployments, err = s.enhancementWatcher.SendAndWaitForEnhancedDeployments(ctx, conn, deployments, env.CentralDeploymentEnhancementTimeout.DurationSetting())
+		if conn.HasCapability(centralsensor.SensorEnhancedDeploymentCheckCap) {
+			deployments, err = s.enhancementWatcher.SendAndWaitForEnhancedDeployments(ctx, conn, deployments, env.CentralDeploymentEnhancementTimeout.DurationSetting())
+		}
 		if err != nil {
 			return nil, errors.Wrap(err, "failed waiting for augmented deployment response")
 		}

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -62,7 +62,7 @@ var (
 	UnifiedCVEDeferral = registerFeature("Enable new unified Vulnerability deferral workflow", "ROX_VULN_MGMT_UNIFIED_CVE_DEFERRAL", false)
 
 	// ClusterAwareDeploymentCheck enables roxctl deployment check to check deployments on the cluster level.
-	ClusterAwareDeploymentCheck = registerFeature("Enables cluster level check for the 'roxctl deployment check' command.", "ROX_CLUSTER_AWARE_DEPLOYMENT_CHECK", false)
+	ClusterAwareDeploymentCheck = registerFeature("Enables cluster level check for the 'roxctl deployment check' command.", "ROX_CLUSTER_AWARE_DEPLOYMENT_CHECK", true)
 
 	// WorkloadCVEsFixabilityFilters enables Workload CVE UI controls for fixability filters and default filters
 	WorkloadCVEsFixabilityFilters = registerFeature("Enables Workload CVE fixability filters", "ROX_WORKLOAD_CVES_FIXABILITY_FILTERS", false)


### PR DESCRIPTION
## Description

This PR enables the feature flag for roxctl deployment check improvements on by default (`ROX_CLUSTER_AWARE_DEPLOYMENT_CHECK`)


## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
Run deployed image and observe log output to ensure the feature is active by default

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
