### PR TITLE
feat(cloud-sources): add OCM support

### DIFF
--- a/central/cloudsources/manager/manager.go
+++ b/central/cloudsources/manager/manager.go
@@ -159,8 +159,10 @@ func (m *managerImpl) getDiscoveredClustersFromCloudSources() []*discoveredclust
 }
 
 func (m *managerImpl) reconcileDiscoveredClusters(clusters []*discoveredclusters.DiscoveredCluster) {
+	log.Info("Fetching discovered clusters from cloud sources")
 	m.matchDiscoveredClusters(clusters)
 
+	log.Infof("Received %d discovered clusters from cloud sources", len(clusters))
 	debugPrintDiscoveredClusters(clusters)
 
 	if err := m.discoveredClustersDataStore.UpsertDiscoveredClusters(discoveredClusterCtx, clusters...); err != nil {

--- a/central/cloudsources/service/service_impl.go
+++ b/central/cloudsources/service/service_impl.go
@@ -44,7 +44,7 @@ var authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
 	},
 })
 
-type cloudSourceClientFactory = func(source *storage.CloudSource) cloudsources.Client
+type cloudSourceClientFactory = func(source *storage.CloudSource) (cloudsources.Client, error)
 
 type serviceImpl struct {
 	v1.UnimplementedCloudSourcesServiceServer
@@ -219,8 +219,11 @@ func (s *serviceImpl) TestCloudSource(ctx context.Context, req *v1.TestCloudSour
 }
 
 func (s *serviceImpl) testCloudSource(ctx context.Context, storageCloudSource *storage.CloudSource) error {
-	client := s.clientFactory(storageCloudSource)
-	_, err := client.GetDiscoveredClusters(ctx)
+	client, err := s.clientFactory(storageCloudSource)
+	if err != nil {
+		return err
+	}
+	_, err = client.GetDiscoveredClusters(ctx)
 	return err
 }
 

--- a/central/cloudsources/service/service_impl_postgres_test.go
+++ b/central/cloudsources/service/service_impl_postgres_test.go
@@ -61,8 +61,8 @@ func (s *servicePostgresTestSuite) SetupTest() {
 	cloudSourceClientMock.EXPECT().GetDiscoveredClusters(gomock.Any()).Return(nil, nil).AnyTimes()
 
 	s.service = newService(s.datastore, mockManager)
-	s.service.(*serviceImpl).clientFactory = func(_ *storage.CloudSource) cloudsources.Client {
-		return cloudSourceClientMock
+	s.service.(*serviceImpl).clientFactory = func(_ *storage.CloudSource) (cloudsources.Client, error) {
+		return cloudSourceClientMock, nil
 	}
 }
 
@@ -410,8 +410,8 @@ func (s *servicePostgresTestSuite) TestDeleteCloudSource() {
 
 func (s *servicePostgresTestSuite) TestCloudSourceTest() {
 	cloudSourceClientMock := cloudSourceClientMocks.NewMockClient(gomock.NewController(s.T()))
-	s.service.(*serviceImpl).clientFactory = func(_ *storage.CloudSource) cloudsources.Client {
-		return cloudSourceClientMock
+	s.service.(*serviceImpl).clientFactory = func(_ *storage.CloudSource) (cloudsources.Client, error) {
+		return cloudSourceClientMock, nil
 	}
 
 	cloudSource := fixtures.GetV1CloudSource()

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,8 @@ require (
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.1
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.1.0
+	github.com/opencontainers/image-spec v1.1.0-rc5
+	github.com/openshift-online/ocm-sdk-go v0.1.401
 	github.com/openshift/api v0.0.0-20231117201702-2ea16bbab164
 	github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1
 	github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b
@@ -175,6 +176,7 @@ require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beevik/etree v1.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.12.0 // indirect
@@ -257,6 +259,7 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
+	github.com/gorilla/css v1.0.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
@@ -307,6 +310,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mholt/archiver/v3 v3.5.1 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.21 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
@@ -353,6 +357,7 @@ require (
 	github.com/sigstore/timestamp-authority v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.2.1 // indirect
+	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/spf13/afero v1.10.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/viper v1.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -733,6 +733,8 @@ github.com/aws/aws-sdk-go-v2/service/sso v1.18.2 h1:xJPydhNm0Hiqct5TVKEuHG7weC0+
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.2 h1:8dU9zqA77C5egbU6yd4hFLaiIdPv3rU+6cp7sz5FjCU=
 github.com/aws/aws-sdk-go-v2/service/sts v1.26.2 h1:fFrLsy08wEbAisqW3KDl/cPHrF43GmV79zXB9EwJiZw=
 github.com/aws/smithy-go v1.18.1 h1:pOdBTUfXNazOlxLrgeYalVnuTpKreACHtc62xLwIB3c=
+github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
+github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/beevik/etree v1.2.0 h1:l7WETslUG/T+xOPs47dtd6jov2Ii/8/OjCldk5fYfQw=
 github.com/beevik/etree v1.2.0/go.mod h1:aiPf89g/1k3AShMVAzriilpcE4R/Vuor90y83zVZWFc=
@@ -1205,6 +1207,8 @@ github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
+github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
@@ -1503,6 +1507,8 @@ github.com/mattn/go-sqlite3 v1.14.18 h1:JL0eqdCOq6DJVNPSvArO/bIV9/P7fbGrV00LZHc+
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mholt/archiver/v3 v3.5.1 h1:rDjOBX9JSF5BvoJGvjqK479aL70qh9DIpZCl+k7Clwo=
 github.com/mholt/archiver/v3 v3.5.1/go.mod h1:e3dqJ7H78uzsRSEACH1joayhuSyhnonssnDhppzS1L4=
+github.com/microcosm-cc/bluemonday v1.0.21 h1:dNH3e4PSyE4vNX+KlRGHT5KrSvjeUkoNPwEORjffHJg=
+github.com/microcosm-cc/bluemonday v1.0.21/go.mod h1:ytNkv4RrDrLJ2pqlsSI46O6IVXmZOBBD4SaJyDwwTkM=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
@@ -1591,12 +1597,14 @@ github.com/onsi/gomega v1.31.1/go.mod h1:y40C95dwAD1Nz36SsEnxvfFe8FFfNxzI5eJ0EYG
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
-github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/opencontainers/image-spec v1.1.0-rc5 h1:Ygwkfw9bpDvs+c9E34SdgGOj41dX/cbdlwvlWt0pnFI=
+github.com/opencontainers/image-spec v1.1.0-rc5/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 github.com/opencontainers/runc v1.1.12 h1:BOIssBaW1La0/qbNZHXOOa71dZfZEQOzW7dqQf3phss=
 github.com/opencontainers/runc v1.1.12/go.mod h1:S+lQwSfncpBha7XTy/5lBwWgm5+y5Ma/O44Ekby9FK8=
 github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bll4AjJ9odEGpg=
 github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/openshift-online/ocm-sdk-go v0.1.401 h1:bnQGsiixlqcBuXUEQtK3cOxWWJO6nY6FGdpVhJyfdeY=
+github.com/openshift-online/ocm-sdk-go v0.1.401/go.mod h1:tke8vKcE7eHKyRbkJv6qo4ljo919zhx04uyQTcgF5cQ=
 github.com/openshift/api v0.0.0-20231117201702-2ea16bbab164 h1:0dwIuUDjrKSnq/ujysraljX8Vk/lxDJDVUcUcl9bx9M=
 github.com/openshift/api v0.0.0-20231117201702-2ea16bbab164/go.mod h1:qNtV0315F+f8ld52TLtPvrfivZpdimOzTi3kn9IVbtU=
 github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1 h1:W1N/3nVciqmjPjn2xldHjb0AwwCQzlGxLvX5BCgE8H4=
@@ -1759,6 +1767,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.2.1 h1:SHWdIUa82uGZz+F+47k8SY4QhhI291cXCpopT1lK2AQ=
 github.com/skeema/knownhosts v1.2.1/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/pkg/cloudsources/client.go
+++ b/pkg/cloudsources/client.go
@@ -18,7 +18,6 @@ type Client interface {
 
 // NewClientForCloudSource creates a new Client based on the cloud source to fetch discovered clusters.
 func NewClientForCloudSource(source *storage.CloudSource) (Client, error) {
-	// For the time being, this only supports paladin cloud clients.
 	switch source.GetType() {
 	case storage.CloudSource_TYPE_PALADIN_CLOUD:
 		return paladin.NewClient(source), nil

--- a/pkg/cloudsources/client.go
+++ b/pkg/cloudsources/client.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cloudsources/discoveredclusters"
+	"github.com/stackrox/rox/pkg/cloudsources/ocm"
 	"github.com/stackrox/rox/pkg/cloudsources/paladin"
 )
 
@@ -16,12 +17,14 @@ type Client interface {
 }
 
 // NewClientForCloudSource creates a new Client based on the cloud source to fetch discovered clusters.
-func NewClientForCloudSource(source *storage.CloudSource) Client {
+func NewClientForCloudSource(source *storage.CloudSource) (Client, error) {
 	// For the time being, this only supports paladin cloud clients.
 	switch source.GetType() {
 	case storage.CloudSource_TYPE_PALADIN_CLOUD:
-		return paladin.NewClient(source)
+		return paladin.NewClient(source), nil
+	case storage.CloudSource_TYPE_OCM:
+		return ocm.NewClient(source)
 	default:
-		return nil
+		return nil, nil
 	}
 }

--- a/pkg/cloudsources/ocm/client.go
+++ b/pkg/cloudsources/ocm/client.go
@@ -46,13 +46,13 @@ func (c *ocmClient) GetDiscoveredClusters(ctx context.Context) ([]*discoveredclu
 
 	// Taken from console.redhat.com/openshift.
 	// Filter for all subscriptions which have:
-	//	- a cluster associated with it,
+	//	- a cluster associated with it
 	// 	- the cluster is a valid OpenShift plan
-	//	- the status is "Active"
-	//  - and name / cluster_id / external_cluster_id are given.
+	//	- the status is "Active", "Disconnected", or "Stale"
+	//  - name / cluster_id / external_cluster_id are given
 	subscriptionSearch := "(cluster_id!='') " +
-		"AND (plan.id NOT IN ('RHACS', 'RHACSTrial', 'RHOSR', 'RHOSRTrial', 'RHOSAK', 'RHOSAKTrial', 'RHOSE', 'RHOSETrial')) " +
-		"AND (status = 'Active') " +
+		"AND (plan.id IN ('ARO', 'OCP', 'MOA', 'OCP-AssistedInstall', 'MOA-HostedControlPlane', 'OSD', 'OSDTrial')) " +
+		"AND (status IN  ('Active', 'Disconnected', 'Stale')) " +
 		"AND (display_name ILIKE '%%' OR external_cluster_id ILIKE '%%' OR cluster_id ILIKE '%%')"
 
 	for {

--- a/pkg/cloudsources/ocm/client.go
+++ b/pkg/cloudsources/ocm/client.go
@@ -1,0 +1,127 @@
+package ocm
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	gogoProto "github.com/gogo/protobuf/types"
+	sdkClient "github.com/openshift-online/ocm-sdk-go"
+	accountsmgmtv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+	pkgErrors "github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/clientconn"
+	"github.com/stackrox/rox/pkg/cloudsources/discoveredclusters"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/urlfmt"
+)
+
+type ocmClient struct {
+	conn          *sdkClient.Connection
+	cloudSourceID string
+}
+
+// NewClient creates a client to interact with OCM APIs.
+func NewClient(config *storage.CloudSource) (*ocmClient, error) {
+	connection, err := sdkClient.NewConnectionBuilder().
+		URL(urlfmt.FormatURL(config.GetOcm().GetEndpoint(), urlfmt.HTTPS, urlfmt.NoTrailingSlash)).
+		Tokens(config.GetCredentials().GetSecret()).Agent(clientconn.GetUserAgent()).Build()
+
+	if err != nil {
+		return nil, pkgErrors.Wrap(err, "creating OCM connection")
+	}
+
+	return &ocmClient{
+		conn:          connection,
+		cloudSourceID: config.GetId(),
+	}, nil
+}
+
+func (c *ocmClient) GetDiscoveredClusters(ctx context.Context) ([]*discoveredclusters.DiscoveredCluster, error) {
+	var (
+		subs  []*accountsmgmtv1.Subscription
+		total int
+		page  = 1
+	)
+
+	// Taken from console.redhat.com/openshift.
+	// Filter for all subscriptions which have:
+	//	- a cluster associated with it,
+	// 	- the cluster is a valid OpenShift plan
+	//	- the status is "Active"
+	//  - and name / cluster_id / external_cluster_id are given.
+	subscriptionSearch := "(cluster_id!='') " +
+		"AND (plan.id NOT IN ('RHACS', 'RHACSTrial', 'RHOSR', 'RHOSRTrial', 'RHOSAK', 'RHOSAKTrial', 'RHOSE', 'RHOSETrial')) " +
+		"AND (status = 'Active') " +
+		"AND (display_name ILIKE '%%' OR external_cluster_id ILIKE '%%' OR cluster_id ILIKE '%%')"
+
+	for {
+		resp, err := c.conn.AccountsMgmt().V1().Subscriptions().List().Size(100).Page(page).Search(subscriptionSearch).SendContext(ctx)
+		if err != nil {
+			return nil, pkgErrors.Wrap(err, "retrieving cluster subscriptions")
+		}
+		total = resp.Total()
+		subs = append(subs, resp.Items().Slice()...)
+		// We've fetched all clusters
+		if len(subs) == total {
+			break
+		}
+		// Increase the page.
+		page++
+	}
+
+	return c.mapToDiscoveredClusters(subs)
+}
+
+func (c *ocmClient) mapToDiscoveredClusters(subs []*accountsmgmtv1.Subscription) ([]*discoveredclusters.DiscoveredCluster, error) {
+	clusters := make([]*discoveredclusters.DiscoveredCluster, 0, len(subs))
+	var createClusterErrs error
+	for _, sub := range subs {
+		createdTime, err := gogoProto.TimestampProto(sub.CreatedAt())
+		if err != nil {
+			createClusterErrs = errors.Join(createClusterErrs, errox.InvariantViolation.New("converting timestamp").CausedBy(err))
+		}
+		clusters = append(clusters, &discoveredclusters.DiscoveredCluster{
+			ID:                sub.ExternalClusterID(),
+			Name:              sub.DisplayName(),
+			Type:              getClusterMetadataType(sub),
+			ProviderType:      getProviderType(sub),
+			Region:            sub.RegionID(),
+			FirstDiscoveredAt: createdTime,
+			CloudSourceID:     c.cloudSourceID,
+		})
+	}
+
+	if createClusterErrs != nil {
+		return nil, createClusterErrs
+	}
+	return clusters, nil
+}
+
+func getClusterMetadataType(sub *accountsmgmtv1.Subscription) storage.ClusterMetadata_Type {
+	switch strings.ToLower(sub.Plan().Type()) {
+	case "ocp":
+		return storage.ClusterMetadata_OCP
+	case "osd":
+		return storage.ClusterMetadata_OSD
+	case "aro":
+		return storage.ClusterMetadata_ARO
+	case "rosa":
+		return storage.ClusterMetadata_ROSA
+	default:
+		return storage.ClusterMetadata_UNSPECIFIED
+	}
+}
+
+func getProviderType(sub *accountsmgmtv1.Subscription) storage.DiscoveredCluster_Metadata_ProviderType {
+	switch strings.ToLower(sub.CloudProviderID()) {
+	case "gcp":
+		return storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_GCP
+	case "aws":
+		return storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AWS
+	case "azure":
+		return storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AZURE
+	default:
+		return storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_UNSPECIFIED
+	}
+}

--- a/pkg/cloudsources/ocm/client_test.go
+++ b/pkg/cloudsources/ocm/client_test.go
@@ -1,0 +1,89 @@
+package ocm
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	gogoProto "github.com/gogo/protobuf/types"
+	accountsmgmtv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/cloudsources/discoveredclusters"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapToDiscoveredClusters(t *testing.T) {
+	c := &ocmClient{
+		cloudSourceID: "12345",
+	}
+
+	cluster1, err := time.Parse(time.RFC3339, "2024-02-13T21:34:35.11432Z")
+	require.NoError(t, err)
+	cluster1TS, err := gogoProto.TimestampProto(cluster1)
+	require.NoError(t, err)
+
+	cluster2, err := time.Parse(time.RFC3339, "2024-02-13T21:34:03.763759Z")
+	require.NoError(t, err)
+	cluster2TS, err := gogoProto.TimestampProto(cluster2)
+	require.NoError(t, err)
+
+	cluster3, err := time.Parse(time.RFC3339, "2024-02-13T21:30:57.000508Z")
+	require.NoError(t, err)
+	cluster3TS, err := gogoProto.TimestampProto(cluster3)
+	require.NoError(t, err)
+
+	cluster4, err := time.Parse(time.RFC3339, "2024-02-13T21:28:54.916088Z")
+	require.NoError(t, err)
+	cluster4TS, err := gogoProto.TimestampProto(cluster4)
+	require.NoError(t, err)
+
+	expectedClusters := []*discoveredclusters.DiscoveredCluster{
+		{
+			ID:                "11b0e5a3-0a38-4484-8272-1fd690bd65b5",
+			Name:              "rosa-cluster",
+			Type:              storage.ClusterMetadata_ROSA,
+			ProviderType:      storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AWS,
+			FirstDiscoveredAt: cluster1TS,
+			Region:            "us-east1",
+			CloudSourceID:     "12345",
+		},
+		{
+			ID:                "22b0e5a3-0a38-4484-8272-1fd690bd65b5",
+			Name:              "aro-cluster",
+			Type:              storage.ClusterMetadata_ARO,
+			ProviderType:      storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AZURE,
+			Region:            "us-east1",
+			FirstDiscoveredAt: cluster2TS,
+			CloudSourceID:     "12345",
+		},
+		{
+			ID:                "338d4973-7a37-4559-afad-f3d75d96c7fd",
+			Name:              "osd-cluster",
+			Type:              storage.ClusterMetadata_OSD,
+			ProviderType:      storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_GCP,
+			Region:            "us-central1",
+			FirstDiscoveredAt: cluster3TS,
+			CloudSourceID:     "12345",
+		},
+		{
+			ID:                "44a6254c-8bc4-4724-abfe-c510747742b8",
+			Name:              "ocp-gcp-cluster",
+			Type:              storage.ClusterMetadata_OCP,
+			ProviderType:      storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_GCP,
+			Region:            "us-central1",
+			FirstDiscoveredAt: cluster4TS,
+			CloudSourceID:     "12345",
+		},
+	}
+
+	data, err := os.ReadFile("testdata/response.json")
+	require.NoError(t, err)
+
+	subs, err := accountsmgmtv1.UnmarshalSubscriptionList(data)
+	require.NoError(t, err)
+
+	clusters, err := c.mapToDiscoveredClusters(subs)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, expectedClusters, clusters)
+}

--- a/pkg/cloudsources/ocm/testdata/response.json
+++ b/pkg/cloudsources/ocm/testdata/response.json
@@ -1,0 +1,67 @@
+[
+  {
+    "cloud_provider_id": "aws",
+    "cluster_billing_model": "standard",
+    "cluster_id": "111111",
+    "kind": "Subscription",
+    "created_at": "2024-02-13T21:34:35.11432Z",
+    "display_name": "rosa-cluster",
+    "external_cluster_id": "11b0e5a3-0a38-4484-8272-1fd690bd65b5",
+    "plan": {
+      "href": "/api/accounts_mgmt/v1/plans/ROSA",
+      "id": "ROSA",
+      "kind": "Plan",
+      "type": "ROSA"
+    },
+    "region_id": "us-east1",
+    "status": "Active"
+  },
+  {
+    "cloud_provider_id": "azure",
+    "cluster_id": "222222",
+    "kind": "Subscription",
+    "created_at": "2024-02-13T21:34:03.763759Z",
+    "display_name": "aro-cluster",
+    "external_cluster_id": "22b0e5a3-0a38-4484-8272-1fd690bd65b5",
+    "plan": {
+      "href": "/api/accounts_mgmt/v1/plans/ARO",
+      "id": "ARO",
+      "kind": "Plan",
+      "type": "ARO"
+    },
+    "region_id": "us-east1",
+    "status": "Active"
+  },
+  {
+    "cloud_provider_id": "gcp",
+    "cluster_id": "333333",
+    "kind": "Subscription",
+    "created_at": "2024-02-13T21:30:57.000508Z",
+    "display_name": "osd-cluster",
+    "external_cluster_id": "338d4973-7a37-4559-afad-f3d75d96c7fd",
+    "plan": {
+      "href": "/api/accounts_mgmt/v1/plans/OSD",
+      "id": "OSD",
+      "kind": "Plan",
+      "type": "OSD"
+    },
+    "region_id": "us-central1",
+    "status": "Active"
+  },
+  {
+    "cloud_provider_id": "gcp",
+    "cluster_id": "444444",
+    "created_at": "2024-02-13T21:28:54.916088Z",
+    "display_name": "ocp-gcp-cluster",
+    "external_cluster_id": "44a6254c-8bc4-4724-abfe-c510747742b8",
+    "kind": "Subscription",
+    "plan": {
+      "href": "/api/accounts_mgmt/v1/plans/OCP",
+      "id": "OCP",
+      "kind": "Plan",
+      "type": "OCP"
+    },
+    "region_id": "us-central1",
+    "status": "Active"
+  }
+]

--- a/pkg/cloudsources/ocm/testdata/response.json
+++ b/pkg/cloudsources/ocm/testdata/response.json
@@ -8,10 +8,10 @@
     "display_name": "rosa-cluster",
     "external_cluster_id": "11b0e5a3-0a38-4484-8272-1fd690bd65b5",
     "plan": {
-      "href": "/api/accounts_mgmt/v1/plans/ROSA",
-      "id": "ROSA",
+      "href": "/api/accounts_mgmt/v1/plans/MAO",
+      "id": "MAO",
       "kind": "Plan",
-      "type": "ROSA"
+      "type": "MAO"
     },
     "region_id": "us-east1",
     "status": "Active"
@@ -44,6 +44,22 @@
       "id": "OSD",
       "kind": "Plan",
       "type": "OSD"
+    },
+    "region_id": "us-central1",
+    "status": "Active"
+  },
+  {
+    "cloud_provider_id": "gcp",
+    "cluster_id": "444444",
+    "created_at": "2024-02-13T21:28:54.916088Z",
+    "display_name": "ocp-gcp-cluster",
+    "external_cluster_id": "44a6254c-8bc4-4724-abfe-c510747742b8",
+    "kind": "Subscription",
+    "plan": {
+      "href": "/api/accounts_mgmt/v1/plans/OCP",
+      "id": "OCP",
+      "kind": "Plan",
+      "type": "OCP"
     },
     "region_id": "us-central1",
     "status": "Active"

--- a/pkg/cloudsources/ocm/testdata/response.json
+++ b/pkg/cloudsources/ocm/testdata/response.json
@@ -9,9 +9,9 @@
     "external_cluster_id": "11b0e5a3-0a38-4484-8272-1fd690bd65b5",
     "plan": {
       "href": "/api/accounts_mgmt/v1/plans/MAO",
-      "id": "MAO",
+      "id": "MOA",
       "kind": "Plan",
-      "type": "MAO"
+      "type": "MOA"
     },
     "region_id": "us-east1",
     "status": "Active"

--- a/pkg/cloudsources/paladin/client.go
+++ b/pkg/cloudsources/paladin/client.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/urlfmt"
 	"github.com/stackrox/rox/pkg/utils"
-	"github.com/stackrox/rox/pkg/version"
 )
 
 const (
@@ -181,7 +180,6 @@ type paladinClient struct {
 type paladinTransportWrapper struct {
 	baseTransport http.RoundTripper
 	token         string
-	acsVersion    string
 }
 
 func (p *paladinTransportWrapper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -200,7 +198,6 @@ func NewClient(cfg *storage.CloudSource) *paladinClient {
 	retryClient.HTTPClient.Transport = &paladinTransportWrapper{
 		baseTransport: proxy.RoundTripper(),
 		token:         cfg.GetCredentials().GetSecret(),
-		acsVersion:    version.GetMainVersion(),
 	}
 	retryClient.HTTPClient.Timeout = 30 * time.Second
 	retryClient.RetryWaitMin = 10 * time.Second
@@ -297,7 +294,7 @@ func (c *paladinClient) mapAssetToDiscoveredCluster(asset Asset) (*discoveredclu
 
 	firstDiscoveredAt, err := gogoProto.TimestampProto(asset.FirstDiscoveredAt)
 	if err != nil {
-		return nil, errox.InvariantViolation.New("converting timestamps")
+		return nil, errox.InvariantViolation.New("converting timestamps").CausedBy(err)
 	}
 	d.FirstDiscoveredAt = firstDiscoveredAt
 

--- a/sensor/kubernetes/clusterstatus/updater_test.go
+++ b/sensor/kubernetes/clusterstatus/updater_test.go
@@ -176,13 +176,16 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 
 	nilGetProviders := func(_ context.Context) *storage.ProviderMetadata { return nil }
 
-	typeMeta := metav1.TypeMeta{Kind: "Infrastructure", APIVersion: "config.openshift.io/v1"}
-	objectMeta := metav1.ObjectMeta{
+	infraTypeMeta := metav1.TypeMeta{Kind: "Infrastructure", APIVersion: "config.openshift.io/v1"}
+	infraObjectMeta := metav1.ObjectMeta{
 		Name: "cluster",
 	}
+	cvTypeMeta := metav1.TypeMeta{Kind: "ClusterVersion", APIVersion: "config.openshift.io/v1"}
+	cvObjectMeta := metav1.ObjectMeta{Name: "version"}
 
 	cases := map[string]struct {
 		infra        *configv1.Infrastructure
+		cv           *configv1.ClusterVersion
 		metadata     *storage.ProviderMetadata
 		getProviders func(ctx context.Context) *storage.ProviderMetadata
 		openshift    bool
@@ -200,8 +203,8 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 			getProviders: nilGetProviders,
 			openshift:    true,
 			infra: &configv1.Infrastructure{
-				TypeMeta:   typeMeta,
-				ObjectMeta: objectMeta,
+				TypeMeta:   infraTypeMeta,
+				ObjectMeta: infraObjectMeta,
 				Status: configv1.InfrastructureStatus{
 					PlatformStatus: &configv1.PlatformStatus{
 						Type: configv1.AWSPlatformType,
@@ -211,6 +214,11 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 					InfrastructureName: "cluster-1",
 				},
 			},
+			cv: &configv1.ClusterVersion{
+				TypeMeta:   cvTypeMeta,
+				ObjectMeta: cvObjectMeta,
+				Spec:       configv1.ClusterVersionSpec{ClusterID: "44a6254c-8bc4-4724-abfe-c510747742b8"},
+			},
 			metadata: &storage.ProviderMetadata{
 				Region:   "us-east1",
 				Provider: &storage.ProviderMetadata_Aws{Aws: &storage.AWSProviderMetadata{}},
@@ -218,6 +226,7 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 				Cluster: &storage.ClusterMetadata{
 					Type: storage.ClusterMetadata_OCP,
 					Name: "cluster-1",
+					Id:   "44a6254c-8bc4-4724-abfe-c510747742b8",
 				},
 			},
 		},
@@ -225,8 +234,8 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 			getProviders: nilGetProviders,
 			openshift:    true,
 			infra: &configv1.Infrastructure{
-				TypeMeta:   typeMeta,
-				ObjectMeta: objectMeta,
+				TypeMeta:   infraTypeMeta,
+				ObjectMeta: infraObjectMeta,
 				Status: configv1.InfrastructureStatus{
 					PlatformStatus: &configv1.PlatformStatus{
 						Type: configv1.GCPPlatformType,
@@ -237,6 +246,11 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 					InfrastructureName: "cluster-1",
 				},
 			},
+			cv: &configv1.ClusterVersion{
+				TypeMeta:   cvTypeMeta,
+				ObjectMeta: cvObjectMeta,
+				Spec:       configv1.ClusterVersionSpec{ClusterID: "44a6254c-8bc4-4724-abfe-c510747742b8"},
+			},
 			metadata: &storage.ProviderMetadata{
 				Region: "us-east1",
 				Provider: &storage.ProviderMetadata_Google{Google: &storage.GoogleProviderMetadata{
@@ -246,6 +260,7 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 				Cluster: &storage.ClusterMetadata{
 					Type: storage.ClusterMetadata_OCP,
 					Name: "cluster-1",
+					Id:   "44a6254c-8bc4-4724-abfe-c510747742b8",
 				},
 			},
 		},
@@ -253,8 +268,8 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 			getProviders: nilGetProviders,
 			openshift:    true,
 			infra: &configv1.Infrastructure{
-				TypeMeta:   typeMeta,
-				ObjectMeta: objectMeta,
+				TypeMeta:   infraTypeMeta,
+				ObjectMeta: infraObjectMeta,
 				Status: configv1.InfrastructureStatus{
 					PlatformStatus: &configv1.PlatformStatus{
 						Type:  configv1.AzurePlatformType,
@@ -263,6 +278,11 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 					InfrastructureName: "cluster-1",
 				},
 			},
+			cv: &configv1.ClusterVersion{
+				TypeMeta:   cvTypeMeta,
+				ObjectMeta: cvObjectMeta,
+				Spec:       configv1.ClusterVersionSpec{ClusterID: "44a6254c-8bc4-4724-abfe-c510747742b8"},
+			},
 			metadata: &storage.ProviderMetadata{
 				Region:   "",
 				Provider: &storage.ProviderMetadata_Azure{Azure: &storage.AzureProviderMetadata{}},
@@ -270,6 +290,7 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 				Cluster: &storage.ClusterMetadata{
 					Type: storage.ClusterMetadata_OCP,
 					Name: "cluster-1",
+					Id:   "44a6254c-8bc4-4724-abfe-c510747742b8",
 				},
 			},
 		},
@@ -277,8 +298,8 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 			getProviders: nilGetProviders,
 			openshift:    true,
 			infra: &configv1.Infrastructure{
-				TypeMeta:   typeMeta,
-				ObjectMeta: objectMeta,
+				TypeMeta:   infraTypeMeta,
+				ObjectMeta: infraObjectMeta,
 				Status: configv1.InfrastructureStatus{
 					PlatformStatus: &configv1.PlatformStatus{
 						Type:         configv1.AlibabaCloudPlatformType,
@@ -287,10 +308,16 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 					InfrastructureName: "cluster-1",
 				},
 			},
+			cv: &configv1.ClusterVersion{
+				TypeMeta:   cvTypeMeta,
+				ObjectMeta: cvObjectMeta,
+				Spec:       configv1.ClusterVersionSpec{ClusterID: "44a6254c-8bc4-4724-abfe-c510747742b8"},
+			},
 			metadata: &storage.ProviderMetadata{
 				Cluster: &storage.ClusterMetadata{
 					Type: storage.ClusterMetadata_OCP,
 					Name: "cluster-1",
+					Id:   "44a6254c-8bc4-4724-abfe-c510747742b8",
 				},
 			},
 		},
@@ -298,8 +325,8 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 			getProviders: nilGetProviders,
 			openshift:    true,
 			infra: &configv1.Infrastructure{
-				TypeMeta:   typeMeta,
-				ObjectMeta: objectMeta,
+				TypeMeta:   infraTypeMeta,
+				ObjectMeta: infraObjectMeta,
 				Status: configv1.InfrastructureStatus{
 					PlatformStatus: &configv1.PlatformStatus{
 						Type: configv1.AWSPlatformType,
@@ -315,6 +342,11 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 					InfrastructureName: "cluster-1",
 				},
 			},
+			cv: &configv1.ClusterVersion{
+				TypeMeta:   cvTypeMeta,
+				ObjectMeta: cvObjectMeta,
+				Spec:       configv1.ClusterVersionSpec{ClusterID: "44a6254c-8bc4-4724-abfe-c510747742b8"},
+			},
 			metadata: &storage.ProviderMetadata{
 				Region:   "us-east1",
 				Provider: &storage.ProviderMetadata_Aws{Aws: &storage.AWSProviderMetadata{}},
@@ -322,6 +354,7 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 				Cluster: &storage.ClusterMetadata{
 					Type: storage.ClusterMetadata_OSD,
 					Name: "cluster-1",
+					Id:   "44a6254c-8bc4-4724-abfe-c510747742b8",
 				},
 			},
 		},
@@ -329,8 +362,8 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 			getProviders: nilGetProviders,
 			openshift:    true,
 			infra: &configv1.Infrastructure{
-				TypeMeta:   typeMeta,
-				ObjectMeta: objectMeta,
+				TypeMeta:   infraTypeMeta,
+				ObjectMeta: infraObjectMeta,
 				Status: configv1.InfrastructureStatus{
 					PlatformStatus: &configv1.PlatformStatus{
 						Type: configv1.GCPPlatformType,
@@ -347,6 +380,11 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 					InfrastructureName: "cluster-1",
 				},
 			},
+			cv: &configv1.ClusterVersion{
+				TypeMeta:   cvTypeMeta,
+				ObjectMeta: cvObjectMeta,
+				Spec:       configv1.ClusterVersionSpec{ClusterID: "44a6254c-8bc4-4724-abfe-c510747742b8"},
+			},
 			metadata: &storage.ProviderMetadata{
 				Region: "us-east1",
 				Provider: &storage.ProviderMetadata_Google{Google: &storage.GoogleProviderMetadata{
@@ -356,6 +394,7 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 				Cluster: &storage.ClusterMetadata{
 					Type: storage.ClusterMetadata_OSD,
 					Name: "cluster-1",
+					Id:   "44a6254c-8bc4-4724-abfe-c510747742b8",
 				},
 			},
 		},
@@ -363,8 +402,8 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 			getProviders: nilGetProviders,
 			openshift:    true,
 			infra: &configv1.Infrastructure{
-				TypeMeta:   typeMeta,
-				ObjectMeta: objectMeta,
+				TypeMeta:   infraTypeMeta,
+				ObjectMeta: infraObjectMeta,
 				Status: configv1.InfrastructureStatus{
 					PlatformStatus: &configv1.PlatformStatus{
 						Type: configv1.AWSPlatformType,
@@ -380,6 +419,11 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 					InfrastructureName: "cluster-1",
 				},
 			},
+			cv: &configv1.ClusterVersion{
+				TypeMeta:   cvTypeMeta,
+				ObjectMeta: cvObjectMeta,
+				Spec:       configv1.ClusterVersionSpec{ClusterID: "44a6254c-8bc4-4724-abfe-c510747742b8"},
+			},
 			metadata: &storage.ProviderMetadata{
 				Region:   "us-east1",
 				Provider: &storage.ProviderMetadata_Aws{Aws: &storage.AWSProviderMetadata{}},
@@ -387,6 +431,7 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 				Cluster: &storage.ClusterMetadata{
 					Type: storage.ClusterMetadata_ROSA,
 					Name: "cluster-1",
+					Id:   "44a6254c-8bc4-4724-abfe-c510747742b8",
 				},
 			},
 		},
@@ -394,8 +439,8 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 			getProviders: nilGetProviders,
 			openshift:    true,
 			infra: &configv1.Infrastructure{
-				TypeMeta:   typeMeta,
-				ObjectMeta: objectMeta,
+				TypeMeta:   infraTypeMeta,
+				ObjectMeta: infraObjectMeta,
 				Status: configv1.InfrastructureStatus{
 					PlatformStatus: &configv1.PlatformStatus{
 						Type: configv1.AzurePlatformType,
@@ -411,6 +456,11 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 					InfrastructureName: "cluster-1",
 				},
 			},
+			cv: &configv1.ClusterVersion{
+				TypeMeta:   cvTypeMeta,
+				ObjectMeta: cvObjectMeta,
+				Spec:       configv1.ClusterVersionSpec{ClusterID: "44a6254c-8bc4-4724-abfe-c510747742b8"},
+			},
 			metadata: &storage.ProviderMetadata{
 				Region:   "",
 				Provider: &storage.ProviderMetadata_Azure{Azure: &storage.AzureProviderMetadata{}},
@@ -418,6 +468,7 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 				Cluster: &storage.ClusterMetadata{
 					Type: storage.ClusterMetadata_ARO,
 					Name: "cluster-1",
+					Id:   "44a6254c-8bc4-4724-abfe-c510747742b8",
 				},
 			},
 		},
@@ -428,7 +479,7 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 			s.T().Setenv(env.OpenshiftAPI.EnvVar(), strconv.FormatBool(tc.openshift))
 			config := configFake.NewSimpleClientset()
 			if tc.infra != nil {
-				config = configFake.NewSimpleClientset(tc.infra)
+				config = configFake.NewSimpleClientset(tc.infra, tc.cv)
 			}
 			s.createUpdater(tc.getProviders, getProviderMetadataFromOpenShiftConfig, config)
 			u := s.updater.(*updaterImpl)


### PR DESCRIPTION
## Description

This introduces OCM support for cloud sources, and covers the following pieces:
- Adding the cluster ID to the cluster metadata collected by Sensor, this is required for matching discovered clusters with secured clusters (where the type is OCP, ARO, ROSA, OSD).
- implement the client for interacting with the OCM API.
- improve the matching to only rely on the ID for matching instead of the tuple of ID & provider type (we can match on ID only since for our known cluster types the IDs have a distinct format irrespective of cluster type).

A few caveats to point out:
The `accounts_mgmt` API was used in favor of the `clusters_mgmt` API; I have found that this is way more performant compared to the cluster one, and also what `console.redhat.com/openshift` does.

The search query to limit the result of clusters (or rather subscriptions) has been taken from `console.redhat.com/openshift` with an adjustment to the `Status` field: we currently only take `Active, Disconnected` clusters into account. We may extend this to also cover other states (such as `Installing`); or we might also want to lower the number of allowed states to only `Active` and `Disconnected`.

The OCM connection currently does not take in the `proxy.RoundTripper()` directly, but rather relies on the call of `proxy.UseWithDefaultTransport` within the main to set the proxy transport that way. The OCM SDK currently only provides a `RoundTripWrapper`. The alternative would be to initialize the accounts client ourselves, but then we lose the benefit of the authN and other wrappers the SDK provides us with.

What still needs to be done after this has landed:
The UI needs to also support the new integration type by providing a new integration form.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

Manual tests:

1. Create a Central cluster + secured cluster (use a provider of choice, e.g. ROSA/ARO)

2. Create an OCM cloud source; use an Offline API token for OCM:
```json
{
    "cloudSource": {
        "name": "test ocm",
        "type": "TYPE_OCM",
        "credentials": {
            "secret": "<redacted>"
        },
        "ocm": {
            "endpoint": "https://api.openshift.com"
        }
    }
}
```

3. Once the discovered clusters have synced, you should see that the discovered cluster is shown as secured.


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
