### PR TITLE
ROX-22205: compliance configuration validation

### DIFF
--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -74,6 +74,10 @@ func (s *serviceImpl) CreateComplianceScanConfiguration(ctx context.Context, req
 		return nil, errors.Wrap(errox.InvalidArgs, "Scan configuration name is required")
 	}
 
+	if err := validateScanConfiguration(req); err != nil {
+		return nil, err
+	}
+
 	// Convert to storage type
 	scanConfig := convertV2ScanConfigToStorage(ctx, req)
 
@@ -93,6 +97,10 @@ func (s *serviceImpl) CreateComplianceScanConfiguration(ctx context.Context, req
 func (s *serviceImpl) UpdateComplianceScanConfiguration(ctx context.Context, req *v2.ComplianceScanConfiguration) (*v2.Empty, error) {
 	if req.GetId() == "" {
 		return nil, errors.Wrap(errox.InvalidArgs, "Scan configuration ID is required")
+	}
+
+	if err := validateScanConfiguration(req); err != nil {
+		return nil, err
 	}
 
 	// Convert to storage type
@@ -186,4 +194,16 @@ func (s *serviceImpl) RunComplianceScanConfiguration(ctx context.Context, reques
 
 	err := s.manager.ProcessRescanRequest(ctx, request.GetId())
 	return &v2.Empty{}, err
+}
+
+func validateScanConfiguration(req *v2.ComplianceScanConfiguration) error {
+	if len(req.GetClusters()) == 0 {
+		return errors.Wrap(errox.InvalidArgs, "At least one cluster is required for a scan configuration")
+	}
+
+	if req.GetScanConfig() == nil || len(req.GetScanConfig().GetProfiles()) == 0 {
+		return errors.Wrap(errox.InvalidArgs, "At least one profile is required for a scan configuration")
+	}
+
+	return nil
 }

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
@@ -123,6 +123,28 @@ func (s *ComplianceScanConfigServiceTestSuite) TestCreateComplianceScanConfigura
 	// ID will be added to the record and returned.  Add it to the validation object
 	request.Id = uuid.NewDummy().String()
 	s.Require().Equal(request, config)
+
+	// reset for error testing
+	request = getTestAPIRec()
+	request.ScanConfig = nil
+	config, err = s.service.CreateComplianceScanConfiguration(allAccessContext, request)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "At least one profile is required for a scan configuration")
+	s.Require().Nil(config)
+
+	request = getTestAPIRec()
+	request.Clusters = []string{}
+	config, err = s.service.CreateComplianceScanConfiguration(allAccessContext, request)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "At least one cluster is required for a scan configuration")
+	s.Require().Nil(config)
+
+	request = getTestAPIRec()
+	request.ScanConfig.Profiles = []string{}
+	config, err = s.service.CreateComplianceScanConfiguration(allAccessContext, request)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "At least one profile is required for a scan configuration")
+	s.Require().Nil(config)
 }
 
 func (s *ComplianceScanConfigServiceTestSuite) TestUpdateComplianceScanConfiguration() {
@@ -143,6 +165,30 @@ func (s *ComplianceScanConfigServiceTestSuite) TestUpdateComplianceScanConfigura
 	_, err = s.service.UpdateComplianceScanConfiguration(allAccessContext, request)
 	s.Require().Error(err)
 	s.Require().Contains(err.Error(), "Scan configuration ID is required: invalid arguments")
+
+	// Test Case 3: No ScanConfig
+	request = getTestAPIRec()
+	request.Id = uuid.NewDummy().String()
+	request.ScanConfig = nil
+	_, err = s.service.UpdateComplianceScanConfiguration(allAccessContext, request)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "At least one profile is required for a scan configuration")
+
+	// Test Case 4: No clusters
+	request = getTestAPIRec()
+	request.Id = uuid.NewDummy().String()
+	request.Clusters = []string{}
+	_, err = s.service.UpdateComplianceScanConfiguration(allAccessContext, request)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "At least one cluster is required for a scan configuration")
+
+	// Test Case 5: No profiles
+	request = getTestAPIRec()
+	request.Id = uuid.NewDummy().String()
+	request.ScanConfig.Profiles = []string{}
+	_, err = s.service.UpdateComplianceScanConfiguration(allAccessContext, request)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "At least one profile is required for a scan configuration")
 }
 
 func (s *ComplianceScanConfigServiceTestSuite) TestDeleteComplianceScanConfiguration() {


### PR DESCRIPTION
## Description

Validate that the compliance scan configuration has clusters and profiles associated with it.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Added UT.  Also tested locally to verify 
```
dashrews-mac:stackrox dashrews$ roxcurl /v2/compliance/scan/configurations -d '{"scanName":"shrewstest6","scanConfig":{"profiles":["rhcos4-moderate"],"oneTimeScan":false,"scanSchedule":{"intervalType":"DAILY","hour":0,"minute":0},"description":"testing"}}' -u admin:****** | json_pp
{
   "code" : 3,
   "details" : [],
   "error" : "At least one cluster is required for a scan configuration: invalid arguments",
   "message" : "At least one cluster is required for a scan configuration: invalid arguments"
}
dashrews-mac:stackrox dashrews$ roxcurl /v2/compliance/scan/configurations -d '{"scanName":"shrewstest6","clusters":["93348685-0910-43d3-a6f8-c384414f7ad0"],"scanConfig":{"oneTimeScan":false,"scanSchedule":{"intervalType":"DAILY","hour":0,"minute":0},"description":"testing"}}' -u admin:******* | json_pp
{
   "code" : 3,
   "details" : [],
   "error" : "At least one profile is required for a scan configuration: invalid arguments",
   "message" : "At least one profile is required for a scan configuration: invalid arguments"
}
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
