### PR TITLE
ROX-21840: Add regression tests for cluster init bundles route in UI

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/init-bundles/InitBundleForm.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/init-bundles/InitBundleForm.test.js
@@ -1,0 +1,79 @@
+import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
+import { generateNameWithDate, getInputByLabel } from '../../../helpers/formHelpers';
+
+import { interactAndVisitClusters } from '../Clusters.helpers';
+
+import {
+    assertInitBundleForm,
+    assertInitBundlePage,
+    assertInitBundlesPage,
+    interactAndWaitForCreateBundle,
+    interactAndWaitForInitBundles,
+    interactAndWaitForRevokeBundle,
+    visitInitBundleForm,
+    visitInitBundlesPage,
+} from './InitBundles.helpers';
+
+describe('Cluster init bundles InitBundlesForm', () => {
+    withAuth();
+
+    before(function () {
+        if (!hasFeatureFlag('ROX_MOVE_INIT_BUNDLES_UI')) {
+            this.skip();
+        }
+    });
+
+    it('visits clusters from breadcrumb link', () => {
+        visitInitBundleForm();
+
+        cy.get('.pf-c-breadcrumb__item:nth-child(3):contains("Create bundle")');
+        interactAndVisitClusters(() => {
+            cy.get('.pf-c-breadcrumb__item:nth-child(1) a:contains("Clusters")').click();
+        });
+    });
+
+    it('visits cluster init bundles from breadcrumb link', () => {
+        visitInitBundleForm();
+
+        cy.get('.pf-c-breadcrumb__item:nth-child(3):contains("Create bundle")');
+        interactAndWaitForInitBundles(() => {
+            cy.get(
+                '.pf-c-breadcrumb__item:nth-child(2) a:contains("Cluster init bundles")'
+            ).click();
+        });
+
+        assertInitBundlePage();
+    });
+
+    it('creates, views, and then deletes a bundle', () => {
+        visitInitBundlesPage();
+
+        const name = generateNameWithDate('Create-bundle').replace(/:/g, ''); // colon in not valid in name
+
+        cy.get(`td[data-label="Name"] a:contains("${name}")`).should('not.exist');
+        cy.get('a:contains("Create bundle")').click();
+
+        assertInitBundleForm();
+        cy.get('button:contains("Download")').should('be.disabled');
+        getInputByLabel('Name').type(name);
+        interactAndWaitForCreateBundle(() => {
+            cy.get('button:contains("Download")').click();
+        });
+
+        assertInitBundlesPage();
+        interactAndWaitForInitBundles(() => {
+            cy.get(`td[data-label="Name"] a:contains("${name}")`).click();
+        });
+
+        assertInitBundlePage();
+        cy.get('button:contains("Revoke bundle")').click();
+        cy.get('.pf-c-modal-box__title:contains("Revoke cluster init bundle")');
+        interactAndWaitForRevokeBundle(() => {
+            cy.get(`[role="dialog"] button:contains("Revoke bundle")`).click();
+        });
+
+        assertInitBundlesPage();
+        cy.get(`td[data-label="Name"] a:contains("${name}")`).should('not.exist');
+    });
+});

--- a/ui/apps/platform/cypress/integration/clusters/init-bundles/InitBundleForm.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/init-bundles/InitBundleForm.test.js
@@ -43,7 +43,7 @@ describe('Cluster init bundles InitBundlesForm', () => {
             ).click();
         });
 
