### PR TITLE
ROX-21625: add kube-api to proxy default excludes 

### DIFF
--- a/image/templates/helm/stackrox-central/config/proxy-config.yaml.default
+++ b/image/templates/helm/stackrox-central/config/proxy-config.yaml.default
@@ -9,6 +9,7 @@
 # # - *.stackrox, *.stackrox.svc
 # # - localhost, localhost.localdomain, 127.0.0.0/8, ::1
 # # - *.local
+# # - $KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT
 # omitDefaultExcludes: false
 # excludes:  # hostnames (may include * components) for which not to use a proxy, like in-cluster repositories.
 # - some.domain

--- a/pkg/httputil/proxy/config.go
+++ b/pkg/httputil/proxy/config.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -167,6 +168,9 @@ func (c *proxyConfig) Compile(envCfg environmentConfig) *compiledConfig {
 	var allExcludes []string
 	allExcludes = append(allExcludes, c.Excludes...)
 	if !c.OmitDefaultExcludes {
+		k8sHost := os.Getenv("KUBERNETES_SERVICE_HOST")
+		k8sPort := os.Getenv("KUBERNETES_SERVICE_PORT")
+		allExcludes = append(allExcludes, net.JoinHostPort(k8sHost, k8sPort))
 		allExcludes = append(allExcludes, defaultExcludes...)
 	}
 


### PR DESCRIPTION
Backports:
- #9566