### PR TITLE
ROX-22478: Rearrange elements at upper edge of Clusters page

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -154,59 +154,6 @@ function ClustersTablePanel({
 
     const { version } = metadata;
 
-    const pageHeader = (
-        <Toolbar inset={{ default: 'insetNone' }} className="pf-u-pb-0">
-            <ToolbarContent>
-                <ToolbarGroup
-                    variant="filter-group"
-                    className="pf-u-flex-grow-1 pf-u-flex-shrink-1"
-                >
-                    <ToolbarItem variant="search-filter" className="pf-u-w-100">
-                        <SearchFilterInput
-                            className="w-full"
-                            searchFilter={searchFilter}
-                            searchOptions={searchOptions}
-                            searchCategory="CLUSTERS"
-                            placeholder="Filter clusters"
-                            handleChangeSearchFilter={setSearchFilter}
-                        />
-                    </ToolbarItem>
-                </ToolbarGroup>
-                <ToolbarGroup variant="button-group">
-                    {hasReadAccessForAdministration && (
-                        <ToolbarItem>
-                            <Button
-                                variant="secondary"
-                                component={LinkShim}
-                                href={clustersDelegatedScanningPath}
-                            >
-                                Delegated scanning
-                            </Button>
-                        </ToolbarItem>
-                    )}
-                    {hasReadAccessForAdministration && (
-                        <ToolbarItem>
-                            <Button
-                                variant="secondary"
-                                component={LinkShim}
-                                href={clustersDiscoveredClustersPath}
-                            >
-                                Discovered clusters
-                            </Button>
-                        </ToolbarItem>
-                    )}
-                    {hasAdminRole && (
-                        <ToolbarItem>
-                            <Button variant="tertiary">
-                                <ManageTokensButton />
-                            </Button>
-                        </ToolbarItem>
-                    )}
-                </ToolbarGroup>
-            </ToolbarContent>
-        </Toolbar>
-    );
-
     /* eslint-disable no-nested-ternary */
     const installMenuOptions = [
         isMoveInitBundlesEnabled ? (
@@ -366,63 +313,6 @@ function ClustersTablePanel({
             });
     }
 
-    const headerActions = (
-        <Toolbar inset={{ default: 'insetNone' }} className="pf-u-pb-0">
-            <ToolbarContent>
-                <ToolbarGroup variant="button-group" alignment={{ default: 'alignRight' }}>
-                    {hasWriteAccessForAdministration && (
-                        <ToolbarItem>
-                            <AutoUpgradeToggle />
-                        </ToolbarItem>
-                    )}
-                    {hasWriteAccessForAdministration && (
-                        <ToolbarItem>
-                            <Button
-                                variant="secondary"
-                                className="pf-u-ml-sm"
-                                onClick={upgradeSelectedClusters}
-                                isDisabled={upgradableClusters.length === 0 || !!selectedClusterId}
-                            >
-                                {`Upgrade (${upgradableClusters.length})`}
-                            </Button>
-                        </ToolbarItem>
-                    )}
-                    {hasWriteAccessForCluster && (
-                        <ToolbarItem>
-                            <Button
-                                variant="danger"
-                                className="pf-u-ml-sm pf-u-mr-sm"
-                                onClick={deleteSelectedClusters}
-                                isDisabled={checkedClusterIds.length === 0 || !!selectedClusterId}
-                            >
-                                {`Delete (${checkedClusterIds.length})`}
-                            </Button>
-                        </ToolbarItem>
-                    )}
-                    {hasWriteAccessForCluster && (
-                        <ToolbarItem>
-                            <Dropdown
-                                onSelect={onSelectInstallMenuItem}
-                                toggle={
-                                    <DropdownToggle
-                                        id="install-toggle"
-                                        toggleVariant="secondary"
-                                        onToggle={onToggleInstallMenu}
-                                    >
-                                        Secure a cluster
-                                    </DropdownToggle>
-                                }
-                                position={DropdownPosition.right}
-                                isOpen={isInstallMenuOpen}
-                                dropdownItems={installMenuOptions}
-                            />
-                        </ToolbarItem>
-                    )}
-                </ToolbarGroup>
-            </ToolbarContent>
-        </Toolbar>
-    );
-
     function calculateUpgradeableClusters(selection) {
         const currentlySelectedClusters = currentClusters.filter((cluster) =>
             selection.includes(cluster.id)
@@ -475,9 +365,113 @@ function ClustersTablePanel({
     return (
         <>
             <PageSection variant="light" component="div">
-                <Title headingLevel="h1">Clusters</Title>
-                {pageHeader}
-                {headerActions}
+                <Toolbar inset={{ default: 'insetNone' }} className="pf-u-pb-0">
+                    <ToolbarContent>
+                        <Title headingLevel="h1">Clusters</Title>
+                        <ToolbarGroup variant="button-group" alignment={{ default: 'alignRight' }}>
+                            {hasReadAccessForAdministration && (
+                                <ToolbarItem>
+                                    <Button
+                                        variant="secondary"
+                                        component={LinkShim}
+                                        href={clustersDelegatedScanningPath}
+                                    >
+                                        Delegated scanning
+                                    </Button>
+                                </ToolbarItem>
+                            )}
+                            {hasReadAccessForAdministration && (
+                                <ToolbarItem>
+                                    <Button
+                                        variant="secondary"
+                                        component={LinkShim}
+                                        href={clustersDiscoveredClustersPath}
+                                    >
+                                        Discovered clusters
+                                    </Button>
+                                </ToolbarItem>
+                            )}
+                            {hasAdminRole && (
+                                <ToolbarItem>
+                                    <Button variant="tertiary">
+                                        <ManageTokensButton />
+                                    </Button>
+                                </ToolbarItem>
+                            )}
+                            {hasWriteAccessForCluster && (
+                                <ToolbarItem>
+                                    <Dropdown
+                                        onSelect={onSelectInstallMenuItem}
+                                        toggle={
+                                            <DropdownToggle
+                                                id="install-toggle"
+                                                toggleVariant="secondary"
+                                                onToggle={onToggleInstallMenu}
+                                            >
+                                                Secure a cluster
+                                            </DropdownToggle>
+                                        }
+                                        position={DropdownPosition.right}
+                                        isOpen={isInstallMenuOpen}
+                                        dropdownItems={installMenuOptions}
+                                    />
+                                </ToolbarItem>
+                            )}
+                        </ToolbarGroup>
+                    </ToolbarContent>
+                </Toolbar>
+                <Toolbar inset={{ default: 'insetNone' }} className="pf-u-pb-0">
+                    <ToolbarContent>
+                        <ToolbarGroup
+                            variant="filter-group"
+                            className="pf-u-flex-grow-1 pf-u-flex-shrink-1"
+                        >
+                            <ToolbarItem variant="search-filter" className="pf-u-w-100">
+                                <SearchFilterInput
+                                    className="w-full"
+                                    searchFilter={searchFilter}
+                                    searchOptions={searchOptions}
+                                    searchCategory="CLUSTERS"
+                                    placeholder="Filter clusters"
+                                    handleChangeSearchFilter={setSearchFilter}
+                                />
+                            </ToolbarItem>
+                        </ToolbarGroup>
+                        <ToolbarGroup variant="button-group" alignment={{ default: 'alignRight' }}>
+                            {hasWriteAccessForAdministration && (
+                                <ToolbarItem>
+                                    <AutoUpgradeToggle />
+                                </ToolbarItem>
+                            )}
+                            {hasWriteAccessForAdministration && (
+                                <ToolbarItem>
+                                    <Button
+                                        variant="secondary"
+                                        onClick={upgradeSelectedClusters}
+                                        isDisabled={
+                                            upgradableClusters.length === 0 || !!selectedClusterId
+                                        }
+                                    >
+                                        {`Upgrade (${upgradableClusters.length})`}
+                                    </Button>
+                                </ToolbarItem>
+                            )}
+                            {hasWriteAccessForCluster && (
+                                <ToolbarItem>
+                                    <Button
+                                        variant="danger"
+                                        onClick={deleteSelectedClusters}
+                                        isDisabled={
+                                            checkedClusterIds.length === 0 || !!selectedClusterId
+                                        }
+                                    >
+                                        {`Delete (${checkedClusterIds.length})`}
+                                    </Button>
+                                </ToolbarItem>
+                            )}
+                        </ToolbarGroup>
+                    </ToolbarContent>
+                </Toolbar>
             </PageSection>
             <Divider component="div" />
             <PageSection variant="light" isFilled>


### PR DESCRIPTION
## Description

Follow up #9881

### Problem

Direct classic-to-PatternFly replacement emphasizes difference in arrangement compared to recent table pages.

### Analysis

1. Violations
    * Heading
    * Filter violations
    * Table row actions (also known as bulk actions) and pagination
2. Workload CVEs
    * Default vulnerability filters
    * Heading and tagline with **Manage watched images** button at the right
    * Search filters
    * Toggle, bulk actions, and pagination
3. Policy Management
    * Heading
    * Tabs
    * Tagline with **Create policy** and **Import policy** buttons at the right
    * Search filter, bulk actions, **Reassess all** button, and pagination
4. Collections
    * Heading and tagline with **Create collection** button at the right
    * Search filter and pagination
5. Administration Events
    * Heading and tagline
    * Search filters, last updated, and pagination

### Solution

Pending future redesign, follow the examples of Policies and especially Collections:
* Heading with **Delegated scanning**, **Discovered clusters**, **Init bundles**, and **Secure a cluster** at the right
* Search filter, **Automatically upgrade secured clusters** switch, **Upgrade** and **Delete** buttons

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_CLOUD_SOURCES=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 3951282 - 3951282
        total -39 = 10529498 - 10529537
    * `ls -al build/static/js/*.js | wc`
        files 0 = 92 - 92
3. `yarn start` in ui

### Manual testing

1. Visit /main/clusters

    * Before changes see 3 rows at 1440px laptop width
        ![3_rows_1440px](https://github.com/stackrox/stackrox/assets/11862657/4ac0ee2c-da25-4a7e-932a-8e4fd0cac70e)
 
    * After changes see 2 rows at 1440px laptop width
        ![2_rows_1440px](https://github.com/stackrox/stackrox/assets/11862657/471cd0ee-6a2d-44c6-9806-6b7e4a1a9d32)

    * Before changes see 3 rows at 1920px panel width
        ![3_rows_1920px](https://github.com/stackrox/stackrox/assets/11862657/a635dcab-e960-4f93-9902-67f19fb67efb)

    * After changes see 2 rows at 1920px panel width
        ![2_rows_1920px](https://github.com/stackrox/stackrox/assets/11862657/886bbfba-8d48-4e80-8b15-2d8d529c9eca)

### Integration testing

* clusters/clusterDeletion.test.js
* clusters/clusters.test.js
* clusters/clustersCertificateExpiration.test.js
* clusters/clustersHealthStatus.test.js
* clusters/clustersManager.test.js
* clusters/delegatedScanning.test.js
* clusters/redirectFromDashboard.test.js
