### PR TITLE
fix: don't block secret informer cache sync

### DIFF
--- a/pkg/cloudproviders/gcp/auth/cred_manager_impl.go
+++ b/pkg/cloudproviders/gcp/auth/cred_manager_impl.go
@@ -101,6 +101,13 @@ func (c *gcpCredentialsManagerImpl) Stop() {
 //     for federated workload identities. Ignored if the secret does not exist.
 //  2. The default GCP credentials chain based on the pod's environment and metadata.
 func (c *gcpCredentialsManagerImpl) GetCredentials(ctx context.Context) (*google.Credentials, error) {
+	if !c.informer.HasSynced() {
+		log.Warnf("The informer for secret %q/%q is out of sync. STS configuration may not be available.",
+			c.namespace,
+			c.secretName,
+		)
+	}
+
 	scopes := []string{storagev1.CloudPlatformScope}
 	scopes = append(scopes, artifactv1.DefaultAuthScopes()...)
 	scopes = append(scopes, securitycenterv1.DefaultAuthScopes()...)

--- a/pkg/secretinformer/informer_test.go
+++ b/pkg/secretinformer/informer_test.go
@@ -141,6 +141,7 @@ func TestSecretInformer(t *testing.T) {
 			err := informer.Start()
 			require.NoError(t, err)
 			defer informer.Stop()
+			require.Eventually(t, informer.HasSynced, 5*time.Second, 100*time.Millisecond)
 			err = c.setupFn(k8sClient)
 			require.NoError(t, err)
 


### PR DESCRIPTION
## Description

Add a timeout condition to the informer cache sync. This is useful because we don't want to block the main loop forever. In particular, this came up in a recent upgrade test failure. The upgrade test switches out the Central image instead of performing a proper Helm upgrade - as a result, k8s roles were not set correctly. This caused the informer to never connect due to a unauthorized access. The test should be adapted to perform a proper Helm upgrade. Nevertheless, such issues should not cause Central to block.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

gke-upgrade test is now passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
