### PR TITLE
ROX-20160: Install RHEL packages into Konflux-built main

### DIFF
--- a/.tekton/main-pull-request.yaml
+++ b/.tekton/main-pull-request.yaml
@@ -59,6 +59,9 @@ spec:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
+  - name: subscription-manager-activation-key
+    secret:
+      secretName: subscription-manager-activation-key
 
   pipelineSpec:
 
@@ -167,6 +170,7 @@ spec:
     workspaces:
     - name: workspace
     - name: git-auth
+    - name: subscription-manager-activation-key
 
     tasks:
 
@@ -217,6 +221,21 @@ spec:
       - name: basic-auth
         workspace: git-auth
 
+    - name: fetch-external-content
+      runAfter:
+      - clone-repository
+      workspaces:
+      - name: source
+        workspace: workspace
+      - name: subscription-manager-activation-key
+        workspace: subscription-manager-activation-key
+      taskSpec:
+        steps:
+        # TODO(ROX-20651): use content sets instead of subscription manager for access to RHEL RPMs once available.
+        - name: smuggle-activation-key
+          image: registry.access.redhat.com/ubi8/ubi:latest
+          script: exec "$(workspaces.source.path)/source/scripts/konflux/subscription-manager/subscription-manager-bro.sh" smuggle
+
     - name: prefetch-dependencies
       params:
       - name: input
@@ -253,6 +272,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       runAfter:
+      - fetch-external-content
       - prefetch-dependencies
       taskRef:
         params:

--- a/.tekton/main-push.yaml
+++ b/.tekton/main-push.yaml
@@ -57,6 +57,9 @@ spec:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
+  - name: subscription-manager-activation-key
+    secret:
+      secretName: subscription-manager-activation-key
 
   pipelineSpec:
 
@@ -165,6 +168,7 @@ spec:
     workspaces:
     - name: workspace
     - name: git-auth
+    - name: subscription-manager-activation-key
 
     tasks:
 
@@ -215,6 +219,21 @@ spec:
       - name: basic-auth
         workspace: git-auth
 
+    - name: fetch-external-content
+      runAfter:
+      - clone-repository
+      workspaces:
+      - name: source
+        workspace: workspace
+      - name: subscription-manager-activation-key
+        workspace: subscription-manager-activation-key
+      taskSpec:
+        steps:
+        # TODO(ROX-20651): use content sets instead of subscription manager for access to RHEL RPMs once available.
+        - name: smuggle-activation-key
+          image: registry.access.redhat.com/ubi8/ubi:latest
+          script: exec "$(workspaces.source.path)/source/scripts/konflux/subscription-manager/subscription-manager-bro.sh" smuggle
+
     - name: prefetch-dependencies
       params:
       - name: input
@@ -251,6 +270,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       runAfter:
+      - fetch-external-content
       - prefetch-dependencies
       taskRef:
         params:

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -1,5 +1,33 @@
 # TODO(ROX-20312): we can't pin image tag or digest because currently there's no mechanism to auto-update that.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS final-base
