### PR TITLE
ROX-21881: compliance check details modal

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsTable.tsx
@@ -101,7 +101,7 @@ function ClusterDetailsTable({
         return (
             clusters.find(
                 (clusterCheckStatus) => clusterCheckStatus.cluster.clusterId === clusterId
-            ) || null
+            ) ?? null
         );
     }
 
@@ -151,12 +151,10 @@ function ClusterDetailsTable({
             return (
                 <Tr key={checkName}>
                     <Td modifier="truncate">
-                        <>
-                            <Text>{checkName}</Text>
-                            <Text component={TextVariants.small} className="pf-u-color-200">
-                                {rationale}
-                            </Text>
-                        </>
+                        <Text>{checkName}</Text>
+                        <Text component={TextVariants.small} className="pf-u-color-200">
+                            {rationale}
+                        </Text>
                     </Td>
                     <Td>
                         {statusObj && (

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Components/CheckStatusModal.css
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Components/CheckStatusModal.css
@@ -1,0 +1,3 @@
+.formatted-text {
+    white-space: pre-wrap;
+}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Components/CheckStatusModal.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Components/CheckStatusModal.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import {
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Divider,
+    Flex,
+    Label,
+    LabelGroup,
+    List,
+    ListItem,
+    Modal,
+    ModalVariant,
+    Text,
+    Title,
+    ToggleGroup,
+    ToggleGroupItem,
+} from '@patternfly/react-core';
+
+import IconText from 'Components/PatternFly/IconText/IconText';
+import { ComplianceCheckResult, ComplianceCheckStatus } from 'services/ComplianceEnhancedService';
+
+import { getClusterResultsStatusObject } from '../compliance.coverage.utils';
+
+type CheckStatusModalProps = {
+    checkResult: ComplianceCheckResult;
+    isOpen: boolean;
+    status: ComplianceCheckStatus | null;
+    handleClose: () => void;
+};
+
+function CheckStatusModal({ checkResult, isOpen, status, handleClose }: CheckStatusModalProps) {
+    const { checkName, description, instructions, rationale, warnings } = checkResult;
+
+    const statusObj = status ? getClusterResultsStatusObject(status) : null;
+
+    const header = (
+        <Flex direction={{ default: 'column' }}>
+            <Title headingLevel="h1">{checkName}</Title>
+            {statusObj && (
+                <LabelGroup numLabels={1}>
+                    <Label>
+                        <IconText icon={statusObj.icon} text={statusObj.statusText} />
+                    </Label>
+                </LabelGroup>
+            )}
+            <Text>{rationale}</Text>
+            <ToggleGroup aria-label="Toggle for check details modal view">
+                <ToggleGroupItem
+                    text="Check details"
+                    buttonId="check-details-toggle-group"
+                    isSelected
+                />
+                <ToggleGroupItem
+                    text="Remediation details (coming soon)"
+                    buttonId="remediation-details-toggle-group"
+                    isDisabled
+                />
+            </ToggleGroup>
+            <Divider component="div" className="pf-u-pb-md" />
+        </Flex>
+    );
+
+    return (
+        <>
+            <Modal
+                isOpen={isOpen}
+                onClose={handleClose}
+                variant={ModalVariant.large}
+                tabIndex={0}
+                header={header}
+                aria-label="Check status details modal"
+            >
+                <DescriptionList>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Description</DescriptionListTerm>
+                        <DescriptionListDescription className="whitespace-pre-wrap">
+                            {description}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Instruction</DescriptionListTerm>
+                        <DescriptionListDescription className="whitespace-pre-wrap">
+                            {instructions}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    {warnings.length > 0 && (
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Warning(s)</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                <List>
+                                    {warnings.map((warning) => (
+                                        <ListItem key={warning}>{warning}</ListItem>
+                                    ))}
+                                </List>
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                    )}
+                </DescriptionList>
+            </Modal>
+        </>
+    );
+}
+
+export default CheckStatusModal;

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Components/CheckStatusModal.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Components/CheckStatusModal.tsx
@@ -23,6 +23,8 @@ import { ComplianceCheckResult, ComplianceCheckStatus } from 'services/Complianc
 
 import { getClusterResultsStatusObject } from '../compliance.coverage.utils';
 
+import './CheckStatusModal.css';
+
 type CheckStatusModalProps = {
     checkResult: ComplianceCheckResult;
     isOpen: boolean;
@@ -75,13 +77,13 @@ function CheckStatusModal({ checkResult, isOpen, status, handleClose }: CheckSta
                 <DescriptionList>
                     <DescriptionListGroup>
                         <DescriptionListTerm>Description</DescriptionListTerm>
-                        <DescriptionListDescription className="whitespace-pre-wrap">
+                        <DescriptionListDescription className="formatted-text">
                             {description}
                         </DescriptionListDescription>
                     </DescriptionListGroup>
                     <DescriptionListGroup>
                         <DescriptionListTerm>Instruction</DescriptionListTerm>
-                        <DescriptionListDescription className="whitespace-pre-wrap">
+                        <DescriptionListDescription className="formatted-text">
                             {instructions}
                         </DescriptionListDescription>
                     </DescriptionListGroup>

--- a/ui/apps/platform/src/services/ComplianceEnhancedService.ts
+++ b/ui/apps/platform/src/services/ComplianceEnhancedService.ts
@@ -130,7 +130,7 @@ export type ClusterCheckStatus = {
     checkUid: string;
 };
 
-type ComplianceCheckResult = {
+export type ComplianceCheckResult = {
     checkId: string;
     checkName: string;
     clusters: ClusterCheckStatus[];


### PR DESCRIPTION
## Description

Work for the compliance v2 check details modal

When a user clicks on the status of an individual check result, we want to provide them more information on the selected compliance check.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
![Screenshot 2024-02-08 at 10 29 09 AM](https://github.com/stackrox/stackrox/assets/61400697/b34aaab0-1ca4-44c3-8417-0f7a42dcd1f9)

![Screenshot 2024-02-08 at 10 29 01 AM](https://github.com/stackrox/stackrox/assets/61400697/3970e38c-aa6b-4e33-9911-460561a84c3a)
