### PR TITLE
fix(scanv4): Reduce flexibility in Scanner V4 config

### DIFF
--- a/image/templates/helm/shared/internal/scanner-v4-config-shape.yaml
+++ b/image/templates/helm/shared/internal/scanner-v4-config-shape.yaml
@@ -23,7 +23,6 @@ scannerV4:
       key: null # string
       generate: null # bool
   matcher:
-    disable: null # bool
     metricsPort: null # int
     logLevel: null # string
     image:

--- a/image/templates/helm/shared/internal/scanner-v4-config-shape.yaml
+++ b/image/templates/helm/shared/internal/scanner-v4-config-shape.yaml
@@ -1,6 +1,7 @@
 scannerV4:
   disable: null # bool
   indexer:
+    disable: null # bool
     metricsPort: null # int
     logLevel: null # string
     image:
@@ -22,6 +23,7 @@ scannerV4:
       key: null # string
       generate: null # bool
   matcher:
+    disable: null # bool
     metricsPort: null # int
     logLevel: null # string
     image:

--- a/image/templates/helm/shared/internal/scanner-v4-config-shape.yaml
+++ b/image/templates/helm/shared/internal/scanner-v4-config-shape.yaml
@@ -2,7 +2,6 @@ scannerV4:
   disable: null # bool
   indexer:
     metricsPort: null # int
-    disable: null # bool
     logLevel: null # string
     image:
       registry: null # string
@@ -24,7 +23,6 @@ scannerV4:
       generate: null # bool
   matcher:
     metricsPort: null # int
-    disable: null # bool
     logLevel: null # string
     image:
       registry: null # string

--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -44,12 +44,10 @@
     {{- $components = $componentsCentralChart -}}
   {{- else -}}
     {{- $components = $componentsSecuredClusterChart -}}
-    {{/* scannerV4.{indexer,matcher}.disable can be used to disable deployment of specific components. */}}
+    {{/* scannerV4.indexer.disable can be used to disable the deployment of indexer.
+         This is required for the operator use-case. */}}
     {{- if $scannerV4Cfg.indexer.disable -}}
       {{- $_ = set $components "indexer" false -}}
-    {{- end -}}
-    {{- if $scannerV4Cfg.indexer.matcher -}}
-      {{- $_ = set $components "matcher" false -}}
     {{- end -}}
   {{- end -}}
 

--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -44,8 +44,14 @@
     {{- $components = $componentsCentralChart -}}
   {{- else -}}
     {{- $components = $componentsSecuredClusterChart -}}
+    {{/* scannerV4.{indexer,matcher}.disable can be used to disable deployment of specific components. */}}
+    {{- if $scannerV4Cfg.indexer.disable -}}
+      {{- $_ = set $components "indexer" false -}}
+    {{- end -}}
+    {{- if $scannerV4Cfg.indexer.matcher -}}
+      {{- $_ = set $components "matcher" false -}}
+    {{- end -}}
   {{- end -}}
-
 
   {{/* Configure images, certificates and passwords as required. */}}
   {{ if get $components "indexer" }}
@@ -137,7 +143,6 @@
   {{ include "srox.safeLookup" (list $ $centralDeployment "apps/v1" "Deployment" $.Release.Namespace "central") }}
   {{ if $centralDeployment.result }}
     {{ include "srox.note" (list $ "Detected central running in the same namespace. Not deploying scanner-v4-indexer from this chart and configuring sensor to use existing scanner-v4-indexer instance, if any.") }}
-    {{ $_ := set $._rox.sensor.localImageScanning "enabled" "true" }}
     {{ $_ := set $components "indexer" false }}
   {{ end }}
 {{- end }}

--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -75,24 +75,21 @@
   {{ if get $components "matcher" }}
     {{/* This is only valid when rendering the central-services chart. */}}
     {{ include "srox.configureImage" (list $ $scannerV4Cfg.matcher.image) }}
