### PR TITLE
chore(scanner): bump scan timeout from 6m to 10m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-20163: Sensor captures runtime events even if it is disconnected from Central.
 - ROX-20280: Fixed bug that prevented user from editing the endpoint from an unauthenticated email notifier. The credentials are still required to change the endpoint if it's not unauthenticated.
 - ROX-21729: - ROX-21729: When deleting a collection that is referenced by other objects such as report configurations, the error message now includes the names of the collection being deleted and its referencing object (report configuration).
+- ROX_SCAN_TIMEOUT environment variable in Central and Sensor now defaults to 10m instead of 6m.
 
 ## [4.3.0]
 

--- a/pkg/env/image_scan.go
+++ b/pkg/env/image_scan.go
@@ -4,5 +4,5 @@ import "time"
 
 var (
 	// ScanTimeout defines the image scan timeout duration.
-	ScanTimeout = registerDurationSetting("ROX_SCAN_TIMEOUT", 6*time.Minute)
+	ScanTimeout = registerDurationSetting("ROX_SCAN_TIMEOUT", 10*time.Minute)
 )


### PR DESCRIPTION
## Description

This gives us more time to handle larger images. It also aligns with Quay's timeout when reaching out to Clair: https://github.com/quay/quay/blob/v3.10.3/util/secscan/v4/api.py#L26

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

nah

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
