### PR TITLE
ROX-22274: Compliance scan config wizard validation

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ClusterSelection.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/ScanConfigs/Wizard/ClusterSelection.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement, useCallback } from 'react';
+import React, { ReactElement, RefObject, useCallback } from 'react';
 import { FormikContextType, useFormikContext } from 'formik';
 import { Link } from 'react-router-dom';
 import {
+    Alert,
     Bullseye,
     Button,
     Divider,
@@ -25,6 +26,7 @@ import { ScanConfigFormValues } from '../compliance.scanConfigs.utils';
 import ComplianceClusterStatus from '../components/ComplianceClusterStatus';
 
 export type ClusterSelectionProps = {
+    alertRef: RefObject<HTMLDivElement>;
     clusters: ComplianceIntegration[];
     isFetchingClusters: boolean;
 };
@@ -37,11 +39,19 @@ function InstallClustersButton() {
     );
 }
 
-function ClusterSelection({ clusters, isFetchingClusters }: ClusterSelectionProps): ReactElement {
+function ClusterSelection({
+    alertRef,
+    clusters,
+    isFetchingClusters,
+}: ClusterSelectionProps): ReactElement {
     const isRouteEnabled = useIsRouteEnabled();
     const isRouteEnabledForClusters = isRouteEnabled('clusters');
-    const { setFieldValue, values: formikValues }: FormikContextType<ScanConfigFormValues> =
-        useFormikContext();
+    const {
+        setFieldValue,
+        setTouched,
+        values: formikValues,
+        touched: formikTouched,
+    }: FormikContextType<ScanConfigFormValues> = useFormikContext();
 
     const clusterIsPreSelected = useCallback(
         (row) => formikValues.clusters.includes(row.clusterId),
@@ -66,6 +76,7 @@ function ClusterSelection({ clusters, isFetchingClusters }: ClusterSelectionProp
             })
             .map((cluster) => cluster.clusterId);
 
+        setTouched({ ...formikTouched, clusters: true });
         setFieldValue('clusters', newSelectedIds);
     };
 
@@ -74,6 +85,7 @@ function ClusterSelection({ clusters, isFetchingClusters }: ClusterSelectionProp
 
         const newSelectedIds = isSelected ? clusters.map((cluster) => cluster.clusterId) : [];
 
+        setTouched({ ...formikTouched, clusters: true });
         setFieldValue('clusters', newSelectedIds);
     };
 
@@ -149,9 +161,19 @@ function ClusterSelection({ clusters, isFetchingClusters }: ClusterSelectionProp
                 </Flex>
             </PageSection>
             <Divider component="div" />
-            <Form className="pf-u-py-lg pf-u-px-lg">
+            <Form className="pf-u-py-lg pf-u-px-lg" ref={alertRef}>
+                {formikTouched.clusters && formikValues.clusters.length === 0 && (
+                    <Alert
+                        title="At least one cluster is required to proceed"
+                        variant="danger"
+                        isInline
+                    />
+                )}
                 <TableComposable>
-                    <Caption>At least one cluster is required.</Caption>
+                    <Caption>
+                        <span className="pf-u-danger-color-100">* </span>
+                        At least one cluster is required
+                    </Caption>
                     <Thead noWrap>
                         <Tr>
                             <Th


### PR DESCRIPTION
## Description

This addresses validation concerns with the scan config wizard

Included:

- An alert banner now appears and scrolls into view if a user does not select a profile or cluster from the table but proceeds to click the "Next" button
- Alerts on the review step related to submission will now be reset if a user changes steps

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- Profiles/Clusters step: alert should not appear until either the user clicks the next button without a selection, or if a user makes a selection then goes back to a state where nothing is selected
- Review step: alerts triggered by submission should go away if user navigates away from the review step by either hitting "Back", or clicking on another step in the wizard nav

![Screenshot 2024-02-14 at 3 21 00 PM](https://github.com/stackrox/stackrox/assets/61400697/a7518172-1be8-4be3-85fe-86ac9f1e055e)
