### PR TITLE
tests: drain stuck OCP 4.14 jobs

### DIFF
--- a/.openshift-ci/begin.sh
+++ b/.openshift-ci/begin.sh
@@ -20,7 +20,7 @@ if [[ -z "${SHARED_DIR:-}" ]]; then
     exit 0 # not fatal but worth highlighting
 fi
 
-if [[ "${JOB_NAME}" =~ ^branch.*ocp-4-11-merge-(qa|ui) ]]; then
+if [[ "${JOB_NAME}" =~ ^branch.*ocp-4-14-merge-(qa|ui) ]]; then
     info "Forced failure to unblock stuck CI jobs"
     exit 1
 fi

--- a/.openshift-ci/begin.sh
+++ b/.openshift-ci/begin.sh
@@ -20,6 +20,11 @@ if [[ -z "${SHARED_DIR:-}" ]]; then
     exit 0 # not fatal but worth highlighting
 fi
 
+if [[ "${JOB_NAME}" =~ ^branch.*ocp-4-11-merge-(qa|ui) ]]; then
+    info "Forced failure to unblock stuck CI jobs"
+    exit 1
+fi
+
 if [[ "${JOB_NAME:-}" =~ -ocp-4- ]]; then
     info "Setting worker node type and count for OCP 4 jobs"
     # https://github.com/stackrox/automation-flavors/blob/e6daf10b7df49fc003584790e25def036b2a3b0b/openshift-4/entrypoint.sh#L76


### PR DESCRIPTION
## Description

We currently have 92 UI and 42 QA OCP 4.14 jobs queued in CI. These will take many days to clear as due to a misconfig on the openshift/release side they are set to run serially. This change will cause the jobs to exit quickly and should drain the queue within 24 hours after which point this PR can be reverted.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

- [x] ensure pull jobs are not affected

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
