### PR TITLE
ROX-22050: Update DiscoveredClustersTable before service is available

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
@@ -39,11 +39,12 @@ function DiscoveredClustersPage(): ReactElement {
     const [count, setCount] = useState(0);
     const [errorMessage, setErrorMessage] = useState('');
     const [clusters, setClusters] = useState<DiscoveredCluster[]>([]);
-    const [isLoading, setIsLoading] = useState(false);
+    // Use currentDatetime === null as substitute for initial isLoading.
+    const [currentDatetime, setCurrentDatetime] = useState<Date | null>(null);
+    const [isReloading, setIsReloading] = useState(false);
 
     useEffect(() => {
-        setIsLoading(true);
-
+        setIsReloading(true);
         // const listArg = getListDiscoveredClustersArg({ page, perPage, searchFilter, sortOption });
         // const { filter } = listArg;
 
@@ -59,9 +60,10 @@ function DiscoveredClustersPage(): ReactElement {
                 setErrorMessage(getAxiosErrorMessage(error));
             })
             .finally(() => {
-                setIsLoading(false);
+                setCurrentDatetime(new Date());
+                setIsReloading(false);
             });
-    }, [page, perPage, searchFilter, setIsLoading, sortOption]);
+    }, [page, perPage, searchFilter, sortOption]);
 
     /* eslint-disable no-nested-ternary */
     return (
@@ -85,7 +87,7 @@ function DiscoveredClustersPage(): ReactElement {
                 </Flex>
             </PageSection>
             <PageSection component="div">
-                {isLoading ? (
+                {currentDatetime === null ? (
                     <Bullseye>
                         <Spinner isSVG />
                     </Bullseye>
@@ -102,7 +104,7 @@ function DiscoveredClustersPage(): ReactElement {
                     <>
                         <DiscoveredClustersToolbar
                             count={count}
-                            isDisabled={isLoading}
+                            isDisabled={isReloading}
                             page={page}
                             perPage={perPage}
                             setPage={setPage}
@@ -112,6 +114,7 @@ function DiscoveredClustersPage(): ReactElement {
                         />
                         <DiscoveredClustersTable
                             clusters={clusters}
+                            currentDatetime={currentDatetime}
                             getSortParams={getSortParams}
                             searchFilter={searchFilter}
                         />

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
@@ -1,22 +1,25 @@
 import React, { ReactElement } from 'react';
-import { TableComposable, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { UseURLSortResult } from 'hooks/useURLSort';
 import { DiscoveredCluster, hasDiscoveredClustersFilter } from 'services/DiscoveredClustersService';
 import { SearchFilter } from 'types/search';
+import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 
 import DiscoveredClustersEmptyState from './DiscoveredClustersEmptyState';
 
-const colSpan = 4; // TODO separate Provider from
+const colSpan = 6;
 
 export type DiscoveredClustersTableProps = {
     clusters: DiscoveredCluster[];
+    currentDatetime: Date;
     getSortParams: UseURLSortResult['getSortParams'];
     searchFilter: SearchFilter;
 };
 
 function DiscoveredClustersTable({
     clusters,
+    currentDatetime,
     getSortParams,
     searchFilter,
 }: DiscoveredClustersTableProps): ReactElement {
@@ -24,10 +27,20 @@ function DiscoveredClustersTable({
         <TableComposable variant="compact" borders={false}>
             <Thead>
                 <Tr>
-                    <Th sort={getSortParams('TODO')}>Cluster</Th>
-                    <Th>Type</Th>
-                    <Th>Provider</Th>
-                    <Th>Region</Th>
+                    <Th width={25} sort={getSortParams('TODO')}>
+                        Cluster
+                    </Th>
+                    <Th width={15}>State</Th>
+                    <Th width={10}>Type</Th>
+                    <Th width={15} modifier="nowrap">
+                        Provider (region)
+                    </Th>
+                    <Th width={20} modifier="nowrap">
+                        Cloud source
+                    </Th>
+                    <Th width={15} modifier="nowrap" sort={getSortParams('TODO')}>
+                        First discovered
+                    </Th>
                 </Tr>
             </Thead>
             {clusters.length === 0 ? (
@@ -36,18 +49,31 @@ function DiscoveredClustersTable({
                     hasFilter={hasDiscoveredClustersFilter(searchFilter)}
                 />
             ) : (
-                clusters.map((cluster) => {
-                    const { id } = cluster;
+                <Tbody>
+                    {clusters.map((cluster) => {
+                        const { id } = cluster;
+                        const firstDiscovered = '2024-01-30T00:00:00Z'; // temporary placeholder
+                        const firstDiscoveredAsPhrase = getDistanceStrictAsPhrase(
+                            firstDiscovered,
+                            currentDatetime
+                        );
 
-                    return (
-                        <Tr key={id}>
-                            <Td dataLabel="Cluster">{'TODO'}</Td>
-                            <Td dataLabel="Type">{'TODO'}</Td>
-                            <Td dataLabel="Provider">{'TODO'}</Td>
-                            <Td dataLabel="Region">{'TODO'}</Td>
-                        </Tr>
-                    );
-                })
+                        return (
+                            <Tr key={id}>
+                                <Td dataLabel="Cluster">{'TODO'}</Td>
+                                <Td dataLabel="State">{'TODO'}</Td>
+                                <Td dataLabel="Type">{'TODO'}</Td>
+                                <Td dataLabel="Provider (region)" modifier="nowrap">
+                                    {'TODO'}
+                                </Td>
+                                <Td dataLabel="Cloud source">{'TODO'}</Td>
+                                <Td dataLabel="First discovered" modifier="nowrap">
+                                    {firstDiscoveredAsPhrase}
+                                </Td>
+                            </Tr>
+                        );
+                    })}
+                </Tbody>
             )}
         </TableComposable>
     );


### PR DESCRIPTION
## Description

Update to most recent design as prerequisite to render data as soon as service is available.

### Changes

1. Add `currentDatetime` in DiscoveredClustersPage to provide as prop so DiscoveredClustersTable is stateless presentation component.
2. Update table head columns with `width` prop and the following:
    * Add **State** column.
    * Combine **Provider** and **Region** columns to follow example of other products.
    * Add **Cloud source** column.
    * Add **First discovered** column.
3. Add missing `Tbody` element.
4. Add placeholder for **First discovered** data cell.

### Residue

1. Destructure properties from response as soon as service is available.
2. Add DiscoveredClusters.utils.tsx file:
    * Export `DiscoveredClusterStateMap` for **State** columm.
    * Export helper function for **Provider (region)** column.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_CLOUD_SOURCES=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 3950646 - 3950646
        total 1946 = 10479098 - 10477152
    * `ls -al build/static/js/*.js | wc`
        files 0 = 90 - 90
3. `yarn start` in ui

### Manual testing

1. Visit /main/clusters/discovered-clusters to see **Discovered clusters** page.
    
    * See empty state.
        ![DiscoveredClustersEmptyState](https://github.com/stackrox/stackrox/assets/11862657/0d0be29e-33dc-41a9-920f-257a054e4904)

    * See temporary data in table.
        ![DiscoveredClustersTable](https://github.com/stackrox/stackrox/assets/11862657/c822ee1b-f261-4ba9-9d38-16e31cf4eee5)
