### PR TITLE
ROX-22203: Fix "Verify intra-cluster connection via internal IP"

### DIFF
--- a/qa-tests-backend/src/main/groovy/common/Constants.groovy
+++ b/qa-tests-backend/src/main/groovy/common/Constants.groovy
@@ -38,6 +38,7 @@ class Constants {
             "OpenShift: Advanced Cluster Security Central Admin Secret Accessed"
     ]
     static final INTERNET_EXTERNAL_SOURCE_ID = "afa12424-bde3-4313-b810-bb463cbe8f90" // pkg/networkgraph/constants.go
+    static final INTERNAL_ENTITIES_SOURCE_ID = "ada12424-bde3-4313-b810-bb463cbe8f90" // pkg/networkgraph/constants.go
     static final STACKROX_ANNOTATION_TRUNCATION_LENGTH = 254
     static final CORE_IMAGE_INTEGRATION_NAME = "core quay"
     // Padding required for test feature timeouts. This is used to configure the

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -613,10 +613,10 @@ class NetworkFlowTest extends BaseSpecification {
         "Check for edge in network graph"
         withRetry(2, 10) {
             log.info "Checking for edge from internal to ${NGINXCONNECTIONTARGET} using its external address"
-            List<Edge> edgesToExternalSource = NetworkGraphUtil.checkForEdge(
-                    Constants.INTERNET_EXTERNAL_SOURCE_ID,
+            List<Edge> edgesToInternalEntities = NetworkGraphUtil.checkForEdge(
+                    Constants.INTERNAL_ENTITIES_SOURCE_ID,
                     deploymentUid, null, 180)
-            assert edgesToExternalSource
+            assert edgesToInternalEntities
         }
 
         cleanup:

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -582,7 +582,7 @@ class NetworkFlowTest extends BaseSpecification {
     }
 
     @Tag("NetworkFlowVisualization")
-    def "Verify intra-cluster connection via external IP"() {
+    def "Verify intra-cluster connection via internal IP"() {
         // We changed the test to reflect the NetworkGraph's current behavior. Communication between two deployments
         // through a LoadBalancer shows an edge from 'External Entities', not an edge between the two deployments.
         // ROX-17936 should address whether we revert to the old behavior or we maintain this new behavior.


### PR DESCRIPTION
## Description

Introducing "Internal Entities" required to update one assertion. It was missed on the PR as the check was not executed.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- CI - [link](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/9723/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1753847053257019392)

![Screenshot 2024-02-05 at 09 02 16](https://github.com/stackrox/stackrox/assets/114479/9512826d-3c32-4c01-8aae-9922bc6ae693)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
