### PR TITLE
ROX-22187:  compliance name conflicting profile

### DIFF
--- a/central/complianceoperator/v2/compliancemanager/manager_impl.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl.go
@@ -159,15 +159,11 @@ func (m *managerImpl) ProcessScanRequest(ctx context.Context, scanRequest *stora
 
 	// Check if there any existing cluster that has the scan configuration with any of profiles being referenced by the scan request.
 	// If so, then we cannot create the scan configuration.
-	found, err := m.scanSettingDS.ScanConfigurationProfileExists(ctx, scanRequest.GetId(), profiles, clusters)
+	err = m.scanSettingDS.ScanConfigurationProfileExists(ctx, scanRequest.GetId(), profiles, clusters)
 
 	if err != nil {
 		log.Error(err)
 		return nil, errors.Wrapf(err, "Unable to create scan configuration named %q.", scanRequest.GetScanConfigName())
-	}
-	// TODO (ROX-22187):  Include the name of the conflicting scan configuration in the error message.
-	if found {
-		return nil, errors.Errorf("Duplicated profiles found in current or existing scan configurations: %q.", scanRequest.GetScanConfigName())
 	}
 
 	err = m.scanSettingDS.UpsertScanConfiguration(ctx, scanRequest)

--- a/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
@@ -186,7 +186,7 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			testContext: suite.testContexts[testutils.UnrestrictedReadWriteCtx],
 			clusters:    []string{testconsts.Cluster1},
 			setMocks: func() {
-				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(suite.testContexts[testutils.UnrestrictedReadWriteCtx], mockScanName).Return(nil, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(nil).Times(1)
@@ -213,7 +213,7 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			clusters:    []string{testconsts.Cluster1},
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(suite.testContexts[testutils.UnrestrictedReadWriteCtx], mockScanName).Return(nil, nil).Times(1)
-				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.Errorf("Duplicated profiles found in current or existing scan configurations: %q.", mockScanName)).Times(1)
 			},
 			isErrorTest: true,
 			expectedErr: errors.Errorf("Duplicated profiles found in current or existing scan configurations: %q.", mockScanName),
@@ -224,7 +224,7 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			testContext: suite.testContexts[testutils.UnrestrictedReadWriteCtx],
 			clusters:    []string{testconsts.Cluster1},
 			setMocks: func() {
-				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(suite.testContexts[testutils.UnrestrictedReadWriteCtx], mockScanName).Return(nil, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(errors.Errorf("Unable to save scan config named %q", mockScanName)).Times(1)
 			},
@@ -237,7 +237,7 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			testContext: suite.testContexts[testutils.UnrestrictedReadWriteCtx],
 			clusters:    []string{testconsts.Cluster1},
 			setMocks: func() {
-				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(suite.testContexts[testutils.UnrestrictedReadWriteCtx], mockScanName).Return(nil, nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(errors.New("Unable to process sensor message")).Times(1)
@@ -273,7 +273,7 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			clusters:    []string{testconsts.Cluster1},
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().GetScanConfiguration(gomock.Any(), mockScanID).Return(getTestRec(), true, nil).Times(1)
-				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(nil).Times(1)
 				suite.clusterDatastore.EXPECT().GetClusterName(gomock.Any(), gomock.Any()).Return("test_cluster", true, nil).Times(1)

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore.go
@@ -24,7 +24,7 @@ type DataStore interface {
 	GetScanConfigurationByName(ctx context.Context, scanName string) (*storage.ComplianceOperatorScanConfigurationV2, error)
 
 	// ScanConfigurationProfileExists takes all the profiles being referenced by the scan configuration and checks if any cluster is using it in any existing scan configurations.
-	ScanConfigurationProfileExists(ctx context.Context, id string, profiles []string, clusters []string) (bool, error)
+	ScanConfigurationProfileExists(ctx context.Context, id string, profiles []string, clusters []string) error
 
 	// GetScanConfigurations retrieves the scan configurations specified by query
 	GetScanConfigurations(ctx context.Context, query *v1.Query) ([]*storage.ComplianceOperatorScanConfigurationV2, error)

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
@@ -388,7 +388,6 @@ func (s *complianceScanConfigDataStoreTestSuite) TestScanConfigurationProfileExi
 		configID    string
 		profiles    []string
 		clusters    []string
-		found       bool
 		isErrorTest bool
 	}{
 		{
@@ -396,7 +395,6 @@ func (s *complianceScanConfigDataStoreTestSuite) TestScanConfigurationProfileExi
 			configID:    uuid.NewV4().String(),
 			profiles:    []string{"no-match-profile", "ocp4-cis-node"},
 			clusters:    []string{s.clusterID1},
-			found:       false,
 			isErrorTest: false,
 		},
 		{
@@ -404,59 +402,52 @@ func (s *complianceScanConfigDataStoreTestSuite) TestScanConfigurationProfileExi
 			configID:    uuid.NewV4().String(),
 			profiles:    []string{"no-match-profile", "ocp4-cis"},
 			clusters:    []string{s.clusterID1},
-			found:       true,
-			isErrorTest: false,
+			isErrorTest: true,
 		},
 		{
 			desc:        "Successful get - duplicate profiles, multiple clusters",
 			configID:    uuid.NewV4().String(),
 			profiles:    []string{"no-match-profile", "ocp4-cis"},
 			clusters:    []string{s.clusterID1, s.clusterID2},
-			found:       true,
-			isErrorTest: false,
+			isErrorTest: true,
 		},
 		{
 			desc:        "Successful get - duplicate profiles, multiple clusters, multiple profiles",
 			configID:    uuid.NewV4().String(),
 			profiles:    []string{"no-match-profile", "ocp4-cis", "ocp4-cis-node"},
 			clusters:    []string{s.clusterID1, s.clusterID2},
-			found:       true,
-			isErrorTest: false,
+			isErrorTest: true,
 		},
 		{
 			desc:        "Successful get - one duplicate profile with version string",
 			configID:    uuid.NewV4().String(),
 			profiles:    []string{"ocp4-cis-1-4-0"},
 			clusters:    []string{s.clusterID1},
-			found:       true,
-			isErrorTest: false,
+			isErrorTest: true,
 		},
 		{
-			desc:        "Successful get - updateing existing config",
+			desc:        "Successful get - updating existing config",
 			configID:    configID,
 			profiles:    []string{"no-match-profile", "ocp4-cis"},
 			clusters:    []string{s.clusterID1},
-			found:       false,
 			isErrorTest: false,
 		},
 		{
-			desc:        "Successful get - updateing existing config",
+			desc:        "Successful get - updating existing config",
 			configID:    configID,
 			profiles:    []string{"no-match-profile", "ocp4-cis", "ocp4-cis-1-4-0"},
 			clusters:    []string{s.clusterID1},
-			found:       true,
-			isErrorTest: false,
+			isErrorTest: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		log.Info(tc.desc)
-		found, err := s.dataStore.ScanConfigurationProfileExists(s.testContexts[unrestrictedReadCtx], tc.configID, tc.profiles, tc.clusters)
+		err := s.dataStore.ScanConfigurationProfileExists(s.testContexts[unrestrictedReadCtx], tc.configID, tc.profiles, tc.clusters)
 		if tc.isErrorTest {
 			s.Require().Error(err)
 		} else {
 			s.Require().NoError(err)
-			s.Require().Equal(tc.found, found)
 		}
 	}
 

--- a/central/complianceoperator/v2/scanconfigurations/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/mocks/datastore.go
@@ -147,12 +147,11 @@ func (mr *MockDataStoreMockRecorder) RemoveClusterFromScanConfig(ctx, clusterID 
 }
 
 // ScanConfigurationProfileExists mocks base method.
-func (m *MockDataStore) ScanConfigurationProfileExists(ctx context.Context, id string, profiles, clusters []string) (bool, error) {
+func (m *MockDataStore) ScanConfigurationProfileExists(ctx context.Context, id string, profiles, clusters []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ScanConfigurationProfileExists", ctx, id, profiles, clusters)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // ScanConfigurationProfileExists indicates an expected call of ScanConfigurationProfileExists.

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -249,7 +249,7 @@ func TestComplianceV2CreateGetScanConfigurations(t *testing.T) {
 
 	// Verify that the duplicate profile was not created and the error message is correct
 	_, err = service.CreateComplianceScanConfiguration(ctx, duplicateProfileReq)
-	assert.Contains(t, err.Error(), "Duplicated profiles found in current or existing scan configurations")
+	assert.Contains(t, err.Error(), "already uses profile")
 
 	query = &v2.RawQuery{Query: ""}
 	scanConfigs, err = service.ListComplianceScanConfigurations(ctx, query)


### PR DESCRIPTION
## Description

Updates to inform the user where they can find the config executing a duplicate profile and what profile is conflicting.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

UT and executed on a local cluster

![Screenshot 2024-02-07 at 10 26 16 AM](https://github.com/stackrox/stackrox/assets/99685630/89b03cd1-51f2-4ac8-9f72-ff5852e22341)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
