### PR TITLE
ROX-22193: Use Admin role for access to cluster init bundles

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpirationWidget.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpirationWidget.tsx
@@ -1,5 +1,8 @@
-import { Flex, FlexItem } from '@patternfly/react-core';
 import React from 'react';
+import { Flex, FlexItem } from '@patternfly/react-core';
+
+import useAuthStatus from 'hooks/useAuthStatus';
+
 import { ClusterStatus } from '../clusterTypes';
 import CredentialExpiration from './CredentialExpiration';
 import CredentialInteraction from './CredentialInteraction';
@@ -18,6 +21,9 @@ const CredentialExpirationWidget = ({
     status,
     isManagerTypeNonConfigurable,
 }: CredentialExpirationWidgetProps) => {
+    const { currentUser } = useAuthStatus();
+    const hasAdminRole = Boolean(currentUser?.userInfo?.roles.some(({ name }) => name === 'Admin')); // optional chaining just in case of the unexpected
+
     const certExpiryStatus = status?.certExpiryStatus;
     const currentDatetime = new Date();
     // Secured cluster is healthy or has no expiration info => no interaction
@@ -34,9 +40,11 @@ const CredentialExpirationWidget = ({
                 <FlexItem>
                     <CredentialExpiration certExpiryStatus={certExpiryStatus} />
                 </FlexItem>
-                <FlexItem>
-                    <ManageTokensButton />
-                </FlexItem>
+                {hasAdminRole && (
+                    <FlexItem>
+                        <ManageTokensButton />
+                    </FlexItem>
+                )}
             </Flex>
         );
     }

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesRoute.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesRoute.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import qs from 'qs';
 
-import usePermissions from 'hooks/usePermissions';
+import useAuthStatus from 'hooks/useAuthStatus'; // TODO after 4.4 release
 
 import InitBundlePage from './InitBundlePage';
 import InitBundlesPage from './InitBundlesPage';
@@ -14,13 +14,19 @@ function hasCreateAction(search: string) {
 }
 
 function InitBundlesRoute(): ReactElement {
-    const { hasReadWriteAccess } = usePermissions();
-    // TODO replace resources with Admin role.
-    const hasWriteAccessForInitBundles =
-        hasReadWriteAccess('Administration') && hasReadWriteAccess('Integration');
+    const { currentUser } = useAuthStatus();
+    const hasAdminRole = Boolean(currentUser?.userInfo?.roles.some(({ name }) => name === 'Admin')); // optional chaining just in case of the unexpected
+    const hasWriteAccessForInitBundles = hasAdminRole; // TODO after 4.4 release becomes redundant
 
     const { search } = useLocation();
     const { id } = useParams(); // see clustersInitBundlesPathWithParam in routePaths.ts
+
+    /*
+    // TODO after 4.4 release
+    if (!hasAdminRole) {
+        return <NotFoundPage />; // factor out reusable component from Body.tsx file
+    }
+    */
 
     const isCreateAction = hasWriteAccessForInitBundles && hasCreateAction(search);
 

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -19,6 +19,7 @@ import { CloudSecurityIcon } from '@patternfly/react-icons';
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import { getProductBranding } from 'constants/productBranding';
+// import useAuthStatus from 'hooks/useAuthStatus'; // TODO after 4.4 release
 import useMetadata from 'hooks/useMetadata';
 import { fetchClusterInitBundles } from 'services/ClustersService';
 import { getVersionedDocs } from 'utils/versioning';
@@ -42,6 +43,12 @@ import { clustersBasePath, clustersInitBundlesPath } from 'routePaths';
  */
 
 function NoClustersPage(): ReactElement {
+    /*
+    // TODO after 4.4 release
+    const { currentUser } = useAuthStatus();
+    const hasAdminRole = Boolean(currentUser?.userInfo?.roles.some(({ name }) => name === 'Admin')); // optional chaining just in case of the unexpected
+    */
+
     // Use promise instead of useRestQuery hook because of role-based access control.
     const [errorMessage, setErrorMessage] = useState('');
     const [initBundlesCount, setInitBundlesCount] = useState(0);
@@ -53,6 +60,7 @@ function NoClustersPage(): ReactElement {
     const textForSuccessAlert = `You have successfully deployed a ${basePageTitle} platform. Now you can configure the clusters you want to secure.`;
 
     useEffect(() => {
+        // TODO after 4.4 release: if (hasAdminRole) {
         setIsLoading(true);
         fetchClusterInitBundles()
             .then(({ response }) => {
@@ -65,8 +73,10 @@ function NoClustersPage(): ReactElement {
             .finally(() => {
                 setIsLoading(false);
             });
-    }, []);
+        // TODO after 4.4 releaes: }
+    }, []); // TODO after 4.4 release [hasAdminRole]
 
+    // TODO after 4.4 release add hasAdminRole to conditional rendering.
     /* eslint-disable no-nested-ternary */
     return (
         <>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/AuthenticationTokensSection.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/AuthenticationTokensSection.tsx
@@ -1,19 +1,23 @@
 import React, { ReactElement } from 'react';
 
-import usePermissions from 'hooks/usePermissions';
+import useAuthStatus from 'hooks/useAuthStatus';
 
 import APITokensTile from './APITokensTile';
 import ClusterInitBundles from './ClusterInitBundlesTile';
 import IntegrationsSection from './IntegrationsSection';
 
 function AuthenticationTokensSection(): ReactElement {
-    const { hasReadAccess } = usePermissions();
-    const hasReadAccessForAdministration = hasReadAccess('Administration');
+    // TODO after 4.4 release:
+    // Delete ClusterInitBundles tile from integrations.
+    // Delete unreachable code.
+    // Delete request from integration sagas and data from integrations reducer.
+    const { currentUser } = useAuthStatus();
+    const hasAdminRole = Boolean(currentUser?.userInfo?.roles.some(({ name }) => name === 'Admin')); // optional chaining just in case of the unexpected
 
     return (
         <IntegrationsSection headerName="Authentication Tokens" id="token-integrations">
             <APITokensTile />
-            {hasReadAccessForAdministration && <ClusterInitBundles />}
+            {hasAdminRole && <ClusterInitBundles />}
         </IntegrationsSection>
     );
 }


### PR DESCRIPTION
## Description

Replace placeholder `'Administration'` resource with `'Admin'` role according to:
https://github.com/stackrox/stackrox/blob/master/central/clusterinit/service/service_impl.go#L21

Here is the code snippet:

```ts
    const { currentUser } = useAuthStatus();
    const hasAdminRole = Boolean(currentUser?.userInfo?.roles.some(({ name }) => name === 'Admin')); // optional chaining just in case of the unexpected
```

### Changes

1. Edit src/Containers/Clusters/Components/CredentialExpirationWidget.tsx
    * Add conditional rendering for `ManageTokensButton` element.
2. Do not (yet) rename src/Containers/Clusters/Components/ManageTokensButton.tsx
    * To minimize changes, if we need to revert this commit in case of emergency.
3. Edit src/Containers/Clusters/NoClustersPage.tsx
    * Write comments about possibility after 4.4 release to use `hasAdminRole` for request and conditional rendering, but not now to minimize risk. Oops, triple negative. Assume that it is likely only **Admin** role sees this page.
4. Edit src/Containers/Clusters/InitBundles/InitBundlesRoute.tsx
    * Use `hasAdminRole` for value of `hasWriteAccessForInitBundles` condition.
    * Write comments about possibility after 4.4 release to render `NotFoundPage` element if user does not have **Admin** role, but not now to minimize risk.
5. Edit src/Containers/Integrations/IntegrationTiles/AuthenticationTokensSection.tsx
    * Add conditional rendering of `ClusterInitBundles` element.
6. Do **not** edit src/routes: a role requirement for only one route seems like low benefit for the cost and risk.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_MOVE_INIT_BUNDLES_UI=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 0 = 3950281 - 3950281
        total: 898 = 10494726 - 10493828
    * `ls -al build/static/js/*.js | wc -l`
        0 = 92 - 92 files
3. `yarn start` in ui

### Manual testing

Monday