### PR TITLE
chore(scanner): update sensor netpol and test monitoring

### DIFF
--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -316,7 +316,7 @@ defaults:
       image:
         name: [< required "" .ScannerV4DBImageRemote >]
         tag: [< required "" .ScannerV4ImageTag >]
-  exposeMonitoring: false
+    exposeMonitoring: false
 [<- end >]
 
   system:

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -316,6 +316,7 @@ defaults:
       image:
         name: [< required "" .ScannerV4DBImageRemote >]
         tag: [< required "" .ScannerV4ImageTag >]
+  exposeMonitoring: false
 [<- end >]
 
   system:

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/70-scanner-v4.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/70-scanner-v4.yaml.htpl
@@ -6,6 +6,7 @@ scannerV4:
     disable: false
     replicas: 2
     logLevel: INFO
+    metricsPort: 9090
     autoscaling:
       disable: false
       minReplicas: 2
@@ -96,6 +97,7 @@ scannerV4:
       limits:
         cpu: "2000m"
         memory: "4Gi"
+  exposeMonitoring: {{ ._rox.exposeMonitoring }}
 
 scannerV4DBPVCDefaults:
   claimName: "scanner-v4-db"

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-netpol.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-netpol.yaml
@@ -26,6 +26,11 @@ spec:
       - podSelector:
           matchLabels:
             app: scanner
+{{ if ._rox.scannerV4._indexerEnabled }}
+      - podSelector:
+          matchLabels:
+            app: scanner-v4-indexer
+{{ end }}
 {{ end }}
     ports:
     - port: 8443

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-netpol.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-netpol.yaml
@@ -22,16 +22,16 @@ spec:
       - podSelector:
           matchLabels:
             app: admission-control
-{{ if ._rox.sensor.localImageScanning.enabled }}
+      {{- if ._rox.sensor.localImageScanning.enabled }}
       - podSelector:
           matchLabels:
             app: scanner
-{{ if ._rox.scannerV4._indexerEnabled }}
+      {{- if ._rox.scannerV4._indexerEnabled }}
       - podSelector:
           matchLabels:
             app: scanner-v4-indexer
-{{ end }}
-{{ end }}
+     {{- end }}
+     {{- end }}
     ports:
     - port: 8443
       protocol: TCP

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/monitoring.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/monitoring.test.yaml
@@ -6,10 +6,6 @@ values:
     allowNone: true
   scannerV4:
     disable: false
-    indexer:
-      metricsPort: 9090
-    matcher:
-      metricsPort: 9090
 tests:
 - name: Central monitoring should not be exposed by default
   expect: |

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/monitoring.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/monitoring.test.yaml
@@ -4,6 +4,12 @@ values:
       none: true
   imagePullSecrets:
     allowNone: true
+  scannerV4:
+    disable: false
+    indexer:
+      metricsPort: 9090
+    matcher:
+      metricsPort: 9090
 tests:
 - name: Central monitoring should not be exposed by default
   expect: |
@@ -40,3 +46,31 @@ tests:
         assertThat(.name == "monitoring")
       ]
     .networkpolicys["scanner-monitoring"] | assertThat(. != null)
+
+- name: Scanner V4 monitoring should not be exposed by default
+  expect: |
+    [.deployments["scanner-v4-indexer"].spec.template.spec.containers[0].ports[] | select(.containerPort == 9090)] | assertThat(length == 0)
+    [.services["scanner-v4-indexer"].spec.ports[] | select(.port == 9090)] | assertThat(length == 0)
+    .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. == null)
+    [.deployments["scanner-v4-matcher"].spec.template.spec.containers[0].ports[] | select(.containerPort == 9090)] | assertThat(length == 0)
+    [.services["scanner-v4-matcher"].spec.ports[] | select(.port == 9090)] | assertThat(length == 0)
+    .networkpolicys["scanner-v4-matcher-monitoring"] | assertThat(. == null)
+
+- name: Scanner V4 monitoring should be exposed when enabled
+  set:
+    scannerV4.exposeMonitoring: true
+  expect: |
+    .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].ports[] | select(.containerPort == 9090)
+      | assertThat(.name == "monitoring")
+    .services["scanner-v4-indexer"].spec.ports[] | select(.port == 9090) | [
+        assertThat(.targetPort == "monitoring"),
+        assertThat(.name == "monitoring")
+      ]
+    .networkpolicys["scanner-v4-matcher-monitoring"] | assertThat(. != null)
+    .deployments["scanner-v4-matcher"].spec.template.spec.containers[0].ports[] | select(.containerPort == 9090)
+      | assertThat(.name == "monitoring")
+    .services["scanner-v4-matcher"].spec.ports[] | select(.port == 9090) | [
+        assertThat(.targetPort == "monitoring"),
+        assertThat(.name == "monitoring")
+      ]
+    .networkpolicys["scanner-v4-matcher-monitoring"] | assertThat(. != null)

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/monitoring.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/monitoring.test.yaml
@@ -21,10 +21,6 @@ tests:
 - name: monitoring should be exposed when enabled
   set:
     exposeMonitoring: true
