### PR TITLE
ROX-22198: fix `EventuallyWithT` tests

### DIFF
--- a/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
@@ -116,8 +116,8 @@ func TestCredentialManager(t *testing.T) {
 		},
 	}
 
-	for name, tc := range cases {
-		tc := tc
+	for name, c := range cases {
+		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()
@@ -125,14 +125,14 @@ func TestCredentialManager(t *testing.T) {
 			manager.Start()
 			defer manager.Stop()
 
-			err := tc.setupFn(k8sClient)
+			err := c.setupFn(k8sClient)
 			require.NoError(t, err)
 
 			// Assert that the secret data has been updated.
-			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.EventuallyWithT(t, func(t *assert.CollectT) {
 				manager.mutex.RLock()
 				defer manager.mutex.RUnlock()
-				assert.Equal(c, []byte(tc.expected), manager.stsConfig)
+				assert.Equal(t, []byte(c.expected), manager.stsConfig)
 			}, 5*time.Second, 100*time.Millisecond)
 		})
 	}

--- a/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
@@ -116,8 +116,8 @@ func TestCredentialManager(t *testing.T) {
 		},
 	}
 
-	for name, c := range cases {
-		c := c
+	for name, tc := range cases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()
@@ -125,14 +125,14 @@ func TestCredentialManager(t *testing.T) {
 			manager.Start()
 			defer manager.Stop()
 
-			err := c.setupFn(k8sClient)
+			err := tc.setupFn(k8sClient)
 			require.NoError(t, err)
 
 			// Assert that the secret data has been updated.
-			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				manager.mutex.RLock()
 				defer manager.mutex.RUnlock()
-				assert.Equal(t, []byte(c.expected), manager.stsConfig)
+				assert.Equal(c, []byte(tc.expected), manager.stsConfig)
 			}, 5*time.Second, 100*time.Millisecond)
 		})
 	}

--- a/pkg/k8scfgwatch/cfg_watcher_test.go
+++ b/pkg/k8scfgwatch/cfg_watcher_test.go
@@ -42,8 +42,8 @@ func TestConfigMapTrigger(t *testing.T) {
 		},
 	}
 
-	for name, tc := range cases {
-		tc := tc
+	for name, c := range cases {
+		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()
@@ -63,13 +63,13 @@ func TestConfigMapTrigger(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: cfgName, Namespace: cfgNamespace},
 				Data:       map[string]string{cfgKey: cfgValue},
 			}
-			tc.triggerFunc(watcher, cm)
+			c.triggerFunc(watcher, cm)
 
 			// Assert that the config map data has been updated.
-			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.EventuallyWithT(t, func(t *assert.CollectT) {
 				mutex.RLock()
 				defer mutex.RUnlock()
-				assert.Equal(c, cfgValue, currentCfgData)
+				assert.Equal(t, cfgValue, currentCfgData)
 			}, 5*time.Second, 100*time.Millisecond)
 		})
 	}

--- a/pkg/k8scfgwatch/cfg_watcher_test.go
+++ b/pkg/k8scfgwatch/cfg_watcher_test.go
@@ -42,8 +42,8 @@ func TestConfigMapTrigger(t *testing.T) {
 		},
 	}
 
-	for name, c := range cases {
-		c := c
+	for name, tc := range cases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()
@@ -63,13 +63,13 @@ func TestConfigMapTrigger(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: cfgName, Namespace: cfgNamespace},
 				Data:       map[string]string{cfgKey: cfgValue},
 			}
-			c.triggerFunc(watcher, cm)
+			tc.triggerFunc(watcher, cm)
 
 			// Assert that the config map data has been updated.
-			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				mutex.RLock()
 				defer mutex.RUnlock()
-				assert.Equal(t, cfgValue, currentCfgData)
+				assert.Equal(c, cfgValue, currentCfgData)
 			}, 5*time.Second, 100*time.Millisecond)
 		})
 	}

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -151,13 +151,13 @@ func TestMetricsServerHTTPRequest(t *testing.T) {
 	server.RunForever()
 
 	url := fmt.Sprintf("http://localhost:%d/metrics", freePort)
-	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, err := http.Get(url)
-		require.NoError(t, err)
+		require.NoError(c, err)
 		defer utils.IgnoreError(resp.Body.Close)
 		msg, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		assert.Contains(t, string(msg), "go_gc_duration_seconds")
+		require.NoError(c, err)
+		assert.Contains(c, string(msg), "go_gc_duration_seconds")
 	}, 1*time.Second, 50*time.Millisecond)
 }
 
