### PR TITLE
ROX-21773: discovered clusters service

### DIFF
--- a/central/convert/storagetov1/discovered_cluster.go
+++ b/central/convert/storagetov1/discovered_cluster.go
@@ -1,0 +1,45 @@
+package storagetov1
+
+import (
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+)
+
+// DiscoveredCluster converts the given storage.DiscoveredCluster to a v1.DiscoveredCluster.
+func DiscoveredCluster(discoveredCluster *storage.DiscoveredCluster) *v1.DiscoveredCluster {
+	metadata := discoveredCluster.GetMetadata()
+	v1DiscoveredCluster := &v1.DiscoveredCluster{
+		Id: discoveredCluster.GetId(),
+		Metadata: &v1.DiscoveredCluster_Metadata{
+			Id:                metadata.GetId(),
+			Name:              metadata.GetName(),
+			Type:              discoveredClusterToV1TypeEnum(metadata.GetType()),
+			ProviderType:      v1.DiscoveredCluster_Metadata_ProviderType(metadata.GetProviderType()),
+			Region:            metadata.GetRegion(),
+			FirstDiscoveredAt: metadata.GetFirstDiscoveredAt(),
+		},
+		Status: discoveredClusterToV1StatusEnum(discoveredCluster.GetStatus()),
+		Source: &v1.DiscoveredCluster_CloudSource{
+			Id: discoveredCluster.GetSourceId(),
+		},
+	}
+	return v1DiscoveredCluster
+}
+
+func discoveredClusterToV1TypeEnum(val storage.ClusterMetadata_Type) v1.DiscoveredCluster_Metadata_Type {
+	return v1.DiscoveredCluster_Metadata_Type(
+		v1.DiscoveredCluster_Metadata_Type_value[val.String()],
+	)
+}
+
+func discoveredClusterToV1ProviderTypeEnum(val storage.DiscoveredCluster_Metadata_ProviderType) v1.DiscoveredCluster_Metadata_ProviderType {
+	return v1.DiscoveredCluster_Metadata_ProviderType(
+		v1.DiscoveredCluster_Metadata_ProviderType_value[val.String()],
+	)
+}
+
+func discoveredClusterToV1StatusEnum(val storage.DiscoveredCluster_Status) v1.DiscoveredCluster_Status {
+	return v1.DiscoveredCluster_Status(
+		v1.DiscoveredCluster_Status_value[val.String()],
+	)
+}

--- a/central/convert/storagetov1/discovered_cluster.go
+++ b/central/convert/storagetov1/discovered_cluster.go
@@ -26,6 +26,15 @@ func DiscoveredCluster(discoveredCluster *storage.DiscoveredCluster) *v1.Discove
 	return v1DiscoveredCluster
 }
 
+// DiscoveredClusterList converts the given ...*storage.DiscoveredCluster to a []*v1.DiscoveredCluster.
+func DiscoveredClusterList(discoveredClusters ...*storage.DiscoveredCluster) []*v1.DiscoveredCluster {
+	v1DiscoveredClusters := make([]*v1.DiscoveredCluster, 0, len(discoveredClusters))
+	for _, dc := range discoveredClusters {
+		v1DiscoveredClusters = append(v1DiscoveredClusters, DiscoveredCluster(dc))
+	}
+	return v1DiscoveredClusters
+}
+
 func discoveredClusterToV1TypeEnum(val storage.ClusterMetadata_Type) v1.DiscoveredCluster_Metadata_Type {
 	return v1.DiscoveredCluster_Metadata_Type(
 		v1.DiscoveredCluster_Metadata_Type_value[val.String()],

--- a/central/convert/storagetov1/discovered_cluster.go
+++ b/central/convert/storagetov1/discovered_cluster.go
@@ -14,7 +14,7 @@ func DiscoveredCluster(discoveredCluster *storage.DiscoveredCluster) *v1.Discove
 			Id:                metadata.GetId(),
 			Name:              metadata.GetName(),
 			Type:              discoveredClusterToV1TypeEnum(metadata.GetType()),
-			ProviderType:      v1.DiscoveredCluster_Metadata_ProviderType(metadata.GetProviderType()),
+			ProviderType:      discoveredClusterToV1ProviderTypeEnum(metadata.GetProviderType()),
 			Region:            metadata.GetRegion(),
 			FirstDiscoveredAt: metadata.GetFirstDiscoveredAt(),
 		},

--- a/central/convert/typetostorage/discovered_cluster.go
+++ b/central/convert/typetostorage/discovered_cluster.go
@@ -23,6 +23,5 @@ func DiscoveredCluster(cluster *discoveredclusters.DiscoveredCluster) *storage.D
 		SourceId:      cluster.GetCloudSourceID(),
 		LastUpdatedAt: types.TimestampNow(),
 	}
