### PR TITLE
ROX-15193: move nightly tag action to GHA

### DIFF
--- a/.github/workflows/nightly-tag.yml
+++ b/.github/workflows/nightly-tag.yml
@@ -1,13 +1,10 @@
 name: Create nightly tag
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - tm/ROX-15193-move-nightly-tag-to-gha
   schedule:
   - cron: 0 0 * * 1,2,3,4,5
 jobs:
-  triage-report:
+  create-nightly-tag:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/nightly-tag.yml
+++ b/.github/workflows/nightly-tag.yml
@@ -2,7 +2,7 @@ name: Create nightly tag
 on:
   workflow_dispatch:
   schedule:
-  - cron: 0 0 * * 1,2,3,4,5
+  - cron: 0 0 * * 1-5
 jobs:
   create-nightly-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-tag.yml
+++ b/.github/workflows/nightly-tag.yml
@@ -1,0 +1,17 @@
+name: Create nightly tag
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: 0 0 * * 1,2,3,4,5
+jobs:
+  triage-report:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: nightlies
+    - name: Rebase branch and create new tag
+      env:
+        GITHUB_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+      run: .openshift-ci/nightlies.sh

--- a/.github/workflows/nightly-tag.yml
+++ b/.github/workflows/nightly-tag.yml
@@ -1,6 +1,9 @@
 name: Create nightly tag
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - tm/ROX-15193-move-nightly-tag-to-gha
   schedule:
   - cron: 0 0 * * 1,2,3,4,5
 jobs:


### PR DESCRIPTION
## Description

Replaces https://github.com/openshift/release/blob/master/ci-operator/config/stackrox/stackrox/stackrox-stackrox-nightlies.yaml#L225-L240.

OSCI jobs failed multiple times in the last few days due to insufficient test capacity and other scheduling issues.
We cannot retry or manually dispatch this job in OSCI. Switching to GHA solves those issues. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Tested workflow run with a push to `tm/ROX-15193-move-nightly-tag-to-gha` triggered https://github.com/stackrox/stackrox/actions/runs/7870585089/job/21472067866, which is what I expected.

This rebased the `nightlies` branch and created https://github.com/stackrox/stackrox/releases/tag/4.3.x-nightly-20240212. 

Afterwards, I removed the branch trigger again. 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
