### PR TITLE
ROX-22253:  compliance update add

### DIFF
--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -210,14 +210,16 @@ func (m *handlerImpl) processUpdateScanRequest(requestID string, request *centra
 	ssObj, err := resSS.Get(m.ctx(), request.GetScanSettings().GetScanName(), v1.GetOptions{})
 	if err != nil {
 		err = errors.Wrapf(err, "namespaces/%s/scansettings/%s not found", ns, request.GetScanSettings().GetScanName())
-		return m.composeAndSendApplyScanConfigResponse(requestID, err)
+		log.Error(err)
+		//return m.composeAndSendApplyScanConfigResponse(requestID, err)
 	}
 
 	resSSB := m.client.Resource(complianceoperator.ScanSettingBinding.GroupVersionResource()).Namespace(ns)
 	ssbObj, err := resSSB.Get(m.ctx(), request.GetScanSettings().GetScanName(), v1.GetOptions{})
 	if err != nil {
 		err = errors.Wrapf(err, "namespaces/%s/scansettingsbindings/%s not found", ns, request.GetScanSettings().GetScanName())
-		return m.composeAndSendApplyScanConfigResponse(requestID, err)
+		log.Error(err)
+		//return m.composeAndSendApplyScanConfigResponse(requestID, err)
 	}
 
 	if ssObj == nil && ssbObj == nil {

--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/message"
 	kubeAPIErr "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/utils/pointer"
@@ -162,17 +163,21 @@ func (m *handlerImpl) processScheduledScanRequest(requestID string, request *cen
 		return m.composeAndSendApplyScanConfigResponse(requestID, errors.Wrap(err, "validating compliance scan request"))
 	}
 
+	return m.createScanResources(requestID, request.GetScanSettings(), request.GetCron())
+}
+
+func (m *handlerImpl) createScanResources(requestID string, request *central.ApplyComplianceScanConfigRequest_BaseScanSettings, cron string) bool {
 	ns := m.complianceOperatorInfo.GetNamespace()
 	if ns == "" {
 		return m.composeAndSendApplyScanConfigResponse(requestID, errors.New("Compliance operator namespace not known"))
 	}
 
-	scanSetting, err := runtimeObjToUnstructured(convertCentralRequestToScanSetting(ns, request))
+	scanSetting, err := runtimeObjToUnstructured(convertCentralRequestToScanSetting(ns, request, cron))
 	if err != nil {
 		return m.composeAndSendApplyScanConfigResponse(requestID, err)
 	}
 
-	scanSettingBinding, err := runtimeObjToUnstructured(convertCentralRequestToScanSettingBinding(ns, request.GetScanSettings()))
+	scanSettingBinding, err := runtimeObjToUnstructured(convertCentralRequestToScanSettingBinding(ns, request))
 	if err != nil {
 		return m.composeAndSendApplyScanConfigResponse(requestID, err)
 	}
@@ -202,27 +207,33 @@ func (m *handlerImpl) processUpdateScanRequest(requestID string, request *centra
 
 	// Retrieve the ScanSetting and ScanSettingBinding objects for update
 	resSS := m.client.Resource(complianceoperator.ScanSetting.GroupVersionResource()).Namespace(ns)
-	obj, err := resSS.Get(m.ctx(), request.GetScanSettings().GetScanName(), v1.GetOptions{})
-	if err != nil || obj == nil {
+	ssObj, err := resSS.Get(m.ctx(), request.GetScanSettings().GetScanName(), v1.GetOptions{})
+	if err != nil {
 		err = errors.Wrapf(err, "namespaces/%s/scansettings/%s not found", ns, request.GetScanSettings().GetScanName())
 		return m.composeAndSendApplyScanConfigResponse(requestID, err)
 	}
 
-	var scanSetting v1alpha1.ScanSetting
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &scanSetting); err != nil {
-		err = errors.Wrap(err, "Could not convert unstructured to scan setting")
-		return m.composeAndSendApplyScanConfigResponse(requestID, err)
-	}
-
 	resSSB := m.client.Resource(complianceoperator.ScanSettingBinding.GroupVersionResource()).Namespace(ns)
-	obj, err = resSSB.Get(m.ctx(), request.GetScanSettings().GetScanName(), v1.GetOptions{})
-	if err != nil || obj == nil {
+	ssbObj, err := resSSB.Get(m.ctx(), request.GetScanSettings().GetScanName(), v1.GetOptions{})
+	if err != nil {
 		err = errors.Wrapf(err, "namespaces/%s/scansettingsbindings/%s not found", ns, request.GetScanSettings().GetScanName())
 		return m.composeAndSendApplyScanConfigResponse(requestID, err)
 	}
 
-	var scanSettingBinding v1alpha1.ScanSettingBinding
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &scanSettingBinding); err != nil {
+	if ssObj == nil && ssbObj == nil {
+		// This is an add instead
+		return m.createScanResources(requestID, request.GetScanSettings(), request.GetCron())
+	}
+
+	// Invalid case because scan setting is created first so we should not have a situation where
+	// we have a scan setting binding and not a scan setting.  This probably isn't even possible.
+	if ssObj == nil {
+		err = errors.Wrap(err, "Could not convert unstructured to scan setting")
+		return m.composeAndSendApplyScanConfigResponse(requestID, err)
+	}
+
+	var scanSetting v1alpha1.ScanSetting
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(ssObj.Object, &scanSetting); err != nil {
 		err = errors.Wrap(err, "Could not convert unstructured to scan setting")
 		return m.composeAndSendApplyScanConfigResponse(requestID, err)
 	}
@@ -232,9 +243,25 @@ func (m *handlerImpl) processUpdateScanRequest(requestID string, request *centra
 		return m.composeAndSendApplyScanConfigResponse(requestID, err)
 	}
 
-	updatedScanSettingBinding, err := runtimeObjToUnstructured(updateScanSettingBindingFromCentralRequest(&scanSettingBinding, request.GetScanSettings()))
-	if err != nil {
-		return m.composeAndSendApplyScanConfigResponse(requestID, err)
+	var updatedScanSettingBinding *unstructured.Unstructured
+	// It is possible that we successfully created the scan setting but had issues on the binding.
+	if ssbObj != nil {
+		var scanSettingBinding v1alpha1.ScanSettingBinding
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(ssbObj.Object, &scanSettingBinding); err != nil {
+			err = errors.Wrap(err, "Could not convert unstructured to scan setting")
+			return m.composeAndSendApplyScanConfigResponse(requestID, err)
+		}
+
+		updatedScanSettingBinding, err = runtimeObjToUnstructured(updateScanSettingBindingFromCentralRequest(&scanSettingBinding, request.GetScanSettings()))
+		if err != nil {
+			return m.composeAndSendApplyScanConfigResponse(requestID, err)
+		}
+
+	} else {
+		updatedScanSettingBinding, err = runtimeObjToUnstructured(convertCentralRequestToScanSettingBinding(ns, request.GetScanSettings()))
+		if err != nil {
+			return m.composeAndSendApplyScanConfigResponse(requestID, err)
+		}
 	}
 
 	_, err = m.client.Resource(complianceoperator.ScanSetting.GroupVersionResource()).Namespace(ns).Update(m.ctx(), updatedScanSetting, v1.UpdateOptions{})
@@ -243,9 +270,18 @@ func (m *handlerImpl) processUpdateScanRequest(requestID string, request *centra
 		return m.composeAndSendApplyScanConfigResponse(requestID, err)
 	}
 
-	_, err = m.client.Resource(complianceoperator.ScanSettingBinding.GroupVersionResource()).Namespace(ns).Update(m.ctx(), updatedScanSettingBinding, v1.UpdateOptions{})
+	// Process SSB as an update
+	if ssbObj != nil {
+		_, err = m.client.Resource(complianceoperator.ScanSettingBinding.GroupVersionResource()).Namespace(ns).Update(m.ctx(), updatedScanSettingBinding, v1.UpdateOptions{})
+		if err != nil {
+			err = errors.Wrapf(err, "Could not update namespaces/%s/scansettingbindings/%s", ns, updatedScanSettingBinding.GetName())
+		}
+		return m.composeAndSendApplyScanConfigResponse(requestID, err)
+	}
+
+	_, err = m.client.Resource(complianceoperator.ScanSettingBinding.GroupVersionResource()).Namespace(ns).Create(m.ctx(), updatedScanSettingBinding, v1.CreateOptions{})
 	if err != nil {
-		err = errors.Wrapf(err, "Could not update namespaces/%s/scansettingbindings/%s", ns, updatedScanSettingBinding.GetName())
+		err = errors.Wrapf(err, "Could not create namespaces/%s/scansettingbindings/%s", ns, updatedScanSettingBinding.GetName())
 	}
 
 	return m.composeAndSendApplyScanConfigResponse(requestID, err)

--- a/sensor/kubernetes/complianceoperator/handler_impl_test.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl_test.go
@@ -367,11 +367,11 @@ func (s *HandlerTestSuite) TestProcessUpdateScheduledScanSuccess() {
 		id: msg.GetComplianceRequest().GetApplyScanConfig().GetId(),
 	}
 
-	// Now do the update
 	s.statusInfo.EXPECT().GetNamespace().Return("ns")
 	actual := s.sendMessage(1, msg)
 	s.assert(expected, actual)
 
+	// Now prepare an update
 	msg = getTestUpdateScanRequestMsg("midnight", "* * * * *", "ocp4-cis")
 	expected = expectedResponse{
 		id: msg.GetComplianceRequest().GetApplyScanConfig().GetId(),
@@ -389,6 +389,17 @@ func (s *HandlerTestSuite) TestProcessUpdateScheduledScanInvalid() {
 		errSubstr: "compliance profiles not specified, schedule is not valid",
 	}
 
+	actual := s.sendMessage(1, msg)
+	s.assert(expected, actual)
+}
+
+func (s *HandlerTestSuite) TestProcessUpdateScheduledScanNewSuccess() {
+	msg := getTestUpdateScanRequestMsg("midnight", "* * * * *", "ocp4-cis")
+	expected := expectedResponse{
+		id: msg.GetComplianceRequest().GetApplyScanConfig().GetId(),
+	}
+
+	s.statusInfo.EXPECT().GetNamespace().Return("ns")
 	actual := s.sendMessage(1, msg)
 	s.assert(expected, actual)
 }

--- a/sensor/kubernetes/complianceoperator/utils.go
+++ b/sensor/kubernetes/complianceoperator/utils.go
@@ -28,14 +28,14 @@ func validateScanName(req scanNameGetter) error {
 	return nil
 }
 
-func convertCentralRequestToScanSetting(namespace string, request *central.ApplyComplianceScanConfigRequest_ScheduledScan) *v1alpha1.ScanSetting {
+func convertCentralRequestToScanSetting(namespace string, request *central.ApplyComplianceScanConfigRequest_BaseScanSettings, cron string) *v1alpha1.ScanSetting {
 	return &v1alpha1.ScanSetting{
 		TypeMeta: v1.TypeMeta{
 			Kind:       complianceoperator.ScanSetting.Kind,
 			APIVersion: complianceoperator.GetGroupVersion().String(),
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name:      request.GetScanSettings().GetScanName(),
+			Name:      request.GetScanName(),
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app.kubernetes.io/name": "stackrox",
@@ -48,7 +48,7 @@ func convertCentralRequestToScanSetting(namespace string, request *central.Apply
 		ComplianceSuiteSettings: v1alpha1.ComplianceSuiteSettings{
 			AutoApplyRemediations:  false,
 			AutoUpdateRemediations: false,
-			Schedule:               request.GetCron(),
+			Schedule:               cron,
 		},
 		ComplianceScanSettings: v1alpha1.ComplianceScanSettings{
 			StrictNodeScan:    pointers.Bool(false),
@@ -94,7 +94,6 @@ func convertCentralRequestToScanSettingBinding(namespace string, request *centra
 }
 
 func updateScanSettingFromCentralRequest(scanSetting *v1alpha1.ScanSetting, request *central.ApplyComplianceScanConfigRequest_UpdateScheduledScan) *v1alpha1.ScanSetting {
-	// TODO: Add ACS labels.
 	// TODO:  Update additional fields as ACS capability expands
 	scanSetting.Roles = []string{masterRole, workerRole}
 	scanSetting.ComplianceSuiteSettings = v1alpha1.ComplianceSuiteSettings{


### PR DESCRIPTION
## Description

The Update compliance message had assumed that all the objects had been created.  However it is possible for an update of a scan configuration to add a cluster.  In those cases the compliance operator CRs would not have been created.  So in those cases we need to treat those as adding resources instead of updating the resources.  This could also occur in an instance where there was an error that was encountered writing the CRs and then the configuration was updated after the error was resolved.  

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Add a unit test case.  CI doesn't really support multi-cluster so tested this locally with a multi-cluster install.  First created a scan configuration for just one cluster.  Then I updated the scan configuration to use both clusters.  Verified that the second cluster had the resources created as expected.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
