### PR TITLE
ROX-21024: fix cscc notifier resource name

### DIFF
--- a/central/notifiers/cscc/convert.go
+++ b/central/notifiers/cscc/convert.go
@@ -171,7 +171,8 @@ func convertAlertDescription(alert *storage.Alert) string {
 func convertProviderMetadataToResourceName(providerMetadata *storage.ProviderMetadata) string {
 	// We are creating a finding from a cluster which isn't deployed on GCP.
 	// We will set a resource name here that is a non-cloud resource.
-	if providerMetadata.GetGoogle() == nil {
+	googleMetadata := providerMetadata.GetGoogle()
+	if googleMetadata == nil {
 		return fmt.Sprintf("%s/%s", providerMetadata.GetCluster().GetType().String(),
 			providerMetadata.GetCluster().GetName())
 	}
@@ -183,10 +184,10 @@ func convertProviderMetadataToResourceName(providerMetadata *storage.ProviderMet
 	switch providerMetadata.GetCluster().GetType() {
 	case storage.ClusterMetadata_GKE:
 		return fmt.Sprintf("//container.googleapis.com/projects/%s/locations/%s/clusters/%s",
-			providerMetadata.GetGoogle().GetProject(), providerMetadata.GetRegion(),
-			providerMetadata.GetGoogle().GetClusterName())
+			googleMetadata.GetProject(), providerMetadata.GetRegion(),
+			googleMetadata.GetClusterName())
 	default:
 		return fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s",
-			providerMetadata.GetGoogle().GetProject())
+			googleMetadata.GetProject())
 	}
 }

--- a/central/notifiers/cscc/convert.go
+++ b/central/notifiers/cscc/convert.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/utils"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -185,7 +186,7 @@ func convertProviderMetadataToResourceName(providerMetadata *storage.ProviderMet
 	case storage.ClusterMetadata_GKE:
 		return fmt.Sprintf("//container.googleapis.com/projects/%s/locations/%s/clusters/%s",
 			googleMetadata.GetProject(), providerMetadata.GetRegion(),
-			googleMetadata.GetClusterName())
+			stringutils.FirstNonEmpty(googleMetadata.GetClusterName(), providerMetadata.GetCluster().GetName()))
 	default:
 		return fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s",
 			googleMetadata.GetProject())

