### PR TITLE
fix(tests): add ROSA HCP support

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -285,4 +285,8 @@ class Env {
     static String getDisableAuditLogAlertsTest() {
         return get("DISABLE_AUDIT_LOG_ALERTS_TEST")
     }
+
+    static String getManagedControlPlane() {
+        return get("MANAGED_CP", "false")
+    }
 }

--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -283,6 +283,6 @@ class Env {
     }
 
     static String getDisableAuditLogAlertsTest() {
-        return envVars.get("DISABLE_AUDIT_LOG_ALERTS_TEST")
+        return get("DISABLE_AUDIT_LOG_ALERTS_TEST")
     }
 }

--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -289,4 +289,8 @@ class Env {
     static String getManagedControlPlane() {
         return get("MANAGED_CP", "false")
     }
+
+    static String getSupportsLoadBalancerSvc() {
+        return get("SUPPORTS_LOAD_BALANCER_SVC", "true")
+    }
 }

--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -281,4 +281,8 @@ class Env {
     static String mustGetSlackAltWebhook() {
         return mustGet("SLACK_ALT_WEBHOOK")
     }
+
+    static String getDisableAuditLogAlertsTest() {
+        return envVars.get("DISABLE_AUDIT_LOG_ALERTS_TEST")
+    }
 }

--- a/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
@@ -13,6 +13,7 @@ import services.ClusterService
 import services.PolicyService
 
 import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Requires
 import spock.lang.Stepwise
 import spock.lang.Tag
@@ -21,6 +22,9 @@ import util.Env
 
 // Audit Log alerts are only supported on OpenShift 4
 @Requires({ Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT })
