### PR TITLE
ROX-22339: Remove init-bundle request from clusterInitBundleSagas

### DIFF
--- a/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
+++ b/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
@@ -119,7 +119,6 @@ function getIntegrationEndpointAddress(integrationSource, integrationType, integ
 const routeMatcherMapForIntegrationsDashboard = Object.fromEntries(
     [
         ['authProviders', 'apitoken'],
-        ['authProviders', 'clusterInitBundle'],
         ['imageIntegrations'],
         ['signatureIntegrations'],
         ['notifiers'],

--- a/ui/apps/platform/src/sagas/index.js
+++ b/ui/apps/platform/src/sagas/index.js
@@ -2,7 +2,7 @@ import { all, fork } from 'redux-saga/effects';
 
 import apiTokens from './apiTokenSagas';
 import authProviders from './authSagas';
-import clusterInitBundles from './clusterInitBundleSagas';
+// import clusterInitBundles from './clusterInitBundleSagas';
 import integrations from './integrationSagas';
 import roles from './roleSagas';
 import searchAutoComplete from './searchAutocompleteSagas';
@@ -13,7 +13,8 @@ export default function* root() {
     yield all([
         fork(apiTokens),
         fork(authProviders),
-        fork(clusterInitBundles),
+        // Delete from reducers and sagas when we delete ROX_MOVE_INIT_BUNDLES_UI after 4.4 release.
+        // fork(clusterInitBundles),
         fork(integrations),
         fork(roles),
         fork(searchAutoComplete),


### PR DESCRIPTION
## Description

Follow up #9711 and #9728

To bad, so sad, sagas do not support feature flags.

Therefore, comment out instead of delete so we could uncomment in the unlikely case we needed to turn off `ROX_MOVE_INIT_BUNDLES_UI` feature flag.

### Residue

When we delete `ROX_MOVE_INIT_BUNDLES_UI` feature flag after 4.4 release.
1. Delete src/reducers/clusterInitBundles.js
2. Delete src/sagas/clusterInitBundleSagas.js

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. Visit /main/integrations with role that has only Integration resource with  READ_ACCESS level

    * Before change: see GET /v1/cluster-init/init-bundles has 403 Forbidden status
        ![with_request_403_Forbidden](https://github.com/stackrox/stackrox/assets/11862657/ef1abdd9-9e49-46da-b837-4b0f9f298da8)

    * After change: see absence of request
        ![without_request](https://github.com/stackrox/stackrox/assets/11862657/ecac0694-65fd-4ac5-8e96-cdf178c74fc8)
