### PR TITLE
ROX-22558: Make changes after team test of discovered clusters UI

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.cy.jsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.cy.jsx
@@ -39,11 +39,15 @@ const filterGroup = (name) => cy.findByRole('group', { name });
 const filterChip = (label) => cy.get(`li:has(*:contains("${label}"))`);
 const removeGroup = (name) =>
     filterGroup(name).within(() => cy.findByLabelText('Close chip group').click());
+// Comment out for 4.4 MVP because testers expected partial match instead of exact match.
+/*
 const removeChip = (name) =>
     filterChip(name).within(() => cy.findByLabelText('Remove filter').click());
+*/
 
 describe(Cypress.spec.relative, () => {
-    it('should correctly handle the name text input', () => {
+    // Skip for 4.4 MVP because testers expected partial match instead of exact match.
+    it.skip('should correctly handle the name text input', () => {
         setup();
 
         // Ensure creating a chip/filter clears the input
@@ -135,9 +139,12 @@ describe(Cypress.spec.relative, () => {
         // Default is no filters
         cy.location('search').should('match', /^$/);
 
+        // Comment out for 4.4 MVP because testers expected partial match instead of exact match.
+        /*
         // Add filters of each type
         cy.findByLabelText('Filter by name').type('cluster-a{enter}');
         cy.findByLabelText('Filter by name').type('cluster-b{enter}');
+        */
 
         openDropdownAnd('Status filter menu toggle', () => {
             cy.findByLabelText('Unsecured').click();
@@ -150,10 +157,13 @@ describe(Cypress.spec.relative, () => {
         });
 
         // Verify that all filters are applied and visible as chips
+        // Comment out for 4.4 MVP because testers expected partial match instead of exact match.
+        /*
         filterGroup('Name').within(() => {
             filterChip('cluster-a');
             filterChip('cluster-b');
         });
+        */
 
         filterGroup('Status').within(() => {
             filterChip('Unsecured');
@@ -167,8 +177,11 @@ describe(Cypress.spec.relative, () => {
 
         // Verify that the filters exist in the URL
         [
+            // Comment out for 4.4 MVP because testers expected partial match instead of exact match.
+            /*
             /s\[Cluster\]\[\d\]=cluster-a/,
             /s\[Cluster\]\[\d\]=cluster-b/,
+            */
             /s\[Cluster%20Status\]\[\d\]=STATUS_UNSECURED/,
             /s\[Cluster%20Status\]\[\d\]=STATUS_UNSPECIFIED/,
             /s\[Cluster%20Type\]\[\d\]=AKS/,
@@ -177,18 +190,24 @@ describe(Cypress.spec.relative, () => {
             cy.location('search').should('match', filter);
         });
 
+        // Comment out for 4.4 MVP because testers expected partial match instead of exact match.
+        /*
         // Remove some filters and verify that the chips are removed
         filterGroup('Name').within(() => {
             removeChip('cluster-b');
         });
+        */
 
         removeGroup('Type');
 
+        // Comment out for 4.4 MVP because testers expected partial match instead of exact match.
+        /*
         // Verify that the correct filters are removed
         filterGroup('Name').within(() => {
             filterChip('cluster-a');
             filterChip('cluster-b').should('not.exist');
         });
+        */
 
         filterGroup('Status').within(() => {
             filterChip('Unsecured');
@@ -199,7 +218,10 @@ describe(Cypress.spec.relative, () => {
 
         // Verify the next URL state
         [
+            // Comment out for 4.4 MVP because testers expected partial match instead of exact match.
+            /*
             /s\[Cluster\]\[\d\]=cluster-a/,
+            */
             /s\[Cluster%20Status\]\[\d\]=STATUS_UNSECURED/,
             /s\[Cluster%20Status\]\[\d\]=STATUS_UNSPECIFIED/,
         ].forEach((filter) => {
@@ -209,7 +231,10 @@ describe(Cypress.spec.relative, () => {
         // Remove all filters and verify that the chips are removed
         cy.findByRole('button', { name: 'Clear filters' }).click();
 
+        // Comment out for 4.4 MVP because testers expected partial match instead of exact match.
+        /*
         filterGroup('Name').should('not.exist');
+        */
         filterGroup('Status').should('not.exist');
         filterGroup('Type').should('not.exist');
 

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
@@ -7,6 +7,8 @@ import {
     ToolbarItem,
 } from '@patternfly/react-core';
 
+// Comment out Names filter for 4.4 MVP because testers expected partial match instead of exact match.
+
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import {
     DiscoveredClusterStatus,
@@ -14,19 +16,19 @@ import {
     getDiscoveredClustersFilter,
     isStatus,
     isType,
-    replaceSearchFilterNames,
+    // replaceSearchFilterNames,
     replaceSearchFilterStatuses,
     replaceSearchFilterTypes,
 } from 'services/DiscoveredClusterService';
 import { SearchFilter } from 'types/search';
 
 import SearchFilterTypes from './SearchFilterTypes';
-import SearchFilterNames from './SearchFilterNames';
+// import SearchFilterNames from './SearchFilterNames';
 import SearchFilterStatuses from './SearchFilterStatuses';
 import { getStatusText, getTypeText } from './DiscoveredCluster';
 
 const searchFilterChipDescriptors = [
-    { displayName: 'Name', searchFilterName: 'Cluster' },
+    // { displayName: 'Name', searchFilterName: 'Cluster' },
     {
         displayName: 'Status',
         searchFilterName: 'Cluster Status',
@@ -41,7 +43,8 @@ const searchFilterChipDescriptors = [
 
 export type DiscoveredClustersToolbarProps = {
     count: number;
-    isDisabled: boolean;
+    // Comment out use of prop for MVP because testers complained about flicker.
+    isDisabled: boolean; // eslint-disable-line react/no-unused-prop-types
     page: number;
     perPage: number;
     setPage: (newPage: number) => void;
@@ -52,7 +55,8 @@ export type DiscoveredClustersToolbarProps = {
 
 function DiscoveredClustersToolbar({
     count,
-    isDisabled,
+    // Comment out for MVP because testers complained about flicker.
+    // isDisabled,
     page,
     perPage,
     setPage,
@@ -60,9 +64,11 @@ function DiscoveredClustersToolbar({
     searchFilter,
     setSearchFilter,
 }: DiscoveredClustersToolbarProps): ReactElement {
+    /*
     function setNamesSelected(names: string[] | undefined) {
         setSearchFilter(replaceSearchFilterNames(searchFilter, names));
     }
+    */
 
     function setStatusesSelected(statuses: DiscoveredClusterStatus[] | undefined) {
         setSearchFilter(replaceSearchFilterStatuses(searchFilter, statuses));
@@ -73,7 +79,7 @@ function DiscoveredClustersToolbar({
     }
 
     const {
-        names: namesSelected,
+        // names: namesSelected,
         types: typesSelected,
         statuses: statusesSelected,
     } = getDiscoveredClustersFilter(searchFilter);
@@ -81,25 +87,32 @@ function DiscoveredClustersToolbar({
     return (
         <Toolbar>
             <ToolbarContent>
+                {/*
                 <ToolbarItem variant="search-filter">
                     <SearchFilterNames
                         namesSelected={namesSelected}
-                        isDisabled={isDisabled}
+                        // Comment out for MVP because testers complained about flicker.
+                        // isDisabled={isDisabled}
                         setNamesSelected={setNamesSelected}
                     />
-                </ToolbarItem>
+                    </ToolbarItem>
+                */}
                 <ToolbarGroup variant="filter-group">
                     <ToolbarItem>
                         <SearchFilterStatuses
                             statusesSelected={statusesSelected}
-                            isDisabled={isDisabled}
+                            // Comment out for MVP because testers complained about flicker.
+                            // isDisabled={isDisabled}
+                            isDisabled={false}
                             setStatusesSelected={setStatusesSelected}
                         />
                     </ToolbarItem>
                     <ToolbarItem>
                         <SearchFilterTypes
                             typesSelected={typesSelected}
-                            isDisabled={isDisabled}
+                            // Comment out for MVP because testers complained about flicker.
+                            // isDisabled={isDisabled}
+                            isDisabled={false}
                             setTypesSelected={setTypesSelected}
                         />
                     </ToolbarItem>
@@ -108,7 +121,8 @@ function DiscoveredClustersToolbar({
                     <ToolbarItem variant="pagination">
                         <Pagination
                             isCompact
-                            isDisabled={isDisabled}
+                            // Comment out for MVP because testers complained about flicker.
+                            // isDisabled={isDisabled}
                             itemCount={count}
                             page={page}
                             perPage={perPage}


### PR DESCRIPTION
## Description

### Changes

1. Because several testers expected **Name** search filter to have partial match, but it has exact match, comment out **Name** filter for MVP.
2. Because a tester complained about flicker, comment out `isDisabled={isDisabled}` prop for filters and pagination.

### Residue

1. Although a tester commented about change in table height as a result of search filter, defer for MVP to be safe. Quick comparison to other recent pages have similar behavior, but much less apparent because those tables are in lower half of the page.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_CLOUD_SOURCES=true
```

### Manual testing

1. Visit /main/clusters and click **Discovered clusters** button.
    * See absence of name filter.
    * Tested filtering to see absence of flicker.
    ![discovered-clusters](https://github.com/stackrox/stackrox/assets/11862657/3fb3c49d-4b03-4641-a55e-a642852622c8)

### Integration testing

Before you `yarn cypress-open` in ui/apps/platform folder:

```sh
export CYPRESS_ROX_CLOUD_SOURCES=true
```

* clusters/discovered-clusters/DiscoveredClustersPage.test.js