### PR TITLE
fix: Run deploy script in stackrox repo

### DIFF
--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pushd "$DIR"
+
 export DEFAULT_IMAGE_REGISTRY="${DEFAULT_IMAGE_REGISTRY:-"$(make --quiet --no-print-directory -C "$(git rev-parse --show-toplevel)" default-image-registry)"}"
 echo "DEFAULT_IMAGE_REGISTRY set to $DEFAULT_IMAGE_REGISTRY"
 


### PR DESCRIPTION
## Description

A minor fix for when deploy/common/deploy.sh is run from outside of the stackrox repository. 

There is automation for deploying long running clusters in the stackrox/actions repository. When I run the following script in the stackrox/actions directory 

```
#!/usr/bin/env bash
set -eou pipefail

export MAIN_IMAGE_TAG=0.0.9
export API_ENDPOINT=localhost:8000
export STORAGE=pvc
export STORAGE_CLASS=faster
export STORAGE_SIZE="100"
export MONITORING_SUPPORT="true"
export LOAD_BALANCER=lb
export ROX_ADMIN_USERNAME=admin
export PAGERDUTY_INTEGRATION_KEY=adfsasdf
export REGISTRY_USERNAME=jvirtane@redhat.com
export REGISTRY_PASSWORD="*********"
export KUBECONFIG=/tmp/artifacts-long-fake-load-0-0-9/kubeconfig
export STACKROX_DIR=/${HOME}/go/src/github.com/stackrox/stackrox
export NAME=long-fake-load-0-0-9
export ROX_TELEMETRY_STORAGE_KEY_V1=********

export GITHUB_STEP_SUMMARY=delete-log.txt
export CI="true"

../../common/common.sh ./start-acs.sh
```

This fails with
```
~/go/src/github.com/stackrox/actions/release/start-acs ~/go/src/github.com/stackrox/actions/release/start-acs
make: *** No rule to make target 'default-image-registry'.  Stop.
DEFAULT_IMAGE_REGISTRY set to 
MAIN_IMAGE_REPO set to /main
StackRox image tag set to 0.0.9
StackRox image set to /main:0.0.9
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] Able to run the start-acs.sh script from stackrox/actions locally
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

This is not a user facing feature.

## Testing Performed

### Here I tell how I validated my change

Ran the above script with the changes here and it worked.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
