### PR TITLE
ROX-22206: Improve decision about internal vs. external IP address

### DIFF
--- a/pkg/net/endpoint.go
+++ b/pkg/net/endpoint.go
@@ -77,7 +77,7 @@ func MakeNumericEndpoint(addr IPAddress, port uint16, proto L4Proto) NumericEndp
 
 // IsValid checks if the given numeric endpoint is valid.
 func (e NumericEndpoint) IsValid() bool {
-	return e.IPAndPort.IsValid()
+	return e.IPAndPort.IsAddressValid()
 }
 
 // String returns a string representation of this numeric endpoint.

--- a/pkg/net/ip_port.go
+++ b/pkg/net/ip_port.go
@@ -24,20 +24,23 @@ func (e NetworkPeerID) IsAddressValid() bool {
 
 // String returns a string representation of this ip:port pair.
 func (e NetworkPeerID) String() string {
-	addr := e.Address.String()
+	addrPrefix := e.Address.String()
 	isIPv6 := e.Address.Family() == IPv6
-	if addr == "" {
-		addr = e.IPNetwork.IP().String()
+	if addrPrefix == "" {
+		addrPrefix = e.IPNetwork.IP().String()
 		isIPv6 = e.IPNetwork.IP().Family() == IPv6
+		if e.IPNetwork.prefixLen > 0 {
+			addrPrefix = fmt.Sprintf("%s/%d", addrPrefix, e.IPNetwork.prefixLen)
+		}
 	}
 	if e.Port == 0 {
-		return addr
+		return addrPrefix
 	}
 	var ldelim, rdelim string
 	if isIPv6 {
 		ldelim, rdelim = "[", "]"
 	}
-	return fmt.Sprintf("%s%s%s:%d", ldelim, addr, rdelim, e.Port)
+	return fmt.Sprintf("%s%s%s:%d", ldelim, addrPrefix, rdelim, e.Port)
 }
 
 // ParseIPPortPair parses a string representation of an ip:port pair. An invalid ip:port pair is returned if the string

--- a/pkg/net/ip_port.go
+++ b/pkg/net/ip_port.go
@@ -21,6 +21,11 @@ func (e NetworkPeerID) IsValid() bool {
 	return e.Address.IsValid()
 }
 
+// DebugIPv4String returns full info in a string
+func (e NetworkPeerID) DebugIPv4String() string {
+	return fmt.Sprintf("Port=%d, Addr=%s, Network=%s", e.Port, e.Address.String(), e.IPNetwork.String())
+}
+
 // String returns a string representation of this ip:port pair.
 func (e NetworkPeerID) String() string {
 	if e.Port == 0 {

--- a/pkg/net/ip_port.go
+++ b/pkg/net/ip_port.go
@@ -24,14 +24,20 @@ func (e NetworkPeerID) IsAddressValid() bool {
 
 // String returns a string representation of this ip:port pair.
 func (e NetworkPeerID) String() string {
+	addr := e.Address.String()
+	isIPv6 := e.Address.Family() == IPv6
+	if addr == "" {
+		addr = e.IPNetwork.IP().String()
+		isIPv6 = e.IPNetwork.IP().Family() == IPv6
+	}
 	if e.Port == 0 {
-		return e.Address.String()
+		return addr
 	}
 	var ldelim, rdelim string
-	if e.Address.Family() == IPv6 {
+	if isIPv6 {
 		ldelim, rdelim = "[", "]"
 	}
-	return fmt.Sprintf("%s%s%s:%d", ldelim, e.Address.String(), rdelim, e.Port)
+	return fmt.Sprintf("%s%s%s:%d", ldelim, addr, rdelim, e.Port)
 }
 
 // ParseIPPortPair parses a string representation of an ip:port pair. An invalid ip:port pair is returned if the string

--- a/pkg/net/ip_port.go
+++ b/pkg/net/ip_port.go
@@ -21,11 +21,6 @@ func (e NetworkPeerID) IsValid() bool {
 	return e.Address.IsValid()
 }
 
-// DebugIPv4String returns full info in a string
-func (e NetworkPeerID) DebugIPv4String() string {
-	return fmt.Sprintf("Port=%d, Addr=%s, Network=%s", e.Port, e.Address.String(), e.IPNetwork.String())
-}
-
 // String returns a string representation of this ip:port pair.
 func (e NetworkPeerID) String() string {
 	if e.Port == 0 {

--- a/pkg/net/ip_port.go
+++ b/pkg/net/ip_port.go
@@ -16,7 +16,7 @@ type NetworkPeerID struct {
 	IPNetwork IPNetwork
 }
 
-// IsAddressValid checks if the ip:port pair of the Address is valid.
+// IsAddressValid checks if the ip Address is valid.
 // This does not check the validity of IPNetwork.
 func (e NetworkPeerID) IsAddressValid() bool {
 	return e.Address.IsValid()

--- a/pkg/net/ip_port.go
+++ b/pkg/net/ip_port.go
@@ -16,8 +16,9 @@ type NetworkPeerID struct {
 	IPNetwork IPNetwork
 }
 
-// IsValid checks if the ip:port pair is valid.
-func (e NetworkPeerID) IsValid() bool {
+// IsAddressValid checks if the ip:port pair of the Address is valid.
+// This does not check the validity of IPNetwork.
+func (e NetworkPeerID) IsAddressValid() bool {
 	return e.Address.IsValid()
 }
 

--- a/pkg/net/ip_port_test.go
+++ b/pkg/net/ip_port_test.go
@@ -89,32 +89,41 @@ func TestNetworkPeerID_String(t *testing.T) {
 		IPNetwork IPNetwork
 		want      string
 	}{
-		"IPv4 Address": {
+		"IPv4 address": {
 			Address:   IPAddress{data: ipv4data{192, 168, 0, 1}},
 			Port:      80,
 			IPNetwork: IPNetwork{},
 			want:      "192.168.0.1:80",
 		},
-		"IPv4 Address without port": {
+		"IPv4 address without port": {
 			Address:   IPAddress{data: ipv4data{192, 168, 0, 1}},
 			Port:      0,
 			IPNetwork: IPNetwork{},
 			want:      "192.168.0.1",
 		},
-		"IPv4 Network Address": {
+		"IPv4 network address": {
 			Address: IPAddress{},
 			Port:    80,
 			IPNetwork: IPNetwork{
 				ip:        IPAddress{data: ipv4data{192, 168, 0, 0}},
 				prefixLen: 24,
 			},
-			want: "192.168.0.0:80",
+			want: "192.168.0.0/24:80",
 		},
-		"IPv6 Address": {
+		"IPv6 address": {
 			Address:   IPAddress{data: ipv6data{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}},
 			Port:      80,
 			IPNetwork: IPNetwork{},
 			want:      "[::1]:80",
+		},
+		"IPv6 network address with prefix": {
+			Address: IPAddress{},
+			Port:    80,
+			IPNetwork: IPNetwork{
+				ip:        IPAddress{data: ipv6data{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}},
+				prefixLen: 128,
+			},
+			want: "[::1/128]:80",
 		},
 	}
 	for name, tt := range tests {

--- a/pkg/net/ip_port_test.go
+++ b/pkg/net/ip_port_test.go
@@ -11,7 +11,7 @@ func TestNumericEndpointV4(t *testing.T) {
 		Address: IPAddress{data: ipv4data{192, 168, 0, 1}},
 		Port:    1234,
 	}
-	assert.True(t, ep.IsValid())
+	assert.True(t, ep.IsAddressValid())
 	assert.Equal(t, "192.168.0.1:1234", ep.String())
 }
 
@@ -19,7 +19,7 @@ func TestNumericEndpointV4NoPort(t *testing.T) {
 	ep := NetworkPeerID{
 		Address: IPAddress{data: ipv4data{192, 168, 0, 1}},
 	}
-	assert.True(t, ep.IsValid())
+	assert.True(t, ep.IsAddressValid())
 	assert.Equal(t, "192.168.0.1", ep.String())
 }
 
@@ -28,7 +28,7 @@ func TestNumericEndpointV6(t *testing.T) {
 		Address: IPAddress{data: ipv6data{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}},
 		Port:    1234,
 	}
-	assert.True(t, ep.IsValid())
+	assert.True(t, ep.IsAddressValid())
 	assert.Equal(t, "[::1]:1234", ep.String())
 }
 
@@ -36,7 +36,7 @@ func TestNumericEndpointV6NoPort(t *testing.T) {
 	ep := NetworkPeerID{
 		Address: IPAddress{data: ipv6data{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}},
 	}
-	assert.True(t, ep.IsValid())
+	assert.True(t, ep.IsAddressValid())
 	assert.Equal(t, "::1", ep.String())
 }
 
@@ -76,8 +76,8 @@ func TestParseNumericEndpointV6NoPort(t *testing.T) {
 
 func TestParseNumericEndpointInvalid(t *testing.T) {
 	ep := ParseIPPortPair("hostname:1234")
-	assert.False(t, ep.IsValid())
+	assert.False(t, ep.IsAddressValid())
 
 	ep = ParseIPPortPair("192.168.0.1:port")
-	assert.False(t, ep.IsValid())
+	assert.False(t, ep.IsAddressValid())
 }

--- a/pkg/net/ip_port_test.go
+++ b/pkg/net/ip_port_test.go
@@ -81,3 +81,50 @@ func TestParseNumericEndpointInvalid(t *testing.T) {
 	ep = ParseIPPortPair("192.168.0.1:port")
 	assert.False(t, ep.IsAddressValid())
 }
+
+func TestNetworkPeerID_String(t *testing.T) {
+	tests := map[string]struct {
+		Address   IPAddress
+		Port      uint16
+		IPNetwork IPNetwork
+		want      string
+	}{
+		"IPv4 Address": {
+			Address:   IPAddress{data: ipv4data{192, 168, 0, 1}},
+			Port:      80,
+			IPNetwork: IPNetwork{},
+			want:      "192.168.0.1:80",
+		},
+		"IPv4 Address without port": {
+			Address:   IPAddress{data: ipv4data{192, 168, 0, 1}},
+			Port:      0,
+			IPNetwork: IPNetwork{},
+			want:      "192.168.0.1",
+		},
+		"IPv4 Network Address": {
+			Address: IPAddress{},
+			Port:    80,
+			IPNetwork: IPNetwork{
+				ip:        IPAddress{data: ipv4data{192, 168, 0, 0}},
+				prefixLen: 24,
+			},
+			want: "192.168.0.0:80",
+		},
+		"IPv6 Address": {
+			Address:   IPAddress{data: ipv6data{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}},
+			Port:      80,
+			IPNetwork: IPNetwork{},
+			want:      "[::1]:80",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			e := NetworkPeerID{
+				Address:   tt.Address,
+				Port:      tt.Port,
+				IPNetwork: tt.IPNetwork,
+			}
+			assert.Equalf(t, tt.want, e.String(), "String()")
+		})
+	}
+}

--- a/pkg/netutil/private_subnet.go
+++ b/pkg/netutil/private_subnet.go
@@ -22,6 +22,8 @@ var (
 	IPv6PrivateNetworks = []*net.IPNet{
 		// Unique Local Addresses (ULA)
 		MustParseCIDR("fd00::/8"),
+		// Link-Local addresses (IP autoconfiguration)
+		MustParseCIDR("fe80::/10"),
 
 		// IPv4-mapped IPv6 for private networks per RFC1918.
 		MustParseCIDR("::ffff:10.0.0.0/104"),

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -206,7 +206,8 @@ func (c *connection) getRemoteIPAddress() (net.IPAddress, error) {
 	if c.remote.IPAndPort.IPNetwork.IsValid() {
 		return c.remote.IPAndPort.IPNetwork.IP(), nil
 	}
-	return net.IPAddress{}, errors.New("remote has invalid IP address and invalid IP network address")
+	return net.IPAddress{}, fmt.Errorf("remote has invalid IP address %q and invalid IP network address %q",
+		c.remote.IPAndPort.Address.String(), c.remote.IPAndPort.IPNetwork.String())
 }
 
 type processInfo struct {

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -192,7 +192,7 @@ func (c *connection) IsExternal() (bool, error) {
 	if c.remote.IPAndPort.Address.IsPublic() {
 		return true, nil
 	}
-	return true, nil
+	return false, nil
 }
 
 type processInfo struct {

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -533,7 +533,7 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 			ext, err := conn.IsExternal()
 			if err != nil { // IP is malformed or unknown - assume it is external and log a warning
 				log.Warnf("%s container %s/%s. Local: %s, Remote: %v. ",
-					dirPrefix, container.Namespace, container.ContainerName, conn.local.String(), conn.remote.String())
+					dirPrefix, container.Namespace, container.ContainerName, conn.local.DebugIPv4String(), conn.remote.IPAndPort.DebugIPv4String())
 			}
 			if !ext {
 				entityType = networkgraph.InternalEntities()

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -540,7 +540,7 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 			entityType := networkgraph.InternetEntity()
 			isExternal, err := conn.IsExternal()
 			if err != nil {
-				// IP is malformed or unknown - assume it is external and log a warning
+				// IP is malformed or unknown - do not show on the graph and log the info
 				// TODO(ROX-22388): Change log level back to warning when potential Collector issue is fixed
 				log.Debugf("Not showing flow on the network graph: %v", err)
 				return

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -186,6 +186,9 @@ func (c *connection) IsExternal() (bool, error) {
 	if err != nil {
 		return true, errors.Wrap(err, "unable to determine if flow is external or internal")
 	}
+	if addr.IsLoopback() {
+		return false, errors.New("connection with localhost")
+	}
 	return addr.IsPublic(), nil
 }
 

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -184,9 +184,9 @@ func (c *connection) String() string {
 func (c *connection) IsExternal() (bool, error) {
 	addr, err := c.getRemoteIPAddress()
 	if err != nil {
-		log.Debugf("Connection has invalid IP address (%q) and IP network (%q). "+
+		log.Debugf("Connection with port %d has invalid IP address (%q) and IP network (%q). "+
 			"Assuming connection to be external.",
-			c.remote.IPAndPort.Address.String(), c.remote.IPAndPort.IPNetwork.String())
+			c.remote.IPAndPort.Port, c.remote.IPAndPort.Address.String(), c.remote.IPAndPort.IPNetwork.String())
 		return true, errors.New("remote has invalid IP address and invalid IP network address")
 	}
 	return addr.IsPublic(), nil

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -539,8 +539,10 @@ func (m *networkFlowManager) enrichConnection(conn *connection, status *connStat
 		if extSrc == nil {
 			entityType := networkgraph.InternetEntity()
 			isExternal, err := conn.IsExternal()
-			if err != nil { // IP is malformed or unknown - assume it is external and log a warning
-				log.Warnf("Not showing flow on the network graph: %v", err)
+			if err != nil {
+				// IP is malformed or unknown - assume it is external and log a warning
+				// TODO(ROX-22388): Change log level back to warning when potential Collector issue is fixed
+				log.Debugf("Not showing flow on the network graph: %v", err)
 				return
 			}
 			if !isExternal {

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -200,7 +200,7 @@ func (c *connection) IsExternal() (bool, error) {
 // (usually on OCP) the latter is provided. Analyzing only one of those two sources may lead to incorrectly reporting
 // a connection as external on the network graph.
 func (c *connection) getRemoteIPAddress() (net.IPAddress, error) {
-	if c.remote.IPAndPort.IsValid() {
+	if c.remote.IPAndPort.IsAddressValid() {
 		return c.remote.IPAndPort.Address, nil
 	}
 	if c.remote.IPAndPort.IPNetwork.IsValid() {

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -179,14 +179,23 @@ func (c *connection) String() string {
 	return fmt.Sprintf("%s: %s %s %s", c.containerID, c.local, arrow, c.remote)
 }
 
+func debugIPv4String(e net.NetworkPeerID) string {
+	return fmt.Sprintf("Port=%d, Addr=%s, Network=%s", e.Port, e.Address.String(), e.IPNetwork.String())
+}
+
 // IsExternal returns true when IPv4 does not belong to the private IP addresses; false otherwise.
 // Error is returned when IP address is malformed
 func (c *connection) IsExternal() (bool, error) {
 	addr, err := c.getRemoteIPAddress()
 	if err != nil {
-		log.Debugf("Connection with port %d has invalid IP address (%q) and IP network (%q). "+
+		dir := "Outgoing"
+		if c.incoming {
+			dir = "Incomming"
+		}
+		log.Debugf("%s connection (%s) with port %d has invalid IP address (%q) and IP network (%q). "+
 			"Assuming connection to be external.",
-			c.remote.IPAndPort.Port, c.remote.IPAndPort.Address.String(), c.remote.IPAndPort.IPNetwork.String())
+			dir, c.String(), c.remote.IPAndPort.Port, c.remote.IPAndPort.Address.String(), c.remote.IPAndPort.IPNetwork.String())
+		log.Debugf("%s connection. Local: %s, Remote: %s", dir, debugIPv4String(c.local), debugIPv4String(c.remote.IPAndPort))
 		return true, errors.New("remote has invalid IP address and invalid IP network address")
 	}
 	return addr.IsPublic(), nil

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -206,8 +206,7 @@ func (c *connection) getRemoteIPAddress() (net.IPAddress, error) {
 	if c.remote.IPAndPort.IPNetwork.IsValid() {
 		return c.remote.IPAndPort.IPNetwork.IP(), nil
 	}
-	return net.IPAddress{}, fmt.Errorf("remote has invalid IP address %q and invalid IP network address %q",
-		c.remote.IPAndPort.Address.String(), c.remote.IPAndPort.IPNetwork.String())
+	return net.IPAddress{}, fmt.Errorf("remote has invalid IP address %q", c.remote.IPAndPort.String())
 }
 
 type processInfo struct {

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -1094,6 +1094,12 @@ func Test_connection_IsExternal(t *testing.T) {
 			expectedExternal: false,
 			wantErr:          true,
 		},
+		"255.255.255.255 is a special value returned from collector and should be treated as external": {
+			remoteIP:         "255.255.255.255",
+			remoteCIDR:       "",
+			expectedExternal: true,
+			wantErr:          false,
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/timestamp"
-	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	mocksDetector "github.com/stackrox/rox/sensor/common/detector/mocks"
@@ -1104,11 +1103,6 @@ func Test_connection_IsExternal(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := &connection{
-				local: net.NetworkPeerID{
-					Address:   net.ParseIP("99.99.99.99"),
-					Port:      80,
-					IPNetwork: net.IPNetwork{},
-				},
 				remote: net.NumericEndpoint{
 					IPAndPort: net.NetworkPeerID{
 						Address:   net.ParseIP(tt.remoteIP),
@@ -1116,8 +1110,6 @@ func Test_connection_IsExternal(t *testing.T) {
 						IPNetwork: net.IPNetworkFromCIDR(tt.remoteCIDR),
 					},
 				},
-				containerID: uuid.NewV4().String(),
-				incoming:    true,
 			}
 			got, err := c.IsExternal()
 			if !tt.wantErr {

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -991,6 +991,12 @@ func Test_connection_IsExternal(t *testing.T) {
 			expectedExternal: false,
 			wantErr:          false,
 		},
+		"127.0.0.1 localhost should return an error (and not be shown on the graph)": {
+			remoteIP:         "127.0.0.1",
+			remoteCIDR:       "",
+			expectedExternal: false,
+			wantErr:          true,
+		},
 		"192.168.1.1 IP address should be internal": {
 			remoteIP:         "192.168.1.1",
 			remoteCIDR:       "",
@@ -1056,6 +1062,36 @@ func Test_connection_IsExternal(t *testing.T) {
 			remoteIP:         "",
 			remoteCIDR:       "",
 			expectedExternal: true,
+			wantErr:          true,
+		},
+		"fd00::/8 Network should be internal": {
+			remoteIP:         "",
+			remoteCIDR:       "fd00::/8",
+			expectedExternal: false,
+			wantErr:          false,
+		},
+		"fe80::/10 Network should be internal": {
+			remoteIP:         "",
+			remoteCIDR:       "fe80::/10",
+			expectedExternal: false,
+			wantErr:          false,
+		},
+		"fd12:3456:789a:1::1 (Unique Local Addresses) should be internal": {
+			remoteIP:         "fd12:3456:789a:1::1",
+			remoteCIDR:       "",
+			expectedExternal: false,
+			wantErr:          false,
+		},
+		"::1 IP address (localhost) should return an error (and not be shown on the graph)": {
+			remoteIP:         "::1",
+			remoteCIDR:       "",
+			expectedExternal: false,
+			wantErr:          true,
+		},
+		"::1/128 (localhost) should return an error (and not be shown on the graph)": {
+			remoteIP:         "",
+			remoteCIDR:       "::1/128",
+			expectedExternal: false,
 			wantErr:          true,
 		},
 	}


### PR DESCRIPTION
## Description

Collector reports network flows to Sensor using the [`NetworkAddress` proto message](https://github.com/stackrox/stackrox/blob/master/proto/internalapi/sensor/network_connection_info.proto#L54-L61).
The message has two fields for carrying IP data information:

```proto
message NetworkAddress {
  bytes address_data = 1; // semantics determined by socket_family of the given connection
  uint32 port = 2; // may be 0 if not applicable (e.g., icmp).
  // Represents an IPV4 or IPV6 network. First 4/16 bytes representing network address whereas following byte represents
  // the length of network prefix. If used, this field must have 5 or 17 bytes; otherwise it should be discarded.
  // `ip_network` and `address_data` usage should be mutually exclusive.
  bytes ip_network = 3;
}
```

Most of the times, Collector uses the `address_data` field to store a concrete IP address, but for some cases, the information the address are unavailable and Collector reports the network IP address - using `ip_network` instead (e.g., `192.168.0.0/24`). 

Sensor used only the `address_data` IP for showing the connections on the network graph. For all cases where `address_data` was empty, the info in `ip_network` were skipped and a connection to `External Entities` was shown on the graph.

### Changes in this PR

In this PR, I change Sensor to read the `ip_network` information (only if `address_data` is empty) and use that to decide whether an edge on the graph as internal, external, or not at all.

Moreover, if Collector is running with `ROX_ENABLE_EXTERNAL_IPS=true`, Sensor is now able to tell whether the connection is internal or external. Before, it relied fully on Collector reporting the IP as 255.255.255.255, which is not working when `ROX_ENABLE_EXTERNAL_IPS=true`.

Finally, I was able to spot one occurrence of both  `ip_network` and `address_data` reported from Collector empty:
```
# Both `ip_network` and `address_data` empty:
Debug: Incomming connection. Local: Port=6443, Addr=, Network=, Remote: Port=0, Addr=, Network=

# Showing a warning in the logs
Warn: Not showing flow on the network graph: unable to determine if flow is external or internal: remote has invalid IP address and invalid IP network address

# Few milliseconds later, the following flow arrives - I suspect that it is the same flow.
Debug: Incoming connection to container openshift-kube-apiserver/kube-apiserver from 35.191.2.235:6443. Marking it as 'External Entities' in the network graph.
```
In that case, I decided to return early and not show the connection without any IP on the graph. As shown above, shortly after that, there is another flow being reported that looks similar and more correct. That one will be included on the network graph.


## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added 

### N/A
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

I plan to add an e2e test that would be covering this in a followup. For now, I am waiting for #9745 to be merged (it should enable that test).

## Testing Performed

### Here I tell how I validated my change

- This happens only on OCP clusters (GKEs fully use `address_data`), so I deployed this manually onto an OCP cluster, enabled debug log in Sensor, enabled `ROX_ENABLE_EXTERNAL_IPS` in Collector, and analyzed Sensor logs manually. Additionally, I looked at the network graph and made sure that all looks as expected (internal vs. external).

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