+// Some OpenShift cluster flavors do not provide access to the audit log e.g.
+// hosted control planes. ROX-22448
+@IgnoreIf({ Env.getDisableAuditLogAlertsTest() == "true" })
 @Stepwise
 @Tag("PZ")
 class AuditLogAlertsTest extends BaseSpecification {

--- a/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
@@ -25,7 +25,10 @@ class DeploymentTest extends BaseSpecification {
         "b73f527d86e3461fd652f62cf47e7b375196063bbbd503e853af5be16597cb2e"
     private static final String CVE_NO = "CVE-2018-18314"
     private static final String GKE_ORCHESTRATOR_DEPLOYMENT_NAME = "kube-dns"
-    private static final String OPENSHIFT_ORCHESTRATOR_DEPLOYMENT_NAME = "apiserver"
+    private static final String OPENSHIFT_ORCHESTRATOR_NAMESPACE = Env.getManagedControlPlane() ?
+        "openshift-console" : "openshift-apiserver"
+    private static final String OPENSHIFT_ORCHESTRATOR_DEPLOYMENT_NAME = Env.getManagedControlPlane() ?
+        "openshift-console" : "apiserver"
     private static final String STACKROX_DEPLOYMENT_NAME = "sensor"
 
     private static final Deployment DEPLOYMENT = new Deployment()
@@ -158,7 +161,7 @@ class DeploymentTest extends BaseSpecification {
         "Data inputs are: "
         deploymentName   |   query    |  result
         "${OPENSHIFT_ORCHESTRATOR_DEPLOYMENT_NAME}" | "Deployment:${OPENSHIFT_ORCHESTRATOR_DEPLOYMENT_NAME}" + \
-                "+Namespace:openshift-apiserver" | true
+                "+Namespace:${OPENSHIFT_ORCHESTRATOR_NAMESPACE}" | true
         "${STACKROX_DEPLOYMENT_NAME}"  | "Deployment:${STACKROX_DEPLOYMENT_NAME}+Namespace:stackrox" | false
     }
 

--- a/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
@@ -25,10 +25,10 @@ class DeploymentTest extends BaseSpecification {
         "b73f527d86e3461fd652f62cf47e7b375196063bbbd503e853af5be16597cb2e"
     private static final String CVE_NO = "CVE-2018-18314"
     private static final String GKE_ORCHESTRATOR_DEPLOYMENT_NAME = "kube-dns"
-    private static final String OPENSHIFT_ORCHESTRATOR_NAMESPACE = Env.getManagedControlPlane() ?
+    private static final String OPENSHIFT_ORCHESTRATOR_NAMESPACE = Env.getManagedControlPlane() == "true" ?
         "openshift-console" : "openshift-apiserver"
-    private static final String OPENSHIFT_ORCHESTRATOR_DEPLOYMENT_NAME = Env.getManagedControlPlane() ?
-        "openshift-console" : "apiserver"
+    private static final String OPENSHIFT_ORCHESTRATOR_DEPLOYMENT_NAME = Env.getManagedControlPlane() == "true" ?
+        "console" : "apiserver"
     private static final String STACKROX_DEPLOYMENT_NAME = "sensor"
 
     private static final Deployment DEPLOYMENT = new Deployment()

--- a/qa-tests-backend/src/test/groovy/RoutesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RoutesTest.groovy
@@ -26,6 +26,8 @@ class RoutesTest extends BaseSpecification {
     def "Verify that routes are detected correctly"() {
         given:
         Assume.assumeTrue(Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT)
+        // ROX-22502 - ROSA HCP is missing LoadBalancer support
+        Assume.assumeTrue({ !loadBalancer || Env.getSupportsLoadBalancerSvc()})
 
         boolean resourcesCreated = false
         when:

--- a/qa-tests-backend/src/test/groovy/RoutesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RoutesTest.groovy
@@ -27,7 +27,7 @@ class RoutesTest extends BaseSpecification {
         given:
         Assume.assumeTrue(Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT)
         // ROX-22502 - ROSA HCP is missing LoadBalancer support
-        Assume.assumeTrue({ !loadBalancer || Env.getSupportsLoadBalancerSvc()})
+        Assume.assumeTrue(!loadBalancer || Env.getSupportsLoadBalancerSvc() == "true")
 
         boolean resourcesCreated = false
         when:

--- a/scripts/ci/jobs/rosa_qa_e2e_tests.py
+++ b/scripts/ci/jobs/rosa_qa_e2e_tests.py
@@ -17,5 +17,7 @@ os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 if "MANAGED_CP" in os.environ and os.environ["MANAGED_CP"] == "true":
     # ROX-22448
     os.environ["DISABLE_AUDIT_LOG_ALERTS_TEST"] = "true"
+    # ROX-22502 - ROSA HCP is missing LoadBalancer support
+    os.environ["SUPPORTS_LOAD_BALANCER_SVC"] = "false"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/rosa_qa_e2e_tests.py
+++ b/scripts/ci/jobs/rosa_qa_e2e_tests.py
@@ -14,7 +14,7 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
-if "MANAGED_CP" in os.environ and os.environ["MANAGED_CP"] == "true":
+if "-hcp-" in os.environ["JOB_NAME"]:
     # ROX-22448
     os.environ["DISABLE_AUDIT_LOG_ALERTS_TEST"] = "true"
     # ROX-22502 - ROSA HCP is missing LoadBalancer support

--- a/scripts/ci/jobs/rosa_qa_e2e_tests.py
+++ b/scripts/ci/jobs/rosa_qa_e2e_tests.py
@@ -14,5 +14,8 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
+if "MANAGED_CP" in os.environ and os.environ["MANAGED_CP"] == "true":
+    # ROX-22448
+    os.environ["DISABLE_AUDIT_LOG_ALERTS_TEST"] = "true"
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/rosa_qa_e2e_tests.py
+++ b/scripts/ci/jobs/rosa_qa_e2e_tests.py
@@ -15,6 +15,7 @@ os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 if "-hcp-" in os.environ["JOB_NAME"]:
+    os.environ["MANAGED_CP"] = "true"
     # ROX-22448
     os.environ["DISABLE_AUDIT_LOG_ALERTS_TEST"] = "true"
     # ROX-22502 - ROSA HCP is missing LoadBalancer support

--- a/scripts/ci/jobs/rosa_qa_e2e_tests.py
+++ b/scripts/ci/jobs/rosa_qa_e2e_tests.py
@@ -17,5 +17,4 @@ os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 if "MANAGED_CP" in os.environ and os.environ["MANAGED_CP"] == "true":
     # ROX-22448
     os.environ["DISABLE_AUDIT_LOG_ALERTS_TEST"] = "true"
-
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()

--- a/scripts/ci/jobs/rosa_qa_e2e_tests.py
+++ b/scripts/ci/jobs/rosa_qa_e2e_tests.py
@@ -17,4 +17,5 @@ os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 if "MANAGED_CP" in os.environ and os.environ["MANAGED_CP"] == "true":
     # ROX-22448
     os.environ["DISABLE_AUDIT_LOG_ALERTS_TEST"] = "true"
+
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()


### PR DESCRIPTION
## Description

Various e2e tests fixes for ROSA HCP:

- AuditLogAlertsTest - disabled due to lack of access under HCP. ROX-22448 opened to cover "Ensure audit log policy collection cannot be enabled under HCP" which may require additional test coverage.
- DeploymentTest - use the openshift-console namespace. ROSA HCP does not surface the apiserver in the openshift-apiserver namespace.
- RoutesTest - LoadBalancers are stuck in Pending under HCP. Disabled the test for now and opened ROX-22502 to investigate ROSA HCP + service LoadBalancer support.

## Checklist
- [x] Investigated and inspected CI test results - K8sRabTest is failing and covered separately in #9944.

## Testing Performed

### Here I tell how I validated my change

CI+:
- [x] - RoutesTest - ensure all cases are still executed in vanilla OCP
- [x] - RoutesTest - ensure all non LoadBalancer cases are executed under HCP

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
