### PR TITLE
ROX-22048: Add search filters for DiscoveredClusters

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/SearchFilterChips.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/SearchFilterChips.tsx
@@ -14,7 +14,7 @@ export type FilterChipGroupDescriptor = {
     /** The name of the search filter category as it appears in the URL */
     searchFilterName: string;
     /** Optional render function for the chip. Defaults to rendering plain text inside a PatternFly `Chip` component */
-    render?: (filter: string) => React.ReactElement;
+    render?: (filter: string) => React.ReactNode;
 };
 
 export type SearchFilterChipsProps = {

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.cy.jsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.cy.jsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import { noop } from 'lodash';
+
+import ComponentTestProviders from 'test-utils/ComponentProviders';
+import useURLSearch from 'hooks/useURLSearch';
+import DiscoveredClustersToolbar from './DiscoveredClustersToolbar';
+
+function Wrapper() {
+    const { searchFilter, setSearchFilter } = useURLSearch();
+
+    return (
+        <DiscoveredClustersToolbar
+            searchFilter={searchFilter}
+            setSearchFilter={setSearchFilter}
+            count={0}
+            page={1}
+            perPage={1}
+            setPage={noop}
+            setPerPage={noop}
+        />
+    );
+}
+
+const setup = () => {
+    cy.mount(
+        <ComponentTestProviders>
+            <Wrapper />
+        </ComponentTestProviders>
+    );
+};
+
+const openDropdownAnd = (label, action) => {
+    cy.findByLabelText(label).click();
+    cy.findByLabelText(label).parent().within(action);
+    cy.findByLabelText(label).click();
+};
+
+const filterGroup = (name) => cy.findByRole('group', { name });
+const filterChip = (label) => cy.get(`li:has(*:contains("${label}"))`);
+const removeGroup = (name) =>
+    filterGroup(name).within(() => cy.findByLabelText('Close chip group').click());
+const removeChip = (name) =>
+    filterChip(name).within(() => cy.findByLabelText('Remove filter').click());
+
+describe(Cypress.spec.relative, () => {
+    it('should correctly handle the name text input', () => {
+        setup();
+
+        // Ensure creating a chip/filter clears the input
+        cy.findByLabelText('Filter by name').type('cluster-a{enter}');
+        filterGroup('Name').within(() => filterChip('cluster-a'));
+        cy.findByLabelText('Filter by name').should('have.value', '');
+
+        // Ensure duplicate filters are not created
+        cy.findByLabelText('Filter by name').type('cluster-a{enter}');
+        filterGroup('Name').within(() => filterChip('cluster-a').should('have.length', 1));
+    });
+
+    it('should handle the "select all" checkbox mutual exclusion in the status and type dropdowns', () => {
+        setup();
+
+        // Simple abstraction to handle each dropdown
+        const dropdowns = [
+            {
+                name: 'Status',
+                label: 'Status filter menu toggle',
+                allOption: 'All statuses',
+                options: ['Unsecured', 'Undetermined'],
+            },
+            {
+                name: 'Type',
+                label: 'Type filter menu toggle',
+                allOption: 'All types',
+                options: ['AKS', 'EKS'],
+            },
+        ];
+
+        dropdowns.forEach(({ label, name, allOption, options: [optionA, optionB] }) => {
+            // Select all in the dropdown is the default
+            openDropdownAnd(label, () => {
+                cy.findByLabelText(allOption).should('be.checked');
+            });
+
+            filterGroup(name).should('not.exist');
+
+            // Select a single option and verify that the "all" checkbox is deselected and the chip appears
+            openDropdownAnd(label, () => {
+                cy.findByLabelText(optionA).click();
+                cy.findByLabelText(optionA).should('be.checked');
+                cy.findByLabelText(allOption).should('not.be.checked');
+            });
+
+            filterGroup(name).within(() => {
+                filterChip(optionA);
+            });
+
+            // Clicking "all" should remove all other applied filters
+            openDropdownAnd(label, () => {
+                cy.findByLabelText(allOption).click();
+                cy.findByLabelText(allOption).should('be.checked');
+                cy.findByLabelText(optionA).should('not.be.checked');
+            });
+
+            filterGroup(name).should('not.exist');
+
+            // Deselecting all filters manually should re-select the "all" checkbox
+            openDropdownAnd(label, () => {
+                cy.findByLabelText(optionA).click();
+                cy.findByLabelText(optionB).click();
+            });
+
+            filterGroup(name).within(() => {
+                filterChip(optionA);
+                filterChip(optionB);
+            });
+
+            openDropdownAnd(label, () => {
+                cy.findByLabelText(optionA).click();
+                cy.findByLabelText(optionB).click();
+                cy.findByLabelText(allOption).should('be.checked');
+                cy.findByLabelText(optionA).should('not.be.checked');
+                cy.findByLabelText(optionB).should('not.be.checked');
+            });
+
+            filterGroup(name).should('not.exist');
+        });
+    });
+
+    it('should correctly handle adding and removing filters', () => {
+        setup();
+
+        // Add filters of each type
+        cy.findByLabelText('Filter by name').type('cluster-a{enter}');
+        cy.findByLabelText('Filter by name').type('cluster-b{enter}');
+
+        openDropdownAnd('Status filter menu toggle', () => {
+            cy.findByLabelText('Unsecured').click();
+            cy.findByLabelText('Undetermined').click();
+        });
+
+        openDropdownAnd('Type filter menu toggle', () => {
+            cy.findByLabelText('AKS').click();
+            cy.findByLabelText('EKS').click();
+        });
+
+        // Verify that all filters are applied and visible as chips
+        filterGroup('Name').within(() => {
+            filterChip('cluster-a');
+            filterChip('cluster-b');
+        });
+
+        filterGroup('Status').within(() => {
+            filterChip('Unsecured');
+            filterChip('Undetermined');
+        });
+
+        filterGroup('Type').within(() => {
+            filterChip('AKS');
+            filterChip('EKS');
+        });
+
+        // Remove some filters and verify that the chips are removed
+        filterGroup('Name').within(() => {
+            removeChip('cluster-b');
+        });
+
+        removeGroup('Type');
+
+        // Verify that the correct filters are removed
+        filterGroup('Name').within(() => {
+            filterChip('cluster-a');
+            filterChip('cluster-b').should('not.exist');
+        });
+
+        filterGroup('Status').within(() => {
+            filterChip('Unsecured');
+            filterChip('Undetermined');
+        });
+
+        filterGroup('Type').should('not.exist');
+
+        // Remove all filters and verify that the chips are removed
+        cy.findByRole('button', { name: 'Clear filters' }).click();
+
+        filterGroup('Name').should('not.exist');
+        filterGroup('Status').should('not.exist');
+        filterGroup('Type').should('not.exist');
+    });
+});

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.cy.jsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.cy.jsx
@@ -54,6 +54,9 @@ describe(Cypress.spec.relative, () => {
         // Ensure duplicate filters are not created
         cy.findByLabelText('Filter by name').type('cluster-a{enter}');
         filterGroup('Name').within(() => filterChip('cluster-a').should('have.length', 1));
+
+        // clear filters
+        removeGroup('Name');
     });
 
     it('should handle the "select all" checkbox mutual exclusion in the status and type dropdowns', () => {
@@ -129,6 +132,9 @@ describe(Cypress.spec.relative, () => {
     it('should correctly handle adding and removing filters', () => {
         setup();
 
+        // Default is no filters
+        cy.location('search').should('match', /^$/);
+
         // Add filters of each type
         cy.findByLabelText('Filter by name').type('cluster-a{enter}');
         cy.findByLabelText('Filter by name').type('cluster-b{enter}');
@@ -159,6 +165,18 @@ describe(Cypress.spec.relative, () => {
             filterChip('EKS');
         });
 
+        // Verify that the filters exist in the URL
+        [
+            /s\[Cluster\]\[\d\]=cluster-a/,
+            /s\[Cluster\]\[\d\]=cluster-b/,
+            /s\[Cluster%20Status\]\[\d\]=STATUS_UNSECURED/,
+            /s\[Cluster%20Status\]\[\d\]=STATUS_UNSPECIFIED/,
+            /s\[Cluster%20Type\]\[\d\]=AKS/,
+            /s\[Cluster%20Type\]\[\d\]=EKS/,
+        ].forEach((filter) => {
+            cy.location('search').should('match', filter);
+        });
+
         // Remove some filters and verify that the chips are removed
         filterGroup('Name').within(() => {
             removeChip('cluster-b');
@@ -179,11 +197,23 @@ describe(Cypress.spec.relative, () => {
 
         filterGroup('Type').should('not.exist');
 
+        // Verify the next URL state
+        [
+            /s\[Cluster\]\[\d\]=cluster-a/,
+            /s\[Cluster%20Status\]\[\d\]=STATUS_UNSECURED/,
+            /s\[Cluster%20Status\]\[\d\]=STATUS_UNSPECIFIED/,
+        ].forEach((filter) => {
+            cy.location('search').should('match', filter);
+        });
+
         // Remove all filters and verify that the chips are removed
         cy.findByRole('button', { name: 'Clear filters' }).click();
 
         filterGroup('Name').should('not.exist');
         filterGroup('Status').should('not.exist');
         filterGroup('Type').should('not.exist');
+
+        // Verify the next URL state
+        cy.location('search').should('match', /^$/);
     });
 });

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
@@ -7,17 +7,37 @@ import {
     ToolbarItem,
 } from '@patternfly/react-core';
 
+import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import {
-    // DiscoveredClusterStatus,
+    DiscoveredClusterStatus,
     DiscoveredClusterType,
     getDiscoveredClustersFilter,
-    // replaceSearchFilterName,
-    // replaceSearchFilterStatuses,
+    isStatus,
+    isType,
+    replaceSearchFilterNames,
+    replaceSearchFilterStatuses,
     replaceSearchFilterTypes,
 } from 'services/DiscoveredClusterService';
 import { SearchFilter } from 'types/search';
 
-import SearchFilterType from './SearchFilterType';
+import SearchFilterTypes from './SearchFilterTypes';
+import SearchFilterNames from './SearchFilterNames';
+import SearchFilterStatuses from './SearchFilterStatuses';
+import { getStatusText, getTypeText } from './DiscoveredCluster';
+
+const searchFilterChipDescriptors = [
+    { displayName: 'Name', searchFilterName: 'Cluster' },
+    {
+        displayName: 'Status',
+        searchFilterName: 'Cluster Status',
+        render: (filter: string) => (isStatus(filter) ? getStatusText(filter) : filter),
+    },
+    {
+        displayName: 'Type',
+        searchFilterName: 'Cluster Type',
+        render: (filter: string) => (isType(filter) ? getTypeText(filter) : filter),
+    },
+];
 
 export type DiscoveredClustersToolbarProps = {
     count: number;
@@ -40,30 +60,44 @@ function DiscoveredClustersToolbar({
     searchFilter,
     setSearchFilter,
 }: DiscoveredClustersToolbarProps): ReactElement {
-    /*
-    function setNameSelected(name: string) {
-        setSearchFilter(replaceSearchFilterName(searchFilter, name));
+    function setNamesSelected(names: string[] | undefined) {
+        setSearchFilter(replaceSearchFilterNames(searchFilter, names));
     }
 
-    function setStatusesSelected(types: DiscoveredClusterStatus[] | undefined) {
+    function setStatusesSelected(statuses: DiscoveredClusterStatus[] | undefined) {
         setSearchFilter(replaceSearchFilterStatuses(searchFilter, statuses));
     }
-    */
 
     function setTypesSelected(types: DiscoveredClusterType[] | undefined) {
         setSearchFilter(replaceSearchFilterTypes(searchFilter, types));
     }
 
-    const { types: typesSelected } = getDiscoveredClustersFilter(searchFilter);
+    const {
+        names: namesSelected,
+        types: typesSelected,
+        statuses: statusesSelected,
+    } = getDiscoveredClustersFilter(searchFilter);
 
     return (
         <Toolbar>
             <ToolbarContent>
-                {/* SearchFilterName */}
-                {/* SearchFilterStatuses */}
+                <ToolbarItem variant="search-filter">
+                    <SearchFilterNames
+                        namesSelected={namesSelected}
+                        isDisabled={isDisabled}
+                        setNamesSelected={setNamesSelected}
+                    />
+                </ToolbarItem>
                 <ToolbarGroup variant="filter-group">
                     <ToolbarItem>
-                        <SearchFilterType
+                        <SearchFilterStatuses
+                            statusesSelected={statusesSelected}
+                            isDisabled={isDisabled}
+                            setStatusesSelected={setStatusesSelected}
+                        />
+                    </ToolbarItem>
+                    <ToolbarItem>
+                        <SearchFilterTypes
                             typesSelected={typesSelected}
                             isDisabled={isDisabled}
                             setTypesSelected={setTypesSelected}
@@ -85,6 +119,9 @@ function DiscoveredClustersToolbar({
                             }}
                         />
                     </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarGroup className="pf-u-w-100">
+                    <SearchFilterChips filterChipGroupDescriptors={searchFilterChipDescriptors} />
                 </ToolbarGroup>
             </ToolbarContent>
         </Toolbar>

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterNames.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterNames.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { SearchInput } from '@patternfly/react-core';
+
+type SearchFilterNamesProps = {
+    namesSelected: string[] | undefined;
+    isDisabled: boolean;
+    setNamesSelected: (names: string[]) => void;
+};
+
+function SearchFilterNames({
+    namesSelected,
+    isDisabled,
+    setNamesSelected,
+}: SearchFilterNamesProps) {
+    const [searchValue, setSearchValue] = useState('');
+
+    function onSearchInputChange(_event, value) {
+        setSearchValue(value);
+    }
+
+    function onSearch() {
+        const previousNames = namesSelected ?? [];
+        const nextNames = previousNames.includes(searchValue)
+            ? previousNames
+            : [...previousNames, searchValue];
+
+        setNamesSelected(nextNames);
+        setSearchValue('');
+    }
+
+    return (
+        <SearchInput
+            aria-label="Filter by name"
+            placeholder="Filter by name"
+            isDisabled={isDisabled}
+            value={searchValue}
+            onChange={onSearchInputChange}
+            onSearch={onSearch}
+            onClear={() => setSearchValue('')}
+        />
+    );
+}
+
+export default SearchFilterNames;

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterStatuses.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterStatuses.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { SelectOption, Divider, Select } from '@patternfly/react-core';
+
+import { DiscoveredClusterStatus, isStatus, statuses } from 'services/DiscoveredClusterService';
+
+import { getStatusText } from './DiscoveredCluster';
+
+const optionAll = 'All_statuses';
+
+type SearchFilterStatusesProps = {
+    statusesSelected: DiscoveredClusterStatus[] | undefined;
+    isDisabled: boolean;
+    setStatusesSelected: (statuses: DiscoveredClusterStatus[] | undefined) => void;
+};
+
+function SearchFilterStatuses({
+    statusesSelected,
+    isDisabled,
+    setStatusesSelected,
+}: SearchFilterStatusesProps) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    function onSelect(_event, selection) {
+        const previousStatuses = statusesSelected ?? [];
+        if (isStatus(selection)) {
+            setStatusesSelected(
+                previousStatuses.includes(selection)
+                    ? previousStatuses.filter((status) => status !== selection)
+                    : [...previousStatuses, selection]
+            );
+        } else {
+            setStatusesSelected(undefined);
+        }
+    }
+
+    const options = statuses.map((status) => (
+        <SelectOption key={status} value={status}>
+            {getStatusText(status)}
+        </SelectOption>
+    ));
+    options.push(
+        <Divider key="Divider" />,
+        <SelectOption key="All" value={optionAll}>
+            All statuses
+        </SelectOption>
+    );
+
+    return (
+        <Select
+            variant="checkbox"
+            placeholderText="Filter by status"
+            aria-label="Status filter menu items"
+            toggleAriaLabel="Status filter menu toggle"
+            onToggle={setIsOpen}
+            onSelect={onSelect}
+            selections={statusesSelected ?? optionAll}
+            isDisabled={isDisabled}
+            isOpen={isOpen}
+        >
+            {options}
+        </Select>
+    );
+}
+
+export default SearchFilterStatuses;

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterTypes.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterTypes.tsx
@@ -7,24 +7,30 @@ import { getTypeText } from './DiscoveredCluster';
 
 const optionAll = 'All_types';
 
-type SearchFilterTypeProps = {
+type SearchFilterTypesProps = {
     typesSelected: DiscoveredClusterType[] | undefined;
     isDisabled: boolean;
     setTypesSelected: (types: DiscoveredClusterType[] | undefined) => void;
 };
 
-// TODO for multiselect rename as SearchFilterTypes (that is, plural).
-function SearchFilterType({ typesSelected, isDisabled, setTypesSelected }: SearchFilterTypeProps) {
+function SearchFilterTypes({
+    typesSelected,
+    isDisabled,
+    setTypesSelected,
+}: SearchFilterTypesProps) {
     const [isOpen, setIsOpen] = useState(false);
 
     function onSelect(_event, selection) {
+        const previousTypes = typesSelected ?? [];
         if (isType(selection)) {
-            // TODO for multiselect, replace set with either spread in or filter out.
-            setTypesSelected([selection]);
+            setTypesSelected(
+                previousTypes.includes(selection)
+                    ? previousTypes.filter((type) => type !== selection)
+                    : [...previousTypes, selection]
+            );
         } else {
             setTypesSelected(undefined);
         }
-        setIsOpen(false);
     }
 
     const options = types.map((type) => (
@@ -34,24 +40,20 @@ function SearchFilterType({ typesSelected, isDisabled, setTypesSelected }: Searc
     ));
     options.push(
         <Divider key="Divider" />,
-        <SelectOption key="All" value={optionAll} isPlaceholder>
+        <SelectOption key="All" value={optionAll}>
             All types
         </SelectOption>
     );
 
-    // TODO replace single with checkbox for multiple selections.
     return (
         <Select
-            variant="single"
+            variant="checkbox"
+            placeholderText="Filter by type"
             aria-label="Type filter menu items"
             toggleAriaLabel="Type filter menu toggle"
             onToggle={setIsOpen}
             onSelect={onSelect}
-            selections={
-                Array.isArray(typesSelected) && typesSelected.length !== 0
-                    ? typesSelected[0]
-                    : optionAll
-            }
+            selections={typesSelected ?? optionAll}
             isDisabled={isDisabled}
             isOpen={isOpen}
         >
@@ -60,4 +62,4 @@ function SearchFilterType({ typesSelected, isDisabled, setTypesSelected }: Searc
     );
 }
 
-export default SearchFilterType;
+export default SearchFilterTypes;

--- a/ui/apps/platform/src/services/DiscoveredClusterService.ts
+++ b/ui/apps/platform/src/services/DiscoveredClusterService.ts
@@ -167,11 +167,8 @@ function getValues(arg: SearchFilterValue): string[] | undefined {
     return undefined;
 }
 
-export function replaceSearchFilterName(searchFilter: SearchFilter, name: string | undefined) {
-    return {
-        ...searchFilter,
-        [nameField]: typeof name === 'string' && name.length !== 0 ? [name] : undefined,
-    };
+export function replaceSearchFilterNames(searchFilter: SearchFilter, names: string[] | undefined) {
+    return { ...searchFilter, [nameField]: names };
 }
 
 // statuses


### PR DESCRIPTION
## Description

Modifies the existing "By type" search filter to be a checkbox multi-select instead of a single, and adds search components to allow the addition of multiple name and type filters.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Via automated testing:
- Verify the behavior of the name input text box independently
- Verify the behavior of the multiselect dropdowns with "select all" option
- Verifies that the full set of search components correctly tracks search state in the URL and displays the current state via chips

Video of manual testing verifying the behavior of the filters in combination together and with the URL:

https://github.com/stackrox/stackrox/assets/1292638/55386475-91e0-44df-91cf-2020893f9ec4


