### PR TITLE
fix(diag-bundle): ignore log limits for Central logs

### DIFF
--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -106,6 +106,10 @@ var (
 
 func init() {
 	mainClusterConfig.PathPrefix = centralClusterPrefix
+	// For the main cluster (i.e. the collection for the Central cluster) we explicitly ignore the log file limits.
+	// The limitation is not required since the GRPC message isn't affected by it, and has proven to be unhelpful
+	// in cases where the logs of Central are quite big (e.g. in larger scale environments).
+	mainClusterConfig.IgnoreLogLimits = true
 }
 
 // Service provides the interface to the gRPC service for debugging

--- a/pkg/k8sintrospect/config.go
+++ b/pkg/k8sintrospect/config.go
@@ -17,7 +17,8 @@ type ObjectConfig struct {
 
 // Config configures the behavior of the Kubernetes self-diagnosis feature.
 type Config struct {
-	Namespaces []string
-	Objects    []ObjectConfig
-	PathPrefix string
+	Namespaces      []string
+	Objects         []ObjectConfig
+	PathPrefix      string
+	IgnoreLogLimits bool
 }


### PR DESCRIPTION
## Description

Disable the log file limits imposed by the `k8sintrospect` package when collectiong logs for the Central cluster / instance.

There are cases in bigger scale environments where this size limit hurts debugging issues, and since there's no danger of hitting the GRPC message size limit due to it being collected locally, we can safely ignore the max log size for Central cluster collection.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

N/A.


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
