### PR TITLE
chore(fix): Be more lenient during initial DB connection

### DIFF
--- a/migrator/main.go
+++ b/migrator/main.go
@@ -135,7 +135,7 @@ func ensureDatabaseExists() error {
 	if !pgconfig.IsExternalDatabase() {
 		return retry.WithRetry(func() error {
 			return dbCheck(sourceMap, adminConfig)
-		}, retry.Tries(10), retry.BetweenAttempts(func(_ int) {
+		}, retry.Tries(60), retry.BetweenAttempts(func(_ int) {
 			time.Sleep(5 * time.Second)
 		}))
 	}


### PR DESCRIPTION
## Description

Try to access the database for a total of 5 minutes. This will help the tests fail less and give more leniency to the database start up time on installs and upgrades.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Trivial 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
