### PR TITLE
ci(scanner): vuln update hardening

### DIFF
--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
     - master
-    - ross/**
 
 jobs:
   upload-dev-vulnerabilities:
@@ -32,7 +31,6 @@ jobs:
         STACKROX_NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         STACKROX_NVD_API_CALL_INTERVAL: 6s
       run: |
-        exit 1
         if [ ! -d "scanner" ]; then
           echo "Scanner directory not found. Terminating current step."
           exit 1

--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
     - master
+    - ross/**
 
 jobs:
   upload-dev-vulnerabilities:
@@ -31,6 +32,7 @@ jobs:
         STACKROX_NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         STACKROX_NVD_API_CALL_INTERVAL: 6s
       run: |
+        exit 1
         if [ ! -d "scanner" ]; then
           echo "Scanner directory not found. Terminating current step."
           exit 1
@@ -49,4 +51,4 @@ jobs:
     steps:
     - name: Send Slack notification on workflow failure
       run: |
-        curl -X POST -H 'Content-type: application/json' --data '{"text":"Workflow failed in workflow ${{ github.workflow }} in repository ${{ github.repository }}: Failed to update vulnerabilities"}' ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
+        curl -X POST -H 'Content-type: application/json' --data '{"text":"<${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Workflow ${{ github.workflow }}> failed in repository ${{ github.repository }}: Failed to update vulnerabilities"}' ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}

--- a/.github/workflows/scanner-pr-vuln-update.yaml
+++ b/.github/workflows/scanner-pr-vuln-update.yaml
@@ -40,5 +40,11 @@ jobs:
         make -C scanner bin/updater
         go clean -cache -modcache
         branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-        ./scanner/bin/updater -output-dir="$branch"
+        if [[ "$branch" == "dev" ]]; then
+          echo "Branch dev is disallowed"
+          exit 1
+        fi
+        # Replace / with -, so the branch name isn't truncated when pushed to GCS.
+        dir=${branch////-}
+        ./scanner/bin/updater -output-dir="$dir"
         gsutil cp -r "$branch" "gs://scanner-v4-test/vulnerability-bundles"

--- a/.github/workflows/scanner-pr-vuln-update.yaml
+++ b/.github/workflows/scanner-pr-vuln-update.yaml
@@ -47,4 +47,4 @@ jobs:
         # Replace / with -, so the branch name isn't truncated when pushed to GCS.
         dir=${branch////-}
         ./scanner/bin/updater -output-dir="$dir"
-        gsutil cp -r "$branch" "gs://scanner-v4-test/vulnerability-bundles"
+        gsutil cp -r "$dir" "gs://scanner-v4-test/vulnerability-bundles"

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -4,7 +4,7 @@ on:
   - cron: "0 */3 * * *"
   push:
     branches:
-    - scanner/*
+    - ross/**
 
 jobs:
   read-release-versions:
@@ -34,6 +34,10 @@ jobs:
     env:
       ROX_PRODUCT_VERSION: ${{ matrix.version }}
     steps:
+    - name: Fail
+      if: |
+        matrix.version == '4.3.0'
+      run: exit 1
     - name: Recover docker image cache space
       run: |
         df --si /
@@ -53,7 +57,6 @@ jobs:
       env:
         STACKROX_NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         STACKROX_NVD_API_CALL_INTERVAL: 6s
-      continue-on-error: true
       run: |
         DOWNLOAD_URL="https://github.com/stackrox/stackrox/archive/refs/tags/${{ env.ROX_PRODUCT_VERSION }}.zip"
         FILE_NAME=$(basename "$DOWNLOAD_URL")
@@ -86,4 +89,4 @@ jobs:
     steps:
     - name: Send Slack notification on workflow failure
       run: |
-        curl -X POST -H 'Content-type: application/json' --data '{"text":"Workflow failed in workflow ${{ github.workflow }} in repository ${{ github.repository }}: Failed to update vulnerabilities"}' ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
+        curl -X POST -H 'Content-type: application/json' --data '{"text":"<${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Workflow ${{ github.workflow }}> failed in repository ${{ github.repository }}: Failed to update vulnerabilities"}' ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -2,9 +2,6 @@ name: Scanner release vulnerability update
 on:
   schedule:
   - cron: "0 */3 * * *"
-  push:
-    branches:
-    - ross/**
 
 jobs:
   read-release-versions:
@@ -34,10 +31,6 @@ jobs:
     env:
       ROX_PRODUCT_VERSION: ${{ matrix.version }}
     steps:
-    - name: Fail
-      if: |
-        matrix.version == '4.3.0'
-      run: exit 1
     - name: Recover docker image cache space
       run: |
         df --si /

--- a/scanner/cmd/updater/main.go
+++ b/scanner/cmd/updater/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 func tryExport(outputDir string) error {
-	const timeout = 35 * time.Minute
+	const timeout = 1 * time.Hour
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 


### PR DESCRIPTION
## Description

We don't want to mess with the "dev" vulns, so disallow branches named "dev". Also, to avoid accidentally overwriting similarly named PRs, swap / for -

This PR also adds a link to the Slack notification for failed builds. See Slack for proof.

Lastly, this also extends the timeout for vuln data from 35 minutes to 1 hour

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI. Check the bucket to find `ross-harden-pr-vulns` instead of just `harden-pr-vulns` (which is what it would have output without this change)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