-    {{- if eq $.Chart.Name "stackrox-central-services" -}}
-      {{/* Only generate certificate when installing central-services. */}}
-      {{- if kindIs "invalid" $._rox.scannerV4.matcher.serviceTLS.generate }}
-        {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
-        {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
-        {{- if $.Release.IsUpgrade -}}
-          {{- $lookupOut := dict -}}
-          {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-matcher-tls") -}}
-          {{- if not $lookupOut.result -}}
-            {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
-            {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
-            {{- $_ := set $._rox.scannerV4.matcher.serviceTLS "generate" true -}}
-          {{- end -}}
-        {{- end }}
+    {{- if kindIs "invalid" $._rox.scannerV4.matcher.serviceTLS.generate }}
+      {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
+      {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
+      {{- if $.Release.IsUpgrade -}}
+        {{- $lookupOut := dict -}}
+        {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-matcher-tls") -}}
+        {{- if not $lookupOut.result -}}
+          {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
+          {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
+          {{- $_ := set $._rox.scannerV4.matcher.serviceTLS "generate" true -}}
+        {{- end -}}
       {{- end }}
-      {{ $cryptoSpec := dict "CN" "SCANNER_V4_MATCHER_SERVICE: Scanner V4 Matcher" "dnsBase" "scanner-v4-matcher" }}
-      {{ include "srox.configureCrypto" (list $ "scannerV4.matcher.serviceTLS" $cryptoSpec) }}
-    {{- end -}}
+    {{- end }}
+    {{ $cryptoSpec := dict "CN" "SCANNER_V4_MATCHER_SERVICE: Scanner V4 Matcher" "dnsBase" "scanner-v4-matcher" }}
+    {{ include "srox.configureCrypto" (list $ "scannerV4.matcher.serviceTLS" $cryptoSpec) }}
   {{ end }}
 
   {{ if or (get $components "indexer") (get $components "matcher") }}

--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -48,8 +48,9 @@
 
 
   {{/* Configure images, certificates and passwords as required. */}}
-  {{/* Note that for secured-cluster-services we don't configure certificates here, instead they will be distributed at runtime by Sensor and Central. */}}
   {{ if get $components "indexer" }}
+    {{/* Note that for secured-cluster-services we don't configure certificates here,
+         instead they will be distributed at runtime by Sensor and Central. */}}
     {{ include "srox.configureImage" (list $ $scannerV4Cfg.indexer.image) }}
     {{- if eq $.Chart.Name "stackrox-central-services" -}}
       {{/* Only generate certificate when installing central-services. */}}
@@ -72,6 +73,7 @@
   {{ end }}
 
   {{ if get $components "matcher" }}
+    {{/* This is only valid when rendering the central-services chart. */}}
     {{ include "srox.configureImage" (list $ $scannerV4Cfg.matcher.image) }}
     {{- if eq $.Chart.Name "stackrox-central-services" -}}
       {{/* Only generate certificate when installing central-services. */}}

--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -49,11 +49,11 @@
 
   {{/* Configure images, certificates and passwords as required. */}}
   {{ if get $components "indexer" }}
-    {{/* Note that for secured-cluster-services we don't configure certificates here,
-         instead they will be distributed at runtime by Sensor and Central. */}}
     {{ include "srox.configureImage" (list $ $scannerV4Cfg.indexer.image) }}
     {{- if eq $.Chart.Name "stackrox-central-services" -}}
-      {{/* Only generate certificate when installing central-services. */}}
+      {{/* Only generate certificate when installing central-services.
+           For secured-cluster-services we don't configure certificates here,
+           instead they will be distributed at runtime by Sensor and Central. */}}
       {{- if kindIs "invalid" $._rox.scannerV4.indexer.serviceTLS.generate }}
         {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
         {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}

--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -24,150 +24,112 @@
 {{ $scannerV4Cfg := index . 1 }}
 {{ $_ := false }}
 
-{{ $componentsCentralChart := dict "indexer" true "matcher" true }}
-{{ $componentsSecuredClusterChart := dict "indexer" true "matcher" false }}
-
-
-{{/* These will be propagated up. */}}
-{{ $components := dict "indexer" false "matcher" false }}
-{{ $dbEnabled  := false }}
-
-{{/* Handle high-level defaulting logic. */}}
-{{- if not $scannerV4Cfg.disable }}
-
 {{/* Sanity check. */}}
 {{- if not (or (eq $.Chart.Name "stackrox-central-services") (eq $.Chart.Name "stackrox-secured-cluster-services")) -}}
   {{- include "srox.fail" (printf "Unexpected Helm chart name %q." $.Chart.Name) -}}
 {{- end -}}
 
-{{- if and (kindIs "invalid" $scannerV4Cfg.indexer.disable) (kindIs "invalid" $scannerV4Cfg.matcher.disable) -}}
+{{ $componentsCentralChart := dict "indexer" true "matcher" true }}
+{{ $componentsSecuredClusterChart := dict "indexer" true "matcher" false }}
 
-  {{/* Both settings scannerV4.indexer.disable and scannerV4.matcher.disable are not set by the user
-       => Pick default configuration based on the chart. */}}
+{{/* These will be propagated up. */}}
+{{ $components := dict "indexer" false "matcher" false }}
+{{ $dbEnabled  := false }}
+
+{{- if not $scannerV4Cfg.disable }}
+  {{/* Scanner V4 is switched on. */}}
+
+  {{/* Scanner V4 component configuration depends on the chart. */}}
   {{- if eq $.Chart.Name "stackrox-central-services" -}}
     {{- $components = $componentsCentralChart -}}
   {{- else -}}
     {{- $components = $componentsSecuredClusterChart -}}
   {{- end -}}
 
-{{- else -}}
 
-  {{/* The user has explicitly set either scannerV4.indexer.disable and/or scannerV4.matcher.disable.
-       Therefore, we use this explicitly set configuration. */}}
-  {{- if not (kindIs "invalid" $scannerV4Cfg.indexer.disable) -}}
-    {{- $_ = set $components "indexer" (not $scannerV4Cfg.indexer.disable) -}}
-  {{- end -}}
-  {{- if not (kindIs "invalid" $scannerV4Cfg.matcher.disable) -}}
-    {{- $_ = set $components "matcher" (not $scannerV4Cfg.matcher.disable) -}}
-  {{- end -}}
-
-  {{/* This is potentially an unsupported configuration. Hence we generate a warning. */}}
-  {{- $msg := printf "indexer is %s and matcher is %s." (ternary "enabled" "disabled" (get $components "indexer")) (ternary "enabled" "disabled" (get $components "matcher")) -}}
-  {{- if eq $.Chart.Name "stackrox-central-services" -}}
-    {{- if or (ne (get $components "indexer") (get $componentsCentralChart "indexer")) (ne (get $components "matcher") (get $componentsCentralChart "matcher")) -}}
-      {{- include "srox.warn" (list $ (printf "Unsupported Scanner V4 configuration detected: %s" $msg)) -}}
+  {{/* Configure images, certificates and passwords as required. */}}
+  {{/* Note that for secured-cluster-services we don't configure certificates here, instead they will be distributed at runtime by Sensor and Central. */}}
+  {{ if get $components "indexer" }}
+    {{ include "srox.configureImage" (list $ $scannerV4Cfg.indexer.image) }}
+    {{- if eq $.Chart.Name "stackrox-central-services" -}}
+      {{/* Only generate certificate when installing central-services. */}}
+      {{- if kindIs "invalid" $._rox.scannerV4.indexer.serviceTLS.generate }}
+        {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
+        {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
+        {{- if $.Release.IsUpgrade -}}
+          {{- $lookupOut := dict -}}
+          {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-indexer-tls") -}}
+          {{- if not $lookupOut.result -}}
+            {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
+            {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
+            {{- $_ := set $._rox.scannerV4.indexer.serviceTLS "generate" true -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end }}
+      {{ $cryptoSpec := dict "CN" "SCANNER_V4_INDEXER_SERVICE: Scanner V4 Indexer" "dnsBase" "scanner-v4-indexer" }}
+      {{ include "srox.configureCrypto" (list $ "scannerV4.indexer.serviceTLS" $cryptoSpec) }}
     {{- end -}}
-  {{- else -}}
-    {{- if or (ne (get $components "indexer") (get $componentsSecuredClusterChart "indexer")) (ne (get $components "matcher") (get $componentsSecuredClusterChart "matcher")) -}}
-      {{- include "srox.warn" (list $ (printf "Unsupported Scanner V4 configuration detected: %s" $msg)) -}}
+  {{ end }}
+
+  {{ if get $components "matcher" }}
+    {{ include "srox.configureImage" (list $ $scannerV4Cfg.matcher.image) }}
+    {{- if eq $.Chart.Name "stackrox-central-services" -}}
+      {{/* Only generate certificate when installing central-services. */}}
+      {{- if kindIs "invalid" $._rox.scannerV4.matcher.serviceTLS.generate }}
+        {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
+        {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
+        {{- if $.Release.IsUpgrade -}}
+          {{- $lookupOut := dict -}}
+          {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-matcher-tls") -}}
+          {{- if not $lookupOut.result -}}
+            {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
+            {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
+            {{- $_ := set $._rox.scannerV4.matcher.serviceTLS "generate" true -}}
+          {{- end -}}
+        {{- end }}
+      {{- end }}
+      {{ $cryptoSpec := dict "CN" "SCANNER_V4_MATCHER_SERVICE: Scanner V4 Matcher" "dnsBase" "scanner-v4-matcher" }}
+      {{ include "srox.configureCrypto" (list $ "scannerV4.matcher.serviceTLS" $cryptoSpec) }}
     {{- end -}}
-  {{- end -}}
+  {{ end }}
 
-{{- end -}}
-
-{{/* Configure images, certificates and passwords as required. */}}
-{{/* Note that for secured-cluster-services we don't configure certificates here, instead they will be distributed at runtime by Sensor and Central. */}}
-{{ if get $components "indexer" }}
-  {{ include "srox.configureImage" (list $ $scannerV4Cfg.indexer.image) }}
-  {{- if eq $.Chart.Name "stackrox-central-services" -}}
-    {{/* Only generate certificate when installing central-services. */}}
-    {{- if kindIs "invalid" $._rox.scannerV4.indexer.serviceTLS.generate }}
+  {{ if or (get $components "indexer") (get $components "matcher") }}
+    {{- if kindIs "invalid" $._rox.scannerV4.db.serviceTLS.generate }}
       {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
       {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
       {{- if $.Release.IsUpgrade -}}
         {{- $lookupOut := dict -}}
-        {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-indexer-tls") -}}
+        {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-db-tls") -}}
         {{- if not $lookupOut.result -}}
           {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
           {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
-          {{- $_ := set $._rox.scannerV4.indexer.serviceTLS "generate" true -}}
+          {{- $_ := set $._rox.scannerV4.db.serviceTLS "generate" true -}}
         {{- end -}}
       {{- end -}}
     {{- end }}
-    {{ $cryptoSpec := dict "CN" "SCANNER_V4_INDEXER_SERVICE: Scanner V4 Indexer" "dnsBase" "scanner-v4-indexer" }}
-    {{ include "srox.configureCrypto" (list $ "scannerV4.indexer.serviceTLS" $cryptoSpec) }}
-  {{- end -}}
-{{ end }}
-
-{{ if get $components "matcher" }}
-  {{ include "srox.configureImage" (list $ $scannerV4Cfg.matcher.image) }}
-  {{- if eq $.Chart.Name "stackrox-central-services" -}}
-    {{/* Only generate certificate when installing central-services. */}}
-    {{- if kindIs "invalid" $._rox.scannerV4.matcher.serviceTLS.generate }}
+    {{- if kindIs "invalid" $._rox.scannerV4.db.password.generate }}
       {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
       {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
-      {{- if $.Release.IsUpgrade -}}
-        {{- $lookupOut := dict -}}
-        {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-matcher-tls") -}}
-        {{- if not $lookupOut.result -}}
-          {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
-          {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
-          {{- $_ := set $._rox.scannerV4.matcher.serviceTLS "generate" true -}}
-        {{- end -}}
-      {{- end }}
-    {{- end }}
-    {{ $cryptoSpec := dict "CN" "SCANNER_V4_MATCHER_SERVICE: Scanner V4 Matcher" "dnsBase" "scanner-v4-matcher" }}
-    {{ include "srox.configureCrypto" (list $ "scannerV4.matcher.serviceTLS" $cryptoSpec) }}
-  {{- end -}}
-{{ end }}
-
-{{ if or (get $components "indexer") (get $components "matcher") }}
-  {{- if kindIs "invalid" $._rox.scannerV4.db.serviceTLS.generate }}
-    {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
-    {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
-    {{- if $.Release.IsUpgrade -}}
       {{- $lookupOut := dict -}}
-      {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-db-tls") -}}
+      {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-db-password") -}}
       {{- if not $lookupOut.result -}}
         {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
         {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
-        {{- $_ := set $._rox.scannerV4.db.serviceTLS "generate" true -}}
+        {{- $_ := set $._rox.scannerV4.db.password "generate" true -}}
       {{- end -}}
+    {{- end }}
+
+    {{ include "srox.configureImage" (list $ $scannerV4Cfg.db.image) }}
+    {{ include "srox.configurePassword" (list $ "scannerV4.db.password") }}
+
+    {{- if eq $.Chart.Name "stackrox-central-services" -}}
+      {{/* Only generate certificate when installing central-services. */}}
+      {{ $cryptoSpec := dict "CN" "SCANNER_V4_DB_SERVICE: Scanner V4 DB" "dnsBase" "scanner-v4-db" }}
+      {{ include "srox.configureCrypto" (list $ "scannerV4.db.serviceTLS" $cryptoSpec) }}
     {{- end -}}
-  {{- end }}
-  {{- if kindIs "invalid" $._rox.scannerV4.db.password.generate }}
-    {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
-    {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
-    {{- $lookupOut := dict -}}
-    {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-db-password") -}}
-    {{- if not $lookupOut.result -}}
-      {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
-      {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
-      {{- $_ := set $._rox.scannerV4.db.password "generate" true -}}
-    {{- end -}}
-  {{- end }}
+  {{ end }}
 
-  {{ include "srox.configureImage" (list $ $scannerV4Cfg.db.image) }}
-  {{ include "srox.configurePassword" (list $ "scannerV4.db.password") }}
-
-  {{- if eq $.Chart.Name "stackrox-central-services" -}}
-    {{/* Only generate certificate when installing central-services. */}}
-    {{ $cryptoSpec := dict "CN" "SCANNER_V4_DB_SERVICE: Scanner V4 DB" "dnsBase" "scanner-v4-db" }}
-    {{ include "srox.configureCrypto" (list $ "scannerV4.db.serviceTLS" $cryptoSpec) }}
-  {{- end -}}
-{{ end }}
-
-{{- else -}}
-
-  {{/* High-level scannerV4.disable is true. */}}
-  {{- if and (not (kindIs "invalid" $scannerV4Cfg.indexer.disable)) (not $scannerV4Cfg.indexer.disable) -}}
-    {{- include "srox.fail" (printf "scannerV4.disable=false required to deploy Scanner V4 indexer.") -}}
-  {{- end -}}
-  {{- if and (not (kindIs "invalid" $scannerV4Cfg.matcher.disable)) (not $scannerV4Cfg.matcher.disable) -}}
-    {{- include "srox.fail" (printf "scannerV4.disable=false required to deploy Scanner V4 matcher.") -}}
-  {{- end -}}
-
-{{- end -}}
+{{- end -}} {{/* if not $scannerV4Cfg.disable */}}
 
 {{- if eq $.Chart.Name "stackrox-secured-cluster-services" -}}
   {{/* Special handling for the secured-cluster-services chart in case it gets deployed
@@ -178,12 +140,10 @@
     {{ include "srox.note" (list $ "Detected central running in the same namespace. Not deploying scanner-v4-indexer from this chart and configuring sensor to use existing scanner-v4-indexer instance, if any.") }}
     {{ $_ := set $._rox.sensor.localImageScanning "enabled" "true" }}
     {{ $_ := set $components "indexer" false }}
-    {{/* Matcher on secured-cluster is unsupported, but just in case make sure it is disabled. */}}
-    {{ $_ := set $components "matcher" false }}
   {{ end }}
 {{- end }}
 
-{{/* Propagate information about Scanner V4 setup. */}}
+{{/* Propagate information about which Scanner V4 components to deploy. */}}
 {{- $_ := set $._rox "_scannerV4Enabled" (not $scannerV4Cfg.disable) -}}
 {{- $_ := set $._rox.scannerV4 "_indexerEnabled" (get $components "indexer") -}}
 {{- $_ := set $._rox.scannerV4 "_matcherEnabled" (get $components "matcher") -}}
@@ -193,13 +153,20 @@
 
 {{/* Provide some human-readable feedback regarding the Scanner V4 configuration to the user installing the Helm chart. */}}
 {{- if and (get $components "indexer") (not (get $components "matcher")) -}}
-  {{- $_ = set $._rox.scannerV4 "_installMode" "indexer-only" -}}
+  {{- $_ = set $._rox.scannerV4 "_installMode" "indexer" -}}
 {{- else if and (not (get $components "indexer")) (get $components "matcher") -}}
-  {{- $_ = set $._rox.scannerV4 "_installMode" "matcher-only" -}}
+  {{/* Just here for completeness, not allowed currently. */}}
+  {{- $_ = set $._rox.scannerV4 "_installMode" "matcher" -}}
 {{- else if and (get $components "indexer") (get $components "matcher") -}}
-  {{- $_ = set $._rox.scannerV4 "_installMode" "indexer-and-matcher" -}}
+  {{- $_ = set $._rox.scannerV4 "_installMode" "indexer and matcher" -}}
 {{- else -}}
-  {{- $_ = set $._rox.scannerV4 "_installMode" "none" -}}
+  {{- $_ = set $._rox.scannerV4 "_installMode" "" -}}
 {{- end -}}
+
+{{- if eq $._rox.scannerV4._installMode "" }}
+  {{ include "srox.note" (list $ (printf "Scanner V4 is enabled and Scanner V4 components are already deployed.")) }}
+{{- else }}
+  {{ include "srox.note" (list $ (printf "Scanner V4 is enabled and the following Scanner V4 components will be deployed: %s" $._rox.scannerV4._installMode)) }}
+{{- end }}
 
 {{- end -}}

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -167,6 +167,7 @@ defaults:
   scannerV4:
     disable: true
     indexer:
+      disable: false
       logLevel: INFO
       metricsPort: 9090
       replicas: 3

--- a/image/templates/helm/stackrox-central/templates/NOTES.txt.htpl
+++ b/image/templates/helm/stackrox-central/templates/NOTES.txt.htpl
@@ -11,8 +11,8 @@ Central Services Configuration Summary:
   Helm Release Name:                           {{ .Release.Name }}
   OpenShift Cluster:                           {{ if eq ._rox.env.openshift 0 -}} false {{ else -}} {{ ._rox.env.openshift }} {{ end }}
 [<- if .FeatureFlags.ROX_SCANNER_V4_SUPPORT >]
-  Scanner V4 Installation Method:              {{ ._rox.scannerV4._installMode }}
-{{- if ._rox._scannerV4Volume }}
+  Scanner V4:                                  {{ if ._rox._scannerV4Enabled -}} enabled {{- else -}} disabled {{- end }}
+{{- if and ._rox._scannerV4Enabled ._rox._scannerV4Volume }}
   Scanner V4 DB Volume:                        {{ ._rox._scannerV4Volume }}
 {{- end }}
 [<- end >]

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/70-scanner-v4.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/70-scanner-v4.yaml.htpl
@@ -3,6 +3,7 @@ scannerV4:
   [</* On secured-clusters local scanners (irregardless of the version) require explicit activation. */>]
   disable: true
   indexer:
+    disable: false
     replicas: 2
     logLevel: INFO
     autoscaling:

--- a/image/templates/helm/stackrox-secured-cluster/templates/NOTES.txt.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/NOTES.txt.htpl
@@ -13,8 +13,8 @@ Secured Cluster Configuration Summary:
   Admission Control Webhooks deployed:         {{ or ._rox.admissionControl.dynamic.listenOnCreates ._rox.admissionControl.dynamic.listenOnUpdates ._rox.admissionControl.dynamic.listenOnEvents}}
   Admission Control Creates/Updates enforced:  {{ or ._rox.admissionControl.dynamic.enforceOnCreates ._rox.admissionControl.dynamic.enforceOnUpdates }}
 [<- if .FeatureFlags.ROX_SCANNER_V4_SUPPORT >]
-  Scanner V4 Installation Method:              {{ ._rox.scannerV4._installMode }}
-{{- if ._rox._scannerV4Volume }}
+  Scanner V4:                                  {{ if ._rox._scannerV4Enabled -}} enabled {{- else -}} disabled {{- end }}
+{{- if and ._rox._scannerV4Enabled ._rox._scannerV4Volume }}
   Scanner V4 DB Volume:                        {{ ._rox._scannerV4Volume }}
 {{- end }}
 [<- end >]

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -251,7 +251,6 @@
   {{ include "srox.safeLookup" (list $ $centralDeployment "apps/v1" "Deployment" $.Release.Namespace "central") }}
   {{ if $centralDeployment.result }}
     {{ include "srox.note" (list $ "Detected central running in the same namespace. Not deploying scanner from this chart and configuring sensor to use existing scanner instance, if any.") }}
-    {{ $_ := set $._rox.sensor.localImageScanning "enabled" "true" }}
     {{ $_ := set $._rox.scanner "disable" true }}
   {{ end }}
 
@@ -298,7 +297,6 @@ already activated, we let `scanner.disable: false` have the implicit side-effect
 {{ end }}
 
 {{ if ._rox.scannerV4._indexerEnabled }}
-  {{ $_ := set $._rox.sensor.localImageScanning "enabled" "true" }}
 [</* Due to historical reasons the image specifications for the secured-cluster-services chart
      are not found under <component-name>.image, but instead under image.<image identifier>.
      Since the image setup code in srox.scannerV4Init configures scannerV4.<scanner V4 component name>

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -47,17 +47,6 @@ tests:
       | .volumes[] | select(.name == "additional-ca-volume")
       | .secret.secretName
       | assertThat(. == "additional-ca")
-- name: "rendering fails if scannerV4 is disabled but"
-  expectError: true
-  set:
-    scannerV4.disable: true
-  tests:
-    - name: "indexer is enabled"
-      set:
-        scannerV4.indexer.disable: false
-    - name: "matcher is enabled"
-      set:
-        scannerV4.matcher.disable: false
 - name: "StorageClass stackrox-gke-ssd is created when scannerV4 references this storage class in its PVC configuration"
   values:
     scannerV4:
@@ -93,26 +82,13 @@ tests:
     set:
       scannerV4.disable: true
     expect: |
-      .notes | assertThat(match("Scanner V4 Installation Method: +none"))
+      .notes | assertThat(match("Scanner V4: +disabled"))
   - name: "when installing indexer and matcher"
     set:
       scannerV4.disable: false
     expect: |
-      .notes | assertThat(match("Scanner V4 Installation Method: +indexer-and-matcher"))
-  - name: "when installing only indexer"
-    set:
-      scannerV4.disable: false
-      scannerV4.indexer.disable: false
-      scannerV4.matcher.disable: true
-    expect: |
-      .notes | assertThat(match("Scanner V4 Installation Method: +indexer-only"))
-  - name: "when installing only matcher"
-    set:
-      scannerV4.disable: false
-      scannerV4.indexer.disable: true
-      scannerV4.matcher.disable: false
-    expect: |
-      .notes | assertThat(match("Scanner V4 Installation Method: +matcher-only"))
+      .notes | assertThat(match("Scanner V4: +enabled"))
+      .notes | assertThat(match("Scanner V4 is enabled and the following Scanner V4 components will be deployed: indexer and matcher"))
 # This test can be deleted once the scanner V2 is removed.
 - name: "enabling scanner V4 keeps scanner V2 enabled"
   set:
@@ -177,27 +153,6 @@ tests:
     .podsecuritypolicys["stackrox-scanner-v4"] | assertThat(. != null)
     .rolebindings["stackrox-scanner-v4-psp"] | assertThat(. != null)
     .clusterroles["stackrox-scanner-v4-psp"] | assertThat(. != null)
-
-- name: "Warning is emitted if"
-  tests:
-    - name: "indexer is enabled and matcher is disabled"
-      values:
-        scannerV4:
-          disable: false
-          indexer:
-            disable: false
-          matcher:
-            disable: true
-    - name: "indexer is disabled and matcher is enabled"
-      values:
-        scannerV4:
-          disable: false
-          indexer:
-            disable: true
-          matcher:
-            disable: false
-  expect:
-    .notes | assertThat(contains("Unsupported Scanner V4 configuration detected"))
 
 - name: "scanner v4 DB uses expected default configuration"
   values:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -23,6 +23,7 @@ tests:
 - name: "scanner v4 with default settings with indexer enabled"
   set:
     imagePullSecrets.allowNone: true
+    scanner.disable: false
     scannerV4.disable: false
   expect: |
     container(.deployments["scanner-v4-indexer"]; "indexer") | assertThat (. != null)
@@ -154,21 +155,37 @@ tests:
         .serviceaccounts["scanner-v4"] | saOnlyRefersTo([
           "secured-cluster-services-main", "stackrox", "stackrox-scanner-v4", "existing-secret1", "existing-secret2"])
 
-- name: "sensor only connects to local scanner V4 when it is enabled"
+- name: "local scanning is"
   set:
     imagePullSecrets.allowNone: true
   tests:
-  - name: "local scanner enabled"
-    set:
-      scannerV4.disable: false
+  - name: "enabled"
     expect: |
       envVars(.deployments.sensor; "sensor")["ROX_LOCAL_IMAGE_SCANNING_ENABLED"] | assertThat(. == "true")
-  - name: "local scanner disabled"
-    set:
-      scannerV4.disable: true
+    tests:
+    - name: "if only StackRox Scanner is enabled"
+      set:
+        scanner.disable: false
+        scannerV4.disable: true
+    - name: "if both scanners are enabled"
+      set:
+        scanner.disable: false
+        scannerV4.disable: false
+    - name: "if localImageScanningScanner is enabled"
+      set:
+        sensor.localImageScanning.enabled: true
+  - name: "disabled"
     expect: |
-      envVars(.deployments.sensor; "sensor")| assertThat(has("ROX_LOCAL_IMAGE_SCANNING_ENABLED") == false)
-
+      envVars(.deployments.sensor; "sensor")["ROX_LOCAL_IMAGE_SCANNING_ENABLED"] | assertThat(. != "true")
+    tests:
+    - name: "if both scanners are disabled"
+      set:
+        scanner.disable: true
+        scannerV4.disable: true
+    - name: "if StackRox Scanner is disabled and Scanner V4 is enabled"
+      set:
+        scanner.disable: true
+        scannerV4.disable: false
 - name: "sensor connects to local scanner using the correct gRPC endpoint"
   release:
     namespace: custom-ns


### PR DESCRIPTION
## Description

[ROX-22542](https://issues.redhat.com/browse/ROX-22542)

Sorry to iterate on this, but...

Let me begin with the status quo: Currently there are three Scanner V4 related `disable` toggles: `scannerV4.disable`, `scannerV4.indexer.disable` and `scannerV4.matcher.disable`. Initially, when Scanner V4 has been integrated into the Helm charts, we (or, I?) thought it might be a good idea to enable the use of all three such toggles with the following semantics:

* The primary switch that should be primarily relevant to users is `scannerV4.disable`, it should cause the Helm chart to pick the right selection of Scanner V4 components to be deployed. On central side that is indexer *and* matcher. On secured-cluster side that is only indexer and now matcher..

* The idea was that even though these defaults are selected the user could additionally modify this selection using `scannerV4.indexer.disable` and `scannerV4.matcher.disable`.

With this PR I would like to challenge this decision, for multiple reasons:

* For the initial rollout of Scanner V4 we are dealing with additional complexity and I think we should attempt to contain that complexity as much as possible. This would imply defining the supported Scanner V4 setup configurations (see above) and not providing any tools for customers to enter unsupported terrain (which we have not tested at all, I believe).

There are essentially two deployment scenarios which these switches could enable, which are:

1. deploying only indexer and no matcher on central-side
2. deploying matcher on secured-cluster side

Regarding 1: I don't know if that would make sense. Would it even work? (I've learned that this is completely untested and unlikely to produce anything besides errors.)
Regarding 2: This wouldn't even work, because there is no support built in for issuing local scanner certificates for matcher. So that would spin up an unhealthy deployment.

On additional note: Why is this PR labelled as a "fix"? Because the feature this PR intends to remove wasn't even working correctly (test coverage was also incomplete).

Hence, my proposal is to simply get rid of it and thereby define very precisely how Scanner V4 components are intended to be deployed.

@dcaravel and @RTann: If you agree with these changes conceptually, then I can also add somebody from Draco as reviewer, since this is essentially just Helm templating.

**Update from February 14:**

@vladbologa analyzed a bug (ROX-22479) causing Scanner V4 not being activated (i.e. `ROX_SCANNER_V4=true` not being added to sensor's environment) on a secured cluster under certain circumstances. This was only affecting secured-clusters. Essentially, the operator was lacking a way to instruct the Helm chart to activate Scanner V4 without deploying Scanner V4 components in the local scanner mode. For Scanner V2 the semantics of `scanner.disable` were somewhat different from the `scannerV4.disable` semantics -- together with a setting `localImageScanning.enable` that was introduced back when the local image scanning was initially implemented, this was sufficient for the operator to convey the "use local image scanning, but don't deploy" (in case we are deploying into the same namespace as central) scenario. For Scanner V4 there was the subtle issue that we were lacking a way to express this. (Remember: auto-sensing within the Helm chart is disabled when rendered by the operator). **Long story short:** For enabling this use-case properly I have added two commits to this which reintroduce the setting `scannerV4.indexer.disable`, which can *only* be used switching the deployment of indexer off and only for secured-clusters. So, the overall simplification of this PR is still valid. Conceptually we still taken away a substantial amount of configurability from the user. It still remains impossible to deploy matcher on secured-clusters and it still remains impossible to deploy only a subset of the scanner V4 components on central.

@vladbologa has been able to verify that this feature allows fixing the aforementioned bug.

## Review Recommendations

Filter out whitespaces changes, since I have improved the indentation in the Helm templating code.

Please simply resolve my own code comments -- they are just meant to be helpful during the reviewing.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~~Unit test and regression tests added~~ (well, tests were removed).
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes~~

## Testing Performed

Manual + CI.

