### PR TITLE
ROX-21841: Add instructions for wizard step 2

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep1.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep1.tsx
@@ -38,7 +38,7 @@ function InitBundleWizardStep1({ formik }: InitBundleWizardStep1Props): ReactEle
             <Alert
                 variant="info"
                 isInline
-                title="You can use one bundle to secure multiple clusters which have the same installation method."
+                title="You can use one bundle to secure multiple clusters that have the same installation method."
                 component="p"
             />
             <Form>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep1.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep1.tsx
@@ -35,6 +35,12 @@ function InitBundleWizardStep1({ formik }: InitBundleWizardStep1Props): ReactEle
     return (
         <Flex direction={{ default: 'column' }}>
             <Title headingLevel="h2">Select options</Title>
+            <Alert
+                variant="info"
+                isInline
+                title="You can use one bundle to secure multiple clusters which have the same installation method."
+                component="p"
+            />
             <Form>
                 <FormLabelGroup
                     fieldId="name"
@@ -53,12 +59,6 @@ function InitBundleWizardStep1({ formik }: InitBundleWizardStep1Props): ReactEle
                         onChange={onChange}
                     />
                 </FormLabelGroup>
-                <Alert
-                    variant="info"
-                    isInline
-                    title="You can use one bundle for multiple clusters on the same platform with the same installation method."
-                    component="p"
-                />
                 <FormGroup fieldId="platform" label="Platform of secured clusters" isRequired>
                     <Flex
                         direction={{ default: 'column' }}

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep2.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep2.tsx
@@ -28,7 +28,7 @@ function InitBundleWizardStep2({ errorMessage, formik }: InitBundleWizardStep2Pr
             <Alert
                 variant="info"
                 isInline
-                title="You can download the YAML file only once when you create a cluster init bundle"
+                title="You can download the YAML file only once when you create a cluster init bundle."
                 component="p"
             >
                 Store the YAML file securely because it contains secrets.

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep2.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep2.tsx
@@ -25,13 +25,11 @@ function InitBundleWizardStep2({ errorMessage, formik }: InitBundleWizardStep2Pr
             ) : (
                 <SecureClusterUsingHelmChart headingLevel={headingLevel} />
             )}
-            <Alert
-                variant="info"
-                isInline
-                title="You can download the YAML file only once when you create a cluster init bundle."
-                component="p"
-            >
-                Store the YAML file securely because it contains secrets.
+            <Alert variant="info" isInline title="Download YAML file" component="p">
+                <p>
+                    You can download the YAML file only once when you create a cluster init bundle.
+                </p>
+                <p>Store the YAML file securely because it contains secrets.</p>
             </Alert>
             {errorMessage && (
                 <Alert

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep2.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleWizardStep2.tsx
@@ -20,20 +20,19 @@ function InitBundleWizardStep2({ errorMessage, formik }: InitBundleWizardStep2Pr
     return (
         <Flex direction={{ default: 'column' }}>
             <Title headingLevel="h2">Download bundle</Title>
-            <Alert
-                variant="info"
-                isInline
-                title="A cluster init bundle can only be downloaded once"
-                component="p"
-            >
-                Store this bundle securely because it contains secrets. You can use the same bundle
-                to secure multiple clusters.
-            </Alert>
             {installation === 'Operator' ? (
                 <SecureClusterUsingOperator headingLevel={headingLevel} />
             ) : (
                 <SecureClusterUsingHelmChart headingLevel={headingLevel} />
             )}
+            <Alert
+                variant="info"
+                isInline
+                title="You can download the YAML file only once when you create a cluster init bundle"
+                component="p"
+            >
+                Store the YAML file securely because it contains secrets.
+            </Alert>
             {errorMessage && (
                 <Alert
                     variant="danger"

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
@@ -69,7 +69,7 @@ function SecureClusterPage(): ReactElement {
                     <Alert
                         variant="info"
                         isInline
-                        title="You can use one bundle to secure multiple clusters which have the same installation method."
+                        title="You can use one bundle to secure multiple clusters that have the same installation method."
                         component="p"
                     />
                 </Flex>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import { useLocation } from 'react-router-dom';
 import qs from 'qs';
 import {
+    Alert,
     Breadcrumb,
     BreadcrumbItem,
     Divider,
@@ -65,6 +66,12 @@ function SecureClusterPage(): ReactElement {
                     ) : (
                         <SecureClusterUsingHelmChart headingLevel={headingLevel} />
                     )}
+                    <Alert
+                        variant="info"
+                        isInline
+                        title="You can use one bundle to secure multiple clusters which have the same installation method."
+                        component="p"
+                    />
                 </Flex>
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
@@ -1,5 +1,27 @@
-import React, { ReactElement } from 'react';
-import { Flex, List, ListItem, Title } from '@patternfly/react-core';
+import React, { ReactElement, useState } from 'react';
+import {
+    ClipboardCopyButton,
+    CodeBlock,
+    CodeBlockAction,
+    CodeBlockCode,
+    Flex,
+    List,
+    ListItem,
+    Title,
+} from '@patternfly/react-core';
+
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import useMetadata from 'hooks/useMetadata';
+import { getVersionedDocs } from 'utils/versioning';
+
+const codeBlock = [
+    'helm install rhacs-secured-cluster-services rhacs/secured-cluster-services -n stackrox \\',
+    '-f <path/to/Helm-values-cluster-init-bundle.yaml> \\',
+    '--set clusterName=<name_of_the_secured_cluster> \\',
+    '--set centralEndpoint=<endpoint_of_central_service> \\',
+    '--set imagePullSecrets.username=<your redhat.com username> \\',
+    '--set imagePullSecrets.password=<your redhat.com password>',
+].join('\n');
 
 export type SecureClusterUsingHelmChartProps = {
     headingLevel: 'h2' | 'h3';
@@ -8,15 +30,95 @@ export type SecureClusterUsingHelmChartProps = {
 function SecureClusterUsingHelmChart({
     headingLevel,
 }: SecureClusterUsingHelmChartProps): ReactElement {
+    const { version } = useMetadata();
+    const subHeadingLevel = headingLevel === 'h2' ? 'h3' : 'h4';
+    const [wasCopied, setWasCopied] = useState(false);
+
+    function onClickCopy() {
+        // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText#browser_compatibility
+        // Chrome 66 Edge 79 Firefox 63 Safari 13.1
+        navigator?.clipboard
+            ?.writeText(codeBlock)
+            .then(() => {
+                setWasCopied(true);
+            })
+            .catch(() => {
+                // TODO addToast(title, message)
+            });
+    }
+
+    const actions = (
+        <CodeBlockAction>
+            <ClipboardCopyButton
+                aria-label="Copy to clipboard"
+                id="ClipboardCopyButton"
+                onClick={onClickCopy}
+                textId="CodeBlockCode"
+                variant="plain"
+            >
+                {wasCopied ? 'Copied to clipboard' : 'Copy to clipboard'}
+            </ClipboardCopyButton>
+        </CodeBlockAction>
+    );
+
     return (
         <Flex direction={{ default: 'column' }}>
             <Title headingLevel={headingLevel}>
                 Secure a cluster using Helm chart installation method
             </Title>
+            {version && (
+                <ExternalLink>
+                    <a
+                        href={getVersionedDocs(
+                            version,
+                            '/installing/installing_other/install-secured-cluster-other.html'
+                        )}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Installing secured cluster services on other platforms
+                    </a>
+                </ExternalLink>
+            )}
+            <Title headingLevel={subHeadingLevel}>Prerequisites</Title>
             <List component="ol">
-                <ListItem>Do something.</ListItem>
-                <ListItem>Do something.</ListItem>
-                <ListItem>Do something.</ListItem>
+                <ListItem>
+                    <p>You must add the Helm chart repository. TODO is this step 2?</p>
+                </ListItem>
+                <ListItem>
+                    <p>
+                        You must have access to the Red Hat Container Registry and a pull secret for
+                        authentication.
+                    </p>
+                </ListItem>
+                <ListItem>
+                    <p>
+                        You must have the address and the port number that you are exposing the
+                        Central service on.
+                    </p>
+                </ListItem>
+                <ListItem>
+                    <p>
+                        You must download the YAML file for a cluster init bundle. You can use one
+                        bundle to secure multiple clusters.
+                    </p>
+                </ListItem>
+            </List>
+            <Title headingLevel={subHeadingLevel}>
+                Procedure to repeat for each secured cluster
+            </Title>
+            <List component="ol">
+                <ListItem>
+                    <Flex
+                        direction={{ default: 'column' }}
+                        spaceItems={{ default: 'spaceItemsSm' }}
+                    >
+                        <p>Run a command similar to the following:</p>
+                        <CodeBlock actions={actions}>
+                            <CodeBlockCode>{codeBlock}</CodeBlockCode>
+                        </CodeBlock>
+                    </Flex>
+                </ListItem>
             </List>
         </Flex>
     );

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import {
+    ClipboardCopy,
     ClipboardCopyButton,
     CodeBlock,
     CodeBlockAction,
@@ -81,9 +82,21 @@ function SecureClusterUsingHelmChart({
                 </ExternalLink>
             )}
             <Title headingLevel={subHeadingLevel}>Prerequisites</Title>
-            <List component="ol">
+            <List component="ul">
                 <ListItem>
-                    <p>You must add the Helm chart repository. TODO is this step 2?</p>
+                    <p>
+                        You must have previously added the Helm chart repository, or add it using
+                        the following command:
+                    </p>
+                    <ClipboardCopy>
+                        helm repo add rhacs https://mirror.openshift.com/pub/rhacs/charts/
+                    </ClipboardCopy>
+                </ListItem>
+                <ListItem>
+                    <p>
+                        You must download the YAML file for a cluster init bundle. You can use one
+                        bundle to secure multiple clusters.
+                    </p>
                 </ListItem>
                 <ListItem>
                     <p>
@@ -95,12 +108,6 @@ function SecureClusterUsingHelmChart({
                     <p>
                         You must have the address and the port number that you are exposing the
                         Central service on.
-                    </p>
-                </ListItem>
-                <ListItem>
-                    <p>
-                        You must download the YAML file for a cluster init bundle. You can use one
-                        bundle to secure multiple clusters.
                     </p>
                 </ListItem>
             </List>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
@@ -43,10 +43,13 @@ function SecureClusterUsingOperator({
             </Title>
             <List component="ol">
                 <ListItem>
-                    <p>Use the OpenShift console to install the ACS Operator from Operator Hub.</p>
                     <p>
-                        Create a new OCP project for ACS. A good name choice is{' '}
-                        <strong>rhacs-operator</strong>
+                        Use the Red Hat OpenShift Container Platform web console to install the
+                        RHACS Operator from OperatorHub.
+                    </p>
+                    <p>
+                        Create a new Red Hat OpenShift Container Platform project for RHACS.{' '}
+                        <strong>rhacs-operator</strong> is a good name choice.
                     </p>
                 </ListItem>
                 <ListItem>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
@@ -58,8 +58,17 @@ function SecureClusterUsingOperator({
                         secure multiple clusters.
                     </p>
                 </ListItem>
+            </List>
+            <Title headingLevel={subHeadingLevel}>
+                Procedure to repeat for each secured cluster
+            </Title>
+            <List component="ol">
                 <ListItem>
-                    <p>With the ACS project selected create the init bundle secrets in OCP.</p>
+                    <p>Apply the init bundle by creating a resource on the secured cluster.</p>
+                    <p>
+                        With the RHACS project selected create the init bundle secrets in OpenShift
+                        Container Platform.
+                    </p>
                     {version && (
                         <ExternalLink>
                             <a
@@ -92,16 +101,17 @@ function SecureClusterUsingOperator({
                                 following:
                             </p>
                             <ClipboardCopy>
-                                oc -n rhacs-operator -f Operator-secrets-cluster-init-bundle.yaml
+                                oc -n stackrox -f Operator-secrets-cluster-init-bundle.yaml
                             </ClipboardCopy>
                         </ListItem>
                     </List>
                 </ListItem>
+                <ListItem>
+                    <p>
+                        Install secured cluster services on each cluster using the RHACS operator.
+                    </p>
+                </ListItem>
             </List>
-            <Title headingLevel={subHeadingLevel}>
-                Procedure to repeat for each secured cluster
-            </Title>
-            <p>TODO just use the operator?</p>
         </Flex>
     );
 }

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
@@ -1,5 +1,9 @@
 import React, { ReactElement } from 'react';
-import { Flex, List, ListItem, Title } from '@patternfly/react-core';
+import { ClipboardCopy, Flex, List, ListItem, Title } from '@patternfly/react-core';
+
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import useMetadata from 'hooks/useMetadata';
+import { getVersionedDocs } from 'utils/versioning';
 
 export type SecureClusterUsingOperatorProps = {
     headingLevel: 'h2' | 'h3';
@@ -8,16 +12,93 @@ export type SecureClusterUsingOperatorProps = {
 function SecureClusterUsingOperator({
     headingLevel,
 }: SecureClusterUsingOperatorProps): ReactElement {
+    const { version } = useMetadata();
+    const subHeadingLevel = headingLevel === 'h2' ? 'h3' : 'h4';
+
     return (
         <Flex direction={{ default: 'column' }}>
             <Title headingLevel={headingLevel}>
                 Secure a cluster using Operator installation method
             </Title>
+            {version && (
+                <ExternalLink>
+                    <a
+                        href={getVersionedDocs(
+                            version,
+                            'installing/installing_ocp/install-secured-cluster-ocp.html'
+                        )}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Installing secured cluster services on Red Hat OpenShift
+                    </a>
+                </ExternalLink>
+            )}
+            <p>
+                You can install secured cluster services on your clusters by using the{' '}
+                <strong>SecuredCluster</strong> custom resource.
+            </p>
+            <Title headingLevel={subHeadingLevel}>
+                Procedure to do only once before you secure the first cluster
+            </Title>
             <List component="ol">
-                <ListItem>Do something.</ListItem>
-                <ListItem>Do something.</ListItem>
-                <ListItem>Do something.</ListItem>
+                <ListItem>
+                    <p>Use the OpenShift console to install the ACS Operator from Operator Hub.</p>
+                    <p>
+                        Create a new OCP project for ACS. A good name choice is{' '}
+                        <strong>rhacs-operator</strong>
+                    </p>
+                </ListItem>
+                <ListItem>
+                    <p>
+                        Download the YAML file for a cluster init bundle. You can use one bundle to
+                        secure multiple clusters.
+                    </p>
+                </ListItem>
+                <ListItem>
+                    <p>With the ACS project selected create the init bundle secrets in OCP.</p>
+                    {version && (
+                        <ExternalLink>
+                            <a
+                                href={getVersionedDocs(
+                                    version,
+                                    'cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply.html#create-resource-init-bundle_init-bundle-cloud-ocp-apply'
+                                )}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Creating resources by using the init bundle
+                            </a>
+                        </ExternalLink>
+                    )}
+                    <List component="ul">
+                        <ListItem>
+                            <p>
+                                In the OpenShift Container Platform web console, in the top menu,
+                                click <strong>+</strong> to open the <strong>Import YAML</strong>{' '}
+                                page.
+                            </p>
+                            <p>
+                                You can drag the init bundle file or copy and paste its contents
+                                into the editor, and then click <strong>Create</strong>.
+                            </p>
+                        </ListItem>
+                        <ListItem>
+                            <p>
+                                Using the Red Hat OpenShift CLI, run a command similar to the
+                                following:
+                            </p>
+                            <ClipboardCopy>
+                                oc -n rhacs-operator -f Operator-secrets-cluster-init-bundle.yaml
+                            </ClipboardCopy>
+                        </ListItem>
+                    </List>
+                </ListItem>
             </List>
+            <Title headingLevel={subHeadingLevel}>
+                Procedure to repeat for each secured cluster
+            </Title>
+            <p>TODO just use the operator?</p>
         </Flex>
     );
 }


### PR DESCRIPTION
## Description

Goal to merge either end of day Friday or morning US Eastern time on Monday as prerequisite to turn on feature flag.

We can follow up with a second round of review if needed.

For cross-functional content review:
* Simon especially for correct and complete for primary audience.
* Kerry especially for clear and complete for primary audience, also that is aligned with docs and follows style guide.
* Mansur especially for user experience.

UI team can review component refactoring. Here are the 2 important files for content review:
* SecureClusterUsingOperator.tsx
* SecureClusterUsingHelmChar.tsx

Here are specific points for improvement from my viewpoint:
* Similar depth of detail between Operator and Helm chart.
* Order of prerequisites. See TODO for Helm chart.
* What is prerequisite to do once versus step for every secured cluster. See TODO for Operator.

Adapt content from cloud service:
* https://github.com/RedHatInsights/acs-ui/blob/main/src/routes/GettingStartedPage/Wizard/InstallWithHelm.js
* https://github.com/RedHatInsights/acs-ui/blob/main/src/routes/GettingStartedPage/Wizard/InstallWithOperator.js

Here are the corresponding docs links:
* https://docs.openshift.com/acs/4.3/installing/installing_ocp/install-secured-cluster-ocp.html
* https://docs.openshift.com/acs/4.3//installing/installing_other/install-secured-cluster-other.html

### Residue

1. Factor out common `ExternalLink` components.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_MOVE_INIT_BUNDLES_UI=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 108 = 3950754 - 3950646
        total: 12256 = 10490034 - 10477778
    * `ls -al build/static/js/*.js | wc -l`
        0 = 90 - 90 files
3. `yarn start` in ui

### Manual testing

1. Visit /main/clusters/init-bundles?action=create to see wizard step 1.
    Although I did not replace the picture, replaced **which** with **that** in blue alert text.
    ![Step_1](https://github.com/stackrox/stackrox/assets/11862657/ae317042-9f27-4dd0-b04e-0329576a0724)

3. Enter a name, and then click **Next** to see wizard step 2 for Operator installation method.
    * Original
        ![Step_2_Operator](https://github.com/stackrox/stackrox/assets/11862657/651e2df6-8794-457c-81ed-f6cf9efbe83b)
    * Changes after first review by Kerry
        ![Step_2_Operator_after_first_review pmg](https://github.com/stackrox/stackrox/assets/11862657/dc6401e2-ccf7-4f9f-861d-a0f8fad96ad9)
    *Changes after second brainstorming with Kerry
        ![Step_2_Operator_after_second_review](https://github.com/stackrox/stackrox/assets/11862657/0551161f-0e36-461b-80b2-9a439f17e8eb)

4. Click **Back** select **GKE** and then click **Next** to see Helm chart installation method.
    * Original
        ![Step_2_Helm_chart](https://github.com/stackrox/stackrox/assets/11862657/b86a2d92-f030-469a-9c6f-13b17e9fcf63)
    * Changes after first review by Kerry
        ![Step_2_Helm_chart_after_first_review](https://github.com/stackrox/stackrox/assets/11862657/bd0da2c9-bbce-42e0-838f-991aaa500787)
    *Changes after second brainstorming with Kerry
        ![Step_2_Helm_chart_after_second_review](https://github.com/stackrox/stackrox/assets/11862657/071a6d82-ae0d-40b2-9553-d205b58b22cd)
