### PR TITLE
ROX-22559: Add banner when a scanner v4 integration is not present

### DIFF
--- a/ui/apps/platform/src/Components/DashboardLayout/DashboardLayout.js
+++ b/ui/apps/platform/src/Components/DashboardLayout/DashboardLayout.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 
 import PageHeader from 'Components/PageHeader';
 
-const DashboardLayout = ({ headerText, headerComponents, children }) => {
+const DashboardLayout = ({ headerText, headerComponents, children, banner }) => {
     return (
         <section className="flex flex-col relative min-h-full">
+            {banner}
             <PageHeader classes="z-10 sticky top-0" header={headerText} subHeader="Dashboard">
                 <div className="flex flex-1 justify-end h-10">{headerComponents}</div>
             </PageHeader>
@@ -30,6 +31,7 @@ DashboardLayout.propTypes = {
     headerComponents: PropTypes.element.isRequired,
     children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)])
         .isRequired,
+    banner: PropTypes.element,
 };
 
 export default DashboardLayout;

--- a/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
+++ b/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Banner, Flex, FlexItem } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { Banner } from '@patternfly/react-core';
 
+import { getProductBranding } from 'constants/productBranding';
 import useRestQuery from 'hooks/useRestQuery';
 import useMetadata from 'hooks/useMetadata';
 import { fetchImageIntegrations } from 'services/ImageIntegrationsService';
