### PR TITLE
fix(tests): use container names for pod restart description

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -620,8 +620,8 @@ check_for_stackrox_restarts() {
         local check_out=""
         # shellcheck disable=SC2086
         if ! check_out="$(scripts/ci/logcheck/check-restart-logs.sh "${CI_JOB_NAME}" $previous_logs)"; then
-            containers=$(echo "${check_out}" | grep "copied to Artifacts" | rev | cut -d- -f2 | rev | sort -u | tr '\n' ' ')
-            save_junit_failure "Pod Restarts" "${containers}" "${check_out}"
+            names=$(echo "${check_out}" | grep "copied to Artifacts" | cut -d- -f1 | sort -u | tr '\n' ' ')
+            save_junit_failure "Pod Restarts" "${names}" "${check_out}"
             die "ERROR: Found at least one unexplained pod restart. ${check_out}"
         fi
         info "Restarts were considered benign"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -620,8 +620,8 @@ check_for_stackrox_restarts() {
         local check_out=""
         # shellcheck disable=SC2086
         if ! check_out="$(scripts/ci/logcheck/check-restart-logs.sh "${CI_JOB_NAME}" $previous_logs)"; then
-            pods=$(echo $check_out | grep "copied to Artifacts" | cut -d- -f1,3 | sort -u | tr '\n' ' ')
-            save_junit_failure "Pod Restarts" "${pods}" "${check_out}"
+            containers=$(echo "${check_out}" | grep "copied to Artifacts" | rev | cut -d- -f2 | rev | sort -u | tr '\n' ' ')
+            save_junit_failure "Pod Restarts" "${containers}" "${check_out}"
             die "ERROR: Found at least one unexplained pod restart. ${check_out}"
         fi
         info "Restarts were considered benign"


### PR DESCRIPTION
## Description

The logic to grep out pod descriptions from the restart check output was missing "". `echo` condenses unquoted multiline strings to a single line and so the cut logic matched on the initial part of the output. This PR changes it to use "" and grab only the first part of the pod name - a compromise to deal with the vagaries of pod names and otherwise we end up with e.g. sensor-ztyvd. 

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

Validated with the output found in:
https://issues.redhat.com/issues/?jql=project%20%3D%20ROX%20AND%20summary%20%20~%20%22Pod%20Restarts%22%20ORDER%20BY%20created%20DESC

- [ ] kill pods during test and ensure the restarts are handled well - test jiras

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
