### PR TITLE
ROX-21632: Make gRPC tests more robust

### DIFF
--- a/pkg/grpc/server_ratelimit_test.go
+++ b/pkg/grpc/server_ratelimit_test.go
@@ -95,8 +95,8 @@ func (a *APIServerSuite) Test_Server_RateLimit_HTTP_Integration() {
 			grpcService := &pingServiceTestImpl{}
 			api.Register(grpcService)
 			a.Assert().NoError(api.Start().Wait())
-			defer func() { api.Stop() }()
 
+			a.T().Cleanup(func() { api.Stop() })
 			var urls []string
 			if tt.useHTTP {
 				urls = append(urls, "https://localhost:8080/test")


### PR DESCRIPTION
## Description

This PR aims to improve the test stability, however, I couldn't reproduce the failing tests as they fail rarely.

These tests can flake sometimes with a panic where gRPC port is already in use. This can be due to multiple tests conflicting with each other, or failing to call stop properly. 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- Ran tests multiple times locally
- CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
