### PR TITLE
ROX-22239: Add Splunk TA to API metrics

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         {{- if ne (._rox.central.telemetry.enabled | toString) "false" }}
         {{- /* If telemetry.enabled is true or null, configure the endpoint and
-               the key, if provided. */}}
+               the key, if provided. Also, configure additional listening endpoints.*/}}
         {{- if ._rox.central.telemetry.storage.endpoint }}
         - name: ROX_TELEMETRY_ENDPOINT
           value: {{ ._rox.central.telemetry.storage.endpoint | quote }}
@@ -84,6 +84,8 @@ spec:
         - name: ROX_TELEMETRY_STORAGE_KEY_V1
           value: {{ ._rox.central.telemetry.storage.key | quote }}
         {{- end }}
+        - name: ROX_TELEMETRY_API_WHITELIST
+          value: "/api/splunk/ta/*"
         {{- /* Otherwise... */}}
         {{- else }}
         {{- /* ... if telemetry.enabled is false, configure the key to disable

--- a/operator/tests/central/central-misc/080-assert-non-openshift.yaml
+++ b/operator/tests/central/central-misc/080-assert-non-openshift.yaml
@@ -34,6 +34,8 @@ spec:
               value: https://telemetry.endpoint
             - name: ROX_TELEMETRY_STORAGE_KEY_V1
               value: my-api-key
+            - name: ROX_TELEMETRY_API_WHITELIST
+              value: "/api/splunk/ta/*"
             - name: ROX_OFFLINE_MODE
               value: "false"
             - name: ROX_INSTALL_METHOD

--- a/operator/tests/central/central-misc/080-assert-openshift.yaml
+++ b/operator/tests/central/central-misc/080-assert-openshift.yaml
@@ -34,6 +34,8 @@ spec:
               value: https://telemetry.endpoint
             - name: ROX_TELEMETRY_STORAGE_KEY_V1
               value: my-api-key
+            - name: ROX_TELEMETRY_API_WHITELIST
+              value: "/api/splunk/ta/*"
             - name: ROX_OFFLINE_MODE
               value: "false"
             - name: ROX_ENABLE_OPENSHIFT_AUTH


### PR DESCRIPTION
## Description
This PR sets an environment variable to enable collection of API endpoint metrics for `/api/splunk/ta`, which is a non-standard endpoint only our Splunk TA uses.
This enables us to get an idea how many centrals are running with a set up connection to Splunk, allowing us to better prioritize RFEs and bug reports for the TA.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
- Automated E2E tests
- Manual testing in Amplitude by setting up a dev central with dev telemetry key


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