-
 	return storageConfig
 }

--- a/central/discoveredclusters/datastore/datastore.go
+++ b/central/discoveredclusters/datastore/datastore.go
@@ -31,8 +31,8 @@ func newDataStore(searcher search.Searcher, storage store.Store) DataStore {
 	}
 }
 
-// getTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func getTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
+// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	searcher := search.New(pgStore.NewIndexer(pool))
 	store := pgStore.New(pool)
 	return newDataStore(searcher, store)

--- a/central/discoveredclusters/datastore/datastore_impl_postgres_test.go
+++ b/central/discoveredclusters/datastore/datastore_impl_postgres_test.go
@@ -46,7 +46,7 @@ func (s *datastorePostgresTestSuite) SetupTest() {
 
 	s.postgresTest = pgtest.ForT(s.T())
 	s.Require().NotNil(s.postgresTest)
-	s.datastore = getTestPostgresDataStore(s.T(), s.postgresTest.DB)
+	s.datastore = GetTestPostgresDataStore(s.T(), s.postgresTest.DB)
 }
 
 func (s *datastorePostgresTestSuite) TearDownTest() {

--- a/central/discoveredclusters/service/service.go
+++ b/central/discoveredclusters/service/service.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/central/discoveredclusters/datastore"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/grpc"
+)
+
+// Service provides the interface to the gRPC service for users.
+type Service interface {
+	grpc.APIService
+
+	AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error)
+
+	v1.DiscoveredClustersServiceServer
+}
+
+func newService(datastore datastore.DataStore) Service {
+	return &serviceImpl{
+		ds: datastore,
+	}
+}

--- a/central/discoveredclusters/service/service_impl.go
+++ b/central/discoveredclusters/service/service_impl.go
@@ -94,11 +94,9 @@ func (s *serviceImpl) ListDiscoveredClusters(ctx context.Context, request *v1.Li
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list discovered clusters")
 	}
