### PR TITLE
ROX-22132: Correct Fixable CVEs errors on certain VM1.0 pages

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.js
@@ -30,7 +30,7 @@ function VulnMgmtComponentOverview({ data, entityContext }) {
     const currentEntityType = workflowState.getCurrentEntityType();
 
     const vulnType =
-        currentEntityType === entityTypes.NODE_COMPONENT || entityTypes.NODE
+        currentEntityType === entityTypes.NODE_COMPONENT || currentEntityType === entityTypes.NODE
             ? entityTypes.NODE_CVE
             : entityTypes.IMAGE_CVE;
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.js
@@ -49,10 +49,7 @@ const TableWidgetFixableCves = ({
 
     const displayedEntityType = entityNounOrdinaryCaseSingular[entityType];
 
-    const queryFieldName =
-        vulnType === entityTypes.NODE_CVE
-            ? queryFieldNames[entityTypes.NODE_COMPONENT] // fix for React state transition
-            : queryFieldNames[entityType];
+    const queryFieldName = queryFieldNames[entityType];
     let queryVulnCounterFieldName = 'imageVulnerabilityCounter';
     let queryVulnsFieldName = 'imageVulnerabilities';
     let queryCVEFieldsName = 'imageCVEFields';


### PR DESCRIPTION
## Description

While troubleshooting an issue that Ross noticed while testing Scanner V4, I noticed a logic error in the code, so I'm assuming certain paths have had a broken Fixable CVEs section for a while. (On the bright side, we now know which paths get practically no usage in our app.)

All Findings sections that show Observed/Deferred/False Positive are good, because they don't use that buggy conditional.

These are the paths I found broken:
- Clusters > Single cluster: Findings->Fixable Node CVEs tab
- Namespace > (0 or more intervening entities) > Single Image: Findings
- Image Components > Single component: Findings
- Node > Single node: Findings

This change fixes the buggy conditional, and makes the code cleaner.

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

I elected not to add automated tests for two reasons:
- The VM 1.0 section is already largely superseded by VM 2.0, which will go GA in release 4.5 in 4 months. VM 1.0 is no longer under active development.
- Given the recent fiasco with the Workload CVEs tests breaking due to environment changes, I don't want to add any tests that rely on fixable CVEs being present, and testing this with mock data would not have caught the error.

Manual tests:
I identified 4 types of pages where the error occurred, based on Ross's initial bug report and Saif's initial troubleshooting.

Here are "before" and "after" screenshots of those page types:

**Clusters > Single cluster: Findings->Fixable Node CVEs tab**
before
<img width="1783" alt="Screenshot 2024-02-01 at 3 23 22 PM" src="https://github.com/stackrox/stackrox/assets/715729/0da9c8a4-c4e9-4447-ad19-16d2716e625e">

after
<img width="1783" alt="Screenshot 2024-02-01 at 4 04 44 PM" src="https://github.com/stackrox/stackrox/assets/715729/1667774b-18cd-4e77-aecf-0e45b96d814c">


**Namespace > (0 or more intervening entities) > Single Image: Findings**
before
<img width="1783" alt="Screenshot 2024-02-01 at 3 24 01 PM" src="https://github.com/stackrox/stackrox/assets/715729/842f769e-f154-45a5-9106-26689ec6aeb0">

after
<img width="1783" alt="Screenshot 2024-02-01 at 4 04 21 PM" src="https://github.com/stackrox/stackrox/assets/715729/608da91e-da7c-4c62-89b5-e099847cb7b4">


Image Components > Single component: Findings
before
<img width="1783" alt="Screenshot 2024-02-01 at 3 24 11 PM" src="https://github.com/stackrox/stackrox/assets/715729/4ec510ef-79e6-4468-b297-c85523153b9c">


after
<img width="1783" alt="Screenshot 2024-02-01 at 4 03 57 PM" src="https://github.com/stackrox/stackrox/assets/715729/6549d9ca-fbe5-413d-8e59-64bb4a52f2b9">


Node > Single node: Findings
before
<img width="1783" alt="Screenshot 2024-02-01 at 3 24 46 PM" src="https://github.com/stackrox/stackrox/assets/715729/d2201d97-096e-4a10-ad42-da8b99238bc5">

after
<img width="1783" alt="Screenshot 2024-02-01 at 3 25 27 PM" src="https://github.com/stackrox/stackrox/assets/715729/2ac6dfea-5f63-45ea-897e-4ca0baaedb83">



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
