### PR TITLE
test(scanv4): Check that scannerv4 Central env var is set correctly

### DIFF
--- a/pkg/renderer/templates/public_values.yaml.tpl
+++ b/pkg/renderer/templates/public_values.yaml.tpl
@@ -202,6 +202,7 @@ scannerV4:
 {{- $_ := unset $envVars "ROX_OFFLINE_MODE" -}}
 {{- $_ := unset $envVars "ROX_TELEMETRY_ENDPOINT" -}}
 {{- $_ := unset $envVars "ROX_TELEMETRY_STORAGE_KEY_V1" -}}
+{{- $_ := unset $envVars "ROX_SCANNER_V4" -}}
 {{- if $envVars }}
 
 customize:

--- a/tests/e2e/run-scanner-v4.bats
+++ b/tests/e2e/run-scanner-v4.bats
@@ -302,12 +302,14 @@ teardown_file() {
     PATH="${EARLIER_ROXCTL_PATH}:${PATH}" MAIN_IMAGE_TAG="${EARLIER_MAIN_IMAGE_TAG}" _deploy_stackrox
     verify_scannerV2_deployed
     verify_no_scannerV4_deployed
+    run ! verify_central_scannerV4_env_var_set "stackrox"
 
     info "Upgrading StackRox using HEAD deployment bundles"
     _deploy_stackrox
 
     verify_scannerV2_deployed
     verify_scannerV4_deployed
+    verify_central_scannerV4_env_var_set "stackrox"
 }
 
 verify_no_scannerV4_deployed() {

--- a/tests/e2e/run-scanner-v4.bats
+++ b/tests/e2e/run-scanner-v4.bats
@@ -190,6 +190,7 @@ teardown_file() {
     # Verify that Scanner v2 and v4 are up.
     verify_scannerV2_deployed "stackrox"
     verify_scannerV4_deployed "stackrox"
+    verify_central_scannerV4_env_var_set "stackrox"
 }
 
 @test "Fresh installation of HEAD Helm chart with Scanner V4 disabled and enabling it later" {
@@ -200,11 +201,13 @@ teardown_file() {
 
     verify_scannerV2_deployed "stackrox"
     verify_no_scannerV4_deployed "stackrox"
+    run ! verify_central_scannerV4_env_var_set "stackrox"
 
     HELM_REUSE_VALUES=true _deploy_stackrox
 
     verify_scannerV2_deployed "stackrox"
     verify_scannerV4_deployed "stackrox"
+    verify_central_scannerV4_env_var_set "stackrox"
 }
 
 @test "Fresh installation of HEAD Helm chart with Scanner v4 enabled" {
@@ -215,6 +218,7 @@ teardown_file() {
 
     verify_scannerV2_deployed "stackrox"
     verify_scannerV4_deployed "stackrox"
+    verify_central_scannerV4_env_var_set "stackrox"
 }
 
 @test "Fresh installation of HEAD Helm charts with Scanner v4 enabled in multi-namespace mode" {
@@ -233,6 +237,7 @@ teardown_file() {
 
     verify_scannerV2_deployed "$central_namespace"
     verify_scannerV4_deployed "$central_namespace"
+    verify_central_scannerV4_env_var_set "$central_namespace"
     verify_scannerV4_indexer_deployed "$sensor_namespace"
 }
 
@@ -251,6 +256,7 @@ teardown_file() {
 
     verify_scannerV2_deployed
     verify_no_scannerV4_deployed
+    run ! verify_central_scannerV4_env_var_set
 
     local scanner_bundle="${ROOT}/deploy/${ORCHESTRATOR_FLAVOR}/scanner-deploy"
     assert [ -d "${scanner_bundle}" ]
@@ -263,6 +269,7 @@ teardown_file() {
     ${ORCH_CMD} apply -R -f "${scanner_bundle}/scanner-v4"
 
     verify_scannerV4_deployed
+    verify_central_scannerV4_env_var_set
 }
 
 @test "Fresh installation using roxctl with Scanner V4 enabled" {
@@ -280,6 +287,7 @@ teardown_file() {
 
     verify_scannerV2_deployed "stackrox"
     verify_scannerV4_deployed "stackrox"
+    verify_central_scannerV4_env_var_set "stackrox"
 }
 
 @test "Upgrade from old version without Scanner V4 support to the version which supports Scanner v4" {
@@ -350,6 +358,18 @@ verify_scannerV4_matcher_deployed() {
     wait_for_ready_pods "${namespace}" "scanner-v4-matcher" 120
 }
 
+verify_central_scannerV4_env_var_set() {
+    local namespace=${1:-stackrox}
+
+    local central_env_vars="$("${ORCH_CMD}" -n "${namespace}" get deploy/central -o jsonpath="{.spec.template.spec.containers[?(@.name=='central')].env}")"
+    local scanner_v4_enabled="$(echo $central_env_vars | jq 'map(select(.name == "ROX_SCANNER_V4" and .value == "true")) | length > 0')"
+
+    if [[ "$scanner_v4_enabled" == "true" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
 
 # We are using our own deploy function, because we want to have the flexibility to patch down resources
 # after deployment. Without this we are only able to special-case local deployments and CI deployments,

--- a/tests/e2e/run-scanner-v4.bats
+++ b/tests/e2e/run-scanner-v4.bats
@@ -362,11 +362,13 @@ verify_scannerV4_matcher_deployed() {
 
 verify_central_scannerV4_env_var_set() {
     local namespace=${1:-stackrox}
+    local central_env_vars
+    local scanner_v4_value
 
-    local central_env_vars="$("${ORCH_CMD}" -n "${namespace}" get deploy/central -o jsonpath="{.spec.template.spec.containers[?(@.name=='central')].env}")"
-    local scanner_v4_enabled="$(echo $central_env_vars | jq 'map(select(.name == "ROX_SCANNER_V4" and .value == "true")) | length > 0')"
+    central_env_vars="$("${ORCH_CMD}" -n "${namespace}" get deploy/central -o jsonpath="{.spec.template.spec.containers[?(@.name=='central')].env}")"
+    scanner_v4_value="$(echo "${central_env_vars}" | jq -r '.[] | select(.name == "ROX_SCANNER_V4").value')"
 
-    if [[ "$scanner_v4_enabled" == "true" ]]; then
+    if [[ "${scanner_v4_value}" == "true" ]]; then
         return 0
     else
         return 1


### PR DESCRIPTION
## Description

Our installation tests check if scanner-v4 is deployed (or not), but they do not check if Central is configured correctly to use scanner-v4 or not.

The checks revealed a problem when doing a fresh installation of HEAD Helm chart with Scanner V4 disabled and enabling it later, and the PR includes a fix for this.

The issue was the following:
* `ROX_SCANNER_V4` is registered as a feature flag, and we have an env var in CI with the same name, and so it gets pulled into the public-values.yaml. (see [here](https://github.com/stackrox/stackrox/blob/daa61eafc079a2b908d064b2ddf555f77ee19028/roxctl/central/generate/generate.go#L185) and [here](https://github.com/stackrox/stackrox/blob/daa61eafc079a2b908d064b2ddf555f77ee19028/pkg/renderer/templates/public_values.yaml.tpl#L200))
* this causes `ROX_SCANNER_V4` to be applied as an env var to all containers in the deployment, and it's overwriting the env var set in the Helm chart, which is based on the value of `scannerV4.disabled`
* when installing without scanner-v4, this mechanism sets `ROX_SCANNER_V4` as `false` in the containers
* when upgrading and enabling scanner-v4 using `--reuse-values`, this re-applies `ROX_SCANNER_V4=false`, even though otherwise the chart would set it to `true`

To prevent this, I am excluding `ROX_SCANNER_V4` from being loaded from the environment, as it interferes with the `scannerV4.disabled` Helm value.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
