### PR TITLE
feat(scanv4): operator SecuredCluster fallback for scanner v4 pvc

### DIFF
--- a/operator/apis/platform/v1alpha1/common_types.go
+++ b/operator/apis/platform/v1alpha1/common_types.go
@@ -151,6 +151,14 @@ type ScannerV4DB struct {
 	DeploymentSpec `json:",inline"`
 }
 
+// GetPersistence returns the configured PVC
+func (sdb *ScannerV4DB) GetPersistence() *ScannerV4Persistence {
+	if sdb == nil {
+		return nil
+	}
+	return sdb.Persistence
+}
+
 // ScannerV4Persistence defines persistence settings for scanner V4.
 type ScannerV4Persistence struct {
 	// Uses a Kubernetes persistent volume claim (PVC) to manage the storage location of persistent data.
@@ -203,6 +211,16 @@ type ScannerV4PersistentVolumeClaim struct {
 	// class, you must select a value here.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Storage Class",order=3,xDescriptors={"urn:alm:descriptor:io.kubernetes:StorageClass"}
 	StorageClassName *string `json:"storageClassName,omitempty"`
+}
+
+// GetStorageClassName gets the StorageClassName string value
+// returns empty string if the object or the StorageClassName pointer is nil
+func (s *ScannerV4PersistentVolumeClaim) GetStorageClassName() string {
+	if s == nil || s.StorageClassName == nil {
+		return ""
+	}
+
+	return *s.StorageClassName
 }
 
 // ScannerComponentScaling defines replication settings of scanner components.

--- a/operator/apis/platform/v1alpha1/common_types.go
+++ b/operator/apis/platform/v1alpha1/common_types.go
@@ -223,6 +223,16 @@ func (s *ScannerV4PersistentVolumeClaim) GetStorageClassName() string {
 	return *s.StorageClassName
 }
 
+// GetClaimName gets the ClaimName string value
+// returns empty string if the object or the ClaimName pointer is nil
+func (s *ScannerV4PersistentVolumeClaim) GetClaimName() string {
+	if s == nil || s.ClaimName == nil {
+		return ""
+	}
+
+	return *s.ClaimName
+}
+
 // ScannerComponentScaling defines replication settings of scanner components.
 type ScannerComponentScaling struct {
 	// When enabled, the number of component replicas is managed dynamically based on the load, within the limits

--- a/operator/pkg/central/values/translation/translation.go
+++ b/operator/pkg/central/values/translation/translation.go
@@ -105,7 +105,7 @@ func (t Translator) translate(ctx context.Context, c platform.Central) (chartuti
 	}
 
 	if c.Spec.ScannerV4 != nil && features.ScannerV4Support.Enabled() {
-		v.AddChild("scannerV4", getCentralScannerV4ComponentValues(c.Spec.ScannerV4))
+		v.AddChild("scannerV4", getCentralScannerV4ComponentValues(ctx, c.Spec.ScannerV4, t.client))
 	}
 
 	v.AddChild("customize", &customize)
@@ -367,13 +367,12 @@ func getCentralScannerComponentValues(s *platform.ScannerComponentSpec) *transla
 	return &sv
 }
 
-func getCentralScannerV4ComponentValues(s *platform.ScannerV4ComponentSpec) *translation.ValuesBuilder {
+func getCentralScannerV4ComponentValues(ctx context.Context, s *platform.ScannerV4ComponentSpec, client ctrlClient.Client) *translation.ValuesBuilder {
 	sv := translation.NewValuesBuilder()
-
 	translation.SetScannerComponentDisableValue(&sv, s.ScannerComponent)
 	translation.SetScannerV4ComponentValues(&sv, "indexer", s.Indexer)
 	translation.SetScannerV4ComponentValues(&sv, "matcher", s.Matcher)
-	translation.SetScannerV4DBValues(&sv, s.DB)
+	translation.SetScannerV4DBValues(ctx, &sv, s.DB, platform.CentralGVK.Kind, client)
 
 	return &sv
 }

--- a/operator/pkg/central/values/translation/translation.go
+++ b/operator/pkg/central/values/translation/translation.go
@@ -105,7 +105,7 @@ func (t Translator) translate(ctx context.Context, c platform.Central) (chartuti
 	}
 
 	if c.Spec.ScannerV4 != nil && features.ScannerV4Support.Enabled() {
-		v.AddChild("scannerV4", getCentralScannerV4ComponentValues(ctx, c.Spec.ScannerV4, t.client))
+		v.AddChild("scannerV4", getCentralScannerV4ComponentValues(ctx, c.Spec.ScannerV4, c.GetNamespace(), t.client))
 	}
 
 	v.AddChild("customize", &customize)
@@ -367,12 +367,12 @@ func getCentralScannerComponentValues(s *platform.ScannerComponentSpec) *transla
 	return &sv
 }
 
-func getCentralScannerV4ComponentValues(ctx context.Context, s *platform.ScannerV4ComponentSpec, client ctrlClient.Client) *translation.ValuesBuilder {
+func getCentralScannerV4ComponentValues(ctx context.Context, s *platform.ScannerV4ComponentSpec, namespace string, client ctrlClient.Client) *translation.ValuesBuilder {
 	sv := translation.NewValuesBuilder()
 	translation.SetScannerComponentDisableValue(&sv, s.ScannerComponent)
 	translation.SetScannerV4ComponentValues(&sv, "indexer", s.Indexer)
 	translation.SetScannerV4ComponentValues(&sv, "matcher", s.Matcher)
-	translation.SetScannerV4DBValues(ctx, &sv, s.DB, platform.CentralGVK.Kind, client)
+	translation.SetScannerV4DBValues(ctx, &sv, s.DB, platform.CentralGVK.Kind, namespace, client)
 
 	return &sv
 }

--- a/operator/pkg/securedcluster/values/translation/translation.go
+++ b/operator/pkg/securedcluster/values/translation/translation.go
@@ -120,7 +120,7 @@ func (t Translator) translate(ctx context.Context, sc platform.SecuredCluster) (
 
 	v.AddChild("scanner", t.getLocalScannerComponentValues(sc, scannerAutoSenseConfig))
 	if sc.Spec.ScannerV4 != nil && features.ScannerV4Support.Enabled() {
-		v.AddChild("scannerV4", t.getLocalScannerV4ComponentValues(sc, scannerV4AutoSenseConfig))
+		v.AddChild("scannerV4", t.getLocalScannerV4ComponentValues(ctx, sc, scannerV4AutoSenseConfig))
 	}
 
 	customize.AddAllFrom(translation.GetCustomize(sc.Spec.Customize))
@@ -362,13 +362,13 @@ func (t Translator) getLocalScannerComponentValues(securedCluster platform.Secur
 	return &sv
 }
 
-func (t Translator) getLocalScannerV4ComponentValues(securedCluster platform.SecuredCluster, config scanner.AutoSenseResult) *translation.ValuesBuilder {
+func (t Translator) getLocalScannerV4ComponentValues(ctx context.Context, securedCluster platform.SecuredCluster, config scanner.AutoSenseResult) *translation.ValuesBuilder {
 	sv := translation.NewValuesBuilder()
 	s := securedCluster.Spec.ScannerV4
 	sv.SetBoolValue("disable", !config.DeployScannerResources)
 
 	translation.SetScannerV4ComponentValues(&sv, "indexer", s.Indexer)
-	translation.SetScannerV4DBValues(&sv, s.DB)
+	translation.SetScannerV4DBValues(ctx, &sv, s.DB, platform.SecuredClusterGVK.Kind, t.client)
 
 	return &sv
 }

--- a/operator/pkg/securedcluster/values/translation/translation.go
+++ b/operator/pkg/securedcluster/values/translation/translation.go
@@ -368,7 +368,7 @@ func (t Translator) getLocalScannerV4ComponentValues(ctx context.Context, secure
 	sv.SetBoolValue("disable", !config.DeployScannerResources)
 
 	translation.SetScannerV4ComponentValues(&sv, "indexer", s.Indexer)
-	translation.SetScannerV4DBValues(ctx, &sv, s.DB, platform.SecuredClusterGVK.Kind, t.client)
+	translation.SetScannerV4DBValues(ctx, &sv, s.DB, platform.SecuredClusterGVK.Kind, securedCluster.GetNamespace(), t.client)
 
 	return &sv
 }

--- a/operator/pkg/securedcluster/values/translation/translation_test.go
+++ b/operator/pkg/securedcluster/values/translation/translation_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"helm.sh/helm/v3/pkg/chartutil"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -48,7 +49,7 @@ func (s *TranslationTestSuite) TestImageOverrides() {
 	u, err := toUnstructured(obj)
 	s.Require().NoError(err)
 
-	translator := Translator{client: newFakeClientWithInitBundle(s.T())}
+	translator := Translator{client: newDefaultFakeClient(s.T())}
 
 	vals, err := translator.Translate(context.Background(), u)
 	s.Require().NoError(err)
@@ -89,7 +90,7 @@ func TestTranslateShouldCreateConfigFingerprint(t *testing.T) {
 	u, err := toUnstructured(sc)
 	require.NoError(t, err)
 
-	translator := Translator{client: newFakeClientWithInitBundle(t)}
+	translator := Translator{client: newDefaultFakeClient(t)}
 	vals, err := translator.Translate(context.Background(), u)
 	require.NoError(t, err)
 
@@ -118,7 +119,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 	}{
 		"minimal spec": {
 			args: args{
-				client: newFakeClientWithInitBundle(t),
+				client: newDefaultFakeClient(t),
 				sc: platform.SecuredCluster{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "stackrox"},
 					Spec: platform.SecuredClusterSpec{
@@ -158,7 +159,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 		},
 		"local scanner autosense suppression": {
 			args: args{
-				client: newFakeClientWithInitBundleAndCentral(t),
+				client: newDefaultFakeClientWithCentral(t),
 				sc: platform.SecuredCluster{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "stackrox"},
 					Spec: platform.SecuredClusterSpec{
@@ -197,9 +198,55 @@ func (s *TranslationTestSuite) TestTranslate() {
 				},
 			},
 		},
+		"scannerV4.db.persistence.none for scanner v4 db without default StorageClass": {
+			args: args{
+				// no default storage class in this fake client, so we expect to default to scannerV4.db.persistence.none
+				client: newDefaultFakeClientWithoutStorageClass(t),
+				sc: platform.SecuredCluster{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "stackrox"},
+					Spec: platform.SecuredClusterSpec{
+						ClusterName: "test-cluster",
+					},
+				},
+			},
+			want: chartutil.Values{
+				"clusterName":   "test-cluster",
+				"ca":            map[string]string{"cert": "ca central content"},
+				"createSecrets": false,
+				"admissionControl": map[string]interface{}{
+					"dynamic": map[string]interface{}{
+						"enforceOnCreates": true,
+						"enforceOnUpdates": true,
+					},
+					"listenOnCreates": true,
+					"listenOnUpdates": true,
+				},
+				"scanner": map[string]interface{}{
+					"disable": false,
+				},
+				"sensor": map[string]interface{}{
+					"localImageScanning": map[string]interface{}{
+						"enabled": "true",
+					},
+				},
+				"monitoring": map[string]interface{}{
+					"openshift": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+				"scannerV4": map[string]interface{}{
+					"disable": false,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"none": true,
+						},
+					},
+				},
+			},
+		},
 		"local scanner autosense no suppression": {
 			args: args{
-				client: newFakeClientWithInitBundle(t),
+				client: newDefaultFakeClient(t),
 				sc: platform.SecuredCluster{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "stackrox"},
 					Spec: platform.SecuredClusterSpec{
@@ -239,7 +286,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 		},
 		"complete spec": {
 			args: args{
-				client: newFakeClientWithInitBundle(t),
+				client: newDefaultFakeClient(t),
 				sc: platform.SecuredCluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-secured-cluster",
@@ -408,7 +455,8 @@ func (s *TranslationTestSuite) TestTranslate() {
 							DB: &platform.ScannerV4DB{
 								Persistence: &platform.ScannerV4Persistence{
 									PersistentVolumeClaim: &platform.ScannerV4PersistentVolumeClaim{
-										ClaimName: pointer.String("scanner-v4-db-pvc"),
+										ClaimName:        pointer.String("scanner-v4-db-pvc"),
+										StorageClassName: pointer.String("test-sc1"),
 									},
 								},
 								DeploymentSpec: platform.DeploymentSpec{
@@ -645,8 +693,9 @@ func (s *TranslationTestSuite) TestTranslate() {
 						},
 						"persistence": map[string]interface{}{
 							"persistentVolumeClaim": map[string]interface{}{
-								"claimName":   "scanner-v4-db-pvc",
-								"createClaim": true,
+								"claimName":    "scanner-v4-db-pvc",
+								"createClaim":  true,
+								"storageClass": "test-sc1",
 							},
 						},
 					},
@@ -695,7 +744,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 		},
 		"translate EBPF to CORE_BPF": {
 			args: args{
-				client: newFakeClientWithInitBundle(t),
+				client: newDefaultFakeClient(t),
 				sc: platform.SecuredCluster{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "stackrox"},
 					Spec: platform.SecuredClusterSpec{
@@ -745,7 +794,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 		},
 		"force EBPF": {
 			args: args{
-				client: newFakeClientWithInitBundle(t),
+				client: newDefaultFakeClient(t),
 				sc: platform.SecuredCluster{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "stackrox"},
 					Spec: platform.SecuredClusterSpec{
@@ -826,26 +875,43 @@ func toUnstructured(sc platform.SecuredCluster) (*unstructured.Unstructured, err
 	return &unstructured.Unstructured{Object: obj}, nil
 }
 
-func newFakeClientWithInitBundle(t *testing.T) ctrlClient.Client {
-	return testutils.NewFakeClientBuilder(t,
-		createSecret(sensorTLSSecretName),
-		createSecret(collectorTLSSecretName),
-		createSecret(admissionControlTLSSecretName),
-		testutils.ValidClusterVersion).Build()
+var defaultObjects = []ctrlClient.Object{
+	createSecret(sensorTLSSecretName),
+	createSecret(collectorTLSSecretName),
+	createSecret(admissionControlTLSSecretName),
+	testutils.ValidClusterVersion,
 }
 
-func newFakeClientWithInitBundleAndCentral(t *testing.T) ctrlClient.Client {
-	return testutils.NewFakeClientBuilder(t,
-		createSecret(sensorTLSSecretName),
-		createSecret(collectorTLSSecretName),
-		createSecret(admissionControlTLSSecretName),
-		testutils.ValidClusterVersion,
-		&platform.Central{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "a-central",
-				Namespace: "stackrox",
-			},
-		}).Build()
+var defaultStorageClasses = []ctrlClient.Object{
+	&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{
+		Name: "test-sc1",
+	}},
+	&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{
+		Name: "test-sc2",
+		Annotations: map[string]string{
+			translation.DefaultStorageClassAnnotationKey: "true",
+		},
+	}},
+}
+
+func newDefaultFakeClient(t *testing.T) ctrlClient.Client {
+	objects := append(defaultObjects, defaultStorageClasses...)
+	return testutils.NewFakeClientBuilder(t, objects...).Build()
+}
+
+func newDefaultFakeClientWithCentral(t *testing.T) ctrlClient.Client {
+	objects := append(defaultObjects, defaultStorageClasses...)
+	objects = append(objects, &platform.Central{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "a-central",
+			Namespace: "stackrox",
+		},
+	})
+	return testutils.NewFakeClientBuilder(t, objects...).Build()
+}
+
+func newDefaultFakeClientWithoutStorageClass(t *testing.T) ctrlClient.Client {
+	return testutils.NewFakeClientBuilder(t, defaultObjects...).Build()
 }
 
 func createSecret(name string) *v1.Secret {

--- a/operator/pkg/securedcluster/values/translation/translation_test.go
+++ b/operator/pkg/securedcluster/values/translation/translation_test.go
@@ -144,6 +144,13 @@ func (s *TranslationTestSuite) TestTranslate() {
 				},
 				"scannerV4": map[string]interface{}{
 					"disable": false,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": true,
+							},
+						},
+					},
 				},
 				"sensor": map[string]interface{}{
 					"localImageScanning": map[string]string{
@@ -195,6 +202,13 @@ func (s *TranslationTestSuite) TestTranslate() {
 				},
 				"scannerV4": map[string]interface{}{
 					"disable": true,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": true,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -271,6 +285,13 @@ func (s *TranslationTestSuite) TestTranslate() {
 				},
 				"scannerV4": map[string]interface{}{
 					"disable": false,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": true,
+							},
+						},
+					},
 				},
 				"sensor": map[string]interface{}{
 					"localImageScanning": map[string]string{
@@ -779,6 +800,13 @@ func (s *TranslationTestSuite) TestTranslate() {
 				},
 				"scannerV4": map[string]interface{}{
 					"disable": false,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": true,
+							},
+						},
+					},
 				},
 				"sensor": map[string]interface{}{
 					"localImageScanning": map[string]string{
@@ -830,6 +858,13 @@ func (s *TranslationTestSuite) TestTranslate() {
 				},
 				"scannerV4": map[string]interface{}{
 					"disable": false,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": true,
+							},
+						},
+					},
 				},
 				"sensor": map[string]interface{}{
 					"localImageScanning": map[string]string{

--- a/operator/pkg/values/translation/translation.go
+++ b/operator/pkg/values/translation/translation.go
@@ -232,20 +232,6 @@ func setScannerV4DBPersistence(sv *ValuesBuilder, persistence *platform.ScannerV
 	sv.AddChild("persistence", &persistenceVB)
 }
 
-func scannerV4PVCValuesBuilder(pvc *platform.ScannerV4PersistentVolumeClaim) ValuesBuilder {
-	pvcBuilder := NewValuesBuilder()
-	if pvc == nil {
-		return pvcBuilder
-	}
-
-	pvcBuilder.SetString("claimName", pvc.ClaimName)
-	pvcBuilder.SetBool("createClaim", pointer.Bool(true))
-	pvcBuilder.SetString("storageClass", pvc.StorageClassName)
-	pvcBuilder.SetString("size", pvc.Size)
-
-	return pvcBuilder
-}
-
 func shouldUseEmptyDir(ctx context.Context, objKind string, db *platform.ScannerV4DB, client ctrlClient.Client) (bool, error) {
 	if objKind != v1alpha1.SecuredClusterGVK.Kind {
 		return false, nil

--- a/operator/pkg/values/translation/translation.go
+++ b/operator/pkg/values/translation/translation.go
@@ -238,7 +238,8 @@ func shouldUseEmptyDir(ctx context.Context, objKind string, db *platform.Scanner
 	}
 
 	storageClassDefined := db != nil && db.Persistence != nil &&
-		db.Persistence.PersistentVolumeClaim != nil && db.Persistence.PersistentVolumeClaim.StorageClassName != nil &&
+		db.Persistence.PersistentVolumeClaim != nil &&
+		db.Persistence.PersistentVolumeClaim.StorageClassName != nil &&
 		*db.Persistence.PersistentVolumeClaim.StorageClassName != ""
 	if storageClassDefined {
 		return false, nil

--- a/operator/pkg/values/translation/translation.go
+++ b/operator/pkg/values/translation/translation.go
@@ -167,6 +167,8 @@ func SetScannerDBValues(sv *ValuesBuilder, db *platform.DeploymentSpec) {
 }
 
 // SetScannerV4DBValues sets values in "sv" based on "db"
+// In case of translating a secured cluster it checks for a default storage class
+// if none is found it sets appropriate values to use an emptyDir.
 // Unlike central-db's PVC we don't use the extension.ReconcilePVCExtension.
 // The operator creates this PVC through the helm chart. This means it is managed
 // by the default helm lifecycle, instead of the operator extension. The difference is
@@ -198,7 +200,6 @@ func SetScannerV4DBValues(ctx context.Context, sv *ValuesBuilder, db *platform.S
 	dbVB.AddChild(ResourcesKey, GetResources(db.Resources))
 	dbVB.AddAllFrom(GetTolerations(TolerationsKey, db.Tolerations))
 	setScannerV4DBPersistence(&dbVB, db.Persistence)
-	dbVB.AddChild("persistence", &persistenceVB)
 	sv.AddChild("db", &dbVB)
 }
 

--- a/operator/pkg/values/translation/translation_test.go
+++ b/operator/pkg/values/translation/translation_test.go
@@ -428,7 +428,7 @@ func TestSetScannerV4DBValues(t *testing.T) {
 			kind: platform.CentralGVK.Kind,
 			want: chartutil.Values{},
 		},
-		"empty for securedcluster default with default StorageClass": {
+		"createClaim for securedcluster default with default StorageClass": {
 			db:   &platform.ScannerV4DB{},
 			kind: platform.SecuredClusterGVK.Kind,
 			fakeObjects: []runtime.Object{
@@ -446,7 +446,15 @@ func TestSetScannerV4DBValues(t *testing.T) {
 					},
 				},
 			},
-			want: chartutil.Values{},
+			want: chartutil.Values{
+				"db": map[string]interface{}{
+					"persistence": map[string]interface{}{
+						"persistentVolumeClaim": map[string]interface{}{
+							"createClaim": true,
+						},
+					},
+				},
+			},
 		},
 		"db.persistence.none for securedcluster default without default StorageClass": {
 			db:   &platform.ScannerV4DB{},

--- a/operator/pkg/values/translation/translation_test.go
+++ b/operator/pkg/values/translation/translation_test.go
@@ -604,7 +604,7 @@ func TestSetScannerV4DBValues(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			vb := NewValuesBuilder()
 			client := fkClient.NewFakeClient(tt.fakeObjects...)
-			SetScannerV4DBValues(context.Background(), &vb, tt.db, tt.kind, client)
+			SetScannerV4DBValues(context.Background(), &vb, tt.db, tt.kind, "test-namespace", client)
 			values, err := vb.Build()
 			if tt.wantErr {
 				require.NotNil(t, err)


### PR DESCRIPTION
## Description

Change SecuredCluster value translation to set `scannerV4.db.persistence.none = true` for scanner v4 DB if no default storage class is available which will instruct the helm chart to use an emptyDir volume.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

On an infractl ocp:

```
# oc login to the cluster
# running with nightly images for other components
export tag=4.3.x-nightly-20240205
export RELATED_IMAGE_SCANNER_V4_MATCHER=quay.io/rhacs-eng/scanner-v4:$tag
export RELATED_IMAGE_SCANNER_V4_INDEXER=quay.io/rhacs-eng/scanner-v4:$tag
export RELATED_IMAGE_SCANNER_V4_DB=quay.io/rhacs-eng/scanner-v4-db:$tag 
export RELATED_IMAGE_SCANNER=quay.io/rhacs-eng/scanner:$tag
export RELATED_IMAGE_SCANNER_DB=quay.io/rhacs-eng/scanner-db:$tag
export RELATED_IMAGE_MAIN=quay.io/rhacs-eng/main:$tag
export RELATED_IMAGE_CENTRAL_DB=quay.io/rhacs-eng/central-db:$tag
export RELATED_IMAGE_COLLECTOR=quay.io/rhacs-eng/collector:$tag
export RELATED_IMAGE_SCANNER_SLIM=quay.io/rhacs-eng/scanner-slim:$tag
export RELATED_IMAGE_SCANNER_DB_SLIM=quay.io/rhacs-eng/scanner-db-slim:$tag
export MAIN_IMAGE_TAG=$tag
export IMAGE_REGISTRY=quay.io
export IMAGE_REPO=quay.io/rhacs-eng

cd operator
make install run

# deploy central
k create ns stackrox
k apply -n stackrox -f tests/common/central-cr.yaml
# expose central via routes
k patch central -n stackrox stackrox-central-services -p '{"spec":{"central":{"exposure":{"route":{"enabled":true}}}}}' --type=merge

k get routes 
NAME           HOST/PORT                                                     PATH   SERVICES   PORT    TERMINATION   WILDCARD
central        central-stackrox.apps.jm-sc4-emptydir.ocp.infra.rox.systems          central    https   passthrough   None
central-mtls   central.stackrox                                                     central    https   passthrough   None

# create a init bundle via central UI use the first host above
# apply your init bundle to a seperate secured cluster namespace
k create ns secured-cluster
k apply -n secured-cluster -f <path-to-inti-secrets>

# Apply the secured cluster since there is a default storage class,
# it should start with a PVC for scanner-v4-db in this config
k apply -n secured-cluster -f tests/common/secured-cluster-cr.yaml 

# Set correct central endpoint:
k patch -n secured-cluster securedcluster stackrox-secured-cluster-services --type=merge -p '{"spec":{"centralEndpoint": "central-stackrox.apps.jm-sc4-emptydir.ocp.infra.rox.systems:443"}}'

# Wait for component to be up
k get pods -n secured-cluster
NAME                                  READY   STATUS    RESTARTS   AGE
admission-control-674495cd46-lzpwh    1/1     Running   0          6m41s
admission-control-674495cd46-mc2rx    1/1     Running   0          6m41s
admission-control-674495cd46-zjpr9    1/1     Running   0          6m41s
collector-2tw5m                       3/3     Running   0          6m41s
collector-7cx4w                       3/3     Running   0          6m41s
collector-gvpnv                       3/3     Running   0          6m41s
collector-wd5hm                       3/3     Running   0          6m41s
collector-zc8kl                       3/3     Running   0          6m41s
scanner-768bc59d9b-kkw4w              1/1     Running   0          6m41s
scanner-768bc59d9b-lz76n              1/1     Running   0          6m41s
scanner-768bc59d9b-tvj8w              1/1     Running   0          6m41s
scanner-db-5f9f465964-6tln2           1/1     Running   0          6m40s
scanner-v4-db-5b4d95c749-npwq8        1/1     Running   0          6m41s
scanner-v4-indexer-7fd76447bb-btxbz   1/1     Running   0          6m41s
scanner-v4-indexer-7fd76447bb-f4czb   1/1     Running   0          6m41s
sensor-787b46f6f-mgn8k                1/1     Running   0          72s

# make sure PVC was created
NAME            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
scanner-v4-db   Bound    pvc-5d3fd3c7-db81-4d8e-b83f-1e07053bb572   10Gi       RWO            standard-csi   5m45s

# delete the secured-cluster again
k delete -n secured-cluster securedcluster stackrox-secured-cluster-services 

# set the annotation on default storage class to false
k annotate sc standard-csi "storageclass.kubernetes.io/is-default-class=false" --overwrite

# install secured cluster again
k apply -n secured-cluster -f tests/common/secured-cluster-cr.yaml

# verify no pvc created
k get pvc -n secured-cluster 
No resources found in secured-cluster namespace.

# Verify pods are running
k get pods -n secured-cluster
NAME                                  READY   STATUS    RESTARTS   AGE
admission-control-77b78589d4-6bbtl    1/1     Running   0          74s
admission-control-77b78589d4-6rz56    1/1     Running   0          74s
admission-control-77b78589d4-8m4mk    1/1     Running   0          74s
collector-47q2v                       3/3     Running   0          75s
collector-4qntd                       3/3     Running   0          75s
collector-4sppc                       3/3     Running   0          75s
collector-mcmcv                       3/3     Running   0          75s
collector-tschl                       3/3     Running   0          75s
scanner-768bc59d9b-9tbqr              1/1     Running   0          74s
scanner-768bc59d9b-jmlnp              1/1     Running   0          74s
scanner-768bc59d9b-rnhr4              1/1     Running   0          74s
scanner-db-5f9f465964-6mgn4           1/1     Running   0          75s
scanner-v4-db-6fb9f45dbb-s8bqt        1/1     Running   0          75s
scanner-v4-indexer-7fd76447bb-clxht   1/1     Running   0          74s
scanner-v4-indexer-7fd76447bb-m7lbr   1/1     Running   0          75s
sensor-6f6986c46d-89s2s               1/1     Running   0          74s

# verify scanner v4 is using empty dir
k get pods -n secured-cluster scanner-v4-db-6fb9f45dbb-s8bqt -o yaml | grep volumes -A 20
  volumes:
  - emptyDir: {}
    name: disk
  - configMap:
      defaultMode: 420
      name: scanner-v4-db-config
    name: config-volume
  - name: scanner-db-tls-volume
    secret:
      defaultMode: 416
      items:
      - key: cert.pem
        path: server.crt
      - key: key.pem
        path: server.key
      - key: ca.pem
        path: root.crt
      secretName: scanner-v4-db-tls
  - emptyDir:
      medium: Memory
      sizeLimit: 250Mi
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
