### PR TITLE
feat(cloud-sources): discovered cluster matching

### DIFF
--- a/central/cloudsources/manager/manager.go
+++ b/central/cloudsources/manager/manager.go
@@ -225,16 +225,3 @@ func clusterIndexForClusterMetadata(obj *storage.ClusterMetadata) clusterIndex {
 func clusterIndexForDiscoveredCluster(obj *discoveredclusters.DiscoveredCluster) clusterIndex {
 	return obj.GetID() + obj.GetName() + obj.GetType().String()
 }
-
-func providerMetadataToProviderType(metadata *storage.ProviderMetadata) storage.DiscoveredCluster_Metadata_ProviderType {
-	switch {
-	case metadata.GetGoogle() != nil:
-		return storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_GCP
-	case metadata.GetAws() != nil:
-		return storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AWS
-	case metadata.GetAzure() != nil:
-		return storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AZURE
-	default:
-		return storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_UNSPECIFIED
-	}
-}

--- a/central/cloudsources/manager/manager_test.go
+++ b/central/cloudsources/manager/manager_test.go
@@ -51,10 +51,6 @@ func TestMatchDiscoveredClusters(t *testing.T) {
 					Provider: &storage.ProviderMetadata_Aws{Aws: &storage.AWSProviderMetadata{
 						AccountId: "666666666666",
 					}},
-					Cluster: &storage.ClusterMetadata{
-						Type: storage.ClusterMetadata_EKS,
-						Id:   "arn:aws:eks:us-east-1:666666666666:cluster/test-cluster-5",
-					},
 				},
 			},
 		},

