### PR TITLE
ROX-22192: Remove location field tooltip when value is present

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocationTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocationTd.tsx
@@ -13,7 +13,7 @@ function ComponentLocationTd({ location, source }: ComponentLocationTdProps) {
     return (
         <Flex spaceItems={{ default: 'spaceItemsXs' }} alignItems={{ default: 'alignItemsCenter' }}>
             <Truncate content={location || 'N/A'} position="middle" />
-            {source === 'OS' && (
+            {source === 'OS' && location === '' && (
                 <Tooltip content="Location is unavailable for operating system packages">
                     <InfoCircleIcon color="var(--pf-global--info-color--100)" />
                 </Tooltip>


### PR DESCRIPTION
## Description

Before Scanner v4, `location` was always an empty string when the source was "OS". Now, we can have both 🎉 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

View a CVE with a source of `"OS"` and a non-empty location:
![image](https://github.com/stackrox/stackrox/assets/1292638/6e1d4c2b-13a1-48fd-bf7b-127b68f9808d)
