### PR TITLE
fix(chatty-errors): Compact error msg for long list of k8s resources

### DIFF
--- a/sensor/upgrader/preflight/access.go
+++ b/sensor/upgrader/preflight/access.go
@@ -98,7 +98,7 @@ func (c accessCheck) Check(ctx *upgradectx.UpgradeContext, execPlan *plan.Execut
 			reporter.Warnf("Evaluation error performing access review check for action %s on resource %s: %s", ra.Verb, ra.Resource, sarResult.Status.EvaluationError)
 		}
 		if !sarResult.Status.Allowed && !sarResult.Status.Denied {
-			actionResourceErr = append(actionResourceErr, fmt.Sprintf("%s: %s", ra.Verb, ra.Resource))
+			actionResourceErr = append(actionResourceErr, fmt.Sprintf("%s:%s", ra.Verb, ra.Resource))
 		} else if !sarResult.Status.Allowed {
 			reporter.Errorf("Action %s on resource %s is not allowed", ra.Verb, ra.Resource)
 		}
@@ -106,7 +106,7 @@ func (c accessCheck) Check(ctx *upgradectx.UpgradeContext, execPlan *plan.Execut
 	if len(actionResourceErr) > 0 {
 		reporter.Errorf("K8s authorizer did not explicitly allow or deny access to perform "+
 			"the following actions on following resources: %s. This usually means access is denied.",
-			strings.Join(actionResourceErr, ","))
+			strings.Join(actionResourceErr, ", "))
 	}
 
 	return nil

--- a/sensor/upgrader/preflight/access.go
+++ b/sensor/upgrader/preflight/access.go
@@ -1,6 +1,9 @@
 package preflight
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/sensor/upgrader/plan"
 	"github.com/stackrox/rox/sensor/upgrader/resources"
@@ -79,6 +82,7 @@ func (c accessCheck) Check(ctx *upgradectx.UpgradeContext, execPlan *plan.Execut
 		return err
 	}
 
+	actionResourceErr := make([]string, 0)
 	for i := range resourceAttribs {
 		ra := resourceAttribs[i]
 		sar := &v1.SelfSubjectAccessReview{
@@ -94,10 +98,16 @@ func (c accessCheck) Check(ctx *upgradectx.UpgradeContext, execPlan *plan.Execut
 			reporter.Warnf("Evaluation error performing access review check for action %s on resource %s: %s", ra.Verb, ra.Resource, sarResult.Status.EvaluationError)
 		}
 		if !sarResult.Status.Allowed && !sarResult.Status.Denied {
-			reporter.Errorf("K8s authorizer did not explicitly allow or deny access to perform action %s on resource %s. This usually means access is denied.", ra.Verb, ra.Resource)
+			actionResourceErr = append(actionResourceErr, fmt.Sprintf("%s: %s", ra.Verb, ra.Resource))
 		} else if !sarResult.Status.Allowed {
 			reporter.Errorf("Action %s on resource %s is not allowed", ra.Verb, ra.Resource)
 		}
 	}
+	if len(actionResourceErr) > 0 {
+		reporter.Errorf("K8s authorizer did not explicitly allow or deny access to perform "+
+			"the following actions on following resources: %s. This usually means access is denied.",
+			strings.Join(actionResourceErr, ","))
+	}
+
 	return nil
 }


### PR DESCRIPTION
## Description

This should prevent really chatty error messages like here: https://redhat-internal.slack.com/archives/C02HX541YQN/p1707422841968359

## Checklist
- [x] Investigated and inspected CI test results


### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- Manually on GKE using the following steps:
    - Install ACS from this branch
    - Set Sensor image manually to 4.2
    - Let the Sensor Upgrader run and attempt to upgrade Sensor
    - Navigate to URL/main/clusters to check the upgrade status
    - Notice Sensor Upgrade error as in the picture below:

![Screenshot 2024-02-16 at 12 29 53](https://github.com/stackrox/stackrox/assets/114479/29dc16ef-25a0-4a84-8e6d-0449ba60eaa1)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