-    scannerV4:
-      disable: false
-      indexer:
-        metricsPort: 9090
   expect: |
     verifyMonitoringExposed(.services.sensor)
     verifyMonitoringContainerPortExposed(container(.deployments.sensor; "sensor"))

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/monitoring.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/monitoring.test.yaml
@@ -1,6 +1,10 @@
 values:
   imagePullSecrets:
     allowNone: true
+  scannerV4:
+    disable: false
+    indexer:
+      metricsPort: 9090
 tests:
 - name: monitoring should not be exposed by default
   expect: |
@@ -10,10 +14,17 @@ tests:
     verifyMonitoringContainerPortExposed(container(.daemonsets.collector; "collector")) | assertThat(not)
     .networkpolicys["collector-monitoring"] | assertThat(. == null)
     .networkpolicys["admission-control-monitoring"] | assertThat(. == null)
+    verifyMonitoringExposed(.services["scanner-v4-indexer"]) | assertThat(not)
+    verifyMonitoringContainerPortExposed(container(.deployments["scanner-v4-indexer"]; "indexer")) | assertThat(not)
+    .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. == null)
 
 - name: monitoring should be exposed when enabled
   set:
     exposeMonitoring: true
+    scannerV4:
+      disable: false
+      indexer:
+        metricsPort: 9090
   expect: |
     verifyMonitoringExposed(.services.sensor)
     verifyMonitoringContainerPortExposed(container(.deployments.sensor; "sensor"))
@@ -21,6 +32,9 @@ tests:
     verifyMonitoringContainerPortExposed(container(.daemonsets.collector; "collector"))
     .networkpolicys["collector-monitoring"] | assertThat(. != null)
     .networkpolicys["admission-control-monitoring"] | assertThat(. != null)
+    verifyMonitoringExposed(.services["scanner-v4-indexer"])
+    verifyMonitoringContainerPortExposed(container(.deployments["scanner-v4-indexer"]; "indexer"))
+    .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. != null)
 
 - name: monitoring should be overridable on a per-component basis (sensor)
   set:
@@ -33,6 +47,8 @@ tests:
     verifyMonitoringContainerPortExposed(container(.daemonsets.collector; "collector"))
     .networkpolicys["collector-monitoring"] | assertThat(. != null)
     .networkpolicys["admission-control-monitoring"] | assertThat(. != null)
+    verifyMonitoringContainerPortExposed(container(.deployments["scanner-v4-indexer"]; "indexer"))
+    .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. != null)
 
 - name: monitoring should be overridable on a per-component basis (collector)
   set:
@@ -45,6 +61,8 @@ tests:
     verifyMonitoringContainerPortExposed(container(.daemonsets.collector; "collector")) | assertThat(not)
     .networkpolicys["collector-monitoring"] | assertThat(. == null)
     .networkpolicys["admission-control-monitoring"] | assertThat(. != null)
+    verifyMonitoringContainerPortExposed(container(.deployments["scanner-v4-indexer"]; "indexer"))
+    .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. != null)
 
 - name: monitoring should be overridable on a per-component basis (admission control)
   set:
@@ -57,3 +75,20 @@ tests:
     verifyMonitoringContainerPortExposed(container(.daemonsets.collector; "collector"))
     .networkpolicys["collector-monitoring"] | assertThat(. != null)
     .networkpolicys["admission-control-monitoring"] | assertThat(. == null)
