### PR TITLE
fix(ci): allow scanner v4 installation to be configurable

### DIFF
--- a/scripts/ci/jobs/gke_scanner_v4_tests.py
+++ b/scripts/ci/jobs/gke_scanner_v4_tests.py
@@ -14,6 +14,8 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 os.environ["STORE_METRICS"] = "true"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_BASELINE_GENERATION_DURATION"] = "5m"
+os.environ["ROX_SCANNER_V4_SUPPORT"] = "true"
+os.environ["ROX_SCANNER_V4"] = "true"
 
 # The current Scanner v4 tests only test Scanner v4 installation in different scenarios.
 # Due to the way the tests are structured the different test cases include a teardown at the end.

--- a/scripts/ci/jobs/gke_scanner_v4_tests.py
+++ b/scripts/ci/jobs/gke_scanner_v4_tests.py
@@ -14,7 +14,6 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 os.environ["STORE_METRICS"] = "true"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_BASELINE_GENERATION_DURATION"] = "5m"
-os.environ["ROX_SCANNER_V4_SUPPORT"] = "true"
 os.environ["ROX_SCANNER_V4"] = "true"
 
 # The current Scanner v4 tests only test Scanner v4 installation in different scenarios.

--- a/scripts/ci/jobs/ocp_scanner_v4_tests.py
+++ b/scripts/ci/jobs/ocp_scanner_v4_tests.py
@@ -14,6 +14,7 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["STORE_METRICS"] = "true"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_BASELINE_GENERATION_DURATION"] = "5m"
+os.environ["ROX_SCANNER_V4"] = "true"
 
 ClusterTestRunner(
     cluster=AutomationFlavorsCluster(),

--- a/scripts/ci/jobs/ocp_scanner_v4_tests.py
+++ b/scripts/ci/jobs/ocp_scanner_v4_tests.py
@@ -14,6 +14,7 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["STORE_METRICS"] = "true"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_BASELINE_GENERATION_DURATION"] = "5m"
+os.environ["ROX_SCANNER_V4_SUPPORT"] = "true"
 os.environ["ROX_SCANNER_V4"] = "true"
 
 ClusterTestRunner(

--- a/scripts/ci/jobs/ocp_scanner_v4_tests.py
+++ b/scripts/ci/jobs/ocp_scanner_v4_tests.py
@@ -14,7 +14,6 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["STORE_METRICS"] = "true"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_BASELINE_GENERATION_DURATION"] = "5m"
-os.environ["ROX_SCANNER_V4_SUPPORT"] = "true"
 os.environ["ROX_SCANNER_V4"] = "true"
 
 ClusterTestRunner(

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -146,6 +146,7 @@ export_test_environment() {
     ci_export ROX_ADMINISTRATION_EVENTS "${ROX_ADMINISTRATION_EVENTS:-true}"
     ci_export ROX_POLICY_CRITERIA_MODAL "${ROX_POLICY_CRITERIA_MODAL:-true}"
     ci_export ROX_TELEMETRY_STORAGE_KEY_V1 "DISABLED"
+    ci_export ROX_SCANNER_V4_SUPPORT "${ROX_SCANNER_V4_SUPPORT:-false}"
     ci_export ROX_CLOUD_CREDENTIALS "${ROX_CLOUD_CREDENTIALS:-true}"
     ci_export ROX_SCANNER_V4 "${ROX_SCANNER_V4:-false}"
     ci_export ROX_CLOUD_SOURCES "${ROX_CLOUD_SOURCES:-true}"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -146,7 +146,6 @@ export_test_environment() {
     ci_export ROX_ADMINISTRATION_EVENTS "${ROX_ADMINISTRATION_EVENTS:-true}"
     ci_export ROX_POLICY_CRITERIA_MODAL "${ROX_POLICY_CRITERIA_MODAL:-true}"
     ci_export ROX_TELEMETRY_STORAGE_KEY_V1 "DISABLED"
-    ci_export ROX_SCANNER_V4_SUPPORT "${ROX_SCANNER_V4_SUPPORT:-true}"
     ci_export ROX_CLOUD_CREDENTIALS "${ROX_CLOUD_CREDENTIALS:-true}"
     ci_export ROX_SCANNER_V4 "${ROX_SCANNER_V4:-false}"
     ci_export ROX_CLOUD_SOURCES "${ROX_CLOUD_SOURCES:-true}"
@@ -262,7 +261,7 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n      - name: ROX_CLOUD_SOURCES'
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_SCANNER_V4'
-    customize_envVars+=$'\n        value: "false"'
+    customize_envVars+=$'\n        value: "'"${ROX_SCANNER_V4:-false}"'"'
 
     CENTRAL_YAML_PATH="tests/e2e/yaml/central-cr.envsubst.yaml"
     # Different yaml for midstream images

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -146,7 +146,6 @@ export_test_environment() {
     ci_export ROX_ADMINISTRATION_EVENTS "${ROX_ADMINISTRATION_EVENTS:-true}"
     ci_export ROX_POLICY_CRITERIA_MODAL "${ROX_POLICY_CRITERIA_MODAL:-true}"
     ci_export ROX_TELEMETRY_STORAGE_KEY_V1 "DISABLED"
-    ci_export ROX_SCANNER_V4_SUPPORT "${ROX_SCANNER_V4_SUPPORT:-false}"
     ci_export ROX_CLOUD_CREDENTIALS "${ROX_CLOUD_CREDENTIALS:-true}"
     ci_export ROX_SCANNER_V4 "${ROX_SCANNER_V4:-false}"
     ci_export ROX_CLOUD_SOURCES "${ROX_CLOUD_SOURCES:-true}"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -263,6 +263,11 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n      - name: ROX_SCANNER_V4'
     customize_envVars+=$'\n        value: "'"${ROX_SCANNER_V4:-false}"'"'
 
+    scanner_v4_component="Disabled"
+    if [[ "${ROX_SCANNER_V4:-false}" == "true" ]]; then
+        scanner_v4_component="Enabled"
+    fi
+
     CENTRAL_YAML_PATH="tests/e2e/yaml/central-cr.envsubst.yaml"
     # Different yaml for midstream images
     if [[ "${USE_MIDSTREAM_IMAGES}" == "true" ]]; then
@@ -275,6 +280,7 @@ deploy_central_via_operator() {
       central_exposure_loadBalancer_enabled="$central_exposure_loadBalancer_enabled" \
       central_exposure_route_enabled="$central_exposure_route_enabled" \
       customize_envVars="$customize_envVars" \
+      scanner_v4_component="$scanner_v4_component" \
     envsubst \
       < "${CENTRAL_YAML_PATH}" | kubectl apply -n "${central_namespace}" -f -
 

--- a/tests/e2e/yaml/central-cr.envsubst.yaml
+++ b/tests/e2e/yaml/central-cr.envsubst.yaml
@@ -29,6 +29,8 @@ spec:
           memory: 1Gi
   customize:
     envVars:$customize_envVars
+  scannerV4:
+    scannerComponent: $scanner_v4_component
   scanner:
     analyzer:
       scaling:


### PR DESCRIPTION
## Description

These changes allow the operator install of scanner v4 to be configurable, defaulting to being disabled.

Related to https://github.com/openshift/release/pull/48344

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
