### PR TITLE
ROX-22117: Link to installing secured clusters services docs pages

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
@@ -30,8 +30,9 @@ describe('Clusters', () => {
         if (hasFeatureFlag('ROX_MOVE_INIT_BUNDLES_UI')) {
             // Replace h1 with h2 if we factor out a minimal Clusters page.
             cy.get('h1:contains("Secure clusters with a reusable init bundle")');
-            // Assert link instead of button, because init bundles exist.
-            cy.get('a:contains("Review init bundle installation methods")');
+            // Assert links instead of button, because init bundles exist.
+            cy.get('a:contains("Installing secured cluster services on Red Hat OpenShift")');
+            cy.get('a:contains("Installing secured cluster services on other platforms")');
         } else {
             cy.get('h2:contains("Configure the clusters you want to secure.")');
             cy.get('a:contains("View instructions")');

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -18,10 +18,12 @@ import { CloudSecurityIcon } from '@patternfly/react-icons';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import LinkShim from 'Components/PatternFly/LinkShim';
-import { fetchClusterInitBundles } from 'services/ClustersService';
 import { getProductBranding } from 'constants/productBranding';
+import useMetadata from 'hooks/useMetadata';
+import { fetchClusterInitBundles } from 'services/ClustersService';
+import { getVersionedDocs } from 'utils/versioning';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { clustersBasePath, clustersInitBundlesPath, clustersSecureClusterPath } from 'routePaths';
+import { clustersBasePath, clustersInitBundlesPath } from 'routePaths';
 
 /*
  * Comments about data flow:
@@ -44,6 +46,8 @@ function NoClustersPage(): ReactElement {
     const [errorMessage, setErrorMessage] = useState('');
     const [initBundlesCount, setInitBundlesCount] = useState(0);
     const [isLoading, setIsLoading] = useState(false);
+
+    const { version } = useMetadata();
 
     const { basePageTitle } = getProductBranding();
     const textForSuccessAlert = `You have successfully deployed a ${basePageTitle} platform. Now you can configure the clusters you want to secure.`;
@@ -108,15 +112,36 @@ function NoClustersPage(): ReactElement {
                                         <Text component="p">
                                             You have successfully created cluster init bundles.
                                         </Text>
-                                        <ExternalLink>
-                                            <a
-                                                href={clustersSecureClusterPath}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                            >
-                                                Review init bundle installation methods
-                                            </a>
-                                        </ExternalLink>
+                                        {version && (
+                                            <>
+                                                <ExternalLink>
+                                                    <a
+                                                        href={getVersionedDocs(
+                                                            version,
+                                                            'installing/installing_ocp/install-secured-cluster-ocp.html'
+                                                        )}
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                    >
+                                                        Installing secured cluster services on Red
+                                                        Hat OpenShift
+                                                    </a>
+                                                </ExternalLink>
+                                                <ExternalLink>
+                                                    <a
+                                                        href={getVersionedDocs(
+                                                            version,
+                                                            'installing/installing_other/install-secured-cluster-other.html'
+                                                        )}
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                    >
+                                                        Installing secured cluster services on other
+                                                        platforms
+                                                    </a>
+                                                </ExternalLink>
+                                            </>
+                                        )}
                                     </FlexItem>
                                 )}
                             </Flex>


### PR DESCRIPTION
## Description

Redirect to /main/clusters in MainPage when there are no clusters
* prevents opening /main/clusters/secure-a-cluster in a new tab
* does not prevent opening the corresponding docs pages in a new tab

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_MOVE_INIT_BUNDLES_UI=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3950646 - 3950646
        total: 378 = 10477777 - 10477399
    * `ls -al build/static/js/*.js | wc -l`
        0 = 90 - 90 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/clusters with simulated no clusters.
    ![installing-secured-cluster-services](https://github.com/stackrox/stackrox/assets/11862657/4bb5fbaf-ee94-482b-9efa-9fac64448e7a)

### Integration testing

Before you `yarn cypress-open` in ui/apps/platform folder:

```sh
export CYPRESS_ROX_MOVE_INIT_BUNDLES_UI=true
```

* clusters/redirectFromDashboard.test.js