### PR TITLE
fix(ui): Clear default filters before running exception flow test

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -1,7 +1,9 @@
 import { addDays, format } from 'date-fns';
 import { getDescriptionListGroup } from '../../../helpers/formHelpers';
 import { visit } from '../../../helpers/visit';
+import { hasFeatureFlag } from '../../../helpers/features';
 import { selectors } from './WorkloadCves.selectors';
+import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
 
 const basePath = '/main/vulnerabilities/workload-cves/';
 
@@ -212,6 +214,11 @@ export function verifySelectedCvesInModal(cveNames) {
 
 export function visitAnyImageSinglePage() {
     visitWorkloadCveOverview();
+    // Clear any filters that may be applied to increase the likelihood of finding a deployment
+    if (hasFeatureFlag('ROX_WORKLOAD_CVES_FIXABILITY_FILTERS')) {
+        cy.get(vulnSelectors.clearFiltersButton).click();
+    }
+
     selectEntityTab('Image');
     cy.get('tbody tr td[data-label="Image"] a').first().click();
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveListExceptionFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveListExceptionFlow.test.js
@@ -57,7 +57,7 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
     });
 
     it('should defer multiple selected CVEs', () => {
-        visitAnyImageSinglePage().then(([image, tag]) => {
+        visitAnyImageSinglePage().then(([image]) => {
             selectMultipleCvesForException('DEFERRAL').then((cveNames) => {
                 verifySelectedCvesInModal(cveNames);
                 fillAndSubmitExceptionForm({
@@ -68,7 +68,7 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
                 verifyExceptionConfirmationDetails({
                     expectedAction: 'Deferral',
                     cves: cveNames,
-                    scope: `${image}:${tag}`,
+                    scope: `${image}:*`,
                     expiry: `${getDateString(getFutureDateByDays(30))} (30 days)`,
                 });
             });
@@ -90,7 +90,7 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
     });
 
     it('should mark multiple selected CVEs as false positive', () => {
-        visitAnyImageSinglePage().then(([image, tag]) => {
+        visitAnyImageSinglePage().then(([image]) => {
             selectMultipleCvesForException('FALSE_POSITIVE').then((cveNames) => {
                 verifySelectedCvesInModal(cveNames);
                 fillAndSubmitExceptionForm({
@@ -99,7 +99,7 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
                 verifyExceptionConfirmationDetails({
                     expectedAction: 'False positive',
                     cves: cveNames,
-                    scope: `${image}:${tag}`,
+                    scope: `${image}:*`,
                 });
             });
         });


### PR DESCRIPTION
## Description

Every changing CVE data has resulted in flakes in the e2e tests due to there being no CVEs that match the default applied filters. This clears the filters in the failing tests when the feature flag is enabled.

Also fixes an incorrect assertion on image scope that honestly I'm not sure how it was passing at all until this point...

See relevant failure here: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/9979/pull-ci-stackrox-stackrox-master-gke-ui-e2e-tests/1758512955600670720

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local Cypress run.
![image](https://github.com/stackrox/stackrox/assets/1292638/b3f29761-819d-4417-9cab-10bf5b23e4b3)


Await CI