### PR TITLE
ROX-22371, ROX-22372: compliance update scan config delete cluster

### DIFF
--- a/central/complianceoperator/v2/compliancemanager/manager.go
+++ b/central/complianceoperator/v2/compliancemanager/manager.go
@@ -22,6 +22,8 @@ type Manager interface {
 
 	// ProcessScanRequest processes a request to apply a compliance scan configuration to one or more Sensors.
 	ProcessScanRequest(ctx context.Context, scanRequest *storage.ComplianceOperatorScanConfigurationV2, clusters []string) (*storage.ComplianceOperatorScanConfigurationV2, error)
+	// UpdateScanRequest processes a request to apply a compliance scan configuration to one or more Sensors.
+	UpdateScanRequest(ctx context.Context, scanRequest *storage.ComplianceOperatorScanConfigurationV2, clusters []string) (*storage.ComplianceOperatorScanConfigurationV2, error)
 	// HandleScanRequestResponse processes response of compliance scan configuration from a sensor.
 	HandleScanRequestResponse(ctx context.Context, requestID string, clusterID string, responsePayload string) error
 

--- a/central/complianceoperator/v2/compliancemanager/manager_impl.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl.go
@@ -137,7 +137,7 @@ func (m *managerImpl) UpdateScanRequest(ctx context.Context, scanRequest *storag
 	}
 
 	if scanRequest.GetId() == "" {
-		return nil, errors.New("Scan Configuration ID is required for an update")
+		return nil, errors.Errorf("Scan Configuration ID is required for an update, %+v", scanRequest)
 	}
 
 	err := validateClusterAccess(ctx, clusters)
@@ -164,8 +164,6 @@ func (m *managerImpl) UpdateScanRequest(ctx context.Context, scanRequest *storag
 	// Use the old config to determine which clusters were deleted from the configuration
 	// TODO(ROX-22398): if we restrict cluster deletion, this is where we would do it before any updates are done.
 	var deletedClusters []string
-	log.Infof("SHREWS -- clusters %v", clusters)
-	log.Infof("SHREWS -- old clusters %v", oldScanConfig.GetClusters())
 	for _, oldCluster := range oldScanConfig.GetClusters() {
 		if sliceutils.Find(clusters, oldCluster.GetClusterId()) == -1 {
 			deletedClusters = append(deletedClusters, oldCluster.ClusterId)
@@ -234,7 +232,6 @@ func (m *managerImpl) processRequestToSensor(ctx context.Context, scanRequest *s
 
 func (m *managerImpl) processClusterDelete(ctx context.Context, scanRequest *storage.ComplianceOperatorScanConfigurationV2, clusters []string) {
 	for _, clusterID := range clusters {
-		log.Infof("SHREWS -- trying to delete cluster %q", clusterID)
 		// id for the request message to sensor
 		sensorRequestID := uuid.NewV4().String()
 

--- a/central/complianceoperator/v2/compliancemanager/manager_impl.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/uuid"
 )
@@ -92,6 +93,13 @@ func (m *managerImpl) ProcessComplianceOperatorInfo(ctx context.Context, complia
 	return m.integrationDS.UpdateComplianceIntegration(ctx, complianceIntegration)
 }
 
+// Plan
+// Create an UpdateScanRequest
+// calculate clusters to delete
+// send deletes
+// remove from cluster status
+// Split ProcessScanRequest into shared pieces
+
 // ProcessScanRequest processes a request to apply a compliance scan configuration to one or more Sensors.
 func (m *managerImpl) ProcessScanRequest(ctx context.Context, scanRequest *storage.ComplianceOperatorScanConfigurationV2, clusters []string) (*storage.ComplianceOperatorScanConfigurationV2, error) {
 	if !features.ComplianceEnhancements.Enabled() {
@@ -103,64 +111,87 @@ func (m *managerImpl) ProcessScanRequest(ctx context.Context, scanRequest *stora
 		return nil, err
 	}
 
-	var cron string
-	if scanRequest.GetSchedule() != nil {
-		cron, err = schedule.ConvertToCronTab(scanRequest.GetSchedule())
-		if err != nil {
-			err = errors.Wrapf(err, "Unable to convert schedule for scan configuration named %q to cron.", scanRequest.GetScanConfigName())
-			log.Error(err)
-			return nil, err
-		}
-		cronValidator := gronx.New()
-		if !cronValidator.IsValid(cron) {
-			err = errors.Errorf("Schedule for scan configuration named %q is invalid.", scanRequest.GetScanConfigName())
-			log.Error(err)
-			return nil, err
+	cron, err := convertSchedule(scanRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if scan configuration already exists by name.
+	scanConfig, err := m.scanSettingDS.GetScanConfigurationByName(ctx, scanRequest.GetScanConfigName())
+	if err != nil {
+		err = errors.Wrapf(err, "Unable to create scan configuration named %q.", scanRequest.GetScanConfigName())
+		log.Error(err)
+		return nil, err
+	}
+	if scanConfig != nil {
+		return nil, errors.Errorf("Scan configuration named %q already exists.", scanRequest.GetScanConfigName())
+	}
+
+	scanRequest.Id = uuid.NewV4().String()
+	scanRequest.CreatedTime = types.TimestampNow()
+
+	return m.processRequestToSensor(ctx, scanRequest, cron, clusters, true)
+}
+
+// UpdateScanRequest processes a request to apply a compliance scan configuration to one or more Sensors.
+func (m *managerImpl) UpdateScanRequest(ctx context.Context, scanRequest *storage.ComplianceOperatorScanConfigurationV2, clusters []string) (*storage.ComplianceOperatorScanConfigurationV2, error) {
+	if !features.ComplianceEnhancements.Enabled() {
+		return nil, errors.Errorf("Compliance is disabled. Cannot process scan request: %q", scanRequest.GetScanConfigName())
+	}
+
+	err := validateClusterAccess(ctx, clusters)
+	if err != nil {
+		return nil, err
+	}
+
+	cron, err := convertSchedule(scanRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify the scan configuration ID is valid
+	oldScanConfig, found, err := m.scanSettingDS.GetScanConfiguration(ctx, scanRequest.GetId())
+	if err != nil {
+		err = errors.Wrapf(err, "Unable to find scan configuration with ID %q.", scanRequest.GetId())
+		log.Error(err)
+		return nil, err
+	}
+	if !found {
+		return nil, errors.Errorf("Scan configuration with ID %q does not exist.", scanRequest.GetId())
+	}
+
+	// Use the old config to determine which clusters were deleted from the configuration
+	// TODO(ROX-22398): if we restrict cluster deletion, this is where we would do it before any updates are done.
+	var deletedClusters []string
+	for _, oldCluster := range oldScanConfig.GetClusters() {
+		if sliceutils.Find(scanRequest.GetClusters(), oldCluster) == -1 {
+			deletedClusters = append(deletedClusters, oldCluster.ClusterId)
 		}
 	}
 
-	createScanRequest := scanRequest.Id == ""
+	// Use the created time from the DB
+	scanRequest.CreatedTime = oldScanConfig.GetCreatedTime()
 
-	// No ID means an add so we need to make sure the name does not already exist
-	if createScanRequest {
-		// Check if scan configuration already exists by name.
-		scanConfig, err := m.scanSettingDS.GetScanConfigurationByName(ctx, scanRequest.GetScanConfigName())
-		if err != nil {
-			err = errors.Wrapf(err, "Unable to create scan configuration named %q.", scanRequest.GetScanConfigName())
-			log.Error(err)
-			return nil, err
-		}
-		if scanConfig != nil {
-			return nil, errors.Errorf("Scan configuration named %q already exists.", scanRequest.GetScanConfigName())
-		}
-
-		scanRequest.Id = uuid.NewV4().String()
-		scanRequest.CreatedTime = types.TimestampNow()
-	} else {
-		// Verify the scan configuration ID is valid
-		scanConfig, found, err := m.scanSettingDS.GetScanConfiguration(ctx, scanRequest.GetId())
-		if err != nil {
-			err = errors.Wrapf(err, "Unable to find scan configuration with ID %q.", scanRequest.GetId())
-			log.Error(err)
-			return nil, err
-		}
-		if !found {
-			return nil, errors.Errorf("Scan configuration with ID %q does not exist.", scanRequest.GetId())
-		}
-
-		// Use the created time from the DB
-		scanRequest.CreatedTime = scanConfig.GetCreatedTime()
+	scanRequest, err = m.processRequestToSensor(ctx, scanRequest, cron, clusters, true)
+	if err != nil {
+		return nil, err
 	}
 
+	// Send delete to sensor for any clusters that were deleted
+	m.processClusterDelete(scanRequest, deletedClusters)
+
+	return scanRequest, nil
+}
+
+func (m *managerImpl) processRequestToSensor(ctx context.Context, scanRequest *storage.ComplianceOperatorScanConfigurationV2, cron string, clusters []string, createScanRequest bool) (*storage.ComplianceOperatorScanConfigurationV2, error) {
 	var profiles []string
 	for _, profile := range scanRequest.GetProfiles() {
 		profiles = append(profiles, profile.GetProfileName())
 	}
 
-	// Check if there any existing cluster that has the scan configuration with any of profiles being referenced by the scan request.
+	// Check if any existing cluster that has the scan configuration with any of profiles being referenced by the scan request.
 	// If so, then we cannot create the scan configuration.
-	err = m.scanSettingDS.ScanConfigurationProfileExists(ctx, scanRequest.GetId(), profiles, clusters)
-
+	err := m.scanSettingDS.ScanConfigurationProfileExists(ctx, scanRequest.GetId(), profiles, clusters)
 	if err != nil {
 		log.Error(err)
 		return nil, errors.Wrapf(err, "Unable to create scan configuration named %q.", scanRequest.GetScanConfigName())
@@ -196,6 +227,31 @@ func (m *managerImpl) ProcessScanRequest(ctx context.Context, scanRequest *stora
 	}
 
 	return scanRequest, nil
+}
+
+func (m *managerImpl) processClusterDelete(scanRequest *storage.ComplianceOperatorScanConfigurationV2, clusters []string) {
+	for _, clusterID := range clusters {
+		// id for the request message to sensor
+		sensorRequestID := uuid.NewV4().String()
+
+		sensorMessage := &central.MsgToSensor{
+			Msg: &central.MsgToSensor_ComplianceRequest{
+				ComplianceRequest: &central.ComplianceRequest{
+					Request: &central.ComplianceRequest_DeleteScanConfig{
+						DeleteScanConfig: &central.DeleteComplianceScanConfigRequest{
+							Id:   sensorRequestID,
+							Name: scanRequest.GetScanConfigName(),
+						},
+					},
+				},
+			},
+		}
+
+		err := m.sensorConnMgr.SendMessage(clusterID, sensorMessage)
+		if err != nil {
+			log.Errorf("error sending deletion of compliance scan config to cluster %q: %v", clusterID, err)
+		}
+	}
 }
 
 // trackSensorRequest adds sensor request to a map with cluster and scan config that was sent for correlating responses.
@@ -357,4 +413,25 @@ func (m *managerImpl) updateClusterStatus(ctx context.Context, scanConfigID stri
 		return errors.Errorf("could not pull config for cluster %q because it does not exist", clusterID)
 	}
 	return m.scanSettingDS.UpdateClusterStatus(ctx, scanConfigID, clusterID, clusterStatus, clusterName)
+}
+
+func convertSchedule(scanRequest *storage.ComplianceOperatorScanConfigurationV2) (string, error) {
+	var cron string
+	var err error
+	if scanRequest.GetSchedule() != nil {
+		cron, err = schedule.ConvertToCronTab(scanRequest.GetSchedule())
+		if err != nil {
+			err = errors.Wrapf(err, "Unable to convert schedule for scan configuration named %q to cron.", scanRequest.GetScanConfigName())
+			log.Error(err)
+			return "", err
+		}
+		cronValidator := gronx.New()
+		if !cronValidator.IsValid(cron) {
+			err = errors.Errorf("Schedule for scan configuration named %q is invalid.", scanRequest.GetScanConfigName())
+			log.Error(err)
+			return "", err
+		}
+	}
+
+	return cron, nil
 }

--- a/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
@@ -204,7 +204,7 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(gomock.Any(), mockScanName).Return(getTestRec(), nil).Times(1)
 			},
 			isErrorTest: true,
-			expectedErr: errors.Errorf("Scan Configuration named %q already exists.", mockScanName),
+			expectedErr: errors.Errorf("Scan configuration named %q already exists.", mockScanName),
 		},
 		{
 			desc:        "Scan configuration has duplicate profiles",
@@ -267,6 +267,103 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			expectedErr: errors.New("access to resource denied"),
 		},
 		{
+			desc:        "Failure try to re-add a scan configuration",
+			testRequest: getTestRec(),
+			testContext: suite.testContexts[testutils.UnrestrictedReadWriteCtx],
+			clusters:    []string{testconsts.Cluster1},
+			setMocks:    func() {},
+			isErrorTest: true,
+			expectedErr: errors.New("The scan configuration already exists and cannot be added.  ID \"mockScanID\" and name \"mockScan\""),
+		},
+	}
+	for _, tc := range cases {
+		suite.T().Run(tc.desc, func(t *testing.T) {
+			tc.setMocks()
+
+			config, err := suite.manager.ProcessScanRequest(tc.testContext, tc.testRequest, tc.clusters)
+			if tc.isErrorTest {
+				suite.Require().Error(err, tc.expectedErr)
+				suite.Require().Nil(config)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().NotNil(config)
+			}
+		})
+	}
+}
+
+func (suite *complianceManagerTestSuite) TestUpdateScanRequest() {
+	cases := []processScanConfigTestCase{
+		{
+			desc:        "Unable to update due to no scan config ID",
+			testRequest: getTestRecNoID(),
+			testContext: suite.testContexts[testutils.UnrestrictedReadWriteCtx],
+			clusters:    []string{testconsts.Cluster1},
+			setMocks:    func() {},
+			isErrorTest: true,
+			expectedErr: errors.New("Scan Configuration ID is required for an update"),
+		},
+		{
+			desc:        "Scan configuration has duplicate profiles",
+			testRequest: getTestRec(),
+			testContext: suite.testContexts[testutils.UnrestrictedReadWriteCtx],
+			clusters:    []string{testconsts.Cluster1},
+			setMocks: func() {
+				suite.scanConfigDS.EXPECT().GetScanConfiguration(gomock.Any(), mockScanID).Return(getTestRec(), true, nil).Times(1)
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.Errorf("Duplicated profiles found in current or existing scan configurations: %q.", mockScanName)).Times(1)
+			},
+			isErrorTest: true,
+			expectedErr: errors.Errorf("Duplicated profiles found in current or existing scan configurations: %q.", mockScanName),
+		},
+		{
+			desc:        "Unable to store scan configuration",
+			testRequest: getTestRec(),
+			testContext: suite.testContexts[testutils.UnrestrictedReadWriteCtx],
+			clusters:    []string{testconsts.Cluster1},
+			setMocks: func() {
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				suite.scanConfigDS.EXPECT().GetScanConfiguration(gomock.Any(), mockScanID).Return(getTestRec(), true, nil).Times(1)
+				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(errors.Errorf("Unable to save scan config named %q", mockScanName)).Times(1)
+			},
+			isErrorTest: true,
+			expectedErr: errors.Errorf("Unable to save scan config named %q", mockScanName),
+		},
+		{
+			desc:        "Error from sensor",
+			testRequest: getTestRec(),
+			testContext: suite.testContexts[testutils.UnrestrictedReadWriteCtx],
+			clusters:    []string{testconsts.Cluster1},
+			setMocks: func() {
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				suite.scanConfigDS.EXPECT().GetScanConfiguration(gomock.Any(), mockScanID).Return(getTestRec(), true, nil).Times(1)
+				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
+				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(errors.New("Unable to process sensor message")).Times(1)
+				suite.clusterDatastore.EXPECT().GetClusterName(gomock.Any(), gomock.Any()).Return("test_cluster", true, nil).Times(1)
+				suite.scanConfigDS.EXPECT().UpdateClusterStatus(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), testconsts.Cluster1, "Unable to process sensor message", "test_cluster")
+			},
+			isErrorTest: false,
+		},
+		{
+			desc:        "Error due to not having write access",
+			testRequest: getTestRecNoID(),
+			testContext: suite.testContexts[testutils.UnrestrictedReadCtx],
+			clusters:    []string{testconsts.Cluster1},
+			setMocks: func() {
+			},
+			isErrorTest: true,
+			expectedErr: errors.New("access to resource denied"),
+		},
+		{
+			desc:        "Error due to only having write access to one of the clusters",
+			testRequest: getTestRecNoID(),
+			testContext: suite.testContexts[testutils.Cluster1ReadWriteCtx],
+			clusters:    []string{testconsts.Cluster1, testconsts.Cluster2},
+			setMocks: func() {
+			},
+			isErrorTest: true,
+			expectedErr: errors.New("access to resource denied"),
+		},
+		{
 			desc:        "Successful update of scan configuration",
 			testRequest: getTestRec(),
 			testContext: suite.testContexts[testutils.UnrestrictedReadWriteCtx],
@@ -281,14 +378,30 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 			},
 			isErrorTest: false,
 		},
+		{
+			desc:        "Successful update of scan configuration that removes cluster 2",
+			testRequest: getTestRec(),
+			testContext: suite.testContexts[testutils.UnrestrictedReadWriteCtx],
+			clusters:    []string{testconsts.Cluster1},
+			setMocks: func() {
+				suite.scanConfigDS.EXPECT().GetScanConfiguration(gomock.Any(), mockScanID).Return(getTestRecMultiCluster(), true, nil).Times(1)
+				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
+				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(nil).Times(1)
+				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster2, gomock.Any()).Return(nil).Times(1)
+				suite.clusterDatastore.EXPECT().GetClusterName(gomock.Any(), gomock.Any()).Return("test_cluster", true, nil).Times(1)
+				suite.scanConfigDS.EXPECT().UpdateClusterStatus(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), testconsts.Cluster1, "", "test_cluster")
+			},
+			isErrorTest: false,
+		},
 	}
 	for _, tc := range cases {
 		suite.T().Run(tc.desc, func(t *testing.T) {
 			tc.setMocks()
 
-			config, err := suite.manager.ProcessScanRequest(tc.testContext, tc.testRequest, tc.clusters)
+			config, err := suite.manager.UpdateScanRequest(tc.testContext, tc.testRequest, tc.clusters)
 			if tc.isErrorTest {
-				suite.Require().NotNil(err)
+				suite.Require().Error(err, tc.expectedErr)
 				suite.Require().Nil(config)
 			} else {
 				suite.Require().NoError(err)
@@ -356,6 +469,26 @@ func getTestRec() *storage.ComplianceOperatorScanConfigurationV2 {
 		},
 		Clusters: []*storage.ComplianceOperatorScanConfigurationV2_Cluster{
 			{ClusterId: testconsts.Cluster1},
+		},
+		StrictNodeScan: false,
+	}
+}
+
+func getTestRecMultiCluster() *storage.ComplianceOperatorScanConfigurationV2 {
+	return &storage.ComplianceOperatorScanConfigurationV2{
+		Id:                     mockScanID,
+		ScanConfigName:         mockScanName,
+		AutoApplyRemediations:  false,
+		AutoUpdateRemediations: false,
+		OneTimeScan:            false,
+		Profiles: []*storage.ComplianceOperatorScanConfigurationV2_ProfileName{
+			{
+				ProfileName: "ocp4-cis",
+			},
+		},
+		Clusters: []*storage.ComplianceOperatorScanConfigurationV2_Cluster{
+			{ClusterId: testconsts.Cluster1},
+			{ClusterId: testconsts.Cluster2},
 		},
 		StrictNodeScan: false,
 	}

--- a/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
@@ -387,6 +387,7 @@ func (suite *complianceManagerTestSuite) TestUpdateScanRequest() {
 				suite.scanConfigDS.EXPECT().GetScanConfiguration(gomock.Any(), mockScanID).Return(getTestRecMultiCluster(), true, nil).Times(1)
 				suite.scanConfigDS.EXPECT().ScanConfigurationProfileExists(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				suite.scanConfigDS.EXPECT().UpsertScanConfiguration(suite.testContexts[testutils.UnrestrictedReadWriteCtx], gomock.Any()).Return(nil).Times(1)
+				suite.scanConfigDS.EXPECT().RemoveClusterStatus(gomock.Any(), mockScanID, testconsts.Cluster2).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster2, gomock.Any()).Return(nil).Times(1)
 				suite.clusterDatastore.EXPECT().GetClusterName(gomock.Any(), gomock.Any()).Return("test_cluster", true, nil).Times(1)

--- a/central/complianceoperator/v2/compliancemanager/mocks/manager.go
+++ b/central/complianceoperator/v2/compliancemanager/mocks/manager.go
@@ -122,3 +122,18 @@ func (mr *MockManagerMockRecorder) Sync(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx)
 }
+
+// UpdateScanRequest mocks base method.
+func (m *MockManager) UpdateScanRequest(ctx context.Context, scanRequest *storage.ComplianceOperatorScanConfigurationV2, clusters []string) (*storage.ComplianceOperatorScanConfigurationV2, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateScanRequest", ctx, scanRequest, clusters)
+	ret0, _ := ret[0].(*storage.ComplianceOperatorScanConfigurationV2)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateScanRequest indicates an expected call of UpdateScanRequest.
+func (mr *MockManagerMockRecorder) UpdateScanRequest(ctx, scanRequest, clusters any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateScanRequest", reflect.TypeOf((*MockManager)(nil).UpdateScanRequest), ctx, scanRequest, clusters)
+}

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore.go
@@ -38,6 +38,9 @@ type DataStore interface {
 	// UpdateClusterStatus updates the scan configuration with the cluster status
 	UpdateClusterStatus(ctx context.Context, scanConfigID string, clusterID string, clusterStatus string, clusterName string) error
 
+	// RemoveClusterStatus removes the scan configuration status for the given cluster
+	RemoveClusterStatus(ctx context.Context, scanConfigID string, clusterID string) error
+
 	// GetScanConfigClusterStatus retrieves the scan configurations status per cluster specified by scan id
 	GetScanConfigClusterStatus(ctx context.Context, scanConfigID string) ([]*storage.ComplianceOperatorClusterScanConfigStatus, error)
 

--- a/central/complianceoperator/v2/scanconfigurations/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/mocks/datastore.go
@@ -146,6 +146,20 @@ func (mr *MockDataStoreMockRecorder) RemoveClusterFromScanConfig(ctx, clusterID 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveClusterFromScanConfig", reflect.TypeOf((*MockDataStore)(nil).RemoveClusterFromScanConfig), ctx, clusterID)
 }
 
+// RemoveClusterStatus mocks base method.
+func (m *MockDataStore) RemoveClusterStatus(ctx context.Context, scanConfigID, clusterID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveClusterStatus", ctx, scanConfigID, clusterID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveClusterStatus indicates an expected call of RemoveClusterStatus.
+func (mr *MockDataStoreMockRecorder) RemoveClusterStatus(ctx, scanConfigID, clusterID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveClusterStatus", reflect.TypeOf((*MockDataStore)(nil).RemoveClusterStatus), ctx, scanConfigID, clusterID)
+}
+
 // ScanConfigurationProfileExists mocks base method.
 func (m *MockDataStore) ScanConfigurationProfileExists(ctx context.Context, id string, profiles, clusters []string) error {
 	m.ctrl.T.Helper()

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -110,8 +110,8 @@ func (s *serviceImpl) UpdateComplianceScanConfiguration(ctx context.Context, req
 	var clusterIDs []string
 	clusterIDs = append(clusterIDs, req.GetClusters()...)
 
-	// Process scan request, config may be updated in the event of errors from sensor.
-	_, err := s.manager.ProcessScanRequest(ctx, scanConfig, clusterIDs)
+	// Update scan request, config may be updated in the event of errors from sensor.
+	_, err := s.manager.UpdateScanRequest(ctx, scanConfig, clusterIDs)
 	if err != nil {
 		return nil, errors.Wrapf(errox.InvalidArgs, "Unable to process scan config. %v", err)
 	}

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
@@ -155,7 +155,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestUpdateComplianceScanConfigura
 	storageRequest := convertV2ScanConfigToStorage(allAccessContext, request)
 	processResponse := convertV2ScanConfigToStorage(allAccessContext, request)
 	processResponse.Id = uuid.NewDummy().String()
-	s.manager.EXPECT().ProcessScanRequest(gomock.Any(), storageRequest, []string{fixtureconsts.Cluster1}).Return(processResponse, nil).Times(1)
+	s.manager.EXPECT().UpdateScanRequest(gomock.Any(), storageRequest, []string{fixtureconsts.Cluster1}).Return(processResponse, nil).Times(1)
 
 	_, err := s.service.UpdateComplianceScanConfiguration(allAccessContext, request)
 	s.Require().NoError(err)


### PR DESCRIPTION
## Description

When a scan configuration was updated such that it removed a cluster, we were not deleting the configuration on the deleted sensor nor were we removing the cluster from the scan configuration status.  This PR does both and refactors things slightly to separate the creation of a scan configuration from the update.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Added some unit test cases.  
Additionally did some testing running on 2 clusters to ensure that the delete was pushed to sensor.

The initial configuration with both clusters
![Screenshot 2024-02-13 at 3 44 13 PM](https://github.com/stackrox/stackrox/assets/99685630/eeb2893f-5442-4d44-98b6-0ca4e36a54be)


After removing the second cluster from the scan configuration
![Screenshot 2024-02-13 at 3 07 52 PM](https://github.com/stackrox/stackrox/assets/99685630/9550454b-d80f-4ba6-b2a8-8679c4327b20)

The before and after of showing the suites running on cluster 2.
<img width="901" alt="Screenshot 2024-02-13 at 3 08 08 PM" src="https://github.com/stackrox/stackrox/assets/99685630/ee898aa1-832e-437b-8a90-9162764b59f7">

The suites that ran on cluster 1.
<img width="978" alt="Screenshot 2024-02-13 at 3 08 20 PM" src="https://github.com/stackrox/stackrox/assets/99685630/3af86458-7226-4847-a242-aa958bb6dcea">


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
