### PR TITLE
ci(scanner): cleanup docker resources

### DIFF
--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -68,16 +68,13 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
+    - uses: ./.github/actions/job-preamble
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-
-    - name: Ignore dubious repository ownership
-      run: |
-        # Prevent fatal error "detected dubious ownership in repository" from recent git.
-        git config --global --add safe.directory "$(pwd)"
 
     - uses: ./.github/actions/handle-tagged-build
 

--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -9,8 +9,6 @@ on:
 jobs:
   upload-dev-vulnerabilities:
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -9,12 +9,16 @@ on:
 jobs:
   upload-dev-vulnerabilities:
     runs-on: ubuntu-latest
+    container:
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61
     steps:
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - uses: ./.github/actions/job-preamble
 
     - name: Authenticate with Google Cloud
       uses: google-github-actions/auth@v2

--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -37,6 +37,7 @@ jobs:
         fi
 
         make -C scanner bin/updater
+        go clean -cache -modcache
         ./scanner/bin/updater -output-dir=dev
         gsutil cp -r "dev" "gs://scanner-v4-test/vulnerability-bundles"
 

--- a/.github/workflows/scanner-pr-vuln-update.yaml
+++ b/.github/workflows/scanner-pr-vuln-update.yaml
@@ -17,6 +17,8 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
+    - uses: ./.github/actions/job-preamble
+
     - name: Authenticate with Google Cloud
       uses: google-github-actions/auth@v2
       with:
@@ -24,6 +26,17 @@ jobs:
 
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v2
+
+    - name: Logs
+      run: |
+        env
+        echo
+        echo
+        go version
+        echo
+        echo
+        df --si /
+      shell: bash
 
     - name: Update vulnerabilities
       env:

--- a/.github/workflows/scanner-pr-vuln-update.yaml
+++ b/.github/workflows/scanner-pr-vuln-update.yaml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
-    #- uses: ./.github/actions/job-preamble
+    - uses: ./.github/actions/job-preamble
 
     - name: Authenticate with Google Cloud
       uses: google-github-actions/auth@v2
@@ -26,17 +26,6 @@ jobs:
 
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v2
-
-    - name: Logs
-      run: |
-        env
-        echo
-        echo
-        go version
-        echo
-        echo
-        df --si /
-      shell: bash
 
     - name: Update vulnerabilities
       env:

--- a/.github/workflows/scanner-pr-vuln-update.yaml
+++ b/.github/workflows/scanner-pr-vuln-update.yaml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - uses: ./.github/actions/job-preamble
+    #- uses: ./.github/actions/job-preamble
 
     - name: Authenticate with Google Cloud
       uses: google-github-actions/auth@v2

--- a/.github/workflows/scanner-pr-vuln-update.yaml
+++ b/.github/workflows/scanner-pr-vuln-update.yaml
@@ -38,6 +38,7 @@ jobs:
         fi
 
         make -C scanner bin/updater
+        go clean -cache -modcache
         branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
         ./scanner/bin/updater -output-dir="$branch"
         gsutil cp -r "$branch" "gs://scanner-v4-test/vulnerability-bundles"

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -26,8 +26,6 @@ jobs:
   upload-release-vulnerabilities:
     needs: read-release-versions
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61
     strategy:
       fail-fast: false # If one of the versions fails, it should not stop others from succeeding.
       max-parallel: 1 # Jobs are memory intensive, so only run one at a time.
@@ -36,6 +34,13 @@ jobs:
     env:
       ROX_PRODUCT_VERSION: ${{ matrix.version }}
     steps:
+    - name: Recover docker image cache space
+      run: |
+        df --si /
+        docker system prune --force --all
+        df --si /
+      shell: bash
+
     - name: Authenticate with Google Cloud
       uses: google-github-actions/auth@v2
       with:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -69,7 +69,12 @@ jobs:
           exit 1
         fi
 
-        go run ./scanner/cmd/updater -output-dir=${{ env.ROX_PRODUCT_VERSION }}
+        # Do not use the make target, as there may be some incompatibilities.
+        # See https://github.com/stackrox/stackrox/pull/9227.
+        cd scanner
+        go build -trimpath -o bin/updater ./cmd/updater
+        go clean -cache -modcache
+        ./bin/updater -output-dir=${{ env.ROX_PRODUCT_VERSION }}
         gsutil cp -r "${{ env.ROX_PRODUCT_VERSION }}" "gs://scanner-v4-test/vulnerability-bundles"
 
   send-notification:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -26,6 +26,8 @@ jobs:
   upload-release-vulnerabilities:
     needs: read-release-versions
     runs-on: ubuntu-latest
+    container:
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61
     strategy:
       fail-fast: false # If one of the versions fails, it should not stop others from succeeding.
       max-parallel: 1 # Jobs are memory intensive, so only run one at a time.


### PR DESCRIPTION
## Description

Cleanup docker resources in hopes we won't run out of disk space. We don't use the `scanner-test` CI image for most of these jobs because it hasn't been needed, it seems. 

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
