### PR TITLE
ROX-22489: Add regression tests for discovered-clusters route in UI

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/Clusters.helpers.js
+++ b/ui/apps/platform/cypress/integration/clusters/Clusters.helpers.js
@@ -63,6 +63,11 @@ export function assertClusterNameInHeading(clusterName) {
     cy.get(`h1:contains("${clusterName}")`);
 }
 
+export function assertClustersPage() {
+    cy.location('pathname').should('eq', clustersPath);
+    cy.get(`h1:contains("${title}")`);
+}
+
 // visit
 
 /**
@@ -85,8 +90,7 @@ export function interactAndVisitClusters(interactionCallback, staticResponseMap)
 export function visitClustersFromLeftNav() {
     visitFromLeftNavExpandable('Platform Configuration', title, routeMatcherMapForClusters);
 
-    cy.location('pathname').should('eq', clustersPath);
-    cy.get(`h1:contains("${title}")`);
+    assertClustersPage();
 }
 
 /**

--- a/ui/apps/platform/cypress/integration/clusters/discovered-clusters/DiscoveredClusters.helpers.js
+++ b/ui/apps/platform/cypress/integration/clusters/discovered-clusters/DiscoveredClusters.helpers.js
@@ -1,0 +1,58 @@
+import { interactAndWaitForResponses } from '../../../helpers/request';
+import { visit } from '../../../helpers/visit';
+
+const pagePath = '/main/clusters/discovered-clusters';
+
+// route
+
+export const countDiscoveredClustersAlias = 'count_discovered-clusters';
+export const discoveredClustersAlias = 'discovered-clusters';
+export const cloudSourcesAlias = 'cloud-sources';
+
+const routeMatcherMapForTable = {
+    [countDiscoveredClustersAlias]: {
+        method: 'GET',
+        url: '/v1/count/discovered-clusters?*',
+    },
+    [discoveredClustersAlias]: {
+        method: 'GET',
+        url: '/v1/discovered-clusters?*',
+    },
+};
+
+const routeMatcherMapForPage = {
+    ...routeMatcherMapForTable,
+    [cloudSourcesAlias]: {
+        method: 'GET',
+        url: '/v1/cloud-sources',
+    },
+};
+
+// assert
+
+export function assertDiscoveredClustersPage() {
+    cy.location('pathname').should('eq', pagePath);
+    cy.get('h1:contains("Discovered clusters")');
+}
+
+export function assertSortByColumn(text, direction, search) {
+    cy.get(`th:contains("${text}")[aria-sort="${direction}"]`);
+    cy.location('search').should('eq', search);
+}
+
+// interact
+
+export function sortByColumn(text) {
+    return interactAndWaitForResponses(() => {
+        cy.get(`th:contains("${text}")`).click();
+    }, routeMatcherMapForTable);
+}
+
+// visit
+
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function visitDiscoveredClusters(staticResponseMap) {
+    visit(pagePath, routeMatcherMapForPage, staticResponseMap);
+}

--- a/ui/apps/platform/cypress/integration/clusters/discovered-clusters/DiscoveredClustersPage.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/discovered-clusters/DiscoveredClustersPage.test.js
@@ -1,0 +1,102 @@
+import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
+
+import { assertClustersPage, visitClusters } from '../Clusters.helpers';
+import {
+    assertDiscoveredClustersPage,
+    assertSortByColumn,
+    sortByColumn,
+    visitDiscoveredClusters,
+} from './DiscoveredClusters.helpers';
+
+describe('Discovered clusters', () => {
+    withAuth();
+
+    before(function () {
+        if (!hasFeatureFlag('ROX_CLOUD_SOURCES')) {
+            this.skip();
+        }
+    });
+
+    it('visits from clusters page', () => {
+        visitClusters();
+
+        cy.get('a:contains("Discovered clusters")').click();
+
+        assertDiscoveredClustersPage();
+    });
+
+    it('visits clusters from breadcrumb link', () => {
+        visitDiscoveredClusters();
+
+        cy.get('.pf-c-breadcrumb__item:nth-child(2):contains("Discovered clusters")');
+        cy.get('.pf-c-breadcrumb__item:nth-child(1) a:contains("Clusters")').click();
+
+        assertClustersPage();
+    });
+
+    it('renders table head cells', () => {
+        visitDiscoveredClusters();
+
+        cy.get('th:contains("Cluster")');
+        cy.get('th:contains("Status")');
+        cy.get('th:contains("Type")');
+        cy.get('th:contains("Provider (region)")');
+        cy.get('th:contains("Cloud source")');
+        cy.get('th:contains("First discovered")');
+    });
+
+    it('renders no discovered clusters', () => {
+        visitDiscoveredClusters();
+
+        // CI has no cloud sources integration.
+        // RegExp distinguish phrase with or without found.
+        cy.contains('h2', /^No discovered clusters$/);
+    });
+
+    // TODO it('renders table data cells with mock response', () => {});
+
+    // TODO it('filters by Status', () => {}); // Unsecured and then All statuses
+
+    // TODO it('filters by Type', () => {}); // AKS and then EKS and then All types
+
+    it('sorts by Cluster', () => {
+        visitDiscoveredClusters();
+
+        const text = 'Cluster';
+
+        sortByColumn(text);
+        assertSortByColumn(
+            text,
+            'descending',
+            '?sortOption[field]=Cluster&sortOption[direction]=desc'
+        );
+
+        sortByColumn(text);
+        assertSortByColumn(
+            text,
+            'ascending',
+            '?sortOption[field]=Cluster&sortOption[direction]=asc'
+        );
+    });
+
+    it('sorts by First discovered', () => {
+        visitDiscoveredClusters();
+
+        const text = 'First discovered';
+
+        sortByColumn(text);
+        assertSortByColumn(
+            text,
+            'descending',
+            '?sortOption[field]=Cluster%20Discovered%20Time&sortOption[direction]=desc'
+        );
+
+        sortByColumn(text);
+        assertSortByColumn(
+            text,
+            'ascending',
+            '?sortOption[field]=Cluster%20Discovered%20Time&sortOption[direction]=asc'
+        );
+    });
+});

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
@@ -44,7 +44,7 @@ function DiscoveredClustersTable({
                     <Th width={25} sort={getSortParams(nameField)}>
                         Cluster
                     </Th>
-                    <Th width={15}>State</Th>
+                    <Th width={15}>Status</Th>
                     <Th width={10}>Type</Th>
                     <Th width={15} modifier="nowrap">
                         Provider (region)


### PR DESCRIPTION
## Description

Replaced one occurrence of **State** (as in visual mock) with **Status** (arguably clearer and also consistent with query and response).

## Checklist
- [x] Investigated and inspected CI test results
- [x] Added regression tests

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_CLOUD_SOURCES=true
```

### Integration testing

Before you `yarn cypress-open` in ui/apps/platform folder:

```sh
export CYPRESS_ROX_CLOUD_SOURCES=true
```

* clusters/discovered-clusters/DiscoveredClustersPage.test.js