### PR TITLE
fix(scanner): Return not found when IRs are unsuccessful

### DIFF
--- a/scanner/config.yaml.sample
+++ b/scanner/config.yaml.sample
@@ -13,7 +13,7 @@ matcher:
   database:
     conn_string: "host=/var/run/postgresql"
     password_file: ""
-  vulnerability_url: https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/dev/vulns.json.zst
+  vulnerabilities_url: https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/dev/vulns.json.zst
 mtls:
   certs_dir: certs/scanner-v4
 log_level: info

--- a/scanner/services/common.go
+++ b/scanner/services/common.go
@@ -1,0 +1,25 @@
+package services
+
+import (
+	"context"
+
+	"github.com/quay/claircore"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/scanner/indexer"
+)
+
+// getClairIndexReport is a wrapper around indexer.GetIndexReport to return
+// errox.NotFound when the report does not exist or if it is not successful.
+func getClairIndexReport(ctx context.Context, indexer indexer.ReportGetter, hashID string) (*claircore.IndexReport, error) {
+	ir, found, err := indexer.GetIndexReport(ctx, hashID)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errox.NotFound.Newf("report %q not found", hashID)
+	}
+	if !ir.Success {
+		return nil, errox.NotFound.Newf("unsuccessful state %q: %s", ir.State, ir.Err)
+	}
+	return ir, nil
+}

--- a/scanner/services/indexer.go
+++ b/scanner/services/indexer.go
@@ -148,9 +148,6 @@ func (s *indexerService) HasIndexReport(ctx context.Context, req *v4.HasIndexRep
 		"hash_id", req.GetHashId(),
 	)
 	_, err := s.getClairIndexReport(ctx, req.GetHashId())
-	if err != nil {
-		return nil, err
-	}
 	var exists bool
 	switch {
 	case errors.Is(err, nil):

--- a/scanner/services/indexer_test.go
+++ b/scanner/services/indexer_test.go
@@ -230,7 +230,12 @@ func (s *indexerServiceTestSuite) Test_GetIndexReport() {
 			Return(&claircore.IndexReport{Success: true, State: "sample state"}, true, nil)
 		r, err := s.service.GetIndexReport(s.ctx, req)
 		s.NoError(err)
-		s.Equal(&v4.IndexReport{HashId: hashID, State: "sample state", Contents: &v4.Contents{}}, r)
+		s.Equal(&v4.IndexReport{
+			Success:  true,
+			HashId:   hashID,
+			State:    "sample state",
+			Contents: &v4.Contents{},
+		}, r)
 	})
 }
 
@@ -296,7 +301,7 @@ func (s *indexerServiceTestSuite) Test_HasIndexReport() {
 		s.Nil(r)
 	})
 
-	s.Run("when get index report returns an unsuccessful report then does not exist", func() {
+	s.Run("when index report is unsuccessful then does not exist", func() {
 		s.indexerMock.
 			EXPECT().
 			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
@@ -306,7 +311,7 @@ func (s *indexerServiceTestSuite) Test_HasIndexReport() {
 		s.False(r.GetExists())
 	})
 
-	s.Run("when get index report returns not found then does not exist", func() {
+	s.Run("when index report not found then does not exist", func() {
 		s.indexerMock.
 			EXPECT().
 			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).

--- a/scanner/services/matcher.go
+++ b/scanner/services/matcher.go
@@ -104,6 +104,9 @@ func (s *matcherService) retrieveIndexReport(ctx context.Context, hashID string)
 	if !found {
 		return nil, errox.NotFound.CausedBy(err)
 	}
+	if !ir.Success {
+		return nil, errox.NotFound.Newf("index report unsuccessful: %s: %s", ir.State, ir.Err)
+	}
 	return ir, nil
 }
 

--- a/scanner/services/matcher_test.go
+++ b/scanner/services/matcher_test.go
@@ -90,7 +90,7 @@ func (s *matcherServiceTestSuite) Test_matcherService_GetVulnerabilities_empty_c
 	}
 
 	s.Run("when empty content is enable and empty contents then retrieve index report", func() {
-		ir := &claircore.IndexReport{}
+		ir := &claircore.IndexReport{Success: true}
 		s.indexerMock.
 			EXPECT().
 			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).


### PR DESCRIPTION
## Description

Change Scanner APIs to return "not found" when the Index Reports in the DB are not successful.

This should allow re-scanning and avoid image scanning being blocked by failed IRs in the workflow such as `GetOrCreateIndexReport.` Also, `GetVulnerabilities` will correctly report "not found" instead of empty scans. 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

```
make build
./bin/scanner --conf config.yaml &
./bin/scannerctl --insecure-skip-tls-verify scan https://quay.io/quay-qetest/python3-test-image:latest | tee /tmp/r.json
```

This image has a permanent error that prevents it from being Indexed. Expect "not found" from the Matcher call, but successful `CreateIndex` calls. Inspect the logs to confirm.

Indexer:

```
{"level":"error","host":"descending","component":"scanner/service/indexer.GetIndexReport","hash_id":"/v4/containerimage/sha256:3afe1491c790a81c4ccb834349297e4edb7929d6c0572fae75a304d5db4841f3","error":"unsuccessful state \"IndexError\": failed to fetch layers: fetcher: encountered errors: error realizing layer sha256:1293406c9c3e109ba1752bc1fcdf9fc5d18281250c2a06309a9c1e322f51a6e7: fetcher: unexpected status code: 403 Forbidden (body starts: \"URL expired at Tue Jan 20 1970 18:18:29 GMT+0000 (Coordinated Universal Time)\")","time":"2024-02-09T14:59:36-08:00"}

...

{"level":"info","host":"descending","resource_type":"containerimage","hash_id":"/v4/containerimage/sha256:3afe1491c790a81c4ccb834349297e4edb7929d6c0572fae75a304d5db4841f3","component":"scanner/backend/indexer.IndexContainerImage","image_reference":"quay.io/quay-qetest/python3-test-image@sha256:3afe1491c790a81c4ccb834349297e4edb7929d6c0572fae75a304d5db4841f3","layers_count":63,"time":"2024-02-09T14:59:37-08:00","message":"retrieving layers to populate container image manifest"}
```

Matcher:

```
TODO
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
