### PR TITLE
fix: ecr registry token expiry

### DIFF
--- a/pkg/registries/ecr/ecr.go
+++ b/pkg/registries/ecr/ecr.go
@@ -135,7 +135,7 @@ func newRegistry(integration *storage.ImageIntegration, disableRepoList bool) (*
 			log.Error("Failed to create ECR client: ", err)
 			return nil, err
 		}
-		cfg.Transport = newAWSTransport(cfg, client)
+		cfg.Transport = newAWSTransport(integration.GetName(), cfg, client)
 	}
 	dockerRegistry, err := docker.NewDockerRegistryWithConfig(cfg, reg.integration)
 	if err != nil {

--- a/pkg/registries/ecr/transport.go
+++ b/pkg/registries/ecr/transport.go
@@ -48,7 +48,7 @@ func (t *awsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (t *awsTransport) isValidNoLock() bool {
-	return t.expiresAt != nil && t.expiresAt.After(time.Now())
+	return t.expiresAt != nil && time.Now().Before(*t.expiresAt)
 }
 
 func (t *awsTransport) refreshNoLock() error {

--- a/pkg/registries/ecr/transport.go
+++ b/pkg/registries/ecr/transport.go
@@ -52,7 +52,7 @@ func (t *awsTransport) isValidNoLock() bool {
 }
 
 func (t *awsTransport) refreshNoLock() error {
-	log.Infof("Refreshing ECR token for image integration %q", t.name)
+	log.Debugf("Refreshing ECR token for image integration %q", t.name)
 	authToken, err := t.client.GetAuthorizationToken(&awsECR.GetAuthorizationTokenInput{})
 	if err != nil {
 		return errors.Wrap(err, "failed to get authorization token")

--- a/pkg/registries/ecr/transport_test.go
+++ b/pkg/registries/ecr/transport_test.go
@@ -1,0 +1,24 @@
+package ecr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestECRTransport(t *testing.T) {
+	transport := awsTransport{}
+	// Token is invalid initially.
+	assert.False(t, transport.isValidNoLock())
+
+	// Token is valid after the first token exchange.
+	expiredAt := time.Now().Add(12 * time.Hour)
+	transport.expiresAt = &expiredAt
+	assert.True(t, transport.isValidNoLock())
+
+	// Token is invalid after it expired.
+	expiredAt = time.Now()
+	transport.expiresAt = &expiredAt
+	assert.False(t, transport.isValidNoLock())
+}

--- a/pkg/registries/google/google.go
+++ b/pkg/registries/google/google.go
@@ -104,7 +104,7 @@ func NewRegistry(integration *storage.ImageIntegration, disableRepoList bool, ma
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create token source")
 	}
-	dockerConfig.Transport = newGoogleTransport(dockerConfig, tokenSource)
+	dockerConfig.Transport = newGoogleTransport(integration.GetName(), dockerConfig, tokenSource)
 	reg, err := docker.NewDockerRegistryWithConfig(dockerConfig, integration)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create docker registry")

--- a/pkg/registries/google/transport.go
+++ b/pkg/registries/google/transport.go
@@ -52,7 +52,7 @@ func (t *googleTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (t *googleTransport) refreshNoLock() error {
-	log.Infof("Refreshing Google registry token for image integration %q", t.name)
+	log.Debugf("Refreshing Google registry token for image integration %q", t.name)
 	token, err := t.tokenSource.Token()
 	if err != nil {
 		return errors.Wrap(err, "failed to get access token")

--- a/pkg/registries/google/transport.go
+++ b/pkg/registries/google/transport.go
@@ -20,14 +20,15 @@ var log = logging.LoggerForModule()
 // accept a standard oauth2 transport.
 type googleTransport struct {
 	registry.Transport
+	name        string
 	config      *docker.Config
 	token       *oauth2.Token
 	tokenSource oauth2.TokenSource
 	mutex       sync.RWMutex
 }
 
-func newGoogleTransport(config *docker.Config, tokenSource oauth2.TokenSource) *googleTransport {
-	transport := &googleTransport{config: config, tokenSource: tokenSource}
+func newGoogleTransport(name string, config *docker.Config, tokenSource oauth2.TokenSource) *googleTransport {
+	transport := &googleTransport{name: name, config: config, tokenSource: tokenSource}
 	if err := transport.refreshNoLock(); err != nil {
 		log.Error("Failed to refresh token: ", err)
 	}
@@ -51,6 +52,7 @@ func (t *googleTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (t *googleTransport) refreshNoLock() error {
+	log.Infof("Refreshing Google registry token for image integration %q", t.name)
 	token, err := t.tokenSource.Token()
 	if err != nil {
 		return errors.Wrap(err, "failed to get access token")


### PR DESCRIPTION
## Description

I caught this embarrassing bug while testing the new STS feature set. The order in the token validity check is reversed, which causes the token to become stale eventually.

The bug went unnoticed because the initial token exchange works as expected, and subsequent requests even refresh the token. A continuous 12 hour period of no scans is required for the token to become permanently broken.

To fix it I flipped the logic from `isExpired` to `isValid` in analogy to Google and other tokens.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Wait for token to expire, and then perform an image scan.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
