### PR TITLE
fix(scanner): do not use default updaters

### DIFF
--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -28,7 +28,6 @@ jobs:
       env:
         STACKROX_NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         STACKROX_NVD_API_CALL_INTERVAL: 6s
-      continue-on-error: true
       run: |
         if [ ! -d "scanner" ]; then
           echo "Scanner directory not found. Terminating current step."

--- a/.github/workflows/scanner-pr-vuln-update.yaml
+++ b/.github/workflows/scanner-pr-vuln-update.yaml
@@ -29,7 +29,6 @@ jobs:
       env:
         STACKROX_NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         STACKROX_NVD_API_CALL_INTERVAL: 6s
-      continue-on-error: true
       run: |
         if [ ! -d "scanner" ]; then
           echo "Scanner directory not found. Terminating current step."

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -41,7 +41,7 @@ var (
 				PasswordFile: "",
 			},
 			// TODO(ROX-19005): replace with a URL related to the desired version.
-			VulnerabilitiesURL: "https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/dev/output.json.zst",
+			VulnerabilitiesURL: "https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/dev/vulns.json.zst",
 		},
 		// Default is empty.
 		MTLS: MTLSConfig{

--- a/scanner/matcher/updater/updater.go
+++ b/scanner/matcher/updater/updater.go
@@ -321,7 +321,7 @@ func (u *Updater) fetch(ctx context.Context, prevTimestamp time.Time) (*os.File,
 		// No updates.
 		return nil, time.Time{}, nil
 	default:
-		return nil, time.Time{}, fmt.Errorf("received status code %q querying update endpoint", resp.StatusCode)
+		return nil, time.Time{}, fmt.Errorf("received status code %d querying update endpoint", resp.StatusCode)
 	}
 
 	f, err := os.CreateTemp(u.root, updateFilePattern)


### PR DESCRIPTION
## Description

Matcher logs have been showing:

```
{"level":"error","host":"scanner-v4-matcher-cdcd57d9d-wqb9w","component":"matcher/updater/Updater.Start","error":"updating enrichements: failed to finish batch enrichment insert: failed in exec iteration 823, ERROR: null value in column \"enrich\" of relation \"uo_enrich\" violates not-null constraint (SQLSTATE 23502)","time":"2024-01-31T20:47:07Z","message":"errors encountered during updater run"}
```

This is because we are running the built-in ClairCore CVSS enricher, accidentally. This PR stops using the default updaters.

Side effects:

* CI was silently failing before. This resolves that issue
* The compressed file is now 149MB instead of 286MB
* The decompressed file is now 22GB instead of 43GB

While we're at it, I've been wanting to switch the file name for a while to something more descriptive.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI.

Also, when deployed and the initial vuln update completes, you'll see the following:

```
# SELECT DISTINCT updater FROM uo_enrich;
 updater 
---------
 nvd
(1 row)
```

```
# SELECT DISTINCT dist_id, dist_version_id, dist_version FROM vuln;
    dist_id    | dist_version_id |  dist_version  
---------------+-----------------+----------------
               |                 | 
 alpine        | 3.10            | 
 alpine        | 3.11            | 
 alpine        | 3.12            | 
 alpine        | 3.13            | 
 alpine        | 3.14            | 
 alpine        | 3.15            | 
 alpine        | 3.16            | 
 alpine        | 3.17            | 
 alpine        | 3.18            | 
 alpine        | 3.19            | 
 alpine        | 3.3             | 
 alpine        | 3.4             | 
 alpine        | 3.5             | 
 alpine        | 3.6             | 
 alpine        | 3.7             | 
 alpine        | 3.8             | 
 alpine        | 3.9             | 
 alpine        | edge            | 
 amzn          | 2               | 2
 amzn          | 2018.03         | 2018.03
 amzn          | 2023            | 2023
 debian        | 10              | 10 (buster)
 debian        | 11              | 11 (bullseye)
 debian        | 12              | 12 (bookworm)
 ol            | 5               | 5
 ol            | 6               | 6
 ol            | 7               | 7
 ol            | 8               | 8
 ol            | 9               | 9
 opensuse-leap | 15.0            | 15.0
 opensuse-leap | 15.1            | 15.1
 photon        | 1.0             | 1.0
 photon        | 2.0             | 2.0
 photon        | 3.0             | 3.0
 rhel          | 5               | 5
 rhel          | 6               | 6
 rhel          | 7               | 7
 rhel          | 8               | 8
 rhel          | 9               | 9
 sles          | 11              | 11
 sles          | 12              | 12
 sles          | 15              | 15
 ubuntu        | 14.04           | 14.04 (Trusty)
 ubuntu        | 16.04           | 16.04 (Xenial)
 ubuntu        | 18.04           | 18.04 (Bionic)
 ubuntu        | 20.04           | 20.04 (Focal)
 ubuntu        | 22.04           | 22.04 (Jammy)
 ubuntu        | 23.10           | 23.10 (Mantic)
(49 rows)
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
