### PR TITLE
ROX-22119: Add warning alert to ClusterEditForm

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterEditForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterEditForm.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Alert } from '@patternfly/react-core';
+import { Alert, Flex, FlexItem } from '@patternfly/react-core';
 
 import Loader from 'Components/Loader';
 import { labelClassName } from 'constants/form.constants';
@@ -53,16 +53,27 @@ function ClusterEditForm({
                 />
             ) : (
                 <Alert variant="warning" isInline title="Legacy installation method" component="p">
-                    <p>
-                        Legacy installation is not recommended. It causes extra operational
-                        complexity.
-                    </p>
-                    <p>
-                        It is strongly recommend to use a cluster init bundle with either of the
-                        following installation methods:
-                    </p>
-                    <p>Operator for Red Hat OpenShift</p>
-                    <p>Helm chart for other platforms</p>
+                    <Flex direction={{ default: 'column' }}>
+                        <FlexItem>
+                            <p>
+                                To avoid extra operational complexity, use a{' '}
+                                <strong>cluster init bundle</strong>
+                                with either of the following installation methods:
+                            </p>
+                            <p>
+                                <strong>Operator</strong> for Red Hat OpenShift
+                            </p>
+                            <p>
+                                <strong>Helm chart</strong> for other platforms
+                            </p>
+                        </FlexItem>
+                        <FlexItem>
+                            <p>
+                                Only use the legacy installation method if you have a specific
+                                installation need that requires using this method.
+                            </p>
+                        </FlexItem>
+                    </Flex>
                 </Alert>
             )}
             <form

--- a/ui/apps/platform/src/Containers/Clusters/ClusterEditForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterEditForm.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import { Alert } from '@patternfly/react-core';
 
 import Loader from 'Components/Loader';
 import { labelClassName } from 'constants/form.constants';
@@ -41,7 +42,7 @@ function ClusterEditForm({
     return (
         <div className="bg-base-200 px-4 w-full">
             {/* @TODO, replace open prop with dynamic logic, based on clusterType */}
-            {selectedCluster.id && (
+            {selectedCluster.id ? (
                 <ClusterSummary
                     healthStatus={selectedCluster.healthStatus}
                     status={selectedCluster.status}
@@ -50,6 +51,19 @@ function ClusterEditForm({
                     clusterRetentionInfo={clusterRetentionInfo}
                     isManagerTypeNonConfigurable={isManagerTypeNonConfigurable}
                 />
+            ) : (
+                <Alert variant="warning" isInline title="Legacy installation method" component="p">
+                    <p>
+                        Legacy installation is not recommended. It causes extra operational
+                        complexity.
+                    </p>
+                    <p>
+                        It is strongly recommend to use a cluster init bundle with either of the
+                        following installation methods:
+                    </p>
+                    <p>Operator for Red Hat OpenShift</p>
+                    <p>Helm chart for other platforms</p>
+                </Alert>
             )}
             <form
                 className="grid grid-columns-1 md:grid-columns-2 grid-gap-4 xl:grid-gap-6 mb-4 w-full"

--- a/ui/apps/platform/src/Containers/Clusters/ClusterEditForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterEditForm.tsx
@@ -57,8 +57,8 @@ function ClusterEditForm({
                         <FlexItem>
                             <p>
                                 To avoid extra operational complexity, use a{' '}
-                                <strong>cluster init bundle</strong>
-                                with either of the following installation methods:
+                                <strong>cluster init bundle</strong> with either of the following
+                                installation methods:
                             </p>
                             <p>
                                 <strong>Operator</strong> for Red Hat OpenShift


### PR DESCRIPTION
## Description

Adapted from first draft by Simon.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. Visit /main/clusters, click **Secure a cluster** and then click **Legacy installation method**
    ![Legacy_installation_method](https://github.com/stackrox/stackrox/assets/11862657/b214521c-bed0-4ee5-856a-5a2b97f47181)

    See /main/clusters/new with **Legacy installation method** warning alert instead of **Cluster Summary** section.
    ![clusters_new](https://github.com/stackrox/stackrox/assets/11862657/44d66e76-fbad-4988-9e6f-e03008933193)

2. Visit /main/clusters and click a row to see /main/clusters/id with **Cluster Summary** section instead of warning alert.
    ![clusters_id](https://github.com/stackrox/stackrox/assets/11862657/ebd2ec9e-1463-4714-8518-947b0df28223)