@@ -219,12 +219,12 @@ func TestSecureMetricsServerHTTPRequest(t *testing.T) {
 	client, err := testClient()
 	require.NoError(t, err)
 	url := fmt.Sprintf("https://localhost:%d/metrics", freePort)
-	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, err := client.Get(url)
-		require.NoError(t, err)
+		require.NoError(c, err)
 		defer utils.IgnoreError(resp.Body.Close)
 		msg, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		assert.Contains(t, string(msg), "go_gc_duration_seconds")
+		require.NoError(c, err)
+		assert.Contains(c, string(msg), "go_gc_duration_seconds")
 	}, 1*time.Second, 50*time.Millisecond)
 }

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -151,13 +151,13 @@ func TestMetricsServerHTTPRequest(t *testing.T) {
 	server.RunForever()
 
 	url := fmt.Sprintf("http://localhost:%d/metrics", freePort)
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
 		resp, err := http.Get(url)
-		require.NoError(c, err)
+		require.NoError(t, err)
 		defer utils.IgnoreError(resp.Body.Close)
 		msg, err := io.ReadAll(resp.Body)
-		require.NoError(c, err)
-		assert.Contains(c, string(msg), "go_gc_duration_seconds")
+		require.NoError(t, err)
+		assert.Contains(t, string(msg), "go_gc_duration_seconds")
 	}, 1*time.Second, 50*time.Millisecond)
 }
 
@@ -219,12 +219,12 @@ func TestSecureMetricsServerHTTPRequest(t *testing.T) {
 	client, err := testClient()
 	require.NoError(t, err)
 	url := fmt.Sprintf("https://localhost:%d/metrics", freePort)
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
 		resp, err := client.Get(url)
-		require.NoError(c, err)
+		require.NoError(t, err)
 		defer utils.IgnoreError(resp.Body.Close)
 		msg, err := io.ReadAll(resp.Body)
-		require.NoError(c, err)
-		assert.Contains(c, string(msg), "go_gc_duration_seconds")
+		require.NoError(t, err)
+		assert.Contains(t, string(msg), "go_gc_duration_seconds")
 	}, 1*time.Second, 50*time.Millisecond)
 }

--- a/pkg/metrics/tls_test.go
+++ b/pkg/metrics/tls_test.go
@@ -29,10 +29,10 @@ func TestTLSConfigurerServerCertLoading(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, cfgrTLSConfig.Certificates)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
 		tlsConfig, err := cfgrTLSConfig.GetConfigForClient(nil)
-		require.NoError(c, err)
-		assert.NotEmpty(c, tlsConfig.Certificates)
+		require.NoError(t, err)
+		assert.NotEmpty(t, tlsConfig.Certificates)
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
@@ -55,12 +55,12 @@ func TestTLSConfigurerClientCALoading(t *testing.T) {
 		Data:       map[string]string{clientCAKey: string(caFileRaw)},
 	})
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
 		tlsConfig, err := cfgrTLSConfig.GetConfigForClient(nil)
-		require.NoError(c, err)
-		require.NotNil(c, tlsConfig.ClientCAs)
+		require.NoError(t, err)
+		require.NotNil(t, tlsConfig.ClientCAs)
 		// Two certs in `./testdata/ca.pem`.
-		assert.Len(c, tlsConfig.ClientCAs.Subjects(), 2)
+		assert.Len(t, tlsConfig.ClientCAs.Subjects(), 2)
 	}, 5*time.Second, 100*time.Millisecond)
 }
 

--- a/pkg/metrics/tls_test.go
+++ b/pkg/metrics/tls_test.go
@@ -29,10 +29,10 @@ func TestTLSConfigurerServerCertLoading(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, cfgrTLSConfig.Certificates)
 
-	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		tlsConfig, err := cfgrTLSConfig.GetConfigForClient(nil)
-		require.NoError(t, err)
-		assert.NotEmpty(t, tlsConfig.Certificates)
+		require.NoError(c, err)
+		assert.NotEmpty(c, tlsConfig.Certificates)
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
@@ -55,12 +55,12 @@ func TestTLSConfigurerClientCALoading(t *testing.T) {
 		Data:       map[string]string{clientCAKey: string(caFileRaw)},
 	})
 
-	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		tlsConfig, err := cfgrTLSConfig.GetConfigForClient(nil)
-		require.NoError(t, err)
-		require.NotNil(t, tlsConfig.ClientCAs)
+		require.NoError(c, err)
+		require.NotNil(c, tlsConfig.ClientCAs)
 		// Two certs in `./testdata/ca.pem`.
