### PR TITLE
feat(scanv4): Fallback if no default StorageClass

### DIFF
--- a/image/templates/helm/shared/templates/_scanner-v4_volume.tpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_volume.tpl
@@ -8,37 +8,74 @@
 {{ $_ := set $ "_rox" $._rox }}
 
 {{ $scannerV4DBCfg := $._rox.scannerV4.db }}
+
 {{/*
     Scanner v4 DB Volume config setup.
   */}}
 {{ $scannerV4DBVolumeCfg := dict }}
 {{ $scannerV4DBVolumeHumanReadable := "" }}
+{{ $pvcConfigShape := $._rox._configShape.scannerV4.db.persistence.persistentVolumeClaim }}
+{{ $pvcDefaults := dict }}
+{{- if eq $.Chart.Name "stackrox-central-services" -}}
+  {{ $pvcDefaults = $._rox._defaults.scannerV4DBPVCDefaults }}
+{{- else -}}
+  {{ $pvcDefaults = $._rox.scannerV4DBPVCDefaults }}
+{{- end -}}
 
-{{ if $scannerV4DBCfg.persistence.none }}
-  {{ include "srox.warn" (list $ "You have selected no persistence backend. Every deletion of the StackRox Scanner v4 DB pod will cause you to lose all your data. This is STRONGLY recommended against.") }}
-  {{ $_ := set $scannerV4DBVolumeCfg "emptyDir" dict }}
-  {{ $scannerV4DBVolumeHumanReadable = "emptyDir" }}
+{{ $extraSettings := dict "createClaim" .Release.IsInstall }}
+{{ if $._rox.env.storageClasses.default }}
+  {{ $_ = set $extraSettings "storageClass" $._rox.env.storageClasses.default }}
 {{ end }}
 
+{{/* First we check that the persistence configuration provided by the user is sane in the sense that only one of the
+     supported backends emptyDir/hostPath/PVC is configured. */}}
+{{ $persistenceBackendsConfigured := list }}
+{{ if $scannerV4DBCfg.persistence.none }}
+  {{ $persistenceBackendsConfigured = append $persistenceBackendsConfigured "emptyDir" }}
+{{ end }}
 {{ if $scannerV4DBCfg.persistence.hostPath }}
+  {{ $persistenceBackendsConfigured = append $persistenceBackendsConfigured "hostPath" }}
+{{ end }}
+{{ if not (deepEqual $pvcConfigShape $scannerV4DBCfg.persistence.persistentVolumeClaim) }}
+  {{ $persistenceBackendsConfigured = append $persistenceBackendsConfigured (printf "PVC:%v" $scannerV4DBCfg.persistence.persistentVolumeClaim) }}
+{{ end }}
+
+{{/* Sanity checks and defaulting. */}}
+{{ if empty $persistenceBackendsConfigured }}
+  {{/* No persistence backend configured, pick a reasonable default. */}}
+  {{ if or $._rox.env.storageClasses.default (eq $.Chart.Name "stackrox-central-services") }}
+    {{/* Either a default StorageClass has been detected or we are currently rendering central-services.
+         In both cases we configure a PVC as persistence backend. */}}
+    {{ if $._rox.env.storageClasses.default }}
+      {{ include "srox.note" (list $ "Default StorageClass detected, a PVC will be used for Scanner V4 DB persistence.") }}
+    {{ else }}
+      {{ include "srox.note" (list $ "A PVC will be used for Scanner V4 DB persistence.") }}
+    {{ end }}
+    {{ $_ = include "srox.mergeInto" (list $scannerV4DBCfg.persistence.persistentVolumeClaim $pvcConfigShape $pvcDefaults $extraSettings) }}
+  {{ else }}
+    {{/* No default StorageClass detected, currently rendering secured-cluster-services chart. */}}
+    {{ include "srox.warn" (list $ (printf "No default StorageClass detected, using emptyDir as persistence backend for Scanner V4 DB. It is highly recommended to use a PVC instead. Please check the documentation for more information on this." )) }}
+    {{ $_ = set $scannerV4DBCfg.persistence "none" true }}
+  {{ end }}
+{{ else if gt (len $persistenceBackendsConfigured) 1 }}
+  {{ include "srox.fail" (printf "Invalid persistence configuration for Scanner V4 DB: more than one persistence backend configured (%v)" $persistenceBackendsConfigured) }}
+{{ end }}
+
+{{/* Update $scannerV4DBVolumeCfg depending on configured persistence backend. */}}
+{{ if $scannerV4DBCfg.persistence.none }}
+  {{ include "srox.warn" (list $ "Persistence for Scanner V4 DB is turned off (it is using an emptyDir volume). Every deletion of the StackRox Scanner V4 DB pod will cause you to lose all your data. This is STRONGLY recommended against.") }}
+  {{ $_ := set $scannerV4DBVolumeCfg "emptyDir" dict }}
+  {{ $scannerV4DBVolumeHumanReadable = "emptyDir" }}
+{{ else if $scannerV4DBCfg.persistence.hostPath }}
   {{ if not $scannerV4DBCfg.nodeSelector }}
