### PR TITLE
fix(tests): unpin GKE version

### DIFF
--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -78,10 +78,6 @@ choose_cluster_version() {
         gcloud container get-server-config --format json | jq .validMasterVersions
         unset GKE_CLUSTER_VERSION
     fi
-    # ROX-19109: Use v1.26 to get a more stable GKE clusters
-    if [[ -z "${GKE_CLUSTER_VERSION:-}" ]]; then
-        GKE_CLUSTER_VERSION="1.26"
-    fi
 }
 
 create_cluster() {


### PR DESCRIPTION
## Description

GKE clusters are broken in CI. `calico-node` pods do not reach a Ready state. This
PR reverts the version pin to v1.26 in the hopes that the stable channel is more
stable :).

Ref: https://redhat-internal.slack.com/archives/CC5UHD0KA/p1708015656314549
and: https://github.com/stackrox/stackrox/pull/7537

## Checklist
- [x] Investigated and inspected CI test results - looks better based on gke jobs.

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
