### PR TITLE
ROX-20222: M2M auth config UI forms

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -71,7 +71,7 @@ var (
 	SensorReconciliationOnReconnect = registerFeature("Enable Sensors to support reconciliation on reconnect", "ROX_SENSOR_RECONCILIATION", true)
 
 	// AuthMachineToMachine allows to exchange ID tokens for Central tokens without requiring user interaction.
-	AuthMachineToMachine = registerFeature("Enable Auth Machine to Machine functionalities", "ROX_AUTH_MACHINE_TO_MACHINE", true)
+	AuthMachineToMachine = registerFeature("Enable Auth Machine to Machine functionalities", "ROX_AUTH_MACHINE_TO_MACHINE", false)
 
 	// PolicyCriteriaModal enables a modal for selecting policy criteria when editing a policy
 	PolicyCriteriaModal = registerFeature("Enable modal to select policy criteria when editing a policy", "ROX_POLICY_CRITERIA_MODAL", false)

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -71,7 +71,7 @@ var (
 	SensorReconciliationOnReconnect = registerFeature("Enable Sensors to support reconciliation on reconnect", "ROX_SENSOR_RECONCILIATION", true)
 
 	// AuthMachineToMachine allows to exchange ID tokens for Central tokens without requiring user interaction.
-	AuthMachineToMachine = registerFeature("Enable Auth Machine to Machine functionalities", "ROX_AUTH_MACHINE_TO_MACHINE", false)
+	AuthMachineToMachine = registerFeature("Enable Auth Machine to Machine functionalities", "ROX_AUTH_MACHINE_TO_MACHINE", true)
 
 	// PolicyCriteriaModal enables a modal for selecting policy criteria when editing a policy
 	PolicyCriteriaModal = registerFeature("Enable modal to select policy criteria when editing a policy", "ROX_POLICY_CRITERIA_MODAL", false)

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -257,6 +257,8 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_CLOUD_SOURCES'
     customize_envVars+=$'\n        value: "true"'
+    customize_envVars+=$'\n      - name: ROX_AUTH_MACHINE_TO_MACHINE'
+    customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_SCANNER_V4'
     customize_envVars+=$'\n        value: "'"${ROX_SCANNER_V4:-false}"'"'
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -149,6 +149,7 @@ export_test_environment() {
     ci_export ROX_CLOUD_CREDENTIALS "${ROX_CLOUD_CREDENTIALS:-true}"
     ci_export ROX_SCANNER_V4 "${ROX_SCANNER_V4:-false}"
     ci_export ROX_CLOUD_SOURCES "${ROX_CLOUD_SOURCES:-true}"
+    ci_export ROX_AUTH_MACHINE_TO_MACHINE "${ROX_AUTH_MACHINE_TO_MACHINE:-true}"
 
     if is_in_PR_context && pr_has_label ci-fail-fast; then
         ci_export FAIL_FAST "true"

--- a/ui/apps/platform/README.md
+++ b/ui/apps/platform/README.md
@@ -166,6 +166,11 @@ Given a feature flag environment variable `"ROX_WHATEVER"` in pkg/features/list.
 4. To turn on a feature flag for continuous integration in **branch** and **master** builds:
 
     * Add `ci_export ROX_WHATEVER "${ROX_WHATEVER:-true}"` to `export_test_environment` function in tests/e2e/lib.sh
+    * Add code below to `deploy_central_via_operator` function in tests/e2e/lib.sh
+    ```
+    customize_envVars+=$'\n      - name: ROX_WHATEVER'
+    customize_envVars+=$'\n        value: "true"'
+   ```
 
     The value of feature flags for **demo** and **release** builds is in pkg/features/list.go 
 

--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -78,6 +78,7 @@ export const integrations = {
     externalBackups: '/v1/externalbackups',
     apiTokens: 'v1/apitokens?revoked=false',
     clusterInitBundles: '/v1/cluster-init/init-bundles',
+    machineAccessConfigs: '/v1/auth/m2m',
 };
 
 export const integration = {

--- a/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
+++ b/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
@@ -56,7 +56,7 @@ function getIntegrationsEndpointAddress(integrationSource, integrationType) {
                 case 'clusterInitBundle': // singular in page address
                     return '/v1/cluster-init/init-bundles'; // plural in endpoint address
                 case 'machineAccess':
-                    return '/v1/auth/m2m'
+                    return '/v1/auth/m2m';
                 default:
                     return '';
             }
@@ -82,7 +82,7 @@ export function getIntegrationsEndpointAlias(integrationSource, integrationType)
                 case 'clusterInitBundle': // singular in page address
                     return 'cluster-init/init-bundles'; // plural in endpoint alias
                 case 'machineAccess':
-                    return '/v1/auth/m2m'
+                    return '/v1/auth/m2m';
                 default:
                     return '';
             }
@@ -153,7 +153,7 @@ const integrationTitleMap = {
     authProviders: {
         apitoken: 'API Token',
         clusterInitBundle: 'Cluster Init Bundle',
-        machineAccess: 'Machine access configuration'
+        machineAccess: 'Machine access configuration',
     },
     backups: {
         gcs: 'Google Cloud Storage',

--- a/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
+++ b/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
@@ -55,6 +55,8 @@ function getIntegrationsEndpointAddress(integrationSource, integrationType) {
                     return '/v1/apitokens'; // plural in endpoint address (and see next function)
                 case 'clusterInitBundle': // singular in page address
                     return '/v1/cluster-init/init-bundles'; // plural in endpoint address
+                case 'machineAccess':
+                    return '/v1/auth/m2m'
                 default:
                     return '';
             }
@@ -79,6 +81,8 @@ export function getIntegrationsEndpointAlias(integrationSource, integrationType)
                     return 'apitokens'; // plural in endpoint alias
                 case 'clusterInitBundle': // singular in page address
                     return 'cluster-init/init-bundles'; // plural in endpoint alias
+                case 'machineAccess':
+                    return '/v1/auth/m2m'
                 default:
                     return '';
             }
@@ -119,6 +123,7 @@ function getIntegrationEndpointAddress(integrationSource, integrationType, integ
 const routeMatcherMapForIntegrationsDashboard = Object.fromEntries(
     [
         ['authProviders', 'apitoken'],
+        ['authProviders', 'machineAccess'],
         ['imageIntegrations'],
         ['signatureIntegrations'],
         ['notifiers'],
@@ -148,6 +153,7 @@ const integrationTitleMap = {
     authProviders: {
         apitoken: 'API Token',
         clusterInitBundle: 'Cluster Init Bundle',
+        machineAccess: 'Machine access configuration'
     },
     backups: {
         gcs: 'Google Cloud Storage',

--- a/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
+++ b/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
@@ -316,7 +316,7 @@ export function clickCreateNewIntegrationInTable(
     const integrationTitle = integrationTitleMap[integrationSource][integrationType];
     cy.get(`${selectors.breadcrumbItem} a:contains("${integrationsTitle}")`);
     cy.get(`${selectors.breadcrumbItem} a:contains("${integrationTitle}")`);
-    cy.get(`${selectors.breadcrumbItem}:contains("Create Integration")`); // TODO Title Case
+    cy.get(`${selectors.breadcrumbItem}:contains("Create integration")`); // TODO Title Case
 }
 
 export function deleteIntegrationInTable(integrationSource, integrationType, integrationName) {

--- a/ui/apps/platform/src/Containers/Integrations/CreateIntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/CreateIntegrationPage.tsx
@@ -4,14 +4,18 @@ import usePageState from './hooks/usePageState';
 
 import IntegrationPage from './IntegrationPage';
 import IntegrationForm from './IntegrationForm';
+import {getIsMachineAccessConfig} from "./utils/integrationUtils";
 
 function CreateIntegrationPage(): ReactElement {
     const {
         params: { source, type },
     } = usePageState();
 
+    const title = getIsMachineAccessConfig(source, type)
+        ? "Create configuration"
+        : "Create Integration";
     return (
-        <IntegrationPage title="Create Integration" name="Create Integration">
+        <IntegrationPage title={title} name={title}>
             <IntegrationForm source={source} type={type} isEditable />
         </IntegrationPage>
     );

--- a/ui/apps/platform/src/Containers/Integrations/CreateIntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/CreateIntegrationPage.tsx
@@ -13,7 +13,7 @@ function CreateIntegrationPage(): ReactElement {
 
     const title = getIsMachineAccessConfig(source, type)
         ? 'Create configuration'
-        : 'Create Integration';
+        : 'Create integration';
     return (
         <IntegrationPage title={title} name={title}>
             <IntegrationForm source={source} type={type} isEditable />

--- a/ui/apps/platform/src/Containers/Integrations/CreateIntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/CreateIntegrationPage.tsx
@@ -4,7 +4,7 @@ import usePageState from './hooks/usePageState';
 
 import IntegrationPage from './IntegrationPage';
 import IntegrationForm from './IntegrationForm';
-import {getIsMachineAccessConfig} from "./utils/integrationUtils";
+import { getIsMachineAccessConfig } from './utils/integrationUtils';
 
 function CreateIntegrationPage(): ReactElement {
     const {
@@ -12,8 +12,8 @@ function CreateIntegrationPage(): ReactElement {
     } = usePageState();
 
     const title = getIsMachineAccessConfig(source, type)
-        ? "Create configuration"
-        : "Create Integration";
+        ? 'Create configuration'
+        : 'Create Integration';
     return (
         <IntegrationPage title={title} name={title}>
             <IntegrationForm source={source} type={type} isEditable />

--- a/ui/apps/platform/src/Containers/Integrations/EditIntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/EditIntegrationPage.tsx
@@ -6,6 +6,7 @@ import useIntegrations from './hooks/useIntegrations';
 import IntegrationPage from './IntegrationPage';
 import IntegrationForm from './IntegrationForm';
 import IntegrationsNotFoundPage from './IntegrationsNotFoundPage';
+import { getIsMachineAccessConfig } from './utils/integrationUtils';
 
 function EditIntegrationPage(): ReactElement {
     const {
@@ -19,7 +20,12 @@ function EditIntegrationPage(): ReactElement {
     }
 
     return (
-        <IntegrationPage title="Edit Integration" name={integration.name}>
+        <IntegrationPage
+            title={
+                getIsMachineAccessConfig(source, type) ? 'Manage configuration' : 'Edit Integration'
+            }
+            name={integration.name}
+        >
             <IntegrationForm source={source} type={type} initialValues={integration} isEditable />
         </IntegrationPage>
     );

--- a/ui/apps/platform/src/Containers/Integrations/EditIntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/EditIntegrationPage.tsx
@@ -22,7 +22,7 @@ function EditIntegrationPage(): ReactElement {
     return (
         <IntegrationPage
             title={
-                getIsMachineAccessConfig(source, type) ? 'Manage configuration' : 'Edit Integration'
+                getIsMachineAccessConfig(source, type) ? 'Manage configuration' : 'Edit integration'
             }
             name={integration.name}
         >

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -9,22 +9,23 @@ import {
     Form,
     FormGroup,
     FormSection,
-    PageSection, Popover,
+    PageSection,
+    Popover,
     SelectOption,
-    TextInput, Tooltip,
+    TextInput,
 } from '@patternfly/react-core';
 import {FieldArray, FormikProvider} from 'formik';
 import {ArrowRightIcon, HelpIcon, PlusCircleIcon, TrashIcon} from '@patternfly/react-icons';
-import {IntegrationFormProps} from '../integrationFormTypes';
-import useIntegrationForm from '../useIntegrationForm';
-import FormMessage from '../../../../Components/PatternFly/FormMessage';
-import FormLabelGroup from '../FormLabelGroup';
-import IntegrationFormActions from '../IntegrationFormActions';
-import FormSaveButton from '../../../../Components/PatternFly/FormSaveButton';
-import FormCancelButton from '../../../../Components/PatternFly/FormCancelButton';
-import SelectSingle from '../../../../Components/SelectSingle';
-import {fetchRolesAsArray, Role} from '../../../../services/RolesService';
-import {MachineConfigType} from '../../../../services/MachineAccessService';
+import {IntegrationFormProps} from 'Containers/Integrations/IntegrationForm/integrationFormTypes';
+import useIntegrationForm from 'Containers/Integrations/IntegrationForm/useIntegrationForm';
+import FormMessage from 'Components/PatternFly/FormMessage';
+import FormLabelGroup from 'Containers/Integrations/IntegrationForm/FormLabelGroup';
+import IntegrationFormActions from 'Containers/Integrations/IntegrationForm/IntegrationFormActions';
+import FormSaveButton from 'Components/PatternFly/FormSaveButton';
+import FormCancelButton from 'Components/PatternFly/FormCancelButton';
+import SelectSingle from 'Components/SelectSingle';
+import {fetchRolesAsArray, Role} from 'services/RolesService';
+import {MachineConfigType} from 'services/MachineAccessService';
 
 export type MachineAccessConfig = {
     id: string;
@@ -94,6 +95,7 @@ function MachineAccessIntegrationForm({
         fetchRolesAsArray()
             .then((rolesFetched) => {
                 setRoles(rolesFetched);
+                setAlertRoles(null);
             })
             .catch((error) => {
                 setAlertRoles(
@@ -213,7 +215,8 @@ function MachineAccessIntegrationForm({
                                                                 <Popover bodyContent={
                                                                     <div>
                                                                         <a href="https://golang.org/s/re2syntax"
-                                                                           target="_blank" rel="noreferrer">Learn how to use regex here</a>
+                                                                           target="_blank" rel="noreferrer">Learn how to
+                                                                            use regex here</a>
                                                                     </div>
                                                                 } headerContent={"Use regex to enter values"}>{
                                                                     <Button
@@ -224,7 +227,8 @@ function MachineAccessIntegrationForm({
                                                                         className="pf-c-form__group-label-help"
                                                                         style={{backgroundColor: 'transparent'}}
                                                                     >
-                                                                        <HelpIcon style={{color: 'black'}} noVerticalAlign/>
+                                                                        <HelpIcon style={{color: 'black'}}
+                                                                                  noVerticalAlign/>
                                                                     </Button>
                                                                 }
                                                                 </Popover>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -1,5 +1,5 @@
 import * as yup from 'yup';
-import React, {ReactElement, useEffect, useState} from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import {
     Alert,
     AlertVariant,
@@ -14,9 +14,9 @@ import {
     SelectOption,
     TextInput,
 } from '@patternfly/react-core';
-import {FieldArray, FormikProvider} from 'formik';
-import {ArrowRightIcon, HelpIcon, PlusCircleIcon, TrashIcon} from '@patternfly/react-icons';
-import {IntegrationFormProps} from 'Containers/Integrations/IntegrationForm/integrationFormTypes';
+import { FieldArray, FormikProvider } from 'formik';
+import { ArrowRightIcon, HelpIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
+import { IntegrationFormProps } from 'Containers/Integrations/IntegrationForm/integrationFormTypes';
 import useIntegrationForm from 'Containers/Integrations/IntegrationForm/useIntegrationForm';
 import FormMessage from 'Components/PatternFly/FormMessage';
 import FormLabelGroup from 'Containers/Integrations/IntegrationForm/FormLabelGroup';
@@ -24,8 +24,8 @@ import IntegrationFormActions from 'Containers/Integrations/IntegrationForm/Inte
 import FormSaveButton from 'Components/PatternFly/FormSaveButton';
 import FormCancelButton from 'Components/PatternFly/FormCancelButton';
 import SelectSingle from 'Components/SelectSingle';
-import {fetchRolesAsArray, Role} from 'services/RolesService';
-import {MachineConfigType} from 'services/MachineAccessService';
+import { fetchRolesAsArray, Role } from 'services/RolesService';
+import { MachineConfigType } from 'services/MachineAccessService';
 
 export type MachineAccessConfig = {
     id: string;
@@ -61,10 +61,10 @@ export const defaultValues: MachineAccessConfig = {
 };
 
 function MachineAccessIntegrationForm({
-                                          initialValues = null,
-                                          isEditable = false,
-                                      }: IntegrationFormProps<MachineAccessConfig>): ReactElement {
-    const formInitialValues = {...defaultValues, ...initialValues};
+    initialValues = null,
+    isEditable = false,
+}: IntegrationFormProps<MachineAccessConfig>): ReactElement {
+    const formInitialValues = { ...defaultValues, ...initialValues };
     const formik = useIntegrationForm<MachineAccessConfig>({
         initialValues: formInitialValues,
         validationSchema,
@@ -110,7 +110,7 @@ function MachineAccessIntegrationForm({
         <>
             {alertRoles}
             <PageSection variant="light" isFilled hasOverflowScroll>
-                <FormMessage message={message}/>
+                <FormMessage message={message} />
                 <Form isWidthLimited>
                     <FormikProvider value={formik}>
                         <FormLabelGroup
@@ -212,25 +212,45 @@ function MachineAccessIntegrationForm({
                                                         <FormLabelGroup
                                                             label="Value"
                                                             labelIcon={
-                                                                <Popover bodyContent={
-                                                                    <div>
-                                                                        <a href="https://golang.org/s/re2syntax"
-                                                                           target="_blank" rel="noreferrer">Learn how to
-                                                                            use regex here</a>
-                                                                    </div>
-                                                                } headerContent={"Use regex to enter values"}>{
-                                                                    <Button
-                                                                        type="button"
-                                                                        aria-label="More info for name field"
-                                                                        onClick={e => e.preventDefault()}
-                                                                        aria-describedby="simple-form-name-02"
-                                                                        className="pf-c-form__group-label-help"
-                                                                        style={{backgroundColor: 'transparent'}}
-                                                                    >
-                                                                        <HelpIcon style={{color: 'black'}}
-                                                                                  noVerticalAlign/>
-                                                                    </Button>
-                                                                }
+                                                                <Popover
+                                                                    bodyContent={
+                                                                        <div>
+                                                                            <a
+                                                                                href="https://golang.org/s/re2syntax"
+                                                                                target="_blank"
+                                                                                rel="noreferrer"
+                                                                            >
+                                                                                Learn how to use
+                                                                                regex here
+                                                                            </a>
+                                                                        </div>
+                                                                    }
+                                                                    headerContent={
+                                                                        'Use regex to enter values'
+                                                                    }
+                                                                >
+                                                                    {
+                                                                        <Button
+                                                                            type="button"
+                                                                            aria-label="More info for name field"
+                                                                            onClick={(e) =>
+                                                                                e.preventDefault()
+                                                                            }
+                                                                            aria-describedby="simple-form-name-02"
+                                                                            className="pf-c-form__group-label-help"
+                                                                            style={{
+                                                                                backgroundColor:
+                                                                                    'transparent',
+                                                                            }}
+                                                                        >
+                                                                            <HelpIcon
+                                                                                style={{
+                                                                                    color: 'black',
+                                                                                }}
+                                                                                noVerticalAlign
+                                                                            />
+                                                                        </Button>
+                                                                    }
                                                                 </Popover>
                                                             }
                                                             fieldId={`mappings[${index}].valueExpression`}
@@ -281,7 +301,7 @@ function MachineAccessIntegrationForm({
                                                                 direction="up"
                                                                 placeholderText="Select a role"
                                                             >
-                                                                {roles.map(({name}) => (
+                                                                {roles.map(({ name }) => (
                                                                     <SelectOption
                                                                         key={name}
                                                                         value={name}
@@ -302,7 +322,7 @@ function MachineAccessIntegrationForm({
                                                                     arrayHelpers.remove(index)
                                                                 }
                                                             >
-                                                                <TrashIcon/>
+                                                                <TrashIcon />
                                                             </Button>
                                                         </FlexItem>
                                                     )}
@@ -315,7 +335,7 @@ function MachineAccessIntegrationForm({
                                                         variant="link"
                                                         isInline
                                                         icon={
-                                                            <PlusCircleIcon className="pf-u-mr-sm"/>
+                                                            <PlusCircleIcon className="pf-u-mr-sm" />
                                                         }
                                                         onClick={() =>
                                                             arrayHelpers.push({

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -125,7 +125,7 @@ function MachineAccessIntegrationForm({
                                     setFieldValue(name, value);
                                     setFieldValue(
                                         'issuer',
-                                        'https://token.actions.githubusercontent.com'
+                                        value === 'GITHUB_ACTIONS' ? 'https://token.actions.githubusercontent.com' : ''
                                     );
                                 }}
                                 direction="down"
@@ -151,8 +151,6 @@ function MachineAccessIntegrationForm({
                                 type="text"
                                 id="issuer"
                                 value={
-                                    // values.type === 'GITHUB_ACTIONS'
-                                    //     ? 'https://token.actions.githubusercontent.com'
                                     values.issuer
                                 }
                                 onChange={onChange}
@@ -171,6 +169,7 @@ function MachineAccessIntegrationForm({
                                 isRequired
                                 type="text"
                                 id="tokenExpirationDuration"
+                                placeholder={'3h20m20s'}
                                 value={values.tokenExpirationDuration}
                                 onChange={onChange}
                                 onBlur={handleBlur}

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -1,0 +1,334 @@
+import * as yup from 'yup';
+import React, { ReactElement, useEffect, useState } from 'react';
+import {
+    Alert,
+    AlertVariant,
+    Button,
+    Flex,
+    FlexItem,
+    Form,
+    FormGroup,
+    FormSection,
+    PageSection,
+    SelectOption,
+    TextInput,
+} from '@patternfly/react-core';
+import { FieldArray, FormikProvider } from 'formik';
+import { ArrowRightIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
+import { IntegrationFormProps } from '../integrationFormTypes';
+import useIntegrationForm from '../useIntegrationForm';
+import FormMessage from '../../../../Components/PatternFly/FormMessage';
+import FormLabelGroup from '../FormLabelGroup';
+import IntegrationFormActions from '../IntegrationFormActions';
+import FormSaveButton from '../../../../Components/PatternFly/FormSaveButton';
+import FormCancelButton from '../../../../Components/PatternFly/FormCancelButton';
+import SelectSingle from '../../../../Components/SelectSingle';
+import { fetchRolesAsArray, Role } from '../../../../services/RolesService';
+import { MachineConfigType } from '../../../../services/MachineAccessService';
+
+export type MachineAccessConfig = {
+    id: string;
+    type: MachineConfigType;
+    tokenExpirationDuration: string;
+    mappings: {
+        key: string;
+        valueExpression: string;
+        role: string;
+    }[];
+    issuer: string;
+};
+
+export const validationSchema = yup.object().shape({
+    type: yup.string().trim().required('Type is required.'),
+    tokenExpirationDuration: yup.string().trim().required('Token expiration duration is required'),
+    mappings: yup.array().of(
+        yup.object().shape({
+            key: yup.string().trim().required('Key is required.'),
+            valueExpression: yup.string().trim().required('Value expression is required.'),
+            role: yup.string().trim().required('Role is required.'),
+        })
+    ),
+    issuer: yup.string().trim().required('Issuer is required.'),
+});
+
+export const defaultValues: MachineAccessConfig = {
+    issuer: '',
+    mappings: [],
+    tokenExpirationDuration: '',
+    type: 'GENERIC',
+    id: '',
+};
+
+function MachineAccessIntegrationForm({
+    initialValues = null,
+    isEditable = false,
+}: IntegrationFormProps<MachineAccessConfig>): ReactElement {
+    const formInitialValues = { ...defaultValues, ...initialValues };
+    const formik = useIntegrationForm<MachineAccessConfig>({
+        initialValues: formInitialValues,
+        validationSchema,
+    });
+    const {
+        values,
+        touched,
+        errors,
+        dirty,
+        isValid,
+        setFieldValue,
+        handleBlur,
+        isSubmitting,
+        isTesting,
+        onSave,
+        onCancel,
+        message,
+    } = formik;
+
+    function onChange(value, event) {
+        return setFieldValue(event.target.id, value);
+    }
+
+    const [roles, setRoles] = useState<Role[]>([]);
+    const [alertRoles, setAlertRoles] = useState<ReactElement | null>(null);
+
+    useEffect(() => {
+        fetchRolesAsArray()
+            .then((rolesFetched) => {
+                setRoles(rolesFetched);
+            })
+            .catch((error) => {
+                setAlertRoles(
+                    <Alert title="Fetch roles failed" variant={AlertVariant.warning} isInline>
+                        {error.message}
+                    </Alert>
+                );
+            });
+    }, []);
+
+    return (
+        <>
+            {alertRoles}
+            <PageSection variant="light" isFilled hasOverflowScroll>
+                <FormMessage message={message} />
+                <Form isWidthLimited>
+                    <FormikProvider value={formik}>
+                        <FormLabelGroup
+                            isRequired
+                            label="Select configuration type"
+                            fieldId="type"
+                            touched={touched}
+                            errors={errors}
+                        >
+                            <SelectSingle
+                                id="type"
+                                value={values.type}
+                                handleSelect={(name, value) => {
+                                    setFieldValue(name, value);
+                                    setFieldValue(
+                                        'issuer',
+                                        'https://token.actions.githubusercontent.com'
+                                    );
+                                }}
+                                direction="down"
+                                isDisabled={!isEditable}
+                            >
+                                <SelectOption key={'GENERIC'} value={'GENERIC'}>
+                                    Generic
+                                </SelectOption>
+                                <SelectOption key={'GITHUB_ACTIONS'} value={'GITHUB_ACTIONS'}>
+                                    Github action
+                                </SelectOption>
+                            </SelectSingle>
+                        </FormLabelGroup>
+                        <FormLabelGroup
+                            isRequired
+                            label="Issuer"
+                            fieldId="issuer"
+                            touched={touched}
+                            errors={errors}
+                        >
+                            <TextInput
+                                isRequired
+                                type="text"
+                                id="issuer"
+                                value={
+                                    // values.type === 'GITHUB_ACTIONS'
+                                    //     ? 'https://token.actions.githubusercontent.com'
+                                    values.issuer
+                                }
+                                onChange={onChange}
+                                onBlur={handleBlur}
+                                isDisabled={!isEditable || values.type === 'GITHUB_ACTIONS'}
+                            />
+                        </FormLabelGroup>
+                        <FormLabelGroup
+                            isRequired
+                            label="Token lifetime"
+                            fieldId="tokenExpirationDuration"
+                            touched={touched}
+                            errors={errors}
+                        >
+                            <TextInput
+                                isRequired
+                                type="text"
+                                id="tokenExpirationDuration"
+                                value={values.tokenExpirationDuration}
+                                onChange={onChange}
+                                onBlur={handleBlur}
+                                isDisabled={!isEditable}
+                            />
+                        </FormLabelGroup>
+                        <FormSection title="Rules" titleElement="h3" className="pf-u-mt-0">
+                            <FieldArray
+                                name="mappings"
+                                render={(arrayHelpers) => (
+                                    <>
+                                        {values.mappings.length === 0 && <p>No rules defined</p>}
+                                        {values.mappings.length > 0 &&
+                                            values.mappings.map((_mapping, index: number) => (
+                                                // eslint-disable-next-line react/no-array-index-key
+                                                <Flex key={`mapping_${index}`}>
+                                                    <FlexItem>
+                                                        <FormLabelGroup
+                                                            label="Key"
+                                                            fieldId={`mappings[${index}].key`}
+                                                            touched={touched}
+                                                            errors={errors}
+                                                        >
+                                                            <TextInput
+                                                                isRequired
+                                                                type="text"
+                                                                id={`mappings[${index}].key`}
+                                                                value={
+                                                                    values.mappings[`${index}`].key
+                                                                }
+                                                                onChange={onChange}
+                                                                onBlur={handleBlur}
+                                                                isDisabled={!isEditable}
+                                                            />
+                                                        </FormLabelGroup>
+                                                    </FlexItem>
+                                                    <FlexItem>
+                                                        <FormLabelGroup
+                                                            label="Value"
+                                                            fieldId={`mappings[${index}].valueExpression`}
+                                                            touched={touched}
+                                                            errors={errors}
+                                                        >
+                                                            <TextInput
+                                                                isRequired
+                                                                type="text"
+                                                                id={`mappings[${index}].valueExpression`}
+                                                                value={
+                                                                    values.mappings[`${index}`]
+                                                                        .valueExpression
+                                                                }
+                                                                onChange={onChange}
+                                                                onBlur={handleBlur}
+                                                                isDisabled={!isEditable}
+                                                            />
+                                                        </FormLabelGroup>
+                                                    </FlexItem>
+                                                    <FlexItem>
+                                                        <ArrowRightIcon
+                                                            style={{
+                                                                transform: 'translate(0, 42px)',
+                                                            }}
+                                                        />
+                                                    </FlexItem>
+                                                    <FlexItem>
+                                                        <FormGroup
+                                                            label="Role"
+                                                            fieldId={`mappings[${index}].role`}
+                                                            helperTextInvalid={
+                                                                errors[index]?.role || ''
+                                                            }
+                                                            validated={
+                                                                errors[index]?.role
+                                                                    ? 'error'
+                                                                    : 'default'
+                                                            }
+                                                        >
+                                                            <SelectSingle
+                                                                id={`mappings[${index}].role`}
+                                                                value={
+                                                                    values.mappings[`${index}`].role
+                                                                }
+                                                                isDisabled={!isEditable}
+                                                                handleSelect={setFieldValue}
+                                                                direction="up"
+                                                                placeholderText="Select a role"
+                                                            >
+                                                                {roles.map(({ name }) => (
+                                                                    <SelectOption
+                                                                        key={name}
+                                                                        value={name}
+                                                                    />
+                                                                ))}
+                                                            </SelectSingle>
+                                                        </FormGroup>
+                                                    </FlexItem>
+                                                    {isEditable && (
+                                                        <FlexItem>
+                                                            <Button
+                                                                variant="plain"
+                                                                aria-label="Delete rule"
+                                                                style={{
+                                                                    transform: 'translate(0, 42px)',
+                                                                }}
+                                                                onClick={() =>
+                                                                    arrayHelpers.remove(index)
+                                                                }
+                                                            >
+                                                                <TrashIcon />
+                                                            </Button>
+                                                        </FlexItem>
+                                                    )}
+                                                </Flex>
+                                            ))}
+                                        {isEditable && (
+                                            <Flex>
+                                                <FlexItem>
+                                                    <Button
+                                                        variant="link"
+                                                        isInline
+                                                        icon={
+                                                            <PlusCircleIcon className="pf-u-mr-sm" />
+                                                        }
+                                                        onClick={() =>
+                                                            arrayHelpers.push({
+                                                                key: '',
+                                                                valueExpression: '',
+                                                                role: '',
+                                                            })
+                                                        }
+                                                    >
+                                                        Add new rule
+                                                    </Button>
+                                                </FlexItem>
+                                            </Flex>
+                                        )}
+                                    </>
+                                )}
+                            />
+                        </FormSection>
+                    </FormikProvider>
+                </Form>
+            </PageSection>
+            {isEditable && (
+                <IntegrationFormActions>
+                    <FormSaveButton
+                        onSave={onSave}
+                        isSubmitting={isSubmitting}
+                        isTesting={isTesting}
+                        isDisabled={!dirty || !isValid}
+                    >
+                        Save
+                    </FormSaveButton>
+                    <FormCancelButton onCancel={onCancel}>Cancel</FormCancelButton>
+                </IntegrationFormActions>
+            )}
+        </>
+    );
+}
+
+export default MachineAccessIntegrationForm;

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -1,5 +1,5 @@
 import * as yup from 'yup';
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, {ReactElement, useEffect, useState} from 'react';
 import {
     Alert,
     AlertVariant,
@@ -9,13 +9,13 @@ import {
     Form,
     FormGroup,
     FormSection,
-    PageSection,
+    PageSection, Popover,
     SelectOption,
-    TextInput,
+    TextInput, Tooltip,
 } from '@patternfly/react-core';
-import { FieldArray, FormikProvider } from 'formik';
-import { ArrowRightIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
-import { IntegrationFormProps } from '../integrationFormTypes';
+import {FieldArray, FormikProvider} from 'formik';
+import {ArrowRightIcon, HelpIcon, PlusCircleIcon, TrashIcon} from '@patternfly/react-icons';
+import {IntegrationFormProps} from '../integrationFormTypes';
 import useIntegrationForm from '../useIntegrationForm';
 import FormMessage from '../../../../Components/PatternFly/FormMessage';
 import FormLabelGroup from '../FormLabelGroup';
@@ -23,8 +23,8 @@ import IntegrationFormActions from '../IntegrationFormActions';
 import FormSaveButton from '../../../../Components/PatternFly/FormSaveButton';
 import FormCancelButton from '../../../../Components/PatternFly/FormCancelButton';
 import SelectSingle from '../../../../Components/SelectSingle';
-import { fetchRolesAsArray, Role } from '../../../../services/RolesService';
-import { MachineConfigType } from '../../../../services/MachineAccessService';
+import {fetchRolesAsArray, Role} from '../../../../services/RolesService';
+import {MachineConfigType} from '../../../../services/MachineAccessService';
 
 export type MachineAccessConfig = {
     id: string;
@@ -60,10 +60,10 @@ export const defaultValues: MachineAccessConfig = {
 };
 
 function MachineAccessIntegrationForm({
-    initialValues = null,
-    isEditable = false,
-}: IntegrationFormProps<MachineAccessConfig>): ReactElement {
-    const formInitialValues = { ...defaultValues, ...initialValues };
+                                          initialValues = null,
+                                          isEditable = false,
+                                      }: IntegrationFormProps<MachineAccessConfig>): ReactElement {
+    const formInitialValues = {...defaultValues, ...initialValues};
     const formik = useIntegrationForm<MachineAccessConfig>({
         initialValues: formInitialValues,
         validationSchema,
@@ -108,7 +108,7 @@ function MachineAccessIntegrationForm({
         <>
             {alertRoles}
             <PageSection variant="light" isFilled hasOverflowScroll>
-                <FormMessage message={message} />
+                <FormMessage message={message}/>
                 <Form isWidthLimited>
                     <FormikProvider value={formik}>
                         <FormLabelGroup
@@ -209,6 +209,26 @@ function MachineAccessIntegrationForm({
                                                     <FlexItem>
                                                         <FormLabelGroup
                                                             label="Value"
+                                                            labelIcon={
+                                                                <Popover bodyContent={
+                                                                    <div>
+                                                                        <a href="https://golang.org/s/re2syntax"
+                                                                           target="_blank" rel="noreferrer">Learn how to use regex here</a>
+                                                                    </div>
+                                                                } headerContent={"Use regex to enter values"}>{
+                                                                    <Button
+                                                                        type="button"
+                                                                        aria-label="More info for name field"
+                                                                        onClick={e => e.preventDefault()}
+                                                                        aria-describedby="simple-form-name-02"
+                                                                        className="pf-c-form__group-label-help"
+                                                                        style={{backgroundColor: 'transparent'}}
+                                                                    >
+                                                                        <HelpIcon style={{color: 'black'}} noVerticalAlign/>
+                                                                    </Button>
+                                                                }
+                                                                </Popover>
+                                                            }
                                                             fieldId={`mappings[${index}].valueExpression`}
                                                             touched={touched}
                                                             errors={errors}
@@ -257,7 +277,7 @@ function MachineAccessIntegrationForm({
                                                                 direction="up"
                                                                 placeholderText="Select a role"
                                                             >
-                                                                {roles.map(({ name }) => (
+                                                                {roles.map(({name}) => (
                                                                     <SelectOption
                                                                         key={name}
                                                                         value={name}
@@ -278,7 +298,7 @@ function MachineAccessIntegrationForm({
                                                                     arrayHelpers.remove(index)
                                                                 }
                                                             >
-                                                                <TrashIcon />
+                                                                <TrashIcon/>
                                                             </Button>
                                                         </FlexItem>
                                                     )}
@@ -291,7 +311,7 @@ function MachineAccessIntegrationForm({
                                                         variant="link"
                                                         isInline
                                                         icon={
-                                                            <PlusCircleIcon className="pf-u-mr-sm" />
+                                                            <PlusCircleIcon className="pf-u-mr-sm"/>
                                                         }
                                                         onClick={() =>
                                                             arrayHelpers.push({

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -125,7 +125,9 @@ function MachineAccessIntegrationForm({
                                     setFieldValue(name, value);
                                     setFieldValue(
                                         'issuer',
-                                        value === 'GITHUB_ACTIONS' ? 'https://token.actions.githubusercontent.com' : ''
+                                        value === 'GITHUB_ACTIONS'
+                                            ? 'https://token.actions.githubusercontent.com'
+                                            : ''
                                     );
                                 }}
                                 direction="down"
@@ -150,9 +152,7 @@ function MachineAccessIntegrationForm({
                                 isRequired
                                 type="text"
                                 id="issuer"
-                                value={
-                                    values.issuer
-                                }
+                                value={values.issuer}
                                 onChange={onChange}
                                 onBlur={handleBlur}
                                 isDisabled={!isEditable || values.type === 'GITHUB_ACTIONS'}

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/IntegrationForm.tsx
@@ -39,12 +39,14 @@ import GcsIntegrationForm from './Forms/GcsIntegrationForm';
 // auth plugins
 import ApiTokenIntegrationForm from './Forms/ApiTokenIntegrationForm';
 import ClusterInitBundleIntegrationForm from './Forms/ClusterInitBundleIntegrationForm';
+import MachineAccessIntegrationForm from './Forms/MachineAccessIntegrationForm';
 // signature integrations
 import SignatureIntegrationForm from './Forms/SignatureIntegrationForm';
 
 // cloud source integrations
-import './IntegrationForm.css';
 import PaladinCloudIntegrationForm from './Forms/PaladinCloudIntegrationForm';
+
+import './IntegrationForm.css';
 
 type IntegrationFormProps = {
     source: IntegrationSource;
@@ -98,6 +100,7 @@ const ComponentFormMap = {
     authProviders: {
         apitoken: ApiTokenIntegrationForm,
         clusterInitBundle: ClusterInitBundleIntegrationForm,
+        machineAccess: MachineAccessIntegrationForm,
     },
     cloudSources: {
         paladinCloud: PaladinCloudIntegrationForm,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
@@ -48,21 +48,16 @@ function IntegrationPage({ title, name, traits, children }: IntegrationPageProps
         pageState !== 'CREATE' && pageState !== 'LIST' && (type === 'generic' || type === 'splunk');
     const hasEditButton =
         pageState === 'VIEW_DETAILS' && permissions[source].write && isUserResource(traits);
-    const actualTitle = getIsMachineAccessConfig(source, type) && title === ''
-        ? 'Manage configuration'
-        : title;
+    const actualTitle =
+        getIsMachineAccessConfig(source, type) && title === '' ? 'Manage configuration' : title;
     return (
         <>
-            <PageTitle
-                title={actualTitle}
-            />
+            <PageTitle title={actualTitle} />
             <PageSection variant="light" className="pf-u-py-md">
                 <Breadcrumb>
                     <BreadcrumbItemLink to={integrationsPath}>Integrations</BreadcrumbItemLink>
                     <BreadcrumbItemLink to={integrationsListPath}>{typeLabel}</BreadcrumbItemLink>
-                    <BreadcrumbItem isActive>
-                        {actualTitle}
-                    </BreadcrumbItem>
+                    <BreadcrumbItem isActive>{actualTitle}</BreadcrumbItem>
                 </Breadcrumb>
             </PageSection>
             <Divider component="div" />

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
@@ -48,23 +48,20 @@ function IntegrationPage({ title, name, traits, children }: IntegrationPageProps
         pageState !== 'CREATE' && pageState !== 'LIST' && (type === 'generic' || type === 'splunk');
     const hasEditButton =
         pageState === 'VIEW_DETAILS' && permissions[source].write && isUserResource(traits);
+    const actualTitle = getIsMachineAccessConfig(source, type) && title === ''
+        ? 'Manage configuration'
+        : title;
     return (
         <>
             <PageTitle
-                title={
-                    getIsMachineAccessConfig(source, type) && title === ''
-                        ? 'Manage configuration'
-                        : title
-                }
+                title={actualTitle}
             />
             <PageSection variant="light" className="pf-u-py-md">
                 <Breadcrumb>
                     <BreadcrumbItemLink to={integrationsPath}>Integrations</BreadcrumbItemLink>
                     <BreadcrumbItemLink to={integrationsListPath}>{typeLabel}</BreadcrumbItemLink>
                     <BreadcrumbItem isActive>
-                        {getIsMachineAccessConfig(source, type) && title === ''
-                            ? 'Manage configuration'
-                            : title}
+                        {actualTitle}
                     </BreadcrumbItem>
                 </Breadcrumb>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
@@ -48,16 +48,14 @@ function IntegrationPage({ title, name, traits, children }: IntegrationPageProps
         pageState !== 'CREATE' && pageState !== 'LIST' && (type === 'generic' || type === 'splunk');
     const hasEditButton =
         pageState === 'VIEW_DETAILS' && permissions[source].write && isUserResource(traits);
-    const actualTitle =
-        getIsMachineAccessConfig(source, type) && title === '' ? 'Manage configuration' : title;
     return (
         <>
-            <PageTitle title={actualTitle} />
+            <PageTitle title={title} />
             <PageSection variant="light" className="pf-u-py-md">
                 <Breadcrumb>
                     <BreadcrumbItemLink to={integrationsPath}>Integrations</BreadcrumbItemLink>
                     <BreadcrumbItemLink to={integrationsListPath}>{typeLabel}</BreadcrumbItemLink>
-                    <BreadcrumbItem isActive>{actualTitle}</BreadcrumbItem>
+                    <BreadcrumbItem isActive>{title}</BreadcrumbItem>
                 </Breadcrumb>
             </PageSection>
             <Divider component="div" />

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
@@ -61,11 +61,11 @@ function IntegrationPage({ title, name, traits, children }: IntegrationPageProps
                 <Breadcrumb>
                     <BreadcrumbItemLink to={integrationsPath}>Integrations</BreadcrumbItemLink>
                     <BreadcrumbItemLink to={integrationsListPath}>{typeLabel}</BreadcrumbItemLink>
-                    <BreadcrumbItem isActive>{
-                        getIsMachineAccessConfig(source, type) && title === ''
+                    <BreadcrumbItem isActive>
+                        {getIsMachineAccessConfig(source, type) && title === ''
                             ? 'Manage configuration'
-                            : title
-                    }</BreadcrumbItem>
+                            : title}
+                    </BreadcrumbItem>
                 </Breadcrumb>
             </PageSection>
             <Divider component="div" />
@@ -73,7 +73,7 @@ function IntegrationPage({ title, name, traits, children }: IntegrationPageProps
                 <Flex>
                     {(name || getIsMachineAccessConfig(source, type)) && (
                         <FlexItem>
-                            <Title headingLevel="h1">{name ? name : 'Manage configuration'}</Title>
+                            <Title headingLevel="h1">{name || 'Manage configuration'}</Title>
                         </FlexItem>
                     )}
                     {hasTraitsLabel && <TraitsOriginLabel traits={traits} />}

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
@@ -20,7 +20,7 @@ import { Traits } from 'types/traits.proto';
 import { TraitsOriginLabel } from 'Containers/AccessControl/TraitsOriginLabel';
 import { isUserResource } from 'Containers/AccessControl/traits';
 import { getIntegrationLabel } from './utils/integrationsList';
-import { getEditDisabledMessage } from './utils/integrationUtils';
+import { getEditDisabledMessage, getIsMachineAccessConfig } from './utils/integrationUtils';
 import usePageState from './hooks/usePageState';
 import useIntegrationPermissions from './hooks/useIntegrationPermissions';
 
@@ -50,7 +50,13 @@ function IntegrationPage({ title, name, traits, children }: IntegrationPageProps
         pageState === 'VIEW_DETAILS' && permissions[source].write && isUserResource(traits);
     return (
         <>
-            <PageTitle title={title} />
+            <PageTitle
+                title={
+                    getIsMachineAccessConfig(source, type) && title === ''
+                        ? 'Manage configuration'
+                        : title
+                }
+            />
             <PageSection variant="light" className="pf-u-py-md">
                 <Breadcrumb>
                     <BreadcrumbItemLink to={integrationsPath}>Integrations</BreadcrumbItemLink>
@@ -61,9 +67,11 @@ function IntegrationPage({ title, name, traits, children }: IntegrationPageProps
             <Divider component="div" />
             <PageSection variant="light">
                 <Flex>
-                    <FlexItem>
-                        <Title headingLevel="h1">{name}</Title>
-                    </FlexItem>
+                    {name && (
+                        <FlexItem>
+                            <Title headingLevel="h1">{name}</Title>
+                        </FlexItem>
+                    )}
                     {hasTraitsLabel && <TraitsOriginLabel traits={traits} />}
                     {hasEditButton && (
                         <FlexItem align={{ default: 'alignRight' }}>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
@@ -61,15 +61,19 @@ function IntegrationPage({ title, name, traits, children }: IntegrationPageProps
                 <Breadcrumb>
                     <BreadcrumbItemLink to={integrationsPath}>Integrations</BreadcrumbItemLink>
                     <BreadcrumbItemLink to={integrationsListPath}>{typeLabel}</BreadcrumbItemLink>
-                    <BreadcrumbItem isActive>{title}</BreadcrumbItem>
+                    <BreadcrumbItem isActive>{
+                        getIsMachineAccessConfig(source, type) && title === ''
+                            ? 'Manage configuration'
+                            : title
+                    }</BreadcrumbItem>
                 </Breadcrumb>
             </PageSection>
             <Divider component="div" />
             <PageSection variant="light">
                 <Flex>
-                    {name && (
+                    {(name || getIsMachineAccessConfig(source, type)) && (
                         <FlexItem>
-                            <Title headingLevel="h1">{name}</Title>
+                            <Title headingLevel="h1">{name ? name : 'Manage configuration'}</Title>
                         </FlexItem>
                     )}
                     {hasTraitsLabel && <TraitsOriginLabel traits={traits} />}

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/AuthenticationTokensSection.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/AuthenticationTokensSection.tsx
@@ -1,10 +1,12 @@
 import React, { ReactElement } from 'react';
 
 import useAuthStatus from 'hooks/useAuthStatus';
+import usePermissions from 'hooks/usePermissions';
 
 import APITokensTile from './APITokensTile';
 import ClusterInitBundles from './ClusterInitBundlesTile';
 import IntegrationsSection from './IntegrationsSection';
+import MachineAccessTile from './MachineAccessTile';
 
 function AuthenticationTokensSection(): ReactElement {
     // TODO after 4.4 release:
@@ -13,11 +15,13 @@ function AuthenticationTokensSection(): ReactElement {
     // Delete request from integration sagas and data from integrations reducer.
     const { currentUser } = useAuthStatus();
     const hasAdminRole = Boolean(currentUser?.userInfo?.roles.some(({ name }) => name === 'Admin')); // optional chaining just in case of the unexpected
+    const hasReadAccessForAccess = hasReadAccess('Access');
 
     return (
         <IntegrationsSection headerName="Authentication Tokens" id="token-integrations">
             <APITokensTile />
             {hasAdminRole && <ClusterInitBundles />}
+            {hasReadAccessForAccess && <MachineAccessTile />}
         </IntegrationsSection>
     );
 }

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/AuthenticationTokensSection.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/AuthenticationTokensSection.tsx
@@ -14,6 +14,7 @@ function AuthenticationTokensSection(): ReactElement {
     // Delete unreachable code.
     // Delete request from integration sagas and data from integrations reducer.
     const { currentUser } = useAuthStatus();
+    const { hasReadAccess } = usePermissions();
     const hasAdminRole = Boolean(currentUser?.userInfo?.roles.some(({ name }) => name === 'Admin')); // optional chaining just in case of the unexpected
     const hasReadAccessForAccess = hasReadAccess('Access');
 

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/IntegrationTile.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/IntegrationTile.tsx
@@ -42,7 +42,9 @@ function IntegrationTile({
                             {numIntegrations > 0 && <Badge>{numIntegrations}</Badge>}
                         </CardActions>
                     </CardHeader>
-                    <CardTitle className="pf-u-color-100">{label}</CardTitle>
+                    <CardTitle className="pf-u-color-100" style={{ whiteSpace: 'nowrap' }}>
+                        {label}
+                    </CardTitle>
                     {categories && <CardFooter className="pf-u-color-200">{categories}</CardFooter>}
                 </Card>
             </Link>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/MachineAccessTile.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/MachineAccessTile.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useEffect, useState } from 'react';
-import IntegrationTile from './IntegrationTile';
 import { fetchMachineAccessConfigs } from 'services/MachineAccessService';
+import IntegrationTile from './IntegrationTile';
 import {
     authenticationTokensSource as source,
     machineAccessDescriptor as descriptor,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/MachineAccessTile.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/MachineAccessTile.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import IntegrationTile from './IntegrationTile';
-import { fetchMachineAccessConfigs } from '../../../services/MachineAccessService';
+import { fetchMachineAccessConfigs } from 'services/MachineAccessService';
 import {
     authenticationTokensSource as source,
     machineAccessDescriptor as descriptor,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/MachineAccessTile.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/MachineAccessTile.tsx
@@ -1,5 +1,6 @@
-import React, { ReactElement, useEffect, useState } from 'react';
-import { fetchMachineAccessConfigs } from 'services/MachineAccessService';
+import React, { ReactElement } from 'react';
+import { selectors } from 'reducers';
+import { useSelector } from 'react-redux';
 import IntegrationTile from './IntegrationTile';
 import {
     authenticationTokensSource as source,
@@ -9,23 +10,13 @@ import {
 
 function MachineAccessConfigTile(): ReactElement {
     const { image, label, type } = descriptor;
-
-    const [numIntegrations, setNumIntegrations] = useState(0);
-
-    useEffect(() => {
-        fetchMachineAccessConfigs()
-            .then(({ response: { configs } }) => {
-                setNumIntegrations(configs.length);
-            })
-            .catch(() => {});
-    }, []);
-
+    const integrations = useSelector(selectors.getMachineAccessConfigs);
     return (
         <IntegrationTile
             image={image}
             label={label}
             linkTo={getIntegrationsListPath(source, type)}
-            numIntegrations={numIntegrations}
+            numIntegrations={integrations.length}
         />
     );
 }

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/MachineAccessTile.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/MachineAccessTile.tsx
@@ -1,0 +1,33 @@
+import React, { ReactElement, useEffect, useState } from 'react';
+import IntegrationTile from './IntegrationTile';
+import { fetchMachineAccessConfigs } from '../../../services/MachineAccessService';
+import {
+    authenticationTokensSource as source,
+    machineAccessDescriptor as descriptor,
+    getIntegrationsListPath,
+} from '../utils/integrationsList';
+
+function MachineAccessConfigTile(): ReactElement {
+    const { image, label, type } = descriptor;
+
+    const [numIntegrations, setNumIntegrations] = useState(0);
+
+    useEffect(() => {
+        fetchMachineAccessConfigs()
+            .then(({ response: { configs } }) => {
+                setNumIntegrations(configs.length);
+            })
+            .catch(() => {});
+    }, []);
+
+    return (
+        <IntegrationTile
+            image={image}
+            label={label}
+            linkTo={getIntegrationsListPath(source, type)}
+            numIntegrations={numIntegrations}
+        />
+    );
+}
+
+export default MachineAccessConfigTile;

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
@@ -17,6 +17,7 @@ import useCentralCapabilities from 'hooks/useCentralCapabilities';
 import { actions as integrationsActions } from 'reducers/integrations';
 import { actions as apitokensActions } from 'reducers/apitokens';
 import { actions as clusterInitBundlesActions } from 'reducers/clusterInitBundles';
+import { actions as machineAccessActions } from 'reducers/machineAccessConfigs';
 import { actions as cloudSourcesActions } from 'reducers/cloudSources';
 import { integrationsPath } from 'routePaths';
 import { ClusterInitBundle } from 'services/ClustersService';
@@ -27,6 +28,7 @@ import {
     getIsAPIToken,
     getIsCloudSource,
     getIsClusterInitBundle,
+    getIsMachineAccessConfig,
     getIsSignatureIntegration,
     getIsScannerV4,
 } from '../utils/integrationUtils';
@@ -43,6 +45,7 @@ function IntegrationsListPage({
     triggerBackup,
     fetchClusterInitBundles,
     revokeAPITokens,
+    deleteMachineAccessConfigs,
     deleteCloudSources,
 }): ReactElement {
     const { source, type } = useParams();
@@ -62,6 +65,7 @@ function IntegrationsListPage({
     const typeLabel = getIntegrationLabel(source, type);
     const isAPIToken = getIsAPIToken(source, type);
     const isClusterInitBundle = getIsClusterInitBundle(source, type);
+    const isMachineAccessConfig = getIsMachineAccessConfig(source, type);
     const isSignatureIntegration = getIsSignatureIntegration(source);
     const isScannerV4 = getIsScannerV4(source, type);
     const isCloudSource = getIsCloudSource(source);
@@ -73,6 +77,8 @@ function IntegrationsListPage({
     function onConfirmDeletingIntegrationIds() {
         if (isAPIToken) {
             revokeAPITokens(deletingIntegrationIds);
+        } else if (isMachineAccessConfig) {
+            deleteMachineAccessConfigs(deletingIntegrationIds);
         } else if (isCloudSource) {
             deleteCloudSources(deletingIntegrationIds);
         } else {
@@ -169,6 +175,7 @@ const mapDispatchToProps = {
     triggerBackup: integrationsActions.triggerBackup,
     fetchClusterInitBundles: clusterInitBundlesActions.fetchClusterInitBundles.request,
     revokeAPITokens: apitokensActions.revokeAPITokens,
+    deleteMachineAccessConfigs: machineAccessActions.deleteMachineAccessConfigs,
     deleteCloudSources: cloudSourcesActions.deleteCloudSources,
 };
 

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -32,6 +32,9 @@ function getNewButtonText(type) {
     if (type === 'clusterInitBundle') {
         return 'Generate bundle';
     }
+    if (type === 'machineAccess') {
+        return 'Create configuration';
+    }
     return 'New integration';
 }
 
@@ -199,7 +202,11 @@ function IntegrationsTable({
                                             />
                                         )}
                                         {columns.map((column) => {
-                                            if (column.Header === 'Name') {
+                                            if (
+                                                column.Header === 'Name' ||
+                                                (type === 'machineAccess' &&
+                                                    column.Header === 'Configuration')
+                                            ) {
                                                 return (
                                                     <Td key="name">
                                                         <Button

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useFetchIntegrations.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useFetchIntegrations.ts
@@ -4,6 +4,7 @@ import { actions as integrationsActions } from 'reducers/integrations';
 import { actions as authActions } from 'reducers/auth';
 import { actions as apitokensActions } from 'reducers/apitokens';
 import { actions as clusterInitBundleActions } from 'reducers/clusterInitBundles';
+import { actions as machineAccessConfigsActions } from 'reducers/machineAccessConfigs';
 import { actions as cloudSourcesActions } from 'reducers/cloudSources';
 import { IntegrationSource } from '../utils/integrationUtils';
 
@@ -25,6 +26,7 @@ const useFetchIntegrations = (source: IntegrationSource): UseFetchIntegrationsRe
         if (source === 'authProviders') {
             dispatch(clusterInitBundleActions.fetchClusterInitBundles.request());
             dispatch(apitokensActions.fetchAPITokens.request());
+            dispatch(machineAccessConfigsActions.fetchMachineAccessConfigs.request());
         } else {
             dispatch(fetchIntegrationsActionMap[source]);
         }

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationActions.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationActions.ts
@@ -15,9 +15,9 @@ import { generateClusterInitBundle } from 'services/ClustersService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import { FormResponseMessage } from 'Components/PatternFly/FormMessage';
+import { createMachineAccessConfig } from 'services/MachineAccessService';
 import useFetchIntegrations from './useFetchIntegrations';
 import usePageState from './usePageState';
-import { createMachineAccessConfig } from 'services/MachineAccessService';
 
 export type UseIntegrationActions = {
     source: IntegrationSource;

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationActions.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationActions.ts
@@ -17,6 +17,7 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { FormResponseMessage } from 'Components/PatternFly/FormMessage';
 import useFetchIntegrations from './useFetchIntegrations';
 import usePageState from './usePageState';
+import { createMachineAccessConfig } from '../../../services/MachineAccessService';
 
 export type UseIntegrationActions = {
     source: IntegrationSource;
@@ -52,6 +53,9 @@ function useIntegrationActions(): UseIntegrationActionsResult {
                 responseData = await generateAPIToken(data);
             } else if (type === 'clusterInitBundle') {
                 responseData = await generateClusterInitBundle(data);
+            } else if (type === 'machineAccess') {
+                responseData = await createMachineAccessConfig(data);
+                history.goBack();
             } else {
                 responseData = await createIntegration(source, data);
                 // we only want to redirect when creating a new (non-apitoken and non-clusterinitbundle) integration

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationActions.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationActions.ts
@@ -17,7 +17,7 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { FormResponseMessage } from 'Components/PatternFly/FormMessage';
 import useFetchIntegrations from './useFetchIntegrations';
 import usePageState from './usePageState';
-import { createMachineAccessConfig } from '../../../services/MachineAccessService';
+import { createMachineAccessConfig } from 'services/MachineAccessService';
 
 export type UseIntegrationActions = {
     source: IntegrationSource;

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrations.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrations.ts
@@ -8,6 +8,7 @@ import { Integration, IntegrationSource, IntegrationType } from '../utils/integr
 const selectIntegrations = createStructuredSelector({
     apiTokens: selectors.getAPITokens,
     clusterInitBundles: selectors.getClusterInitBundles,
+    machineAccessConfigs: selectors.getMachineAccessConfigs,
     notifiers: selectors.getNotifiers,
     imageIntegrations: selectors.getImageIntegrations,
     backups: selectors.getBackups,
@@ -26,6 +27,7 @@ const useIntegrations = ({ source, type }: UseIntegrations): UseIntegrationsResp
     const {
         apiTokens,
         clusterInitBundles,
+        machineAccessConfigs,
         notifiers,
         backups,
         imageIntegrations,
@@ -45,6 +47,9 @@ const useIntegrations = ({ source, type }: UseIntegrations): UseIntegrationsResp
                 }
                 if (type === 'clusterInitBundle') {
                     return clusterInitBundles;
+                }
+                if (type === 'machineAccess') {
+                    return machineAccessConfigs;
                 }
                 return [];
             }

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.test.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.test.ts
@@ -1,0 +1,29 @@
+import { transformDurationLongForm } from './integrationUtils';
+
+describe('integrationUtils', () => {
+    describe('transformDurationLongForm', () => {
+        it('should return correct result when format is correct', () => {
+            let result = transformDurationLongForm('3h');
+            expect(result).toBe('3 hours');
+            result = transformDurationLongForm('40m');
+            expect(result).toBe('40 minutes');
+            result = transformDurationLongForm('1s');
+            expect(result).toBe('1 second');
+            result = transformDurationLongForm('1h1m');
+            expect(result).toBe('1 hour 1 minute');
+            result = transformDurationLongForm('20m59s');
+            expect(result).toBe('20 minutes 59 seconds');
+            result = transformDurationLongForm('2h3m4s');
+            expect(result).toBe('2 hours 3 minutes 4 seconds');
+        });
+
+        it('should return empty when incorrect format', () => {
+            let result = transformDurationLongForm('3');
+            expect(result).toBe('');
+            result = transformDurationLongForm('40f');
+            expect(result).toBe('');
+            result = transformDurationLongForm('');
+            expect(result).toBe('');
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
@@ -87,24 +87,35 @@ export function getEditDisabledMessage(type) {
 }
 
 export function transformDurationLongForm(duration: string): string {
-    const splitHoursSeparate = duration.split('h');
-    let result = pluralizeMeasurement(splitHoursSeparate[0], 'hour');
-    if (splitHoursSeparate.length === 1) {
-        return result;
+    const hours = extractUnitsOfTime(duration, 'h');
+    const minutes = extractUnitsOfTime(duration, 'm');
+    const seconds = extractUnitsOfTime(duration, 's');
+    let result = '';
+    if (hours && hours > 0) {
+        result += pluralizeMeasurement(hours, 'hour');
     }
-    const splitMinutesSeparate = splitHoursSeparate[1].split('m');
-    result = `${result} ${pluralizeMeasurement(splitMinutesSeparate[0], 'minute')}`;
-    if (
-        splitMinutesSeparate.length === 1 ||
-        (splitMinutesSeparate.length === 2 && splitMinutesSeparate[1] === '')
-    ) {
-        return result;
+    if (minutes && minutes > 0) {
+        result += ' ';
+        result += pluralizeMeasurement(minutes, 'minute');
     }
-    return `${result} ${pluralizeMeasurement(splitMinutesSeparate[1].split('s')[0], 'second')}`;
+    if (seconds && seconds > 0) {
+        result += ' ';
+        result += pluralizeMeasurement(seconds, 'second');
+    }
+    return result;
 }
 
 function pluralizeMeasurement(count, measurement: string): string {
     return `${count} ${pluralize(measurement, parseInt(count))}`;
+}
+
+function extractUnitsOfTime(duration, unit: string,) : number {
+    const unitRegex = new RegExp('[0-9]+' + unit);
+    const matchHours = duration.match(unitRegex);
+    if (matchHours && matchHours.length !== 0) {
+       return parseInt(matchHours[0].replace(unit, ''))
+    }
+    return 0;
 }
 
 export const daysOfWeek = [

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
@@ -1,12 +1,12 @@
 import isEqual from 'lodash/isEqual';
 import set from 'lodash/set';
+import pluralize from 'pluralize';
 
 import { IntegrationBase } from 'services/IntegrationsService';
 import { IntegrationSource, IntegrationType } from 'types/integration';
 import { ImageIntegrationCategory } from 'types/imageIntegration.proto';
 
 import { Traits } from 'types/traits.proto';
-import pluralize from 'pluralize';
 
 export type { IntegrationSource, IntegrationType };
 
@@ -92,24 +92,24 @@ export function transformDurationLongForm(duration: string): string {
     const seconds = extractUnitsOfTime(duration, 's');
     let result = '';
     if (hours && hours > 0) {
-        result += pluralizeMeasurement(hours, 'hour');
+        result += pluralizeUnit(hours, 'hour');
     }
     if (minutes && minutes > 0) {
         result += ' ';
-        result += pluralizeMeasurement(minutes, 'minute');
+        result += pluralizeUnit(minutes, 'minute');
     }
     if (seconds && seconds > 0) {
         result += ' ';
-        result += pluralizeMeasurement(seconds, 'second');
+        result += pluralizeUnit(seconds, 'second');
     }
     return result;
 }
 
-function pluralizeMeasurement(count, measurement: string): string {
-    return `${count} ${pluralize(measurement, parseInt(count))}`;
+function pluralizeUnit(count: number, unit: string): string {
+    return `${count} ${pluralize(unit, count)}`;
 }
 
-function extractUnitsOfTime(duration, unit: string): number {
+function extractUnitsOfTime(duration: string, unit: string): number {
     const unitRegex = new RegExp(`[0-9]+${unit}`);
     const matchHours = duration.match(unitRegex);
     if (matchHours && matchHours.length !== 0) {

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
@@ -95,11 +95,11 @@ export function transformDurationLongForm(duration: string): string {
         result += pluralizeUnit(hours, 'hour');
     }
     if (minutes && minutes > 0) {
-        result += ' ';
+        result += hours && hours > 0 ? ' ' : '';
         result += pluralizeUnit(minutes, 'minute');
     }
     if (seconds && seconds > 0) {
-        result += ' ';
+        result += (hours && hours > 0) || (minutes && minutes > 0) ? ' ' : '';
         result += pluralizeUnit(seconds, 'second');
     }
     return result;
@@ -111,9 +111,9 @@ function pluralizeUnit(count: number, unit: string): string {
 
 function extractUnitsOfTime(duration: string, unit: string): number {
     const unitRegex = new RegExp(`[0-9]+${unit}`);
-    const matchHours = duration.match(unitRegex);
-    if (matchHours && matchHours.length !== 0) {
-        return parseInt(matchHours[0].replace(unit, ''));
+    const matchUnits = duration.match(unitRegex);
+    if (matchUnits && matchUnits.length !== 0) {
+        return parseInt(matchUnits[0].replace(unit, ''));
     }
     return 0;
 }

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
@@ -6,7 +6,7 @@ import { IntegrationSource, IntegrationType } from 'types/integration';
 import { ImageIntegrationCategory } from 'types/imageIntegration.proto';
 
 import { Traits } from 'types/traits.proto';
-import pluralize from "pluralize";
+import pluralize from 'pluralize';
 
 export type { IntegrationSource, IntegrationType };
 
@@ -109,11 +109,11 @@ function pluralizeMeasurement(count, measurement: string): string {
     return `${count} ${pluralize(measurement, parseInt(count))}`;
 }
 
-function extractUnitsOfTime(duration, unit: string,) : number {
-    const unitRegex = new RegExp('[0-9]+' + unit);
+function extractUnitsOfTime(duration, unit: string): number {
+    const unitRegex = new RegExp(`[0-9]+${unit}`);
     const matchHours = duration.match(unitRegex);
     if (matchHours && matchHours.length !== 0) {
-       return parseInt(matchHours[0].replace(unit, ''))
+        return parseInt(matchHours[0].replace(unit, ''));
     }
     return 0;
 }

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
@@ -6,6 +6,7 @@ import { IntegrationSource, IntegrationType } from 'types/integration';
 import { ImageIntegrationCategory } from 'types/imageIntegration.proto';
 
 import { Traits } from 'types/traits.proto';
+import pluralize from "pluralize";
 
 export type { IntegrationSource, IntegrationType };
 
@@ -22,6 +23,13 @@ export function getIsAPIToken(source: IntegrationSource, type: IntegrationType):
 
 export function getIsClusterInitBundle(source: IntegrationSource, type: IntegrationType): boolean {
     return source === 'authProviders' && type === 'clusterInitBundle';
+}
+
+export function getIsMachineAccessConfig(
+    source: IntegrationSource,
+    type: IntegrationType
+): boolean {
+    return source === 'authProviders' && type === 'machineAccess';
 }
 
 export function getIsSignatureIntegration(source: IntegrationSource): boolean {
@@ -76,6 +84,27 @@ export function getEditDisabledMessage(type) {
         return 'This API Token can not be edited. Create a new API Token or delete an existing one.';
     }
     return '';
+}
+
+export function transformDurationLongForm(duration: string): string {
+    const splitHoursSeparate = duration.split('h');
+    let result = pluralizeMeasurement(splitHoursSeparate[0], 'hour');
+    if (splitHoursSeparate.length === 1) {
+        return result;
+    }
+    const splitMinutesSeparate = splitHoursSeparate[1].split('m');
+    result = `${result} ${pluralizeMeasurement(splitMinutesSeparate[0], 'minute')}`;
+    if (
+        splitMinutesSeparate.length === 1 ||
+        (splitMinutesSeparate.length === 2 && splitMinutesSeparate[1] === '')
+    ) {
+        return result;
+    }
+    return `${result} ${pluralizeMeasurement(splitMinutesSeparate[1].split('s')[0], 'second')}`;
+}
+
+function pluralizeMeasurement(count, measurement: string): string {
+    return `${count} ${pluralize(measurement, parseInt(count))}`;
 }
 
 export const daysOfWeek = [

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
@@ -270,7 +270,17 @@ export const clusterInitBundleDescriptor: AuthProviderDescriptor = {
     type: 'clusterInitBundle',
 };
 
-const authenticationTokensDescriptors = [apiTokenDescriptor, clusterInitBundleDescriptor];
+export const machineAccessDescriptor: AuthProviderDescriptor = {
+    image: logo,
+    label: 'Machine access configuration',
+    type: 'machineAccess',
+};
+
+const authenticationTokensDescriptors = [
+    apiTokenDescriptor,
+    clusterInitBundleDescriptor,
+    machineAccessDescriptor,
+];
 
 export const cloudSourcesSource = 'cloudSources';
 

--- a/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
@@ -24,6 +24,7 @@ import {
 import { SignatureIntegration } from 'types/signatureIntegration.proto';
 
 import { getOriginLabel } from 'Containers/AccessControl/traits';
+import { AuthMachineToMachineConfig } from 'services/MachineAccessService';
 import { CloudSourceIntegration } from 'services/CloudSourceService';
 import {
     categoriesUtilsForClairifyScanner,
@@ -32,7 +33,6 @@ import {
     timesOfDay,
     transformDurationLongForm,
 } from './integrationUtils';
-import { AuthMachineToMachineConfig } from '../../../services/MachineAccessService';
 
 const { getCategoriesText: getCategoriesTextForClairifyScanner } =
     categoriesUtilsForClairifyScanner;

--- a/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
@@ -13,7 +13,6 @@ import {
     BaseIntegration,
     CloudSourceIntegrationType,
     ImageIntegrationType,
-    MachineAccessConfiguration,
     NotifierIntegrationType,
     SignatureIntegrationType,
 } from 'types/integration';
@@ -33,6 +32,7 @@ import {
     timesOfDay,
     transformDurationLongForm,
 } from './integrationUtils';
+import { AuthMachineToMachineConfig } from '../../../services/MachineAccessService';
 
 const { getCategoriesText: getCategoriesTextForClairifyScanner } =
     categoriesUtilsForClairifyScanner;
@@ -105,9 +105,14 @@ const tableColumnDescriptor: Readonly<IntegrationTableColumnDescriptorMap> = {
         machineAccess: [
             {
                 accessor: (config) => {
-                    return (<MachineAccessConfiguration>config).type === 'GENERIC'
-                        ? 'Generic'
-                        : 'Github action';
+                    const { type } = <AuthMachineToMachineConfig>config;
+                    if (type === 'GENERIC') {
+                        return 'Generic';
+                    }
+                    if (type === 'GITHUB_ACTIONS') {
+                        return 'Github action';
+                    }
+                    return 'Unknown';
                 },
                 Header: 'Configuration',
             },
@@ -115,7 +120,7 @@ const tableColumnDescriptor: Readonly<IntegrationTableColumnDescriptorMap> = {
             {
                 accessor: (config) => {
                     return transformDurationLongForm(
-                        (<MachineAccessConfiguration>config).tokenExpirationDuration
+                        (<AuthMachineToMachineConfig>config).tokenExpirationDuration
                     );
                 },
                 Header: 'Token lifetime',

--- a/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
@@ -7,11 +7,13 @@ import {
     QuayImageIntegration,
 } from 'types/imageIntegration.proto';
 import {
+    AuthProviderIntegration,
     AuthProviderType,
     BackupIntegrationType,
     BaseIntegration,
     CloudSourceIntegrationType,
     ImageIntegrationType,
+    MachineAccessConfiguration,
     NotifierIntegrationType,
     SignatureIntegrationType,
 } from 'types/integration';
@@ -29,6 +31,7 @@ import {
     categoriesUtilsForRegistryScanner,
     daysOfWeek,
     timesOfDay,
+    transformDurationLongForm,
 } from './integrationUtils';
 
 const { getCategoriesText: getCategoriesTextForClairifyScanner } =
@@ -52,7 +55,10 @@ export type IntegrationTableColumnDescriptor<Integration> = {
  */
 
 type IntegrationTableColumnDescriptorMap = {
-    authProviders: Record<AuthProviderType, IntegrationTableColumnDescriptor<BaseIntegration>[]>;
+    authProviders: Record<
+        AuthProviderType,
+        IntegrationTableColumnDescriptor<AuthProviderIntegration>[]
+    >;
     backups: Record<
         BackupIntegrationType,
         IntegrationTableColumnDescriptor<BaseBackupIntegration>[]
@@ -95,6 +101,25 @@ const tableColumnDescriptor: Readonly<IntegrationTableColumnDescriptorMap> = {
         apitoken: [
             { accessor: 'name', Header: 'Name' },
             { accessor: 'role', Header: 'Role' },
+        ],
+        machineAccess: [
+            {
+                accessor: (config) => {
+                    return (<MachineAccessConfiguration>config).type === 'GENERIC'
+                        ? 'Generic'
+                        : 'Github action';
+                },
+                Header: 'Configuration',
+            },
+            { accessor: 'issuer', Header: 'Issuer' },
+            {
+                accessor: (config) => {
+                    return transformDurationLongForm(
+                        (<MachineAccessConfiguration>config).tokenExpirationDuration
+                    );
+                },
+                Header: 'Token lifetime',
+            },
         ],
     },
     notifiers: {

--- a/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
@@ -10,7 +10,6 @@ import {
     AuthProviderIntegration,
     AuthProviderType,
     BackupIntegrationType,
-    BaseIntegration,
     CloudSourceIntegrationType,
     ImageIntegrationType,
     NotifierIntegrationType,

--- a/ui/apps/platform/src/reducers/index.js
+++ b/ui/apps/platform/src/reducers/index.js
@@ -6,6 +6,9 @@ import bindSelectors from 'utils/bindSelectors';
 import apiTokens, { selectors as apiTokenSelectors } from './apitokens';
 import auth, { selectors as authSelectors } from './auth';
 import clusterInitBundles, { selectors as clusterInitBundleSelectors } from './clusterInitBundles';
+import machineAccessConfigs, {
+    selectors as machineAccessConfigSelectors,
+} from './machineAccessConfigs';
 import feedback, { selectors as feedbackSelectors } from './feedback';
 import formMessages, { selectors as formMessageSelectors } from './formMessages';
 import integrations, { selectors as integrationSelectors } from './integrations';
@@ -35,6 +38,7 @@ const appReducer = combineReducers({
     apiTokens,
     auth,
     clusterInitBundles,
+    machineAccessConfigs,
     feedback,
     formMessages,
     integrations,
@@ -71,6 +75,7 @@ const getApp = (state) => state.app;
 const getAPITokens = (state) => getApp(state).apiTokens;
 const getAuth = (state) => getApp(state).auth;
 const getClusterInitBundles = (state) => getApp(state).clusterInitBundles;
+const getMachineAccessConfigs = (state) => getApp(state).machineAccessConfigs;
 const getFeedback = (state) => getApp(state).feedback;
 const getFormMessages = (state) => getApp(state).formMessages;
 const getIntegrations = (state) => getApp(state).integrations;
@@ -93,6 +98,7 @@ const boundSelectors = {
     ...bindSelectors(getAPITokens, apiTokenSelectors),
     ...bindSelectors(getAuth, authSelectors),
     ...bindSelectors(getClusterInitBundles, clusterInitBundleSelectors),
+    ...bindSelectors(getMachineAccessConfigs, machineAccessConfigSelectors),
     ...bindSelectors(getFeedback, feedbackSelectors),
     ...bindSelectors(getFormMessages, formMessageSelectors),
     ...bindSelectors(getIntegrations, integrationSelectors),

--- a/ui/apps/platform/src/reducers/machineAccessConfigs.js
+++ b/ui/apps/platform/src/reducers/machineAccessConfigs.js
@@ -1,0 +1,34 @@
+import isEqual from 'lodash/isEqual';
+import { combineReducers } from 'redux';
+import { createFetchingActions, createFetchingActionTypes } from '../utils/fetchingReduxRoutines';
+
+export const types = {
+    FETCH_MACHINE_ACCESS_CONFIGS: createFetchingActionTypes(
+        'machineAccessConfigs/FETCH_MACHINE_ACCESS_CONFIGS'
+    ),
+    DELETE_MACHINE_ACCESS_CONFIGS: 'machineAccessConfigs/DELETE_MACHINE_ACCESS_CONFIGS',
+};
+
+export const actions = {
+    fetchMachineAccessConfigs: createFetchingActions(types.FETCH_MACHINE_ACCESS_CONFIGS),
+    deleteMachineAccessConfigs: (ids) => ({ type: types.DELETE_MACHINE_ACCESS_CONFIGS, ids }),
+};
+
+const machineAccessConfigs = (state = [], action) => {
+    if (action.type === types.FETCH_MACHINE_ACCESS_CONFIGS.SUCCESS) {
+        return isEqual(action.response.configs, state) ? state : action.response.configs;
+    }
+    return state;
+};
+
+const reducer = combineReducers({
+    machineAccessConfigs,
+});
+
+const getMachineAccessConfigs = (state) => state.machineAccessConfigs;
+
+export const selectors = {
+    getMachineAccessConfigs,
+};
+
+export default reducer;

--- a/ui/apps/platform/src/sagas/index.js
+++ b/ui/apps/platform/src/sagas/index.js
@@ -3,6 +3,7 @@ import { all, fork } from 'redux-saga/effects';
 import apiTokens from './apiTokenSagas';
 import authProviders from './authSagas';
 // import clusterInitBundles from './clusterInitBundleSagas';
+import machineAccessConfigs from './machineAccessSagas';
 import integrations from './integrationSagas';
 import cloudSources from './cloudSourceSagas';
 import roles from './roleSagas';
@@ -14,6 +15,7 @@ export default function* root() {
     yield all([
         fork(apiTokens),
         fork(authProviders),
+        fork(machineAccessConfigs),
         // Delete from reducers and sagas when we delete ROX_MOVE_INIT_BUNDLES_UI after 4.4 release.
         // fork(clusterInitBundles),
         fork(integrations),

--- a/ui/apps/platform/src/sagas/machineAccessSagas.js
+++ b/ui/apps/platform/src/sagas/machineAccessSagas.js
@@ -1,0 +1,43 @@
+import { all, take, call, fork, put, takeLatest } from 'redux-saga/effects';
+
+import { integrationsPath } from 'routePaths';
+import * as service from 'services/MachineAccessService';
+import { actions, types } from 'reducers/machineAccessConfigs';
+import { takeEveryNewlyMatchedLocation } from 'utils/sagaEffects';
+
+function* getMachineAccessConfigs() {
+    try {
+        const result = yield call(service.fetchMachineAccessConfigs);
+        yield put(actions.fetchMachineAccessConfigs.success(result.response));
+    } catch (error) {
+        yield put(actions.fetchMachineAccessConfigs.failure(error));
+    }
+}
+
+function* deleteMachineAccessConfigs({ ids }) {
+    try {
+        yield call(service.deleteMachineAccessConfigs, ids);
+        yield put(actions.fetchMachineAccessConfigs.request());
+    } catch (error) {
+        yield put(actions.deleteMachineAccessConfigs.failure(error));
+    }
+}
+
+function* watchLocation() {
+    yield takeEveryNewlyMatchedLocation(integrationsPath, getMachineAccessConfigs);
+}
+
+function* watchFetchRequest() {
+    while (true) {
+        yield take([types.FETCH_MACHINE_ACCESS_CONFIGS.REQUEST]);
+        yield fork(getMachineAccessConfigs);
+    }
+}
+
+function* watchDeleteRequest() {
+    yield takeLatest(types.DELETE_MACHINE_ACCESS_CONFIGS, deleteMachineAccessConfigs);
+}
+
+export default function* integrations() {
+    yield all([fork(watchLocation), fork(watchFetchRequest), fork(watchDeleteRequest)]);
+}

--- a/ui/apps/platform/src/services/IntegrationsService.ts
+++ b/ui/apps/platform/src/services/IntegrationsService.ts
@@ -1,5 +1,6 @@
 import axios from './instance';
 import { Empty } from './types';
+import { AuthMachineToMachineConfig, updateMachineAccessConfig } from './MachineAccessService';
 
 export type IntegrationSource =
     | 'authProviders'
@@ -104,7 +105,7 @@ export function saveIntegrationV2(
     }
     // Machine access configs should be wrapped.
     if (source === 'authProviders') {
-        return axios.put(`${getPath(source)}/${(data as IntegrationBase).id}`, { config: data });
+        return updateMachineAccessConfig(data as AuthMachineToMachineConfig);
     }
     return axios.put(`${getPath(source)}/${(data as IntegrationBase).id}`, data);
 }

--- a/ui/apps/platform/src/services/IntegrationsService.ts
+++ b/ui/apps/platform/src/services/IntegrationsService.ts
@@ -19,6 +19,8 @@ function getPath(source: IntegrationSource): string {
             return '/v1/externalbackups';
         case 'signatureIntegrations':
             return '/v1/signatureintegrations';
+        case 'authProviders':
+            return '/v1/auth/m2m';
         case 'cloudSources':
             return '/v1/cloud-sources';
         default:
@@ -99,6 +101,10 @@ export function saveIntegrationV2(
         // If the data has a config object, use the contents of that config object.
         const config = data[getJsonFieldBySource(source)] as IntegrationBase;
         return axios.patch(`${getPath(source)}/${config.id}`, data);
+    }
+    // Machine access configs should be wrapped.
+    if (source === 'authProviders') {
+        return axios.put(`${getPath(source)}/${(data as IntegrationBase).id}`, { config: data });
     }
     return axios.put(`${getPath(source)}/${(data as IntegrationBase).id}`, data);
 }

--- a/ui/apps/platform/src/services/MachineAccessService.ts
+++ b/ui/apps/platform/src/services/MachineAccessService.ts
@@ -1,7 +1,9 @@
 import axios from './instance';
 import { Empty } from './types';
 
-export type MachineConfigType = 'GENERIC' | 'GITHUB_ACTIONS';
+const configTypes = ['GENERIC', 'GITHUB_ACTIONS'] as const;
+
+export type MachineConfigType = (typeof configTypes)[number];
 
 export type MachineConfigMapping = {
     key: string;
@@ -17,18 +19,22 @@ export type AuthMachineToMachineConfig = {
     mappings: MachineConfigMapping[];
 };
 
+const machineAccessURL = `/v1/auth/m2m`;
+
 export function fetchMachineAccessConfigs(): Promise<{
     response: { configs: AuthMachineToMachineConfig[] };
 }> {
-    return axios.get<{ configs: AuthMachineToMachineConfig[] }>(`/v1/auth/m2m`).then((response) => {
-        return {
-            response: response.data || { configs: [] },
-        };
-    });
+    return axios
+        .get<{ configs: AuthMachineToMachineConfig[] }>(machineAccessURL)
+        .then((response) => {
+            return {
+                response: response.data || { configs: [] },
+            };
+        });
 }
 
 export function deleteMachineAccessConfig(id: string): Promise<Empty> {
-    return axios.delete(`/v1/auth/m2m/${id}`);
+    return axios.delete(`${machineAccessURL}/${id}`);
 }
 
 export function deleteMachineAccessConfigs(ids: string[]): Promise<Empty[]> {
@@ -39,10 +45,14 @@ export function createMachineAccessConfig(data: AuthMachineToMachineConfig): Pro
     response: AuthMachineToMachineConfig;
 }> {
     return axios
-        .post<AuthMachineToMachineConfig>(`/v1/auth/m2m`, { config: data })
+        .post<AuthMachineToMachineConfig>(machineAccessURL, { config: data })
         .then((response) => {
             return {
                 response: response.data || {},
             };
         });
+}
+
+export function updateMachineAccessConfig(data: AuthMachineToMachineConfig): Promise<Empty> {
+    return axios.put(`${machineAccessURL}/${data.id}`, { config: data });
 }

--- a/ui/apps/platform/src/services/MachineAccessService.ts
+++ b/ui/apps/platform/src/services/MachineAccessService.ts
@@ -1,0 +1,48 @@
+import axios from './instance';
+import { Empty } from './types';
+
+export type MachineConfigType = 'GENERIC' | 'GITHUB_ACTIONS';
+
+export type MachineConfigMapping = {
+    key: string;
+    valueExpression: string;
+    role: string;
+};
+
+export type AuthMachineToMachineConfig = {
+    id: string;
+    tokenExpirationDuration: string;
+    type: MachineConfigType;
+    issuer: string;
+    mappings: MachineConfigMapping[];
+};
+
+export function fetchMachineAccessConfigs(): Promise<{
+    response: { configs: AuthMachineToMachineConfig[] };
+}> {
+    return axios.get<{ configs: AuthMachineToMachineConfig[] }>(`/v1/auth/m2m`).then((response) => {
+        return {
+            response: response.data || { configs: [] },
+        };
+    });
+}
+
+export function deleteMachineAccessConfig(id: string): Promise<Empty> {
+    return axios.delete(`/v1/auth/m2m/${id}`);
+}
+
+export function deleteMachineAccessConfigs(ids: string[]): Promise<Empty[]> {
+    return Promise.all(ids.map(deleteMachineAccessConfig));
+}
+
+export function createMachineAccessConfig(data: AuthMachineToMachineConfig): Promise<{
+    response: AuthMachineToMachineConfig;
+}> {
+    return axios
+        .post<AuthMachineToMachineConfig>(`/v1/auth/m2m`, { config: data })
+        .then((response) => {
+            return {
+                response: response.data || {},
+            };
+        });
+}

--- a/ui/apps/platform/src/types/featureFlag.ts
+++ b/ui/apps/platform/src/types/featureFlag.ts
@@ -14,4 +14,5 @@ export type FeatureFlagEnvVar =
     | 'ROX_VULN_MGMT_WORKLOAD_CVES'
     | 'ROX_WORKLOAD_CVES_FIXABILITY_FILTERS'
     | 'ROX_SCANNER_V4'
+    | 'ROX_AUTH_MACHINE_TO_MACHINE'
     ;

--- a/ui/apps/platform/src/types/featureFlag.ts
+++ b/ui/apps/platform/src/types/featureFlag.ts
@@ -14,5 +14,4 @@ export type FeatureFlagEnvVar =
     | 'ROX_VULN_MGMT_WORKLOAD_CVES'
     | 'ROX_WORKLOAD_CVES_FIXABILITY_FILTERS'
     | 'ROX_SCANNER_V4'
-    | 'ROX_AUTH_MACHINE_TO_MACHINE'
     ;

--- a/ui/apps/platform/src/types/integration.ts
+++ b/ui/apps/platform/src/types/integration.ts
@@ -14,7 +14,7 @@ export type IntegrationType =
     | SignatureIntegrationType
     | CloudSourceIntegrationType;
 
-export type AuthProviderType = 'apitoken' | 'clusterInitBundle';
+export type AuthProviderType = 'apitoken' | 'clusterInitBundle' | 'machineAccess';
 
 // Investigate why the following occur in tableColumnDescriptor but not in integrationsList:
 /*
@@ -62,4 +62,20 @@ export type CloudSourceIntegrationType = 'paladinCloud';
 export type BaseIntegration = {
     id: string;
     name: string;
+};
+
+export type AuthProviderIntegration = BaseIntegration | MachineAccessConfiguration;
+
+export type MachineAccessConfigMapping = {
+    key: string;
+    valueExpression: string;
+    role: string;
+};
+
+export type MachineAccessConfiguration = {
+    id: string;
+    type: string;
+    issuer: string;
+    tokenExpirationDuration: string;
+    mapping: MachineAccessConfigMapping[];
 };

--- a/ui/apps/platform/src/types/integration.ts
+++ b/ui/apps/platform/src/types/integration.ts
@@ -1,3 +1,5 @@
+import { AuthMachineToMachineConfig } from 'services/MachineAccessService';
+
 export type IntegrationSource =
     | 'authProviders'
     | 'notifiers'
@@ -64,18 +66,4 @@ export type BaseIntegration = {
     name: string;
 };
 
-export type AuthProviderIntegration = BaseIntegration | MachineAccessConfiguration;
-
-export type MachineAccessConfigMapping = {
-    key: string;
-    valueExpression: string;
-    role: string;
-};
-
-export type MachineAccessConfiguration = {
-    id: string;
-    type: string;
-    issuer: string;
-    tokenExpirationDuration: string;
-    mapping: MachineAccessConfigMapping[];
-};
+export type AuthProviderIntegration = BaseIntegration | AuthMachineToMachineConfig;


### PR DESCRIPTION
## Description

Implementation of mocks by @mansursyed. 

A few differences: 
* There's no documentation on configuration types, so that is left out
* The format used for token expiration is the same as the backend one (example: `3h20m30s`). 

This PR implements list view, as well as create/update/view page for [M2M authentication configs](https://github.com/stackrox/stackrox/blob/master/proto/api/v1/auth_service.proto#L37-L82). Backend is already implemented by @dhaus67.

Epic link: [ROX-20100](https://issues.redhat.com/browse/ROX-20100)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

1. Deployed backend with  latest `master` version on infra
2. Enabled `ROX_AUTH_MACHINE_TO_MACHINE` env flag
3. Deployed UI locally and connected to infra backend
4. Verified that create, update, delete, view, list functionality works 

<img width="1782" alt="Screenshot 2024-02-02 at 19 48 08" src="https://github.com/stackrox/stackrox/assets/78353299/72d14e0c-e2ba-4205-8741-6d45d0b9d601">

<img width="1776" alt="Screenshot 2024-02-02 at 19 47 47" src="https://github.com/stackrox/stackrox/assets/78353299/f5afc65a-308d-44e3-a390-e16595094be5">

<img width="1789" alt="Screenshot 2024-02-02 at 19 47 09" src="https://github.com/stackrox/stackrox/assets/78353299/4e8e228b-74f6-459e-a83b-2bd9585485d6">
