### PR TITLE
fix(CI): default spec log url to stackrox-e2e

### DIFF
--- a/qa-tests-backend/scripts/lib.sh
+++ b/qa-tests-backend/scripts/lib.sh
@@ -106,7 +106,7 @@ get_spec_log_url() {
     else
         url="${url}/logs"
     fi
-    url="${url}/${JOB_NAME}/${BUILD_ID}/artifacts/${JOB_NAME_SAFE}/${OPENSHIFT_CI_STEP_NAME}/artifacts"
+    url="${url}/${JOB_NAME}/${BUILD_ID}/artifacts/${JOB_NAME_SAFE}/${OPENSHIFT_CI_STEP_NAME:-stackrox-e2e}/artifacts"
     url="${url}/${log##"${ARTIFACT_DIR}"/}"
 
     echo "${url}"


### PR DESCRIPTION
We expect OPENSHIFT_CI_STEP_NAME to be set when executing tests from OSCI. However, it is not set from the interop testing.

Can we default it to the old value?

example test failure:
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-stackrox-stackrox-master-ocp-4-15-lp-interop-acs-tests-aws/1757901512584990720
```
INFO: Thu Feb 15 22:15:30 UTC 2024: Artifacts are stored in a GCS bucket (gs://stackrox-ci-artifacts)
Running post command: ['qa-tests-backend/scripts/lib.sh', 'surface_spec_logs']
qa-tests-backend/scripts/lib.sh: line 109: OPENSHIFT_CI_STEP_NAME: unbound variable
Exception raised in ['qa-tests-backend/scripts/lib.sh', 'surface_spec_logs'], Command '['qa-tests-backend/scripts/lib.sh', 'surface_spec_logs']' returned non-zero exit status 1.
```