### PR TITLE
test(scanv4): Scanner V4 not installed when Helm option not specified

### DIFF
--- a/tests/e2e/run-scanner-v4.bats
+++ b/tests/e2e/run-scanner-v4.bats
@@ -221,6 +221,17 @@ teardown_file() {
     verify_central_scannerV4_env_var_set "stackrox"
 }
 
+@test "Fresh installation of HEAD Helm chart with default Scanner V4 setting" {
+    info "Fresh installation of HEAD Helm chart with default Scanner V4 setting"
+    # shellcheck disable=SC2030,SC2031
+    export OUTPUT_FORMAT=helm
+    ROX_SCANNER_V4="" _deploy_stackrox
+
+    verify_scannerV2_deployed "stackrox"
+    verify_no_scannerV4_deployed "stackrox"
+    run ! verify_central_scannerV4_env_var_set "stackrox"
+}
+
 @test "Fresh installation of HEAD Helm charts with Scanner v4 enabled in multi-namespace mode" {
     local central_namespace="$CUSTOM_CENTRAL_NAMESPACE"
     local sensor_namespace="$CUSTOM_SENSOR_NAMESPACE"


### PR DESCRIPTION
## Description

Adds e2e test that tests that Scanner-V4 is not installed when the option is not set.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

The PR adds a new test.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
