### PR TITLE
fix(test): Disable TestProcessPipelineOnline due to timeout

### DIFF
--- a/sensor/common/processsignal/pipeline_test.go
+++ b/sensor/common/processsignal/pipeline_test.go
@@ -411,6 +411,7 @@ func collectEventsFor(ctx context.Context, ch <-chan *message.ExpiringMessage, t
 }
 
 func TestProcessPipelineOnline(t *testing.T) {
+	t.Skip("ROX-22262: Skipping due to timeout")
 	sensorEvents := make(chan *message.ExpiringMessage)
 
 	mockCtrl := gomock.NewController(t)


### PR DESCRIPTION
## Description

Testing is failing and created: https://issues.redhat.com/browse/ROX-22262

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Unit tests

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