+
+
+# TODO(ROX-20651): use content sets instead of subscription manager for access to RHEL RPMs once available.
+FROM registry.access.redhat.com/ubi8/ubi:latest AS rpm-installer
+
+ARG FINAL_STAGE_PATH="/mnt/final"
+
+COPY --from=final-base / "$FINAL_STAGE_PATH"
+
+COPY ./scripts/konflux/subscription-manager/* /tmp/.konflux/
+RUN /tmp/.konflux/subscription-manager-bro.sh register "$FINAL_STAGE_PATH"
+
+RUN dnf -y --installroot="$FINAL_STAGE_PATH" upgrade --nobest && \
+    dnf -y --installroot="$FINAL_STAGE_PATH" module enable postgresql:13 && \
+    # find is used in /stackrox/import-additional-cas \
+    # snappy provides libsnappy.so.1, which is needed by most stackrox binaries \
+    dnf -y --installroot="$FINAL_STAGE_PATH" install findutils snappy zstd postgresql && \
+    # We can do usual cleanup while we're here: remove packages that would trigger violations. \
+    dnf -y --installroot="$FINAL_STAGE_PATH" clean all && \
+    rpm --root="$FINAL_STAGE_PATH" --verbose -e --nodeps $(rpm --root="$FINAL_STAGE_PATH" -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rm -rf "$FINAL_STAGE_PATH/var/cache/dnf" "$FINAL_STAGE_PATH/var/cache/yum"
+
+RUN /tmp/.konflux/subscription-manager-bro.sh cleanup
+
+
+FROM scratch
+
+COPY --from=rpm-installer /mnt/final /
 
 LABEL \
     com.redhat.component="rhacs-main-container" \

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -33,14 +33,18 @@ LABEL \
     com.redhat.component="rhacs-main-container" \
     com.redhat.license_terms="https://www.redhat.com/agreements" \
     description="Main Image for Red Hat Advanced Cluster Security for Kubernetes" \
+    distribution-scope="public" \
     io.k8s.description="Main Image for Red Hat Advanced Cluster Security for Kubernetes" \
     io.k8s.display-name="main" \
     io.openshift.tags="rhacs,main,stackrox" \
     maintainer="Red Hat, Inc." \
     name="rhacs-main-rhel8" \
+    # TODO(ROX-20236): release label is required by EC, figure what to put in the release version on rebuilds.
+    release="0" \
     source-location="https://github.com/stackrox/stackrox" \
     summary="Main Image for RHACS" \
     url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
+    vendor="Red Hat, Inc." \
     # We must set version label to prevent inheriting value set in the base stage.
     # TODO(ROX-20236): configure injection of dynamic version value when it becomes possible.
     version="0.0.1-todo"

--- a/scripts/konflux/subscription-manager/.dockerignore
+++ b/scripts/konflux/subscription-manager/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+.gitignore
+bro.self-test*.Dockerfile

--- a/scripts/konflux/subscription-manager/.gitignore
+++ b/scripts/konflux/subscription-manager/.gitignore
@@ -1,0 +1,1 @@
+activation-key

--- a/scripts/konflux/subscription-manager/bro.self-test-demo.Dockerfile
+++ b/scripts/konflux/subscription-manager/bro.self-test-demo.Dockerfile
@@ -1,0 +1,43 @@
+# This demonstrates the usage of subscription-manager-bro.sh and verifies important assumptions.
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS target-base
+
+# Sanity-check we don't have the target package already.
+RUN ! psql --version && \
+    ! rpm -q postgresql && \
+    ! microdnf -y module enable postgresql:15 && \
+    ! microdnf -y install postgresql
+
+
+FROM registry.access.redhat.com/ubi8/ubi:latest AS installer
+
+# Put the target image into installer's /mnt. That's where it will be manipulated by the installer.
+COPY --from=target-base / /mnt
+
+# Copy our helper script and the activation key to the installer.
+COPY ./subscription-manager-bro.sh ./activation-key /tmp/.konflux/
+
+# Sanity-check the installer is not entitled (yet).
+RUN ! dnf -y --installroot=/mnt module enable postgresql:15 && \
+    ! dnf -y --installroot=/mnt install postgresql
+
+# Here's how to use `register` and `cleanup` subcommands.
+RUN /tmp/.konflux/subscription-manager-bro.sh register /mnt && \
+    dnf -y --installroot=/mnt module enable postgresql:15 && \
+    dnf -y --installroot=/mnt install postgresql && \
+    /tmp/.konflux/subscription-manager-bro.sh cleanup
+
+
+FROM scratch AS target
+
+# This makes this `target` stage as desired: target_base + postgresql
+COPY --from=installer /mnt /
+
+# The command must be found.
+RUN psql --version
+
+# rpmdb must contain an entry for the package.
+RUN rpm -q postgresql
+
+# There must be no way to further install entitled packages.
+RUN microdnf repolist && ! microdnf -y install snappy

--- a/scripts/konflux/subscription-manager/bro.self-test-multiple-targets.Dockerfile
+++ b/scripts/konflux/subscription-manager/bro.self-test-multiple-targets.Dockerfile
@@ -1,0 +1,48 @@
+# This verifies that subscription-manager-bro.sh can prepare multiple distinct target stages from one installer stage.
+
+# We use the same base as target for both stages, but these could as well be different.
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS target-base
+
+# Sanity-check we don't have any of the target packages already.
+RUN ! rpm -q bpftool && \
+    ! rpm -q snappy && \
+    ! microdnf -y install bpftool && \
+    ! microdnf -y install snappy
+
+
+FROM registry.access.redhat.com/ubi9/ubi:latest AS installer
+
+COPY --from=target-base / /mnt/stage1
+COPY --from=target-base / /mnt/stage2
+
+COPY ./subscription-manager-bro.sh ./activation-key /tmp/.konflux/
+
+# Register both target paths at once.
+RUN /tmp/.konflux/subscription-manager-bro.sh register /mnt/stage1 /mnt/stage2
+
+# Install a package to the first target,
+RUN dnf -y --installroot=/mnt/stage1 install bpftool && \
+    rpm --root=/mnt/stage1 -q bpftool && ! rpm --root=/mnt/stage1 -q snappy && \
+    dnf -y --installroot=/mnt/stage1 remove bpftool && dnf -y --installroot=/mnt/stage1 autoremove
+
+# and another to the second one.
+RUN dnf -y --installroot=/mnt/stage2 install snappy && \
+    rpm --root=/mnt/stage2 -q snappy && ! rpm --root=/mnt/stage2 -q bpftool && \
+    dnf -y --installroot=/mnt/stage2 remove snappy && dnf -y --installroot=/mnt/stage2 autoremove
+
+# The cleanup triggered with a single command happens for everything previously registered.
+RUN /tmp/.konflux/subscription-manager-bro.sh cleanup
+
+
+FROM installer AS assert-no-significant-diff-after-cleanup
+
+RUN dnf -y install diffutils less
+COPY ./ /tmp/.konflux
+
+COPY --from=target-base / /mnt/expected/
+
+COPY --from=installer /mnt/stage1 /mnt/actual1/
+COPY --from=installer /mnt/stage2 /mnt/actual2/
+
+RUN /tmp/.konflux/subscription-manager-bro.sh diff /mnt/expected /mnt/actual1
+RUN /tmp/.konflux/subscription-manager-bro.sh diff /mnt/expected /mnt/actual2

--- a/scripts/konflux/subscription-manager/bro.self-test.Dockerfile
+++ b/scripts/konflux/subscription-manager/bro.self-test.Dockerfile
@@ -1,0 +1,43 @@
+# This tests ability of subscription-manager-bro.sh to install entitled packages cleanly.
+
+ARG TEST_RHEL_PACKAGE=snappy
+
+ARG TARGET_BASE=registry.access.redhat.com/ubi8/ubi-micro:latest
+ARG INSTALLER_MAJOR_VERSION=8
+
+FROM $TARGET_BASE AS target-base
+# This stage must stay empty so we find 100% original container aliased as target-base.
+
+
+# The installer must be ubi (not minimal) and must be 8.9 or later since the earlier versions complain:
+#  subscription-manager is disabled when running inside a container. Please refer to your host system for subscription management.
+FROM registry.access.redhat.com/ubi${INSTALLER_MAJOR_VERSION}/ubi:latest AS installer
+
+
+FROM installer AS test-no-entitlement
+COPY --from=target-base / /mnt
+ARG TEST_RHEL_PACKAGE
+RUN ! dnf -y --installroot=/mnt install "$TEST_RHEL_PACKAGE"
+
+
+FROM installer AS test-yes-entitlement
+
+COPY --from=target-base / /mnt
+COPY ./ /tmp/.konflux
+
+ARG TEST_RHEL_PACKAGE
+RUN /tmp/.konflux/subscription-manager-bro.sh register /mnt && \
+    dnf -y --installroot=/mnt install "$TEST_RHEL_PACKAGE" && \
+    dnf -y --installroot=/mnt remove "$TEST_RHEL_PACKAGE" && \
+    /tmp/.konflux/subscription-manager-bro.sh cleanup
+
+
+FROM installer AS assert-no-significant-diff-after-cleanup
+
+RUN dnf -y install diffutils less
+COPY ./ /tmp/.konflux
+
+COPY --from=target-base / /mnt/expected/
+COPY --from=test-yes-entitlement /mnt /mnt/actual/
+
+RUN /tmp/.konflux/subscription-manager-bro.sh diff /mnt/expected /mnt/actual

--- a/scripts/konflux/subscription-manager/subscription-manager-bro.sh
+++ b/scripts/konflux/subscription-manager/subscription-manager-bro.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+
+# This script is for registering container with Red Hat subscription-manager during Konflux builds for getting access
+# to RHEL RPMs during the build.
+# The script was created as a workaround in absence of better options.
+# TODO(ROX-20651): remove this script and switch to use content sets once available.
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename -- "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+SECRET_NAME_IN_KONFLUX="subscription-manager-activation-key"
+SECRET_KONFLUX_WORKSPACE_PATH="/workspace/${SECRET_NAME_IN_KONFLUX}"
+SECRET_KEY="activation-key"
+SECRET_LOCAL_PATH="${SCRIPT_DIR}/${SECRET_KEY}"
+SECRET_INFO_URL='https://docs.engineering.redhat.com/pages/viewpage.action?pageId=407312060'
+
+RED_HAT_ORG_ID="11009103"
+TARGETS_LIST_FILE="/tmp/subscription-manager-bro-targets"
+
+# These were figured experimentally with the help of self-test subcommand.
+TARGET_BACKUP_PATHS=(
+    etc/pki/consumer
+    etc/pki/entitlement
+    etc/pki/product
+    etc/pki/product-default
+    etc/yum.repos.d
+    var/lib/rhsm
+    var/cache/ldconfig
+)
+
+
+function main {
+    if [[ "$#" == "0" ]] ; then
+        >&2 echo "Error: command is missing. See the usage below."
+        usage
+        exit 2
+    fi
+
+    local cmd="$1"
+    shift
+
+    local fn
+
+    case "$cmd" in
+    "help" | "--help" | "-h")
+        fn=usage ;;
+    "smuggle")
+        fn=smuggle ;;
+    "register")
+        fn=register ;;
+    "cleanup")
+        fn=cleanup ;;
+    "self-test")
+        fn=self_test ;;
+    "diff")
+        fn=assert_diff ;;
+    *)
+        >&2 echo "Error: unknown command '$1'; call '$SCRIPT_NAME help' to see the usage."
+        exit 2
+        ;;
+    esac
+
+    if [[ "$#" -gt "0" && "$cmd" != "diff" && "$cmd" != "register" ]]; then
+        >&2 echo "Error: too many arguments; call '$SCRIPT_NAME help' to see the usage."
+        exit 2
+    fi
+
+    "$fn" "$@"
+}
+
+function usage {
+    local example_target_dir="/mnt"
+
+    echo "Usage: $SCRIPT_NAME smuggle|register|cleanup|self-test"
+    echo
+    echo "This script enables access to RHEL RPMs during Konflux builds. The intended usage is as follows."
+    echo
+
+    echo -n "1. Make sure there is a '$SECRET_NAME_IN_KONFLUX' secret in Konflux with key name '$SECRET_KEY' and "
+    echo "the actual activation key as a value."
+    echo "   Find where to get the secret from ${SECRET_INFO_URL}"
+
+    echo -n "2. In a Tekton pipeline step before the container build, copy the subscription manager activation "
+    echo "key secret to the source workspace. Use:"
+    echo "   \$ <source-workspace>/$SCRIPT_NAME smuggle"
+    echo -n "   This expects the '$SECRET_NAME_IN_KONFLUX' secret to be mounted as a workspace with the same name "
+    echo "('$SECRET_KONFLUX_WORKSPACE_PATH')."
+
+    echo "3. Arrange Dockerfile stages to have UBI (normal) as an installer and other RHEL/UBI (any) as a target."
+    echo "   Make sure to match major versions: 8/8 is ok but 9/8 or 8/9 will result in errors."
+    echo "   Copy the target contents to some directory, e.g. ${example_target_dir}, in the installer stage."
+    echo "   See self-test Dockerfiles as examples."
+
+    echo "4. In the installer stage, register the container with the subscription manager. Use:"
+    echo "   \$ $SCRIPT_NAME register ${example_target_dir}"
+    echo -n "   It is possible to provide multiple target directories as arguments if the script is used to prepare "
+    echo "multiple distinct stages."
+
+    echo -n "5. Use 'dnf --installroot=${example_target_dir} ...' to install RHEL RPMs, enable RHEL modules, etc. "
+    echo "in the target contents."
+
+    echo -n "6. In the same installer stage, deregister the container so that the end users can't use "
+    echo "our subscription on our behalf. Use:"
+    echo "   \$ $SCRIPT_NAME cleanup"
+    echo "   This step is mandatory because it cleans entitlements on the target in the right way."
+
+    echo -n "7. Copy out ${example_target_dir} contents from the installer stage to a new 'scratch' stage. "
+    echo "That's your target container."
+
+    echo
+    echo "When altering this script, use the 'self-test' command as a (regression) test tool:"
+    echo "   \$ $SCRIPT_NAME self-test"
+    echo "For it to work, you need to put a valid activation key in ${SECRET_LOCAL_PATH} file."
+    echo "Find out where to get it from ${SECRET_INFO_URL}"
+}
+
+function smuggle {
+    mkdir -p "$(dirname "${SECRET_LOCAL_PATH}" )"
+    cp --verbose "${SECRET_KONFLUX_WORKSPACE_PATH}/${SECRET_KEY}" "${SECRET_LOCAL_PATH}"
+}
+
+function register {
+    if [[ ! -s "${SECRET_LOCAL_PATH}" ]]; then
+        >&2 echo "Error: it does not look like the activation key is present in ${SECRET_LOCAL_PATH}"
+        exit 3
+    fi
+    local secret
+    secret="$(cat "${SECRET_LOCAL_PATH}")"
+
+    if [[ "$#" -lt 1 ]]; then
+        >&2 echo "Error: target path(s) must be provided for the 'register' command."
+        exit 2
+    fi
+
+    local target_dirs=( "$@" )
+
+    check_targets_and_store_paths_for_cleanup "${target_dirs[@]}"
+
+    # Besides just installing packages and making the desired updates to rpmdb, the use of subscription-manager with
+    # the subsequent installation introduces some side-effects that seem undesired. Backup and restore is how I suggest
+    # maintaining the original state of the target.
+    for target_dir in "${target_dirs[@]}"; do
+        echo "Backing up the original artifacts in $target_dir"
+        mkdir -p "${target_dir}/tmp/restore"
+        tar --create -vf "${target_dir}/tmp/restore/backup.tar" --files-from /dev/null
+        for item in "${TARGET_BACKUP_PATHS[@]}"; do
+            if [[ -e "${target_dir}/${item}" ]]; then
+                tar --append -vf "${target_dir}/tmp/restore/backup.tar" -C "${target_dir}" "${item}"
+            fi
+        done
+    done
+
+    echo "Registering the installer container with the subscription manager"
+    subscription-manager register --org="$RED_HAT_ORG_ID" --activationkey="$secret"
+
+    # It is suggested in the following articles that certain files can be linked to $target_dir/run/secrets,
+    # but I was not able to make it work, therefore doing it differently.
+    # https://www.neteye-blog.com/2022/07/how-to-use-a-hosts-redhat-subscription-to-run-containers-using-docker-instead-of-podman/
+    # https://access.redhat.com/solutions/5870841
+    for target_dir in "${target_dirs[@]}"; do
+        echo "Enabling entitled rpm repos in $target_dir"
+        mkdir -p "${target_dir}/etc/pki/entitlement"
+        ln --verbose -s /etc/pki/entitlement/*.pem "${target_dir}/etc/pki/entitlement"
+        ln --verbose --force -s /etc/yum.repos.d/redhat.repo "${target_dir}/etc/yum.repos.d/"
+    done
+
+    echo "Looks like the registration succeeded. Don't forget to call '$SCRIPT_NAME cleanup' when done with rpms!"
+}
+
+function check_targets_and_store_paths_for_cleanup {
+    local target_dirs=( "$@" )
+
+    for target_dir in "${target_dirs[@]}"; do
+        if [[ ! -d "${target_dir}/etc" ]]; then
+            >&2 echo "Error: Looks like the target system is not placed at ${target_dir}"
+            exit 4
+        fi
+    done
+
+    if [[ -f "${TARGETS_LIST_FILE}" ]]; then
+        >&2 echo "Error: ${TARGETS_LIST_FILE} already exists. Are you trying to register again without doing a cleanup?"
+        exit 5
+    fi
+
+    printf "%s\n" "${target_dirs[@]}" > "${TARGETS_LIST_FILE}"
+}
+
+function cleanup {
+    local -a target_dirs
+    readarray -t target_dirs < "${TARGETS_LIST_FILE}"
+
+    for target_dir in "${target_dirs[@]}"; do
+        echo "Cleaning up entitlement artifacts in $target_dir"
+
+        echo "Restoring original artifacts"
+        for item in "${TARGET_BACKUP_PATHS[@]}"; do
+            rm --verbose -rf "${target_dir:?}/${item}"
+        done
+        tar --extract -vf "${target_dir}/tmp/restore/backup.tar" -C "${target_dir}"
+
+        echo "Removing original artifacts backups"
+        rm --verbose -rf "${target_dir:?}/tmp/restore"
+    done
+
+    # It should be good to unregister this installer container so that it's not left hanging in some Red Hat database.
+    echo "Unregistering the installer container"
+    subscription-manager unregister
+
+    rm --verbose "${TARGETS_LIST_FILE}"
+
+    echo "Cleanup complete."
+}
+
+function self_test {
+    local command="podman"
+
+    local targets=(
+        "registry.access.redhat.com/ubi8/ubi-micro:latest"
+        "registry.access.redhat.com/ubi8/ubi-minimal:latest"
+        "registry.access.redhat.com/ubi8/ubi:latest"
+        "registry.redhat.io/rhel8/toolbox:latest"
+
+        "registry.access.redhat.com/ubi9/ubi-micro:latest"
+        "registry.access.redhat.com/ubi9/ubi-minimal:latest"
+        "registry.access.redhat.com/ubi9/ubi:latest"
+        "registry.redhat.io/rhel9/toolbox:latest"
+    )
+
+    for target in "${targets[@]}"; do
+        [[ $target =~ /(ubi|rhel)([0-9]+)/ ]]
+        local major_version="${BASH_REMATCH[2]}"
+
+        echo
+        echo
+        echo "Testing against ${target} with the installer major version ${major_version}"
+        echo
+        echo
+
+        set -x
+        "${command}" build \
+            -f "${SCRIPT_DIR}/bro.self-test.Dockerfile" \
+            --build-arg TARGET_BASE="${target}" \
+            --build-arg INSTALLER_MAJOR_VERSION="${major_version}" \
+            "${SCRIPT_DIR}"
+        set +x
+    done
+
+    "${command}" build -f "${SCRIPT_DIR}/bro.self-test-demo.Dockerfile" "${SCRIPT_DIR}"
+    "${command}" build -f "${SCRIPT_DIR}/bro.self-test-multiple-targets.Dockerfile" "${SCRIPT_DIR}"
+    echo "Self-tests passed."
+}
+
+function assert_diff {
+    if [[ "$#" != "2" ]]; then
+        >&2 echo "Error: expecting two arguments: expected and actual paths"
+        exit 2
+    fi
+
+    local expected="$1"
+    local actual="$2"
+
+    local failed_check_file
+    failed_check_file="$(mktemp)"
+
+    echo "Comparing /etc"
+    if ! diff --brief --recursive --no-dereference --exclude='ld.so.cache' "$expected/etc" "$actual/etc" ; then
+        echo 1 >> "$failed_check_file"
+    fi
+
+    echo "Comparing /var"
+    local var_exclusions
+    var_exclusions="$(mktemp)"
+    {
+        # Before adding any exclusions here, make sure you check there's nothing sensitive in these files.
+        # If sensitive, they should be added to backup/restore (TARGET_BACKUP_PATHS) or cleanup.
+        echo '/var/lib: dnf'
+        echo '/var/lib/dnf/history\.sqlite'
+        echo '/var/lib/rpm(:|/)'
+        echo '/var/log: (dnf.*|hawkey)\.log'
+        echo '/var/log/(dnf.*|hawkey)\.log'
+        # /var/cache/dnf should be kept on Target, otherwise Konflux Enterprise Check fails not finding SBOM.
+        echo '/var/cache(: |/)dnf'
+    } >> "$var_exclusions"
+
+    if { diff --brief --recursive --no-dereference "$expected/var" "$actual/var" || true; } | \
+        grep -vEf "$var_exclusions" | { grep '.'; }; then
+        echo 2 >> "$failed_check_file"
+    fi
+
+    local other_dirs_to_compare=(bin home lib lib64 media mnt opt root sbin srv tmp usr)
+
+    for dir in "${other_dirs_to_compare[@]}"; do
+        echo "Comparing /$dir"
+        if ! diff --brief --recursive --no-dereference "$expected/$dir" "$actual/$dir"; then
+            echo 3 >> "$failed_check_file"
+        fi
+    done
+
+    if [[ -s "$failed_check_file" ]]; then
+        >&2 echo "Error: differences detected"
+        exit 6
+    fi
+
+    echo "Diff check for $expected and $actual passed."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
## Description

The use of entitled packages required inventing something new. I hope it does not live for long and we'll be able to use Konflux solution for that. That said, I tested the script many times in different combinations, locally and in Konflux, and I'm fairly confident in it for the time being.

See commit messages where I tried supplying relevant info.

## Checklist
- [x] Investigated and inspected CI test results

These aren't needed and won't be done:
- ~~[ ] Unit test and regression tests added~~ - not this time, see notes on testing below.
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

Check that Konflux CI is green, including EC.

Used `subscription-manager-bro.sh self-test` to test locally. Decided to not put this in CI for the following reasons, I hope having it as a local-only tool is ok.

1. It takes ~10 minutes to run on my machine.
2. Automating in CI requires setting up secrets.
3. I hope this script will go away as soon as we get access to content sets.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
