### PR TITLE
docs(roxctl): Mention Scanner V4 in roxctl doc string

### DIFF
--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -91,7 +91,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	c := &cobra.Command{
 		Use:   "generate",
-		Short: "Generate the required YAML configuration files to deploy StackRox Scanner",
+		Short: "Generate the required YAML configuration files to deploy StackRox Scanner and Scanner V4",
 		Args:  cobra.NoArgs,
 		RunE: func(c *cobra.Command, args []string) error {
 			scannerGenerateCmd.construct(c)


### PR DESCRIPTION
## Description

Scanner manifest bundles also contain V4 manifests nowadays. Hence the slight adjustment in the description of the sub command.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~~Unit test and regression tests added~~
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes~~
