### PR TITLE
ROX-22459:  compliance results card sort

### DIFF
--- a/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
@@ -89,13 +89,13 @@ func (d *datastoreImpl) ComplianceCheckResultStats(ctx context.Context, query *v
 		cloned.Pagination = &v1.QueryPagination{}
 		cloned.Pagination.SortOptions = []*v1.QuerySortOption{
 			{
+				Field: search.ComplianceOperatorScanConfigName.String(),
+			},
+			{
 				Field: search.ClusterID.String(),
 			},
 			{
 				Field: search.Cluster.String(),
-			},
-			{
-				Field: search.ComplianceOperatorScanConfigName.String(),
 			},
 		}
 	}

--- a/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
@@ -87,17 +87,17 @@ func (d *datastoreImpl) ComplianceCheckResultStats(ctx context.Context, query *v
 
 	if cloned.Pagination == nil {
 		cloned.Pagination = &v1.QueryPagination{}
-		cloned.Pagination.SortOptions = []*v1.QuerySortOption{
-			{
-				Field: search.ComplianceOperatorScanConfigName.String(),
-			},
-			{
-				Field: search.ClusterID.String(),
-			},
-			{
-				Field: search.Cluster.String(),
-			},
-		}
+	}
+	cloned.Pagination.SortOptions = []*v1.QuerySortOption{
+		{
+			Field: search.ComplianceOperatorScanConfigName.String(),
+		},
+		{
+			Field: search.ClusterID.String(),
+		},
+		{
+			Field: search.Cluster.String(),
+		},
 	}
 
 	countQuery := d.withCountByResultSelectQuery(cloned, search.ClusterID)


### PR DESCRIPTION
## Description

The sort ordered wasn't being applied.  it was only applied if pagination was nil.  But the service layer adds the default pagination to the max number of pages.  As such the pagination was never nil and thus sort order was not applied.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Ran scans and verified the sort order of the cards is now as one would expect.

Before:
![Screenshot 2024-02-12 at 11 19 31 AM](https://github.com/stackrox/stackrox/assets/99685630/47d57830-7645-4e51-bbed-46e28389b374)


After:
![Screenshot 2024-02-12 at 11 52 43 AM](https://github.com/stackrox/stackrox/assets/99685630/76ad0d93-e0d8-4e6b-bdb9-9acc70553f05)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
