### PR TITLE
ROX-21034: qa-e2e test for GCS backup integration

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/ExternalBackupService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ExternalBackupService.groovy
@@ -29,7 +29,7 @@ class ExternalBackupService extends BaseService {
             String endpoint = "",
             String accessKeyId = Env.mustGetAWSAccessKeyID(),
             String accessKey = Env.mustGetAWSSecretAccessKey())  {
-        ExternalBackupOuterClass.S3Config s3Config =  ExternalBackupOuterClass.S3Config.newBuilder()
+        ExternalBackupOuterClass.S3Config s3Config = ExternalBackupOuterClass.S3Config.newBuilder()
                 .setObjectPrefix(UUID.randomUUID().toString())
                 .setBucket(bucket)
                 .setRegion(region)
@@ -49,6 +49,32 @@ class ExternalBackupService extends BaseService {
                         .build()
                 )
                 .setS3(s3Config)
+                .build()
+    }
+
+    static ExternalBackupOuterClass.ExternalBackup getGCSIntegrationConfig(
+            String name,
+            Boolean useWorkloadId = false,
+            String bucket = Env.mustGetGCSBucketName(),
+            String serviceAccount = Env.mustGetGCSServiceAccount()) {
+
+        ExternalBackupOuterClass.GCSConfig gcsConfig = ExternalBackupOuterClass.GCSConfig.newBuilder()
+                .setObjectPrefix(UUID.randomUUID().toString())
+                .setBucket(bucket)
+                .setServiceAccount(useWorkloadId ? "" : serviceAccount)
+                .setUseWorkloadId(useWorkloadId)
+                .build()
+
+        return ExternalBackupOuterClass.ExternalBackup.newBuilder()
+                .setName(name)
+                .setType("gcs")
+                .setBackupsToKeep(1)
+                .setSchedule(ScheduleOuterClass.Schedule.newBuilder()
+                        .setIntervalType(ScheduleOuterClass.Schedule.IntervalType.DAILY)
+                        .setHour(0) //12:00 AM
+                        .build()
+                )
+                .setGcs(gcsConfig)
                 .build()
     }
 }

--- a/qa-tests-backend/src/main/groovy/services/ExternalBackupService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ExternalBackupService.groovy
@@ -1,35 +1,29 @@
 package services
 
+import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.stackrox.proto.api.v1.ExternalBackupServiceGrpc
-import io.stackrox.proto.storage.ExternalBackupOuterClass
-import io.stackrox.proto.storage.ScheduleOuterClass
+import io.stackrox.proto.storage.ExternalBackupOuterClass.ExternalBackup
+import io.stackrox.proto.storage.ExternalBackupOuterClass.S3Config
+import io.stackrox.proto.storage.ExternalBackupOuterClass.GCSConfig
+import io.stackrox.proto.storage.ScheduleOuterClass.Schedule
 import util.Env
 
