### PR TITLE
fix(scanv4): Fix find invocation

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -740,7 +740,7 @@ function launch_sensor {
         fi
         sensor_namespace="${NAMESPACE_OVERRIDE}"
         echo "Changing namespace to ${NAMESPACE_OVERRIDE} due to NAMESPACE_OVERRIDE set in the environment."
-        find "${k8s_dir}/sensor-deploy" -name '*.yaml' -depth 1 | while read -r file; do
+        find "${k8s_dir}/sensor-deploy" -maxdepth 2 -name '*.yaml' | while read -r file; do
           sed -i'.original' -e 's/namespace: stackrox/namespace: '"${sensor_namespace}"'/g' "${file}"
         done
         sed -itmp.bak 's/set -e//g' "${k8s_dir}/sensor-deploy/sensor.sh"


### PR DESCRIPTION
## Description

The find invocation in `k8sbased.sh` was bogus. This PR adjust the parameters for the find invocation.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~~Unit test and regression tests added~~
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes~~

## Testing Performed

* Manually tested that the find invocation lists the files it it supposed to list.
* It was confirmed that these tests fix the scale tests run locally.
* CI.
 