--- a/central/cloudsources/manager/manager_test.go
+++ b/central/cloudsources/manager/manager_test.go
@@ -27,24 +27,33 @@ func (m *mockClusterStore) WalkClusters(_ context.Context, fn func(obj *storage.
 func TestMatchDiscoveredClusters(t *testing.T) {
 	clusterStore := &mockClusterStore{clusters: []*storage.Cluster{
 		createCluster(
-			"MC_testing_test-cluster-1_eastus",
+			"123123213123_MC_testing_test-cluster-1_eastus",
 			"test-cluster-1",
 			storage.ClusterMetadata_AKS,
 		),
-		createCluster("something-else", "something-else", storage.ClusterMetadata_ROSA),
-		createCluster("another-thing", "another-thing", storage.ClusterMetadata_OSD),
+		createCluster(
+			"2c507da1-b882-48cc-8143-b74e14c5cd4f",
+			"rosa-cluster",
+			storage.ClusterMetadata_ROSA,
+		),
+		createCluster(
+			"460c8808-9f70-51e7-9f3a-973f44ab8595",
+			"osd-cluster",
+			storage.ClusterMetadata_OSD,
+		),
 		createCluster("1231245342513", "test-cluster-2", storage.ClusterMetadata_GKE),
-		createCluster("1231234124123541", "test-cluster-3", storage.ClusterMetadata_EKS),
+		createCluster("arn:aws:eks:us-east-1:test-account:cluster/test-cluster-3",
+			"test-cluster-3", storage.ClusterMetadata_EKS),
 		nil,
 		{
 			Status: &storage.ClusterStatus{
 				ProviderMetadata: &storage.ProviderMetadata{
 					Provider: &storage.ProviderMetadata_Aws{Aws: &storage.AWSProviderMetadata{
-						AccountId: "12345",
+						AccountId: "666666666666",
 					}},
 					Cluster: &storage.ClusterMetadata{
 						Type: storage.ClusterMetadata_EKS,
-						Id:   "some-id",
+						Id:   "arn:aws:eks:us-east-1:666666666666:cluster/test-cluster-5",
 					},
 				},
 			},
@@ -53,7 +62,7 @@ func TestMatchDiscoveredClusters(t *testing.T) {
 
 	discoveredClusters := []*discoveredclusters.DiscoveredCluster{
 		{
-			ID:           "MC_testing_test-cluster-1_eastus",
+			ID:           "123123213123_MC_testing_test-cluster-1_eastus",
 			Name:         "test-cluster-1",
 			Type:         storage.ClusterMetadata_AKS,
 			ProviderType: storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AZURE,
@@ -65,20 +74,20 @@ func TestMatchDiscoveredClusters(t *testing.T) {
 			ProviderType: storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_GCP,
 		},
 		{
-			ID:           "1231234124123541",
+			ID:           "arn:aws:eks:us-east-1:test-account:cluster/test-cluster-3",
 			Name:         "test-cluster-3",
 			Type:         storage.ClusterMetadata_EKS,
 			ProviderType: storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AWS,
 		},
 		{
-			ID:           "55555555",
+			ID:           "5553424234234_MC_testing_unsecured_eastus",
 			Name:         "unsecured",
 			Type:         storage.ClusterMetadata_AKS,
 			ProviderType: storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AZURE,
 		},
 		{
-			ID:           "6666666",
-			Name:         "unspecified",
+			ID:           "arn:aws:eks:us-east-1:666666666666:cluster/test-cluster-5",
+			Name:         "test-cluster-5",
 			Type:         storage.ClusterMetadata_EKS,
 			ProviderType: storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AWS,
 		},

--- a/central/cloudsources/manager/manager_test.go
+++ b/central/cloudsources/manager/manager_test.go
@@ -1,0 +1,95 @@
+package manager
+
+import (
+	"context"
+	"testing"
+
+	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/cloudsources/discoveredclusters"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockClusterStore struct {
+	clusters []*storage.Cluster
+
+	clusterDS.DataStore
+}
+
+func (m *mockClusterStore) WalkClusters(_ context.Context, fn func(obj *storage.Cluster) error) error {
+	for _, cluster := range m.clusters {
+		_ = fn(cluster)
+	}
+	return nil
+}
+
+func TestMatchDiscoveredClusters(t *testing.T) {
+	clusterStore := &mockClusterStore{clusters: []*storage.Cluster{
+		createCluster(
+			"MC_testing_test-cluster-1_eastus",
+			"test-cluster-1",
+			storage.ClusterMetadata_AKS,
+		),
+		createCluster("something-else", "something-else", storage.ClusterMetadata_ROSA),
+		createCluster("another-thing", "another-thing", storage.ClusterMetadata_OSD),
+		createCluster("1231245342513", "test-cluster-2", storage.ClusterMetadata_GKE),
+		createCluster("1231234124123541", "test-cluster-3", storage.ClusterMetadata_EKS),
+	}}
+
+	discoveredClusters := []*discoveredclusters.DiscoveredCluster{
+		{
+			ID:   "MC_testing_test-cluster-1_eastus",
+			Name: "test-cluster-1",
+			Type: storage.ClusterMetadata_AKS,
+		},
+		{
+			ID:   "1231245342513",
+			Name: "test-cluster-2",
+			Type: storage.ClusterMetadata_GKE,
+		},
+		{
+			ID:   "1231234124123541",
+			Name: "test-cluster-3",
+			Type: storage.ClusterMetadata_EKS,
+		},
+		{
+			ID:   "55555555",
+			Name: "unsecured",
+			Type: storage.ClusterMetadata_AKS,
+		},
+	}
+
+	securedIds := set.NewFrozenStringSet(discoveredClusters[0].GetID(),
+		discoveredClusters[1].GetID(), discoveredClusters[2].GetID())
+	unsecuredIds := set.NewFrozenStringSet(discoveredClusters[3].GetID())
+
+	m := &managerImpl{
+		clusterDataStore: clusterStore,
+	}
+
+	m.matchDiscoveredClusters(discoveredClusters)
+
+	for _, cluster := range discoveredClusters {
+		if securedIds.Contains(cluster.GetID()) {
+			assert.Equal(t, storage.DiscoveredCluster_STATUS_SECURED, cluster.GetStatus())
+		}
+		if unsecuredIds.Contains(cluster.GetID()) {
+			assert.Equal(t, storage.DiscoveredCluster_STATUS_UNSECURED, cluster.GetStatus())
+		}
+	}
+}
+
+func createCluster(id, name string, clusterType storage.ClusterMetadata_Type) *storage.Cluster {
+	return &storage.Cluster{
+		Status: &storage.ClusterStatus{
+			ProviderMetadata: &storage.ProviderMetadata{
+				Cluster: &storage.ClusterMetadata{
+					Type: clusterType,
+					Name: name,
+					Id:   id,
+				},
+			},
+		},
+	}
+}

--- a/central/cloudsources/manager/singleton.go
+++ b/central/cloudsources/manager/singleton.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	cloudSourcesDS "github.com/stackrox/rox/central/cloudsources/datastore"
+	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
 	discoveredClustersDS "github.com/stackrox/rox/central/discoveredclusters/datastore"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sync"
@@ -30,7 +31,7 @@ func Singleton() Manager {
 	}
 
 	once.Do(func() {
-		m = newManager(cloudSourcesDS.Singleton(), discoveredClustersDS.Singleton())
+		m = newManager(cloudSourcesDS.Singleton(), discoveredClustersDS.Singleton(), clusterDS.Singleton())
 	})
 	return m
 }

--- a/central/cluster/datastore/datastore.go
+++ b/central/cluster/datastore/datastore.go
@@ -49,6 +49,7 @@ type DataStore interface {
 	GetClustersForSAC(ctx context.Context) ([]*storage.Cluster, error)
 	CountClusters(ctx context.Context) (int, error)
 	Exists(ctx context.Context, id string) (bool, error)
+	WalkClusters(ctx context.Context, fn func(obj *storage.Cluster) error) error
 
 	AddCluster(ctx context.Context, cluster *storage.Cluster) (string, error)
 	UpdateCluster(ctx context.Context, cluster *storage.Cluster) error

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -292,6 +292,10 @@ func (ds *datastoreImpl) Exists(ctx context.Context, id string) (bool, error) {
 	return ok, nil
 }
 
+func (ds *datastoreImpl) WalkClusters(ctx context.Context, fn func(obj *storage.Cluster) error) error {
+	return ds.clusterStorage.Walk(ctx, fn)
+}
+
 func (ds *datastoreImpl) SearchRawClusters(ctx context.Context, q *v1.Query) ([]*storage.Cluster, error) {
 	clusters, err := ds.searchRawClusters(ctx, q)
 	if err != nil {

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -293,7 +293,17 @@ func (ds *datastoreImpl) Exists(ctx context.Context, id string) (bool, error) {
 }
 
 func (ds *datastoreImpl) WalkClusters(ctx context.Context, fn func(obj *storage.Cluster) error) error {
-	return ds.clusterStorage.Walk(ctx, fn)
+	walkFn := func() error {
+		return ds.clusterStorage.Walk(ctx, func(cluster *storage.Cluster) error {
+			ds.populateHealthInfos(ctx, cluster)
+			ds.updateClusterPriority(cluster)
+			return fn(cluster)
+		})
+	}
+	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (ds *datastoreImpl) SearchRawClusters(ctx context.Context, q *v1.Query) ([]*storage.Cluster, error) {

--- a/central/cluster/datastore/mocks/datastore.go
+++ b/central/cluster/datastore/mocks/datastore.go
@@ -337,3 +337,17 @@ func (mr *MockDataStoreMockRecorder) UpdateSensorDeploymentIdentification(ctx, i
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSensorDeploymentIdentification", reflect.TypeOf((*MockDataStore)(nil).UpdateSensorDeploymentIdentification), ctx, id, identification)
 }
+
+// WalkClusters mocks base method.
+func (m *MockDataStore) WalkClusters(ctx context.Context, fn func(*storage.Cluster) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WalkClusters", ctx, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WalkClusters indicates an expected call of WalkClusters.
+func (mr *MockDataStoreMockRecorder) WalkClusters(ctx, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WalkClusters", reflect.TypeOf((*MockDataStore)(nil).WalkClusters), ctx, fn)
+}

--- a/pkg/cloudsources/paladin/client_test.go
+++ b/pkg/cloudsources/paladin/client_test.go
@@ -40,6 +40,10 @@ func TestClient_GetAssets(t *testing.T) {
 	require.NoError(t, err)
 	testCluster3FirstDiscoveredAtTS, err := gogoProto.TimestampProto(testCluster3FirstDiscoveredAt)
 	require.NoError(t, err)
+	testCluster4FirstDiscoveredAt, err := time.Parse(timeFormat, "2024-02-09 08:00:00+0000")
+	require.NoError(t, err)
+	testCluster4FirstDiscoveredAtTS, err := gogoProto.TimestampProto(testCluster4FirstDiscoveredAt)
+	require.NoError(t, err)
 
 	expectedDiscoveredClusters := []*discoveredclusters.DiscoveredCluster{
 		{
@@ -69,6 +73,15 @@ func TestClient_GetAssets(t *testing.T) {
 			CloudSourceID:     "id",
 			FirstDiscoveredAt: testCluster3FirstDiscoveredAtTS,
 		},
+		{
+			ID:                "arn:aws:eks:us-east-1:test-account:cluster/test-cluster-4",
+			Name:              "test-cluster-4",
+			Type:              storage.ClusterMetadata_EKS,
+			ProviderType:      storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AWS,
+			Region:            "us-east-1",
+			CloudSourceID:     "id",
+			FirstDiscoveredAt: testCluster4FirstDiscoveredAtTS,
+		},
 	}
 
 	client := NewClient(&storage.CloudSource{
@@ -81,7 +94,7 @@ func TestClient_GetAssets(t *testing.T) {
 
 	resp, err := client.GetDiscoveredClusters(context.Background())
 	require.NoError(t, err)
-	assert.Len(t, resp, 3)
+	assert.Len(t, resp, 4)
 
 	assert.ElementsMatch(t, resp, expectedDiscoveredClusters)
 }

--- a/pkg/cloudsources/paladin/testdata/response.json
+++ b/pkg/cloudsources/paladin/testdata/response.json
@@ -38,7 +38,20 @@
       "discoveryDate": "2024-02-06 07:41:00+0000",
       "firstDiscoveryDate": "2024-02-01 13:52:00+0000",
       "metadata": {}
+    },
+    {
+      "id": "arn:aws:eks:us-east-1:test-account:cluster/test-cluster-4",
+      "name": "",
+      "type": "eks",
+      "typeName": "EKS",
+      "source": "aws",
+      "region": "us-east-1",
+      "accountId": "test-account",
+      "accountName": "test-account",
+      "discoveryDate": "2024-02-09 08:00:00+0000",
+      "firstDiscoveryDate": "2024-02-09 08:00:00+0000",
+      "metadata": {}
     }
   ],
-  "total": 3
+  "total": 4
 }


### PR DESCRIPTION
## Description

This PR adds the matching logic to match discovered clusters with existing secured clusters.

This will ensure that discovered clusters will have their status (i.e. whether they are already secured or not) populated based on existing secured clusters known to Central.

Matching currently works as follows:
- In case secured clusters do not have any `ProviderMetadata` associated with them, they will not be considered for matching.
- In case secured clusters have partial `ProviderMetadata` (this can mean either that the `ClusterMetadata` type is unspecified _or_ the name / ID of the cluster is empty), the provider type will be marked as `Unspecified` during matching. The reason we decided to go with this is to avoid having false-positives (i.e. mark a cluster Unsecured even though it _may_ be secured).
- In case the secured cluster has all we need for matching in its `ProviderMetadata`, we create an index out of the cluster ID, name, and type. This will then be used to match against discovered clusters from cloud sources.

Each cloud source will then be associated with its type accordingly.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see added unit tests.

1. Create a valid Cloud source integration (e.g. Paladin one).

2. Observe within the logs after creation that clusters have been discovered
```log
Got the following discovered clusters: ...
```

3. Check the `v1/discovered-clusters` endpoint and see the clusters correctly matched:
```json
{
  "clusters": [
    {
      "id": "d24abbe8-e52d-53f4-bdd2-178efab6c3a5",
      "metadata": {
...
      },
      "status": "STATUS_UNSECURED",
      "source": {
        "id": "0c31f1f5-6082-4bed-a158-dba032a9d969"
      }
    },
    {
      "id": "bd032f2e-42b8-52cd-b1ba-203460b0431b",
      "metadata": {
...
      },
      "status": "STATUS_UNSECURED",
      "source": {
        "id": "0c31f1f5-6082-4bed-a158-dba032a9d969"
      }
    },
    {
      "id": "6b70865b-2eb7-5ae4-bad6-882fab89cd10",
      "metadata": {
...
      },
      "status": "STATUS_UNSECURED",
      "source": {
        "id": "0c31f1f5-6082-4bed-a158-dba032a9d969"
      }
    },
    {
      "id": "1da3a02c-54b7-5202-a89b-e927ebb7e991",
      "metadata": {
...
      },
      "status": "STATUS_UNSECURED",
      "source": {
        "id": "0c31f1f5-6082-4bed-a158-dba032a9d969"
      }
    },
    {
      "id": "8f451291-6db5-5a20-bdb9-abec4b76b859",
      "metadata": {
...
      },
      "status": "STATUS_UNSECURED",
      "source": {
        "id": "0c31f1f5-6082-4bed-a158-dba032a9d969"
      }
    }
  ]
}
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
