### PR TITLE
fix(cloud-sources): remove discovered clusters with cloud sources

### DIFF
--- a/central/cloudsources/datastore/singleton.go
+++ b/central/cloudsources/datastore/singleton.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"github.com/stackrox/rox/central/cloudsources/datastore/internal/search"
 	pgStore "github.com/stackrox/rox/central/cloudsources/datastore/internal/store/postgres"
+	discoveredClustersDS "github.com/stackrox/rox/central/discoveredclusters/datastore"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -17,7 +18,7 @@ func Singleton() DataStore {
 	once.Do(func() {
 		searcher := search.New(pgStore.NewIndexer(globaldb.GetPostgres()))
 		store := pgStore.New(globaldb.GetPostgres())
-		ds = newDataStore(searcher, store)
+		ds = newDataStore(searcher, store, discoveredClustersDS.Singleton())
 	})
 	return ds
 }

--- a/central/cloudsources/service/service_impl.go
+++ b/central/cloudsources/service/service_impl.go
@@ -190,8 +190,6 @@ func (s *serviceImpl) DeleteCloudSource(ctx context.Context, request *v1.DeleteC
 	if err := s.ds.DeleteCloudSource(ctx, resourceID); err != nil {
 		return nil, errors.Wrapf(err, "failed to delete cloud source %q", resourceID)
 	}
-	// Short-circuit the cloud sources manager to ensure the latest changes are propagated.
-	s.mgr.ShortCircuit()
 	return &v1.Empty{}, nil
 }
 


### PR DESCRIPTION
## Description

Previously, discovered clusters associated with specific cloud sources have been kept upon removal.

This PR ensures that we remove the associated discovered clusters once we remove a cloud source.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI tests.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
