### PR TITLE
test: allow both plural and singular tests, docs

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Check if the PR title is well dressed
         env:
-          CONV: '(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([\w\-\.]+\))?!?'
+          CONV: '(build|chore|ci|docs?|feat|fix|perf|refactor|revert|style|tests?)(\([\w\-\.]+\))?!?'
           JIRA: '([A-Z]+-[0-9]+, ?)*[A-Z]+-[0-9]+'
           TEXT: ': .+'
         run: |


### PR DESCRIPTION
## Description

I never remember whether it should be plural or singular. How about allowing both forms?

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI should be sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