-		assert.Len(t, tlsConfig.ClientCAs.Subjects(), 2)
+		assert.Len(c, tlsConfig.ClientCAs.Subjects(), 2)
 	}, 5*time.Second, 100*time.Millisecond)
 }
 

--- a/pkg/secretinformer/informer_test.go
+++ b/pkg/secretinformer/informer_test.go
@@ -108,8 +108,8 @@ func TestSecretInformer(t *testing.T) {
 		},
 	}
 
-	for name, tc := range cases {
-		tc := tc
+	for name, c := range cases {
+		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()
@@ -123,13 +123,13 @@ func TestSecretInformer(t *testing.T) {
 					mutex.Lock()
 					defer mutex.Unlock()
 					onAddCnt++
-					assert.Equal(t, tc.expectedData, string(s.Data[secretKey]))
+					assert.Equal(t, c.expectedData, string(s.Data[secretKey]))
 				},
 				func(s *v1.Secret) {
 					mutex.Lock()
 					defer mutex.Unlock()
 					onUpdateCnt++
-					assert.Equal(t, tc.expectedData, string(s.Data[secretKey]))
+					assert.Equal(t, c.expectedData, string(s.Data[secretKey]))
 				},
 				func() {
 					mutex.Lock()
@@ -141,15 +141,15 @@ func TestSecretInformer(t *testing.T) {
 			err := informer.Start()
 			require.NoError(t, err)
 			defer informer.Stop()
-			err = tc.setupFn(k8sClient)
+			err = c.setupFn(k8sClient)
 			require.NoError(t, err)
 
-			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.EventuallyWithT(t, func(t *assert.CollectT) {
 				mutex.RLock()
 				defer mutex.RUnlock()
-				assert.Equal(c, tc.expectedOnAddCnt, onAddCnt)
-				assert.Equal(c, tc.expectedOnUpdateCnt, onUpdateCnt)
-				assert.Equal(c, tc.expectedOnDeleteCnt, onDeleteCnt)
+				assert.Equal(t, c.expectedOnAddCnt, onAddCnt)
+				assert.Equal(t, c.expectedOnUpdateCnt, onUpdateCnt)
+				assert.Equal(t, c.expectedOnDeleteCnt, onDeleteCnt)
 			}, 5*time.Second, 100*time.Millisecond)
 		})
 	}

--- a/pkg/secretinformer/informer_test.go
+++ b/pkg/secretinformer/informer_test.go
@@ -108,8 +108,8 @@ func TestSecretInformer(t *testing.T) {
 		},
 	}
 
-	for name, c := range cases {
-		c := c
+	for name, tc := range cases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()
@@ -123,13 +123,13 @@ func TestSecretInformer(t *testing.T) {
 					mutex.Lock()
 					defer mutex.Unlock()
 					onAddCnt++
-					assert.Equal(t, c.expectedData, string(s.Data[secretKey]))
+					assert.Equal(t, tc.expectedData, string(s.Data[secretKey]))
 				},
 				func(s *v1.Secret) {
 					mutex.Lock()
 					defer mutex.Unlock()
 					onUpdateCnt++
-					assert.Equal(t, c.expectedData, string(s.Data[secretKey]))
+					assert.Equal(t, tc.expectedData, string(s.Data[secretKey]))
 				},
 				func() {
 					mutex.Lock()
@@ -141,15 +141,15 @@ func TestSecretInformer(t *testing.T) {
 			err := informer.Start()
 			require.NoError(t, err)
 			defer informer.Stop()
-			err = c.setupFn(k8sClient)
+			err = tc.setupFn(k8sClient)
 			require.NoError(t, err)
 
-			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				mutex.RLock()
 				defer mutex.RUnlock()
-				assert.Equal(t, c.expectedOnAddCnt, onAddCnt)
-				assert.Equal(t, c.expectedOnUpdateCnt, onUpdateCnt)
-				assert.Equal(t, c.expectedOnDeleteCnt, onDeleteCnt)
+				assert.Equal(c, tc.expectedOnAddCnt, onAddCnt)
+				assert.Equal(c, tc.expectedOnUpdateCnt, onUpdateCnt)
+				assert.Equal(c, tc.expectedOnDeleteCnt, onDeleteCnt)
 			}, 5*time.Second, 100*time.Millisecond)
 		})
 	}


### PR DESCRIPTION
## Description

I noticed a bug in several tests using `assert.EventuallyWithT` - the wrong testing context was used (parent instead of inner most one). The fix should also rid of us another open test flake related to this issue (https://issues.redhat.com/browse/ROX-22198). 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Verified eventually calls with explicit fails.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