-    {{ include "srox.warn" (list $ "You have selected host path persistence, but not specified a node selector. This is unlikely to work reliably.") }}
+    {{ include "srox.warn" (list $ "A hostPath volume will be used by the Scanner V4 DB. At the same time no node selector is specified. This is unlikely to work reliably.") }}
   {{ end }}
   {{ $_ := set $scannerV4DBVolumeCfg "hostPath" (dict "path" $scannerV4DBCfg.persistence.hostPath) }}
   {{ $scannerV4DBVolumeHumanReadable = printf "hostPath (%s)" $scannerV4DBCfg.persistence.hostPath}}
-{{ end }}
-
-{{/* Configure PVC if any of the settings in `scannerV4.db.persistence.persistentVolumeClaim` is provided
-     or no other persistence backend has been configured yet. */}}
-{{ if or (not (deepEqual $._rox._configShape.scannerV4.db.persistence.persistentVolumeClaim $scannerV4DBCfg.persistence.persistentVolumeClaim)) (not $scannerV4DBVolumeCfg) }}
+{{ else }}
+  {{ include "srox.note" (list $ (printf "A PVC using the storage class %q will be used by the Scanner V4 DB." $scannerV4DBCfg.persistence.persistentVolumeClaim.storageClass)) }}
   {{ $scannerV4DBPVCCfg := $scannerV4DBCfg.persistence.persistentVolumeClaim }}
-  {{ if and ($._rox._defaults) ($._rox._defaults.scannerV4DBPVCDefaults) }}
-    {{/* Central Services defaults are added to `_defaults` object */}}
-    {{ $_ := include "srox.mergeInto" (list $scannerV4DBPVCCfg $._rox._defaults.scannerV4DBPVCDefaults (dict "createClaim" .Release.IsInstall)) }}
-  {{ else }}
-    {{/* Secured Cluster services defaults are at object root */}}
-    {{ $_ := include "srox.mergeInto" (list $scannerV4DBPVCCfg $._rox.scannerV4DBPVCDefaults (dict "createClaim" .Release.IsInstall)) }}
-  {{ end }}
+  {{ $_ := include "srox.mergeInto" (list $scannerV4DBPVCCfg $pvcDefaults $extraSettings) }}
   {{ $_ = set $scannerV4DBVolumeCfg "persistentVolumeClaim" (dict "claimName" $scannerV4DBPVCCfg.claimName) }}
   {{ if $scannerV4DBPVCCfg.createClaim }}
     {{ $_ = set $scannerV4DBCfg.persistence "_pvcCfg" $scannerV4DBPVCCfg }}
@@ -51,7 +88,6 @@
 
 {{ $allPersistenceMethods := keys $scannerV4DBVolumeCfg | sortAlpha }}
 {{ if ne (len $allPersistenceMethods) 1 }}
-  {{ include "srox.fail" (printf "Invalid or no persistence configurations for scanner-v4-db: [%s]" (join "," $allPersistenceMethods)) }}
 {{ end }}
 
 {{ $_ = set $scannerV4DBCfg.persistence "_volumeCfg" $scannerV4DBVolumeCfg }}

--- a/image/templates/helm/shared/templates/_storage_classes.tpl
+++ b/image/templates/helm/shared/templates/_storage_classes.tpl
@@ -28,7 +28,7 @@
     {{- end -}}
   {{- end -}}
 
-  {{ $_ := set $._rox.env.storageClasses "all" (dict "all" $storageClasses) }}
+  {{ $_ := set $._rox.env.storageClasses "all" $storageClasses }}
   {{- if ne $defaultStorageClass "" -}}
     {{- $_ := set $._rox.env.storageClasses "default" $defaultStorageClass -}}
   {{- end -}}

--- a/image/templates/helm/shared/templates/_storage_classes.tpl
+++ b/image/templates/helm/shared/templates/_storage_classes.tpl
@@ -1,5 +1,14 @@
 {{/*
-  srox.getStorageClasses
+  srox.getStorageClasses $
+
+  This function attempts to retrieve information about all available StorageClasses on the
+  cluster and write it to
+
+    $._rox.env.storageClasses.all: A dict mapping storage class names to dicts containing
+      relevant properties of the storage class.
+
+    $._rox.env.storageClasses.default: Either nil or a string containing the name of the
+      default StorageClass.
    */}}
 {{- define "srox.getStorageClasses" -}}
 
