### PR TITLE
fix(tests): Update multiarch image CVE counts for DefaultPolicesTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -176,10 +176,10 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         switch (Env.REMOTE_CLUSTER_ARCH) {
             case "s390x":
-                componentCount=92
+                componentCount="9[2-9]"
                 break
             case "ppc64le":
-                componentCount=91
+                componentCount="9[1-9]"
                 break
             default:
                 componentCount="1(6[6-9]|7[0-5])"


### PR DESCRIPTION
## Description

Update hard coded CVE counts for defaultPolicesTests with regex for power and s390x image layers


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change
Relying on CI