@@ -11,6 +11,7 @@ import { scannerV4ImageIntegrationType } from 'types/imageIntegration.proto';
 function ScannerV4IntegrationBanner() {
     const { version } = useMetadata();
     const { data, loading, error } = useRestQuery(fetchImageIntegrations);
+    const branding = getProductBranding();
 
     // Don't show the banner if we don't have successful responses
     if (!data || loading || error || !version) {
@@ -24,31 +25,27 @@ function ScannerV4IntegrationBanner() {
         return null;
     }
 
+    const brandedText =
+        branding.type === 'RHACS_BRANDING'
+            ? 'New Scanner V4 now generally available in RHACS 4.4.'
+            : 'New Scanner V4 now generally available in StackRox 4.4.';
+
+    const docsLink = (
+        <a
+            href={getVersionedDocs(
+                version,
+                'integration/integrate-with-image-vulnerability-scanners.html'
+            )}
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            RHACS documentation
+        </a>
+    );
+
     return (
-        <Banner variant="info">
-            <Flex
-                alignItems={{ default: 'alignItemsCenter' }}
-                justifyContent={{ default: 'justifyContentCenter' }}
-            >
-                <FlexItem>
-                    <InfoCircleIcon />
-                </FlexItem>
-                <FlexItem>
-                    New Scanner V4 now generally available in RHACS 4.4. Refer to the{' '}
-                    {/* TODO When we have a more specific link to Scanner v4 we may want to change this URL */}
-                    <a
-                        href={getVersionedDocs(
-                            version,
-                            'integration/integrate-with-image-vulnerability-scanners.html'
-                        )}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        RHACS documentation
-                    </a>{' '}
-                    to learn more.
-                </FlexItem>
-            </Flex>
+        <Banner variant="info" className="pf-u-text-align-center">
+            {brandedText} Refer to the {docsLink} to learn more.
         </Banner>
     );
 }

--- a/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
+++ b/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
@@ -32,10 +32,7 @@ function ScannerV4IntegrationBanner() {
 
     const docsLink = (
         <a
-            href={getVersionedDocs(
-                version,
-                'integration/integrate-with-image-vulnerability-scanners.html'
-            )}
+            href={getVersionedDocs(version, 'operating/examine-images-for-vulnerabilities.html')}
             target="_blank"
             rel="noopener noreferrer"
         >

--- a/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
+++ b/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Banner, Flex, FlexItem } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+
+import useRestQuery from 'hooks/useRestQuery';
+import useMetadata from 'hooks/useMetadata';
+import { fetchImageIntegrations } from 'services/ImageIntegrationsService';
+import { getVersionedDocs } from 'utils/versioning';
+import { scannerV4ImageIntegrationType } from 'types/imageIntegration.proto';
+
+function ScannerV4IntegrationBanner() {
+    const { version } = useMetadata();
+    const { data, loading, error } = useRestQuery(fetchImageIntegrations);
+
+    // Don't show the banner if we don't have successful responses
+    if (!data || loading || error || !version) {
+        return null;
+    }
+
+    const hasScannerV4Integration = data.some(({ type }) => type === scannerV4ImageIntegrationType);
+
+    // Don't show the banner if we have a Scanner V4 integration
+    if (hasScannerV4Integration) {
+        return null;
+    }
+
+    return (
+        <Banner variant="info">
+            <Flex
+                alignItems={{ default: 'alignItemsCenter' }}
+                justifyContent={{ default: 'justifyContentCenter' }}
+            >
+                <FlexItem>
+                    <InfoCircleIcon />
+                </FlexItem>
+                <FlexItem>
+                    New Scanner V4 now generally available in RHACS 4.4. Refer to the{' '}
+                    {/* TODO When we have a more specific link to Scanner v4 we may want to change this URL */}
+                    <a
+                        href={getVersionedDocs(
+                            version,
+                            'integration/integrate-with-image-vulnerability-scanners.html'
+                        )}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        RHACS documentation
+                    </a>{' '}
+                    to learn more.
+                </FlexItem>
+            </Flex>
+        </Banner>
+    );
+}
+
+export default ScannerV4IntegrationBanner;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.js
@@ -2,12 +2,14 @@ import React, { useContext } from 'react';
 import { withRouter } from 'react-router-dom';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
+import usePermissions from 'hooks/usePermissions';
 import entityTypes from 'constants/entityTypes';
 import { createOptions } from 'utils/workflowUtils';
 import DashboardLayout from 'Components/DashboardLayout';
 import PageTitle from 'Components/PageTitle';
 import RadioButtonGroup from 'Components/RadioButtonGroup';
 import workflowStateContext from 'Containers/workflowStateContext';
+import ScannerV4IntegrationBanner from 'Components/ScannerV4IntegrationBanner';
 import { DASHBOARD_LIMIT } from 'constants/workflowPages.constants';
 import DashboardMenu from 'Components/DashboardMenu';
 import ImagesCountTile from '../Components/ImagesCountTile';
@@ -28,6 +30,8 @@ const entityMenuTypes = [
 ];
 
 const VulnDashboardPage = ({ history }) => {
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForIntegration = hasReadAccess('Integration');
     const workflowState = useContext(workflowStateContext);
     const searchState = workflowState.getCurrentSearchState();
 
@@ -92,6 +96,7 @@ const VulnDashboardPage = ({ history }) => {
     return (
         <>
             <DashboardLayout
+                banner={hasReadAccessForIntegration && <ScannerV4IntegrationBanner />}
                 headerText="Vulnerability Management"
                 headerComponents={headerComponents}
             >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -7,6 +7,8 @@ import PageTitle from 'Components/PageTitle';
 
 import { vulnManagementPath, vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import TechPreviewBanner from 'Components/TechPreviewBanner';
+import ScannerV4IntegrationBanner from 'Components/ScannerV4IntegrationBanner';
+import usePermissions from 'hooks/usePermissions';
 import DeploymentPage from './Deployment/DeploymentPage';
 import ImagePage from './Image/ImagePage';
 import WorkloadCvesOverviewPage from './Overview/WorkloadCvesOverviewPage';
@@ -19,8 +21,12 @@ const vulnerabilitiesWorkloadCveImageSinglePath = `${vulnerabilitiesWorkloadCves
 const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesWorkloadCvesPath}/deployments/:deploymentId`;
 
 function WorkloadCvesPage() {
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForIntegration = hasReadAccess('Integration');
+
     return (
         <>
+            {hasReadAccessForIntegration && <ScannerV4IntegrationBanner />}
             <TechPreviewBanner
                 featureURL={vulnManagementPath}
                 featureName="Vulnerability Management (1.0)"

--- a/ui/apps/platform/src/types/imageIntegration.proto.ts
+++ b/ui/apps/platform/src/types/imageIntegration.proto.ts
@@ -173,8 +173,10 @@ export type RhelImageIntegration = {
     type: 'rhel';
 } & BaseImageIntegration;
 
+export const scannerV4ImageIntegrationType = 'scannerv4';
+
 export type ScannerV4ImageIntegration = {
-    type: 'scannerv4';
+    type: typeof scannerV4ImageIntegrationType;
     scannerV4: {
         numConcurrentScans: number;
         indexerEndpoint: string;


### PR DESCRIPTION
## Description

Adds a banner to the UI in VM 1.0 and VM 2.0 when a Scanner V4 integration does not exist. If the user does not have integration permissions, this banner will not be shown and the request will not be sent.

## Open questions

1. Thoughts on a `<Banner variant="info" />` (shown below) vs an `<Alert />`? The Banner seems semantically correct, but VM 2.0 does use an Alert to declare that the feature is tech preview. Using two persistent Alerts may look odd though.
2. Currently a new request will be sent and the banner will flicker each time the user navigates back to the VM 1.0 dashboard from within another VM 1.0 page. In contrast, VM 2.0 shows the banner persistently which results in no flicker and a single network request (until the user leaves that Container). Thoughts on making the banner persistent across all VM 1.0 pages as well? This will be more consistent with VM 2.0, only require a single request per Container visit, and make the render implementation a little less intrusive to old code.
3. The render issue above could be solved by integrating the request with Redux, but that is a more involved, global change for a banner that we are going to be removing in 4.5 anyway (?) so it is better to avoid if possible.
4. Right now the banner links to the top level image integrations documentation page. We might want to change this to a scanner v4 specific section if possible when the docs are updated.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

As admin with Scanner V4 integration:
![image](https://github.com/stackrox/stackrox/assets/1292638/29dcdd16-627f-45cf-b241-eaae614dba2b)
![image](https://github.com/stackrox/stackrox/assets/1292638/c5631775-0454-4aa6-bc97-a71ddec39041)
![image](https://github.com/stackrox/stackrox/assets/1292638/cccdb984-b31a-4379-a9ea-35f4e5b6b9c3)

As admin with no Scanner V4 integrations:
![image](https://github.com/stackrox/stackrox/assets/1292638/5c3c4ba7-2774-4f9a-bb78-0ae992391340)
![image](https://github.com/stackrox/stackrox/assets/1292638/cfb1eac8-b015-427b-9792-3aa71a9565e5)
![image](https://github.com/stackrox/stackrox/assets/1292638/285f622f-4840-4296-9cb0-76605f84455b)

Visit the link in the banner (we may update this link in the future):
![image](https://github.com/stackrox/stackrox/assets/1292638/a91f0fc3-7fcf-4c69-9eb0-408c1f971436)

With a user _without_ Integration permissions and _without_ a Scanner V4 integration:
![image](https://github.com/stackrox/stackrox/assets/1292638/750aa8a1-4e58-48a7-bf06-ddc44fd72aad)
![image](https://github.com/stackrox/stackrox/assets/1292638/53e557a2-64f3-41f7-8fea-96e7959a2165)
![image](https://github.com/stackrox/stackrox/assets/1292638/74b33b89-0576-4cf9-9e5a-ca94752a8f3f)





