### PR TITLE
ROX-22068: simplify scanner-v4 setup script

### DIFF
--- a/image/templates/common/setup-scanner-v4.sh
+++ b/image/templates/common/setup-scanner-v4.sh
@@ -6,14 +6,4 @@
 KUBE_COMMAND=${KUBE_COMMAND:-{{.K8sConfig.Command}}}
 NAMESPACE="${ROX_NAMESPACE:-stackrox}"
 
-${KUBE_COMMAND} -n "$NAMESPACE" patch deploy/central --patch-file <(cat <<EOF
-spec:
-  template:
-    spec:
-      containers:
-      - name: central
-        env:
-        - name: "ROX_SCANNER_V4"
-          value: "true"
-EOF
-)
+${KUBE_COMMAND} -n "$NAMESPACE" set env deploy/central -c="central" ROX_SCANNER_V4=true


### PR DESCRIPTION
## Description

Follow-up to [this comment](https://github.com/stackrox/stackrox/pull/9642#discussion_r1476286530) by @dcaravel 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

I generated a manifest bundle using `roxctl` and deployed it to an infra cluster, and verified that:
* `ROX_SCANNER_V4=true` is set after the Scanner-v4 installation step
* the deployment is successful
### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
