### PR TITLE
chore(deps): dependabot ignore claircore

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -54,9 +54,9 @@ updates:
     ignore:
       - dependency-name: "github.com/aws/aws-sdk-go"
         update-types: ["version-update:semver-patch"]
-      # This version of ClairCore does not build on Darwin.
+      # The Scanner team wants full control over ClairCore updates,
+      # so we ensure Scanner V4 does not have any unexpected changes.
       - dependency-name: "github.com/quay/claircore"
-        versions: ["1.5.20"]
     groups:
       k8s.io:
         patterns:


### PR DESCRIPTION
## Description

We want full control over the ClairCore dependency, so do not allow Dependabot to touch it.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

no

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
