### PR TITLE
ROX-22519: compliance sort profiles summaries

### DIFF
--- a/central/complianceoperator/v2/profiles/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/profiles/datastore/datastore_impl.go
@@ -56,7 +56,13 @@ func (d *datastoreImpl) DeleteProfileForCluster(ctx context.Context, uid string,
 
 // GetProfilesByClusters gets the list of profiles for a given clusters
 func (d *datastoreImpl) GetProfilesByClusters(ctx context.Context, clusterIDs []string) ([]*storage.ComplianceOperatorProfileV2, error) {
-	return d.store.GetByQuery(ctx, search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterIDs...).ProtoQuery())
+	query := search.NewQueryBuilder().
+		AddExactMatches(search.ClusterID, clusterIDs...).
+		WithPagination(search.NewPagination().
+			AddSortOption(search.NewSortOption(search.ComplianceOperatorProfileName))).
+		ProtoQuery()
+
+	return d.store.GetByQuery(ctx, query)
 }
 
 // CountProfiles returns count of profiles matching query


### PR DESCRIPTION
## Description

Profile summaries weren't being sorted.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Before:
![Screenshot 2024-02-14 at 3 18 23 PM](https://github.com/stackrox/stackrox/assets/99685630/12c6bc21-4461-4a5b-91d9-18f7d4e74c36)


After:
![Screenshot 2024-02-15 at 6 10 44 AM](https://github.com/stackrox/stackrox/assets/99685630/7e73235c-d855-41e3-8087-b12beb7a4d6c)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
