### PR TITLE
ROX-21171: skip test on rosa and osd

### DIFF
--- a/qa-tests-backend/src/test/groovy/RbacAuthTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RbacAuthTest.groovy
@@ -12,8 +12,10 @@ import services.BaseService
 import services.ClusterService
 import services.NetworkPolicyService
 import services.RoleService
+import util.Env
 import util.Helpers
 
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Unroll
@@ -100,6 +102,7 @@ spec:
 
     @Unroll
     @Tag("BAT")
+    @IgnoreIf({ Env.CI_JOB_NAME.contains("rosa") || Env.CI_JOB_NAME.contains("osd") }) // ROX-21171
     def "Verify RBAC with Role/Token combinations: #resourceAccess"() {
         when:
         "Create a test role"


### PR DESCRIPTION
## Description

Test is failing on ROSA and OSD since Nov 2023. Let's skip it and enable once we debug why it started failing. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