+@CompileStatic
 @Slf4j
 class ExternalBackupService extends BaseService {
     static getExternalBackupClient() {
         return ExternalBackupServiceGrpc.newBlockingStub(getChannel())
     }
 
-    static testExternalBackup(ExternalBackupOuterClass.ExternalBackup backup) {
-        try {
-            getExternalBackupClient().testExternalBackup(backup)
-            return true
-        } catch (Exception e) {
-            log.warn("test external backup failed", e)
-            return false
-        }
-    }
-
-    static ExternalBackupOuterClass.ExternalBackup getS3IntegrationConfig(
+    static ExternalBackup getS3IntegrationConfig(
             String name,
             String bucket = Env.mustGetAWSS3BucketName(),
             String region = Env.mustGetAWSS3BucketRegion(),
             String endpoint = "",
             String accessKeyId = Env.mustGetAWSAccessKeyID(),
             String accessKey = Env.mustGetAWSSecretAccessKey())  {
-        ExternalBackupOuterClass.S3Config s3Config = ExternalBackupOuterClass.S3Config.newBuilder()
+        S3Config s3Config = S3Config.newBuilder()
                 .setObjectPrefix(UUID.randomUUID().toString())
                 .setBucket(bucket)
                 .setRegion(region)
@@ -39,12 +33,12 @@ class ExternalBackupService extends BaseService {
                 .setSecretAccessKey(accessKey)
                 .build()
 
-        return ExternalBackupOuterClass.ExternalBackup.newBuilder()
+        return ExternalBackup.newBuilder()
                 .setName(name)
                 .setType("s3")
                 .setBackupsToKeep(1)
-                .setSchedule(ScheduleOuterClass.Schedule.newBuilder()
-                        .setIntervalType(ScheduleOuterClass.Schedule.IntervalType.DAILY)
+                .setSchedule(Schedule.newBuilder()
+                        .setIntervalType(Schedule.IntervalType.DAILY)
                         .setHour(0) //12:00 AM
                         .build()
                 )
@@ -52,25 +46,25 @@ class ExternalBackupService extends BaseService {
                 .build()
     }
 
-    static ExternalBackupOuterClass.ExternalBackup getGCSIntegrationConfig(
+    static ExternalBackup getGCSIntegrationConfig(
             String name,
             Boolean useWorkloadId = false,
             String bucket = Env.mustGetGCSBucketName(),
             String serviceAccount = Env.mustGetGCSServiceAccount()) {
 
-        ExternalBackupOuterClass.GCSConfig gcsConfig = ExternalBackupOuterClass.GCSConfig.newBuilder()
+        GCSConfig gcsConfig = GCSConfig.newBuilder()
                 .setObjectPrefix(UUID.randomUUID().toString())
                 .setBucket(bucket)
                 .setServiceAccount(useWorkloadId ? "" : serviceAccount)
                 .setUseWorkloadId(useWorkloadId)
                 .build()
 
-        return ExternalBackupOuterClass.ExternalBackup.newBuilder()
+        return ExternalBackup.newBuilder()
                 .setName(name)
                 .setType("gcs")
                 .setBackupsToKeep(1)
-                .setSchedule(ScheduleOuterClass.Schedule.newBuilder()
-                        .setIntervalType(ScheduleOuterClass.Schedule.IntervalType.DAILY)
+                .setSchedule(Schedule.newBuilder()
+                        .setIntervalType(Schedule.IntervalType.DAILY)
                         .setHour(0) //12:00 AM
                         .build()
                 )

--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -252,23 +252,23 @@ class Env {
     }
 
     static String mustGetGCSBucketName() {
-        return mustGet("GCP_GCS_BACKUP_TEST_BUCKET_NAME") // stackrox-qa-gcs-test
+        return mustGet("GCP_GCS_BACKUP_TEST_BUCKET_NAME_V2")
     }
 
     static String mustGetGCSBucketRegion() {
-        return mustGet("GCP_GCS_BACKUP_TEST_BUCKET_REGION") // us-east-1
+        return mustGet("GCP_GCS_BACKUP_TEST_BUCKET_REGION_V2")
     }
 
     static String mustGetGCPAccessKeyID() {
-        return mustGet("GCP_ACCESS_KEY_ID")
+        return mustGet("GCP_ACCESS_KEY_ID_V2")
     }
 
     static String mustGetGCPAccessKey() {
-        return mustGet("GCP_SECRET_ACCESS_KEY")
+        return mustGet("GCP_SECRET_ACCESS_KEY_V2")
     }
 
     static String mustGetGCSServiceAccount() {
-        return mustGet("GOOGLE_GCS_BACKUP_SERVICE_ACCOUNT")
+        return mustGet("GOOGLE_GCS_BACKUP_SERVICE_ACCOUNT_V2")
     }
 
     static String mustGetPagerdutyToken() {

--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -267,6 +267,10 @@ class Env {
         return mustGet("GCP_SECRET_ACCESS_KEY")
     }
 
+    static String mustGetGCSServiceAccount() {
+        return mustGet("GOOGLE_GCS_BACKUP_SERVICE_ACCOUNT")
+    }
+
     static String mustGetPagerdutyToken() {
         return mustGet("PAGERDUTY_TOKEN")
     }

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -508,7 +508,7 @@ class IntegrationsTest extends BaseSpecification {
         then:
         "verify test integration"
         // Test integration for S3 performs test backup (and rollback).
-        assert ExternalBackupService.testExternalBackup(backup)
+        ExternalBackupService.getExternalBackupClient().testExternalBackup(backup)
 
         where:
         "configurations are:"
@@ -540,7 +540,7 @@ class IntegrationsTest extends BaseSpecification {
         then:
         "verify test integration"
         // Test integration for GCS performs test backup (and rollback).
-        assert ExternalBackupService.testExternalBackup(backup)
+        ExternalBackupService.getExternalBackupClient().testExternalBackup(backup)
 
         where:
         "configurations are:"

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -546,10 +546,8 @@ class IntegrationsTest extends BaseSpecification {
         "configurations are:"
 
         integrationName                | bucket                     | useWorkloadId
-        // Bucket is in stackrox-ci.
         "GCS with service account key" | Env.mustGetGCSBucketName() | false
-        // Bucket is in acs-san-stackroxci.
-        "GCS with workload identity"   | "stackrox-qa-wif-gcs-test" | true
+        "GCS with workload identity"   | Env.mustGetGCSBucketName() | true
     }
 
     @Unroll

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -528,6 +528,31 @@ class IntegrationsTest extends BaseSpecification {
     }
 
     @Unroll
+    @Tag("Integration")
+    def "Verify GCS Integration: #integrationName"() {
+        setup:
+        Assume.assumeTrue(!useWorkloadId || Env.HAS_WORKLOAD_IDENTITIES)
+
+        when:
+        "the integration is tested"
+        def backup = ExternalBackupService.getGCSIntegrationConfig(integrationName, useWorkloadId)
+
+        then:
+        "verify test integration"
+        // Test integration for GCS performs test backup (and rollback).
+        assert ExternalBackupService.testExternalBackup(backup)
+
+        where:
+        "configurations are:"
+
+        integrationName                | bucket                     | useWorkloadId
+        // Bucket is in stackrox-ci.
+        "GCS with service account key" | Env.mustGetGCSBucketName() | false
+        // Bucket is in acs-san-stackroxci.
+        "GCS with workload identity"   | "stackrox-qa-wif-gcs-test" | true
+    }
+
+    @Unroll
     @Tag("BAT")
     @Tag("Notifiers")
     def "Verify Policy Violation Notifications Destination Overrides: #type"() {


### PR DESCRIPTION
## Description

Add qa-e2e test for GCS external backups using both a service account key and a workload identity.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

See tests.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
