### PR TITLE
fix(deploy-tooling): Generate scanner bundles if roxctl exists

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -747,16 +747,17 @@ function launch_sensor {
              "${ORCH}" \
              "${extra_config[@]+"${extra_config[@]}"}"
         mv "sensor-${CLUSTER}" "$k8s_dir/sensor-deploy"
+        if [[ "${GENERATE_SCANNER_DEPLOYMENT_BUNDLE:-}" == "true" ]]; then
+            roxctl -p "${ROX_ADMIN_PASSWORD}" --endpoint "${API_ENDPOINT}" scanner generate \
+                  --output-dir="scanner-deploy" "${scanner_extra_config[@]+"${scanner_extra_config[@]}"}"
+            mv "scanner-deploy" "${k8s_dir}/scanner-deploy"
+            echo "Note: A Scanner deployment bundle has been stored at ${k8s_dir}/scanner-deploy"
+        fi
       else
         get_cluster_zip "$API_ENDPOINT" "$CLUSTER" "${CLUSTER_TYPE}" "${MAIN_IMAGE}" "$CLUSTER_API_ENDPOINT" "$k8s_dir" "$COLLECTION_METHOD" "$extra_json_config"
         unzip "$k8s_dir/sensor-deploy.zip" -d "$k8s_dir/sensor-deploy"
         rm "$k8s_dir/sensor-deploy.zip"
       fi
-
-      roxctl -p "${ROX_ADMIN_PASSWORD}" --endpoint "${API_ENDPOINT}" scanner generate \
-            --output-dir="scanner-deploy" "${scanner_extra_config[@]+"${scanner_extra_config[@]}"}"
-      mv "scanner-deploy" "${k8s_dir}/scanner-deploy"
-      echo "Note: A Scanner deployment bundle has been stored at ${k8s_dir}/scanner-deploy"
 
       if [[ -n "${NAMESPACE_OVERRIDE}" ]]; then
         if [[ "${sensor_namespace}" != "stackrox" && "${sensor_namespace}" != "${NAMESPACE_OVERRIDE}" ]]; then

--- a/tests/e2e/run-scanner-v4.bats
+++ b/tests/e2e/run-scanner-v4.bats
@@ -268,6 +268,8 @@ teardown_file() {
     if [[ "${ORCHESTRATOR_FLAVOR:-}" == "openshift" ]]; then
       export ROX_OPENSHIFT_VERSION=4
     fi
+    export GENERATE_SCANNER_DEPLOYMENT_BUNDLE="true"
+    local scanner_bundle="${ROOT}/deploy/${ORCHESTRATOR_FLAVOR}/scanner-deploy"
 
     _deploy_stackrox
 
@@ -275,7 +277,6 @@ teardown_file() {
     verify_no_scannerV4_deployed
     run ! verify_central_scannerV4_env_var_set
 
-    local scanner_bundle="${ROOT}/deploy/${ORCHESTRATOR_FLAVOR}/scanner-deploy"
     assert [ -d "${scanner_bundle}" ]
     assert [ -d "${scanner_bundle}/scanner-v4" ]
 


### PR DESCRIPTION
## Description

Currently `launch_sensor()` attempts to generate scanner deployment bundles unconditionally.

This PR changes the behaviour so that this bundle is only generate if

1) `roxctl` is found (and the version matches)
and
2) the variable `GENERATE_SCANNER_DEPLOYMENT_BUNDLE` is set to `true` in the environment.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes~~

CI testing should be sufficient for this change.

