### PR TITLE
chore(scanner): update resources and postgres configs

### DIFF
--- a/image/templates/helm/shared/config-templates/scanner-v4-db/postgresql.conf.default
+++ b/image/templates/helm/shared/config-templates/scanner-v4-db/postgresql.conf.default
@@ -11,7 +11,7 @@ hba_file = '/etc/stackrox.d/config/pg_hba.conf'
 # - Connection Settings -
 
 listen_addresses = '*'
-max_connections = 100
+max_connections = 500
 
 # - Authentication -
 
@@ -30,7 +30,11 @@ ssl_key_file = '/run/secrets/stackrox.io/certs/server.key'
 
 # - Memory -
 
-shared_buffers = 250MB
+# Keep this in sync with the shared-memory volume in the
+# templates/02-scanner-v4-07-db-deployment.yaml
+shared_buffers = 750MB
+work_mem = 16MB
+maintenance_work_mem = 128MB
 dynamic_shared_memory_type = posix
 
 #------------------------------------------------------------------------------
@@ -39,7 +43,7 @@ dynamic_shared_memory_type = posix
 
 # - Checkpoints -
 
-max_wal_size = 1GB
+max_wal_size = 3GB
 min_wal_size = 80MB
 
 #------------------------------------------------------------------------------

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
@@ -132,7 +132,7 @@ spec:
         emptyDir:
           medium: Memory
           {{- /* Keep this in sync with shared_buffers in config-templates/scanner-v4-db/postgresql.conf.default */}}
-          sizeLimit: 250Mi
+          sizeLimit: 750Mi
       - name: scanner-v4-db-password
         secret:
           secretName: scanner-v4-db-password

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
@@ -48,7 +48,8 @@ spec:
         - name: ROX_MEMLIMIT
           valueFrom:
             resourceFieldRef:
-              resource: limits.memory
+              {{- /* This is set to requests.memory on purpose in an attempt to minimize memory usage. */}}
+              resource: requests.memory
         - name: GOMAXPROCS
           valueFrom:
             resourceFieldRef:

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -270,6 +270,9 @@ defaults:
     db:
       postgresConfig: "@config-templates/scanner-v4-db/postgresql.conf|config-templates/scanner-v4-db/postgresql.conf.default"
       hbaConfig: "@config-templates/scanner-v4-db/pg_hba.conf|config-templates/scanner-v4-db/pg_hba.conf.default"
+      source:
+        minConns: 5
+        maxConns: 40
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -306,7 +309,7 @@ defaults:
       resources:
         requests:
           cpu: "200m"
-          memory: "2Gi"
+          memory: "3Gi"
         limits:
           cpu: "2000m"
           memory: "4Gi"

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/70-scanner-v4.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/70-scanner-v4.yaml.htpl
@@ -54,7 +54,8 @@ scannerV4:
     postgresConfig: "@config-templates/scanner-v4-db/postgresql.conf|config-templates/scanner-v4-db/postgresql.conf.default"
     hbaConfig: "@config-templates/scanner-v4-db/pg_hba.conf|config-templates/scanner-v4-db/pg_hba.conf.default"
     source:
-      statementTimeoutMs: 60000
+      minConns: 10
+      maxConns: 80
     affinity:
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -162,8 +162,8 @@ tests:
     .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.database.password_file | assertThat(. == "/run/secrets/stackrox.io/secrets/password")
     .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.database.conn_string | assertThat(contains("sslrootcert=/run/secrets/stackrox.io/certs/ca.pem"))
     .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.database.conn_string | assertThat(contains("host=scanner-v4-db.stackrox.svc"))
-    .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.database.conn_string | assertThat(contains("min_conns=") | not)
-    .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.database.conn_string | assertThat(contains("max_conns=") | not)
+    .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.database.conn_string | assertThat(contains("min_conns="))
+    .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.database.conn_string | assertThat(contains("max_conns="))
     .configmaps["scanner-v4-indexer-config"].data.["config.yaml"] | fromyaml | .indexer.database.conn_string | assertThat(contains("statement_timeout=") | not)
 
 - name: "scanner v4 DB configuration can be fine-tuned"


### PR DESCRIPTION
## Description

Resource updates:

* Matcher's soft memory limit set to 3.80GiB instead of 4.75GiB
  * This is an attempt to minimize memory usage and avoid OOMs
  * This tells the Go runtime to do its best to keep memory usage to at most 3.80GiB, but we will have a 1.2GiB buffer, if needed
  * Setting it to a level below the requested memory in an attempt to ensure we can still update vulnerabilities when we cannot use more than the requested amount of memory
* Bump DB memory request to 3GiB. Testing with the following postgres settings showed higher memory usage, so might as well require more memory

Postgres configuration changes:

* max_connections 100 -> 500
  * This is computed via 1.25 *(40 * maxIndexers + 40 * maxMatchers) in the Central Cluster
  * SecuredCluster is 1.25 * 80 * maxIndexers
* Increase sharedBuffers to 25% of RAM, as recommended in the [docs](https://www.postgresql.org/docs/15/runtime-config-resource.html#RUNTIME-CONFIG-RESOURCE-MEMORY)
* Bump work_mem and maintenance_work_mem to a quarter of Central DB's current settings
* Bump max_wal_size, to about half of Central DB's
* Set maxConns and minConns to some number that I think is reasonable

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Deployed this PR and let it run

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
