### PR TITLE
ROX-21614: Show Scanner V4 Credential Expiry Banner

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -40,6 +40,8 @@ function MainPage(): ReactElement {
     const isLoadingCentralCapabilities = useSelector(selectors.getIsLoadingCentralCapabilities);
     const [isLoadingClustersCount, setIsLoadingClustersCount] = useState(false);
 
+    const isScannerV4Enabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+
     const hasWriteAccessForCluster = hasReadWriteAccess('Cluster');
 
     const hasAdministrationWritePermission = hasReadWriteAccess('Administration');
@@ -95,6 +97,12 @@ function MainPage(): ReactElement {
                 component="SCANNER"
                 showCertGenerateAction={currentUserCanGenerateCert}
             />
+            {isScannerV4Enabled && (
+                <CredentialExpiryBanner
+                    component="SCANNER_V4"
+                    showCertGenerateAction={currentUserCanGenerateCert}
+                />
+            )}
             <OutdatedVersionBanner />
             <DatabaseStatusBanner />
             <ServerStatusBanner />


### PR DESCRIPTION
## Description

This PR displays the credential expiry banner for Scanner V4. This builds off the changes made in the following PRs:

https://github.com/stackrox/stackrox/pull/9532
https://github.com/stackrox/stackrox/pull/9551

<img width="721" alt="Screenshot 2024-01-31 at 9 40 36 AM" src="https://github.com/stackrox/stackrox/assets/4805485/e7e1db1a-37a3-4ca6-9740-f47e8ebeb5f9">

