### PR TITLE
ROX-21344: Add deployment enhancement metrics

### DIFF
--- a/central/metrics/central.go
+++ b/central/metrics/central.go
@@ -239,10 +239,23 @@ var (
 			256_000_000,
 		}, // Bucket sizes selected arbitrary based on current default limits for grpc message size
 	}, []string{"Type"})
+
+	deploymentEnhancementRoundTripDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "deployment_enhancement_duration_ms",
+		Help:      "Total round trip duration in milliseconds for enhancing deployments",
+		Buckets:   prometheus.LinearBuckets(50, 100, 10), // 50, 150, 250...
+	})
 )
 
 func startTimeToMS(t time.Time) float64 {
 	return float64(time.Since(t).Nanoseconds()) / float64(time.Millisecond)
+}
+
+// ObserveDeploymentEnhancementTime registers how long a sensor deployment request took
+func ObserveDeploymentEnhancementTime(ms float64) {
+	deploymentEnhancementRoundTripDuration.Observe(ms)
 }
 
 // ObserveSentSize registers central payload sent size.

--- a/central/metrics/central.go
+++ b/central/metrics/central.go
@@ -245,7 +245,7 @@ var (
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "deployment_enhancement_duration_ms",
 		Help:      "Total round trip duration in milliseconds for enhancing deployments",
-		Buckets:   prometheus.LinearBuckets(50, 100, 10), // 50, 150, 250...
+		Buckets:   prometheus.LinearBuckets(500, 1000, 10),
 	})
 )
 

--- a/central/metrics/init.go
+++ b/central/metrics/init.go
@@ -36,5 +36,6 @@ func init() {
 		grpcLastMessageSizeSent,
 		grpcLastMessageSizeReceived,
 		grpcError,
+		deploymentEnhancementRoundTripDuration,
 	)
 }

--- a/central/sensor/enhancement/broker.go
+++ b/central/sensor/enhancement/broker.go
@@ -53,7 +53,7 @@ func (b *Broker) NotifyDeploymentReceived(msg *central.DeploymentEnhancementResp
 		log.Warnf("Received response to an unknown Deployment Enrichment Request ID %s", reqID)
 		return
 	}
-	elapsed := time.Now().UnixMilli() - sig.requestTime.UnixMilli()
+	elapsed := time.Now().Sub(sig.requestTime).Milliseconds()
 	log.Debugf("Received answer for Deployment Enrichment Request ID %s (time elapsed %dms)", reqID, elapsed)
 	sig.msg = msg
 	metrics.ObserveDeploymentEnhancementTime(float64(elapsed))

--- a/central/sensor/enhancement/broker.go
+++ b/central/sensor/enhancement/broker.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -19,8 +20,9 @@ var (
 )
 
 type enhancementSignal struct {
-	msgArrived concurrency.Signal
-	msg        *central.DeploymentEnhancementResponse
+	requestTime time.Time
+	msgArrived  concurrency.Signal
+	msg         *central.DeploymentEnhancementResponse
 }
 
 // The Broker coordinates and matches deployment enhancement requests to responses
@@ -51,8 +53,10 @@ func (b *Broker) NotifyDeploymentReceived(msg *central.DeploymentEnhancementResp
 		log.Warnf("Received response to an unknown Deployment Enrichment Request ID %s", reqID)
 		return
 	}
-	log.Debugf("Received answer for Deployment Enrichment Request ID %s", reqID)
+	elapsed := time.Now().UnixMilli() - sig.requestTime.UnixMilli()
+	log.Debugf("Received answer for Deployment Enrichment Request ID %s (time elapsed %dms)", reqID, elapsed)
 	sig.msg = msg
+	metrics.ObserveDeploymentEnhancementTime(float64(elapsed))
 	delete(b.activeRequests, reqID)
 	sig.msgArrived.Signal()
 }
