### PR TITLE
ROX-22262: Fix ProcessPipelineOnline test

### DIFF
--- a/sensor/common/processsignal/pipeline_test.go
+++ b/sensor/common/processsignal/pipeline_test.go
@@ -411,8 +411,7 @@ func collectEventsFor(ctx context.Context, ch <-chan *message.ExpiringMessage, t
 }
 
 func TestProcessPipelineOnline(t *testing.T) {
-	t.Skip("ROX-22262: Skipping due to timeout")
-	sensorEvents := make(chan *message.ExpiringMessage)
+	sensorEvents := make(chan *message.ExpiringMessage, 10)
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
## Description

The `indicators` channel is a buffered channel that will drop signals if full. 

```
The output channel is full. Dropping process indicator event for deployment mock-deployment with id c7a47bac-7bc6-4331-ba09-62a1e9e7e2dd and process name
```

The test needs to make sure that the channel is big enough for messages not to be dropped.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- [x] I've run the unit tests multiple times locally.
- [x] CI should be green.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
