### PR TITLE
ROX-16918: Ensure Java scanner is air gapped

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc5
 	github.com/openshift/api v0.0.0-20231117201702-2ea16bbab164
 	github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1
+	github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b
 	github.com/operator-framework/helm-operator-plugins v0.0.0-00010101000000-000000000000
 	github.com/owenrumney/go-sarif/v2 v2.3.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc5
 	github.com/openshift/api v0.0.0-20231117201702-2ea16bbab164
 	github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1
-	github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b
 	github.com/operator-framework/helm-operator-plugins v0.0.0-00010101000000-000000000000
 	github.com/owenrumney/go-sarif/v2 v2.3.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
@@ -89,7 +88,7 @@ require (
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/client_model v0.5.0
 	github.com/prometheus/common v0.46.0
-	github.com/quay/claircore v1.5.21
+	github.com/quay/claircore v1.5.22-0.20240205234224-ab19eb86ce40
 	github.com/quay/claircore/toolkit v1.1.1
 	github.com/quay/goval-parser v0.8.8
 	github.com/quay/zlog v1.1.8

--- a/go.sum
+++ b/go.sum
@@ -1733,6 +1733,8 @@ github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/quay/claircore v1.5.21 h1:IW86mFmNz8Vn/HSA0Xp0iSABCSmBs7RDM9O24qcqywI=
 github.com/quay/claircore v1.5.21/go.mod h1:LIO3JnHZNiKsrVX1c7lHhlijGs/lxDktGmSdUSfWSWg=
+github.com/quay/claircore v1.5.22-0.20240205234224-ab19eb86ce40 h1:CXTPCJnVkuj/Afh7c0P+JNRhC+YB7CA2Cg9jypyyKcg=
+github.com/quay/claircore v1.5.22-0.20240205234224-ab19eb86ce40/go.mod h1:LIO3JnHZNiKsrVX1c7lHhlijGs/lxDktGmSdUSfWSWg=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=
 github.com/quay/claircore/toolkit v1.1.1 h1:9GFy14ffOkIOpl0fbR+bHr4i19VEwms1pXw8S8up0e4=
 github.com/quay/claircore/toolkit v1.1.1/go.mod h1:ZZHA/b/qpfUcNHFJeYVA0bOp7aL4r3CTFhlBV/ezoFI=

--- a/go.sum
+++ b/go.sum
@@ -1731,8 +1731,6 @@ github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/quay/claircore v1.5.21 h1:IW86mFmNz8Vn/HSA0Xp0iSABCSmBs7RDM9O24qcqywI=
-github.com/quay/claircore v1.5.21/go.mod h1:LIO3JnHZNiKsrVX1c7lHhlijGs/lxDktGmSdUSfWSWg=
 github.com/quay/claircore v1.5.22-0.20240205234224-ab19eb86ce40 h1:CXTPCJnVkuj/Afh7c0P+JNRhC+YB7CA2Cg9jypyyKcg=
 github.com/quay/claircore v1.5.22-0.20240205234224-ab19eb86ce40/go.mod h1:LIO3JnHZNiKsrVX1c7lHhlijGs/lxDktGmSdUSfWSWg=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -203,6 +203,9 @@ func newLibindex(ctx context.Context, indexerCfg config.IndexerConfig, client *h
 					cfg.Name2ReposMappingURL = indexerCfg.NameToReposURL
 					cfg.Name2ReposMappingFile = indexerCfg.NameToReposFile
 				}),
+				"java": castToConfig(func(cfg *java.ScannerConfig) {
+					cfg.DisableAPI = true
+				}),
 			},
 		},
 	}

--- a/scanner/indexer/indexer_test.go
+++ b/scanner/indexer/indexer_test.go
@@ -100,6 +100,7 @@ log_level: info
 	require.NoError(t, err)
 	assert.NotNil(t, indexer.Options.ScannerConfig.Repo["rhel-repository-scanner"])
 	assert.NotNil(t, indexer.Options.ScannerConfig.Package["rhel_containerscanner"])
+	assert.NotNil(t, indexer.Options.ScannerConfig.Package["java"])
 }
 
 // loadIndexerConfig parses the provided YAML data and returns the IndexerConfig.


### PR DESCRIPTION
## Description

These changes update the ClairCore version to an unreleased version containing the feature to disable the Java PackageScanner from reaching out to Maven. This configuration is intended to air gap the Java indexer.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

A unit test was added to ClairCore to for disabling the HTTP client from reaching out to Maven. The unit test included in this PR ensures we add that the ClairCore configuration.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