-	v1DiscoveredClusters := make([]*v1.DiscoveredCluster, 0, len(discoveredClusters))
-	for _, dc := range discoveredClusters {
-		v1DiscoveredClusters = append(v1DiscoveredClusters, storagetov1.DiscoveredCluster(dc))
-	}
-	return &v1.ListDiscoveredClustersResponse{Clusters: v1DiscoveredClusters}, nil
+	return &v1.ListDiscoveredClustersResponse{
+		Clusters: storagetov1.DiscoveredClusterList(discoveredClusters...),
+	}, nil
 }
 
 func getQueryBuilderFromFilter(filter *v1.DiscoveredClustersFilter) *search.QueryBuilder {

--- a/central/discoveredclusters/service/service_impl.go
+++ b/central/discoveredclusters/service/service_impl.go
@@ -1,0 +1,127 @@
+package service
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/convert/storagetov1"
+	"github.com/stackrox/rox/central/discoveredclusters/datastore"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/grpc/authz"
+	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
+	"github.com/stackrox/rox/pkg/grpc/authz/user"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
+	"github.com/stackrox/rox/pkg/sliceutils"
+	"google.golang.org/grpc"
+)
+
+const (
+	maxPaginationLimit = 1000
+)
+
+var authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
+	user.With(permissions.View(resources.Administration)): {
+		"/v1.DiscoveredClustersService/CountDiscoveredClusters",
+		"/v1.DiscoveredClustersService/GetDiscoveredCluster",
+		"/v1.DiscoveredClustersService/ListDiscoveredClusters",
+	},
+})
+
+type serviceImpl struct {
+	v1.UnimplementedDiscoveredClustersServiceServer
+
+	ds datastore.DataStore
+}
+
+// RegisterServiceServer registers this service with the given gRPC Server.
+func (s *serviceImpl) RegisterServiceServer(server *grpc.Server) {
+	v1.RegisterDiscoveredClustersServiceServer(server, s)
+}
+
+// RegisterServiceHandler registers this service with the given gRPC Gateway endpoint.
+func (s *serviceImpl) RegisterServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
+	return v1.RegisterDiscoveredClustersServiceHandler(ctx, mux, conn)
+}
+
+// AuthFuncOverride specifies the auth criteria for this API.
+func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
+	return ctx, authorizer.Authorized(ctx, fullMethodName)
+}
+
+// CountDiscoveredClusters returns the number of discovered clusters matching the request query.
+func (s *serviceImpl) CountDiscoveredClusters(ctx context.Context, request *v1.CountDiscoveredClustersRequest,
+) (*v1.CountDiscoveredClustersResponse, error) {
+	query := getQueryBuilderFromFilter(request.GetFilter()).ProtoQuery()
+	count, err := s.ds.CountDiscoveredClusters(ctx, query)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to count discovered clusters")
+	}
+	return &v1.CountDiscoveredClustersResponse{Count: int32(count)}, nil
+}
+
+// GetDiscoveredCluster returns a specific discovered cluster based on its ID.
+func (s *serviceImpl) GetDiscoveredCluster(ctx context.Context, request *v1.GetDiscoveredClusterRequest,
+) (*v1.GetDiscoveredClusterResponse, error) {
+	resourceID := request.GetId()
+	if resourceID == "" {
+		return nil, errors.Wrap(errox.InvalidArgs, "id must be provided")
+	}
+	discoveredCluster, err := s.ds.GetDiscoveredCluster(ctx, resourceID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get discovered cluster %q", resourceID)
+	}
+	return &v1.GetDiscoveredClusterResponse{Cluster: storagetov1.DiscoveredCluster(discoveredCluster)}, nil
+}
+
+// ListDiscoveredClusters returns all discovered clusters matching the request query.
+func (s *serviceImpl) ListDiscoveredClusters(ctx context.Context, request *v1.ListDiscoveredClustersRequest,
+) (*v1.ListDiscoveredClustersResponse, error) {
+	query := getQueryBuilderFromFilter(request.GetFilter()).ProtoQuery()
+	paginated.FillPagination(query, request.GetPagination(), maxPaginationLimit)
+	paginated.FillDefaultSortOption(
+		query,
+		&v1.QuerySortOption{
+			Field: search.Cluster.String(),
+		},
+	)
+
+	discoveredClusters, err := s.ds.ListDiscoveredClusters(ctx, query)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list discovered clusters")
+	}
+	v1DiscoveredClusters := make([]*v1.DiscoveredCluster, 0, len(discoveredClusters))
+	for _, dc := range discoveredClusters {
+		v1DiscoveredClusters = append(v1DiscoveredClusters, storagetov1.DiscoveredCluster(dc))
+	}
+	return &v1.ListDiscoveredClustersResponse{Clusters: v1DiscoveredClusters}, nil
+}
+
+func getQueryBuilderFromFilter(filter *v1.DiscoveredClustersFilter) *search.QueryBuilder {
+	queryBuilder := search.NewQueryBuilder()
+	if names := filter.GetNames(); len(names) != 0 {
+		queryBuilder = queryBuilder.AddExactMatches(search.Cluster,
+			sliceutils.Unique(names)...,
+		)
+	}
+	if types := filter.GetTypes(); len(types) != 0 {
+		queryBuilder = queryBuilder.AddExactMatches(search.ClusterType,
+			sliceutils.Unique(sliceutils.StringSlice(types...))...,
+		)
+	}
+	if statuses := filter.GetStatuses(); len(statuses) != 0 {
+		queryBuilder = queryBuilder.AddExactMatches(search.ClusterStatus,
+			sliceutils.Unique(sliceutils.StringSlice(statuses...))...,
+		)
+	}
+	if sources := filter.GetSourceIds(); len(sources) != 0 {
+		queryBuilder = queryBuilder.AddExactMatches(search.IntegrationID,
+			sliceutils.Unique(sources)...,
+		)
+	}
+	return queryBuilder
+}

