### PR TITLE
fix: Directory change in deploy script

### DIFF
--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -40,6 +40,8 @@ echo "StackRox roxctl image set to $ROXCTL_IMAGE"
 export ROXCTL_ROX_IMAGE_FLAVOR="${ROXCTL_ROX_IMAGE_FLAVOR:-$(make --quiet --no-print-directory -C "$(git rev-parse --show-toplevel)" image-flavor)}"
 echo "Image flavor for roxctl set to $ROXCTL_ROX_IMAGE_FLAVOR"
 
+popd
+
 function curl_central() {
 	cmd=(curl --retry 10 --retry-delay 10 --retry-connrefused --silent --show-error --insecure)
 	local admin_user="${ROX_ADMIN_USER:-admin}"


### PR DESCRIPTION
## Description

Adds a popd at the end of a script that has a pushd at the beginning. This can cause errors in some cases, for example if the KUBECONFIG is a relative path. This bug was preventing the long running clusters from being deployed correctly.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Started long running clusters
- [x] Ran deploy script locally
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

#### Long running clusters

The workflow for the long running clusters can be found here https://github.com/stackrox/test-gh-actions/actions/runs/7926610760

The workflow used this branch.

#### Deploying locally

I ran the following script locally

```
#!/usr/bin/env bash
set -eou pipefail

export MAIN_IMAGE_TAG=0.0.44
export API_ENDPOINT=localhost:8000
export STORAGE=pvc
export STORAGE_CLASS=faster
export STORAGE_SIZE="100"
export MONITORING_SUPPORT="true"
export LOAD_BALANCER=lb
export ROX_ADMIN_USERNAME=admin
export PAGERDUTY_INTEGRATION_KEY=adfsasdf
export REGISTRY_USERNAME=jvirtane@redhat.com
export REGISTRY_PASSWORD="2DEg1O2n&PcKmHCk"
export KUBECONFIG=/tmp/artifacts-long-fake-32-0-0-44/kubeconfig
export STACKROX_DIR=/home/jvirtane/go/src/github.com/stackrox/stackrox
export NAME=long-fake-32-0-0-44
export ROX_TELEMETRY_STORAGE_KEY_V1=R5fMyO9n0gibSGzOXtlP2qCFWCGb8uoW

export GITHUB_STEP_SUMMARY=delete-log.txt
export CI="true"

../../common/common.sh ./start-acs.sh
```

After the script was run the pods in the stackrox namespace were checked.

```
$ ks get pod
NAME                                                     READY   STATUS    RESTARTS   AGE
admission-control-754c5c9ffb-f6qln                       1/1     Running   0          2m56s
admission-control-754c5c9ffb-q449j                       1/1     Running   0          2m56s
admission-control-754c5c9ffb-qrc9s                       1/1     Running   0          2m56s
central-6c6d95d4dd-sfl4g                                 1/1     Running   0          2m44s
central-db-5b558ffb7c-j4m4l                              1/1     Running   0          6m35s
collector-5fq9m                                          2/2     Running   0          2m15s
collector-kz4rf                                          2/2     Running   0          119s
collector-m2fjv                                          2/2     Running   0          2m9s
collector-pq4s5                                          2/2     Running   0          2m5s
collector-v96c6                                          2/2     Running   0          2m7s
monitoring-8675957788-lbfc8                              2/2     Running   0          6m44s
scanner-79c856f7cf-6q286                                 1/1     Running   0          6m32s
scanner-db-656b7b7bc6-dsc7x                              1/1     Running   0          6m32s
sensor-598fdd4b57-5xmtp                                  1/1     Running   0          2m5s
stackrox-monitoring-alertmanager-0                       2/2     Running   0          5h46m
stackrox-monitoring-kube-state-metrics-5b8568b84-c9qhz   1/1     Running   0          6m44s

```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