+    verifyMonitoringContainerPortExposed(container(.deployments["scanner-v4-indexer"]; "indexer"))
+    .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. != null)
+
+- name: monitoring should be overridable on a per-component basis (scanner v4)
+  set:
+    exposeMonitoring: true
+    scannerV4.indexer.metricsPort: 9090
+    scannerV4.exposeMonitoring: false
+  expect: |
+    verifyMonitoringExposed(.services.sensor)
+    verifyMonitoringContainerPortExposed(container(.deployments.sensor; "sensor"))
+    .networkpolicys["sensor-monitoring"] | assertThat(. != null)
+    verifyMonitoringContainerPortExposed(container(.daemonsets.collector; "collector"))
+    .networkpolicys["collector-monitoring"] | assertThat(. != null)
+    .networkpolicys["admission-control-monitoring"] | assertThat(. != null)
+    verifyMonitoringContainerPortExposed(container(.deployments["scanner-v4-indexer"]; "indexer")) | assertThat(not)
+    .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. == null)

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/monitoring.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/monitoring.test.yaml
@@ -3,8 +3,6 @@ values:
     allowNone: true
   scannerV4:
     disable: false
-    indexer:
-      metricsPort: 9090
 tests:
 - name: monitoring should not be exposed by default
   expect: |

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/sensor-netpol.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/sensor-netpol.test.yaml
@@ -6,8 +6,6 @@ values:
       enabled: false
   scannerV4:
     disable: true
-    indexer:
-      metricsPort: 9090
 tests:
 - name: sensor should not allow any scanner traffic by default
   expect: |

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/sensor-netpol.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/sensor-netpol.test.yaml
@@ -1,0 +1,42 @@
+values:
+  imagePullSecrets:
+    allowNone: true
+  sensor:
+    localImageScanning:
+      enabled: false
+  scannerV4:
+    disable: true
+    indexer:
+      metricsPort: 9090
+tests:
+- name: sensor should not allow any scanner traffic by default
+  expect: |
+    .networkpolicys["sensor"].spec.ingress | assertThat(length == 2)
+    .networkpolicys["sensor"].spec.ingress[0].from | assertThat(length == 3)
+    .networkpolicys["sensor"].spec.ingress[0] | .from[0].podSelector.matchLabels.app | assertThat(. == "collector")
+    .networkpolicys["sensor"].spec.ingress[0] | .from[1].podSelector.matchLabels.service | assertThat(. == "collector")
+    .networkpolicys["sensor"].spec.ingress[0] | .from[2].podSelector.matchLabels.app | assertThat(. == "admission-control")
+
+- name: sensor should allow scanner traffic when enabled
+  set:
+    sensor.localImageScanning.enabled: true
+  expect: |
+    .networkpolicys["sensor"].spec.ingress | assertThat(length == 2)
+    .networkpolicys["sensor"].spec.ingress[0].from | assertThat(length == 4)
+    .networkpolicys["sensor"].spec.ingress[0] | .from[0].podSelector.matchLabels.app | assertThat(. == "collector")
+    .networkpolicys["sensor"].spec.ingress[0] | .from[1].podSelector.matchLabels.service | assertThat(. == "collector")
+    .networkpolicys["sensor"].spec.ingress[0] | .from[2].podSelector.matchLabels.app | assertThat(. == "admission-control")
+    .networkpolicys["sensor"].spec.ingress[0] | .from[3].podSelector.matchLabels.app | assertThat(. == "scanner")
+
+- name: sensor should allow scanner v4 traffic when enabled
+  set:
+    sensor.localImageScanning.enabled: true
+    scannerV4.disable: false
+  expect: |
+    .networkpolicys["sensor"].spec.ingress | assertThat(length == 2)
+    .networkpolicys["sensor"].spec.ingress[0].from | assertThat(length == 5)
+    .networkpolicys["sensor"].spec.ingress[0] | .from[0].podSelector.matchLabels.app | assertThat(. == "collector")
+    .networkpolicys["sensor"].spec.ingress[0] | .from[1].podSelector.matchLabels.service | assertThat(. == "collector")
+    .networkpolicys["sensor"].spec.ingress[0] | .from[2].podSelector.matchLabels.app | assertThat(. == "admission-control")
+    .networkpolicys["sensor"].spec.ingress[0] | .from[3].podSelector.matchLabels.app | assertThat(. == "scanner")
+    .networkpolicys["sensor"].spec.ingress[0] | .from[4].podSelector.matchLabels.app | assertThat(. == "scanner-v4-indexer")


### PR DESCRIPTION
## Description

This enables traffic from Scanner V4 Indexer to Sensor when `localImageScanning` is enabled and adds tests for that.

This also adds tests for Scanner V4 monitoring.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
