### PR TITLE
fix: Eliminate `find: ‘packages’` error in `ui/Makefile`

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -4,8 +4,7 @@ YARN_NETWORK_TIMEOUT ?= 60000
 .PHONY: all
 all: deps lint test test-component build
 
-SOURCES := $(shell find packages -type d \( -name node_modules \) -prune -o -print)
-SOURCES += $(shell find apps -type d \( -name node_modules \) -prune -o -print)
+SOURCES := $(shell find apps -type d \( -name node_modules \) -prune -o -print)
 
 # in monorepo yarn.lock might remain unchanged when new NPM packages are created,
 # tracking package.json files of monorepo packages is the easiest way to discover such situations
@@ -60,7 +59,7 @@ clean:
 	rm -f deps
 	rm -f lint
 	rm -rf build
-	rm -rf node_modules apps/*/node_modules packages/*/node_modules
+	rm -rf node_modules apps/*/node_modules
 
 .PHONY: publish-packages
 publish-packages:


### PR DESCRIPTION
## Description

When I ran a UI `Makefile`, it produced the following error on the console

```
$ make lint
find: ‘packages’: No such file or directory
# ... followed by normal output
```

Apparently, this comes from
```Makefile
SOURCES := $(shell find packages -type d \( -name node_modules \) -prune -o -print)
```
line trying to work on `packages` directory which no longer exists.

The last files from this directory were removed in this commit <https://github.com/stackrox/stackrox/commit/4d7209c1c374366b28dcd86d7d4de2be427a5c6c>. Compare the tree
- as of this commit https://github.com/stackrox/stackrox/tree/4d7209c1c374366b28dcd86d7d4de2be427a5c6c/ui - no `packages`
- and as of its parent (previous) https://github.com/stackrox/stackrox/tree/87a59e845f7bf1aaeb1b5856d968eb73f3ea8834/ui - `packages` were there before.

In this change I simply remove the find command because it produced an empty list (the error message went to `stderr` and did not get included in the `SOURCES` variable). I also remove another mention of `packages` in the `Makefile`.
It could be there are still other mentions of it somewhere else, but I decided to fix what was in the immediate reach.

## Checklist
- [x] Investigated and inspected CI test results

None of these will be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

Ran `make lint` locally after the change to make sure the error is not printed any more.
I did not do any other testing and hope CI and reviewers help to catch problems.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
