### PR TITLE
Revert "tests: drain stuck OCP 4.14 jobs"

### DIFF
--- a/.openshift-ci/begin.sh
+++ b/.openshift-ci/begin.sh
@@ -20,11 +20,6 @@ if [[ -z "${SHARED_DIR:-}" ]]; then
     exit 0 # not fatal but worth highlighting
 fi
 
-if [[ "${JOB_NAME}" =~ ^branch.*ocp-4-14-merge-(qa|ui) ]]; then
-    info "Forced failure to unblock stuck CI jobs"
-    exit 1
-fi
-
 if [[ "${JOB_NAME:-}" =~ -ocp-4- ]]; then
     info "Setting worker node type and count for OCP 4 jobs"
     # https://github.com/stackrox/automation-flavors/blob/e6daf10b7df49fc003584790e25def036b2a3b0b/openshift-4/entrypoint.sh#L76


### PR DESCRIPTION
Reverts stackrox/stackrox#9796

The original PR does not work as intended because the queued jobs are tested in relation to their commit (of course - doh!) 