### PR TITLE
chore(deploy-tooling): log when docker is used in deploy script

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -163,7 +163,7 @@ function launch_central {
     elif [[ -x "$(command -v roxctl)" && "$(roxctl version)" == "$MAIN_IMAGE_TAG" ]]; then
       echo "Using $(command -v roxctl) for install due to version match with MAIN_IMAGE_TAG $MAIN_IMAGE_TAG"
       use_docker=0
-    else
+    elif [[ -z "$CI" ]]; then
       echo "Using docker with $ROXCTL_IMAGE for install. Set USE_LOCAL_ROXCTL=true if you want to use your local version of roxctl"
       if ! docker pull "$ROXCTL_IMAGE"; then
         echo "Failed to pull $ROXCTL_IMAGE"
@@ -176,7 +176,11 @@ function launch_central {
         local image
         for image in "${images[@]}"; do
           if ! docker manifest inspect "${image}" > /dev/null; then
-            yes_no_prompt "Couldn't find ${image}. Do you want to continue anyway?" || { echo >&2 "Exiting as requested"; exit 1; }
+            if [[ -t 1 ]]; then
+              yes_no_prompt "Couldn't find ${image}. Do you want to continue anyway?" || { echo >&2 "Exiting as requested"; exit 1; }
+            else
+              echo >&2 "WARNING: Couldn't find ${image}. Continuing the deployment, but note deployments uses this image may fail"
+            fi
           fi
         done
       }

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -181,7 +181,7 @@ function launch_central {
           if [[ -t 1 ]]; then
             yes_no_prompt "Couldn't find ${image}. Do you want to continue anyway?" || { echo >&2 "Exiting as requested"; exit 1; }
           else
-            echo >&2 "WARNING: Couldn't find ${image}. Continuing the deployment, but note workloads uses this image may fail"
+            echo >&2 "WARNING: Couldn't find ${image}. Continuing the deployment, but note workloads using this image may fail"
           fi
         fi
       done

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -170,22 +170,21 @@ function launch_central {
         exit 1
       fi
 
-      _check_images() {
-        local images=("$@")
+      local images_to_check=("${MAIN_IMAGE}" "${CENTRAL_DB_IMAGE}")
+      if [[ "$SCANNER_SUPPORT" == "true" && "$ROX_SCANNER_V4" == "true" ]]; then
+        images_to_check+=("${DEFAULT_IMAGE_REGISTRY}/scanner-v4:${MAIN_IMAGE_TAG}" "${DEFAULT_IMAGE_REGISTRY}/scanner-v4-db:${MAIN_IMAGE_TAG}")
+      fi
 
-        local image
-        for image in "${images[@]}"; do
-          if ! docker manifest inspect "${image}" > /dev/null; then
-            if [[ -t 1 ]]; then
-              yes_no_prompt "Couldn't find ${image}. Do you want to continue anyway?" || { echo >&2 "Exiting as requested"; exit 1; }
-            else
-              echo >&2 "WARNING: Couldn't find ${image}. Continuing the deployment, but note deployments uses this image may fail"
-            fi
+      local image
+      for image in "${images_to_check[@]}"; do
+        if ! docker manifest inspect "${image}" > /dev/null; then
+          if [[ -t 1 ]]; then
+            yes_no_prompt "Couldn't find ${image}. Do you want to continue anyway?" || { echo >&2 "Exiting as requested"; exit 1; }
+          else
+            echo >&2 "WARNING: Couldn't find ${image}. Continuing the deployment, but note workloads uses this image may fail"
           fi
-        done
-      }
-
-      _check_images "${MAIN_IMAGE}" "${CENTRAL_DB_IMAGE}" "${DEFAULT_IMAGE_REGISTRY}/scanner-v4:${MAIN_IMAGE_TAG}" "${DEFAULT_IMAGE_REGISTRY}/scanner-v4-db:${MAIN_IMAGE_TAG}"
+        fi
+      done
     fi
 
     add_args() {


### PR DESCRIPTION
## Description

These changes make it clearer when docker is used and what container image it's using for `roxctl` when using the deploy scripts.

## Checklist
- ~~[ ] Investigated and inspected CI test results~~
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

These changes only affect local development.

## Testing Performed

### Here I tell how I validated my change

New log:
```
❯ ./deploy/deploy-local.sh
...
Generating central config...
Using docker with quay.io/stackrox-io/roxctl:latest for install. Set USE_LOCAL_ROXCTL=true if you want to use your local version of roxctl
...
```

When some of the images exist but other don't:
```
❯ ROX_SCANNER_V4=true MAIN_IMAGE_TAG=latest ./deploy/deploy-local.sh
...
Generating central config...
Using docker with quay.io/stackrox-io/roxctl:latest for install. Set USE_LOCAL_ROXCTL=true if you want to use your local version of roxctl
latest: Pulling from stackrox-io/roxctl
Digest: sha256:a5564efd07211af00076df85ad09781f6691e6dd424c8959ca715c63269a0cd3
Status: Image is up to date for quay.io/stackrox-io/roxctl:latest
quay.io/stackrox-io/roxctl:latest
no such manifest: quay.io/stackrox-io/scanner-v4:latest
Couldn't find quay.io/stackrox-io/scanner-v4:latest. Do you want to continue anyway?
...
```

When the `roxctl` image doesn't exit:
```
❯ MAIN_IMAGE_TAG=DoesNotExist ./deploy/deploy-local.sh
...
Generating central config...
Using docker with quay.io/stackrox-io/roxctl:DoesNotExist for install. Set USE_LOCAL_ROXCTL=true if you want to use your local version of roxctl
Error response from daemon: manifest for quay.io/stackrox-io/roxctl:DoesNotExist not found: manifest unknown: manifest unknown
Failed to pull quay.io/stackrox-io/roxctl:DoesNotExist
...
```

When shell isn't tty:
```
❯ ROX_SCANNER_V4=true MAIN_IMAGE_TAG=latest ./deploy/deploy-local.sh | cat
...
Generating central config...
Using docker with quay.io/stackrox-io/roxctl:latest for install. Set USE_LOCAL_ROXCTL=true if you want to use your local version of roxctl
latest: Pulling from stackrox-io/roxctl
Digest: sha256:fbdc545e649f94926814b297808b6c21ac6fa8bb10bec89ba042971cee4fe051
Status: Image is up to date for quay.io/stackrox-io/roxctl:latest
quay.io/stackrox-io/roxctl:latest
no such manifest: quay.io/stackrox-io/scanner-v4:latest
WARNING: Couldn't find quay.io/stackrox-io/scanner-v4:latest. Continuing the deployment, but note workloads uses this image may fail
...
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