@@ -65,7 +69,8 @@ func (b *Broker) SendAndWaitForEnhancedDeployments(ctx context.Context, conn con
 	concurrency.WithLock(&b.lock, func() {
 		id = uuid.NewV4().String()
 		s = enhancementSignal{
-			msgArrived: concurrency.NewSignal(),
+			requestTime: time.Now(),
+			msgArrived:  concurrency.NewSignal(),
 		}
 		b.activeRequests[id] = &s
 	})

--- a/central/sensor/enhancement/broker.go
+++ b/central/sensor/enhancement/broker.go
@@ -53,7 +53,7 @@ func (b *Broker) NotifyDeploymentReceived(msg *central.DeploymentEnhancementResp
 		log.Warnf("Received response to an unknown Deployment Enrichment Request ID %s", reqID)
 		return
 	}
-	elapsed := time.Now().Sub(sig.requestTime).Milliseconds()
+	elapsed := time.Since(sig.requestTime).Milliseconds()
 	log.Debugf("Received answer for Deployment Enrichment Request ID %s (time elapsed %dms)", reqID, elapsed)
 	sig.msg = msg
 	metrics.ObserveDeploymentEnhancementTime(float64(elapsed))

--- a/sensor/common/deploymentenhancer/component.go
+++ b/sensor/common/deploymentenhancer/component.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/common/store"
 )
 
@@ -54,6 +55,7 @@ func (d *DeploymentEnhancer) ProcessMessage(msg *central.MsgToSensor) error {
 
 	select {
 	case d.deploymentsQueue <- toEnhance:
+		metrics.IncrementDeploymentEnhancerQueueSize()
 		return nil
 	default:
 		return errox.ResourceExhausted.Newf("DeploymentEnhancer queue has reached its limit of %d", env.SensorDeploymentEnhancementQueueSize.IntegerSetting())
@@ -71,6 +73,7 @@ func (d *DeploymentEnhancer) Start() error {
 				if !more {
 					return
 				}
+				metrics.DecrementDeploymentEnhancerQueueSize()
 				if deploymentMsg.GetMsg() == nil {
 					log.Warnf("Received empty deploymentEnhancement message. Discarding request.")
 					return

--- a/sensor/common/metrics/init.go
+++ b/sensor/common/metrics/init.go
@@ -40,5 +40,6 @@ func init() {
 		telemetryInfo,
 		telemetrySecuredNodes,
 		telemetrySecuredVCPU,
+		deploymentEnhancementQueueSize,
 	)
 }

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -202,6 +202,13 @@ var (
 		Help:      "A gauge to track how large ResourcesSynced message is",
 	})
 
+	deploymentEnhancementQueueSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "deployment_enhancement_queue_size",
+		Help:      "A counter to track deployments queued up in Sensor to be enhanced",
+	})
+
 	k8sObjectIngestionToSendDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
@@ -308,6 +315,16 @@ func IncrementProcessDedupeCacheMisses() {
 // RegisterSensorIndicatorChannelFullCounter registers the number of indicators dropped
 func RegisterSensorIndicatorChannelFullCounter() {
 	sensorIndicatorChannelFullCounter.Inc()
+}
+
+// IncrementDeploymentEnhancerQueueSize increments the deployment enhancer queue size by one.
+func IncrementDeploymentEnhancerQueueSize() {
+	deploymentEnhancementQueueSize.Inc()
+}
+
+// DecrementDeploymentEnhancerQueueSize decrements the deployment enhancer queue size by one.
+func DecrementDeploymentEnhancerQueueSize() {
+	deploymentEnhancementQueueSize.Dec()
 }
 
 // IncrementTotalResourcesSyncSent sets the number of resources synced transmitted in the last sync event


### PR DESCRIPTION
## Description

This PR adds two new metrics:
- **[Sensor]** the enhancement queue size, to track if sensors are getting more requests that they can handle
- **[Central]** histogram of the roudtrip time (i.e. how long it takes in average to get a sensor enhancement from sensor 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [ ] Sensor metric observed in test scenario
- [ ] Central metrics observed in test scenario

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
