### PR TITLE
ROX-21839: cluster init bundle analytics

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -7,6 +7,7 @@ import { ClipLoader } from 'react-spinners';
 import CollapsibleCard from 'Components/CollapsibleCard';
 import ToggleSwitch from 'Components/ToggleSwitch';
 import { ClusterManagerType } from 'types/cluster.proto';
+import useAnalytics, { LEGACY_CLUSTER_DOWNLOAD_YAML } from 'hooks/useAnalytics';
 
 const baseClass = 'py-6';
 
@@ -29,6 +30,8 @@ function ClusterDeployment({
     toggleSA,
     managerType,
 }: ClusterDeploymentProps): ReactElement {
+    const { analyticsTrack } = useAnalytics();
+
     let managerTypeTitle = 'Dynamic configurations are automatically applied';
     let managerTypeText =
         'If you edited static configurations or you need to redeploy, download a new bundle.';
@@ -72,7 +75,10 @@ function ClusterDeployment({
                                     <Button
                                         variant="secondary"
                                         icon={<DownloadIcon />}
-                                        onClick={onFileDownload}
+                                        onClick={() => {
+                                            onFileDownload();
+                                            analyticsTrack(LEGACY_CLUSTER_DOWNLOAD_YAML);
+                                        }}
                                         isDisabled={isDownloadingBundle}
                                         isLoading={isDownloadingBundle}
                                     >

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -25,6 +25,10 @@ import Dialog from 'Components/Dialog';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import SearchFilterInput from 'Components/SearchFilterInput';
 import { DEFAULT_PAGE_SIZE } from 'Components/Table';
+import useAnalytics, {
+    LEGACY_SECURE_A_CLUSTER_LINK_CLICKED,
+    SECURE_A_CLUSTER_LINK_CLICKED,
+} from 'hooks/useAnalytics';
 import useAuthStatus from 'hooks/useAuthStatus';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useInterval from 'hooks/useInterval';
@@ -69,6 +73,7 @@ function ClustersTablePanel({
     selectedClusterId,
     searchOptions,
 }: ClustersTablePanelProps): ReactElement {
+    const { analyticsTrack } = useAnalytics();
     const history = useHistory();
 
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
@@ -212,6 +217,12 @@ function ClustersTablePanel({
         isMoveInitBundlesEnabled ? (
             <DropdownItem
                 key="init-bundle"
+                onClick={() => {
+                    analyticsTrack({
+                        event: SECURE_A_CLUSTER_LINK_CLICKED,
+                        properties: { source: 'Secure a Cluster Dropdown' },
+                    });
+                }}
                 component={
                     <Link to={clustersSecureClusterPath}>Init bundle installation methods</Link>
                 }
@@ -234,7 +245,15 @@ function ClustersTablePanel({
         <DropdownItem
             key="legacy"
             component={
-                <Link to={`${clustersBasePath}/new`}>
+                <Link
+                    to={`${clustersBasePath}/new`}
+                    onClick={() =>
+                        analyticsTrack({
+                            event: LEGACY_SECURE_A_CLUSTER_LINK_CLICKED,
+                            properties: { source: 'Secure a Cluster Dropdown' },
+                        })
+                    }
+                >
                     {isMoveInitBundlesEnabled ? 'Legacy installation method' : 'New cluster'}
                 </Link>
             }

--- a/ui/apps/platform/src/Containers/Clusters/DownloadHelmValues.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DownloadHelmValues.tsx
@@ -4,6 +4,7 @@ import { Button } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
 
 import CollapsibleCard from 'Components/CollapsibleCard';
+import useAnalytics, { LEGACY_CLUSTER_DOWNLOAD_HELM_VALUES } from 'hooks/useAnalytics';
 import { actions as notificationActions } from 'reducers/notifications';
 import { downloadClusterHelmValuesYaml } from 'services/ClustersService';
 
@@ -20,6 +21,7 @@ const DownloadHelmValues = ({
     addToast,
     removeToast,
 }: DownloadHelmValuesProps): ReactElement => {
+    const { analyticsTrack } = useAnalytics();
     const [isFetchingValues, setIsFetchingValues] = useState(false);
 
     function downloadValues(): void {
@@ -47,7 +49,10 @@ const DownloadHelmValues = ({
                 <Button
                     variant="secondary"
                     icon={<DownloadIcon />}
-                    onClick={downloadValues}
+                    onClick={() => {
+                        downloadValues();
+                        analyticsTrack(LEGACY_CLUSTER_DOWNLOAD_HELM_VALUES);
+                    }}
                     isDisabled={isFetchingValues}
                     isLoading={isFetchingValues}
                 >

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
@@ -19,6 +19,7 @@ import * as yup from 'yup';
 
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import useAnalytics, { DOWNLOAD_INIT_BUNDLE } from 'hooks/useAnalytics';
 import { generateClusterInitBundle } from 'services/ClustersService'; // ClusterInitBundle
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
@@ -61,6 +62,7 @@ const validationSchema: yup.ObjectSchema<InitBundleFormValues> = yup.object().sh
 });
 
 function InitBundleForm(): ReactElement {
+    const { analyticsTrack } = useAnalytics();
     const history = useHistory();
     const [errorMessage, setErrorMessage] = useState('');
     const {
@@ -218,7 +220,10 @@ function InitBundleForm(): ReactElement {
                             variant="primary"
                             isDisabled={isSubmitting || !isValid}
                             isLoading={isSubmitting}
-                            onClick={submitForm}
+                            onClick={() => {
+                                analyticsTrack(DOWNLOAD_INIT_BUNDLE);
+                                return submitForm();
+                            }}
                         >
                             Download
                         </Button>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, useState } from 'react';
 import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
+import useAnalytics, { CREATE_INIT_BUNDLE_CLICKED } from 'hooks/useAnalytics';
 import useRestQuery from 'hooks/useRestQuery';
 import { ClusterInitBundle, fetchClusterInitBundles } from 'services/ClustersService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -16,12 +17,19 @@ export type InitBundlesPageProps = {
 };
 
 function InitBundlesPage({ hasWriteAccessForInitBundles }: InitBundlesPageProps): ReactElement {
+    const { analyticsTrack } = useAnalytics();
     const [initBundleToRevoke, setInitBundleToRevoke] = useState<ClusterInitBundle | null>(null);
     const headerActions = hasWriteAccessForInitBundles ? (
         <Button
             variant="primary"
             component={LinkShim}
             href={`${clustersInitBundlesPath}?action=create`}
+            onClick={() => {
+                analyticsTrack({
+                    event: CREATE_INIT_BUNDLE_CLICKED,
+                    properties: { source: 'Cluster Init Bundles' },
+                });
+            }}
         >
             Create bundle
         </Button>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/RevokeBundleModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/RevokeBundleModal.tsx
@@ -12,6 +12,7 @@ import {
     Modal,
 } from '@patternfly/react-core';
 
+import useAnalytics, { REVOKE_INIT_BUNDLE } from 'hooks/useAnalytics';
 import {
     ClusterInitBundle,
     ImpactedCluster,
@@ -25,6 +26,7 @@ export type RevokeBundleModalProps = {
 };
 
 function RevokeBundleModal({ initBundle, onCloseModal }: RevokeBundleModalProps): ReactElement {
+    const { analyticsTrack } = useAnalytics();
     const [errorMessage, setErrorMessage] = useState('');
     const [impactedClusters, setImpactedClusters] = useState<ImpactedCluster[]>(
         initBundle.impactedClusters
@@ -49,6 +51,7 @@ function RevokeBundleModal({ initBundle, onCloseModal }: RevokeBundleModalProps)
                     setHasMoreClusters(true);
                     setImpactedClusters(initBundleRevocationErrors[0].impactedClusters);
                 }
+                analyticsTrack(REVOKE_INIT_BUNDLE);
             })
             .catch((error) => {
                 setErrorMessage(getAxiosErrorMessage(error));

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -18,6 +18,11 @@ import { CloudSecurityIcon } from '@patternfly/react-icons';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 import { getProductBranding } from 'constants/productBranding';
+import useAnalytics, {
+    CREATE_INIT_BUNDLE_CLICKED,
+    LEGACY_SECURE_A_CLUSTER_LINK_CLICKED,
+    SECURE_A_CLUSTER_LINK_CLICKED,
+} from 'hooks/useAnalytics';
 // import useAuthStatus from 'hooks/useAuthStatus'; // TODO after 4.4 release
 import { fetchClusterInitBundles } from 'services/ClustersService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -45,6 +50,8 @@ export type NoClustersPageProps = {
 };
 
 function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
+    const { analyticsTrack } = useAnalytics();
+
     /*
     // TODO after 4.4 release
     const { currentUser } = useAuthStatus();
@@ -132,6 +139,12 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
                                 isLarge
                                 component={LinkShim}
                                 href={`${clustersInitBundlesPath}?action=create`}
+                                onClick={() =>
+                                    analyticsTrack({
+                                        event: CREATE_INIT_BUNDLE_CLICKED,
+                                        properties: { source: 'No Clusters' },
+                                    })
+                                }
                             >
                                 Create bundle
                             </Button>
@@ -141,13 +154,27 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
                                 isLarge
                                 onClick={() => {
                                     setIsModalOpen(true);
+                                    analyticsTrack({
+                                        event: SECURE_A_CLUSTER_LINK_CLICKED,
+                                        properties: { source: 'No Clusters' },
+                                    });
                                 }}
                             >
                                 Review installation methods
                             </Button>
                         )}
                         <div className="pf-u-mt-xl">
-                            <Link to={`${clustersBasePath}/new`}>Legacy installation method</Link>
+                            <Link
+                                to={`${clustersBasePath}/new`}
+                                onClick={() => {
+                                    analyticsTrack({
+                                        event: LEGACY_SECURE_A_CLUSTER_LINK_CLICKED,
+                                        properties: { source: 'No Clusters' },
+                                    });
+                                }}
+                            >
+                                Legacy installation method
+                            </Link>
                         </div>
                         <SecureClusterModal
                             isModalOpen={isModalOpen}

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -21,6 +21,14 @@ export const VULNERABILITY_REPORT_DOWNLOAD_GENERATED = 'Vulnerability Report Dow
 export const VULNERABILITY_REPORT_SENT_MANUALLY = 'Vulnerability Report Sent Manually';
 export const GLOBAL_SNOOZE_CVE = 'Global Snooze CVE';
 
+export const CREATE_INIT_BUNDLE_CLICKED = 'Create Init Bundle Clicked';
+export const SECURE_A_CLUSTER_LINK_CLICKED = 'Secure a Cluster Link Clicked';
+export const LEGACY_SECURE_A_CLUSTER_LINK_CLICKED = 'Legacy Secure a Cluster Link Clicked';
+export const DOWNLOAD_INIT_BUNDLE = 'Download Init Bundle';
+export const REVOKE_INIT_BUNDLE = 'Revoke Init Bundle';
+export const LEGACY_CLUSTER_DOWNLOAD_YAML = 'Legacy Cluster Download YAML';
+export const LEGACY_CLUSTER_DOWNLOAD_HELM_VALUES = 'Legacy Cluster Download Helm Values';
+
 /**
  * Boolean fields should be tracked with 0 or 1 instead of true/false. This
  * allows us to use the boolean fields in numeric aggregations in the
@@ -139,7 +147,50 @@ type AnalyticsEvent =
               type: 'NODE' | 'PLATFORM';
               duration: string;
           };
-      };
+      }
+    /**
+     * Tracks each time the user clicks the "Create Bundle" button
+     */
+    | {
+          event: typeof CREATE_INIT_BUNDLE_CLICKED;
+          properties: {
+              source: 'No Clusters' | 'Cluster Init Bundles';
+          };
+      }
+    /**
+     * Tracks each time the user clicks a link to visit the "Secure a Cluster" page
+     */
+    | {
+          event: typeof SECURE_A_CLUSTER_LINK_CLICKED;
+          properties: {
+              source: 'No Clusters' | 'Secure a Cluster Dropdown';
+          };
+      }
+    /**
+     * Tracks each time the user clicks a link to visit the legacy installation method page
+     */
+    | {
+          event: typeof LEGACY_SECURE_A_CLUSTER_LINK_CLICKED;
+          properties: {
+              source: 'No Clusters' | 'Secure a Cluster Dropdown';
+          };
+      }
+    /**
+     * Tracks each time the user downloads an init bundle
+     */
+    | typeof DOWNLOAD_INIT_BUNDLE
+    /**
+     * Tracks each time the user revokes an init bundle
+     */
+    | typeof REVOKE_INIT_BUNDLE
+    /**
+     * Tracks each time the user downloads a cluster's YAML file and keys
+     */
+    | typeof LEGACY_CLUSTER_DOWNLOAD_YAML
+    /**
+     * Tracks each time the user downloads a cluster's Helm values
+     */
+    | typeof LEGACY_CLUSTER_DOWNLOAD_HELM_VALUES;
 
 const useAnalytics = () => {
     const telemetry = useSelector(selectors.publicConfigTelemetrySelector);


### PR DESCRIPTION
## Description

Adds analytics for new and legacy user actions related to generating cluster init bundles.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Set the development API key for segment analytics:
`kubectl -n stackrox set env deploy/central ROX_TELEMETRY_STORAGE_KEY_V1="<API_KEY_HERE>"`

Perform the following actions, verify that an analytics payload is sent, then verify that the event is visible in the Amplitude dashboard:

Click the "Create bundle" button from the "No Clusters" page:
![image](https://github.com/stackrox/stackrox/assets/1292638/dd3d3636-a58d-4818-a8ca-6f0deab513c0)
![image](https://github.com/stackrox/stackrox/assets/1292638/062944b5-a045-48cd-8267-3d338255c137)

...from the Init Bundles page:
![image](https://github.com/stackrox/stackrox/assets/1292638/5c26e338-bc95-41b8-b056-4b9b7f2b4c3a)
![image](https://github.com/stackrox/stackrox/assets/1292638/b63e48fa-dff6-4006-8418-4cc4dc6f2302)
![image](https://github.com/stackrox/stackrox/assets/1292638/6025da6e-ab3e-47b7-9d49-8d1136d6216c)


Visit the "secure a cluster" instructions via the "No Clusters" page:
![image](https://github.com/stackrox/stackrox/assets/1292638/f0b248e0-870d-4cec-ba9b-f2cb8193d6be)
![image](https://github.com/stackrox/stackrox/assets/1292638/b4acba98-d1c3-406b-9959-a2255d1475ac)

...via clusters table page dropdown:
![image](https://github.com/stackrox/stackrox/assets/1292638/1f0c6f52-fd7e-4131-a5a6-ef3053adc9e5)
![image](https://github.com/stackrox/stackrox/assets/1292638/fe1fd970-3b55-4bab-8a08-e453b37653a1)

Visit the legacy installation instructions via the "No Clusters" page:
![image](https://github.com/stackrox/stackrox/assets/1292638/efe5d0c0-d8c2-43a7-b1af-7bc68ca03cbb)
![image](https://github.com/stackrox/stackrox/assets/1292638/1cdc161d-e82c-458d-b7c6-72781844ab23)

...via clusters table page dropdown:
![image](https://github.com/stackrox/stackrox/assets/1292638/8eab9a5a-d92b-4ecc-a32a-e6841311c8f5)
![image](https://github.com/stackrox/stackrox/assets/1292638/e1e5032f-17fc-469f-a3c7-b54a3fedcb4c)

Click the "Download" button for init bundle:
![image](https://github.com/stackrox/stackrox/assets/1292638/dca774b8-1316-4a7e-926c-b2949836d586)
![image](https://github.com/stackrox/stackrox/assets/1292638/c5c91e6d-a683-458a-864f-5e968248347c)


Click the "Revoke" confirmation in the revoke bundle modal:
![image](https://github.com/stackrox/stackrox/assets/1292638/085e0a9e-5bc8-4048-90f1-365f99f1b8d6)
![image](https://github.com/stackrox/stackrox/assets/1292638/d8d465c2-d12e-4ade-bac7-9877d10d83e7)

Click the "Download YAML" or "Download Helm Values" buttons in the legacy installation method:
![image](https://github.com/stackrox/stackrox/assets/1292638/4480cfa5-baee-4f39-9e4d-4f82bdbf7673)
![image](https://github.com/stackrox/stackrox/assets/1292638/d242c9de-2bcc-4da3-b6a0-b0d0c8aa475f)
![image](https://github.com/stackrox/stackrox/assets/1292638/3cbef7ba-29d4-4db4-ad1b-00761382e9d9)

View that all of the above events are properly tracked in the Amplitude dashboard:
![image](https://github.com/stackrox/stackrox/assets/1292638/5e3b8968-bde7-4123-a1cf-b3a146d93780)