--- a/central/notifiers/cscc/convert.go
+++ b/central/notifiers/cscc/convert.go
@@ -17,18 +17,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// A clusterID creates a structured ID for the ResourceName field.
-type clusterID struct {
-	Project string
-	Zone    string
-	Name    string
-}
-
-// ResourceName is the format needed for the ResourceName field.
-func (c clusterID) ResourceName() string {
-	return fmt.Sprintf("//container.googleapis.com/projects/%s/zones/%s/clusters/%s", c.Project, c.Zone, c.Name)
-}
-
 // An Enforcement object reports that an enforcement action has been taken.
 type Enforcement struct {
 	Action    string               `json:"action,omitempty"`
@@ -68,17 +56,13 @@ func convertAlertToFinding(alert *storage.Alert, sourceID string, notifierEndpoi
 	findingID := convertAlertUUID(alert.GetId())
 
 	finding := &securitycenterpb.Finding{
-		Name:   fmt.Sprintf("%s/findings/%s", sourceID, findingID),
-		Parent: sourceID,
-		ResourceName: clusterID{
-			Project: providerMetadata.GetGoogle().GetProject(),
-			Zone:    providerMetadata.GetZone(),
-			Name:    providerMetadata.GetGoogle().GetClusterName(),
-		}.ResourceName(),
-		Category:    alert.GetPolicy().GetName(),
-		ExternalUri: notifiers.AlertLink(notifierEndpoint, alert),
-		EventTime:   timestamppb.New(protoconv.ConvertTimestampToTimeOrNow(alert.GetTime())),
-		Severity:    convertSeverity(alert.GetPolicy().GetSeverity()),
+		Name:         fmt.Sprintf("%s/findings/%s", sourceID, findingID),
+		Parent:       sourceID,
+		ResourceName: convertProviderMetadataToResourceName(providerMetadata),
+		Category:     alert.GetPolicy().GetName(),
+		ExternalUri:  notifiers.AlertLink(notifierEndpoint, alert),
+		EventTime:    timestamppb.New(protoconv.ConvertTimestampToTimeOrNow(alert.GetTime())),
+		Severity:     convertSeverity(alert.GetPolicy().GetSeverity()),
 		State: utils.IfThenElse(alert.GetState() == storage.ViolationState_ATTEMPTED,
 			securitycenterpb.Finding_INACTIVE,
 			securitycenterpb.Finding_ACTIVE),
@@ -182,4 +166,27 @@ func convertAlertDescription(alert *storage.Alert) string {
 	}
 	sort.Strings(distinctSlice)
 	return strings.Join(distinctSlice, " ")
+}
+
+func convertProviderMetadataToResourceName(providerMetadata *storage.ProviderMetadata) string {
+	// We are creating a finding from a cluster which isn't deployed on GCP.
+	// We will set a resource name here that is a non-cloud resource.
+	if providerMetadata.GetGoogle() == nil {
+		return fmt.Sprintf("%s/%s", providerMetadata.GetCluster().GetType().String(),
+			providerMetadata.GetCluster().GetName())
+	}
+
+	// When the cluster is deployed on Google, it can either be a GKE cluster or an OpenShift cluster.
+	// For the GKE cluster, we can link the specific cluster as the resource, for the OpenShift cluster
+	// we will link the project instead.
+	// See https://cloud.google.com/iam/docs/full-resource-names for a list of resource names supported by GCP.
+	switch providerMetadata.GetCluster().GetType() {
+	case storage.ClusterMetadata_GKE:
+		return fmt.Sprintf("//container.googleapis.com/projects/%s/locations/%s/clusters/%s",
+			providerMetadata.GetGoogle().GetProject(), providerMetadata.GetRegion(),
+			providerMetadata.GetGoogle().GetClusterName())
+	default:
+		return fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s",
+			providerMetadata.GetGoogle().GetProject())
+	}
 }

--- a/central/notifiers/cscc/cscc.go
+++ b/central/notifiers/cscc/cscc.go
@@ -2,7 +2,6 @@ package cscc
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	securitycenter "cloud.google.com/go/securitycenter/apiv1"
@@ -18,6 +17,7 @@ import (
 	gcpUtils "github.com/stackrox/rox/pkg/cloudproviders/gcp/utils"
 	"github.com/stackrox/rox/pkg/cryptoutils/cryptocodec"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/notifiers"
@@ -150,17 +150,7 @@ func (c *cscc) getCluster(id string, clusterDatastore clusterDatastore.DataStore
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("Could not retrieve cluster %q because it does not exist", id)
-	}
-	providerMetadata := cluster.GetStatus().GetProviderMetadata()
-	if providerMetadata.GetGoogle().GetProject() == "" {
-		return nil, fmt.Errorf("Could not find Google project for cluster %q", id)
-	}
-	if providerMetadata.GetGoogle().GetClusterName() == "" {
-		return nil, fmt.Errorf("Could not find Google cluster name for cluster %q", id)
-	}
-	if providerMetadata.GetZone() == "" {
-		return nil, fmt.Errorf("Could not find Google zone for cluster %q", id)
+		return nil, errox.NotFound.Newf("cluster %q does not exist", id)
 	}
 	return cluster, nil
 }


### PR DESCRIPTION
## Description

This PR fixes a few misbehaviors of the CSCC notifier, namely the following:
- when receiving an alert from a cluster that is _not_ deployed on GCP, the notifier would fail to send the violation to CSCC due to missing project ID information.
- when receiving an alert from a cluster that _is_ deployed on GCP, the notifier would always assume as a linked resource to the finding a GKE cluster.

The first issue can happen pretty often, in the case of OpenShift clusters deployed on GCP the metadata is currently always failing (is fixed in [pull/9659](https://github.com/stackrox/stackrox/pull/9659)).

To overcome the first issue, and also fixing the second one, the following is now established:
- In case the associated cluster is not running on GCP (either plain or GKE), the resource name will be the `cluster_type/cluster_name`. This is conform with [the API doc for the resource name field for non-Google Cloud resources](https://pkg.go.dev/cloud.google.com/go/securitycenter/apiv1beta1/securitycenterpb#Finding).
- In case the associated cluster is running on GCP _but_ is not a GKE cluster, the resource name will be `//cloudresourcemanager.googleapis.com/projects/PROJECT_ID`, which is a link to the project according to [the Google IAM full resource names](https://cloud.google.com/iam/docs/full-resource-names).
- In case the associated cluster is a GKE cluster, the resource name has now changed to `//container.googleapis.com/projects/PROJECT_ID/locations/LOCATION/clusters/CLUSTER_ID`. This seems like the more common link for the GKE cluster compared to the zone.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see the added unit tests.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
