### PR TITLE
fix(cache-store): fix Delete for global resources.

### DIFF
--- a/central/cloudsources/datastore/internal/store/postgres/gen.go
+++ b/central/cloudsources/datastore/internal/store/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.CloudSource --search-category CLOUD_SOURCES
+//go:generate pg-table-bindings-wrapper --type=storage.CloudSource --search-category CLOUD_SOURCES --cached-store

--- a/central/cloudsources/datastore/internal/store/postgres/store.go
+++ b/central/cloudsources/datastore/internal/store/postgres/store.go
@@ -55,7 +55,10 @@ type Store interface {
 
 // New returns a new Store instance using the provided sql instance.
 func New(db postgres.DB) Store {
-	return pgSearch.NewGenericStore[storeType, *storeType](
+	// Use of pgSearch.NewGenericStoreWithCache can be dangerous with high cardinality stores,
+	// and be the source of memory pressure. Think twice about the need for in-memory caching
+	// of the whole store.
+	return pgSearch.NewGenericStoreWithCache[storeType, *storeType](
 		db,
 		schema,
 		pkGetter,
@@ -63,6 +66,8 @@ func New(db postgres.DB) Store {
 		copyFromCloudSources,
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
+		metricsSetCacheOperationDurationTime,
+
 		pgSearch.GloballyScopedUpsertChecker[storeType, *storeType](targetResource),
 		targetResource,
 	)
@@ -80,6 +85,10 @@ func metricsSetPostgresOperationDurationTime(start time.Time, op ops.Op) {
 
 func metricsSetAcquireDBConnDuration(start time.Time, op ops.Op) {
 	metrics.SetAcquireDBConnDuration(start, op, storeName)
+}
+
+func metricsSetCacheOperationDurationTime(start time.Time, op ops.Op) {
+	metrics.SetCacheOperationDurationTime(start, op, storeName)
 }
 
 func insertIntoCloudSources(batch *pgx.Batch, obj *storage.CloudSource) error {

--- a/pkg/search/postgres/store_cache.go
+++ b/pkg/search/postgres/store_cache.go
@@ -158,7 +158,7 @@ func (c *cachedStore[T, PT]) Delete(ctx context.Context, id string) error {
 		// when write is not allowed. The cached store needs to respect that behavior for the time being.
 		// Ultimately, we have to convey on the behavior: either _always_ return sac.ErrResourceAccessDenied or return
 		// nil.
-		// TODO(ROX-XXXXX): Once the behavior is fixed, remove this special casing.
+		// TODO(ROX-22408): Once the behavior is fixed, remove this special casing.
 		if c.targetResource.GetScope() == permissions.GlobalScope {
 			return sac.ErrResourceAccessDenied
 		}

--- a/pkg/search/postgres/store_cache.go
+++ b/pkg/search/postgres/store_cache.go
@@ -153,10 +153,18 @@ func (c *cachedStore[T, PT]) Delete(ctx context.Context, id string) error {
 		obj, found := c.cache[id]
 		return obj, found
 	})
-	if !found {
+	if !c.isWriteAllowed(ctx, obj) {
+		// Special case: the query generator for global scoped resources currently returns sac.ErrResourceAccessDenied
+		// when write is not allowed. The cached store needs to respect that behavior for the time being.
+		// Ultimately, we have to convey on the behavior: either _always_ return sac.ErrResourceAccessDenied or return
+		// nil.
+		// TODO(ROX-XXXXX): Once the behavior is fixed, remove this special casing.
+		if c.targetResource.GetScope() == permissions.GlobalScope {
+			return sac.ErrResourceAccessDenied
+		}
 		return nil
 	}
-	if !c.isWriteAllowed(ctx, obj) {
+	if !found {
 		return nil
 	}
 	err := c.underlyingStore.Delete(ctx, id)


### PR DESCRIPTION
## Description

This PR fixes a difference in behavior of the cached store and the generic store: when using the cached store with global resources, it currently fails the generated tests.

The tests expect during a Delete to return `sac.ErrResourceAccessDenied` when write isn't allowed. The generic store returns no error for namespace / cluster scoped resources, but an error for global resources.

For the time being, this fixes the behavior of failing tests, as well as enables the `cached-store` for the cloud-sources which were initially blocked by it.

A follow-up should be created to fix the behavior for _all_ stores: either return `sac.ErrResourceAccessDenied` for _all permission failures_ irrespective of resource scope, or return nil.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing for the `cloud-sources` store with `cache-store` set.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
