### PR TITLE
ROX-18443: Remove tech-preview warning for NP-Guard integrated code

### DIFF
--- a/roxctl/connectivity-map/command.go
+++ b/roxctl/connectivity-map/command.go
@@ -2,7 +2,6 @@ package connectivitymap
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	connectivitymap "github.com/stackrox/rox/roxctl/netpol/connectivity/map"
 )
@@ -13,7 +12,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "connectivity-map <folder-path>",
 		Short: "(Technology Preview) Analyze connectivity based on network policies and other resources.",
-		Long:  `Based on a given folder containing deployment and network policy YAMLs, will analyze permitted cluster connectivity. Will write to stdout if no output flags are provided.` + common.TechPreviewLongText,
+		Long:  `Based on a given folder containing deployment and network policy YAMLs, will analyze permitted cluster connectivity. Will write to stdout if no output flags are provided.`,
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			cliEnvironment.Logger().WarnfLn("Command 'connectivity-map' is deprecated. Use 'netpol connectivity map' instead.")

--- a/roxctl/generate/generate.go
+++ b/roxctl/generate/generate.go
@@ -2,7 +2,6 @@ package generate
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/generate/netpol"
 )
@@ -12,7 +11,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "generate",
 		Short: "(Technology Preview) Commands related to generating different resources.",
