### PR TITLE
ROX-21963: increase timeout in nongroovy test

### DIFF
--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -25,7 +25,7 @@ const (
 	nginxDeploymentName     = `nginx`
 	expectedLatestTagPolicy = `Latest tag`
 
-	waitTimeout = 2 * time.Minute
+	waitTimeout = 5 * time.Minute
 )
 
 var (


### PR DESCRIPTION
## Description

Test is failing with a timeout. Let's increase it to give pod more time to be stopped.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
