### PR TITLE
ROX-22479: set Scanner V4 env vars in Sensor correctly

### DIFF
--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -176,7 +176,7 @@
   {{ include "srox.safeLookup" (list $ $centralDeployment "apps/v1" "Deployment" $.Release.Namespace "central") }}
   {{ if $centralDeployment.result }}
     {{ include "srox.note" (list $ "Detected central running in the same namespace. Not deploying scanner-v4-indexer from this chart and configuring sensor to use existing scanner-v4-indexer instance, if any.") }}
-    {{ $_ := set $._rox.sensor.localImageScanning "enabled" "true" }}
+    {{ $_ := set $._rox.sensor.localImageScanningV4 "enabled" "true" }}
     {{ $_ := set $components "indexer" false }}
     {{/* Matcher on secured-cluster is unsupported, but just in case make sure it is disabled. */}}
     {{ $_ := set $components "matcher" false }}

--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -88,8 +88,13 @@ sensor:
     # sensor reaching out to a scanner instance.
     # This setting does not relate to the scanner deployment configuration which configures whether scanner should be deployed.
     enabled: null # bool
+  localImageScanningV4:
+    # Enables the local image scanning feature in Sensor, using Scanner V4. This disabled if local image scanning should
+    # not be used to prevent sensor reaching out to a scanner instance.
+    # This setting does not relate to the scanner deployment configuration which configures whether scanner should be deployed.
+    enabled: null # bool
 admissionControl:
-  listenOnCreates: null # bool
+  listenOnCreates: null # bools
   listenOnUpdates: null # bool
   listenOnEvents:  null # bool
   dynamic:

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -31,6 +31,8 @@ sensor:
   endpoint: "sensor.{{ required "unknown namespace" ._rox._namespace }}.svc:443"
   localImageScanning:
     enabled: false
+  localImageScanningV4:
+    enabled: false
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -298,7 +298,7 @@ already activated, we let `scanner.disable: false` have the implicit side-effect
 {{ end }}
 
 {{ if ._rox.scannerV4._indexerEnabled }}
-  {{ $_ := set $._rox.sensor.localImageScanning "enabled" "true" }}
+  {{ $_ := set $._rox.sensor.localImageScanningV4 "enabled" "true" }}
 [</* Due to historical reasons the image specifications for the secured-cluster-services chart
      are not found under <component-name>.image, but instead under image.<image identifier>.
      Since the image setup code in srox.scannerV4Init configures scannerV4.<scanner V4 component name>

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-netpol.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-netpol.yaml
@@ -22,7 +22,7 @@ spec:
       - podSelector:
           matchLabels:
             app: admission-control
-{{ if ._rox.sensor.localImageScanning.enabled }}
+{{ if or ._rox.sensor.localImageScanning.enabled ._rox.sensor.localImageScanningV4.enabled }}
       - podSelector:
           matchLabels:
             app: scanner

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -116,7 +116,7 @@ spec:
           value: {{ quote ._rox._configFP }}
         [<- end >]
         [<- if and (not .KubectlOutput) .FeatureFlags.ROX_SCANNER_V4_SUPPORT >]
-        {{- if ._rox._scannerV4Enabled }}
+        {{- if ._rox.sensor.localImageScanningV4.enabled }}
         - name: ROX_SCANNER_V4_GRPC_ENDPOINT
           value: {{ printf "scanner-v4-indexer.%s.svc:8443" .Release.Namespace }}
         - name: ROX_SCANNER_V4

--- a/operator/pkg/securedcluster/values/translation/translation.go
+++ b/operator/pkg/securedcluster/values/translation/translation.go
@@ -194,8 +194,12 @@ func (t Translator) getSensorValues(sensor *platform.SensorComponentSpec, scanne
 		sv.AddAllFrom(translation.GetTolerations(translation.TolerationsKey, sensor.Tolerations))
 	}
 
-	if scannerAutosense.EnableLocalImageScanning || scannerV4Autosense.EnableLocalImageScanning {
+	if scannerAutosense.EnableLocalImageScanning {
 		sv.SetPathValue("localImageScanning.enabled", strconv.FormatBool(true))
+	}
+
+	if scannerV4Autosense.EnableLocalImageScanning {
+		sv.SetPathValue("localImageScanningV4.enabled", strconv.FormatBool(true))
 	}
 
 	return &sv

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -26,7 +26,7 @@ tests:
     scannerV4.disable: false
   expect: |
     container(.deployments["scanner-v4-indexer"]; "indexer") | assertThat (. != null)
-    envVars(.deployments.sensor; "sensor")["ROX_LOCAL_IMAGE_SCANNING_ENABLED"] | assertThat(. == "true")
+    envVars(.deployments.sensor; "sensor")["ROX_SCANNER_V4"] | assertThat(. == "true")
   tests:
   - name: "on openshift 4"
     set:
@@ -162,12 +162,12 @@ tests:
     set:
       scannerV4.disable: false
     expect: |
-      envVars(.deployments.sensor; "sensor")["ROX_LOCAL_IMAGE_SCANNING_ENABLED"] | assertThat(. == "true")
+      envVars(.deployments.sensor; "sensor")["ROX_SCANNER_V4"] | assertThat(. == "true")
   - name: "local scanner disabled"
     set:
       scannerV4.disable: true
     expect: |
-      envVars(.deployments.sensor; "sensor")| assertThat(has("ROX_LOCAL_IMAGE_SCANNING_ENABLED") == false)
+      envVars(.deployments.sensor; "sensor")| assertThat(has("ROX_SCANNER_V4") == false)
 
 - name: "sensor connects to local scanner using the correct gRPC endpoint"
   release:


### PR DESCRIPTION
## Description

Alternative approach to https://github.com/stackrox/stackrox/pull/9904, in which I modify the Helm templates.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