-		Long:  `Commands related to generating different resources.` + common.TechPreviewLongText,
+		Long:  `Commands related to generating different resources.`,
 	}
 
 	c.AddCommand(

--- a/roxctl/netpol/connectivity/connectivity.go
+++ b/roxctl/netpol/connectivity/connectivity.go
@@ -11,7 +11,7 @@ import (
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "connectivity",
-		Short: "(Technology Preview) Commands related to connectivity analysis of network policy resources.",
+		Short: "Commands related to connectivity analysis of network policy resources.",
 		Long:  `Commands related to connectivity analysis of network policy resources.`,
 	}
 

--- a/roxctl/netpol/connectivity/connectivity.go
+++ b/roxctl/netpol/connectivity/connectivity.go
@@ -2,7 +2,6 @@ package connectivity
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/netpol/connectivity/diff"
 	connectivitymap "github.com/stackrox/rox/roxctl/netpol/connectivity/map"
@@ -13,7 +12,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "connectivity",
 		Short: "(Technology Preview) Commands related to connectivity analysis of network policy resources.",
-		Long:  `Commands related to connectivity analysis of network policy resources.` + common.TechPreviewLongText,
+		Long:  `Commands related to connectivity analysis of network policy resources.`,
 	}
 
 	c.AddCommand(

--- a/roxctl/netpol/connectivity/diff/README.md
+++ b/roxctl/netpol/connectivity/diff/README.md
@@ -1,10 +1,5 @@
 # Static Network Policy Connectivity Diff
 
-## Technology Preview Notice
-
-The static network policy connectivity diff feature is offered as a developer preview feature.
-While we are open to receiving feedback about this feature, our technical support will not be able to assist and answer questions about it.
-
 ## About
 
 The static network policy connectivity diff is a tool that analyzes two sets of Kubernetes manifests, including network policies.

--- a/roxctl/netpol/connectivity/diff/command.go
+++ b/roxctl/netpol/connectivity/diff/command.go
@@ -31,7 +31,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	diffNetpolCmd := &diffNetpolCommand{env: cliEnvironment}
 	c := &cobra.Command{
 		Use:   "diff",
-		Short: "(Technology Preview) Report connectivity-diff based on two directories containing network policies and YAML manifests with workload resources.",
+		Short: "Report connectivity-diff based on two directories containing network policies and YAML manifests with workload resources.",
 		Long:  `Based on two input folders containing Kubernetes workloads and network policy YAMLs, this command will report all differences in allowed connections between the resources.`,
 
 		Args: cobra.ExactArgs(0),

--- a/roxctl/netpol/connectivity/diff/command.go
+++ b/roxctl/netpol/connectivity/diff/command.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/errox"
-	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/npg"
 )
@@ -33,11 +32,10 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "diff",
 		Short: "(Technology Preview) Report connectivity-diff based on two directories containing network policies and YAML manifests with workload resources.",
-		Long:  `Based on two input folders containing Kubernetes workloads and network policy YAMLs, this command will report all differences in allowed connections between the resources.` + common.TechPreviewLongText,
+		Long:  `Based on two input folders containing Kubernetes workloads and network policy YAMLs, this command will report all differences in allowed connections between the resources.`,
 
 		Args: cobra.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
-			diffNetpolCmd.env.Logger().WarnfLn("This is a Technology Preview feature. Red Hat does not recommend using Technology Preview features in production.")
 			analyzer, err := diffNetpolCmd.construct()
 			if err != nil {
 				return err

--- a/roxctl/netpol/connectivity/map/README.md
+++ b/roxctl/netpol/connectivity/map/README.md
@@ -1,8 +1,5 @@
 # Static Network Policy Analysis and Visualization
 
-## Developer Preview Notice
-The static network policy analysis feature is offered as a developer preview feature. While we are open to receiving feedback about this feature, our technical support will not be able to assist and answer questions about it.
-
 ## About
 The static network policy analyzer is a tool that analyzes Kubernetes network policies.
 Based on a given folder containing deployment and network policy YAMLs, it analyzes the permitted cluster connectivity.

--- a/roxctl/netpol/connectivity/map/command.go
+++ b/roxctl/netpol/connectivity/map/command.go
@@ -6,7 +6,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/errox"
-	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/npg"
 )
@@ -33,7 +32,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "map <folder-path>",
 		Short: "(Technology Preview) Analyze connectivity based on network policies and other resources.",
-		Long:  `Based on a given folder containing deployment and network policy YAMLs, will analyze permitted cluster connectivity. Will write to stdout if no output flags are provided.` + common.TechPreviewLongText,
+		Long:  `Based on a given folder containing deployment and network policy YAMLs, will analyze permitted cluster connectivity. Will write to stdout if no output flags are provided.`,
 
 		Args: cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
@@ -61,7 +60,6 @@ func (cmd *Cmd) setupPath(path string) error {
 
 // RunE executes the command and returns potential errors
 func (cmd *Cmd) RunE(_ *cobra.Command, args []string) error {
-	cmd.env.Logger().WarnfLn("This is a Technology Preview feature. Red Hat does not recommend using Technology Preview features in production.")
 	analyzer, err := cmd.construct(args)
 	if err != nil {
 		return err

--- a/roxctl/netpol/connectivity/map/command.go
+++ b/roxctl/netpol/connectivity/map/command.go
@@ -31,7 +31,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	cmd := NewCmd(cliEnvironment)
 	c := &cobra.Command{
 		Use:   "map <folder-path>",
-		Short: "(Technology Preview) Analyze connectivity based on network policies and other resources.",
+		Short: "Analyze connectivity based on network policies and other resources.",
 		Long:  `Based on a given folder containing deployment and network policy YAMLs, will analyze permitted cluster connectivity. Will write to stdout if no output flags are provided.`,
 
 		Args: cobra.ExactArgs(1),

--- a/roxctl/netpol/generate/README.md
+++ b/roxctl/netpol/generate/README.md
@@ -1,11 +1,5 @@
 # Static Network Policy Generator
 
-## Developer Preview Notice
-
-The static network policy generation feature is offered as a _developer preview_ feature.
-While we are open to receiving feedback about this feature, our technical support will not be able to
-assist and answer questions about it.
-
 ## About
 
 The static network policy generator is a tool that analyzes k8s manifests and generates a set of suggested network policies in form of yaml documents that may be directly applied to a k8s cluster. It is integrated with [NP-Guard's Cluster Topology Analyzer](https://github.com/np-guard/cluster-topology-analyzer) component, which discovers the network connections and generates the network policies. For more details, refer to the [NP-Guard webpage](https://np-guard.github.io/).

--- a/roxctl/netpol/generate/generate.go
+++ b/roxctl/netpol/generate/generate.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/protoconv/networkpolicy"
-	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/npg"
 	"github.com/stackrox/rox/roxctl/common/printer"
@@ -83,12 +82,11 @@ func (cmd *NetpolGenerateCmd) ShortText() string {
 
 // LongText provides long command description
 func (cmd *NetpolGenerateCmd) LongText() string {
-	return `Based on a given folder containing deployment YAMLs, will generate a list of recommended Network Policies. Will write to stdout if no output flags are provided.` + common.TechPreviewLongText
+	return `Based on a given folder containing deployment YAMLs, will generate a list of recommended Network Policies. Will write to stdout if no output flags are provided.`
 }
 
 // RunE runs the command
 func (cmd *NetpolGenerateCmd) RunE(c *cobra.Command, args []string) error {
-	cmd.env.Logger().WarnfLn("This is a Technology Preview feature. Red Hat does not recommend using Technology Preview features in production.")
 	synth, err := cmd.construct(args, c)
 	if err != nil {
 		return err

--- a/roxctl/netpol/generate/generate.go
+++ b/roxctl/netpol/generate/generate.go
@@ -77,7 +77,7 @@ func (cmd *NetpolGenerateCmd) AddFlags(c *cobra.Command) *cobra.Command {
 
 // ShortText provides short command description
 func (cmd *NetpolGenerateCmd) ShortText() string {
-	return "(Technology Preview) Recommend Network Policies based on deployment information."
+	return "Recommend Network Policies based on deployment information."
 }
 
 // LongText provides long command description

--- a/roxctl/netpol/netpol.go
+++ b/roxctl/netpol/netpol.go
@@ -2,7 +2,6 @@ package netpol
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/netpol/connectivity"
 	"github.com/stackrox/rox/roxctl/netpol/generate"
@@ -13,7 +12,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "netpol",
 		Short: "(Technology Preview) Commands related to network policies.",
-		Long:  `Commands related to to network policies.` + common.TechPreviewLongText,
+		Long:  `Commands related to to network policies.`,
 	}
 
 	c.AddCommand(

--- a/roxctl/netpol/netpol.go
+++ b/roxctl/netpol/netpol.go
@@ -11,7 +11,7 @@ import (
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "netpol",
-		Short: "(Technology Preview) Commands related to network policies.",
+		Short: "Commands related to network policies.",
 		Long:  `Commands related to to network policies.`,
 	}
 


### PR DESCRIPTION
## Description

As in the title.

## Checklist
- [x] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- Running the commands locally and making sure that the tech preview warning is not visible
- Running the commands with `-h` argument and checking that help texts do not contain any tech preview text

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