@@ -20,15 +29,6 @@
   {{- end -}}
 
   {{ $_ := set $._rox.env.storageClasses "all" (dict "all" $storageClasses) }}
-
-  {{- range $storageClassName, $storageClassProperties := $storageClasses -}}
-    {{/* Would like to use `break`, but there are quite a few Helm 3.x versions out there not supporting that...
-        On the other hand there should, of course, only be at most one default storage class on a cluster. ¯\_(ツ)_/¯ */}}
-    {{- if and (get $storageClassProperties "isDefault") (not $defaultStorageClass) -}}
-      {{- $defaultStorageClass = $storageClassName -}}
-    {{- end -}}
-  {{- end -}}
-
   {{- if ne $defaultStorageClass "" -}}
     {{- $_ := set $._rox.env.storageClasses "default" $defaultStorageClass -}}
   {{- end -}}

--- a/image/templates/helm/shared/templates/_storage_classes.tpl
+++ b/image/templates/helm/shared/templates/_storage_classes.tpl
@@ -1,0 +1,36 @@
+{{/*
+  srox.getStorageClasses
+   */}}
+{{- define "srox.getStorageClasses" -}}
+
+  {{- $ := index . 0 -}}
+  {{- $storageClasses := dict -}}
+  {{- $defaultStorageClass := "" -}}
+
+  {{- $lookupResult := dict -}}
+  {{- $_ := include "srox.safeLookup" (list $ $lookupResult "storage.k8s.io/v1" "StorageClass" "" "") -}}
+  {{- range $sc := get ($lookupResult.result | default dict) "items" | default list -}}
+    {{- $storageClassName := $sc.metadata.name -}}
+    {{- $annotations := $sc.metadata.annotations | default dict -}}
+    {{- $isDefault := index $annotations "storageclass.kubernetes.io/is-default-class" | default false -}}
+    {{- $_ := set $storageClasses $storageClassName (dict "isDefault" $isDefault) -}}
+    {{- if and $isDefault (not $defaultStorageClass) -}}
+      {{- $defaultStorageClass = $storageClassName -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{ $_ := set $._rox.env.storageClasses "all" (dict "all" $storageClasses) }}
+
+  {{- range $storageClassName, $storageClassProperties := $storageClasses -}}
+    {{/* Would like to use `break`, but there are quite a few Helm 3.x versions out there not supporting that...
+        On the other hand there should, of course, only be at most one default storage class on a cluster. ¯\_(ツ)_/¯ */}}
+    {{- if and (get $storageClassProperties "isDefault") (not $defaultStorageClass) -}}
+      {{- $defaultStorageClass = $storageClassName -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if ne $defaultStorageClass "" -}}
+    {{- $_ := set $._rox.env.storageClasses "default" $defaultStorageClass -}}
+  {{- end -}}
+
+{{- end -}}

--- a/image/templates/helm/stackrox-central/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-central/internal/config-shape.yaml
@@ -14,6 +14,9 @@ env:
   platform: null # string
   offlineMode: null # bool
   proxyConfig: null # string | dict
+  storageClasses:
+    all: {} # dict
+    default: null # string
 ca:
   cert: null # string
   key: null # string

--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -65,6 +65,9 @@ image:
 env:
   openshift: null # bool | int
   istio: null # bool
+  storageClasses:
+    all: {} # dict
+    default: null # string
 ca:
   cert: null # string
 sensor:

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -116,6 +116,8 @@
 
 {{ include "srox.applyDefaults" $ }}
 
+{{ include "srox.getStorageClasses" (list $) }}
+
 {{/* Expand applicable config values */}}
 {{ $expandables := $.Files.Get "internal/expandables.yaml" | fromYaml }}
 {{ include "srox.expandAll" (list $ $rox $expandables) }}

--- a/pkg/helm/charts/tests/centralservices/flavor/testdata/helmtest/suite.yaml
+++ b/pkg/helm/charts/tests/centralservices/flavor/testdata/helmtest/suite.yaml
@@ -14,6 +14,16 @@ defs: |
 server:
   visibleSchemas:
   - kubernetes-1.20.2
+  objects:
+    # Apparently, for the `lookup` function in the Helm chart to be able to list the objects of a certain kind
+    # at least on such object needs to exist. Therefore, we create a StorageClass here solely
+    # for enabling lookups in the charts under test.
+    - apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: some-sc-that-we-dont-care-about
+        annotations:
+          storageclass.kubernetes.io/is-default-class: false
 values:
   imagePullSecrets:
     allowNone: true

--- a/pkg/helm/charts/tests/centralservices/flavor/testdata/helmtest/suite.yaml
+++ b/pkg/helm/charts/tests/centralservices/flavor/testdata/helmtest/suite.yaml
@@ -16,7 +16,7 @@ server:
   - kubernetes-1.20.2
   objects:
     # Apparently, for the `lookup` function in the Helm chart to be able to list the objects of a certain kind
-    # at least on such object needs to exist. Therefore, we create a StorageClass here solely
+    # at least one such object needs to exist. Therefore, we create a StorageClass here solely
     # for enabling lookups in the charts under test.
     - apiVersion: storage.k8s.io/v1
       kind: StorageClass

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -292,3 +292,43 @@ tests:
     .networkpolicys["scanner-v4-matcher"].spec.ingress | assertThat(length == 1)
     .networkpolicys["scanner-v4-matcher"].spec.ingress[0] | .ports | assertThat(length == 1)
     .networkpolicys["scanner-v4-matcher"].spec.ingress[0] | .from[0].podSelector.matchLabels.app | assertThat(. == "central")
+
+- name: "Scanner V4 DB persistence"
+  set:
+    scannerV4.disable: false
+  defs: |
+    def getVolume(deploymentName; volumeName):
+      .deployments[deploymentName].spec.template.spec.volumes[] | select(.name == "disk");
+    def getScannerV4Disk:
+      getVolume("scanner-v4-db"; "disk");
+    def getScannerV4PVC:
+      getScannerV4Disk | .persistentVolumeClaim;
+  tests:
+    - name: "defaults to PVC in absence of a default StorageClass"
+      expect: |
+        getScannerV4Disk | assertThat(.persistentVolumeClaim != null)
+        .persistentvolumeclaims["scanner-v4-db"] | assertThat(. != null)
+    - name: "can be configured to use a specific PVC"
+      values:
+        scannerV4:
+          db:
+            persistence:
+              persistentVolumeClaim:
+                claimName: "starfleet"
+                createClaim: true
+      expect: |
+        getScannerV4Disk | assertThat(.persistentVolumeClaim != null)
+        getScannerV4PVC | assertThat(.claimName == "starfleet")
+      tests:
+        - name: "which is newly created"
+          expect: |
+            .persistentvolumeclaims["starfleet"] | assertThat(. != null)
+        - name: "which is assumed to exist"
+          values:
+            scannerV4:
+              db:
+                persistence:
+                  persistentVolumeClaim:
+                    createClaim: false
+          expect: |
+            .persistentvolumeclaims["starfleet"] | assertThat(. == null)

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/suite.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/suite.yaml
@@ -29,6 +29,17 @@ defs: |
 server:
   visibleSchemas:
     - kubernetes-1.20.2
+  objects:
+    # Apparently, for the `lookup` function in the Helm chart to be able to list the objects of a certain kind
+    # at least on such object needs to exist. Therefore, we create a StorageClass here solely
+    # for enabling lookups in the charts under test.
+    - apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: some-sc
+        annotations:
+          storageclass.kubernetes.io/is-default-class: false
+
 values:
   ca:
     cert: "CA cert"

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/suite.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/suite.yaml
@@ -31,7 +31,7 @@ server:
     - kubernetes-1.20.2
   objects:
     # Apparently, for the `lookup` function in the Helm chart to be able to list the objects of a certain kind
-    # at least on such object needs to exist. Therefore, we create a StorageClass here solely
+    # at least one such object needs to exist. Therefore, we create a StorageClass here solely
     # for enabling lookups in the charts under test.
     - apiVersion: storage.k8s.io/v1
       kind: StorageClass

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/suite.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/suite.yaml
@@ -21,6 +21,16 @@ defs: |
 server:
   visibleSchemas:
   - kubernetes-1.20.2
+  objects:
+    # Apparently, for the `lookup` function in the Helm chart to be able to list the objects of a certain kind
+    # at least on such object needs to exist. Therefore, we create a StorageClass here solely
+    # for enabling lookups in the charts under test.
+    - apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: some-sc
+        annotations:
+          storageclass.kubernetes.io/is-default-class: false
 values:
   clusterName: "testcluster"
   imagePullSecrets:

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/suite.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/suite.yaml
@@ -23,7 +23,7 @@ server:
   - kubernetes-1.20.2
   objects:
     # Apparently, for the `lookup` function in the Helm chart to be able to list the objects of a certain kind
-    # at least on such object needs to exist. Therefore, we create a StorageClass here solely
+    # at least one such object needs to exist. Therefore, we create a StorageClass here solely
     # for enabling lookups in the charts under test.
     - apiVersion: storage.k8s.io/v1
       kind: StorageClass

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -223,3 +223,80 @@ tests:
     .networkpolicys["scanner-v4-indexer"].spec.ingress | assertThat(length == 1)
     .networkpolicys["scanner-v4-indexer"].spec.ingress[0] | .ports | assertThat(length == 1)
     .networkpolicys["scanner-v4-indexer"].spec.ingress[0] | .from[0].podSelector.matchLabels.app | assertThat(. == "sensor")
+
+- name: "Scanner V4 DB is backed by an emptyDir"
+  set:
+    scannerV4.disable: false
+    imagePullSecrets.allowNone: true
+  tests:
+  - name: "if configured explicitly"
+    set:
+      scannerV4.db.persistence.none: true
+    expect: |
+      .deployments["scanner-v4-db"].spec.template.spec.volumes[] | select(.name == "disk") | assertThat(.emptyDir != null)
+    tests:
+    - name: "in absence of a default StorageClass"
+    - name: "in presence of a default StorageClass"
+      server:
+        objects:
+        - apiVersion: storage.k8s.io/v1
+          kind: StorageClass
+          metadata:
+            name: def-sc
+            annotations:
+              storageclass.kubernetes.io/is-default-class: true
+
+- name: "Scanner V4 DB is backed by a PVC"
+  set:
+    imagePullSecrets.allowNone: true
+    scannerV4.disable: false
+  tests:
+  - name: "by default if a default StorageClass exists"
+    server:
+      objects:
+      - apiVersion: storage.k8s.io/v1
+        kind: StorageClass
+        metadata:
+          name: def-sc
+          annotations:
+            storageclass.kubernetes.io/is-default-class: true
+    expect: |
+      .deployments["scanner-v4-db"].spec.template.spec.volumes[] | select(.name == "disk") | assertThat(.persistentVolumeClaim != null)
+  - name: "if configured explicitly"
+    values:
+      scannerV4:
+        db:
+          persistence:
+            persistentVolumeClaim:
+              claimName: "foo"
+              size: "10Gi"
+              storageClass: "somes-sc"
+              createClaim: true
+    server:
+      objects:
+      - apiVersion: storage.k8s.io/v1
+        kind: StorageClass
+        metadata:
+          name: some-sc
+          annotations:
+            storageclass.kubernetes.io/is-default-class: false
+    defs: |
+      def getVolume(deploymentName; volumeName):
+        .deployments[deploymentName].spec.template.spec.volumes[] | select(.name == "disk");
+      def getScannerV4Disk:
+        getVolume("scanner-v4-db"; "disk");
+    expect: |
+      getScannerV4Disk | assertThat(.persistentVolumeClaim != null)
+      getScannerV4Disk | assumeThat(.persistentVolumeClaim != null) | .persistentVolumeClaim | assertThat(.claimName == "foo")
+      .persistentvolumeclaims["foo"] | assertThat(. != null)
+    tests:
+      - name: "in absence of a default StorageClass"
+      - name: "in presence of a default StorageClass"
+        server:
+          objects:
+          - apiVersion: storage.k8s.io/v1
+            kind: StorageClass
+            metadata:
+              name: a-default-sc
+              annotations:
+                storageclass.kubernetes.io/is-default-class: true

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/suite.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/suite.yaml
@@ -62,7 +62,7 @@ server:
   - kubernetes-1.20.2
   objects:
     # Apparently, for the `lookup` function in the Helm chart to be able to list the objects of a certain kind
-    # at least on such object needs to exist. Therefore, we create a StorageClass here solely
+    # at least one such object needs to exist. Therefore, we create a StorageClass here solely
     # for enabling lookups in the charts under test.
     - apiVersion: storage.k8s.io/v1
       kind: StorageClass

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/suite.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/suite.yaml
@@ -60,6 +60,16 @@ defs: |
 server:
   visibleSchemas:
   - kubernetes-1.20.2
+  objects:
+    # Apparently, for the `lookup` function in the Helm chart to be able to list the objects of a certain kind
+    # at least on such object needs to exist. Therefore, we create a StorageClass here solely
+    # for enabling lookups in the charts under test.
+    - apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: some-sc-that-we-dont-care-about
+        annotations:
+          storageclass.kubernetes.io/is-default-class: false
 values:
   clusterName: "testcluster"
   createSecrets: false


### PR DESCRIPTION
## Description

Implement fallback for environments not having a default StorageClass configured.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
