### PR TITLE
fix(docs): Incorrect API doc for CountImages

### DIFF
--- a/generated/api/v1/image_service.pb.go
+++ b/generated/api/v1/image_service.pb.go
@@ -1697,9 +1697,9 @@ const _ = grpc.SupportPackageIsVersion6
 type ImageServiceClient interface {
 	// GetImage returns the image given its ID.
 	GetImage(ctx context.Context, in *GetImageRequest, opts ...grpc.CallOption) (*storage.Image, error)
-	// ListImages returns all the images.
+	// CountImages returns a count of images that match the input query.
 	CountImages(ctx context.Context, in *RawQuery, opts ...grpc.CallOption) (*CountImagesResponse, error)
-	// ListImages returns all the images.
+	// ListImages returns all the images that match the input query.
 	ListImages(ctx context.Context, in *RawQuery, opts ...grpc.CallOption) (*ListImagesResponse, error)
 	// ScanImage scans a single image and returns the result
 	ScanImage(ctx context.Context, in *ScanImageRequest, opts ...grpc.CallOption) (*storage.Image, error)
@@ -1891,9 +1891,9 @@ func (x *imageServiceExportImagesClient) Recv() (*ExportImageResponse, error) {
 type ImageServiceServer interface {
 	// GetImage returns the image given its ID.
 	GetImage(context.Context, *GetImageRequest) (*storage.Image, error)
-	// ListImages returns all the images.
+	// CountImages returns a count of images that match the input query.
 	CountImages(context.Context, *RawQuery) (*CountImagesResponse, error)
-	// ListImages returns all the images.
+	// ListImages returns all the images that match the input query.
 	ListImages(context.Context, *RawQuery) (*ListImagesResponse, error)
 	// ScanImage scans a single image and returns the result
 	ScanImage(context.Context, *ScanImageRequest) (*storage.Image, error)

--- a/generated/api/v1/image_service.swagger.json
+++ b/generated/api/v1/image_service.swagger.json
@@ -59,7 +59,7 @@
     },
     "/v1/images": {
       "get": {
-        "summary": "ListImages returns all the images.",
+        "summary": "ListImages returns all the images that match the input query.",
         "operationId": "ImageService_ListImages",
         "responses": {
           "200": {
@@ -314,7 +314,7 @@
     },
     "/v1/imagescount": {
       "get": {
-        "summary": "ListImages returns all the images.",
+        "summary": "CountImages returns a count of images that match the input query.",
         "operationId": "ImageService_CountImages",
         "responses": {
           "200": {

--- a/proto/api/v1/image_service.proto
+++ b/proto/api/v1/image_service.proto
@@ -152,12 +152,12 @@ service ImageService {
     option (google.api.http) = {get: "/v1/images/{id}"};
   }
 
-  // ListImages returns all the images.
+  // CountImages returns a count of images that match the input query.
   rpc CountImages(RawQuery) returns (CountImagesResponse) {
     option (google.api.http) = {get: "/v1/imagescount"};
   }
 
-  // ListImages returns all the images.
+  // ListImages returns all the images that match the input query.
   rpc ListImages(RawQuery) returns (ListImagesResponse) {
     option (google.api.http) = {get: "/v1/images"};
   }


### PR DESCRIPTION
## Description

It was wrong before

Before:
![Screenshot 2024-02-07 at 6 17 35 PM](https://github.com/stackrox/stackrox/assets/1407686/4442d106-c170-48da-a7f7-b527c164aae4)

After:
![Screenshot 2024-02-07 at 11 36 11 PM](https://github.com/stackrox/stackrox/assets/1407686/1c616d6e-447c-460b-b2da-369d17449d8e)


## Checklist
~[ ] Investigated and inspected CI test results~
~[ ] Unit test and regression tests added~
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~
~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

I looked at the docs.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
