### PR TITLE
ROX-22455: compliance prune cluster status bug

### DIFF
--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -275,8 +275,11 @@ func (ds *datastoreImpl) deleteClusterFromScanConfigWithLock(ctx context.Context
 		return err
 	}
 
+	// Remove the status for the cluster as well.
 	_, err = ds.statusStorage.DeleteByQuery(ctx, search.NewQueryBuilder().
-		AddExactMatches(search.ComplianceOperatorScanConfig, scanConfig.GetId()).ProtoQuery())
+		AddExactMatches(search.ComplianceOperatorScanConfig, scanConfig.GetId()).
+		AddExactMatches(search.ClusterID, clusterID).
+		ProtoQuery())
 	if err != nil {
 		return errors.Wrapf(err, "Unable to delete scan status for scan configuration id %q", scanConfig.GetId())
 	}

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
@@ -239,7 +239,7 @@ func (s *complianceScanConfigDataStoreTestSuite) TestRemoveClusterFromScanConfig
 
 	scanConfigStatus, err := s.dataStore.GetScanConfigClusterStatus(s.testContexts[unrestrictedReadWriteCtx], scanConfig1.GetId())
 	s.Require().NoError(err)
-	s.Require().Empty(scanConfigStatus)
+	s.Require().Equal(len(newscanConfig.GetClusters()), len(scanConfigStatus))
 
 	err = s.dataStore.RemoveClusterFromScanConfig(s.testContexts[unrestrictedReadWriteCtx], scanConfig2.Clusters[0].GetClusterId())
 	s.Require().NoError(err)


### PR DESCRIPTION
## Description

When a cluster was removed we were deleting all the status rows for a scan config instead of just the rows for the cluster being deleted.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Updated the unit test
Tested locally with 2 clusters.  Created a scan configuration applied to both clusters.  Deleted one of the clusters.  Ensured that the details of the scan configuration showed that the remaining cluster was still in the scan configuration.

Before after 1 of 2 clusters was deleted:
![Screenshot 2024-02-12 at 9 03 50 AM](https://github.com/stackrox/stackrox/assets/99685630/cb868deb-fe4f-4c43-b0a6-1178596c5a30)


After:
![Screenshot 2024-02-12 at 9 32 11 AM](https://github.com/stackrox/stackrox/assets/99685630/c44ec86b-53e1-4e63-9d21-032bbb2d1ff7)
![Screenshot 2024-02-12 at 9 32 21 AM](https://github.com/stackrox/stackrox/assets/99685630/11b560ec-0270-4f04-b5a1-c168f041a89a)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
