### PR TITLE
ROX-21880: Compliance cluster results table

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedDashboard.test.js
@@ -4,7 +4,6 @@ import { getRegExpForTitleWithBranding } from '../../helpers/title';
 
 import {
     visitComplianceEnhancedDashboard,
-    visitComplianceEnhancedFromLeftNav,
     statusDashboardPath,
 } from './ComplianceEnhanced.helpers';
 
@@ -17,13 +16,13 @@ describe('Compliance Dashboard', () => {
         }
     });
 
-    it('should visit using the left nav', () => {
-        visitComplianceEnhancedFromLeftNav();
+    // it('should visit using the left nav', () => {
+    //     visitComplianceEnhancedFromLeftNav();
 
-        cy.location('pathname').should('eq', statusDashboardPath);
+    //     cy.location('pathname').should('eq', statusDashboardPath);
 
-        cy.title().should('match', getRegExpForTitleWithBranding('Compliance Status Dashboard'));
-    });
+    //     cy.title().should('match', getRegExpForTitleWithBranding('Compliance Status Dashboard'));
+    // });
 
     it('should have expected elements on the status page', () => {
         visitComplianceEnhancedDashboard();

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetails.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetails.tsx
@@ -124,7 +124,10 @@ function ClusterDetails() {
                         ) : (
                             scanStats &&
                             scanStats.length > 0 && (
-                                <ClusterDetailsContent scanRecords={scanStats} />
+                                <ClusterDetailsContent
+                                    scanRecords={scanStats}
+                                    clusterId={clusterId}
+                                />
                             )
                         )}
                     </PageSection>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsContent.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsContent.tsx
@@ -5,12 +5,14 @@ import useURLStringUnion from 'hooks/useURLStringUnion';
 import { ComplianceClusterScanStats } from 'services/ComplianceEnhancedService';
 
 import RadioButtonWithStats from '../Components/RadioButtonWithStats';
+import ClusterDetailsTable from './ClusterDetailsTable';
 
 export type ClusterDetailsContentProps = {
     scanRecords: ComplianceClusterScanStats[];
+    clusterId: string;
 };
 
-function ClusterDetailsContent({ scanRecords }: ClusterDetailsContentProps) {
+function ClusterDetailsContent({ scanRecords, clusterId }: ClusterDetailsContentProps) {
     const scanNames = scanRecords.map((item) => item.scanStats.scanName) as [string, ...string[]];
     const [urlSelectedScan, setUrlSelectedScan] = useURLStringUnion('selectedScan', scanNames);
     const [selectedScan, setSelectedScan] = useState('');
@@ -62,6 +64,11 @@ function ClusterDetailsContent({ scanRecords }: ClusterDetailsContentProps) {
             </FlexItem>
             <FlexItem>
                 <Divider component="div" />
+            </FlexItem>
+            <FlexItem>
+                {clusterId && selectedScan && (
+                    <ClusterDetailsTable clusterId={clusterId} scanName={selectedScan} />
+                )}
             </FlexItem>
         </Flex>
     );

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { generatePath, Link } from 'react-router-dom';
 import {
     Bullseye,
@@ -12,6 +12,7 @@ import {
     ToolbarContent,
     ToolbarItem,
 } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import omit from 'lodash/omit';
 
@@ -31,8 +32,9 @@ import { SearchFilter } from 'types/search';
 import { SortOption } from 'types/table';
 import { searchValueAsArray } from 'utils/searchUtils';
 
+// TODO: move to a shared location
 import TableErrorComponent from 'Containers/Vulnerabilities/WorkloadCves/components/TableErrorComponent';
-import { SearchIcon } from '@patternfly/react-icons';
+
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { getClusterResultsStatusObject } from '../compliance.coverage.utils';
 import CheckStatusDropdown from '../Components/CheckStatusDropdown';
@@ -80,9 +82,21 @@ function ClusterDetailsTable({
     );
     const { data: scanResultsCount } = useRestQuery(countQuery);
 
+    useEffect(() => {
+        const checkNameFilter = searchFilter['Compliance Check Name'];
+
+        if (typeof checkNameFilter === 'string') {
+            setSearchCheckValue(checkNameFilter);
+        } else {
+            setSearchCheckValue('');
+        }
+    }, [searchFilter]);
+
     function getStatusByClusterId(clusters: ClusterCheckStatus[]): ComplianceCheckStatus | null {
-        const cluster = clusters.find((cluster) => cluster.cluster.clusterId === clusterId);
-        return cluster ? cluster.status : null;
+        const matchingCluster = clusters.find(
+            (clusterCheckStatus) => clusterCheckStatus.cluster.clusterId === clusterId
+        );
+        return matchingCluster ? matchingCluster.status : null;
     }
 
     function onChangeSearchFilter(newFilter: SearchFilter) {
@@ -132,7 +146,7 @@ function ClusterDetailsTable({
                         <>
                             <Link to={scanConfigUrl}>{checkName}</Link>
                             <br />
-                            <small>{rationale}</small>
+                            <small className="pf-u-color-200">{rationale}</small>
                         </>
                     </Td>
                     <Td>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsTable.tsx
@@ -1,0 +1,253 @@
+import React, { useCallback, useState } from 'react';
+import { generatePath, Link } from 'react-router-dom';
+import {
+    Bullseye,
+    Button,
+    Pagination,
+    SearchInput,
+    Spinner,
+    Text,
+    Title,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+} from '@patternfly/react-core';
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import omit from 'lodash/omit';
+
+import { complianceEnhancedScanConfigDetailPath } from 'routePaths';
+import IconText from 'Components/PatternFly/IconText/IconText';
+import useRestQuery from 'hooks/useRestQuery';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSearch from 'hooks/useURLSearch';
+import useURLSort from 'hooks/useURLSort';
+import {
+    ComplianceCheckStatus,
+    ClusterCheckStatus,
+    getSingleClusterResultsByScanConfig,
+    getSingleClusterResultsByScanConfigCount,
+} from 'services/ComplianceEnhancedService';
+import { SearchFilter } from 'types/search';
+import { SortOption } from 'types/table';
+import { searchValueAsArray } from 'utils/searchUtils';
+
+import TableErrorComponent from 'Containers/Vulnerabilities/WorkloadCves/components/TableErrorComponent';
+import { SearchIcon } from '@patternfly/react-icons';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+import { getClusterResultsStatusObject } from '../compliance.coverage.utils';
+import CheckStatusDropdown from '../Components/CheckStatusDropdown';
+
+type ClusterDetailsTableProps = {
+    clusterId: string;
+    scanName: string;
+};
+
+const sortFields = ['Compliance Check Name'];
+const defaultSortOption = {
+    field: 'Compliance Check Name',
+    direction: 'asc',
+} as SortOption;
+
+function ClusterDetailsTable({
+    clusterId,
+    scanName,
+}: ClusterDetailsTableProps): React.ReactElement {
+    const [searchCheckValue, setSearchCheckValue] = useState('');
+    const { searchFilter, setSearchFilter } = useURLSearch();
+    const { page, perPage, setPage, setPerPage } = useURLPagination(10);
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields,
+        defaultSortOption,
+    });
+
+    const listQuery = useCallback(
+        () =>
+            getSingleClusterResultsByScanConfig(
+                clusterId,
+                scanName,
+                searchFilter,
+                sortOption,
+                page - 1,
+                perPage
+            ),
+        [clusterId, scanName, searchFilter, sortOption, page, perPage]
+    );
+    const { data: scanResults, loading: isLoading, error } = useRestQuery(listQuery);
+
+    const countQuery = useCallback(
+        () => getSingleClusterResultsByScanConfigCount(clusterId, scanName, searchFilter),
+        [clusterId, scanName, searchFilter]
+    );
+    const { data: scanResultsCount } = useRestQuery(countQuery);
+
+    function getStatusByClusterId(clusters: ClusterCheckStatus[]): ComplianceCheckStatus | null {
+        const cluster = clusters.find((cluster) => cluster.cluster.clusterId === clusterId);
+        return cluster ? cluster.status : null;
+    }
+
+    function onChangeSearchFilter(newFilter: SearchFilter) {
+        setSearchFilter(newFilter);
+    }
+
+    function onSearchInputChange(_event, value) {
+        setSearchCheckValue(value);
+    }
+
+    const handleCheckInputSearch = () => {
+        const newFilter = {
+            ...searchFilter,
+            'Compliance Check Name': searchCheckValue,
+        };
+        setSearchFilter(newFilter);
+    };
+
+    const handleCheckInputClear = () => {
+        const newFilters = omit(searchFilter, 'Compliance Check Name');
+        setSearchCheckValue('');
+        setSearchFilter(newFilters);
+    };
+
+    function onSelect(type: 'Compliance Check Status', checked: boolean, selection: string) {
+        const selectedSearchFilter = searchValueAsArray(searchFilter[type]);
+        onChangeSearchFilter({
+            ...searchFilter,
+            [type]: checked
+                ? [...selectedSearchFilter, selection]
+                : selectedSearchFilter.filter((value) => value !== selection),
+        });
+    }
+
+    const renderTableContent = () => {
+        return scanResults?.checkResults.map(({ checkName, rationale, clusters }) => {
+            const scanConfigUrl = generatePath(complianceEnhancedScanConfigDetailPath, {
+                scanConfigId: checkName,
+            });
+
+            const status = getStatusByClusterId(clusters);
+            const statusObj = status ? getClusterResultsStatusObject(status) : null;
+
+            return (
+                <Tr key={checkName}>
+                    <Td modifier="truncate">
+                        <>
+                            <Link to={scanConfigUrl}>{checkName}</Link>
+                            <br />
+                            <small>{rationale}</small>
+                        </>
+                    </Td>
+                    <Td>
+                        {statusObj && (
+                            <IconText icon={statusObj.icon} text={statusObj.statusText} />
+                        )}
+                    </Td>
+                </Tr>
+            );
+        });
+    };
+
+    const renderLoadingContent = () => (
+        <Tr>
+            <Td colSpan={2}>
+                <Bullseye>
+                    <Spinner isSVG />
+                </Bullseye>
+            </Td>
+        </Tr>
+    );
+
+    const renderErrorContent = () => {
+        if (error) {
+            return (
+                <Tr>
+                    <Td colSpan={2}>
+                        <TableErrorComponent
+                            error={error}
+                            message="An error occurred. Try refreshing again"
+                        />
+                    </Td>
+                </Tr>
+            );
+        }
+        return <></>;
+    };
+
+    const renderEmptyContent = () => (
+        <Tr>
+            <Td colSpan={2}>
+                <Bullseye>
+                    <EmptyStateTemplate
+                        title="No results found"
+                        headingLevel="h2"
+                        icon={SearchIcon}
+                    >
+                        <Text>Clear all filters and try again.</Text>
+                        <Button variant="link" onClick={() => setSearchFilter({})}>
+                            Clear filters
+                        </Button>
+                    </EmptyStateTemplate>
+                </Bullseye>
+            </Td>
+        </Tr>
+    );
+
+    const renderTableBodyContent = () => {
+        if (isLoading) {
+            return renderLoadingContent();
+        }
+        if (scanResults && scanResults.checkResults.length > 0) {
+            return renderTableContent();
+        }
+        if (error) {
+            return renderErrorContent();
+        }
+        return renderEmptyContent();
+    };
+
+    return (
+        <>
+            <Title headingLevel="h2" className="pf-u-px-md">
+                {scanName}
+            </Title>
+            <Toolbar>
+                <ToolbarContent>
+                    <ToolbarItem variant="search-filter" className="pf-u-flex-grow-1">
+                        <SearchInput
+                            aria-label="Filter results by check"
+                            placeholder="Filter results by check"
+                            value={searchCheckValue}
+                            onChange={onSearchInputChange}
+                            onSearch={handleCheckInputSearch}
+                            onClear={handleCheckInputClear}
+                        />
+                    </ToolbarItem>
+                    <ToolbarItem>
+                        <CheckStatusDropdown searchFilter={searchFilter} onSelect={onSelect} />
+                    </ToolbarItem>
+                    <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
+                        <Pagination
+                            itemCount={scanResultsCount ?? 0}
+                            page={page}
+                            perPage={perPage}
+                            onSetPage={(_, newPage) => setPage(newPage)}
+                            onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                        />
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
+
+            <TableComposable>
+                <Thead noWrap>
+                    <Tr>
+                        <Th width={90} sort={getSortParams('Compliance Check Name')}>
+                            Compliance check
+                        </Th>
+                        <Th>Status</Th>
+                    </Tr>
+                </Thead>
+                <Tbody>{renderTableBodyContent()}</Tbody>
+            </TableComposable>
+        </>
+    );
+}
+
+export default ClusterDetailsTable;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Components/CheckStatusDropdown.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Components/CheckStatusDropdown.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { Select, SelectOption } from '@patternfly/react-core';
+
+import { SearchFilter } from 'types/search';
+
+type CheckStatusDropdownProps = {
+    searchFilter: SearchFilter;
+    onSelect: (filterType: 'Compliance Check Status', checked: boolean, selection: string) => void;
+};
+
+function CheckStatusDropdown({ searchFilter, onSelect }: CheckStatusDropdownProps) {
+    const [checkStatusIsOpen, setCheckStatusIsOpen] = useState(false);
+
+    function onCveSeverityToggle(isOpen: boolean) {
+        setCheckStatusIsOpen(isOpen);
+    }
+
+    return (
+        <Select
+            variant="checkbox"
+            aria-label="CVE severity filter menu items"
+            toggleAriaLabel="CVE severity filter menu toggle"
+            onToggle={onCveSeverityToggle}
+            onSelect={(event, selection) => {
+                const { checked } = event.target as HTMLInputElement;
+                onSelect('Compliance Check Status', checked, selection.toString());
+            }}
+            selections={searchFilter['Compliance Check Status']}
+            isOpen={checkStatusIsOpen}
+            placeholderText="Compliance status"
+        >
+            <SelectOption key="PASS" value="Pass" />
+            <SelectOption key="FAIL" value="Fail" />
+            <SelectOption key="ERROR" value="Error" />
+            <SelectOption key="INFO" value="Info" />
+            <SelectOption key="MANUAL" value="Manual" />
+            <SelectOption key="NOT_APPLICABLE" value="Not Applicable" />
+            <SelectOption key="INCONSISTENT" value="Inconsistent" />
+        </Select>
+    );
+}
+
+export default CheckStatusDropdown;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Components/CheckStatusDropdown.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Components/CheckStatusDropdown.tsx
@@ -11,16 +11,16 @@ type CheckStatusDropdownProps = {
 function CheckStatusDropdown({ searchFilter, onSelect }: CheckStatusDropdownProps) {
     const [checkStatusIsOpen, setCheckStatusIsOpen] = useState(false);
 
-    function onCveSeverityToggle(isOpen: boolean) {
+    function onCheckStatusToggle(isOpen: boolean) {
         setCheckStatusIsOpen(isOpen);
     }
 
     return (
         <Select
             variant="checkbox"
-            aria-label="CVE severity filter menu items"
-            toggleAriaLabel="CVE severity filter menu toggle"
-            onToggle={onCveSeverityToggle}
+            aria-label="Check status filter menu items"
+            toggleAriaLabel="Check status filter menu toggle"
+            onToggle={onCheckStatusToggle}
             onSelect={(event, selection) => {
                 const { checked } = event.target as HTMLInputElement;
                 onSelect('Compliance Check Status', checked, selection.toString());

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/compliance.coverage.utils.tsx
@@ -1,4 +1,15 @@
+import React, { ReactElement } from 'react';
 import { LabelProps } from '@patternfly/react-core';
+import {
+    BanIcon,
+    CheckCircleIcon,
+    ExclamationCircleIcon,
+    ExclamationTriangleIcon,
+    ResourcesEmptyIcon,
+    SecurityIcon,
+    UnknownIcon,
+    WrenchIcon,
+} from '@patternfly/react-icons';
 
 import {
     ComplianceCheckStatus,
@@ -10,6 +21,11 @@ const DANGER_THRESHOLD = 50;
 const WARNING_THRESHOLD = 75;
 
 type LabelColor = LabelProps['color'];
+
+type ClusterStatusObject = {
+    icon: ReactElement;
+    statusText: string;
+};
 
 export const ComplianceStatus = {
     SUCCESS: 'success',
@@ -91,4 +107,43 @@ export function getComplianceLabelGroupColor(
         return 'gold';
     }
     return 'blue';
+}
+
+const statusIconTextMap: { [key in ComplianceCheckStatus]: ClusterStatusObject } = {
+    [ComplianceCheckStatus.PASS]: {
+        icon: <CheckCircleIcon color="var(--pf-global--success-color--100)" />,
+        statusText: 'Pass',
+    },
+    [ComplianceCheckStatus.FAIL]: {
+        icon: <SecurityIcon color="var(--pf-global--danger-color--100)" />,
+        statusText: 'Fail',
+    },
+    [ComplianceCheckStatus.ERROR]: {
+        icon: <ExclamationTriangleIcon color="var(--pf-global--disabled-color--100)" />,
+        statusText: 'Error',
+    },
+    [ComplianceCheckStatus.INFO]: {
+        icon: <ExclamationCircleIcon color="var(--pf-global--disabled-color--100)" />,
+        statusText: 'Info',
+    },
+    [ComplianceCheckStatus.MANUAL]: {
+        icon: <WrenchIcon color="var(--pf-global--disabled-color--100)" />,
+        statusText: 'Manual',
+    },
+    [ComplianceCheckStatus.NOT_APPLICABLE]: {
+        icon: <BanIcon color="var(--pf-global--disabled-color--100)" />,
+        statusText: 'Not Applicable',
+    },
+    [ComplianceCheckStatus.INCONSISTENT]: {
+        icon: <UnknownIcon color="var(--pf-global--disabled-color--100)" />,
+        statusText: 'Inconsistent',
+    },
+    [ComplianceCheckStatus.UNSET_CHECK_STATUS]: {
+        icon: <ResourcesEmptyIcon color="var(--pf-global--disabled-color--100)" />,
+        statusText: 'Unset', // TODO: ask about this status
+    },
+};
+
+export function getClusterResultsStatusObject(status: ComplianceCheckStatus): ClusterStatusObject {
+    return statusIconTextMap[status];
 }

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -127,13 +127,9 @@ const navDescriptions: NavDescription[] = [
         children: [
             {
                 type: 'link',
-                content: 'Compliance Status',
-                path: complianceEnhancedStatusPath,
-                routeKey: 'compliance-enhanced',
-            },
-            {
-                type: 'link',
-                content: 'Cluster Compliance',
+                content: (
+                    <NavigationContent variant="TechPreview">Cluster Compliance</NavigationContent>
+                ),
                 path: complianceEnhancedClusterComplianceBasePath,
                 routeKey: 'compliance-enhanced',
             },

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -13,7 +13,6 @@ import {
     clustersBasePath,
     collectionsBasePath,
     complianceBasePath,
-    complianceEnhancedStatusPath,
     complianceEnhancedClusterComplianceBasePath,
     configManagementPath,
     dashboardPath,

--- a/ui/apps/platform/src/services/ComplianceEnhancedService.ts
+++ b/ui/apps/platform/src/services/ComplianceEnhancedService.ts
@@ -122,6 +122,32 @@ export interface ListComplianceScanResultsOverviewResponse {
     scanOverviews: ComplianceScanResultsOverview[];
 }
 
+export type ClusterCheckStatus = {
+    cluster: ComplianceScanCluster;
+    status: ComplianceCheckStatus;
+    createdTime: string; // ISO 8601 date string
+    checkUid: string;
+};
+
+type ComplianceCheckResult = {
+    checkId: string;
+    checkName: string;
+    clusters: ClusterCheckStatus[];
+    description: string;
+    instructions: string;
+    standard: string;
+    control: string;
+    rationale: string;
+    valuesUsed: string[];
+    warnings: string[];
+};
+
+type ComplianceScanResult = {
+    scanName: string;
+    profileName: string;
+    checkResults: ComplianceCheckResult[];
+};
+
 // API types for Compliance Profiles:
 // https://github.com/stackrox/stackrox/blob/master/proto/api/v2/compliance_profile_service
 interface ComplianceRule {
@@ -285,6 +311,71 @@ export function getSingleClusterStatsByScanConfig(
         }>(`${complianceResultsServiceUrl}/stats/cluster?${params}`)
         .then((response) => {
             return response?.data?.scanStats ?? [];
+        });
+}
+
+export function getSingleClusterResultsByScanConfig(
+    clusterId: string,
+    scanName: string,
+    searchFilter: SearchFilter,
+    sortOption: ApiSortOption,
+    page?: number,
+    pageSize?: number
+): Promise<ComplianceScanResult | null> {
+    if (!clusterId || !scanName) {
+        return Promise.reject(new Error('clusterId and scanName are required'));
+    }
+    const searchQuery = getRequestQueryStringForSearchFilter({
+        'Cluster ID': clusterId,
+        'Compliance Scan Config Name': scanName,
+        ...searchFilter,
+    });
+
+    let offset: number | undefined;
+    if (typeof page === 'number' && typeof pageSize === 'number') {
+        offset = page > 0 ? page * pageSize : 0;
+    }
+    const query = {
+        query: searchQuery,
+        pagination: { offset, limit: pageSize, sortOption },
+    };
+    const params = qs.stringify(query, { arrayFormat: 'repeat', allowDots: true });
+
+    return axios
+        .get<{
+            scanResults: ComplianceScanResult[];
+        }>(`${complianceResultsServiceUrl}/results?${params}`)
+        .then((response) => {
+            const results = response?.data?.scanResults ?? [];
+            if (results.length > 1) {
+                throw new Error('Expected a single result set, but received multiple');
+            }
+            return results[0] || null;
+        });
+}
+
+export function getSingleClusterResultsByScanConfigCount(
+    clusterId: string,
+    scanName: string,
+    searchFilter: SearchFilter
+): Promise<number> {
+    const searchQuery = getRequestQueryStringForSearchFilter({
+        'Cluster ID': clusterId,
+        'Compliance Scan Config Name': scanName,
+        ...searchFilter,
+    });
+
+    const query = {
+        query: searchQuery,
+    };
+    const params = qs.stringify(query, { arrayFormat: 'repeat', allowDots: true });
+
+    return axios
+        .get<{
+            count: number;
+        }>(`${complianceResultsServiceUrl}/count/results?${params}`)
+        .then((response) => {
+            return response?.data?.count ?? 0;
         });
 }
 


### PR DESCRIPTION
## Description

This adds the table for viewing cluster compliance check results by scan configuration

Notes:

- Mocks show the compliance checks filtering as a dropdown with prefilled checks, however, we don't have an endpoint to get the list of checks currently. So we went with a free form input field instead for now

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Default table view:
![Screenshot 2024-01-31 at 4 38 59 PM](https://github.com/stackrox/stackrox/assets/61400697/ae78d5f8-fbcc-46f1-87d3-84691f292eb4)

Filtered:
![Screenshot 2024-01-31 at 4 39 30 PM](https://github.com/stackrox/stackrox/assets/61400697/b72c71b0-3954-4bfd-acc6-bac85c96b86a)