-        assertInitBundlePage();
+        assertInitBundlesPage();
     });
 
     it('creates, views, and then deletes a bundle', () => {

--- a/ui/apps/platform/cypress/integration/clusters/init-bundles/InitBundles.helpers.js
+++ b/ui/apps/platform/cypress/integration/clusters/init-bundles/InitBundles.helpers.js
@@ -38,8 +38,7 @@ export function assertInitBundlesPage() {
 // interact
 
 /**
- * Visit init bundles by interaction from another container.
- * Filter or sort init bundles table.
+ * Visit init bundles or init bundle page.
  *
  * @param {function} interactionCallback
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]

--- a/ui/apps/platform/cypress/integration/clusters/init-bundles/InitBundles.helpers.js
+++ b/ui/apps/platform/cypress/integration/clusters/init-bundles/InitBundles.helpers.js
@@ -2,7 +2,7 @@ import { interactAndWaitForResponses } from '../../../helpers/request';
 import { visit } from '../../../helpers/visit';
 
 const pagePath = '/main/clusters/init-bundles';
-const formSearch = '?action=create';
+const formAction = '?action=create';
 
 // routeMatcherMap
 
@@ -21,7 +21,7 @@ const routeMatcherMapForInitBundles = {
 
 export function assertInitBundleForm() {
     cy.location('pathname').should('eq', pagePath);
-    cy.location('search').should('eq', formSearch);
+    cy.location('search').should('eq', formAction);
     cy.get('h1:contains("Create bundle")');
 }
 
@@ -100,7 +100,7 @@ export function interactAndWaitForRevokeBundle(interactionCallback, staticRespon
 // visit
 
 export function visitInitBundleForm() {
-    visit(`${pagePath}${formSearch}`);
+    visit(`${pagePath}${formAction}`);
 
     assertInitBundleForm();
 }

--- a/ui/apps/platform/cypress/integration/clusters/init-bundles/InitBundles.helpers.js
+++ b/ui/apps/platform/cypress/integration/clusters/init-bundles/InitBundles.helpers.js
@@ -26,7 +26,7 @@ export function assertInitBundleForm() {
 }
 
 export function assertInitBundlePage() {
-    cy.location('pathname').should('eq', pagePath);
+    cy.location('pathname').should('contain', pagePath); // contain because of id
     cy.contains('h1', /^Cluster init bundle$/); // singular
 }
 

--- a/ui/apps/platform/cypress/integration/clusters/init-bundles/InitBundles.helpers.js
+++ b/ui/apps/platform/cypress/integration/clusters/init-bundles/InitBundles.helpers.js
@@ -1,0 +1,116 @@
+import { interactAndWaitForResponses } from '../../../helpers/request';
+import { visit } from '../../../helpers/visit';
+
+const pagePath = '/main/clusters/init-bundles';
+const formSearch = '?action=create';
+
+// routeMatcherMap
+
+const urlForInitBundles = '/v1/cluster-init/init-bundles';
+
+export const initBundlesAlias = 'init-bundles';
+
+const routeMatcherMapForInitBundles = {
+    [initBundlesAlias]: {
+        method: 'GET',
+        url: urlForInitBundles,
+    },
+};
+
+// assert
+
+export function assertInitBundleForm() {
+    cy.location('pathname').should('eq', pagePath);
+    cy.location('search').should('eq', formSearch);
+    cy.get('h1:contains("Create bundle")');
+}
+
+export function assertInitBundlePage() {
+    cy.location('pathname').should('eq', pagePath);
+    cy.contains('h1', /^Cluster init bundle$/); // singular
+}
+
+export function assertInitBundlesPage() {
+    cy.location('pathname').should('eq', pagePath);
+    cy.contains('h1', /^Cluster init bundles$/); // plural
+}
+
+// interact
+
+/**
+ * Visit init bundles by interaction from another container.
+ * Filter or sort init bundles table.
+ *
+ * @param {function} interactionCallback
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function interactAndWaitForInitBundles(interactionCallback, staticResponseMap) {
+    return interactAndWaitForResponses(
+        () => {
+            interactionCallback();
+        },
+        routeMatcherMapForInitBundles,
+        staticResponseMap
+    );
+}
+
+/**
+ * Create bundle and go back to init bundles page.
+ *
+ * @param {function} interactionCallback
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function interactAndWaitForCreateBundle(interactionCallback, staticResponseMap) {
+    return interactAndWaitForResponses(
+        () => {
+            interactionCallback();
+        },
+        {
+            'POST_init-bundles': {
+                method: 'POST',
+                url: urlForInitBundles,
+            },
+            ...routeMatcherMapForInitBundles,
+        },
+        staticResponseMap
+    );
+}
+
+/**
+ * Revoke bundle via either button in page or row action in table.
+ *
+ * @param {function} interactionCallback
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function interactAndWaitForRevokeBundle(interactionCallback, staticResponseMap) {
+    return interactAndWaitForResponses(
+        () => {
+            interactionCallback();
+        },
+        {
+            'PATCH_init-bundles': {
+                method: 'PATCH',
+                url: `${urlForInitBundles}/revoke`,
+            },
+            ...routeMatcherMapForInitBundles,
+        },
+        staticResponseMap
+    );
+}
+
+// visit
+
+export function visitInitBundleForm() {
+    visit(`${pagePath}${formSearch}`);
+
+    assertInitBundleForm();
+}
+
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function visitInitBundlesPage(staticResponseMap) {
+    visit(pagePath, routeMatcherMapForInitBundles, staticResponseMap);
+
+    assertInitBundlesPage();
+}

--- a/ui/apps/platform/cypress/integration/clusters/init-bundles/InitBundlesPage.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/init-bundles/InitBundlesPage.test.js
@@ -1,0 +1,48 @@
+import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
+
+import { interactAndVisitClusters, visitClusters } from '../Clusters.helpers';
+
+import {
+    assertInitBundlesPage,
+    interactAndWaitForInitBundles,
+    visitInitBundlesPage,
+} from './InitBundles.helpers';
+
+describe('Cluster init bundles InitBundlesPage', () => {
+    withAuth();
+
+    before(function () {
+        if (!hasFeatureFlag('ROX_MOVE_INIT_BUNDLES_UI')) {
+            this.skip();
+        }
+    });
+
+    it('visits from clusters page', () => {
+        visitClusters();
+
+        interactAndWaitForInitBundles(() => {
+            cy.get('a:contains("Init bundles")').click();
+        });
+
+        assertInitBundlesPage();
+    });
+
+    it('visits clusters from breadcrumb link', () => {
+        visitInitBundlesPage();
+
+        cy.get('.pf-c-breadcrumb__item:nth-child(2):contains("Cluster init bundles")');
+        interactAndVisitClusters(() => {
+            cy.get('.pf-c-breadcrumb__item:nth-child(1) a:contains("Clusters")').click();
+        });
+    });
+
+    it('renders table head cells', () => {
+        visitInitBundlesPage();
+
+        cy.get('th:contains("Name")');
+        cy.get('th:contains("Created by")');
+        cy.get('th:contains("Created at")');
+        cy.get('th:contains("Expires at")');
+    });
+});


### PR DESCRIPTION
## Description

## Checklist
- [x] Investigated and inspected CI test results
- [x] Added regression tests

## Testing Performed

### Integration testing

Before you `yarn cypress-open` in ui/apps/platform folder:

```sh
export CYPRESS_ROX_MOVE_INIT_BUNDLES_UI=true
```

* clusters/init-bundles/InitBundleForm.test.js
* clusters/init-bundles/InitBundlesPage.test.js