### PR TITLE
chore(scanner): stop blocking traffic until Central is ready

### DIFF
--- a/scanner/matcher/matcher.go
+++ b/scanner/matcher/matcher.go
@@ -130,9 +130,9 @@ func NewMatcher(ctx context.Context, cfg config.MatcherConfig) (Matcher, error) 
 	// If this is a release build, Matcher should only reach out to Central,
 	// so deny (and log) any other traffic.
 	// TODO(ROX-19004): re-add this when complete.
-	//if buildinfo.ReleaseBuild {
-	//	defaultTransport = httputil.DenyTransport
-	//}
+	// if buildinfo.ReleaseBuild {
+	// 	 defaultTransport = httputil.DenyTransport
+	// }
 	// Matcher should never reach out to Sensor, so ensure all Sensor-traffic is always denied.
 	transport, err := httputil.TransportMux(defaultTransport, httputil.WithDenyStackRoxServices(!cfg.StackRoxServices), httputil.WithDenySensor(true))
 	if err != nil {

--- a/scanner/matcher/matcher.go
+++ b/scanner/matcher/matcher.go
@@ -13,7 +13,6 @@ import (
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/pkg/ctxlock"
 	"github.com/quay/zlog"
-	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/scanner/config"
 	"github.com/stackrox/rox/scanner/datastore/postgres"
@@ -130,9 +129,10 @@ func NewMatcher(ctx context.Context, cfg config.MatcherConfig) (Matcher, error) 
 	defaultTransport := http.DefaultTransport
 	// If this is a release build, Matcher should only reach out to Central,
 	// so deny (and log) any other traffic.
-	if buildinfo.ReleaseBuild {
-		defaultTransport = httputil.DenyTransport
-	}
+	// TODO(ROX-19004): re-add this when complete.
+	//if buildinfo.ReleaseBuild {
+	//	defaultTransport = httputil.DenyTransport
+	//}
 	// Matcher should never reach out to Sensor, so ensure all Sensor-traffic is always denied.
 	transport, err := httputil.TransportMux(defaultTransport, httputil.WithDenyStackRoxServices(!cfg.StackRoxServices), httputil.WithDenySensor(true))
 	if err != nil {


### PR DESCRIPTION
## Description

Staging uses release builds, which still requires access to the data, directly, instead of through Central/Sensor. For now, disable the requirement of going through Central/Sensor in release builds until ROX-19004 is complete.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
