### PR TITLE
ROX-22422: fall back to NVD for CVSS scores/severities when missing

### DIFF
--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -182,7 +182,7 @@ func setScoresAndScoreVersion(vuln *storage.EmbeddedVulnerability, vulnCVSS *v4.
 			// Use the report's score if it exists.
 			if baseScore := v2.GetBaseScore(); baseScore != 0.0 && baseScore != c.Score {
 				log.Debugf("Calculated CVSSv2 score does not match given base score (%f != %f) for %s. Using given score...", c.Score, baseScore, vuln.GetCve())
-				c.Score = v2.GetBaseScore()
+				c.Score = baseScore
 			}
 			c.Severity = cvssv2.Severity(c.Score)
 			vuln.CvssV2 = c
@@ -203,7 +203,7 @@ func setScoresAndScoreVersion(vuln *storage.EmbeddedVulnerability, vulnCVSS *v4.
 			// Use the report's score if it exists.
 			if baseScore := v3.GetBaseScore(); baseScore != 0.0 && baseScore != c.Score {
 				log.Debugf("Calculated CVSSv3 score does not match given base score (%f != %f) for %s. Using given score...", c.Score, baseScore, vuln.GetCve())
-				c.Score = v3.GetBaseScore()
+				c.Score = baseScore
 			}
 			c.Severity = cvssv3.Severity(c.Score)
 			vuln.CvssV3 = c

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -8,6 +8,7 @@ import (
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/clair"
+	"github.com/stackrox/rox/pkg/cvss"
 	"github.com/stackrox/rox/pkg/cvss/cvssv2"
 	"github.com/stackrox/rox/pkg/cvss/cvssv3"
 	"github.com/stackrox/rox/pkg/errorhelpers"
@@ -151,9 +152,10 @@ func vulnerabilities(vulnerabilities map[string]*v4.VulnerabilityReport_Vulnerab
 			VulnerabilityType: storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
 			Severity:          normalizedSeverity(ccVuln.GetNormalizedSeverity()),
 		}
-		if err := setCvss(vuln, ccVuln.GetCvss()); err != nil {
+		if err := setScoresAndScoreVersion(vuln, ccVuln.GetCvss()); err != nil {
 			utils.Should(err)
 		}
+		maybeOverwriteSeverity(vuln)
 		if ccVuln.GetFixedInVersion() != "" {
 			vuln.SetFixedBy = &storage.EmbeddedVulnerability_FixedBy{
 				FixedBy: ccVuln.GetFixedInVersion(),
@@ -166,44 +168,46 @@ func vulnerabilities(vulnerabilities map[string]*v4.VulnerabilityReport_Vulnerab
 	return vulns
 }
 
-func setCvss(vuln *storage.EmbeddedVulnerability, cvss *v4.VulnerabilityReport_Vulnerability_CVSS) error {
-	if cvss == nil {
+func setScoresAndScoreVersion(vuln *storage.EmbeddedVulnerability, vulnCVSS *v4.VulnerabilityReport_Vulnerability_CVSS) error {
+	if vulnCVSS == nil {
 		return nil
 	}
 	errList := errorhelpers.NewErrorList("failed to parse vector")
-	if v2 := cvss.GetV2(); v2 != nil {
+	if v2 := vulnCVSS.GetV2(); v2 != nil {
 		if c, err := cvssv2.ParseCVSSV2(v2.GetVector()); err == nil {
 			err = cvssv2.CalculateScores(c)
 			if err != nil {
 				errList.AddError(fmt.Errorf("calculating CVSS v2 scores: %w", err))
 			}
 			// Use the report's score if it exists.
-			if v2.GetBaseScore() != 0.0 {
+			if baseScore := v2.GetBaseScore(); baseScore != 0.0 && baseScore != c.Score {
+				log.Debugf("Calculated CVSSv2 score does not match given base score (%f != %f) for %s. Using given score...", c.Score, baseScore, vuln.GetCve())
 				c.Score = v2.GetBaseScore()
 			}
 			c.Severity = cvssv2.Severity(c.Score)
 			vuln.CvssV2 = c
-			// This sets the top level score for use in policies. It will be overwritten if
-			// v3 exists.
+			// This sets the top level score for use in policies.
+			// It will be overwritten if v3 exists.
 			vuln.ScoreVersion = storage.EmbeddedVulnerability_V2
 			vuln.Cvss = c.Score
 		} else {
 			errList.AddError(fmt.Errorf("v2: %w", err))
 		}
 	}
-	if v3 := cvss.GetV3(); v3 != nil {
+	if v3 := vulnCVSS.GetV3(); v3 != nil {
 		if c, err := cvssv3.ParseCVSSV3(v3.GetVector()); err == nil {
 			err = cvssv3.CalculateScores(c)
 			if err != nil {
 				errList.AddError(fmt.Errorf("calculating CVSS v3 scores: %w", err))
 			}
 			// Use the report's score if it exists.
-			if v3.GetBaseScore() != 0.0 {
+			if baseScore := v3.GetBaseScore(); baseScore != 0.0 && baseScore != c.Score {
+				log.Debugf("Calculated CVSSv3 score does not match given base score (%f != %f) for %s. Using given score...", c.Score, baseScore, vuln.GetCve())
 				c.Score = v3.GetBaseScore()
 			}
 			c.Severity = cvssv3.Severity(c.Score)
 			vuln.CvssV3 = c
-			// Overwrite V2 if set.
+			// Overwrite v2, if set.
 			vuln.ScoreVersion = storage.EmbeddedVulnerability_V3
 			vuln.Cvss = c.Score
 		} else {
@@ -218,6 +222,12 @@ func setCvss(vuln *storage.EmbeddedVulnerability, cvss *v4.VulnerabilityReport_V
 func link(links string) string {
 	link, _, _ := strings.Cut(links, " ")
 	return link
+}
+
+// maybeOverwriteSeverity overwrites vuln.Severity with one derived from the CVSS scores
+// if vuln.Severity == storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY.
+func maybeOverwriteSeverity(vuln *storage.EmbeddedVulnerability) {
+	vuln.Severity = cvss.VulnToSeverity(cvss.NewFromEmbeddedVulnerability(vuln))
 }
 
 func normalizedSeverity(severity v4.VulnerabilityReport_Vulnerability_Severity) storage.VulnerabilitySeverity {

--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -351,7 +351,7 @@ func TestMaybeOverwriteSeverity(t *testing.T) {
 		expected storage.VulnerabilitySeverity
 	}{
 		{
-			name: "low no overwrite",
+			name:     "low no overwrite",
 			expected: storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY,
 			vuln: &storage.EmbeddedVulnerability{
 				Severity: storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY,
@@ -364,7 +364,7 @@ func TestMaybeOverwriteSeverity(t *testing.T) {
 			},
 		},
 		{
-			name: "moderate no overwrite",
+			name:     "moderate no overwrite",
 			expected: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
 			vuln: &storage.EmbeddedVulnerability{
 				Severity: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
@@ -377,7 +377,7 @@ func TestMaybeOverwriteSeverity(t *testing.T) {
 			},
 		},
 		{
-			name: "important no overwrite",
+			name:     "important no overwrite",
 			expected: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
 			vuln: &storage.EmbeddedVulnerability{
 				Severity: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
@@ -390,7 +390,7 @@ func TestMaybeOverwriteSeverity(t *testing.T) {
 			},
 		},
 		{
-			name: "critical no overwrite",
+			name:     "critical no overwrite",
 			expected: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
 			vuln: &storage.EmbeddedVulnerability{
 				Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
@@ -403,7 +403,7 @@ func TestMaybeOverwriteSeverity(t *testing.T) {
 			},
 		},
 		{
-			name: "CVSSv3 overwrite",
+			name:     "CVSSv3 overwrite",
 			expected: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
 			vuln: &storage.EmbeddedVulnerability{
 				Severity: storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY,
@@ -416,7 +416,7 @@ func TestMaybeOverwriteSeverity(t *testing.T) {
 			},
 		},
 		{
-			name: "CVSSv2 overwrite",
+			name:     "CVSSv2 overwrite",
 			expected: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
 			vuln: &storage.EmbeddedVulnerability{
 				Severity: storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY,

--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -119,6 +119,322 @@ func TestConvert(t *testing.T) {
 	assert.Equal(t, expected.OperatingSystem, actual.OperatingSystem)
 }
 
+func TestSetScoresAndScoreVersion(t *testing.T) {
+	testcases := []struct {
+		name     string
+		vulnCVSS *v4.VulnerabilityReport_Vulnerability_CVSS
+		expected *storage.EmbeddedVulnerability
+		wantErr  bool
+	}{
+		{
+			name: "CVSS 3.1 parse error",
+			vulnCVSS: &v4.VulnerabilityReport_Vulnerability_CVSS{
+				V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
+					BaseScore: 8.2,
+					Vector:    "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:Q",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "CVSS 3.1 only",
+			vulnCVSS: &v4.VulnerabilityReport_Vulnerability_CVSS{
+				V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
+					BaseScore: 8.2,
+					Vector:    "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:H",
+				},
+			},
+			expected: &storage.EmbeddedVulnerability{
+				Cvss:         8.2,
+				ScoreVersion: storage.EmbeddedVulnerability_V3,
+				CvssV3: &storage.CVSSV3{
+					Vector:              "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:H",
+					ExploitabilityScore: 2.8,
+					ImpactScore:         4.7,
+					AttackVector:        storage.CVSSV3_ATTACK_ADJACENT,
+					AttackComplexity:    storage.CVSSV3_COMPLEXITY_LOW,
+					PrivilegesRequired:  storage.CVSSV3_PRIVILEGE_NONE,
+					UserInteraction:     storage.CVSSV3_UI_NONE,
+					Scope:               storage.CVSSV3_CHANGED,
+					Confidentiality:     storage.CVSSV3_IMPACT_LOW,
+					Integrity:           storage.CVSSV3_IMPACT_NONE,
+					Availability:        storage.CVSSV3_IMPACT_HIGH,
+					Score:               8.2,
+					Severity:            storage.CVSSV3_HIGH,
+				},
+			},
+		},
+		{
+			name: "CVSS 3.0 only",
+			vulnCVSS: &v4.VulnerabilityReport_Vulnerability_CVSS{
+				V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
+					BaseScore: 8.2,
+					Vector:    "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:H",
+				},
+			},
+			expected: &storage.EmbeddedVulnerability{
+				Cvss:         8.2,
+				ScoreVersion: storage.EmbeddedVulnerability_V3,
+				CvssV3: &storage.CVSSV3{
+					Vector:              "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:H",
+					ExploitabilityScore: 2.8,
+					ImpactScore:         4.7,
+					AttackVector:        storage.CVSSV3_ATTACK_ADJACENT,
+					AttackComplexity:    storage.CVSSV3_COMPLEXITY_LOW,
+					PrivilegesRequired:  storage.CVSSV3_PRIVILEGE_NONE,
+					UserInteraction:     storage.CVSSV3_UI_NONE,
+					Scope:               storage.CVSSV3_CHANGED,
+					Confidentiality:     storage.CVSSV3_IMPACT_LOW,
+					Integrity:           storage.CVSSV3_IMPACT_NONE,
+					Availability:        storage.CVSSV3_IMPACT_HIGH,
+					Score:               8.2,
+					Severity:            storage.CVSSV3_HIGH,
+				},
+			},
+		},
+		{
+			name: "CVSS 3.1 score differs from calculated",
+			vulnCVSS: &v4.VulnerabilityReport_Vulnerability_CVSS{
+				V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
+					BaseScore: 4.0,
+					Vector:    "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:H",
+				},
+			},
+			expected: &storage.EmbeddedVulnerability{
+				Cvss:         4.0,
+				ScoreVersion: storage.EmbeddedVulnerability_V3,
+				CvssV3: &storage.CVSSV3{
+					Vector:              "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:H",
+					ExploitabilityScore: 2.8,
+					ImpactScore:         4.7,
+					AttackVector:        storage.CVSSV3_ATTACK_ADJACENT,
+					AttackComplexity:    storage.CVSSV3_COMPLEXITY_LOW,
+					PrivilegesRequired:  storage.CVSSV3_PRIVILEGE_NONE,
+					UserInteraction:     storage.CVSSV3_UI_NONE,
+					Scope:               storage.CVSSV3_CHANGED,
+					Confidentiality:     storage.CVSSV3_IMPACT_LOW,
+					Integrity:           storage.CVSSV3_IMPACT_NONE,
+					Availability:        storage.CVSSV3_IMPACT_HIGH,
+					Score:               4.0,
+					Severity:            storage.CVSSV3_MEDIUM,
+				},
+			},
+		},
+		{
+			name: "CVSS 2 parse error",
+			vulnCVSS: &v4.VulnerabilityReport_Vulnerability_CVSS{
+				V2: &v4.VulnerabilityReport_Vulnerability_CVSS_V2{
+					BaseScore: 8.2,
+					Vector:    "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:Q",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "CVSS 2 only",
+			vulnCVSS: &v4.VulnerabilityReport_Vulnerability_CVSS{
+				V2: &v4.VulnerabilityReport_Vulnerability_CVSS_V2{
+					BaseScore: 6.4,
+					Vector:    "AV:N/AC:M/Au:M/C:C/I:N/A:P",
+				},
+			},
+			expected: &storage.EmbeddedVulnerability{
+				Cvss:         6.4,
+				ScoreVersion: storage.EmbeddedVulnerability_V2,
+				CvssV2: &storage.CVSSV2{
+					Vector:              "AV:N/AC:M/Au:M/C:C/I:N/A:P",
+					AttackVector:        storage.CVSSV2_ATTACK_NETWORK,
+					AccessComplexity:    storage.CVSSV2_ACCESS_MEDIUM,
+					Authentication:      storage.CVSSV2_AUTH_MULTIPLE,
+					Confidentiality:     storage.CVSSV2_IMPACT_COMPLETE,
+					Integrity:           storage.CVSSV2_IMPACT_NONE,
+					Availability:        storage.CVSSV2_IMPACT_PARTIAL,
+					ExploitabilityScore: 5.5,
+					ImpactScore:         7.8,
+					Score:               6.4,
+					Severity:            storage.CVSSV2_MEDIUM,
+				},
+			},
+		},
+		{
+			name: "CVSS 2 score differs from calculated",
+			vulnCVSS: &v4.VulnerabilityReport_Vulnerability_CVSS{
+				V2: &v4.VulnerabilityReport_Vulnerability_CVSS_V2{
+					BaseScore: 1.2,
+					Vector:    "AV:N/AC:M/Au:M/C:C/I:N/A:P",
+				},
+			},
+			expected: &storage.EmbeddedVulnerability{
+				Cvss:         1.2,
+				ScoreVersion: storage.EmbeddedVulnerability_V2,
+				CvssV2: &storage.CVSSV2{
+					Vector:              "AV:N/AC:M/Au:M/C:C/I:N/A:P",
+					AttackVector:        storage.CVSSV2_ATTACK_NETWORK,
+					AccessComplexity:    storage.CVSSV2_ACCESS_MEDIUM,
+					Authentication:      storage.CVSSV2_AUTH_MULTIPLE,
+					Confidentiality:     storage.CVSSV2_IMPACT_COMPLETE,
+					Integrity:           storage.CVSSV2_IMPACT_NONE,
+					Availability:        storage.CVSSV2_IMPACT_PARTIAL,
+					ExploitabilityScore: 5.5,
+					ImpactScore:         7.8,
+					Score:               1.2,
+					Severity:            storage.CVSSV2_LOW,
+				},
+			},
+		},
+		{
+			name: "Both CVSS 3.1 and 2",
+			vulnCVSS: &v4.VulnerabilityReport_Vulnerability_CVSS{
+				V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
+					BaseScore: 8.2,
+					Vector:    "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:H",
+				},
+				V2: &v4.VulnerabilityReport_Vulnerability_CVSS_V2{
+					BaseScore: 6.4,
+					Vector:    "AV:N/AC:M/Au:M/C:C/I:N/A:P",
+				},
+			},
+			expected: &storage.EmbeddedVulnerability{
+				Cvss:         8.2,
+				ScoreVersion: storage.EmbeddedVulnerability_V3,
+				CvssV3: &storage.CVSSV3{
+					Vector:              "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:H",
+					ExploitabilityScore: 2.8,
+					ImpactScore:         4.7,
+					AttackVector:        storage.CVSSV3_ATTACK_ADJACENT,
+					AttackComplexity:    storage.CVSSV3_COMPLEXITY_LOW,
+					PrivilegesRequired:  storage.CVSSV3_PRIVILEGE_NONE,
+					UserInteraction:     storage.CVSSV3_UI_NONE,
+					Scope:               storage.CVSSV3_CHANGED,
+					Confidentiality:     storage.CVSSV3_IMPACT_LOW,
+					Integrity:           storage.CVSSV3_IMPACT_NONE,
+					Availability:        storage.CVSSV3_IMPACT_HIGH,
+					Score:               8.2,
+					Severity:            storage.CVSSV3_HIGH,
+				},
+				CvssV2: &storage.CVSSV2{
+					Vector:              "AV:N/AC:M/Au:M/C:C/I:N/A:P",
+					AttackVector:        storage.CVSSV2_ATTACK_NETWORK,
+					AccessComplexity:    storage.CVSSV2_ACCESS_MEDIUM,
+					Authentication:      storage.CVSSV2_AUTH_MULTIPLE,
+					Confidentiality:     storage.CVSSV2_IMPACT_COMPLETE,
+					Integrity:           storage.CVSSV2_IMPACT_NONE,
+					Availability:        storage.CVSSV2_IMPACT_PARTIAL,
+					ExploitabilityScore: 5.5,
+					ImpactScore:         7.8,
+					Score:               6.4,
+					Severity:            storage.CVSSV2_MEDIUM,
+				},
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			vuln := &storage.EmbeddedVulnerability{}
+			err := setScoresAndScoreVersion(vuln, testcase.vulnCVSS)
+			if testcase.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, testcase.expected, vuln)
+		})
+	}
+}
+
+func TestMaybeOverwriteSeverity(t *testing.T) {
+	testcases := []struct {
+		name     string
+		vuln     *storage.EmbeddedVulnerability
+		expected storage.VulnerabilitySeverity
+	}{
+		{
+			name: "low no overwrite",
+			expected: storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY,
+			vuln: &storage.EmbeddedVulnerability{
+				Severity: storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY,
+				CvssV3: &storage.CVSSV3{
+					Severity: storage.CVSSV3_MEDIUM,
+				},
+				CvssV2: &storage.CVSSV2{
+					Severity: storage.CVSSV2_HIGH,
+				},
+			},
+		},
+		{
+			name: "moderate no overwrite",
+			expected: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+			vuln: &storage.EmbeddedVulnerability{
+				Severity: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+				CvssV3: &storage.CVSSV3{
+					Severity: storage.CVSSV3_MEDIUM,
+				},
+				CvssV2: &storage.CVSSV2{
+					Severity: storage.CVSSV2_HIGH,
+				},
+			},
+		},
+		{
+			name: "important no overwrite",
+			expected: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+			vuln: &storage.EmbeddedVulnerability{
+				Severity: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+				CvssV3: &storage.CVSSV3{
+					Severity: storage.CVSSV3_MEDIUM,
+				},
+				CvssV2: &storage.CVSSV2{
+					Severity: storage.CVSSV2_HIGH,
+				},
+			},
+		},
+		{
+			name: "critical no overwrite",
+			expected: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+			vuln: &storage.EmbeddedVulnerability{
+				Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+				CvssV3: &storage.CVSSV3{
+					Severity: storage.CVSSV3_MEDIUM,
+				},
+				CvssV2: &storage.CVSSV2{
+					Severity: storage.CVSSV2_HIGH,
+				},
+			},
+		},
+		{
+			name: "CVSSv3 overwrite",
+			expected: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+			vuln: &storage.EmbeddedVulnerability{
+				Severity: storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY,
+				CvssV3: &storage.CVSSV3{
+					Severity: storage.CVSSV3_MEDIUM,
+				},
+				CvssV2: &storage.CVSSV2{
+					Severity: storage.CVSSV2_HIGH,
+				},
+			},
+		},
+		{
+			name: "CVSSv2 overwrite",
+			expected: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+			vuln: &storage.EmbeddedVulnerability{
+				Severity: storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY,
+				CvssV2: &storage.CVSSV2{
+					Severity: storage.CVSSV2_HIGH,
+				},
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			maybeOverwriteSeverity(testcase.vuln)
+			assert.Equal(t, testcase.expected, testcase.vuln.Severity)
+		})
+	}
+}
+
 func TestParsePackageDB(t *testing.T) {
 	testcases := []struct {
 		packageDB          string

--- a/scanner/mappers/mappers.go
+++ b/scanner/mappers/mappers.go
@@ -610,7 +610,6 @@ func severityAndScores(ctx context.Context, vuln *claircore.Vulnerability, nvdVu
 			break
 		}
 		return sev, nil
-	default:
 	}
 
 	// Default/fallback is NVD.

--- a/scanner/mappers/mappers_test.go
+++ b/scanner/mappers/mappers_test.go
@@ -59,7 +59,7 @@ func Test_ToProtoV4VulnerabilityReport(t *testing.T) {
 		wantErr string
 	}{
 		"when nil then nil": {},
-		"when default values then attributes are definde": {
+		"when default values then attributes are defined": {
 			arg:  &claircore.VulnerabilityReport{},
 			want: &v4.VulnerabilityReport{Contents: &v4.Contents{}},
 		},
@@ -654,7 +654,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 				},
 			},
 		},
-		"when vuln with range and no fixedIn then use upper limit": {
+		"when vuln with range and no fixedIn then not fixed": {
 			ccVulnerabilities: map[string]*claircore.Vulnerability{
 				"foo": {
 					Issued: now,
@@ -669,7 +669,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
 				"foo": {
 					Issued:         protoNow,
-					FixedInVersion: "1.2.3",
+					FixedInVersion: "",
 				},
 			},
 		},
@@ -802,7 +802,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 				},
 			},
 		},
-		"when severity with CVSSv2 is invalid then skip": {
+		"when severity with CVSSv2 is invalid skip CVSS": {
 			ccVulnerabilities: map[string]*claircore.Vulnerability{
 				"foo": {
 					Issued: now,
@@ -813,8 +813,14 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 					Updater: "RHEL8-updater",
 				},
 			},
+			want: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"foo": {
+					Issued:   protoNow,
+					Severity: "sample severity",
+				},
+			},
 		},
-		"when severity with CVSSv3 is invalid then skip": {
+		"when severity with CVSSv3 is invalid skip CVSS": {
 			ccVulnerabilities: map[string]*claircore.Vulnerability{
 				"foo": {
 					Issued: now,
@@ -823,6 +829,12 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 						"cvss3_vector": []string{"invalid cvss3 vector"},
 					}.Encode(),
 					Updater: "RHEL8-updater",
+				},
+			},
+			want: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"foo": {
+					Issued:   protoNow,
+					Severity: "sample severity",
 				},
 			},
 		},
@@ -837,6 +849,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
 				"foo": {
 					Issued: protoNow,
+					Severity: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
 					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
 						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
 							Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
@@ -851,6 +864,41 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 					ID:      "foo",
 					Issued:  now,
 					Updater: "unknown updater",
+				},
+			},
+			nvdVulns: map[string]*nvdschema.CVEAPIJSON20CVEItem{
+				"foo": {
+					ID: "CVE-1234-567",
+					Metrics: &nvdschema.CVEAPIJSON20CVEItemMetrics{
+						CvssMetricV31: []*nvdschema.CVEAPIJSON20CVSSV31{
+							{
+								CvssData: &nvdschema.CVSSV31{
+									Version:      "3.1",
+									VectorString: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"foo": {
+					Id:     "foo",
+					Issued: protoNow,
+					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
+						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
+							Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+						},
+					},
+				},
+			},
+		},
+		"when OSV missing severity then return NVD scores": {
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"foo": {
+					ID:      "foo",
+					Issued:  now,
+					Updater: "osv/sample-updater",
 				},
 			},
 			nvdVulns: map[string]*nvdschema.CVEAPIJSON20CVEItem{

--- a/scanner/mappers/mappers_test.go
+++ b/scanner/mappers/mappers_test.go
@@ -654,46 +654,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 				},
 			},
 		},
-		"when vuln with range and no fixedIn then not fixed": {
-			ccVulnerabilities: map[string]*claircore.Vulnerability{
-				"foo": {
-					Issued: now,
-					Range: &claircore.Range{
-						Upper: claircore.Version{
-							Kind: "test",
-							V:    [10]int32{0, 1, 2, 3},
-						},
-					},
-				},
-			},
-			want: map[string]*v4.VulnerabilityReport_Vulnerability{
-				"foo": {
-					Issued:         protoNow,
-					FixedInVersion: "",
-				},
-			},
-		},
-		"when vuln with range and with fixeIn then use fixedIn": {
-			ccVulnerabilities: map[string]*claircore.Vulnerability{
-				"foo": {
-					Issued:         now,
-					FixedInVersion: "4.5.6",
-					Range: &claircore.Range{
-						Upper: claircore.Version{
-							Kind: "test",
-							V:    [10]int32{0, 1, 2, 3},
-						},
-					},
-				},
-			},
-			want: map[string]*v4.VulnerabilityReport_Vulnerability{
-				"foo": {
-					Issued:         protoNow,
-					FixedInVersion: "4.5.6",
-				},
-			},
-		},
-		"when vuln urlencoded fixeIn then use fixed value in fixedIn": {
+		"when vuln urlencoded fixedIn then use fixed value in fixedIn": {
 			ccVulnerabilities: map[string]*claircore.Vulnerability{
 				"foo": {
 					Issued:         now,
@@ -848,7 +809,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			},
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
 				"foo": {
-					Issued: protoNow,
+					Issued:   protoNow,
 					Severity: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
 					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
 						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{


### PR DESCRIPTION
## Description

Scanner V2 falls back to NVD data when the vendors do not provide severities/scores. We already do that here, too, except for OSV, which we originally assumed would populate the `Severity` field. Unfortunately, not every entry in OSV populates this, so we will fall back to NVD data for this case.

Note: it's still possible we do not see any CVSS score/severity when falling back, as the vuln may not have an NVD entry. This makes sense for a brand new vulnerability, but this may also be the case for OSV vulns which cannot be attributed to a CVE in any way.

For example: https://osv-vulnerabilities.storage.googleapis.com/Go/GO-2023-2375.json

Though the alias says `CVE-2023-45287`, we miss this, as ClairCore does not read the aliases at this time. We at least will no longer skip this vulnerability, but the severity will be unknown.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI and deployed this PR to an OpenShift cluster. I found the following:


Example of vulnerabilities lacking severity/scores which we will not detect:
<img width="1376" alt="Screenshot 2024-02-20 at 5 25 56 PM" src="https://github.com/stackrox/stackrox/assets/7704495/64b9e03d-0f47-4b5d-a39d-523c337a1240">



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
