### PR TITLE
ROX-22049: Conditionally render Discovered clusters button

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/Clusters.selectors.js
+++ b/ui/apps/platform/cypress/integration/clusters/Clusters.selectors.js
@@ -1,10 +1,10 @@
 import scopeSelectors from '../../helpers/scopeSelectors';
 
 export const selectors = {
-    clusters: scopeSelectors('[data-testid="clusters-table"]', {
+    clusters: {
         // Ignore the first checkbox column and last delete column.
         tableDataCell: '.rt-tr-group:not(.hidden) .rt-td:not(:first-child):not(.hidden)',
-    }),
+    },
     clusterForm: scopeSelectors('[data-testid="cluster-form"]', {
         nameInput: 'input[name="name"]',
     }),

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -5,23 +5,26 @@ import {
     Alert,
     Bullseye,
     Button,
+    Divider,
     Dropdown,
     DropdownItem,
     DropdownPosition,
     DropdownToggle,
     PageSection,
+    Title,
+    Toolbar,
+    ToolbarContent,
+    ToolbarGroup,
+    ToolbarItem,
     Spinner,
 } from '@patternfly/react-core';
 
 import CheckboxTable from 'Components/CheckboxTable';
 import CloseButton from 'Components/CloseButton';
 import Dialog from 'Components/Dialog';
-import PageHeader from 'Components/PageHeader';
-import { PanelNew, PanelBody, PanelHead, PanelHeadEnd } from 'Components/Panel';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import SearchFilterInput from 'Components/SearchFilterInput';
 import { DEFAULT_PAGE_SIZE } from 'Components/Table';
-import TableHeader from 'Components/TableHeader';
 import useAuthStatus from 'hooks/useAuthStatus';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useInterval from 'hooks/useInterval';
@@ -45,6 +48,7 @@ import { getVersionedDocs } from 'utils/versioning';
 import {
     clustersBasePath,
     clustersDelegatedScanningPath,
+    clustersDiscoveredClustersPath,
     clustersSecureClusterPath,
 } from 'routePaths';
 
@@ -68,7 +72,7 @@ function ClustersTablePanel({
     const history = useHistory();
 
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
-    const hasReadAccessForDelegatedScanning = hasReadAccess('Administration');
+    const hasReadAccessForAdministration = hasReadAccess('Administration');
     const hasWriteAccessForAdministration = hasReadWriteAccess('Administration');
     const hasWriteAccessForCluster = hasReadWriteAccess('Cluster');
 
@@ -108,9 +112,6 @@ function ClustersTablePanel({
     const [showDialog, setShowDialog] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
     const [hasFetchedClusters, setHasFetchedClusters] = useState(false);
-
-    // Handle changes to applied search options.
-    const [isViewFiltered, setIsViewFiltered] = useState(false);
 
     const [currentClusters, setCurrentClusters] = useState<Cluster[]>([]);
     const [clusterIdToRetentionInfo, setClusterIdToRetentionInfo] =
@@ -154,36 +155,56 @@ function ClustersTablePanel({
     const { version } = metadata;
 
     const pageHeader = (
-        <PageHeader header="Clusters" subHeader="Resource list">
-            <div className="flex flex-1 items-center justify-end">
-                <SearchFilterInput
-                    className="w-full"
-                    searchFilter={searchFilter}
-                    searchOptions={searchOptions}
-                    searchCategory="CLUSTERS"
-                    placeholder="Filter clusters"
-                    handleChangeSearchFilter={setSearchFilter}
-                />
-                {hasReadAccessForDelegatedScanning && (
-                    <div className="flex items-center ml-4 mr-1">
-                        <Button
-                            variant="secondary"
-                            component={LinkShim}
-                            href={clustersDelegatedScanningPath}
-                        >
-                            Delegated scanning
-                        </Button>
-                    </div>
-                )}
-                {hasAdminRole && (
-                    <div className="flex items-center ml-1">
-                        <Button variant="tertiary">
-                            <ManageTokensButton />
-                        </Button>
-                    </div>
-                )}
-            </div>
-        </PageHeader>
+        <Toolbar inset={{ default: 'insetNone' }} className="pf-u-pb-0">
+            <ToolbarContent>
+                <ToolbarGroup
+                    variant="filter-group"
+                    className="pf-u-flex-grow-1 pf-u-flex-shrink-1"
+                >
+                    <ToolbarItem variant="search-filter" className="pf-u-w-100">
+                        <SearchFilterInput
+                            className="w-full"
+                            searchFilter={searchFilter}
+                            searchOptions={searchOptions}
+                            searchCategory="CLUSTERS"
+                            placeholder="Filter clusters"
+                            handleChangeSearchFilter={setSearchFilter}
+                        />
+                    </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarGroup variant="button-group">
+                    {hasReadAccessForAdministration && (
+                        <ToolbarItem>
+                            <Button
+                                variant="secondary"
+                                component={LinkShim}
+                                href={clustersDelegatedScanningPath}
+                            >
+                                Delegated scanning
+                            </Button>
+                        </ToolbarItem>
+                    )}
+                    {hasReadAccessForAdministration && (
+                        <ToolbarItem>
+                            <Button
+                                variant="secondary"
+                                component={LinkShim}
+                                href={clustersDiscoveredClustersPath}
+                            >
+                                Discovered clusters
+                            </Button>
+                        </ToolbarItem>
+                    )}
+                    {hasAdminRole && (
+                        <ToolbarItem>
+                            <Button variant="tertiary">
+                                <ManageTokensButton />
+                            </Button>
+                        </ToolbarItem>
+                    )}
+                </ToolbarGroup>
+            </ToolbarContent>
+        </Toolbar>
     );
 
     /* eslint-disable no-nested-ternary */
@@ -240,12 +261,6 @@ function ClustersTablePanel({
     const filteredSearch = filterAllowedSearch(searchOptions, searchFilter || {});
     const restSearch = convertToRestSearch(filteredSearch || {});
     useDeepCompareEffect(() => {
-        if (restSearch.length) {
-            setIsViewFiltered(true);
-        } else {
-            setIsViewFiltered(false);
-        }
-
         refreshClusterList(restSearch);
     }, [restSearch, pollingCount]);
 
@@ -351,58 +366,61 @@ function ClustersTablePanel({
             });
     }
 
-    const headerComponent = (
-        <TableHeader
-            length={currentClusters?.length || 0}
-            type="cluster"
-            isViewFiltered={isViewFiltered}
-        />
-    );
-
     const headerActions = (
-        <>
-            {hasWriteAccessForAdministration && (
-                <>
-                    <AutoUpgradeToggle />
-                    <Button
-                        variant="secondary"
-                        className="pf-u-ml-sm"
-                        onClick={upgradeSelectedClusters}
-                        isDisabled={upgradableClusters.length === 0 || !!selectedClusterId}
-                    >
-                        {`Upgrade (${upgradableClusters.length})`}
-                    </Button>
-                </>
-            )}
-            {hasWriteAccessForCluster && (
-                <>
-                    <Button
-                        variant="danger"
-                        className="pf-u-ml-sm pf-u-mr-sm"
-                        onClick={deleteSelectedClusters}
-                        isDisabled={checkedClusterIds.length === 0 || !!selectedClusterId}
-                    >
-                        {`Delete (${checkedClusterIds.length})`}
-                    </Button>
-                    <Dropdown
-                        className="mr-4"
-                        onSelect={onSelectInstallMenuItem}
-                        toggle={
-                            <DropdownToggle
-                                id="install-toggle"
-                                toggleVariant="secondary"
-                                onToggle={onToggleInstallMenu}
+        <Toolbar inset={{ default: 'insetNone' }} className="pf-u-pb-0">
+            <ToolbarContent>
+                <ToolbarGroup variant="button-group" alignment={{ default: 'alignRight' }}>
+                    {hasWriteAccessForAdministration && (
+                        <ToolbarItem>
+                            <AutoUpgradeToggle />
+                        </ToolbarItem>
+                    )}
+                    {hasWriteAccessForAdministration && (
+                        <ToolbarItem>
+                            <Button
+                                variant="secondary"
+                                className="pf-u-ml-sm"
+                                onClick={upgradeSelectedClusters}
+                                isDisabled={upgradableClusters.length === 0 || !!selectedClusterId}
                             >
-                                Secure a cluster
-                            </DropdownToggle>
-                        }
-                        position={DropdownPosition.right}
-                        isOpen={isInstallMenuOpen}
-                        dropdownItems={installMenuOptions}
-                    />
-                </>
-            )}
-        </>
+                                {`Upgrade (${upgradableClusters.length})`}
+                            </Button>
+                        </ToolbarItem>
+                    )}
+                    {hasWriteAccessForCluster && (
+                        <ToolbarItem>
+                            <Button
+                                variant="danger"
+                                className="pf-u-ml-sm pf-u-mr-sm"
+                                onClick={deleteSelectedClusters}
+                                isDisabled={checkedClusterIds.length === 0 || !!selectedClusterId}
+                            >
+                                {`Delete (${checkedClusterIds.length})`}
+                            </Button>
+                        </ToolbarItem>
+                    )}
+                    {hasWriteAccessForCluster && (
+                        <ToolbarItem>
+                            <Dropdown
+                                onSelect={onSelectInstallMenuItem}
+                                toggle={
+                                    <DropdownToggle
+                                        id="install-toggle"
+                                        toggleVariant="secondary"
+                                        onToggle={onToggleInstallMenu}
+                                    >
+                                        Secure a cluster
+                                    </DropdownToggle>
+                                }
+                                position={DropdownPosition.right}
+                                isOpen={isInstallMenuOpen}
+                                dropdownItems={installMenuOptions}
+                            />
+                        </ToolbarItem>
+                    )}
+                </ToolbarGroup>
+            </ToolbarContent>
+        </Toolbar>
     );
 
     function calculateUpgradeableClusters(selection) {
@@ -455,48 +473,45 @@ function ClustersTablePanel({
     // After there is a response, if there are clusters or search filter.
     // Conditionally render a subsequent error in addition to most recent successful respnse.
     return (
-        <div className="overflow-hidden w-full">
-            {pageHeader}
-            <PanelNew testid="panel">
-                <PanelHead>
-                    {headerComponent}
-                    <PanelHeadEnd>{headerActions}</PanelHeadEnd>
-                </PanelHead>
-                <PanelBody>
-                    {errorMessage && (
-                        <Alert
-                            variant="warning"
-                            isInline
-                            title="Unable to fetch clusters"
-                            component="p"
-                        >
-                            {errorMessage}
-                        </Alert>
-                    )}
-                    {messages.length > 0 && (
-                        <div className="flex flex-col w-full items-center bg-warning-200 text-warning-8000 justify-center font-700 text-center">
-                            {messages}
-                        </div>
-                    )}
-                    <div data-testid="clusters-table" className="h-full w-full">
-                        <CheckboxTable
-                            ref={(table) => {
-                                setTableRef(table);
-                            }}
-                            rows={currentClusters}
-                            columns={clusterColumns}
-                            onRowClick={setSelectedClusterId}
-                            toggleRow={toggleCluster}
-                            toggleSelectAll={toggleAllClusters}
-                            selection={checkedClusterIds}
-                            selectedRowId={selectedClusterId}
-                            noDataText="No clusters to show."
-                            minRows={20}
-                            pageSize={pageSize}
-                        />
+        <>
+            <PageSection variant="light" component="div">
+                <Title headingLevel="h1">Clusters</Title>
+                {pageHeader}
+                {headerActions}
+            </PageSection>
+            <Divider component="div" />
+            <PageSection variant="light" isFilled>
+                {errorMessage && (
+                    <Alert
+                        variant="warning"
+                        isInline
+                        title="Unable to fetch clusters"
+                        component="p"
+                    >
+                        {errorMessage}
+                    </Alert>
+                )}
+                {messages.length > 0 && (
+                    <div className="flex flex-col w-full items-center bg-warning-200 text-warning-8000 justify-center font-700 text-center">
+                        {messages}
                     </div>
-                </PanelBody>
-            </PanelNew>
+                )}
+                <CheckboxTable
+                    ref={(table) => {
+                        setTableRef(table);
+                    }}
+                    rows={currentClusters}
+                    columns={clusterColumns}
+                    onRowClick={setSelectedClusterId}
+                    toggleRow={toggleCluster}
+                    toggleSelectAll={toggleAllClusters}
+                    selection={checkedClusterIds}
+                    selectedRowId={selectedClusterId}
+                    noDataText="No clusters to show."
+                    minRows={20}
+                    pageSize={pageSize}
+                />
+            </PageSection>
             <Dialog
                 className="w-1/3"
                 isOpen={showDialog}
@@ -507,7 +522,7 @@ function ClustersTablePanel({
                 isDestructive
             />
             <SecureClusterModal isModalOpen={isModalOpen} setIsModalOpen={setIsModalOpen} />
-        </div>
+        </>
     );
 }
 


### PR DESCRIPTION
## Description

Because Tailwind spacing seemed questionable for conditional rendering of anywhere between all and none of the buttons, I took a chance to replace classic page layout above the table with PatternFly:
* Except for `AutoUpgradeToggle` element.
* Tailwind `h-full` for table concerned me, so I temporarily cloned the one row to see whether scrolling worked for 10 rows. Because there was indeed a scrolling problem with a mix of PatternFly `PageSection` and class panel components, I took one more step to replace `div` with `PageSection` element which has `isFilled` prop.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited regression tests

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_CLOUD_SOURCES=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 28 = 3950590 - 3950562
        total -606 = 10532211 - 10532817
    * `ls -al build/static/js/*.js | wc`
        files 0 = 92 - 92
3. `yarn start` in ui

### Manual testing

1. Visit /main/clusters

    * Without button before changes
        ![clusters_without_button](https://github.com/stackrox/stackrox/assets/11862657/8f3013b4-5c69-4d39-9cc8-18d6b7eb0a61)

    * With button after changes
        ![clusters_with_button](https://github.com/stackrox/stackrox/assets/11862657/6d745633-c0a5-4b52-88d6-0f546aff9f7d)

    * Verify scrolling in table: first row
        ![tbody_tr_first](https://github.com/stackrox/stackrox/assets/11862657/b88d10d3-d4ce-4396-8ff7-6661c20b0722)

    * Verify scrolling in table: last row
        ![tbody_tf_last](https://github.com/stackrox/stackrox/assets/11862657/679af55a-cc4b-4f75-8fdc-068d339c9a98)

2. Click **Discovered clusters** button
    ![clusters_delegated-image-scanning](https://github.com/stackrox/stackrox/assets/11862657/945105d9-5132-4d4c-846f-a7b61592ca35)

### Integration testing

* clusters/clusterDeletion.test.js
* clusters/clusters.test.js
* clusters/clustersCertificateExpiration.test.js
* clusters/clustersHealthStatus.test.js
* clusters/clustersManager.test.js
* clusters/delegatedScanning.test.js
* clusters/redirectFromDashboard.test.js
