### PR TITLE
fix: pagination default sort

### DIFF
--- a/central/administration/events/service/service_impl.go
+++ b/central/administration/events/service/service_impl.go
@@ -81,7 +81,7 @@ func (s *serviceImpl) GetAdministrationEvent(ctx context.Context, resource *v1.R
 func (s *serviceImpl) ListAdministrationEvents(ctx context.Context, request *v1.ListAdministrationEventsRequest) (*v1.ListAdministrationEventsResponse, error) {
 	query := getQueryBuilderFromFilter(request.GetFilter()).ProtoQuery()
 	paginated.FillPagination(query, request.GetPagination(), maxPaginationLimit)
-	paginated.FillDefaultSortOption(
+	query = paginated.FillDefaultSortOption(
 		query,
 		&v1.QuerySortOption{
 			Field:    search.LastUpdatedTime.String(),

--- a/central/cloudsources/service/service_impl.go
+++ b/central/cloudsources/service/service_impl.go
@@ -95,7 +95,7 @@ func (s *serviceImpl) ListCloudSources(ctx context.Context, request *v1.ListClou
 ) (*v1.ListCloudSourcesResponse, error) {
 	query := getQueryBuilderFromFilter(request.GetFilter()).ProtoQuery()
 	paginated.FillPagination(query, request.GetPagination(), maxPaginationLimit)
-	paginated.FillDefaultSortOption(
+	query = paginated.FillDefaultSortOption(
 		query,
 		&v1.QuerySortOption{
 			Field: search.IntegrationName.String(),

--- a/central/cloudsources/service/service_impl_postgres_test.go
+++ b/central/cloudsources/service/service_impl_postgres_test.go
@@ -82,7 +82,7 @@ func (s *servicePostgresTestSuite) TestCount() {
 	// 2.b. Filter cloud sources based on the name - one match.
 	resp, err = s.service.CountCloudSources(s.readCtx, &v1.CountCloudSourcesRequest{
 		Filter: &v1.CloudSourcesFilter{
-			Names: []string{"sample name 0"},
+			Names: []string{"sample name 00"},
 		},
 	})
 	s.Require().NoError(err)
@@ -129,7 +129,7 @@ func (s *servicePostgresTestSuite) TestListCloudSources() {
 	// 2.b. Filter cloud sources based on the name - one match.
 	resp, err = s.service.ListCloudSources(s.readCtx, &v1.ListCloudSourcesRequest{
 		Filter: &v1.CloudSourcesFilter{
-			Names: []string{"sample name 0"},
+			Names: []string{"sample name 00"},
 		},
 	})
 	s.Require().NoError(err)

--- a/central/discoveredclusters/service/service_impl.go
+++ b/central/discoveredclusters/service/service_impl.go
@@ -83,7 +83,7 @@ func (s *serviceImpl) ListDiscoveredClusters(ctx context.Context, request *v1.Li
 ) (*v1.ListDiscoveredClustersResponse, error) {
 	query := getQueryBuilderFromFilter(request.GetFilter()).ProtoQuery()
 	paginated.FillPagination(query, request.GetPagination(), maxPaginationLimit)
-	paginated.FillDefaultSortOption(
+	query = paginated.FillDefaultSortOption(
 		query,
 		&v1.QuerySortOption{
 			Field: search.Cluster.String(),

--- a/central/discoveredclusters/service/service_impl_postgres_test.go
+++ b/central/discoveredclusters/service/service_impl_postgres_test.go
@@ -76,7 +76,7 @@ func (s *servicePostgresTestSuite) TestCount() {
 	// 2.b. Filter discovered clusters based on the name - one match.
 	resp, err = s.service.CountDiscoveredClusters(s.readCtx, &v1.CountDiscoveredClustersRequest{
 		Filter: &v1.DiscoveredClustersFilter{
-			Names: []string{"my-cluster-0"},
+			Names: []string{"my-cluster-00"},
 		},
 	})
 	s.Require().NoError(err)
@@ -140,7 +140,7 @@ func (s *servicePostgresTestSuite) TestListDiscoveredClusters() {
 	// 2.b. Filter discovered clusters based on the name - one match.
 	resp, err = s.service.ListDiscoveredClusters(s.readCtx, &v1.ListDiscoveredClustersRequest{
 		Filter: &v1.DiscoveredClustersFilter{
-			Names: []string{"my-cluster-0"},
+			Names: []string{"my-cluster-00"},
 		},
 	})
 	s.Require().NoError(err)

--- a/central/resourcecollection/service/service_impl.go
+++ b/central/resourcecollection/service/service_impl.go
@@ -247,7 +247,7 @@ func resolveQuery(rawQuery *v1.RawQuery, withPagination bool) (*v1.Query, error)
 	}
 	if withPagination {
 		paginated.FillPagination(query, rawQuery.GetPagination(), defaultPageSize)
-		paginated.FillDefaultSortOption(query, defaultCollectionSortOption)
+		query = paginated.FillDefaultSortOption(query, defaultCollectionSortOption)
 	}
 	return query, nil
 }
@@ -308,6 +308,6 @@ func (s *serviceImpl) tryDeploymentMatching(ctx context.Context, collection *sto
 	}
 	query := search.ConjunctionQuery(collectionQuery, filterQuery)
 	paginated.FillPagination(query, matchOptions.GetFilterQuery().GetPagination(), defaultPageSize)
-	paginated.FillDefaultSortOption(query, defaultDeploymentSortOption)
+	query = paginated.FillDefaultSortOption(query, defaultDeploymentSortOption)
 	return s.deploymentDS.SearchListDeployments(ctx, query)
 }

--- a/pkg/fixtures/cloud_sources.go
+++ b/pkg/fixtures/cloud_sources.go
@@ -40,7 +40,7 @@ func GetManyStorageCloudSources(num int) []*storage.CloudSource {
 	for i := 0; i < num; i++ {
 		cloudSource := &storage.CloudSource{
 			Id:          uuid.NewV4().String(),
-			Name:        fmt.Sprintf("sample name %d", i),
+			Name:        fmt.Sprintf("sample name %02d", i),
 			Credentials: &storage.CloudSource_Credentials{Secret: "1234"},
 		}
 		if i < num/2 {

--- a/pkg/fixtures/discovered_cluster.go
+++ b/pkg/fixtures/discovered_cluster.go
@@ -27,8 +27,8 @@ func GetManyDiscoveredClusters(num int) []*discoveredclusters.DiscoveredCluster 
 	res := make([]*discoveredclusters.DiscoveredCluster, 0, num)
 	for i := 0; i < num; i++ {
 		discoveredCluster := GetDiscoveredCluster()
-		discoveredCluster.ID = fmt.Sprintf("my-cluster-%d", i)
-		discoveredCluster.Name = fmt.Sprintf("my-cluster-%d", i)
+		discoveredCluster.ID = fmt.Sprintf("my-cluster-%02d", i)
+		discoveredCluster.Name = fmt.Sprintf("my-cluster-%02d", i)
 		if i < num/2 {
 			discoveredCluster.Type = storage.ClusterMetadata_GKE
 			discoveredCluster.Status = storage.DiscoveredCluster_STATUS_SECURED


### PR DESCRIPTION
## Description

I noticed a bug while looking at the pagination code of some services. Confusingly, `paginated.FillDefaultSortOption` does not behave like `paginated.FillPagination` and does not modify the input query. Instead it returns a copy of the filled query.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Tested sort options for admin events and cloud sources API.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
