### PR TITLE
fix(scanv4): Mark Scanner V4 as optional in manifest based install

### DIFF
--- a/pkg/renderer/readme.go
+++ b/pkg/renderer/readme.go
@@ -47,6 +47,8 @@ the login page, and log in with username "admin" and the password found in the
   - Deploy Scanner components
     - Run scanner/scripts/setup.sh
     - Run {{.K8sConfig.Command}} create -R -f scanner
+
+  - Optional: Deploy Scanner components
     - Run scanner-v4/scripts/setup.sh
     - Run {{.K8sConfig.Command}} create -R -f scanner-v4
 `

--- a/pkg/renderer/readme.go
+++ b/pkg/renderer/readme.go
@@ -48,7 +48,7 @@ the login page, and log in with username "admin" and the password found in the
     - Run scanner/scripts/setup.sh
     - Run {{.K8sConfig.Command}} create -R -f scanner
 
-  - Optional: Deploy Scanner components
+  - Optional: Deploy Scanner V4 components
     - Run scanner-v4/scripts/setup.sh
     - Run {{.K8sConfig.Command}} create -R -f scanner-v4
 `


### PR DESCRIPTION
## Description

Due to the fact that Scanner V4 installation is optional in 4.4, this PR changes the README in the `central-bundle` of roxctl manifest-based installs to show:

```
  - Deploy Scanner components
    - Run scanner/scripts/setup.sh
    - Run oc create -R -f scanner

  - Optional: Deploy Scanner V4 components
    - Run scanner-v4/scripts/setup.sh
    - Run oc create -R -f scanner-v4
```

Note that this only makes it clear to the user that the Scanner V4 step is optional. Not installing Scanner V4 is already supported.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

```bash
make cli
roxctl central generate openshift pvc
```

And verified that the `README` file is generated as expected.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
