### PR TITLE
ROX-22404:  compliance profile fix summary

### DIFF
--- a/central/complianceoperator/v2/profiles/service/service_impl.go
+++ b/central/complianceoperator/v2/profiles/service/service_impl.go
@@ -102,7 +102,7 @@ func (s *serviceImpl) ListProfileSummaries(ctx context.Context, request *v2.Clus
 	}
 
 	return &v2.ListComplianceProfileSummaryResponse{
-		Profiles: storagetov2.ComplianceProfileSummary(profiles),
+		Profiles: storagetov2.ComplianceProfileSummary(profiles, request.GetClusterIds()),
 	}, nil
 }
 

--- a/central/convert/storagetov2/compliance_profile_service.go
+++ b/central/convert/storagetov2/compliance_profile_service.go
@@ -39,16 +39,48 @@ func ComplianceV2Profiles(incoming []*storage.ComplianceOperatorProfileV2) []*v2
 }
 
 // ComplianceProfileSummary converts summary object to V2 API summary object
-func ComplianceProfileSummary(incoming []*storage.ComplianceOperatorProfileV2) []*v2.ComplianceProfileSummary {
-	summaries := make([]*v2.ComplianceProfileSummary, 0, len(incoming))
+func ComplianceProfileSummary(incoming []*storage.ComplianceOperatorProfileV2, clusterIDs []string) []*v2.ComplianceProfileSummary {
+	// incoming will contain all the profiles matching the clusters.  This is a non-distinct
+	// list that needs to be reduced to a summary and only include profiles that match all profiles.
+	profileClusterMap := make(map[string][]string, len(incoming))
+	profileSummaryMap := make(map[string]*v2.ComplianceProfileSummary)
+
 	for _, summary := range incoming {
+		profileClusters, clusterFound := profileClusterMap[summary.GetName()]
+
+		// First time seeing this profile.
+		if !clusterFound {
+			profileClusterMap[summary.GetName()] = []string{summary.GetClusterId()}
+		} else {
+			// Append the new cluster status to the profile cluster map.
+			profileClusterMap[summary.GetName()] = append(profileClusters, summary.GetClusterId())
+		}
+		if _, found := profileSummaryMap[summary.GetName()]; !found {
+			profileSummaryMap[summary.GetName()] = &v2.ComplianceProfileSummary{
+				Name:           summary.Name,
+				ProductType:    summary.ProductType,
+				Description:    summary.Description,
+				Title:          summary.Title,
+				RuleCount:      int32(len(summary.Rules)),
+				ProfileVersion: summary.ProfileVersion,
+			}
+		}
+	}
+
+	summaries := make([]*v2.ComplianceProfileSummary, 0, len(profileSummaryMap))
+	for k, v := range profileSummaryMap {
+		// Verify the profile is in all clusters
+		if len(profileClusterMap[k]) != len(clusterIDs) {
+			continue
+		}
+
 		summaries = append(summaries, &v2.ComplianceProfileSummary{
-			Name:           summary.Name,
-			ProductType:    summary.ProductType,
-			Description:    summary.Description,
-			Title:          summary.Title,
-			RuleCount:      int32(len(summary.Rules)),
-			ProfileVersion: summary.ProfileVersion,
+			Name:           v.Name,
+			ProductType:    v.ProductType,
+			Description:    v.Description,
+			Title:          v.Title,
+			RuleCount:      v.RuleCount,
+			ProfileVersion: v.ProfileVersion,
 		})
 	}
 


### PR DESCRIPTION
## Description

When the profile refactoring was done to better fit with SAC, there was a comment to not build a query to get distinct summaries in the datastore layer but to get the data and reduce it in the storage layer.  Apparently when I implemented that, I made all the updates except the reduce part.  It was difficult to see because you need multiple clusters to drive the condition.  This PR resolves that by reducing it to unique profiles for the given clusters.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Tested locally running multiple clusters.  The results previously had one profile entry per cluster.  Now they have been consolidated as the point of this is to provide a snapshot of what profiles you can use in a configuration across multiple clusters:
[summary-2.json](https://github.com/stackrox/stackrox/files/14213169/summary-2.json)
  

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
