### PR TITLE
ROX-22341: Render Init bundles button for Admin role only

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -22,6 +22,7 @@ import LinkShim from 'Components/PatternFly/LinkShim';
 import SearchFilterInput from 'Components/SearchFilterInput';
 import { DEFAULT_PAGE_SIZE } from 'Components/Table';
 import TableHeader from 'Components/TableHeader';
+import useAuthStatus from 'hooks/useAuthStatus';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useInterval from 'hooks/useInterval';
 import useMetadata from 'hooks/useMetadata';
@@ -67,9 +68,11 @@ function ClustersTablePanel({
 
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
     const hasReadAccessForDelegatedScanning = hasReadAccess('Administration');
-    const hasWriteAccessForIntegration = hasReadWriteAccess('Integration');
     const hasWriteAccessForAdministration = hasReadWriteAccess('Administration');
     const hasWriteAccessForCluster = hasReadWriteAccess('Cluster');
+
+    const { currentUser } = useAuthStatus();
+    const hasAdminRole = Boolean(currentUser?.userInfo?.roles.some(({ name }) => name === 'Admin')); // optional chaining just in case of the unexpected
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isMoveInitBundlesEnabled = isFeatureFlagEnabled('ROX_MOVE_INIT_BUNDLES_UI');
@@ -170,7 +173,7 @@ function ClustersTablePanel({
                         </Button>
                     </div>
                 )}
-                {hasWriteAccessForIntegration && (
+                {hasAdminRole && (
                     <div className="flex items-center ml-1">
                         <Button variant="tertiary">
                             <ManageTokensButton />


### PR DESCRIPTION
## Description

My bad to omit from #9728

Replace `hasWritePermissionForIntegration` with `hasAdminRole` to conditionally render `ManageTokens` element.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. Visit /main/clusters with role other than **Admin** that has READ_WRITE_ACCESS for all resources

    * Before change: see **Init bundles** button and click to see GET /v1/cluster-init/init-bundles has 403 Forbidden status
        ![clusters_with_button](https://github.com/stackrox/stackrox/assets/11862657/53e48d5d-523a-478f-b429-ecc98fbffb76)
        ![clusters_init-bundles_403_Forbidden](https://github.com/stackrox/stackrox/assets/11862657/3de518e7-1bb3-458a-8146-5683fd81d1f6)

    * After change: see absence of button
        ![clusters_without_button](https://github.com/stackrox/stackrox/assets/11862657/4715f4d9-2500-4b60-84cd-8b09104d505a)

2. Visit /main/clusters with **Admin** role

    * Before and after change: see **Init bundles** button and click to see GET /v1/cluster-init/init-bundles has 200 OK status
