### PR TITLE
fix(ui): Fix visuals of image name copy button

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameTd.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { ClipboardCopyButton, Flex, FlexItem, Truncate } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Tooltip, Truncate } from '@patternfly/react-core';
+import { OutlinedCopyIcon } from '@patternfly/react-icons';
 
 import { getEntityPagePath } from '../searchUtils';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
@@ -32,33 +33,36 @@ function ImageNameTd({ name, id, children }: ImageNameTdProps) {
         <Flex
             direction={{ default: 'row' }}
             flexWrap={{ default: 'nowrap' }}
-            justifyContent={{ default: 'justifyContentSpaceBetween' }}
             alignItems={{ default: 'alignItemsFlexStart' }}
             spaceItems={{ default: 'spaceItemsNone' }}
         >
-            <Flex
-                grow={{ default: 'grow' }}
-                direction={{ default: 'column' }}
-                spaceItems={{ default: 'spaceItemsNone' }}
-            >
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsNone' }}>
                 <Link to={getEntityPagePath('Image', id, vulnerabilityState)}>
                     <Truncate position="middle" content={`${remote}:${tag}`} />
                 </Link>{' '}
                 <span className="pf-u-color-200 pf-u-font-size-sm">in {registry}</span>
                 <div>{children}</div>
             </Flex>
-            <FlexItem shrink={{ default: 'shrink' }}>
-                <ClipboardCopyButton
-                    id={`copy-image-name-button-${id}`}
-                    textId={`copy-image-name-text-${id}`}
-                    className="pf-u-pt-xs"
-                    variant="plain"
+            <FlexItem>
+                <Tooltip
+                    trigger="mouseenter focus click"
+                    aria-live="polite"
+                    aria="none"
                     exitDelay={1000}
                     onTooltipHidden={() => setCopyIconTooltip('Copy image name')}
-                    onClick={copyImageName}
+                    content={<div>{copyIconTooltip}</div>}
                 >
-                    {copyIconTooltip}
-                </ClipboardCopyButton>
+                    <Button
+                        className="pf-u-pt-xs"
+                        id={`copy-image-name-button-${id}`}
+                        aria-labelledby={`copy-image-name-text-${id}`}
+                        type="button"
+                        variant="plain"
+                        onClick={copyImageName}
+                    >
+                        <OutlinedCopyIcon />
+                    </Button>
+                </Tooltip>
             </FlexItem>
         </Flex>
     );


### PR DESCRIPTION
## Description

### > Not high priority for review. <

Updates the icon of the copy button and fixes alignment so that icon is not right aligned to table cell.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Before:
![image](https://github.com/stackrox/stackrox/assets/1292638/07c1dd2a-8682-44be-85d1-3f898310f8a4)
![image](https://github.com/stackrox/stackrox/assets/1292638/bc6a33ef-e063-4b3e-8229-1f0de247eae2)


After:
![image](https://github.com/stackrox/stackrox/assets/1292638/f6e5e29f-3359-4c75-9e96-b1c4173bd29b)
![image](https://github.com/stackrox/stackrox/assets/1292638/4c8a8118-c8c3-47ad-8d9e-e01009bf9010)
