### PR TITLE
ROX-21599: Prevent scan configurations with incompatible profiles

### DIFF
--- a/central/complianceoperator/v2/compliancemanager/manager_impl.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl.go
@@ -193,17 +193,12 @@ func (m *managerImpl) processRequestToSensor(ctx context.Context, scanRequest *s
 		profiles = append(profiles, profile.GetProfileName())
 	}
 
-	// Check if there any existing cluster that has the scan configuration with any of profiles being referenced by the scan request.
+	// Check if there are any existing clusters that have a scan configuration with any of profiles being referenced by the scan request.
 	// If so, then we cannot create the scan configuration.
 	err := m.scanSettingDS.ScanConfigurationProfileExists(ctx, scanRequest.GetId(), profiles, clusters)
 	if err != nil {
 		log.Error(err)
 		return nil, errors.Wrapf(err, "Unable to create scan configuration named %q.", scanRequest.GetScanConfigName())
-	}
-
-	// check if cluster is selected
-	if len(clusters) == 0 {
-		return nil, errors.Errorf("No clusters selected for scan configuration named %q.", scanRequest.GetScanConfigName())
 	}
 
 	returnedProfiles, err := m.profileDS.SearchProfiles(ctx, search.NewQueryBuilder().
@@ -212,7 +207,7 @@ func (m *managerImpl) processRequestToSensor(ctx context.Context, scanRequest *s
 
 	if err != nil {
 		log.Error(err)
-		return nil, errors.Wrapf(err, "Unable to create scan configuration named %q.", scanRequest.GetScanConfigName())
+		return nil, errors.Wrapf(err, "Unable to retrieve profiles for scan configuration named %q.", scanRequest.GetScanConfigName())
 	}
 
 	if len(returnedProfiles) != len(profiles) {
@@ -304,7 +299,7 @@ func (m *managerImpl) removeSensorRequestForCluster(scanConfigID, clusterID stri
 	}
 }
 
-// validateProfiles checks if the profiles are valid and returns an error if not.
+// validateProfiles checks if the profiles are compatible and returns an error if not.
 // Check if node profiles have more than one product
 // ex. we can not have rhcos node profile and ocp node profile in the same scan configuration
 // as this is not allowed on Compliance Operator ScanSettingBinding

--- a/central/complianceoperator/v2/compliancemanager/manager_impl.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl.go
@@ -2,6 +2,7 @@ package compliancemanager
 
 import (
 	"context"
+	"strings"
 
 	"github.com/adhocore/gronx"
 	"github.com/gogo/protobuf/types"
@@ -201,12 +202,12 @@ func (m *managerImpl) processRequestToSensor(ctx context.Context, scanRequest *s
 		return nil, errors.Wrapf(err, "Unable to create scan configuration named %q.", scanRequest.GetScanConfigName())
 	}
 
+	// Get all profiles from the database to validate that they exist and are compatible
 	returnedProfiles, err := m.profileDS.SearchProfiles(ctx, search.NewQueryBuilder().
 		AddExactMatches(search.ClusterID, clusters[0]).
 		AddExactMatches(search.ComplianceOperatorProfileName, profiles...).ProtoQuery())
 
 	if err != nil {
-		log.Error(err)
 		return nil, errors.Wrapf(err, "Unable to retrieve profiles for scan configuration named %q.", scanRequest.GetScanConfigName())
 	}
 
@@ -306,7 +307,7 @@ func (m *managerImpl) removeSensorRequestForCluster(scanConfigID, clusterID stri
 func validateProfiles(profiles []*storage.ComplianceOperatorProfileV2) error {
 	var product string
 	for _, profile := range profiles {
-		if profile.GetProductType() == "node" {
+		if strings.Contains(strings.ToLower(profile.GetProductType()), "node") {
 			if product == "" {
 				product = profile.GetProduct()
 			} else if product != profile.GetProduct() {

--- a/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
@@ -331,6 +331,9 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(suite.testContexts[testutils.UnrestrictedReadWriteCtx], mockScanName).Return(nil, nil).Times(1)
+				suite.profileDS.EXPECT().SearchProfiles(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return([]*storage.ComplianceOperatorProfileV2{
+					getTestProfile("ocp4-cis", "1.0.0", "platform", "ocp4", testconsts.Cluster1, 1),
+				}, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(errors.New("Unable to process sensor message")).Times(1)
 				suite.clusterDatastore.EXPECT().GetClusterName(gomock.Any(), gomock.Any()).Return("", false, nil).Times(1)

--- a/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	clusterDatastoreMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	"github.com/stackrox/rox/central/complianceoperator/v2/integration/datastore/mocks"
+	profileMocks "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore/mocks"
 	scanConfigMocks "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore/mocks"
 	sensorMocks "github.com/stackrox/rox/central/sensor/service/connection/mocks"
 	"github.com/stackrox/rox/generated/storage"
@@ -59,6 +60,7 @@ type complianceManagerTestSuite struct {
 	mockCtrl         *gomock.Controller
 	integrationDS    *mocks.MockDataStore
 	scanConfigDS     *scanConfigMocks.MockDataStore
+	profileDS        *profileMocks.MockDataStore
 	connectionMgr    *sensorMocks.MockManager
 	clusterDatastore *clusterDatastoreMocks.MockDataStore
 	manager          Manager
@@ -86,7 +88,8 @@ func (suite *complianceManagerTestSuite) SetupTest() {
 	suite.scanConfigDS = scanConfigMocks.NewMockDataStore(suite.mockCtrl)
 	suite.connectionMgr = sensorMocks.NewMockManager(suite.mockCtrl)
 	suite.clusterDatastore = clusterDatastoreMocks.NewMockDataStore(suite.mockCtrl)
-	suite.manager = New(suite.connectionMgr, suite.integrationDS, suite.scanConfigDS, suite.clusterDatastore)
+	suite.profileDS = profileMocks.NewMockDataStore(suite.mockCtrl)
+	suite.manager = New(suite.connectionMgr, suite.integrationDS, suite.scanConfigDS, suite.clusterDatastore, suite.profileDS)
 }
 
 func (suite *complianceManagerTestSuite) TearDownTest() {
@@ -188,6 +191,9 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			clusters:    []string{testconsts.Cluster1},
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				suite.profileDS.EXPECT().SearchProfiles(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return([]*storage.ComplianceOperatorProfileV2{
+					getTestProfile("ocp4-cis", "1.0.0", "platform", "ocp4", testconsts.Cluster1, 1),
+				}, nil).Times(1)
 				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(suite.testContexts[testutils.UnrestrictedReadWriteCtx], mockScanName).Return(nil, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(nil).Times(1)
@@ -202,10 +208,15 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			testContext: suite.testContexts[testutils.UnrestrictedReadWriteCtx],
 			clusters:    []string{testconsts.Cluster1},
 			setMocks: func() {
-				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
-				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(suite.testContexts[testutils.UnrestrictedReadWriteCtx], mockScanName).Return(nil, nil).Times(1)
+				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(gomock.Any(), mockScanName).Return(nil, nil).Times(1)
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				suite.profileDS.EXPECT().SearchProfiles(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return([]*storage.ComplianceOperatorProfileV2{
+					getTestProfile("ocp4-cis", "1.0.0", "platform", "ocp4", testconsts.Cluster1, 1),
+					getTestProfile("rhcos4-cis", "1.0.0", "node", "rhcos4", testconsts.Cluster1, 1),
+				}, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(nil).Times(1)
+				suite.clusterDatastore.EXPECT().GetClusterName(gomock.Any(), gomock.Any()).Return("test_cluster", true, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpdateClusterStatus(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), testconsts.Cluster1, "", "test_cluster")
 			},
 			isErrorTest: false,
@@ -216,7 +227,12 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			testContext: suite.testContexts[testutils.UnrestrictedReadWriteCtx],
 			clusters:    []string{testconsts.Cluster1},
 			setMocks: func() {
-				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(suite.testContexts[testutils.UnrestrictedReadWriteCtx], mockScanName).Return(nil, nil).Times(1)
+				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(gomock.Any(), mockScanName).Return(nil, nil).Times(1)
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				suite.profileDS.EXPECT().SearchProfiles(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return([]*storage.ComplianceOperatorProfileV2{
+					getTestProfile("ocp4-cis-node", "1.0.0", "node", "ocp4", testconsts.Cluster1, 1),
+					getTestProfile("rhcos4-cis", "1.0.0", "node", "rhcos4", testconsts.Cluster1, 1),
+				}, nil).Times(1)
 			},
 			isErrorTest: true,
 			expectedErr: errors.Errorf("Invalid profiles found in scan configuration: %q.", mockScanName),
@@ -251,6 +267,9 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			clusters:    []string{testconsts.Cluster1},
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				suite.profileDS.EXPECT().SearchProfiles(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return([]*storage.ComplianceOperatorProfileV2{
+					getTestProfile("ocp4-cis", "1.0.0", "platform", "ocp4", testconsts.Cluster1, 1),
+				}, nil).Times(1)
 				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(suite.testContexts[testutils.UnrestrictedReadWriteCtx], mockScanName).Return(nil, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(errors.Errorf("Unable to save scan config named %q", mockScanName)).Times(1)
 			},
@@ -265,6 +284,9 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(suite.testContexts[testutils.UnrestrictedReadWriteCtx], mockScanName).Return(nil, nil).Times(1)
+				suite.profileDS.EXPECT().SearchProfiles(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return([]*storage.ComplianceOperatorProfileV2{
+					getTestProfile("ocp4-cis", "1.0.0", "platform", "ocp4", testconsts.Cluster1, 1),
+				}, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(errors.New("Unable to process sensor message")).Times(1)
 				suite.clusterDatastore.EXPECT().GetClusterName(gomock.Any(), gomock.Any()).Return("test_cluster", true, nil).Times(1)
@@ -364,6 +386,9 @@ func (suite *complianceManagerTestSuite) TestUpdateScanRequest() {
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				suite.scanConfigDS.EXPECT().GetScanConfiguration(gomock.Any(), mockScanID).Return(getTestRec(), true, nil).Times(1)
+				suite.profileDS.EXPECT().SearchProfiles(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return([]*storage.ComplianceOperatorProfileV2{
+					getTestProfile("ocp4-cis", "1.0.0", "platform", "ocp4", testconsts.Cluster1, 1),
+				}, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(errors.Errorf("Unable to save scan config named %q", mockScanName)).Times(1)
 			},
 			isErrorTest: true,
@@ -377,6 +402,9 @@ func (suite *complianceManagerTestSuite) TestUpdateScanRequest() {
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				suite.scanConfigDS.EXPECT().GetScanConfiguration(gomock.Any(), mockScanID).Return(getTestRec(), true, nil).Times(1)
+				suite.profileDS.EXPECT().SearchProfiles(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return([]*storage.ComplianceOperatorProfileV2{
+					getTestProfile("ocp4-cis", "1.0.0", "platform", "ocp4", testconsts.Cluster1, 1),
+				}, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(errors.New("Unable to process sensor message")).Times(1)
 				suite.clusterDatastore.EXPECT().GetClusterName(gomock.Any(), gomock.Any()).Return("test_cluster", true, nil).Times(1)
@@ -412,6 +440,9 @@ func (suite *complianceManagerTestSuite) TestUpdateScanRequest() {
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().GetScanConfiguration(gomock.Any(), mockScanID).Return(getTestRec(), true, nil).Times(1)
 				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				suite.profileDS.EXPECT().SearchProfiles(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return([]*storage.ComplianceOperatorProfileV2{
+					getTestProfile("ocp4-cis", "1.0.0", "platform", "ocp4", testconsts.Cluster1, 1),
+				}, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(nil).Times(1)
 				suite.clusterDatastore.EXPECT().GetClusterName(gomock.Any(), gomock.Any()).Return("test_cluster", true, nil).Times(1)
@@ -427,6 +458,9 @@ func (suite *complianceManagerTestSuite) TestUpdateScanRequest() {
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().GetScanConfiguration(gomock.Any(), mockScanID).Return(getTestRecMultiCluster(), true, nil).Times(1)
 				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				suite.profileDS.EXPECT().SearchProfiles(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return([]*storage.ComplianceOperatorProfileV2{
+					getTestProfile("ocp4-cis", "1.0.0", "platform", "ocp4", testconsts.Cluster1, 1),
+				}, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
 				suite.scanConfigDS.EXPECT().RemoveClusterStatus(gomock.Any(), mockScanID, testconsts.Cluster2).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(nil).Times(1)
@@ -495,6 +529,35 @@ func (suite *complianceManagerTestSuite) TestDeleteScanConfiguration() {
 				suite.Require().NoError(err)
 			}
 		})
+	}
+}
+
+func getTestProfile(profileName string, version string, platform string, product string, clusterID string, ruleCount int) *storage.ComplianceOperatorProfileV2 {
+	var rules []*storage.ComplianceOperatorProfileV2_Rule
+
+	if ruleCount > 0 {
+		rules = make([]*storage.ComplianceOperatorProfileV2_Rule, 0, ruleCount)
+		for i := 0; i < ruleCount; i++ {
+			rules = append(rules, &storage.ComplianceOperatorProfileV2_Rule{
+				RuleName: fmt.Sprintf("name-%d", i),
+			})
+		}
+	}
+
+	return &storage.ComplianceOperatorProfileV2{
+		Id:             uuid.NewV4().String(),
+		ProfileId:      uuid.NewV4().String(),
+		Name:           profileName,
+		ProfileVersion: version,
+		ProductType:    platform,
+		Standard:       profileName,
+		Description:    "this is a test",
+		Labels:         nil,
+		Annotations:    nil,
+		Product:        product,
+		ClusterId:      clusterID,
+		Title:          "A Title",
+		Rules:          rules,
 	}
 }
 

--- a/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
@@ -235,7 +235,7 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 				}, nil).Times(1)
 			},
 			isErrorTest: true,
-			expectedErr: errors.Errorf("Invalid profiles found in scan configuration: %q.", mockScanName),
+			expectedErr: fmt.Sprintf("Unable to create scan configuration named %q.", mockScanName),
 		},
 		{
 			desc:        "Scan configuration already exists",

--- a/central/complianceoperator/v2/compliancemanager/singleton.go
+++ b/central/complianceoperator/v2/compliancemanager/singleton.go
@@ -3,6 +3,7 @@ package compliancemanager
 import (
 	clusterDatastore "github.com/stackrox/rox/central/cluster/datastore"
 	compIntegration "github.com/stackrox/rox/central/complianceoperator/v2/integration/datastore"
+	profileDatastore "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
 	compScanSetting "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	"github.com/stackrox/rox/pkg/sync"
@@ -16,7 +17,7 @@ var (
 // Singleton returns the compliance operator manager
 func Singleton() Manager {
 	once.Do(func() {
-		manager = New(connection.ManagerSingleton(), compIntegration.Singleton(), compScanSetting.Singleton(), clusterDatastore.Singleton())
+		manager = New(connection.ManagerSingleton(), compIntegration.Singleton(), compScanSetting.Singleton(), clusterDatastore.Singleton(), profileDatastore.Singleton())
 	})
 	return manager
 }

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -265,7 +265,7 @@ func TestComplianceV2CreateGetScanConfigurations(t *testing.T) {
 		Clusters: []string{clusterID},
 		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
 			OneTimeScan: false,
-			Profiles:    []string{"rhcos4-moderate-rev-4", "ocp4-cis-node"},
+			Profiles:    []string{"rhcos4-high", "ocp4-cis-node"},
 			Description: "test config with invalid profiles",
 			ScanSchedule: &v2.Schedule{
 				IntervalType: 1,
@@ -280,9 +280,9 @@ func TestComplianceV2CreateGetScanConfigurations(t *testing.T) {
 		},
 	}
 
-	// Verify that the invalid profile was not created and the error message is correct
+	// Verify that the invalid scan configuration was not created and the error message is correct
 	_, err = service.CreateComplianceScanConfiguration(ctx, invalidProfileReq)
-	assert.Contains(t, err.Error(), "cannot have both ocp4 node profile and rhcos4 node profile")
+	assert.Contains(t, err.Error(), "profiles must have the same product")
 
 	query = &v2.RawQuery{Query: ""}
 	scanConfigs, err = service.ListComplianceScanConfigurations(ctx, query)
@@ -343,7 +343,7 @@ func TestComplianceV2DeleteComplianceScanConfigurations(t *testing.T) {
 	assert.Empty(t, scanconfigID)
 }
 
-func TestComplianceV2ComplianceObjectMetadata(t *testing.T){
+func TestComplianceV2ComplianceObjectMetadata(t *testing.T) {
 	ctx := context.Background()
 	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v2.NewComplianceScanConfigurationServiceClient(conn)

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -282,6 +282,9 @@ func TestComplianceV2CreateGetScanConfigurations(t *testing.T) {
 
 	// Verify that the invalid scan configuration was not created and the error message is correct
 	_, err = service.CreateComplianceScanConfiguration(ctx, invalidProfileReq)
+	if err == nil {
+		t.Fatal("expected error creating scan configuration with invalid profiles")
+	}
 	assert.Contains(t, err.Error(), "profiles must have the same product")
 
 	query = &v2.RawQuery{Query: ""}

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -256,6 +256,38 @@ func TestComplianceV2CreateGetScanConfigurations(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(scanConfigs.GetConfigurations()), 1)
 
+	// Create a scan configuration with invalid profiles configuration
+	// contains both rhcos4-moderate and ocp4-cis-node profiles
+	invalidProfileTestName := fmt.Sprintf("test-%s", uuid.NewV4().String())
+	invalidProfileReq := &v2.ComplianceScanConfiguration{
+		ScanName: invalidProfileTestName,
+		Id:       "",
+		Clusters: []string{clusterID},
+		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
+			OneTimeScan: false,
+			Profiles:    []string{"rhcos4-moderate-rev-4", "ocp4-cis-node"},
+			Description: "test config with invalid profiles",
+			ScanSchedule: &v2.Schedule{
+				IntervalType: 1,
+				Hour:         15,
+				Minute:       0,
+				Interval: &v2.Schedule_DaysOfWeek_{
+					DaysOfWeek: &v2.Schedule_DaysOfWeek{
+						Days: []int32{1, 2, 3, 4, 5, 6},
+					},
+				},
+			},
+		},
+	}
+
+	// Verify that the invalid profile was not created and the error message is correct
+	_, err = service.CreateComplianceScanConfiguration(ctx, invalidProfileReq)
+	assert.Contains(t, err.Error(), "cannot have both ocp4 node profile and rhcos4 node profile")
+
+	query = &v2.RawQuery{Query: ""}
+	scanConfigs, err = service.ListComplianceScanConfigurations(ctx, query)
+	assert.NoError(t, err)
+	assert.Equal(t, len(scanConfigs.GetConfigurations()), 1)
 }
 
 func TestComplianceV2DeleteComplianceScanConfigurations(t *testing.T) {


### PR DESCRIPTION
## Description

Added validation to the scanrequest so it does not contains any incompatible profiles, ex. we want to prevent scan being created if it contains both rhcos and ocp node profiles as they are not yet supportted by Compliance Operator

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Added e2e test and unit test to test creating scan config with both rhcos4 and ocp4 node profiles in single request.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