--- a/central/discoveredclusters/service/service_impl_postgres_test.go
+++ b/central/discoveredclusters/service/service_impl_postgres_test.go
@@ -1,0 +1,186 @@
+//go:build sql_integration
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/central/convert/storagetov1"
+	"github.com/stackrox/rox/central/convert/typetostorage"
+	"github.com/stackrox/rox/central/discoveredclusters/datastore"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestServicePostgres(t *testing.T) {
+	suite.Run(t, new(servicePostgresTestSuite))
+}
+
+type servicePostgresTestSuite struct {
+	suite.Suite
+
+	readCtx   context.Context
+	writeCtx  context.Context
+	pool      *pgtest.TestPostgres
+	datastore datastore.DataStore
+	service   Service
+}
+
+func (s *servicePostgresTestSuite) SetupTest() {
+	s.readCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Administration),
+		),
+	)
+	s.writeCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Administration),
+		),
+	)
+	s.pool = pgtest.ForT(s.T())
+	s.Require().NotNil(s.pool)
+	s.datastore = datastore.GetTestPostgresDataStore(s.T(), s.pool)
+	s.service = newService(s.datastore)
+}
+
+func (s *servicePostgresTestSuite) TearDownTest() {
+	s.pool.Teardown(s.T())
+	s.pool.Close()
+}
+
+func (s *servicePostgresTestSuite) TestCount() {
+	s.addDiscoveredClusters(50)
+
+	// 1. Count discovered clusters without providing a query filter.
+	resp, err := s.service.CountDiscoveredClusters(s.readCtx, &v1.CountDiscoveredClustersRequest{})
+	s.Require().NoError(err)
+	s.Assert().Equal(int32(50), resp.GetCount())
+
+	// 2.a. Filter discovered clusters based on the name - no match.
+	resp, err = s.service.CountDiscoveredClusters(s.readCtx, &v1.CountDiscoveredClustersRequest{
+		Filter: &v1.DiscoveredClustersFilter{
+			Names: []string{"this name does not exist"},
+		},
+	})
+	s.Require().NoError(err)
+	s.Assert().Equal(int32(0), resp.GetCount())
+
+	// 2.b. Filter discovered clusters based on the name - one match.
+	resp, err = s.service.CountDiscoveredClusters(s.readCtx, &v1.CountDiscoveredClustersRequest{
+		Filter: &v1.DiscoveredClustersFilter{
+			Names: []string{"my-cluster-0"},
+		},
+	})
+	s.Require().NoError(err)
+	s.Assert().Equal(int32(1), resp.GetCount())
+
+	// 3. Filter discovered clusters based on the type.
+	resp, err = s.service.CountDiscoveredClusters(s.readCtx, &v1.CountDiscoveredClustersRequest{
+		Filter: &v1.DiscoveredClustersFilter{
+			Types: []v1.DiscoveredCluster_Metadata_Type{v1.DiscoveredCluster_Metadata_GKE},
+		},
+	})
+	s.Require().NoError(err)
+	s.Assert().Equal(int32(25), resp.GetCount())
+
+	// 4. Filter discovered clusters based on the status.
+	resp, err = s.service.CountDiscoveredClusters(s.readCtx, &v1.CountDiscoveredClustersRequest{
+		Filter: &v1.DiscoveredClustersFilter{
+			Statuses: []v1.DiscoveredCluster_Status{v1.DiscoveredCluster_STATUS_SECURED},
+		},
+	})
+	s.Require().NoError(err)
+	s.Assert().Equal(int32(25), resp.GetCount())
+
+	// 5. Filter discovered clusters based on the cloud source id.
+	resp, err = s.service.CountDiscoveredClusters(s.readCtx, &v1.CountDiscoveredClustersRequest{
+		Filter: &v1.DiscoveredClustersFilter{
+			SourceIds: []string{"fb28231c-54d1-41e1-9551-ede4c0e15c6c"},
+		},
+	})
+	s.Require().NoError(err)
+	s.Assert().Equal(int32(25), resp.GetCount())
+}
+
+func (s *servicePostgresTestSuite) TestGetDiscoveredCluster() {
+	discoveredClusters := s.addDiscoveredClusters(1)
+
+	resp, err := s.service.GetDiscoveredCluster(s.readCtx, &v1.GetDiscoveredClusterRequest{
+		Id: discoveredClusters[0].GetId(),
+	})
+	s.Require().NoError(err)
+	s.Assert().Equal(discoveredClusters[0], resp.GetCluster())
+}
+
+func (s *servicePostgresTestSuite) TestListDiscoveredClusters() {
+	discoveredClusters := s.addDiscoveredClusters(50)
+
+	// 1. Count discovered clusters without providing a query filter.
+	resp, err := s.service.ListDiscoveredClusters(s.readCtx, &v1.ListDiscoveredClustersRequest{})
+	s.Require().NoError(err)
+	s.Assert().Equal(discoveredClusters, resp.GetClusters())
+
+	// 2.a. Filter discovered clusters based on the name - no match.
+	resp, err = s.service.ListDiscoveredClusters(s.readCtx, &v1.ListDiscoveredClustersRequest{
+		Filter: &v1.DiscoveredClustersFilter{
+			Names: []string{"this name does not exist"},
+		},
+	})
+	s.Require().NoError(err)
+	s.Assert().Empty(resp.GetClusters())
+
+	// 2.b. Filter discovered clusters based on the name - one match.
+	resp, err = s.service.ListDiscoveredClusters(s.readCtx, &v1.ListDiscoveredClustersRequest{
+		Filter: &v1.DiscoveredClustersFilter{
+			Names: []string{"my-cluster-0"},
+		},
+	})
+	s.Require().NoError(err)
+	s.Assert().Equal([]*v1.DiscoveredCluster{discoveredClusters[0]}, resp.GetClusters())
+
+	// 3. Filter discovered clusters based on the type.
+	resp, err = s.service.ListDiscoveredClusters(s.readCtx, &v1.ListDiscoveredClustersRequest{
+		Filter: &v1.DiscoveredClustersFilter{
+			Types: []v1.DiscoveredCluster_Metadata_Type{v1.DiscoveredCluster_Metadata_GKE},
+		},
+	})
+	s.Require().NoError(err)
+	s.Assert().Equal(discoveredClusters[0:25], resp.GetClusters())
+
+	// 4. Filter discovered clusters based on the status.
+	resp, err = s.service.ListDiscoveredClusters(s.readCtx, &v1.ListDiscoveredClustersRequest{
+		Filter: &v1.DiscoveredClustersFilter{
+			Statuses: []v1.DiscoveredCluster_Status{v1.DiscoveredCluster_STATUS_SECURED},
+		},
+	})
+	s.Require().NoError(err)
+	s.Assert().Equal(discoveredClusters[0:25], resp.GetClusters())
+
+	// 5. Filter discovered clusters based on the cloud source id.
+	resp, err = s.service.ListDiscoveredClusters(s.readCtx, &v1.ListDiscoveredClustersRequest{
+		Filter: &v1.DiscoveredClustersFilter{
+			SourceIds: []string{"fb28231c-54d1-41e1-9551-ede4c0e15c6c"},
+		},
+	})
+	s.Require().NoError(err)
+	s.Assert().Equal(discoveredClusters[0:25], resp.GetClusters())
+}
+
+func (s *servicePostgresTestSuite) addDiscoveredClusters(num int) []*v1.DiscoveredCluster {
+	fakeClusters := fixtures.GetManyDiscoveredClusters(num)
+	s.Require().NoError(s.datastore.UpsertDiscoveredClusters(s.writeCtx, fakeClusters))
+	v1Clusters := []*v1.DiscoveredCluster{}
+	for _, dc := range fakeClusters {
+		storageCluster := typetostorage.DiscoveredCluster(dc)
+		v1Clusters = append(v1Clusters, storagetov1.DiscoveredCluster(storageCluster))
+	}
+	return v1Clusters
+}

