### PR TITLE
chore(scanner): update Scanner V4 installation configurations

### DIFF
--- a/image/templates/helm/shared/internal/scanner-v4-config-shape.yaml
+++ b/image/templates/helm/shared/internal/scanner-v4-config-shape.yaml
@@ -60,6 +60,7 @@ scannerV4:
       generate: null # bool
     nodeSelector: null # string | dict
     tolerations: null # [dict]
+    affinity: null # dict
     resources: null # string | dict
     serviceTLS:
       cert: null # string

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
@@ -40,38 +40,7 @@ spec:
         {{- toYaml ._rox.scannerV4.db.tolerations | nindent 8 }}
       {{- end }}
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          # Scanner v4 DB is single-homed, so avoid preemptible nodes.
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: cloud.google.com/gke-preemptible
-                operator: NotIn
-                values:
-                - "true"
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/infra
-                operator: Exists
-          - weight: 25
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/compute
-                operator: Exists
-          # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
-          # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: DoesNotExist
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/control-plane
-                operator: DoesNotExist
+        {{- toYaml ._rox.scannerV4.db.affinity | nindent 8 }}
       serviceAccountName: scanner-v4
       terminationGracePeriodSeconds: 120
       initContainers:

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     matchLabels:
       app: scanner-v4-indexer
   strategy:
-    type: Recreate
+    type: RollingUpdate
   template:
     metadata:
       namespace: {{ .Release.Namespace }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     matchLabels:
       app: scanner-v4-matcher
   strategy:
-    type: Recreate
+    type: RollingUpdate
   template:
     metadata:
       namespace: {{ .Release.Namespace }}

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -171,8 +171,41 @@ defaults:
       metricsPort: 9090
       replicas: 3
       autoscaling:
-        minReplicas: 1
+        minReplicas: 2
         maxReplicas: 5
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scanner-v4-indexer
+              topologyKey: kubernetes.io/hostname
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+          - weight: 25
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/compute
+                operator: Exists
+          # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
+          # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
       resources:
         requests:
           memory: "1500Mi"
@@ -186,10 +219,43 @@ defaults:
     matcher:
       logLevel: INFO
       metricsPort: 9090
-      replicas: 1
+      replicas: 2
       autoscaling:
-        minReplicas: 1
+        minReplicas: 2
         maxReplicas: 3
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scanner-v4-matcher
+              topologyKey: kubernetes.io/hostname
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+          - weight: 25
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/compute
+                operator: Exists
+          # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
+          # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
       resources:
         requests:
           memory: "4Gi"
@@ -203,6 +269,39 @@ defaults:
     db:
       postgresConfig: "@config-templates/scanner-v4-db/postgresql.conf|config-templates/scanner-v4-db/postgresql.conf.default"
       hbaConfig: "@config-templates/scanner-v4-db/pg_hba.conf|config-templates/scanner-v4-db/pg_hba.conf.default"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          # Scanner V4 DB is single-homed, so avoid preemptible nodes.
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: cloud.google.com/gke-preemptible
+                operator: NotIn
+                values:
+                  - "true"
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+          - weight: 25
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/compute
+                operator: Exists
+          # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
+          # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
       resources:
         requests:
           cpu: "200m"

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/70-scanner-v4.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/70-scanner-v4.yaml.htpl
@@ -7,8 +7,41 @@ scannerV4:
     logLevel: INFO
     autoscaling:
       disable: false
-      minReplicas: 1
+      minReplicas: 2
       maxReplicas: 5
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app: scanner-v4-indexer
+            topologyKey: kubernetes.io/hostname
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/infra
+              operator: Exists
+        - weight: 25
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/compute
+              operator: Exists
+        # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
+        # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
+        - weight: 100
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/master
+              operator: DoesNotExist
+        - weight: 100
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: DoesNotExist
     resources:
       requests:
         memory: "1500Mi"
@@ -21,6 +54,39 @@ scannerV4:
     hbaConfig: "@config-templates/scanner-v4-db/pg_hba.conf|config-templates/scanner-v4-db/pg_hba.conf.default"
     source:
       statementTimeoutMs: 60000
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        # Scanner V4 DB is single-homed, so avoid preemptible nodes.
+        - weight: 100
+          preference:
+            matchExpressions:
+            - key: cloud.google.com/gke-preemptible
+              operator: NotIn
+              values:
+                - "true"
+        - weight: 50
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/infra
+              operator: Exists
+        - weight: 25
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/compute
+              operator: Exists
+        # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
+        # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
+        - weight: 100
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/master
+              operator: DoesNotExist
+        - weight: 100
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: DoesNotExist
     resources:
       requests:
         cpu: "200m"


### PR DESCRIPTION
## Description

This does the following:

* Bump the minimum replicas for Indexer to 2
* Bump the minimum replicas for Matcher to 2
* Add `affinity` configurations for Indexer and Matcher
* Move `affinity` configuration for Scanner V4 DB into a separate location to match Indexer and Matcher

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
