### PR TITLE
ROX-21603: check for stray pods at test end

### DIFF
--- a/operator/tests/central/central-basic/990-assert-pods-debug.yaml
+++ b/operator/tests/central/central-basic/990-assert-pods-debug.yaml
@@ -1,0 +1,1 @@
+../../common/pods-debug.yaml

--- a/operator/tests/central/central-basic/990-errors-no-pods-left.yaml
+++ b/operator/tests/central/central-basic/990-errors-no-pods-left.yaml
@@ -1,0 +1,1 @@
+../../common/no-pods-left.yaml

--- a/operator/tests/central/central-misc/990-assert-pods-debug.yaml
+++ b/operator/tests/central/central-misc/990-assert-pods-debug.yaml
@@ -1,0 +1,1 @@
+../../common/pods-debug.yaml

--- a/operator/tests/central/central-misc/990-errors-no-pods-left.yaml
+++ b/operator/tests/central/central-misc/990-errors-no-pods-left.yaml
@@ -1,0 +1,1 @@
+../../common/no-pods-left.yaml

--- a/operator/tests/common/central-cr-assert.yaml
+++ b/operator/tests/common/central-cr-assert.yaml
@@ -29,6 +29,7 @@ collectors:
 - command: kubectl describe pod -n $NAMESPACE -l app=scanner-v4-indexer
 - command: kubectl describe pod -n $NAMESPACE -l app=scanner-v4-matcher
 - command: kubectl describe pod -n $NAMESPACE -l app=scanner-v4-db
+# Please keep the above lists in sync with pods-debug.yaml
 timeout: 1500
 ---
 apiVersion: platform.stackrox.io/v1alpha1

--- a/operator/tests/common/no-pods-left.yaml
+++ b/operator/tests/common/no-pods-left.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: admission-control
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: central
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: central-db
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: collector
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: scanner
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: scanner-db
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: scanner-v4-db
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: scanner-v4-indexer
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: scanner-v4-matcher
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: sensor

--- a/operator/tests/common/pods-debug.yaml
+++ b/operator/tests/common/pods-debug.yaml
@@ -1,0 +1,45 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app=central
+  tail: -1
+- type: pod
+  selector: app=central-db
+  tail: -1
+- type: pod
+  selector: app=scanner
+  tail: -1
+- type: pod
+  selector: app=scanner-db
+  tail: -1
+- type: pod
+  selector: app=scanner-v4-indexer
+  tail: -1
+- type: pod
+  selector: app=scanner-v4-matcher
+  tail: -1
+- type: pod
+  selector: app=scanner-v4-db
+  tail: -1
+- command: kubectl describe pod -n $NAMESPACE -l app=central
+- command: kubectl describe pod -n $NAMESPACE -l app=central-db
+- command: kubectl describe pod -n $NAMESPACE -l app=scanner
+- command: kubectl describe pod -n $NAMESPACE -l app=scanner-db
+- command: kubectl describe pod -n $NAMESPACE -l app=scanner-v4-indexer
+- command: kubectl describe pod -n $NAMESPACE -l app=scanner-v4-matcher
+- command: kubectl describe pod -n $NAMESPACE -l app=scanner-v4-db
+# Please keep the above lists in sync with central-cr-assert.yaml
+- type: pod
+  selector: app=sensor
+  tail: -1
+- type: pod
+  selector: app=admission-control
+  tail: -1
+- type: pod
+  selector: app=collector
+  tail: -1
+- command: kubectl describe pod -n $NAMESPACE -l app=sensor
+- command: kubectl describe pod -n $NAMESPACE -l app=admission-control
+- command: kubectl describe pod -n $NAMESPACE -l app=collector
+# Please keep the above lists in sync with secured-cluster-cr-assert.yaml

--- a/operator/tests/common/secured-cluster-cr-assert.yaml
+++ b/operator/tests/common/secured-cluster-cr-assert.yaml
@@ -7,8 +7,13 @@ collectors:
 - type: pod
   selector: app=admission-control
   tail: -1
+- type: pod
+  selector: app=collector
+  tail: -1
 - command: kubectl describe pod -n $NAMESPACE -l app=sensor
 - command: kubectl describe pod -n $NAMESPACE -l app=admission-control
+- command: kubectl describe pod -n $NAMESPACE -l app=collector
+# Please keep the above lists in sync with pods-debug.yaml
 timeout: 1500
 ---
 apiVersion: platform.stackrox.io/v1alpha1

--- a/operator/tests/securedcluster/sc-basic/990-assert-pods-debug.yaml
+++ b/operator/tests/securedcluster/sc-basic/990-assert-pods-debug.yaml
@@ -1,0 +1,1 @@
+../../common/pods-debug.yaml

--- a/operator/tests/securedcluster/sc-basic/990-errors-no-pods-left.yaml
+++ b/operator/tests/securedcluster/sc-basic/990-errors-no-pods-left.yaml
@@ -1,0 +1,1 @@
+../../common/no-pods-left.yaml

--- a/operator/tests/upgrade/upgrade/990-assert-pods-debug.yaml
+++ b/operator/tests/upgrade/upgrade/990-assert-pods-debug.yaml
@@ -1,0 +1,1 @@
+../../common/pods-debug.yaml

--- a/operator/tests/upgrade/upgrade/990-errors-no-pods-left.yaml
+++ b/operator/tests/upgrade/upgrade/990-errors-no-pods-left.yaml
@@ -1,0 +1,1 @@
+../../common/no-pods-left.yaml


### PR DESCRIPTION
## Description

The ticket was a case where the test timed out due to a stray pod left in a namespace.

This change adds checks for existence of such pods as the last step of each test, and if some are founds, gathers debug info so we can troubleshoot this more in case it repeats in the future.

It also adds `collector` log/description collection on errors that was missing so far.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI should be enough.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
