### PR TITLE
fix(scanner): scannerctl --insecure-skip-tls-verify

### DIFF
--- a/pkg/scannerv4/client/client.go
+++ b/pkg/scannerv4/client/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v3"
@@ -98,11 +97,8 @@ func (c *gRPCScanner) Close() error {
 }
 
 func createGRPCConn(ctx context.Context, o connOptions) (*grpc.ClientConn, error) {
-	// Replace HTTP(S) with DNS for client-side load balancing.
-	// This ensures we use the builtin DNS name resolver.
-	address := strings.TrimPrefix(o.address, "https://")
-	address = strings.TrimPrefix(address, "http://")
-	address = "dns:///" + address
+	// Prefix address with dns:/// to use the DNS name resolver.
+	address := "dns:///" + o.address
 
 	dialOpts := []grpc.DialOption{
 		// Scanner v4 Indexer and Matcher pods are accessed via gRPC, which Kubernetes Services

--- a/pkg/scannerv4/client/options.go
+++ b/pkg/scannerv4/client/options.go
@@ -139,9 +139,11 @@ func makeOptions(opts ...Option) (options, error) {
 }
 
 func validateOptions(o options) error {
+	// If this check is removed, make sure we still properly use the DNS name resolver.
 	if _, _, err := net.SplitHostPort(o.indexerOpts.address); err != nil {
 		return fmt.Errorf("invalid indexer address (want [host]:port): %w", err)
 	}
+	// If this check is removed, make sure we still properly use the DNS name resolver.
 	if _, _, err := net.SplitHostPort(o.matcherOpts.address); err != nil {
 		return fmt.Errorf("invalid matcher address (want [host]:port): %w", err)
 	}

--- a/pkg/scannerv4/client/options.go
+++ b/pkg/scannerv4/client/options.go
@@ -10,16 +10,16 @@ import (
 var (
 	defaultOptions = options{
 		indexerOpts: connOptions{
-			mTLSSubject: mtls.ScannerV4IndexerSubject,
-			address:     ":8443",
-			serverName:  fmt.Sprintf("scanner-v4-indexer.%s.svc", env.Namespace.Setting()),
-			skipTLS:     false,
+			mTLSSubject:   mtls.ScannerV4IndexerSubject,
+			address:       ":8443",
+			serverName:    fmt.Sprintf("scanner-v4-indexer.%s.svc", env.Namespace.Setting()),
+			skipTLSVerify: false,
 		},
 		matcherOpts: connOptions{
-			mTLSSubject: mtls.ScannerV4MatcherSubject,
-			address:     ":8443",
-			serverName:  fmt.Sprintf("scanner-v4-matcher.%s.svc", env.Namespace.Setting()),
-			skipTLS:     false,
+			mTLSSubject:   mtls.ScannerV4MatcherSubject,
+			address:       ":8443",
+			serverName:    fmt.Sprintf("scanner-v4-matcher.%s.svc", env.Namespace.Setting()),
+			skipTLSVerify: false,
 		},
 		comboMode: false,
 	}
@@ -29,10 +29,10 @@ var (
 type Option func(*options)
 
 type connOptions struct {
-	mTLSSubject mtls.Subject
-	address     string
-	serverName  string
-	skipTLS     bool
+	mTLSSubject   mtls.Subject
+	address       string
+	serverName    string
+	skipTLSVerify bool
 }
 
 type options struct {
@@ -89,7 +89,7 @@ func WithIndexerServerName(serverName string) Option {
 // SkipIndexerTLSVerification disables TLS verification, preventing the reading and usage
 // of client certificates (mTLS).
 func SkipIndexerTLSVerification(o *options) {
-	o.indexerOpts.skipTLS = true
+	o.indexerOpts.skipTLSVerify = true
 }
 
 // WithIndexerAddress specifies the gRPC address to connect.
@@ -116,7 +116,7 @@ func WithMatcherServerName(serverName string) Option {
 // SkipMatcherTLSVerification disables TLS verification, preventing the reading and usage
 // of client certificates (mTLS).
 func SkipMatcherTLSVerification(o *options) {
-	o.matcherOpts.skipTLS = true
+	o.matcherOpts.skipTLSVerify = true
 }
 
 // WithMatcherAddress specifies the gRPC address to connect.

--- a/pkg/scannerv4/client/options_test.go
+++ b/pkg/scannerv4/client/options_test.go
@@ -9,7 +9,8 @@ import (
 
 func TestOptions(t *testing.T) {
 	t.Run("When no setters then options should be default", func(t *testing.T) {
-		o := makeOptions()
+		o, err := makeOptions()
+		assert.NoError(t, err)
 		assert.Equal(t, defaultOptions, o)
 	})
 
@@ -19,44 +20,62 @@ func TestOptions(t *testing.T) {
 		address := "localhost:9000"
 		serverName := "newServer"
 
-		o := makeOptions(
+		o, err := makeOptions(
 			WithSubject(subject),
 			WithAddress(address),
 			WithServerName(serverName),
 		)
 
+		assert.NoError(t, err)
 		assert.Equal(t, subject, o.indexerOpts.mTLSSubject)
 		assert.Equal(t, subject, o.matcherOpts.mTLSSubject)
 		assert.Equal(t, address, o.indexerOpts.address)
 		assert.Equal(t, address, o.matcherOpts.address)
 		assert.Equal(t, serverName, o.indexerOpts.serverName)
 		assert.Equal(t, serverName, o.matcherOpts.serverName)
-		assert.False(t, o.matcherOpts.skipTLS)
-		assert.False(t, o.indexerOpts.skipTLS)
+		assert.False(t, o.matcherOpts.skipTLSVerify)
+		assert.False(t, o.indexerOpts.skipTLSVerify)
 		assert.True(t, o.comboMode)
 	})
 
 	t.Run("When skip TLS is set, then both indexer and matcher comply", func(t *testing.T) {
-		o := makeOptions(SkipTLSVerification)
-		assert.True(t, o.indexerOpts.skipTLS)
-		assert.True(t, o.matcherOpts.skipTLS)
+		o, err := makeOptions(SkipTLSVerification)
+		assert.NoError(t, err)
+		assert.True(t, o.indexerOpts.skipTLSVerify)
+		assert.True(t, o.matcherOpts.skipTLSVerify)
 	})
 
 	t.Run("When different options are set for indexer and matcher, then comboMode should be false", func(t *testing.T) {
-		o := makeOptions(
+		o, err := makeOptions(
 			WithIndexerAddress("localhost:9001"),
 			WithMatcherAddress("localhost:9002"),
 		)
+		assert.NoError(t, err)
 		assert.False(t, o.comboMode)
 	})
 
 	t.Run("When the same options are set for indexer and matcher, then comboMode should be true", func(t *testing.T) {
-		o := makeOptions(
+		o, err := makeOptions(
 			WithSubject(mtls.ScannerV4IndexerSubject), // Doesn't matter.
 			WithIndexerAddress("localhost:9001"),
 			WithMatcherAddress("localhost:9001"),
 			WithServerName("scanner-v4-combo"),
 		)
+		assert.NoError(t, err)
 		assert.True(t, o.comboMode)
+	})
+
+	t.Run("When indexer address is not valid host:port, should error", func(t *testing.T) {
+		_, err := makeOptions(
+			WithIndexerAddress("https://localhost:9001"),
+		)
+		assert.Error(t, err)
+	})
+
+	t.Run("When matcher address is not valid host:port, should error", func(t *testing.T) {
+		_, err := makeOptions(
+			WithMatcherAddress("https://localhost:9001"),
+		)
+		assert.Error(t, err)
 	})
 }

--- a/scanner/cmd/scannerctl/main.go
+++ b/scanner/cmd/scannerctl/main.go
@@ -55,7 +55,7 @@ func rootCmd(ctx context.Context) *cobra.Command {
 		"Address of the matcher service.")
 	serverName := flags.String(
 		"server-name",
-		"scanner-v4.stackrox",
+		"",
 		"Server name of the scanner service, primarily used for TLS verification.")
 	skipTLSVerify := flags.Bool(
 		"insecure-skip-tls-verify",
@@ -83,11 +83,13 @@ func rootCmd(ctx context.Context) *cobra.Command {
 		}
 		// Set options for the gRPC connection.
 		opts := []client.Option{
-			client.WithServerName(*serverName),
 			client.WithAddress(*address),
 		}
 		if *skipTLSVerify {
 			opts = append(opts, client.SkipTLSVerification)
+		}
+		if *serverName != "" {
+			opts = append(opts, client.WithServerName(*serverName))
 		}
 		if *indexerAddr != "" {
 			opts = append(opts, client.WithIndexerAddress(*indexerAddr))

--- a/scanner/cmd/scannerctl/main.go
+++ b/scanner/cmd/scannerctl/main.go
@@ -55,8 +55,16 @@ func rootCmd(ctx context.Context) *cobra.Command {
 		"Address of the matcher service.")
 	serverName := flags.String(
 		"server-name",
-		"",
+		"scanner-v4.stackrox",
 		"Server name of the scanner service, primarily used for TLS verification.")
+	indexerServerName := flags.String(
+		"indexer-server-name",
+		"",
+		"Server name of the indexer service, primarily used for TLS verification.")
+	matcherServerName := flags.String(
+		"matcher-server-name",
+		"",
+		"Server name of the matcher service, primarily used for TLS verification.")
 	skipTLSVerify := flags.Bool(
 		"insecure-skip-tls-verify",
 		false,
@@ -84,18 +92,22 @@ func rootCmd(ctx context.Context) *cobra.Command {
 		// Set options for the gRPC connection.
 		opts := []client.Option{
 			client.WithAddress(*address),
+			client.WithServerName(*serverName),
 		}
 		if *skipTLSVerify {
 			opts = append(opts, client.SkipTLSVerification)
-		}
-		if *serverName != "" {
-			opts = append(opts, client.WithServerName(*serverName))
 		}
 		if *indexerAddr != "" {
 			opts = append(opts, client.WithIndexerAddress(*indexerAddr))
 		}
 		if *matcherAddr != "" {
 			opts = append(opts, client.WithMatcherAddress(*matcherAddr))
+		}
+		if *indexerServerName != "" {
+			opts = append(opts, client.WithIndexerServerName(*indexerServerName))
+		}
+		if *matcherServerName != "" {
+			opts = append(opts, client.WithMatcherServerName(*matcherServerName))
 		}
 		// Create the client factory.
 		factory = opts


### PR DESCRIPTION
## Description

This allows us to use `scannerctl --insecure-tls-verify` again.

https://github.com/stackrox/stackrox/pull/9555 enabled mTLS between StackRox services, but broke this workflow due to `clientconn.UseInsecureNoTLS(o.skipTLS)`. In that PR, this line was accidentally added because I thought `o.skipTLS` meant to skip TLS. It turns out it meant `skipTLSVerify`, so I updated the name and stopped using `UseInsecureNoTLS`. We don't actually want to disable TLS, just the cert/host name verification.

Before this change I found `./bin/scannerctl --insecure-tls-verify scan https://quay.io/stackrox-io/scanner:4.3.0` would error:

Client:

```
{"level":"debug","method":"GetOrCreateImageIndex","image":"quay.io/stackrox-io/scanner@sha256:6d9067814d1b6959c992aa925efbedc5ae8e39564f464791b26231f092b838a6","component":"scanner/client","rpc":"indexer.GetOrCreateIndexReport","error":"rpc error: code = Unavailable desc = connection error: desc = \"error reading server preface: EOF\"","duration":1153.1025,"time":"2024-02-06T22:45:48-08:00","message":"retrying gRPC call"}
```

Server:

```
pkg/grpc: 2024/02/07 07:06:42.753476 tls_conn_creds.go:40: Debug: TLS handshake error from "[::1]:49630": tls: first record does not look like a TLS handshake
grpc_internal: 2024/02/07 07:06:42.753738 logging.go:35: Debug: [core][Server #1] grpc: Server.Serve failed to create ServerTransport: connection error: desc = "ServerHandshake(\"[::1]:49630\") failed: tls: first record does not look like a TLS handshake"
```

This PR also stops defaulting `--server-name` to `scanner-v4.stackrox`. Instead, it uses the indexer and matcher defaults (scanner-v4-indexer.stackrox.svc and scanner-v4-matcher.stackrox.svc)

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

`./bin/scannerctl --insecure-tls-verify scan https://quay.io/stackrox-io/scanner:4.3.0`

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
