### PR TITLE
fix(cloud-sources): react on secured cluster status health

### DIFF
--- a/central/cloudsources/manager/manager.go
+++ b/central/cloudsources/manager/manager.go
@@ -98,10 +98,12 @@ func (m *managerImpl) ShortCircuit() {
 }
 
 func (m *managerImpl) MarkClusterSecured(id string) {
+	log.Infof("Marking discovered clusters matching cluster %q as secured", id)
 	m.changeStatusForDiscoveredClusters(id, storage.DiscoveredCluster_STATUS_SECURED)
 }
 
 func (m *managerImpl) MarkClusterUnsecured(id string) {
+	log.Infof("Marking discovered clusters matching cluster %q as unsecured", id)
 	m.changeStatusForDiscoveredClusters(id, storage.DiscoveredCluster_STATUS_UNSECURED)
 }
 

--- a/central/cloudsources/manager/manager.go
+++ b/central/cloudsources/manager/manager.go
@@ -271,6 +271,8 @@ func (m *managerImpl) changeStatusForDiscoveredClusters(clusterID string, status
 	for _, discoveredCluster := range discoveredClusters {
 		// If we reset the status to unsecured, we need to make sure to also respect the unspecified status that
 		// the discovered cluster may contain.
+		// We currently set this to unspecified because we do not distinguish between clusters being removed
+		// or the cluster just lost connectivity.
 		if status == storage.DiscoveredCluster_STATUS_UNSECURED &&
 			unspecifiedProviders.Contains(discoveredCluster.GetMetadata().GetProviderType().String()) {
 			discoveredCluster.Status = storage.DiscoveredCluster_STATUS_UNSPECIFIED

--- a/central/cloudsources/manager/manager_postgres_test.go
+++ b/central/cloudsources/manager/manager_postgres_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/search"
-	"github.com/stackrox/rox/pkg/set"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +54,6 @@ func TestChangeDiscoveredClustersStatus(t *testing.T) {
 		cloudSourcesDataStore:       csDS,
 		discoveredClustersDataStore: dcDS,
 		clusterDataStore:            clusterStore,
-		unspecifiedProviderTypes:    set.NewStringSet(storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AWS.String()),
 	}
 
 	m.MarkClusterUnsecured("2c507da1-b882-48cc-8143-b74e14c5cd4f")
@@ -65,7 +63,7 @@ func TestChangeDiscoveredClustersStatus(t *testing.T) {
 	require.Len(t, clusters, 1)
 	storedDiscoveredCluster := clusters[0]
 	expectedDiscoveredCluster := typetostorage.DiscoveredCluster(discoveredCluster)
-	expectedDiscoveredCluster.Status = storage.DiscoveredCluster_STATUS_UNSPECIFIED
+	expectedDiscoveredCluster.Status = storage.DiscoveredCluster_STATUS_UNSECURED
 
 	assert.Equal(t, expectedDiscoveredCluster.GetId(), storedDiscoveredCluster.GetId())
 	assert.Equal(t, expectedDiscoveredCluster.GetStatus(), storedDiscoveredCluster.GetStatus())

--- a/central/cloudsources/manager/manager_postgres_test.go
+++ b/central/cloudsources/manager/manager_postgres_test.go
@@ -1,0 +1,72 @@
+//go:build sql_integration
+
+package manager
+
+import (
+	"testing"
+
+	cloudSourcesDS "github.com/stackrox/rox/central/cloudsources/datastore"
+	"github.com/stackrox/rox/central/convert/typetostorage"
+	discoveredClustersDS "github.com/stackrox/rox/central/discoveredclusters/datastore"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/cloudsources/discoveredclusters"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangeDiscoveredClustersStatus(t *testing.T) {
+	pool := pgtest.ForT(t)
+	defer func() {
+		pool.Teardown(t)
+		pool.Close()
+	}()
+	dcDS := discoveredClustersDS.GetTestPostgresDataStore(t, pool)
+
+	csDS := cloudSourcesDS.GetTestPostgresDataStore(t, pool)
+
+	cloudSource := fixtures.GetStorageCloudSource()
+	err := csDS.UpsertCloudSource(cloudSourceCtx, cloudSource)
+	require.NoError(t, err)
+
+	clusterStore := &mockClusterStore{clusters: []*storage.Cluster{
+		createCluster(
+			"2c507da1-b882-48cc-8143-b74e14c5cd4f",
+			"test-cluster-1",
+			storage.ClusterMetadata_ROSA,
+		),
+	}}
+
+	discoveredCluster := &discoveredclusters.DiscoveredCluster{
+		ID:            "2c507da1-b882-48cc-8143-b74e14c5cd4f",
+		Name:          "test-cluster-1",
+		Type:          storage.ClusterMetadata_ROSA,
+		ProviderType:  storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AWS,
+		Status:        storage.DiscoveredCluster_STATUS_SECURED,
+		CloudSourceID: cloudSource.GetId(),
+	}
+
+	require.NoError(t, dcDS.UpsertDiscoveredClusters(discoveredClusterCtx, discoveredCluster))
+
+	m := &managerImpl{
+		cloudSourcesDataStore:       csDS,
+		discoveredClustersDataStore: dcDS,
+		clusterDataStore:            clusterStore,
+		unspecifiedProviderTypes:    set.NewStringSet(storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AWS.String()),
+	}
+
+	m.MarkClusterUnsecured("2c507da1-b882-48cc-8143-b74e14c5cd4f")
+
+	clusters, err := dcDS.ListDiscoveredClusters(discoveredClusterCtx, search.EmptyQuery())
+	require.NoError(t, err)
+	require.Len(t, clusters, 1)
+	storedDiscoveredCluster := clusters[0]
+	expectedDiscoveredCluster := typetostorage.DiscoveredCluster(discoveredCluster)
+	expectedDiscoveredCluster.Status = storage.DiscoveredCluster_STATUS_UNSPECIFIED
+
+	assert.Equal(t, expectedDiscoveredCluster.GetId(), storedDiscoveredCluster.GetId())
+	assert.Equal(t, expectedDiscoveredCluster.GetStatus(), storedDiscoveredCluster.GetStatus())
+}

--- a/central/cloudsources/manager/manager_test.go
+++ b/central/cloudsources/manager/manager_test.go
@@ -1,23 +1,14 @@
-//go:build sql_integration
-
 package manager
 
 import (
 	"context"
 	"testing"
 
-	cloudSourcesDS "github.com/stackrox/rox/central/cloudsources/datastore"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
-	"github.com/stackrox/rox/central/convert/typetostorage"
-	discoveredClustersDS "github.com/stackrox/rox/central/discoveredclusters/datastore"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cloudsources/discoveredclusters"
-	"github.com/stackrox/rox/pkg/fixtures"
-	"github.com/stackrox/rox/pkg/postgres/pgtest"
-	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type mockClusterStore struct {
@@ -138,59 +129,6 @@ func TestMatchDiscoveredClusters(t *testing.T) {
 			assert.Equal(t, storage.DiscoveredCluster_STATUS_UNSPECIFIED, cluster.GetStatus())
 		}
 	}
-}
-
-func TestChangeDiscoveredClustersStatus(t *testing.T) {
-	pool := pgtest.ForT(t)
-	defer func() {
-		pool.Teardown(t)
-		pool.Close()
-	}()
-	dcDS := discoveredClustersDS.GetTestPostgresDataStore(t, pool)
-
-	csDS := cloudSourcesDS.GetTestPostgresDataStore(t, pool)
-
-	cloudSource := fixtures.GetStorageCloudSource()
-	err := csDS.UpsertCloudSource(cloudSourceCtx, cloudSource)
-	require.NoError(t, err)
-
-	clusterStore := &mockClusterStore{clusters: []*storage.Cluster{
-		createCluster(
-			"2c507da1-b882-48cc-8143-b74e14c5cd4f",
-			"test-cluster-1",
-			storage.ClusterMetadata_ROSA,
-		),
-	}}
-
-	discoveredCluster := &discoveredclusters.DiscoveredCluster{
-		ID:            "2c507da1-b882-48cc-8143-b74e14c5cd4f",
-		Name:          "test-cluster-1",
-		Type:          storage.ClusterMetadata_ROSA,
-		ProviderType:  storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AWS,
-		Status:        storage.DiscoveredCluster_STATUS_SECURED,
-		CloudSourceID: cloudSource.GetId(),
-	}
-
-	require.NoError(t, dcDS.UpsertDiscoveredClusters(discoveredClusterCtx, discoveredCluster))
-
-	m := &managerImpl{
-		cloudSourcesDataStore:       csDS,
-		discoveredClustersDataStore: dcDS,
-		clusterDataStore:            clusterStore,
-		unspecifiedProviderTypes:    set.NewStringSet(storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AWS.String()),
-	}
-
-	m.MarkClusterUnsecured("2c507da1-b882-48cc-8143-b74e14c5cd4f")
-
-	clusters, err := dcDS.ListDiscoveredClusters(discoveredClusterCtx, search.EmptyQuery())
-	require.NoError(t, err)
-	require.Len(t, clusters, 1)
-	storedDiscoveredCluster := clusters[0]
-	expectedDiscoveredCluster := typetostorage.DiscoveredCluster(discoveredCluster)
-	expectedDiscoveredCluster.Status = storage.DiscoveredCluster_STATUS_UNSPECIFIED
-
-	assert.Equal(t, expectedDiscoveredCluster.GetId(), storedDiscoveredCluster.GetId())
-	assert.Equal(t, expectedDiscoveredCluster.GetStatus(), storedDiscoveredCluster.GetStatus())
 }
 
 func createCluster(id, name string, clusterType storage.ClusterMetadata_Type) *storage.Cluster {

--- a/central/cloudsources/manager/manager_test.go
+++ b/central/cloudsources/manager/manager_test.go
@@ -1,14 +1,23 @@
+//go:build sql_integration
+
 package manager
 
 import (
 	"context"
 	"testing"
 
+	cloudSourcesDS "github.com/stackrox/rox/central/cloudsources/datastore"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
+	"github.com/stackrox/rox/central/convert/typetostorage"
+	discoveredClustersDS "github.com/stackrox/rox/central/discoveredclusters/datastore"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cloudsources/discoveredclusters"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockClusterStore struct {
@@ -22,6 +31,15 @@ func (m *mockClusterStore) WalkClusters(_ context.Context, fn func(obj *storage.
 		_ = fn(cluster)
 	}
 	return nil
+}
+
+func (m *mockClusterStore) GetCluster(_ context.Context, id string) (*storage.Cluster, bool, error) {
+	for _, cluster := range m.clusters {
+		if cluster.GetId() == id {
+			return cluster, true, nil
+		}
+	}
+	return nil, false, nil
 }
 
 func TestMatchDiscoveredClusters(t *testing.T) {
@@ -46,11 +64,20 @@ func TestMatchDiscoveredClusters(t *testing.T) {
 			"test-cluster-3", storage.ClusterMetadata_EKS),
 		nil,
 		{
+			HealthStatus: &storage.ClusterHealthStatus{OverallHealthStatus: storage.ClusterHealthStatus_HEALTHY},
 			Status: &storage.ClusterStatus{
 				ProviderMetadata: &storage.ProviderMetadata{
 					Provider: &storage.ProviderMetadata_Aws{Aws: &storage.AWSProviderMetadata{
 						AccountId: "666666666666",
 					}},
+				},
+			},
+		},
+		{
+			HealthStatus: &storage.ClusterHealthStatus{OverallHealthStatus: storage.ClusterHealthStatus_UNHEALTHY},
+			Status: &storage.ClusterStatus{
+				ProviderMetadata: &storage.ProviderMetadata{
+					Cluster: &storage.ClusterMetadata{Id: "5553424234234_MC_testing_unsecured_eastus"},
 				},
 			},
 		},
@@ -113,8 +140,63 @@ func TestMatchDiscoveredClusters(t *testing.T) {
 	}
 }
 
+func TestChangeDiscoveredClustersStatus(t *testing.T) {
+	pool := pgtest.ForT(t)
+	defer func() {
+		pool.Teardown(t)
+		pool.Close()
+	}()
+	dcDS := discoveredClustersDS.GetTestPostgresDataStore(t, pool)
+
+	csDS := cloudSourcesDS.GetTestPostgresDataStore(t, pool)
+
+	cloudSource := fixtures.GetStorageCloudSource()
+	err := csDS.UpsertCloudSource(cloudSourceCtx, cloudSource)
+	require.NoError(t, err)
+
+	clusterStore := &mockClusterStore{clusters: []*storage.Cluster{
+		createCluster(
+			"2c507da1-b882-48cc-8143-b74e14c5cd4f",
+			"test-cluster-1",
+			storage.ClusterMetadata_ROSA,
+		),
+	}}
+
+	discoveredCluster := &discoveredclusters.DiscoveredCluster{
+		ID:            "2c507da1-b882-48cc-8143-b74e14c5cd4f",
+		Name:          "test-cluster-1",
+		Type:          storage.ClusterMetadata_ROSA,
+		ProviderType:  storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AWS,
+		Status:        storage.DiscoveredCluster_STATUS_SECURED,
+		CloudSourceID: cloudSource.GetId(),
+	}
+
+	require.NoError(t, dcDS.UpsertDiscoveredClusters(discoveredClusterCtx, discoveredCluster))
+
+	m := &managerImpl{
+		cloudSourcesDataStore:       csDS,
+		discoveredClustersDataStore: dcDS,
+		clusterDataStore:            clusterStore,
+		unspecifiedProviderTypes:    set.NewStringSet(storage.DiscoveredCluster_Metadata_PROVIDER_TYPE_AWS.String()),
+	}
+
+	m.MarkClusterUnsecured("2c507da1-b882-48cc-8143-b74e14c5cd4f")
+
+	clusters, err := dcDS.ListDiscoveredClusters(discoveredClusterCtx, search.EmptyQuery())
+	require.NoError(t, err)
+	require.Len(t, clusters, 1)
+	storedDiscoveredCluster := clusters[0]
+	expectedDiscoveredCluster := typetostorage.DiscoveredCluster(discoveredCluster)
+	expectedDiscoveredCluster.Status = storage.DiscoveredCluster_STATUS_UNSPECIFIED
+
+	assert.Equal(t, expectedDiscoveredCluster.GetId(), storedDiscoveredCluster.GetId())
+	assert.Equal(t, expectedDiscoveredCluster.GetStatus(), storedDiscoveredCluster.GetStatus())
+}
+
 func createCluster(id, name string, clusterType storage.ClusterMetadata_Type) *storage.Cluster {
 	return &storage.Cluster{
+		Id:           id,
+		HealthStatus: &storage.ClusterHealthStatus{OverallHealthStatus: storage.ClusterHealthStatus_HEALTHY},
 		Status: &storage.ClusterStatus{
 			ProviderMetadata: &storage.ProviderMetadata{
 				Cluster: &storage.ClusterMetadata{

--- a/central/cloudsources/manager/mocks/singleton.go
+++ b/central/cloudsources/manager/mocks/singleton.go
@@ -38,6 +38,30 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
+// MarkClusterSecured mocks base method.
+func (m *MockManager) MarkClusterSecured(id string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "MarkClusterSecured", id)
+}
+
+// MarkClusterSecured indicates an expected call of MarkClusterSecured.
+func (mr *MockManagerMockRecorder) MarkClusterSecured(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkClusterSecured", reflect.TypeOf((*MockManager)(nil).MarkClusterSecured), id)
+}
+
+// MarkClusterUnsecured mocks base method.
+func (m *MockManager) MarkClusterUnsecured(id string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "MarkClusterUnsecured", id)
+}
+
+// MarkClusterUnsecured indicates an expected call of MarkClusterUnsecured.
+func (mr *MockManagerMockRecorder) MarkClusterUnsecured(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkClusterUnsecured", reflect.TypeOf((*MockManager)(nil).MarkClusterUnsecured), id)
+}
+
 // ShortCircuit mocks base method.
 func (m *MockManager) ShortCircuit() {
 	m.ctrl.T.Helper()

--- a/central/cloudsources/manager/singleton.go
+++ b/central/cloudsources/manager/singleton.go
@@ -22,6 +22,14 @@ type Manager interface {
 
 	// ShortCircuit signals the manager to short circuit the collection of clusters from cloud sources.
 	ShortCircuit()
+
+	// MarkClusterSecured is received when a new secured cluster is added and marks any discovered clusters
+	// associated with the cluster ID as secured.
+	MarkClusterSecured(id string)
+
+	// MarkClusterUnsecured is received when a secured cluster is removed and marks any discovered clusters
+	// associated with the cluster ID as unsecured
+	MarkClusterUnsecured(id string)
 }
 
 // Singleton creates a singleton instance of the cloud sources Manager.

--- a/central/convert/storagetotype/discovered_clusters.go
+++ b/central/convert/storagetotype/discovered_clusters.go
@@ -1,0 +1,31 @@
+package storagetotype
+
+import (
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/cloudsources/discoveredclusters"
+)
+
+// DiscoveredCluster converts the given storage.DiscoveredCluster
+// to discoveredclusters.DiscoveredCluster.
+func DiscoveredCluster(cluster *storage.DiscoveredCluster) *discoveredclusters.DiscoveredCluster {
+	return &discoveredclusters.DiscoveredCluster{
+		ID:                cluster.GetMetadata().GetId(),
+		Name:              cluster.GetMetadata().GetName(),
+		Type:              cluster.GetMetadata().GetType(),
+		ProviderType:      cluster.GetMetadata().GetProviderType(),
+		Region:            cluster.GetMetadata().GetRegion(),
+		FirstDiscoveredAt: cluster.GetMetadata().GetFirstDiscoveredAt(),
+		Status:            cluster.GetStatus(),
+		CloudSourceID:     cluster.GetSourceId(),
+	}
+}
+
+// DiscoveredClusters converts the given list of storage.DiscoveredCluster
+// to a list of discoveredclusters.DiscoveredCluster.
+func DiscoveredClusters(clusters ...*storage.DiscoveredCluster) []*discoveredclusters.DiscoveredCluster {
+	convClusters := make([]*discoveredclusters.DiscoveredCluster, 0, len(clusters))
+	for _, cluster := range clusters {
+		convClusters = append(convClusters, DiscoveredCluster(cluster))
+	}
+	return convClusters
+}

--- a/central/sensor/service/pipeline/clusterstatusupdate/pipeline.go
+++ b/central/sensor/service/pipeline/clusterstatusupdate/pipeline.go
@@ -72,7 +72,7 @@ func (s *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 		}
 		go s.cveFetcher.HandleClusterConnection()
 		if features.CloudSources.Enabled() {
-			s.cloudSourcesManager.ShortCircuit()
+			s.cloudSourcesManager.MarkClusterSecured(clusterID)
 		}
 		return nil
 	default:
@@ -82,4 +82,7 @@ func (s *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 
 func (s *pipelineImpl) OnFinish(clusterID string) {
 	s.deploymentEnvsMgr.MarkClusterInactive(clusterID)
+	if features.CloudSources.Enabled() {
+		s.cloudSourcesManager.MarkClusterUnsecured(clusterID)
+	}
 }


### PR DESCRIPTION
## Description

This PR adds support to react on the cluster status health change, i.e. when a cluster is becoming unhealthy.

Previously, clusters that haven't been secured anymore (i.e. they have become unhealthy) would still show up as secured in the discovered clusters section.

This now adds hooks to the manager to ensure we react on the events of sensor disconnects correctly and set the discovered cluster state, if any exists, to unsecured.
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI.

Manual tests:

1. Create a cloud source integration which contains a cluster of your choice.

2. Make this cluster as secure, logs should be shown for marking the cluster as secure; also verify this in the UI:
```log
cloudsources/manager: 2024/02/19 01:30:10.158088 manager.go:101: Info: Marking discovered clusters matching cluster "<redacted>" as secured
```

3. Make the secured cluster lose connection, i.e. change the `ROX_CENTRAL_ENDPOINT` to something non-existent. Logs should indicate that the cluster is marked as unsecured; also verify this in the UI
```log
cloudsources/manager: 2024/02/19 01:28:12.909320 manager.go:106: Info: Marking discovered clusters matching cluster "<redacted>" as unsecured
```

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
