### PR TITLE
ROX-22083: Provide validation details through API for ScanConfig

### DIFF
--- a/central/complianceoperator/v2/compliancemanager/manager_impl.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl.go
@@ -223,7 +223,7 @@ func (m *managerImpl) processRequestToSensor(ctx context.Context, scanRequest *s
 		err = m.updateClusterStatus(ctx, scanRequest.GetId(), clusterID, status)
 		if err != nil {
 			log.Error(err)
-			return nil, errors.Errorf("Unable to save scan configuration status for scan named %q.", scanRequest.GetScanConfigName())
+			return nil, errors.Wrapf(err, "Unable to save scan configuration status for scan named %q", scanRequest.GetScanConfigName())
 		}
 	}
 


### PR DESCRIPTION
## Description

API requests to create Scan Configs currently lack details about why a request failed validation. This change tacks an error message onto the return string bubbled up to the HTTP API if the cluster used in the request doesn't exist. Otherwise, the user doesn't know exactly why their request failed.

This change might be a good place to discuss additional validation cases we want to test, and how we can do that consistently for a better user experience. Additionally, these validation errors could be useful to the front end.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Add an integration test that asserts the returned error contains a specific error message. If we generalize this pattern, we'll likely want to explore other, more scalable testing solutions for exercising the API.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
