### PR TITLE
ROX-21818: Add Scan Now functionality to Compliance 2.0

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/ViewScanConfigDetail.tsx
@@ -107,7 +107,7 @@ function ViewScanConfigDetail({
                                         component={Button}
                                         onClick={onTriggerRescan}
                                         isLoading={isTriggeringRescan}
-                                        isDisabled={!scanConfig || isTriggeringRescan}
+                                        isDisabled={isTriggeringRescan}
                                     >
                                         Re-scan
                                     </Button>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ClusterSelection.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ClusterSelection.tsx
@@ -12,7 +12,7 @@ import {
     Spinner,
     Title,
 } from '@patternfly/react-core';
-import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Caption, TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { SearchIcon } from '@patternfly/react-icons';
 
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
@@ -147,6 +147,7 @@ function ClusterSelection({ clusters, isFetchingClusters }: ClusterSelectionProp
             <Divider component="div" />
             <Form className="pf-u-py-lg pf-u-px-lg">
                 <TableComposable variant="compact">
+                    <Caption>At least one cluster is required.</Caption>
                     <Thead noWrap>
                         <Tr>
                             <Th

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ProfileSelection.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ProfileSelection.tsx
@@ -10,7 +10,7 @@ import {
     Spinner,
     Title,
 } from '@patternfly/react-core';
-import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Caption, TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { SearchIcon } from '@patternfly/react-icons';
 
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
@@ -133,6 +133,7 @@ function ProfileSelection({ profiles, isFetchingProfiles }: ProfileSelectionProp
             <Divider component="div" />
             <Form className="pf-u-py-lg pf-u-px-lg">
                 <TableComposable variant="compact">
+                    <Caption>At least one profile is required.</Caption>
                     <Thead noWrap>
                         <Tr>
                             <Th

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/useFormikScanConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/useFormikScanConfig.tsx
@@ -44,6 +44,8 @@ const validationSchema = yup.object().shape({
                     : schema.notRequired()
             ),
     }),
+    clusters: yup.array().min(1),
+    profiles: yup.array().min(1),
 });
 
 function useFormikScanConfig(initialFormValues): FormikProps<ScanConfigFormValues> {

--- a/ui/apps/platform/src/hooks/useAlert.test.ts
+++ b/ui/apps/platform/src/hooks/useAlert.test.ts
@@ -1,0 +1,49 @@
+import { renderHook, act } from '@testing-library/react';
+
+import useAlert, { AlertObj } from './useAlert';
+
+describe('useAlert hook', () => {
+    test('useAlert should start with null', () => {
+        const { result } = renderHook(() => useAlert());
+
+        expect(result.current.alertObj).toBe(null);
+        expect(typeof result.current.setAlertObj).toBe('function');
+        expect(typeof result.current.clearAlertObj).toBe('function');
+    });
+
+    test('useAlert should update its stored value', () => {
+        const { result } = renderHook(() => useAlert());
+
+        const newAlert: AlertObj = {
+            type: 'danger',
+            title: 'The operation failed',
+            children: '403 Unauthorized',
+        };
+
+        act(() => {
+            result.current.setAlertObj(newAlert);
+        });
+
+        expect(result.current.alertObj).toEqual(newAlert);
+    });
+
+    test('useAlert should clear its stored value', () => {
+        const { result } = renderHook(() => useAlert());
+
+        const oldAlert: AlertObj = {
+            type: 'danger',
+            title: 'The operation failed',
+            children: '403 Unauthorized',
+        };
+
+        act(() => {
+            result.current.setAlertObj(oldAlert);
+        });
+        expect(result.current.alertObj).toEqual(oldAlert);
+
+        act(() => {
+            result.current.clearAlertObj();
+        });
+        expect(result.current.alertObj).toBe(null);
+    });
+});

--- a/ui/apps/platform/src/hooks/useAlert.ts
+++ b/ui/apps/platform/src/hooks/useAlert.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+
+export type AlertObj = {
+    type: 'success' | 'danger' | 'warning' | 'info' | 'default';
+    title: string;
+    children?: React.ReactNode; // inclusive of ReactElement | ReactFragment, or primitives like string or number
+};
+
+function useAlert() {
+    const [alertObj, setAlertObj] = useState<AlertObj | null>(null);
+
+    function clearAlertObj() {
+        setAlertObj(null);
+    }
+
+    return { alertObj, setAlertObj, clearAlertObj };
+}
+
+export default useAlert;

--- a/ui/apps/platform/src/services/ComplianceEnhancedService.ts
+++ b/ui/apps/platform/src/services/ComplianceEnhancedService.ts
@@ -447,13 +447,13 @@ export function getScanConfigsCount(): Promise<number> {
 }
 
 export function deleteScanConfig(scanConfigId: string) {
-    return axios.delete<Empty | Error>(`${scanScheduleUrl}/${scanConfigId}`).then((response) => {
+    return axios.delete<Empty>(`${scanScheduleUrl}/${scanConfigId}`).then((response) => {
         return response.data;
     });
 }
 
 export function runComplianceScanConfiguration(scanConfigId: string) {
-    return axios.post<Empty | Error>(`${scanScheduleUrl}/${scanConfigId}/run`).then((response) => {
+    return axios.post<Empty>(`${scanScheduleUrl}/${scanConfigId}/run`).then((response) => {
         return response.data;
     });
 }

--- a/ui/apps/platform/src/services/ComplianceEnhancedService.ts
+++ b/ui/apps/platform/src/services/ComplianceEnhancedService.ts
@@ -452,6 +452,12 @@ export function deleteScanConfig(scanConfigId: string) {
     });
 }
 
+export function runComplianceScanConfiguration(scanConfigId: string) {
+    return axios.post<Empty | Error>(`${scanScheduleUrl}/${scanConfigId}/run`).then((response) => {
+        return response.data;
+    });
+}
+
 export function listComplianceProfiles(): Promise<ComplianceProfile[]> {
     // TODO: delete the below code once the actual API is ready
     return new Promise((resolve) => {


### PR DESCRIPTION
## Description

This change adds a Re-scan button to the Detail View page for a scan configuration.

(Note: I'm using this PR to add a re-usable hook for managing Alert state, because we do that in several places in the app with bespoke code on each page. If we find this useful, we could replace the bespoke code with this pattern.)

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added


## Testing Performed

### Here I tell how I validated my change

I tested that the new button is on the read-only detail view when the user has Write permission for Compliance.
<img width="1628" alt="Screenshot 2024-02-06 at 11 36 56 AM" src="https://github.com/stackrox/stackrox/assets/715729/e4fffc96-7aec-494a-a9ae-08b479dc3408">

I clicked the button, and observed in the Network panel of the browser's developer tools, that the correct API call is made to trigger a new scan. I also disable the Re-scan and edit buttons, and show a progress indicator in the Re-scan button.
<img width="1628" alt="Screenshot 2024-02-06 at 11 37 09 AM" src="https://github.com/stackrox/stackrox/assets/715729/f93bafc7-c271-427b-a609-aa56ba016471">

If the API call succeeds, I show a dismissible Success Alert below the toolbar, near the button that triggered it.
<img width="1584" alt="Screenshot 2024-02-06 at 11 38 22 AM" src="https://github.com/stackrox/stackrox/assets/715729/818c78e8-4ed3-47d0-a77a-1bbcceaf5a38">

I blocked that API URL, to simulate an error, to test the error state when the call fails. I show a dismissible Danger Alert in that case. 
(Both alerts get dismissed if the Re-scan button is clicked again.)
<img width="1628" alt="Screenshot 2024-02-06 at 11 38 50 AM" src="https://github.com/stackrox/stackrox/assets/715729/56012300-2263-448f-990c-56dfb8477595">


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
