### PR TITLE
fix(compliance): Rename function to `getComplianceOperatorDeployment`

### DIFF
--- a/generated/internalapi/central/compliance_operator.pb.go
+++ b/generated/internalapi/central/compliance_operator.pb.go
@@ -116,7 +116,7 @@ type ComplianceOperatorInfo struct {
 	// Types that are valid to be assigned to TotalReadyPodsOpt:
 	//	*ComplianceOperatorInfo_TotalReadyPods
 	TotalReadyPodsOpt isComplianceOperatorInfo_TotalReadyPodsOpt `protobuf_oneof:"total_ready_pods_opt"`
-	// Collection of errors that occurred while trying to obtain collector health info.
+	// Collection of errors that occurred while trying to obtain compliance health info.
 	StatusError          string   `protobuf:"bytes,5,opt,name=status_error,json=statusError,proto3" json:"status_error,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/proto/internalapi/central/compliance_operator.proto
+++ b/proto/internalapi/central/compliance_operator.proto
@@ -19,7 +19,7 @@ message ComplianceOperatorInfo {
     int32 total_ready_pods = 4;
   }
 
-  // Collection of errors that occurred while trying to obtain collector health info.
+  // Collection of errors that occurred while trying to obtain compliance health info.
   string status_error = 5;
 }
 

--- a/sensor/kubernetes/complianceoperator/updater.go
+++ b/sensor/kubernetes/complianceoperator/updater.go
@@ -160,6 +160,7 @@ func (u *updaterImpl) getComplianceOperatorInfo() *central.ComplianceOperatorInf
 
 	var version string
 	for key, val := range complianceOperatorDeployment.Labels {
+		// Info: This label is set by OLM, if a custom compliance operator build was deployed via e.g. Helm, this label does not exist.
 		if strings.HasSuffix(key, "owner") {
 			version = strings.TrimPrefix(val, complianceoperator.Name+".")
 		}


### PR DESCRIPTION
## Description

Rename function for better readability to `getComplianceOperatorDeployment`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

 - CI
