### PR TITLE
ROX-21984: Update source name and sorting in discovered clusters

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
@@ -13,9 +13,11 @@ import {
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import PageTitle from 'Components/PageTitle';
+import usePermissions from 'hooks/usePermissions';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
+import { fetchCloudSources } from 'services/CloudSourceService';
 import {
     DiscoveredCluster,
     countDiscoveredClusters,
@@ -43,6 +45,22 @@ function DiscoveredClustersPage(): ReactElement {
     // Use currentDatetime === null as substitute for initial isLoading.
     const [currentDatetime, setCurrentDatetime] = useState<Date | null>(null);
     const [isReloading, setIsReloading] = useState(false);
+
+    const { hasReadAccess } = usePermissions();
+    const [sourceNameMap, setSourceNameMap] = useState<Map<string, string>>(new Map());
+
+    const hasReadAccessForIntegration = hasReadAccess('Integration');
+    useEffect(() => {
+        if (hasReadAccessForIntegration) {
+            fetchCloudSources()
+                .then(({ response: { cloudSources } }) => {
+                    setSourceNameMap(new Map(cloudSources.map(({ id, name }) => [id, name])));
+                })
+                .catch(() => {
+                    // TODO
+                });
+        }
+    }, [hasReadAccessForIntegration]);
 
     useEffect(() => {
         setIsReloading(true);
@@ -118,6 +136,7 @@ function DiscoveredClustersPage(): ReactElement {
                             currentDatetime={currentDatetime}
                             getSortParams={getSortParams}
                             searchFilter={searchFilter}
+                            sourceNameMap={sourceNameMap}
                         />
                     </>
                 )}

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
@@ -3,7 +3,12 @@ import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-tab
 
 import IconText from 'Components/PatternFly/IconText/IconText';
 import { UseURLSortResult } from 'hooks/useURLSort';
-import { DiscoveredCluster, hasDiscoveredClustersFilter } from 'services/DiscoveredClusterService';
+import {
+    DiscoveredCluster,
+    firstDiscoveredAtField,
+    hasDiscoveredClustersFilter,
+    nameField,
+} from 'services/DiscoveredClusterService';
 import { SearchFilter } from 'types/search';
 import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 
@@ -22,6 +27,7 @@ export type DiscoveredClustersTableProps = {
     currentDatetime: Date;
     getSortParams: UseURLSortResult['getSortParams'];
     searchFilter: SearchFilter;
+    sourceNameMap: Map<string, string>;
 };
 
 function DiscoveredClustersTable({
@@ -29,12 +35,13 @@ function DiscoveredClustersTable({
     currentDatetime,
     getSortParams,
     searchFilter,
+    sourceNameMap,
 }: DiscoveredClustersTableProps): ReactElement {
     return (
         <TableComposable variant="compact" borders={false}>
             <Thead>
                 <Tr>
-                    <Th width={25} sort={getSortParams('TODO')}>
+                    <Th width={25} sort={getSortParams(nameField)}>
                         Cluster
                     </Th>
                     <Th width={15}>State</Th>
@@ -45,7 +52,7 @@ function DiscoveredClustersTable({
                     <Th width={20} modifier="nowrap">
                         Cloud source
                     </Th>
-                    <Th width={15} modifier="nowrap" sort={getSortParams('TODO')}>
+                    <Th width={15} modifier="nowrap" sort={getSortParams(firstDiscoveredAtField)}>
                         First discovered
                     </Th>
                 </Tr>
@@ -78,7 +85,9 @@ function DiscoveredClustersTable({
                                 <Td dataLabel="Provider (region)" modifier="nowrap">
                                     {getProviderRegionText(providerType, region)}
                                 </Td>
-                                <Td dataLabel="Cloud source">{source.name}</Td>
+                                <Td dataLabel="Cloud source">
+                                    {sourceNameMap.get(source.id) ?? 'Not available'}
+                                </Td>
                                 <Td dataLabel="First discovered" modifier="nowrap">
                                     {firstDiscoveredAsPhrase}
                                 </Td>

--- a/ui/apps/platform/src/services/DiscoveredClusterService.ts
+++ b/ui/apps/platform/src/services/DiscoveredClusterService.ts
@@ -60,7 +60,6 @@ export type DiscoveredClusterStatus = (typeof statuses)[number];
 
 export type DiscoveredClusterCloudSource = {
     id: string;
-    name: string;
 };
 
 // endpoints
@@ -226,7 +225,7 @@ export function replaceSearchFilterTypes(
 
 // For useURLSort hook.
 
-export const firstDiscoveredAtField = 'TODO';
+export const firstDiscoveredAtField = 'Cluster Discovered Time';
 
 export const sortFields = [nameField];
 export const defaultSortOption: SortOption = {


### PR DESCRIPTION
## Description

Follow up backend changes in #9837

### Changes

1. Edit src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
    * Add `useEffect` to call `fetchCloudSources` and instantiate `sourceNameMap` if user role has `'Integration'` resource.
2. Edit src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
    * Add `sourceNameMap` prop and replace `source.name` with `sourceNameMap.get(source.id) ?? 'Not available'`
    * Replace TODO with `nameField` and `firstDiscoveredAtField` as args in `getSortParams` function calls.
3. Edit src/services/DiscoveredClusterService.ts
    * Delete `name` property from `DiscoveredClusterCloudSource` type according to service proto:
        https://github.com/stackrox/stackrox/blob/master/proto/api/v1/discovered_cluster_service.proto#L68-L70
    * Replace TODO for `firstDiscoveredAtField` according to storage proto:
        https://github.com/stackrox/stackrox/blob/master/proto/storage/discovered_cluster.proto#L33

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_CLOUD_SOURCES=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 101 = 3948793 - 3948692
        total 498 = 10523957 - 10523459
    * `ls -al build/static/js/*.js | wc`
        files 0 = 92 - 92
3. `yarn start` in ui

### Manual testing

Sorting does not affect count request: GET /v1/count/discovered-clusters?

1. Visit /main/clusters/discovered-clusters
    * See absence of query string in page address
    * See GET /v1/cloud-sources
    * See GET /v1/discovered-clusters?pagination.limit=10&pagination.offset=0&pagination.sortOption.field=Cluster&pagination.sortOption.reversed=false

2. Click **Name** to sort in reverse.
    * See `?sortOption[field]=Cluster&sortOption[direction]=desc` query string in page address
    * See GET /v1/discovered-clusters?pagination.limit=10&pagination.offset=0&pagination.sortOption.field=Cluster&pagination.sortOption.reversed=true

3. Click **First discovered** to sort.
    * See `?sortOption[field]=Cluster%20Discovered%20Time&sortOption[direction]=desc` query string in page address
    * See GET /v1/discovered-clusters?pagination.limit=10&pagination.offset=0&pagination.sortOption.field=Cluster%20Discovered%20Time&pagination.sortOption.reversed=true

4. Click **First discovered** again to sort in reverse.
    * See `?sortOption[field]=Cluster%20Discovered%20Time&sortOption[direction]=asc` query string in page address
    * See GET /v1/discovered-clusters?pagination.limit=10&pagination.offset=0&pagination.sortOption.field=Cluster%20Discovered%20Time&pagination.sortOption.reversed=false