### PR TITLE
fix(auth): use transaction during m2m config update / delete

### DIFF
--- a/central/auth/datastore/datastore.go
+++ b/central/auth/datastore/datastore.go
@@ -12,8 +12,7 @@ import (
 type DataStore interface {
 	GetAuthM2MConfig(ctx context.Context, id string) (*storage.AuthMachineToMachineConfig, bool, error)
 	ListAuthM2MConfigs(ctx context.Context) ([]*storage.AuthMachineToMachineConfig, error)
-	AddAuthM2MConfig(ctx context.Context, config *storage.AuthMachineToMachineConfig) (*storage.AuthMachineToMachineConfig, error)
-	UpdateAuthM2MConfig(ctx context.Context, config *storage.AuthMachineToMachineConfig) error
+	UpsertAuthM2MConfig(ctx context.Context, config *storage.AuthMachineToMachineConfig) (*storage.AuthMachineToMachineConfig, error)
 	RemoveAuthM2MConfig(ctx context.Context, id string) error
 
 	GetTokenExchanger(ctx context.Context, issuer string) (m2m.TokenExchanger, bool)

--- a/central/auth/datastore/datastore_impl.go
+++ b/central/auth/datastore/datastore_impl.go
@@ -48,7 +48,7 @@ func (d *datastoreImpl) listAuthM2MConfigsNoLock(ctx context.Context) ([]*storag
 }
 
 func (d *datastoreImpl) AddAuthM2MConfig(ctx context.Context, config *storage.AuthMachineToMachineConfig) (*storage.AuthMachineToMachineConfig, error) {
-	if err := sac.VerifyAuthzOK(accessSAC.ReadAllowed(ctx)); err != nil {
+	if err := sac.VerifyAuthzOK(accessSAC.WriteAllowed(ctx)); err != nil {
 		return nil, err
 	}
 
@@ -74,7 +74,7 @@ func (d *datastoreImpl) AddAuthM2MConfig(ctx context.Context, config *storage.Au
 }
 
 func (d *datastoreImpl) UpdateAuthM2MConfig(ctx context.Context, config *storage.AuthMachineToMachineConfig) error {
-	if err := sac.VerifyAuthzOK(accessSAC.ReadAllowed(ctx)); err != nil {
+	if err := sac.VerifyAuthzOK(accessSAC.WriteAllowed(ctx)); err != nil {
 		return err
 	}
 
@@ -125,7 +125,7 @@ func (d *datastoreImpl) GetTokenExchanger(ctx context.Context, issuer string) (m
 }
 
 func (d *datastoreImpl) RemoveAuthM2MConfig(ctx context.Context, id string) error {
-	if err := sac.VerifyAuthzOK(accessSAC.ReadAllowed(ctx)); err != nil {
+	if err := sac.VerifyAuthzOK(accessSAC.WriteAllowed(ctx)); err != nil {
 		return err
 	}
 
@@ -183,10 +183,10 @@ func (d *datastoreImpl) wrapRollback(ctx context.Context, tx *pgPkg.Tx, err erro
 
 	rollbackErr := tx.Rollback(ctx)
 	if exchangerErr != nil {
-		err = pkgErrors.Wrapf(exchangerErr, "rolling back due to exchanger error: %v", err)
+		err = pkgErrors.Wrapf(exchangerErr, "rolling back due to: %v", err)
 	}
 	if rollbackErr != nil {
-		err = pkgErrors.Wrapf(rollbackErr, "rolling back due to err: %v", err)
+		err = pkgErrors.Wrapf(rollbackErr, "rolling back due to: %v", err)
 	}
 
 	return err

--- a/central/auth/datastore/datastore_impl_test.go
+++ b/central/auth/datastore/datastore_impl_test.go
@@ -70,11 +70,10 @@ func (s *datastorePostgresTestSuite) SetupTest() {
 	s.addRoles()
 
 	s.mockSet = mocks.NewMockTokenExchangerSet(gomock.NewController(s.T()))
-	s.mockSet.EXPECT().UpsertTokenExchanger(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockSet.EXPECT().UpsertTokenExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	s.mockSet.EXPECT().RemoveTokenExchanger(gomock.Any()).Return(nil).AnyTimes()
 	s.mockSet.EXPECT().GetTokenExchanger(gomock.Any()).Return(nil, true).AnyTimes()
-	s.mockSet.EXPECT().RollbackExchanger(gomock.Any()).Return(nil).AnyTimes()
-	s.mockSet.EXPECT().NewTokenExchangerFromConfig(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	s.mockSet.EXPECT().RollbackExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	s.authDataStore = New(store, s.mockSet)
 }
 

--- a/central/auth/datastore/datastore_impl_test.go
+++ b/central/auth/datastore/datastore_impl_test.go
@@ -83,7 +83,7 @@ func (s *datastorePostgresTestSuite) TearDownTest() {
 }
 
 func (s *datastorePostgresTestSuite) TestAddFKConstraint() {
-	config, err := s.authDataStore.AddAuthM2MConfig(s.ctx, &storage.AuthMachineToMachineConfig{
+	config, err := s.authDataStore.UpsertAuthM2MConfig(s.ctx, &storage.AuthMachineToMachineConfig{
 		Id:                      "80c053c2-24a7-4b97-bd69-85b3a511241e",
 		Type:                    storage.AuthMachineToMachineConfig_GITHUB_ACTIONS,
 		TokenExpirationDuration: "5m",
@@ -100,7 +100,7 @@ func (s *datastorePostgresTestSuite) TestAddFKConstraint() {
 }
 
 func (s *datastorePostgresTestSuite) TestDeleteFKConstraint() {
-	config, err := s.authDataStore.AddAuthM2MConfig(s.ctx, &storage.AuthMachineToMachineConfig{
+	config, err := s.authDataStore.UpsertAuthM2MConfig(s.ctx, &storage.AuthMachineToMachineConfig{
 		Id:                      "80c053c2-24a7-4b97-bd69-85b3a511241e",
 		Type:                    storage.AuthMachineToMachineConfig_GITHUB_ACTIONS,
 		TokenExpirationDuration: "5m",
@@ -122,7 +122,7 @@ func (s *datastorePostgresTestSuite) TestDeleteFKConstraint() {
 }
 
 func (s *datastorePostgresTestSuite) TestAddUniqueIssuerConstraint() {
-	_, err := s.authDataStore.AddAuthM2MConfig(s.ctx, &storage.AuthMachineToMachineConfig{
+	_, err := s.authDataStore.UpsertAuthM2MConfig(s.ctx, &storage.AuthMachineToMachineConfig{
 		Id:                      "80c053c2-24a7-4b97-bd69-85b3a511241e",
 		Type:                    storage.AuthMachineToMachineConfig_GENERIC,
 		TokenExpirationDuration: "5m",
@@ -138,7 +138,7 @@ func (s *datastorePostgresTestSuite) TestAddUniqueIssuerConstraint() {
 
 	s.NoError(err)
 
-	_, err = s.authDataStore.AddAuthM2MConfig(s.ctx, &storage.AuthMachineToMachineConfig{
+	_, err = s.authDataStore.UpsertAuthM2MConfig(s.ctx, &storage.AuthMachineToMachineConfig{
 		Id:                      "12c153c2-24a7-4b97-bd69-85b3a511241e",
 		Type:                    storage.AuthMachineToMachineConfig_GENERIC,
 		TokenExpirationDuration: "5m",

--- a/central/auth/datastore/datastore_impl_test.go
+++ b/central/auth/datastore/datastore_impl_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/central/auth/m2m/mocks"
-	pgStore "github.com/stackrox/rox/central/auth/store/postgres"
+	"github.com/stackrox/rox/central/auth/store"
 	roleDataStore "github.com/stackrox/rox/central/role/datastore"
 	permissionSetPostgresStore "github.com/stackrox/rox/central/role/store/permissionset/postgres"
 	rolePostgresStore "github.com/stackrox/rox/central/role/store/role/postgres"
@@ -58,7 +58,7 @@ func (s *datastorePostgresTestSuite) SetupTest() {
 	s.pool = pgtest.ForT(s.T())
 	s.Require().NotNil(s.pool)
 
-	store := pgStore.New(s.pool.DB)
+	store := store.New(s.pool.DB)
 
 	permSetStore := permissionSetPostgresStore.New(s.pool.DB)
 	accessScopeStore := accessScopePostgresStore.New(s.pool.DB)

--- a/central/auth/datastore/datastore_impl_test.go
+++ b/central/auth/datastore/datastore_impl_test.go
@@ -70,9 +70,10 @@ func (s *datastorePostgresTestSuite) SetupTest() {
 	s.addRoles()
 
 	s.mockSet = mocks.NewMockTokenExchangerSet(gomock.NewController(s.T()))
-	s.mockSet.EXPECT().UpsertTokenExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	s.mockSet.EXPECT().UpsertTokenExchanger(gomock.Any(), gomock.Any()).AnyTimes()
 	s.mockSet.EXPECT().RemoveTokenExchanger(gomock.Any()).Return(nil).AnyTimes()
 	s.mockSet.EXPECT().GetTokenExchanger(gomock.Any()).Return(nil, true).AnyTimes()
+	s.mockSet.EXPECT().RollbackExchanger(gomock.Any()).Return(nil).AnyTimes()
 	s.mockSet.EXPECT().NewTokenExchangerFromConfig(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	s.authDataStore = New(store, s.mockSet)
 }

--- a/central/auth/datastore/singleton.go
+++ b/central/auth/datastore/singleton.go
@@ -2,7 +2,7 @@ package datastore
 
 import (
 	"github.com/stackrox/rox/central/auth/m2m"
-	pgStore "github.com/stackrox/rox/central/auth/store/postgres"
+	"github.com/stackrox/rox/central/auth/store"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/jwt"
 	roleDataStore "github.com/stackrox/rox/central/role/datastore"
@@ -20,7 +20,7 @@ var (
 func Singleton() DataStore {
 	once.Do(func() {
 		set := m2m.TokenExchangerSetSingleton(roleDataStore.Singleton(), jwt.IssuerFactorySingleton())
-		ds = New(pgStore.New(globaldb.GetPostgres()), set)
+		ds = New(store.New(globaldb.GetPostgres()), set)
 
 		// On initialization of the store, list all existing configs and fill the set.
 		// However, we do this in the background since the creation of the token exchanger

--- a/central/auth/m2m/exchanger.go
+++ b/central/auth/m2m/exchanger.go
@@ -26,7 +26,6 @@ var (
 type TokenExchanger interface {
 	ExchangeToken(ctx context.Context, rawIDToken string) (string, error)
 	Provider() authproviders.Provider
-	RecreateIssuer(issuerFactory tokens.IssuerFactory) error
 }
 
 type machineToMachineTokenExchanger struct {
@@ -119,22 +118,6 @@ func (m *machineToMachineTokenExchanger) ExchangeToken(ctx context.Context, rawI
 	}
 
 	return tokenInfo.Token, nil
-}
-
-func (m *machineToMachineTokenExchanger) RecreateIssuer(issuerFactory tokens.IssuerFactory) error {
-	tokenTTL, err := time.ParseDuration(m.config.GetTokenExpirationDuration())
-	// Technically, this shouldn't happen, as the config is expected to be validated beforehand (i.e. when added to the
-	// data store).
-	if err != nil {
-		return errors.Wrap(err, "parsing token expiration duration")
-	}
-
-	issuer, err := issuerFactory.CreateIssuer(m.provider, tokens.WithTTL(tokenTTL))
-	if err != nil {
-		return errors.Wrap(err, "creating token issuer")
-	}
-	m.issuer = issuer
-	return nil
 }
 
 func mapToStringClaims(claims map[string]interface{}) map[string][]string {

--- a/central/auth/m2m/exchanger.go
+++ b/central/auth/m2m/exchanger.go
@@ -26,6 +26,7 @@ var (
 type TokenExchanger interface {
 	ExchangeToken(ctx context.Context, rawIDToken string) (string, error)
 	Provider() authproviders.Provider
+	Config() *storage.AuthMachineToMachineConfig
 }
 
 type machineToMachineTokenExchanger struct {
@@ -118,6 +119,10 @@ func (m *machineToMachineTokenExchanger) ExchangeToken(ctx context.Context, rawI
 	}
 
 	return tokenInfo.Token, nil
+}
+
+func (m *machineToMachineTokenExchanger) Config() *storage.AuthMachineToMachineConfig {
+	return m.config
 }
 
 func mapToStringClaims(claims map[string]interface{}) map[string][]string {

--- a/central/auth/m2m/mocks/exchanger.go
+++ b/central/auth/m2m/mocks/exchanger.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 
 	authproviders "github.com/stackrox/rox/pkg/auth/authproviders"
-	tokens "github.com/stackrox/rox/pkg/auth/tokens"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -68,18 +67,4 @@ func (m *MockTokenExchanger) Provider() authproviders.Provider {
 func (mr *MockTokenExchangerMockRecorder) Provider() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Provider", reflect.TypeOf((*MockTokenExchanger)(nil).Provider))
-}
-
-// RecreateIssuer mocks base method.
-func (m *MockTokenExchanger) RecreateIssuer(issuerFactory tokens.IssuerFactory) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecreateIssuer", issuerFactory)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RecreateIssuer indicates an expected call of RecreateIssuer.
-func (mr *MockTokenExchangerMockRecorder) RecreateIssuer(issuerFactory any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecreateIssuer", reflect.TypeOf((*MockTokenExchanger)(nil).RecreateIssuer), issuerFactory)
 }

--- a/central/auth/m2m/mocks/exchanger.go
+++ b/central/auth/m2m/mocks/exchanger.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	authproviders "github.com/stackrox/rox/pkg/auth/authproviders"
+	tokens "github.com/stackrox/rox/pkg/auth/tokens"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -67,4 +68,18 @@ func (m *MockTokenExchanger) Provider() authproviders.Provider {
 func (mr *MockTokenExchangerMockRecorder) Provider() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Provider", reflect.TypeOf((*MockTokenExchanger)(nil).Provider))
+}
+
+// RecreateIssuer mocks base method.
+func (m *MockTokenExchanger) RecreateIssuer(issuerFactory tokens.IssuerFactory) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RecreateIssuer", issuerFactory)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RecreateIssuer indicates an expected call of RecreateIssuer.
+func (mr *MockTokenExchangerMockRecorder) RecreateIssuer(issuerFactory any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecreateIssuer", reflect.TypeOf((*MockTokenExchanger)(nil).RecreateIssuer), issuerFactory)
 }

--- a/central/auth/m2m/mocks/exchanger.go
+++ b/central/auth/m2m/mocks/exchanger.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	storage "github.com/stackrox/rox/generated/storage"
 	authproviders "github.com/stackrox/rox/pkg/auth/authproviders"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -38,6 +39,20 @@ func NewMockTokenExchanger(ctrl *gomock.Controller) *MockTokenExchanger {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTokenExchanger) EXPECT() *MockTokenExchangerMockRecorder {
 	return m.recorder
+}
+
+// Config mocks base method.
+func (m *MockTokenExchanger) Config() *storage.AuthMachineToMachineConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Config")
+	ret0, _ := ret[0].(*storage.AuthMachineToMachineConfig)
+	return ret0
+}
+
+// Config indicates an expected call of Config.
+func (mr *MockTokenExchangerMockRecorder) Config() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockTokenExchanger)(nil).Config))
 }
 
 // ExchangeToken mocks base method.

--- a/central/auth/m2m/mocks/set.go
+++ b/central/auth/m2m/mocks/set.go
@@ -85,12 +85,24 @@ func (mr *MockTokenExchangerSetMockRecorder) RemoveTokenExchanger(issuer any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTokenExchanger", reflect.TypeOf((*MockTokenExchangerSet)(nil).RemoveTokenExchanger), issuer)
 }
 
-// UpsertTokenExchanger mocks base method.
-func (m *MockTokenExchangerSet) UpsertTokenExchanger(exchanger m2m.TokenExchanger, issuer string) error {
+// RollbackExchanger mocks base method.
+func (m *MockTokenExchangerSet) RollbackExchanger(issuer string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertTokenExchanger", exchanger, issuer)
+	ret := m.ctrl.Call(m, "RollbackExchanger", issuer)
 	ret0, _ := ret[0].(error)
 	return ret0
+}
+
+// RollbackExchanger indicates an expected call of RollbackExchanger.
+func (mr *MockTokenExchangerSetMockRecorder) RollbackExchanger(issuer any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollbackExchanger", reflect.TypeOf((*MockTokenExchangerSet)(nil).RollbackExchanger), issuer)
+}
+
+// UpsertTokenExchanger mocks base method.
+func (m *MockTokenExchangerSet) UpsertTokenExchanger(exchanger m2m.TokenExchanger, issuer string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpsertTokenExchanger", exchanger, issuer)
 }
 
 // UpsertTokenExchanger indicates an expected call of UpsertTokenExchanger.

--- a/central/auth/m2m/mocks/set.go
+++ b/central/auth/m2m/mocks/set.go
@@ -56,21 +56,6 @@ func (mr *MockTokenExchangerSetMockRecorder) GetTokenExchanger(issuer any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTokenExchanger", reflect.TypeOf((*MockTokenExchangerSet)(nil).GetTokenExchanger), issuer)
 }
 
-// NewTokenExchangerFromConfig mocks base method.
-func (m *MockTokenExchangerSet) NewTokenExchangerFromConfig(ctx context.Context, config *storage.AuthMachineToMachineConfig) (m2m.TokenExchanger, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewTokenExchangerFromConfig", ctx, config)
-	ret0, _ := ret[0].(m2m.TokenExchanger)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// NewTokenExchangerFromConfig indicates an expected call of NewTokenExchangerFromConfig.
-func (mr *MockTokenExchangerSetMockRecorder) NewTokenExchangerFromConfig(ctx, config any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewTokenExchangerFromConfig", reflect.TypeOf((*MockTokenExchangerSet)(nil).NewTokenExchangerFromConfig), ctx, config)
-}
-
 // RemoveTokenExchanger mocks base method.
 func (m *MockTokenExchangerSet) RemoveTokenExchanger(issuer string) error {
 	m.ctrl.T.Helper()
@@ -86,27 +71,29 @@ func (mr *MockTokenExchangerSetMockRecorder) RemoveTokenExchanger(issuer any) *g
 }
 
 // RollbackExchanger mocks base method.
-func (m *MockTokenExchangerSet) RollbackExchanger(issuer string) error {
+func (m *MockTokenExchangerSet) RollbackExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RollbackExchanger", issuer)
+	ret := m.ctrl.Call(m, "RollbackExchanger", ctx, config)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RollbackExchanger indicates an expected call of RollbackExchanger.
-func (mr *MockTokenExchangerSetMockRecorder) RollbackExchanger(issuer any) *gomock.Call {
+func (mr *MockTokenExchangerSetMockRecorder) RollbackExchanger(ctx, config any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollbackExchanger", reflect.TypeOf((*MockTokenExchangerSet)(nil).RollbackExchanger), issuer)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollbackExchanger", reflect.TypeOf((*MockTokenExchangerSet)(nil).RollbackExchanger), ctx, config)
 }
 
 // UpsertTokenExchanger mocks base method.
-func (m *MockTokenExchangerSet) UpsertTokenExchanger(exchanger m2m.TokenExchanger, issuer string) {
+func (m *MockTokenExchangerSet) UpsertTokenExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpsertTokenExchanger", exchanger, issuer)
+	ret := m.ctrl.Call(m, "UpsertTokenExchanger", ctx, config)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // UpsertTokenExchanger indicates an expected call of UpsertTokenExchanger.
-func (mr *MockTokenExchangerSetMockRecorder) UpsertTokenExchanger(exchanger, issuer any) *gomock.Call {
+func (mr *MockTokenExchangerSetMockRecorder) UpsertTokenExchanger(ctx, config any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertTokenExchanger", reflect.TypeOf((*MockTokenExchangerSet)(nil).UpsertTokenExchanger), exchanger, issuer)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertTokenExchanger", reflect.TypeOf((*MockTokenExchangerSet)(nil).UpsertTokenExchanger), ctx, config)
 }

--- a/central/auth/m2m/set.go
+++ b/central/auth/m2m/set.go
@@ -101,6 +101,10 @@ func (t *tokenExchangerSet) UpsertTokenExchanger(exchanger TokenExchanger, issue
 // RemoveTokenExchanger removes the token exchanger for the specific configuration ID.
 // In case no config with the specific ID exists, nil will be returned.
 func (t *tokenExchangerSet) RemoveTokenExchanger(id string) error {
+	// NOTE: If the behavior of the function changes, we need to make sure that the datastore and the rollback
+	// scenarios are changed accordingly as well. Currently, no rollback will be attempted when delete returns
+	// an error.
+
 	exchanger, exists := t.tokenExchangers[id]
 	if !exists {
 		return nil

--- a/central/auth/m2m/set.go
+++ b/central/auth/m2m/set.go
@@ -23,11 +23,10 @@ var (
 //
 //go:generate mockgen-wrapper
 type TokenExchangerSet interface {
-	NewTokenExchangerFromConfig(ctx context.Context, config *storage.AuthMachineToMachineConfig) (TokenExchanger, error)
-	UpsertTokenExchanger(exchanger TokenExchanger, issuer string)
+	UpsertTokenExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error
 	RemoveTokenExchanger(issuer string) error
 	GetTokenExchanger(issuer string) (TokenExchanger, bool)
-	RollbackExchanger(issuer string) error
+	RollbackExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error
 }
 
 // TokenExchangerFactory factory for creating a new token exchanger.
@@ -64,26 +63,28 @@ type tokenExchangerSet struct {
 	tokenExchangerFactory TokenExchangerFactory
 }
 
-// NewTokenExchangerFromConfig creates a TokenExchanger from the given config.
+// UpsertTokenExchanger upserts a token exchanger based from the given config.
 // It will make sure the TokenExchanger is registered as a tokens.Source.
 // Note that during creation of the TokenExchanger, an external HTTP request is done to the OIDC issuer
 // to retrieve additional metadata for token validation (i.e. JWKS metadata).
-func (t *tokenExchangerSet) NewTokenExchangerFromConfig(ctx context.Context, config *storage.AuthMachineToMachineConfig) (TokenExchanger, error) {
+// In case a token exchanger already exists for the given config, it will be replaced.
+func (t *tokenExchangerSet) UpsertTokenExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error {
 	exchanger, exists := t.tokenExchangers[config.GetIssuer()]
 	if exists {
 		// Need to unregister the source temporarily, otherwise we receive an error on creation that the
 		// source is already registered.
 		if err := t.issuerFactory.UnregisterSource(exchanger.Provider()); err != nil {
-			return nil, pkgErrors.Wrapf(err, "unregistering source for config %s", config.GetId())
+			return pkgErrors.Wrapf(err, "unregistering source for config %s", config.GetId())
 		}
 	}
 
 	tokenExchanger, err := t.tokenExchangerFactory(ctx, config, t.roleDS, t.issuerFactory)
 	if err != nil {
-		return nil, pkgErrors.Wrapf(err, "creating token exchanger for config %s", config.GetId())
+		return pkgErrors.Wrapf(err, "creating token exchanger for config %s", config.GetId())
 	}
 
-	return tokenExchanger, nil
+	t.tokenExchangers[config.GetIssuer()] = tokenExchanger
+	return nil
 }
 
 // GetTokenExchanger retrieves a TokenExchanger based on the issuer.
@@ -92,19 +93,9 @@ func (t *tokenExchangerSet) GetTokenExchanger(issuer string) (TokenExchanger, bo
 	return tokenExchanger, exists
 }
 
-// UpsertTokenExchanger upserts a token exchanger based off the given config.
-// In case a token exchanger already exists for the given config, it will be replaced.
-func (t *tokenExchangerSet) UpsertTokenExchanger(exchanger TokenExchanger, issuer string) {
-	t.tokenExchangers[issuer] = exchanger
-}
-
 // RemoveTokenExchanger removes the token exchanger for the specific configuration ID.
 // In case no config with the specific ID exists, nil will be returned.
 func (t *tokenExchangerSet) RemoveTokenExchanger(id string) error {
-	// NOTE: If the behavior of the function changes, we need to make sure that the datastore and the rollback
-	// scenarios are changed accordingly as well. Currently, no rollback will be attempted when delete returns
-	// an error.
-
 	exchanger, exists := t.tokenExchangers[id]
 	if !exists {
 		return nil
@@ -113,7 +104,8 @@ func (t *tokenExchangerSet) RemoveTokenExchanger(id string) error {
 	// We need to unregister the source with the issuer factory.
 	// This will lead to all tokens issued by the previous token exchanger to be rejected by Central.
 	if err := t.issuerFactory.UnregisterSource(exchanger.Provider()); err != nil {
-		return pkgErrors.Wrapf(err, "unregistering source for config %s", id)
+		log.Warnf("Unregistering source for config %s failed: %v", id, err)
+		return nil
 	}
 
 	delete(t.tokenExchangers, id)
@@ -122,14 +114,16 @@ func (t *tokenExchangerSet) RemoveTokenExchanger(id string) error {
 
 // RollbackExchanger is used to roll back any changes made to an existing exchanger.
 // In particular, it will ensure that the source is correctly registered.
-func (t *tokenExchangerSet) RollbackExchanger(issuer string) error {
-	exchanger, exists := t.tokenExchangers[issuer]
+func (t *tokenExchangerSet) RollbackExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error {
+	// In case the config does not exist anymore, re-create it.
+	_, exists := t.tokenExchangers[config.GetIssuer()]
 	if !exists {
-		return nil
+		return t.UpsertTokenExchanger(ctx, config)
 	}
 
-	if err := exchanger.RecreateIssuer(t.issuerFactory); err != nil {
+	// In case the config still exists, we remove and re-create it to ensure we have the correct state in our set.
+	if err := t.RemoveTokenExchanger(config.GetIssuer()); err != nil {
 		return err
 	}
-	return nil
+	return t.UpsertTokenExchanger(ctx, config)
 }

--- a/central/auth/service/service_impl.go
+++ b/central/auth/service/service_impl.go
@@ -171,7 +171,7 @@ func (s *serviceImpl) AddAuthMachineToMachineConfig(ctx context.Context, request
 		return nil, err
 	}
 	config.Id = uuid.NewV4().String()
-	storageConfig, err := s.authDataStore.AddAuthM2MConfig(ctx, v1tostorage.AuthM2MConfig(config))
+	storageConfig, err := s.authDataStore.UpsertAuthM2MConfig(ctx, v1tostorage.AuthM2MConfig(config))
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (s *serviceImpl) UpdateAuthMachineToMachineConfig(ctx context.Context, requ
 		return nil, err
 	}
 
-	if err := s.authDataStore.UpdateAuthM2MConfig(ctx, v1tostorage.AuthM2MConfig(config)); err != nil {
+	if _, err := s.authDataStore.UpsertAuthM2MConfig(ctx, v1tostorage.AuthM2MConfig(config)); err != nil {
 		return nil, err
 	}
 

--- a/central/auth/service/service_impl_test.go
+++ b/central/auth/service/service_impl_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stackrox/rox/central/auth/datastore"
 	"github.com/stackrox/rox/central/auth/m2m"
 	"github.com/stackrox/rox/central/auth/m2m/mocks"
-	pgStore "github.com/stackrox/rox/central/auth/store/postgres"
+	"github.com/stackrox/rox/central/auth/store"
 	roleDataStore "github.com/stackrox/rox/central/role/datastore"
 	permissionSetPostgresStore "github.com/stackrox/rox/central/role/store/permissionset/postgres"
 	rolePostgresStore "github.com/stackrox/rox/central/role/store/role/postgres"
@@ -107,7 +107,7 @@ func (s *authServiceAccessControlTestSuite) SetupTest() {
 
 	s.addRoles()
 
-	store := pgStore.New(s.pool.DB)
+	store := store.New(s.pool.DB)
 
 	s.mockIssuerFactory = tokensMocks.NewMockIssuerFactory(gomock.NewController(s.T()))
 	s.mockTokenExchanger = mocks.NewMockTokenExchanger(gomock.NewController(s.T()))

--- a/central/auth/service/service_impl_test.go
+++ b/central/auth/service/service_impl_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/central/auth/m2m"
 	"github.com/stackrox/rox/central/auth/m2m/mocks"
 	"github.com/stackrox/rox/central/auth/store"
+	"github.com/stackrox/rox/central/convert/v1tostorage"
 	roleDataStore "github.com/stackrox/rox/central/role/datastore"
 	permissionSetPostgresStore "github.com/stackrox/rox/central/role/store/permissionset/postgres"
 	rolePostgresStore "github.com/stackrox/rox/central/role/store/role/postgres"
@@ -64,9 +65,10 @@ type authServiceAccessControlTestSuite struct {
 	withNoRoleCtx    context.Context
 	anonymousCtx     context.Context
 
-	mockIssuerFactory  *tokensMocks.MockIssuerFactory
-	mockTokenExchanger *mocks.MockTokenExchanger
-	tokenExchangerSet  m2m.TokenExchangerSet
+	mockIssuerFactory    *tokensMocks.MockIssuerFactory
+	mockTokenExchanger   *mocks.MockTokenExchanger
+	tokenExchangerSet    m2m.TokenExchangerSet
+	mockExchangerFactory *mockExchangerFactory
 
 	accessCtx context.Context
 }
@@ -113,7 +115,10 @@ func (s *authServiceAccessControlTestSuite) SetupTest() {
 	s.mockIssuerFactory = tokensMocks.NewMockIssuerFactory(gomock.NewController(s.T()))
 	s.mockTokenExchanger = mocks.NewMockTokenExchanger(gomock.NewController(s.T()))
 
-	s.tokenExchangerSet = m2m.TokenExchangerSetForTesting(s.T(), s.roleDS, s.mockIssuerFactory, mockTokenExchangerFactory(s.mockTokenExchanger))
+	s.mockExchangerFactory = &mockExchangerFactory{mockExchanger: s.mockTokenExchanger}
+
+	s.tokenExchangerSet = m2m.TokenExchangerSetForTesting(s.T(), s.roleDS, s.mockIssuerFactory,
+		s.mockExchangerFactory.factory())
 	authDataStore := datastore.New(store, s.tokenExchangerSet)
 	s.svc = &serviceImpl{authDataStore: authDataStore}
 }
@@ -750,6 +755,8 @@ func (s *authServiceAccessControlTestSuite) TestUpdateRollback() {
 	})
 	s.Require().NoError(err)
 
+	s.mockTokenExchanger.EXPECT().Config().Return(v1tostorage.AuthM2MConfig(newConfig)).Times(2)
+
 	// No error during rollback.
 	gomock.InOrder(
 		s.mockTokenExchanger.EXPECT().Provider().Return(nil),
@@ -760,7 +767,7 @@ func (s *authServiceAccessControlTestSuite) TestUpdateRollback() {
 
 	sameConfig := &v1.AuthMachineToMachineConfig{
 		Id:                      "80c053c2-24a7-4b97-bd69-85b3a511241e",
-		TokenExpirationDuration: "1m",
+		TokenExpirationDuration: "5m",
 		Type:                    v1.AuthMachineToMachineConfig_GITHUB_ACTIONS,
 	}
 	_, err = s.svc.UpdateAuthMachineToMachineConfig(s.accessCtx, &v1.UpdateAuthMachineToMachineConfigRequest{
@@ -768,6 +775,7 @@ func (s *authServiceAccessControlTestSuite) TestUpdateRollback() {
 	})
 	s.Error(err)
 	s.NotContains(err.Error(), "rollback")
+	s.Equal(v1tostorage.AuthM2MConfig(newConfig), s.mockExchangerFactory.currentExchangerConfig)
 }
 
 func (s *authServiceAccessControlTestSuite) addRoles() {
@@ -802,8 +810,14 @@ func (s *authServiceAccessControlTestSuite) addRoles() {
 
 // Mocks used within tests.
 
-func mockTokenExchangerFactory(mockExchanger *mocks.MockTokenExchanger) m2m.TokenExchangerFactory {
+type mockExchangerFactory struct {
+	currentExchangerConfig *storage.AuthMachineToMachineConfig
+	mockExchanger          *mocks.MockTokenExchanger
+}
+
+func (m *mockExchangerFactory) factory() m2m.TokenExchangerFactory {
 	return func(_ context.Context, config *storage.AuthMachineToMachineConfig, _ roleDataStore.DataStore, _ tokens.IssuerFactory) (m2m.TokenExchanger, error) {
-		return mockExchanger, nil
+		m.currentExchangerConfig = config
+		return m.mockExchanger, nil
 	}
 }

--- a/central/auth/store/store.go
+++ b/central/auth/store/store.go
@@ -3,7 +3,7 @@ package store
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/auth/store/postgres"
+	authPGStore "github.com/stackrox/rox/central/auth/store/postgres"
 	"github.com/stackrox/rox/generated/storage"
 	pgPkg "github.com/stackrox/rox/pkg/postgres"
 )
@@ -22,14 +22,14 @@ type Store interface {
 // and require rollbacks for upsert and delete.
 type storeWrapper struct {
 	db    pgPkg.DB
-	store postgres.Store
+	store authPGStore.Store
 }
 
 // New creates a new store.
 func New(db pgPkg.DB) Store {
 	return &storeWrapper{
 		db:    db,
-		store: postgres.New(db),
+		store: authPGStore.New(db),
 	}
 }
 

--- a/central/auth/store/store.go
+++ b/central/auth/store/store.go
@@ -3,7 +3,9 @@ package store
 import (
 	"context"
 
+	"github.com/stackrox/rox/central/auth/store/postgres"
 	"github.com/stackrox/rox/generated/storage"
+	pgPkg "github.com/stackrox/rox/pkg/postgres"
 )
 
 // Store is the interface to the auth machine to machine data layer.
@@ -12,4 +14,46 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.AuthMachineToMachineConfig) error
 	Delete(ctx context.Context, id string) error
 	GetAll(ctx context.Context) ([]*storage.AuthMachineToMachineConfig, error)
+	Begin(ctx context.Context) (context.Context, *pgPkg.Tx, error)
+}
+
+// storeWrapper is a wrapper around the generated store which also exposes transaction functionality.
+// The reason for requiring this is that we also have an in-memory store for the auth machine to machine config,
+// and require rollbacks for upsert and delete.
+type storeWrapper struct {
+	db    pgPkg.DB
+	store postgres.Store
+}
+
+// New creates a new store.
+func New(db pgPkg.DB) Store {
+	return &storeWrapper{
+		db:    db,
+		store: postgres.New(db),
+	}
+}
+
+func (s *storeWrapper) Get(ctx context.Context, id string) (*storage.AuthMachineToMachineConfig, bool, error) {
+	return s.store.Get(ctx, id)
+}
+
+func (s *storeWrapper) Upsert(ctx context.Context, obj *storage.AuthMachineToMachineConfig) error {
+	return s.store.Upsert(ctx, obj)
+}
+
+func (s *storeWrapper) Delete(ctx context.Context, id string) error {
+	return s.store.Delete(ctx, id)
+}
+
+func (s *storeWrapper) GetAll(ctx context.Context) ([]*storage.AuthMachineToMachineConfig, error) {
+	return s.store.GetAll(ctx)
+}
+
+// Begin begins a transaction, returning the transaction context from the given context and the transaction itself.
+func (s *storeWrapper) Begin(ctx context.Context) (context.Context, *pgPkg.Tx, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return pgPkg.ContextWithTx(ctx, tx), tx, nil
 }


### PR DESCRIPTION
## Description

This changes the auth m2m datastore to use a transaction during the update of m2m configs.

This is required due to the nature of the issuer store, which is an in-memory store for token issuer sources.

It would happen in cases where an existing configuration would be updated that:
- a new token exchanger from the config is created, since it is an existing token exchanger the token source will be unregistered, otherwise this fails during creation.
- in case DB upsert fails or any other operation, we would be left in a broken state: a token exchanger with no existing source will be left.

This would then also lead to failures in the removal, since the token issuer store cannot find the associated source, and will error out.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
