### PR TITLE
ROX-22433: scan config profile error duplicate

### DIFF
--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -98,7 +98,7 @@ func (ds *datastoreImpl) ScanConfigurationProfileExists(ctx context.Context, id 
 	for _, profile := range profiles {
 		for profileName, configs := range profileMap {
 			if areProfilesEqual(profile, profileName) {
-				return errors.Errorf("a cluster in scan configurations %v already uses profile %q", configs, profileName)
+				return errors.Errorf("a cluster in scan configurations %v already uses profile %q", configs.AsSlice(), profileName)
 			}
 		}
 	}

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/uuid"
 )
@@ -77,14 +78,19 @@ func (ds *datastoreImpl) ScanConfigurationProfileExists(ctx context.Context, id 
 	}
 
 	// Create a map for quick lookup of profiles.
-	profileMap := make(map[string][]string)
+	profileMap := make(map[string]set.StringSet)
 
 	for _, scanConfig := range scanConfigs {
 		if scanConfig.GetId() == id {
 			continue
 		}
 		for _, profile := range scanConfig.GetProfiles() {
-			profileMap[profile.GetProfileName()] = append(profileMap[profile.GetProfileName()], scanConfig.GetScanConfigName())
+			configSet, found := profileMap[profile.GetProfileName()]
+			if !found {
+				profileMap[profile.GetProfileName()] = set.NewStringSet()
+			}
+			configSet.Add(scanConfig.GetScanConfigName())
+			profileMap[profile.GetProfileName()] = configSet
 		}
 	}
 


### PR DESCRIPTION
## Description

The error for when a profile was used in multiple scan configurations was showing an array of scan configurations.  Meaning if you had a conflict on multiple clusters it would list the offending configuration once per cluster.  See this:

![Screenshot 2024-02-09 at 2 55 53 PM](https://github.com/stackrox/stackrox/assets/99685630/008056b1-b357-4b3b-856f-5858ac5b4784)

Switched the map to use a set to the offending configuration on shows up once.
![Screenshot 2024-02-09 at 3 30 19 PM](https://github.com/stackrox/stackrox/assets/99685630/6cbb5355-650a-4d35-bef2-010b84127073)


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

See screenshots above from actual runs and execution of the scenario.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
