### PR TITLE
ROX-21981: Support v4 offline bundle in Central

### DIFF
--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -289,9 +289,10 @@ func (h *httpHandler) handleZipContentsFromVulnDump(ctx context.Context, zipPath
 	}
 	defer utils.IgnoreError(zipR.Close)
 	var count int
-	// It is expected a ZIP file be uploaded with a ZIP of Scanner's vulnerability definitions.
-	// Currently, this is the only desired file. In the future, we may decide to
-	// support other files (like we have in the past), which is why we
+	// It is expected a ZIP file be uploaded with both Scanner V2 and V4 vulnerability definitions.
+	// scanner-defs.zip contains data required by Scanner V2.
+	// scanner-v4-defs-*.zip contains data required by Scanner v4.
+	// In the future, we may decide to support other files (like we have in the past), which is why we
 	// expect this ZIP of a single ZIP.
 	for _, zipF := range zipR.File {
 		if zipF.Name == scannerDefsSubZipName {

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -257,34 +257,3 @@ func (s *handlerTestSuite) mustWriteOffline(content string, modTime time.Time) {
 	}
 	s.Require().NoError(s.datastore.Upsert(s.ctx, blob, bytes.NewBuffer([]byte(content))))
 }
-
-func (s *handlerTestSuite) TestCompareOfflineFileVersion() {
-	t := s.T()
-	var err error
-	tempFile, err = os.CreateTemp("", "manifest-*.json")
-	if err != nil {
-		t.Fatalf("Failed to create temp file: %v", err)
-	}
-	defer os.Remove(tempFile.Name())
-
-	jsonContent := `{
-		"version": "4.2",
-		"created": "2024-02-13T15:01:47+00:00"
-	}`
-	_, err = tempFile.WriteString(jsonContent)
-	s.Require().NoError(err)
-
-	err = tempFile.Close()
-	s.Require().NoError(err)
-
-	file, err := os.Open(tempFile.Name())
-	s.Require().NoError(err)
-	defer utils.IgnoreError(file.Close)
-
-	version := "4.2.x-nightly"
-	expectedResult := true
-	result, err := compareOfflineFileVersion(file, versionToCompare)
-	if err != nil || result != expectedResult {
-		t.Errorf("compareOfflineFileVersion(%q) = %t, %v; want %t, <nil>", versionToCompare, result, err, expectedResult)
-	}
-}

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -3,9 +3,12 @@
 package handler
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -256,4 +259,68 @@ func (s *handlerTestSuite) mustWriteOffline(content string, modTime time.Time) {
 		LastUpdated:  types.TimestampNow(),
 	}
 	s.Require().NoError(s.datastore.Upsert(s.ctx, blob, bytes.NewBuffer([]byte(content))))
+}
+
+func (s *handlerTestSuite) TestServeHTTP_v4_Offline_Get() {
+	t := s.T()
+	t.Setenv(env.OfflineModeEnv.EnvVar(), "true")
+	h := New(s.datastore, handlerOpts{})
+	w := mock.NewResponseWriter()
+
+	// No scanner defs found.
+	req := s.getRequestWithVersionedFile(t, "4.3.0")
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	// Try download offline zip, only abort test when download fails
+	tempDir := t.TempDir()
+	filePath := tempDir + "/test.zip"
+
+	url := "https://storage.googleapis.com/scanner-support-public/offline/v1/4.3/scanner-vulns-4.3.zip"
+	resp, err := http.Get(url)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return
+	}
+
+	outFile, err := os.Create(filePath)
+	s.Require().NoError(err)
+
+	_, err = io.Copy(outFile, resp.Body)
+	s.Require().NoError(err)
+	utils.IgnoreError(outFile.Close)
+
+	err = s.mockHandleZipContents(filePath)
+	s.Require().NoError(err)
+}
+
+func (s *handlerTestSuite) mockHandleDefsFile(zipF *zip.File, blobName string) error {
+	r, err := zipF.Open()
+	s.Require().NoError(err)
+	defer utils.IgnoreError(r.Close)
+
+	b := &storage.Blob{
+		Name:         blobName,
+		LastUpdated:  types.TimestampNow(),
+		ModifiedTime: types.TimestampNow(),
+		Length:       zipF.FileInfo().Size(),
+	}
+
+	return s.datastore.Upsert(s.ctx, b, r)
+}
+
+func (s *handlerTestSuite) mockHandleZipContents(zipPath string) error {
+	zipR, err := zip.OpenReader(zipPath)
+	s.Require().NoError(err)
+	defer utils.IgnoreError(zipR.Close)
+	for _, zipF := range zipR.File {
+		if strings.HasPrefix(zipF.Name, scannerV4DefsPrefix) {
+			err = s.mockHandleDefsFile(zipF, "testBlob")
+			s.Require().NoError(err)
+			return nil
+		}
+	}
+	return errors.New("test failed")
 }

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -300,6 +300,7 @@ func (s *handlerTestSuite) TestServeHTTP_v4_Offline_Get() {
 	req = s.getRequestWithVersionedFile(t, "4.3.0")
 	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/zstd", w.Header().Get("Content-Type"))
 }
 
 func (s *handlerTestSuite) mockHandleDefsFile(zipF *zip.File, blobName string) error {


### PR DESCRIPTION
## Description
Update scanner definitions handler to support v4 vuln bundle file

1. Support scanner-v4-defs upload via POST
2. Support reading scanner-v4-defs while scanner request for vuln file

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Test scanner-vlun-updates.zip

0. Deploy
`export OFFLINE_MODE=true`
use this PR's image
run deploy-local.sh

1. 

```
unzip -l scanner-vuln-updates.zip
Archive:  scanner-vuln-updates.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
140154404  02-14-2024 11:41   scanner-defs.zip
   248088  02-14-2024 11:41   k8s-istio.zip
144211510  02-14-2024 11:41   scanner-v4-defs-4.3.zip
---------                     -------
284614002                     3 files
```

2. Upload
`curl --insecure -u admin:[PWD] -F "file=@scanner-vuln-updates.zip" https://localhost:8000/api/extensions/scannerdefinitions -v`

```
...
* Server auth using Basic with user 'admin'
* [HTTP/2] [1] OPENED stream for https://localhost:8000/api/extensions/scannerdefinitions
* [HTTP/2] [1] [:method: POST]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: localhost:8000]
* [HTTP/2] [1] [:path: /api/extensions/scannerdefinitions]
* [HTTP/2] [1] [authorization: Basic YWRtaW46NTg5SFBMSWhrd0x3dFkwZ1JzRGw2U2hXNA==]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
* [HTTP/2] [1] [content-length: 284614740]
* [HTTP/2] [1] [content-type: multipart/form-data; boundary=------------------------B5fhya2XGEQJZxIurZ7LB5]
> POST /api/extensions/scannerdefinitions HTTP/2
> Host: localhost:8000
> Authorization: Basic YWRtaW46NTg5SFBMSWhrd0x3dFkwZ1JzRGw2U2hXNA==
> User-Agent: curl/8.4.0
> Accept: */*
> Content-Length: 284614740
> Content-Type: multipart/form-data; boundary=------------------------B5fhya2XGEQJZxIurZ7LB5
> 
* We are completely uploaded and fine
< HTTP/2 200 
< vary: Accept-Encoding
< content-type: text/plain; charset=utf-8
< content-length: 57
< date: Mon, 19 Feb 2024 00:31:51 GMT
< 
* Connection #0 to host localhost left intact
Successfully stored the offline vulnerability definitions
```

3. Get offline file:
```
curl --insecure -u admin:[pwd] https://localhost:8000/api/extensions/scannerdefinitions?uuid=asdfasdgf > test.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  133M  100  133M    0     0  10.2M      0  0:00:12  0:00:12 --:--:-- 15.0M
yli3-mac:stackrox yili$ ls -lh test.zip 
-rw-r--r-- 1 yili staff 134M Feb 18 17:45 test.zip
```

```
curl --insecure -u admin:[pwd] https://localhost:8000/api/extensions/scannerdefinitions?file=repo2cpe > repo2cpe.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2041k  100 2041k    0     0  1109k      0  0:00:01  0:00:01 --:--:-- 1109k

ls -lh repo2cpe.json 
-rw-r--r-- 1 yili staff 2.0M Feb 18 23:49 repo2cpe.json
```

```
curl --insecure -u admin:[pwd] https://localhost:8000/api/extensions/scannerdefinitions?version=4.3.1 > 4.3-defs.json.zst
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  138M  100  138M    0     0  8722k      0  0:00:16  0:00:16 --:--:-- 9951k
ls -lh 4.3-defs.json.zst 
-rw-r--r-- 1 yili staff 139M Feb 19 11:05 4.3-defs.json.zst
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