--- a/central/discoveredclusters/service/service_impl_postgres_test.go
+++ b/central/discoveredclusters/service/service_impl_postgres_test.go
@@ -176,7 +176,7 @@ func (s *servicePostgresTestSuite) TestListDiscoveredClusters() {
 
 func (s *servicePostgresTestSuite) addDiscoveredClusters(num int) []*v1.DiscoveredCluster {
 	fakeClusters := fixtures.GetManyDiscoveredClusters(num)
-	s.Require().NoError(s.datastore.UpsertDiscoveredClusters(s.writeCtx, fakeClusters))
+	s.Require().NoError(s.datastore.UpsertDiscoveredClusters(s.writeCtx, fakeClusters...))
 	v1Clusters := []*v1.DiscoveredCluster{}
 	for _, dc := range fakeClusters {
 		storageCluster := typetostorage.DiscoveredCluster(dc)

--- a/central/discoveredclusters/service/service_impl_test.go
+++ b/central/discoveredclusters/service/service_impl_test.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"testing"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/grpc/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthz(t *testing.T) {
+	testutils.AssertAuthzWorks(t, &serviceImpl{})
+}
+
+func TestDiscoveredClustersQueryBuilder(t *testing.T) {
+	t.Parallel()
+	filter := &v1.DiscoveredClustersFilter{
+		Names: []string{"my-cluster"},
+		Types: []v1.DiscoveredCluster_Metadata_Type{
+			v1.DiscoveredCluster_Metadata_EKS,
+			v1.DiscoveredCluster_Metadata_GKE,
+		},
+		Statuses: []v1.DiscoveredCluster_Status{v1.DiscoveredCluster_STATUS_UNSECURED},
+	}
+	queryBuilder := getQueryBuilderFromFilter(filter)
+
+	rawQuery, err := queryBuilder.RawQuery()
+	require.NoError(t, err)
+
+	assert.Contains(t, rawQuery, `Cluster:"my-cluster"`)
+	assert.Contains(t, rawQuery, `Cluster Type:"EKS","GKE"`)
+	assert.Contains(t, rawQuery, `Cluster Status:"STATUS_UNSECURED"`)
+}
+
+func TestDiscoveredClustersQueryBuilderNilFilter(t *testing.T) {
+	t.Parallel()
+	queryBuilder := getQueryBuilderFromFilter(nil)
+
+	rawQuery, err := queryBuilder.RawQuery()
+	require.NoError(t, err)
+
+	assert.Empty(t, rawQuery)
+}

--- a/central/discoveredclusters/service/singleton.go
+++ b/central/discoveredclusters/service/singleton.go
@@ -1,0 +1,20 @@
+package service
+
+import (
+	"github.com/stackrox/rox/central/discoveredclusters/datastore"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	once sync.Once
+
+	svc Service
+)
+
+// Singleton provides the instance of the Service interface to register.
+func Singleton() Service {
+	once.Do(func() {
+		svc = newService(datastore.Singleton())
+	})
+	return svc
+}

--- a/central/main.go
+++ b/central/main.go
@@ -68,6 +68,7 @@ import (
 	deploymentService "github.com/stackrox/rox/central/deployment/service"
 	detectionService "github.com/stackrox/rox/central/detection/service"
 	developmentService "github.com/stackrox/rox/central/development/service"
+	discoveredClustersService "github.com/stackrox/rox/central/discoveredclusters/service"
 	"github.com/stackrox/rox/central/docs"
 	"github.com/stackrox/rox/central/endpoints"
 	"github.com/stackrox/rox/central/enrichment"
@@ -461,6 +462,7 @@ func servicesToRegister() []pkgGRPC.APIService {
 
 	if features.CloudSources.Enabled() {
 		servicesToRegister = append(servicesToRegister, cloudSourcesService.Singleton())
+		servicesToRegister = append(servicesToRegister, discoveredClustersService.Singleton())
 	}
 
 	autoTriggerUpgrades := sensorUpgradeService.Singleton().AutoUpgradeSetting()

--- a/pkg/fixtures/discovered_cluster.go
+++ b/pkg/fixtures/discovered_cluster.go
@@ -18,7 +18,7 @@ func GetDiscoveredCluster() *discoveredclusters.DiscoveredCluster {
 		Region:            "us-east-1",
 		FirstDiscoveredAt: types.TimestampNow(),
 		Status:            storage.DiscoveredCluster_STATUS_SECURED,
-		CloudSourceID:     "1234",
+		CloudSourceID:     "fb28231c-54d1-41e1-9551-ede4c0e15c6c",
 	}
 }
 
@@ -28,10 +28,15 @@ func GetManyDiscoveredClusters(num int) []*discoveredclusters.DiscoveredCluster 
 	for i := 0; i < num; i++ {
 		discoveredCluster := GetDiscoveredCluster()
 		discoveredCluster.ID = fmt.Sprintf("my-cluster-%d", i)
+		discoveredCluster.Name = fmt.Sprintf("my-cluster-%d", i)
 		if i < num/2 {
 			discoveredCluster.Type = storage.ClusterMetadata_GKE
+			discoveredCluster.Status = storage.DiscoveredCluster_STATUS_SECURED
+			discoveredCluster.CloudSourceID = "fb28231c-54d1-41e1-9551-ede4c0e15c6c"
 		} else {
 			discoveredCluster.Type = storage.ClusterMetadata_EKS
+			discoveredCluster.Status = storage.DiscoveredCluster_STATUS_UNSECURED
+			discoveredCluster.CloudSourceID = "4f026c43-8b8a-465a-8c09-664f16c9e8e3"
 		}
 		res = append(res, discoveredCluster)
 	}


### PR DESCRIPTION
## Description

The service for the discovered cluster API. Discovered clusters are returned by cloud source integrations (e.g. PaladinCloud, OCM) and represent a cloud provider inventory of potential clusters to secure. We want to fetch these clusters and show them along with their status in a discovered cluster list in the UI.

What's potentially missing is populating the `source.name` field with the cloud source name depending on UI need.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI integration test

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
