### PR TITLE
feat(scanner): Enable stand-alone E2E tests

### DIFF
--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -149,3 +149,12 @@ jobs:
         architectures="amd64,arm64,ppc64le,s390x"
 
         push_scanner_image_manifest_lists "$architectures"
+
+  run-e2e-tests:
+    name: Run standalone E2E test
+    # The test requires the DB init bundle.
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'pr-scanner-db-init-bundle') }}
+    needs:
+      - push-manifests
+    uses: ./.github/workflows/scanner-e2e-test.yaml
+    secrets: inherit

--- a/.github/workflows/scanner-e2e-test.yaml
+++ b/.github/workflows/scanner-e2e-test.yaml
@@ -1,0 +1,69 @@
+name: Scanner standalone E2E tests
+
+on:
+  workflow_call:
+
+jobs:
+  e2e-run:
+    name: "Deploy and run"
+    runs-on: ubuntu-latest
+    env:
+      SCANNER_E2E_QUAY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+      SCANNER_E2E_QUAY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+      SCANNER_E2E_GOOGLE_SA_TOKEN: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
+      # TODO Add registry.redhat.io secrets.
+      SCANNER_E2E_REDHAT_USERNAME: ${{ secrets.REDHAT_USERNAME }}
+      SCANNER_E2E_REDHAT_PASSWORD: ${{ secrets.REDHAT_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Preamble
+        uses: ./.github/actions/job-preamble
+
+      - name: Start minikube
+        uses: medyagh/setup-minikube@master
+        with:
+          driver: docker
+          cpus: max
+          memory: max
+          mount-path: ${{ runner.temp }}:/runner
+
+      - name: Deploy
+        run: |
+          mkdir -m 777 "${{ runner.temp }}"/pgdata
+          make -C scanner e2e-deploy db-host-path="/runner/pgdata"
+
+      - name: Show deployment
+        if: success() || failure()
+        run: |
+          set +e
+          kubectl -n stackrox describe pods -l app=scanner-v4-db
+          kubectl -n stackrox logs -l app=scanner-v4-db --all-containers=true
+          kubectl -n stackrox describe pods -l app=scanner-v4
+          kubectl -n stackrox logs -l app=scanner-v4 --all-containers=true
+
+      - name: Run
+        run: |
+          set -x
+          kubectl -n stackrox expose deployment scanner-v4
+          kubectl -n stackrox get svc
+          while true; do
+              kubectl -n stackrox port-forward \
+                  "$(kubectl -n stackrox get pods \
+                             -l app=scanner-v4 \
+                             -o jsonpath="{.items[*].metadata.name}")" \
+                  8443:8443 || continue
+          done &
+          trap 'kill $!' EXIT
+          make -C scanner e2e-run NODEPS=1
+
+      - name: Show logs on failure
+        if: failure()
+        run: |
+          set +e
+          kubectl -n stackrox logs -l app=scanner-v4-db --all-containers=true
+          kubectl -n stackrox logs -l app=scanner-v4 --all-containers=true

--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -312,15 +312,42 @@ $(certs-d)/%/.verified: $(certs-d)/%/cert.pem
 # E2E vars
 # ========
 
-SCANNER_E2E_IMAGE_TAG ?= $(TAG)
-SCANNER_E2E_NAMESPACE ?= $(SCANNER_NAMESPACE)
+# E2E vars to config images
+# -------------------------
 
-e2e-d         := e2etests
-e2e-chart     := $(e2e-d)/helmchart
-e2e-namespace := $(SCANNER_E2E_NAMESPACE)
-e2e-image-tag := $(SCANNER_E2E_IMAGE_TAG)
-e2e-go-tag    := e2etests
-e2e-timeout   := 20m
+SCANNER_E2E_IMAGE_REGISTRY ?= quay.io/stackrox-io
+SCANNER_E2E_IMAGE_NAME     ?=
+SCANNER_E2E_IMAGE_TAG      ?= $(TAG)
+
+SCANNER_E2E_DB_IMAGE_REGISTRY ?= $(SCANNER_E2E_IMAGE_REGISTRY)
+SCANNER_E2E_DB_IMAGE_NAME     ?= $(or $(SCANNER_E2E_IMAGE_NAME),scanner-v4-db)
+SCANNER_E2E_DB_IMAGE_TAG      ?= $(SCANNER_E2E_IMAGE_TAG)
+
+SCANNER_E2E_SCANNER_IMAGE_REGISTRY ?= $(SCANNER_E2E_IMAGE_REGISTRY)
+SCANNER_E2E_SCANNER_IMAGE_NAME     ?= $(or $(SCANNER_E2E_IMAGE_NAME),scanner-v4)
+SCANNER_E2E_SCANNER_IMAGE_TAG      ?= $(SCANNER_E2E_IMAGE_TAG)
+
+# E2E vars to config credentials
+# ------------------------------
+
+SCANNER_E2E_QUAY_USERNAME ?=
+SCANNER_E2E_QUAY_PASSWORD ?=
+
+SCANNER_E2E_REDHAT_USERNAME ?=
+SCANNER_E2E_REDHAT_PASSWORD ?=
+
+SCANNER_E2E_DOCKER_USERNAME ?=
+SCANNER_E2E_DOCKER_PASSWORD ?=
+
+SCANNER_E2E_GOOGLE_SA_TOKEN ?=
+
+# E2E vars other
+# --------------
+
+SCANNER_E2E_DEBUG ?=
+
+# E2E rules
+# =========
 
 e2e-conf-files := db-postgresql.conf \
                   db-pg_hba.conf
@@ -331,41 +358,93 @@ e2e-certs := ca.pem \
              scanner-v4-db-key.pem \
              scanner-v4-db-cert.pem
 
-e2e-files-d      := $(e2e-chart)/files
+e2e-d            := e2etests
+e2e-chart-d      := $(e2e-d)/helmchart
+e2e-files-d      := $(e2e-chart-d)/files
 e2e-conf-files-t := $(addprefix $(e2e-files-d)/,$(e2e-conf-files))
 e2e-certs-t      := $(addprefix $(e2e-files-d)/,$(e2e-certs))
 
-# E2E rules
-# =========
-
-.PHONY: e2e-deploy clean-e2e
-
-ifeq ($(SILENT),@)
-.SILENT: e2e-deploy $(e2e-conf-files-t)
-endif
-
-e2e-deploy: $(e2e-conf-files-t) $(e2e-certs-t)
-	@echo "+ $@" $(e2e-image-tag)
-	$(SILENT)-kubectl create namespace $(e2e-namespace)
-	helm upgrade scanner-v4-e2e $(e2e-chart) \
-	    --install \
-	    --namespace $(e2e-namespace) \
-	    --set image.tag="$(e2e-image-tag)"
-
-.PHONY: e2e-run
-e2e-run: $(build-deps-t)
-	@echo "+ $@"
-	$(SILENT)$(GO_TEST_CMD) -tags $(e2e-go-tag) -count=1 -timeout=$(e2e-timeout) -v ./$(e2e-d)/...
+# E2E General rules
+# -----------------
 
 .PHONY: e2e
 e2e: e2e-deploy e2e-run
 
+.PHONY: clean-e2e
 clean-e2e:
 	@echo "+ $@"
 	$(SILENT)rm -rf $(e2e-files-d)/*
 
-# DB configuration files.
-#
+# E2E Deploy Rules
+# ----------------
+
+.PHONY: e2e-deploy
+
+e2e-deploy: namespace := $(SCANNER_NAMESPACE)
+e2e-deploy: release   := scanner-v4-e2e
+
+e2e-deploy: registry :=
+e2e-deploy: name     :=
+e2e-deploy: tag      :=
+
+e2e-deploy: db-registry := $(or $(registry),$(SCANNER_E2E_DB_IMAGE_REGISTRY))
+e2e-deploy: db-name     := $(or $(name),$(SCANNER_E2E_DB_IMAGE_NAME))
+e2e-deploy: db-tag      := $(or $(tag),$(SCANNER_E2E_DB_IMAGE_TAG))
+
+e2e-deploy: scanner-registry := $(or $(registry),$(SCANNER_E2E_SCANNER_IMAGE_REGISTRY))
+e2e-deploy: scanner-name     := $(or $(name),$(SCANNER_E2E_SCANNER_IMAGE_NAME))
+e2e-deploy: scanner-tag      := $(or $(tag),$(SCANNER_E2E_SCANNER_IMAGE_TAG))
+
+# If set will set DB's volume under the specified host path.
+e2e-deploy: db-host-path :=
+
+# If set will debug the helm templates.
+e2e-deploy: debug-templates :=
+
+# Wait timeout for the E2E deployment to be successful.
+e2e-deploy: timeout := 10m
+
+e2e-deploy: $(e2e-chart-d) $(e2e-conf-files-t) $(e2e-certs-t)
+	@echo "+ $@" db=$(db-tag) scanner=$(scanner-tag)
+	helm $(if $(debug-templates),template,upgrade --install) --debug $(release) $< \
+	    --namespace $(namespace) \
+	    --create-namespace \
+	    $(if $(CI),--wait,--atomic) \
+	    --timeout $(timeout) \
+	    $(and $(db-host-path),--set app.db.persistence.hostPath=$(db-host-path)) \
+	    --set app.db.image.registry=$(db-registry) \
+	    --set app.db.image.name=$(db-name) \
+	    --set app.db.image.tag=$(db-tag) \
+	    --set app.scanner.image.registry=$(scanner-registry) \
+	    --set app.scanner.image.name=$(scanner-name) \
+	    --set app.scanner.image.tag=$(scanner-tag)
+
+# E2E Run Rules
+# -------------
+
+.PHONY: e2e-run
+
+e2e-run: matcher-addr := :8443
+e2e-run: indexer-addr := :8443
+
+e2e-run: go-tag  := scanner_e2e_tests
+e2e-run: timeout := 30m
+e2e-run: re :=
+
+e2e-run: export SCANNER_E2E_MATCHER_ADDRESS=$(matcher-addr)
+e2e-run: export SCANNER_E2E_INDEXER_ADDRESS=$(indexer-addr)
+e2e-run: export QUAY_RHACS_ENG_RO_USERNAME=$(SCANNER_E2E_QUAY_USERNAME)
+e2e-run: export QUAY_RHACS_ENG_RO_PASSWORD=$(SCANNER_E2E_QUAY_PASSWORD)
+e2e-run: export REDHAT_USERNAME=$(SCANNER_E2E_REDHAT_USERNAME)
+e2e-run: export REDHAT_PASSWORD=$(SCANNER_E2E_REDHAT_PASSWORD)
+e2e-run: export DOCKER_USERNAME=$(SCANNER_E2E_DOCKER_USERNAME)
+e2e-run: export DOCKER_PASSWORD=$(SCANNER_E2E_DOCKER_PASSWORD)
+e2e-run: export GOOGLE_SA_CIRCLECI_SCANNER=$(SCANNER_E2E_GOOGLE_SA_TOKEN)
+
+e2e-run: $(build-deps-t)
+	@echo "+ $@"
+	$(GO_TEST_CMD) -tags $(go-tag) -count=1 -timeout=$(timeout) $(and $(re),--run $(re)) --v ./$(e2e-d)/...
+
 $(e2e-files-d)/db-%.conf: ../image/templates/helm/shared/config-templates/scanner-v4-db/%.conf.default
 	$(SILENT)mkdir -p $(@D)
 	$(SILENT)cp $^ $@

--- a/scanner/e2etests/helmchart/templates/db-deployment.yaml
+++ b/scanner/e2etests/helmchart/templates/db-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 70  # Set the group ownership to the `postgres` group, see dockerfile.
       initContainers:
       - name: init-db
-        image: "{{ (printf "%s/%s:%s" .Values.image.repository .Values.app.db.name .Values.image.tag ) }}"
+        image: "{{ (printf "%s/%s:%s" .Values.app.db.image.registry .Values.app.db.image.name .Values.app.db.image.tag ) }}"
         imagePullPolicy: IfNotPresent
         command:
         - init-entrypoint.sh
@@ -33,13 +33,15 @@ spec:
           value: "scram-sha-256"
         - name: POSTGRES_PASSWORD_FILE
           value: "/run/secrets/stackrox.io/secrets/password"
+        - name: SCANNER_DB_INIT_BUNDLE_ENABLED
+          value: "true"
         resources:
           limits:
-            cpu: 2
+            cpu: 4
             memory: 4Gi
           requests:
-            cpu: 200m
-            memory: 200Mi
+            cpu: 1
+            memory: 1Gi
         volumeMounts:
         - name: disk
           mountPath: /var/lib/postgresql/data
@@ -51,7 +53,7 @@ spec:
           readOnly: true
       containers:
       - name: db
-        image: "{{ (printf "%s/%s:%s" .Values.image.repository .Values.app.db.name .Values.image.tag ) }}"
+        image: "{{ (printf "%s/%s:%s" .Values.app.db.image.registry .Values.app.db.image.name .Values.app.db.image.tag ) }}"
         imagePullPolicy: IfNotPresent
         env:
         - name: PGDATA
@@ -67,8 +69,8 @@ spec:
             cpu: 2
             memory: 4Gi
           requests:
-            cpu: 200m
-            memory: 200Mi
+            cpu: 1
+            memory: 1Gi
         volumeMounts:
         - name: disk
           mountPath: /var/lib/postgresql/data
@@ -85,7 +87,12 @@ spec:
         configMap:
           name: {{ .Values.app.db.name }}-config
       - name: disk
+        {{- if .Values.app.db.persistence.hostPath }}
+        hostPath:
+          path: "{{ .Values.app.db.persistence.hostPath }}"
+        {{- else }}
         emptyDir: {}
+        {{- end }}
       - name: tls-volume
         secret:
           secretName: {{ .Values.app.db.name }}-tls

--- a/scanner/e2etests/helmchart/templates/scanner-config.yaml
+++ b/scanner/e2etests/helmchart/templates/scanner-config.yaml
@@ -14,4 +14,5 @@ data:
       database:
         conn_string: host={{ .Values.app.db.name }}.{{ .Release.Namespace }} port=5432 user=postgres sslmode=verify-ca statement_timeout=60000 sslrootcert=/run/secrets/stackrox.io/certs/ca.pem
         password_file: /run/secrets/stackrox.io/postgresql/password
+      vulnerabilities_url: "https://localhost:9443"
     log_level: debug

--- a/scanner/e2etests/helmchart/templates/scanner-deployment.yaml
+++ b/scanner/e2etests/helmchart/templates/scanner-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 65534  # Set the group ownership to the `nobody` group, see dockerfile.
       containers:
       - name: scanner
-        image: "{{ ( printf "%s/%s:%s" .Values.image.repository .Values.app.scanner.name .Values.image.tag ) }}"
+        image: "{{ ( printf "%s/%s:%s" .Values.app.scanner.image.registry .Values.app.scanner.image.name .Values.app.scanner.image.tag ) }}"
         imagePullPolicy: IfNotPresent
         command:
           - entrypoint.sh
@@ -46,13 +46,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        ports:
+          - name: grpc
+            protocol: TCP
+            containerPort: 8443
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 10Gi
           requests:
-            cpu: 200m
-            memory: 200Mi
+            cpu: 1
+            memory: 1Gi
         volumeMounts:
         - name: config
           mountPath: /etc/stackrox.d/scanner
@@ -67,6 +71,8 @@ spec:
           mountPath: /etc/ssl
         - name: etc-pki-volume
           mountPath: /etc/pki/ca-trust
+        - name: tmp-volume
+          mountPath: /tmp
       volumes:
       - name: config
         configMap:
@@ -83,3 +89,6 @@ spec:
         emptyDir: {}
       - name: etc-pki-volume
         emptyDir: {}
+      - name: tmp-volume
+        emptyDir:
+          medium: Memory

--- a/scanner/e2etests/helmchart/values.yaml
+++ b/scanner/e2etests/helmchart/values.yaml
@@ -2,11 +2,18 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-image:
-  tag: latest
-  repository: quay.io/stackrox-io
 app:
   scanner:
     name: scanner-v4
+    image:
+      registry: quay.io/stackrox-io
+      name: scanner-v4
+      tag: latest
   db:
     name: scanner-v4-db
+    image:
+      registry: quay.io/stackrox-io
+      name: scanner-v4-db
+      tag: latest
+    persistence:
+      hostPath: null

--- a/scanner/e2etests/image_test.go
+++ b/scanner/e2etests/image_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"testing"
@@ -31,7 +32,6 @@ type Vulnerability struct {
 // Vulnerability describes a feature in a TestCase.
 type Feature struct {
 	Name            string          `json:"Name"`
-	NamespaceName   string          `json:"NamespaceName"`
 	VersionFormat   string          `json:"VersionFormat"`
 	Version         string          `json:"Version"`
 	Arch            string          `json:"Arch"`
@@ -62,20 +62,31 @@ type TestCase struct {
 	// Test flags.
 	DisabledReason           string `json:"disabled_reason"`
 	OnlyCheckSpecifiedVulns  bool   `json:"only_check_specified_vulns"`
-	UncertifiedRhel          bool   `json:"uncertified_rhel"`
-	CheckProvidedExecutables bool   `json:"check_provided_executables"`
 }
 
 // TestImage is the E2E test for container image scans.
 func TestImage(t *testing.T) {
+	indexerAddr := os.Getenv("SCANNER_E2E_INDEXER_ADDRESS")
+	if indexerAddr == "" {
+		indexerAddr = ":8443"
+	}
+	matcherAddr := os.Getenv("SCANNER_E2E_MATCHER_ADDRESS")
+	if matcherAddr == "" {
+		matcherAddr = ":8443"
+	}
+	debug := os.Getenv("SCANNER_E2E_DEBUG") == "1"
+	t.Logf("Indexer Address: %s", indexerAddr)
+	t.Logf("Matcher Address: %s", matcherAddr)
+	t.Logf("Debug: %v", debug)
 	ctx := context.Background()
 	c, err := client.NewGRPCScanner(ctx,
-		client.WithAddress(":8443"),
+		client.WithIndexerAddress(indexerAddr),
+		client.WithMatcherAddress(matcherAddr),
 		client.SkipTLSVerification)
 	require.NoError(t, err)
 
 	testCases, err := loadTestCases("testdata/image_tests.json")
-	require.NoError(t, err)
+	require.NoError(t, err, "parsing testdata/image_tests.json")
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s/%s", tc.Namespace, tc.Image), func(t *testing.T) {
@@ -93,12 +104,14 @@ func TestImage(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := tc.TestWant
-			actual := tc.mapFillReport(vr)
-			defer func() {
-				if t.Failed() && vr != nil {
-					tc.logReport(t, vr)
-				}
-			}()
+			actual := tc.mapFillReport(t, vr)
+			if debug {
+				defer func() {
+					if t.Failed() && vr != nil {
+						tc.logReport(t, vr)
+					}
+				}()
+			}
 			assert.Equal(t, &expected, actual,
 				"The vulnerability report did not contain the expected values.")
 		})
@@ -136,17 +149,17 @@ func (tc *TestCase) authConfig() authn.Authenticator {
 	}
 }
 
-func (tc *TestCase) mapFillReport(vr *v4.VulnerabilityReport) *TestWant {
+func (tc *TestCase) mapFillReport(t *testing.T, vr *v4.VulnerabilityReport) *TestWant {
 	return &TestWant{
 		Namespace: mapNamespace(vr),
 		Source:    tc.Source,
-		Features:  tc.mapFillFeatures(vr),
+		Features:  tc.mapFillFeatures(t, vr),
 	}
 }
 
 // mapFillFeatures creates a features slice by converting values found in the
-// vulnerability report or using empty entries when not found.
-func (tc *TestCase) mapFillFeatures(vr *v4.VulnerabilityReport) []Feature {
+// vulnerability report.
+func (tc *TestCase) mapFillFeatures(t *testing.T, vr *v4.VulnerabilityReport) []Feature {
 	type VA struct {
 		V string
 		A string
@@ -159,65 +172,109 @@ func (tc *TestCase) mapFillFeatures(vr *v4.VulnerabilityReport) []Feature {
 			versions = make(map[VA]*v4.Package)
 			pkgs[p.Name] = versions
 		}
-		versions[VA{V: p.Version, A: p.Arch}] = p
+		va := VA{V: p.Version, A: p.Arch}
+		if _, ok := versions[va]; ok {
+			t.Logf("Ignoring a duplicated package-version found in the vulnerability report: %v", va)
+			continue
+		}
+		versions[va] = p
 	}
-	// Convert every expected package found in the report, or convert an empty
-	// package if not found.
+	// Convert every expected package found in the report.
 	var ret []Feature
 	for idx := range tc.Features {
 		f := &tc.Features[idx]
-		versions, nameFound := pkgs[f.Name]
-		var p *v4.Package
-		if nameFound {
-			version, versionFound := versions[VA{V: f.Version, A: f.Arch}]
-			if versionFound {
-				p = version
-			} else {
-				p = &v4.Package{Name: f.Name}
+		versions, ok := pkgs[f.Name]
+		if !ok {
+			t.Logf("Expected package name not found in the vulnerability report: %s", f.Name)
+			var c []string
+			for n := range pkgs {
+				if strings.Contains(n, f.Name) {
+					c = append(c, n)
+				}
 			}
-		} else {
-			p = &v4.Package{}
+			if len(c) > 0 {
+				t.Logf("Potential candidates: %v", c)
+			} else {
+				t.Log("No potential candidates found.")
+			}
+			continue
 		}
-		ret = append(ret, Feature{
-			Name:            p.GetName(),
-			NamespaceName:   mapNamespace(vr),
-			Version:         p.GetVersion(),
-			Arch:            p.GetArch(),
-			Vulnerabilities: tc.mapFillVulns(vr, p, f),
-			// TODO Pending fields not currently available in the vulnerability report.
-			VersionFormat: f.VersionFormat,
-			AddedBy:       f.AddedBy,
-			Location:      f.Location,
-			FixedBy:       f.FixedBy,
-		})
+		va := VA{V: f.Version, A: f.Arch}
+		p, ok := versions[va]
+		if !ok {
+			t.Logf("Package %q with {version arch} %v not found in the vulnerability report", f.Name, va)
+			t.Logf("Available versions: %+#v", versions)
+			continue
+		}
+		if p != nil {
+			env := environment(t, vr, p)
+			ret = append(ret, Feature{
+				Name:            p.GetName(),
+				Version:         p.GetVersion(),
+				Arch:            p.GetArch(),
+				Vulnerabilities: tc.mapFillVulns(t, vr.GetVulnerabilities(), vr.GetPackageVulnerabilities()[p.GetId()].GetValues(), f),
+				FixedBy:         p.GetFixedInVersion(),
+				AddedBy:         env.GetIntroducedIn(),
+				Location:        env.GetPackageDb(),
+			})
+		}
 	}
 	return ret
 }
 
-func (tc *TestCase) mapFillVulns(vr *v4.VulnerabilityReport, pkg *v4.Package, feat *Feature) []Vulnerability {
-	// Create map with all vulnerabilities found for the package found in the report.
+func environment(t *testing.T, vr *v4.VulnerabilityReport, pkg *v4.Package) *v4.Environment {
+	envList, ok := vr.GetContents().GetEnvironments()[pkg.GetId()]
+	if !ok {
+		return nil
+	}
+	envs := envList.GetEnvironments()
+	if len(envs) == 0 {
+		return nil
+	}
+	var pkgDB, introIn string
+	for i, e := range envs {
+		if i == 0 {
+			pkgDB, introIn = e.GetPackageDb(), e.GetIntroducedIn()
+			continue
+		}
+		if pkgDB != e.GetPackageDb() || introIn != e.GetIntroducedIn() {
+			t.Logf("Ignoring environment #%d for package %q: %v", i, pkg.GetName(), e)
+		}
+	}
+	return envs[0]
+}
+
+func (tc *TestCase) mapFillVulns(t *testing.T, vr map[string]*v4.VulnerabilityReport_Vulnerability, vrIDs []string, feat *Feature) []Vulnerability {
 	vrVulns := make(map[string]*v4.VulnerabilityReport_Vulnerability)
-	for _, id := range vr.GetPackageVulnerabilities()[pkg.GetId()].GetValues() {
-		v := vr.GetVulnerabilities()[id]
+	for _, id := range vrIDs {
+		v := vr[id]
+		if _, ok := vrVulns[v.GetName()]; ok {
+			continue
+		}
 		vrVulns[v.GetName()] = v
 	}
-	// Convert all package vulnerabilities.
 	var vulns []Vulnerability
 	for idx := range feat.Vulnerabilities {
 		featVuln := &feat.Vulnerabilities[idx]
 		// If not found, convert an empty vulnerability case.
-		v, ok := vrVulns[featVuln.Name]
+		vrVuln, ok := vrVulns[featVuln.Name]
 		if !ok {
-			v = &v4.VulnerabilityReport_Vulnerability{}
-		} else if !tc.OnlyCheckSpecifiedVulns {
-			// Delete from map, so we can check the remaining items.
-			delete(vrVulns, featVuln.Name)
+			t.Logf("Missing vulnerability in the report: %q", featVuln.Name)
+			continue
 		}
-		vulns = append(vulns, tc.mapFillVuln(v, featVuln))
+		// We delete the vuln from the VR vulns map because we want to check after this
+		// loop if anything was not matched (based on tc.OnlyCheckSpecifiedVulns).
+		delete(vrVulns, featVuln.Name)
+		vulns = append(vulns, tc.mapFillVuln(vrVuln, featVuln))
 	}
-	if !tc.OnlyCheckSpecifiedVulns {
-		// Add the remaining vulnerabilities.
+	if tc.OnlyCheckSpecifiedVulns {
+		return vulns
+	}
+	// See if there is any remaining vulnerabilities, and complain about them.
+	if len(vrVulns) > 0 {
+		t.Logf("Some vulnerabilities were not matched, and we want to match all of them")
 		for _, v := range vrVulns {
+			t.Logf("- Name: %q\n  ID: %q", v.GetName(), v.GetId())
 			vulns = append(vulns, tc.mapFillVuln(v, &Vulnerability{}))
 		}
 	}
@@ -244,36 +301,67 @@ func (tc *TestCase) mapFillVuln(v *v4.VulnerabilityReport_Vulnerability, featVul
 	if !ok {
 		severity = "Unknown"
 	}
+	var metadata map[string]any
+	// TODO Use the CVSS score source type provided by the report when
+	//      provided.
+	var metadataKey string
+	for k := range featVuln.Metadata {
+		metadataKey = k
+		break
+	}
+	f64 := func(f float32) float64 {
+		return math.Round(float64(f)*100) / 100
+	}
+	if v.GetCvss() != nil {
+		scores := map[string]any{}
+		if v.GetCvss().GetV2() != nil {
+			scores["CVSSv2"] = map[string]any{
+				"Score": f64(v.GetCvss().GetV2().GetBaseScore()),
+				"Vectors": v.GetCvss().GetV2().GetVector(),
+			}
+		}
+		if v.GetCvss().GetV3() != nil {
+			scores["CVSSv3"] = map[string]any{
+				"Score": f64(v.GetCvss().GetV3().GetBaseScore()),
+				"Vectors": v.GetCvss().GetV3().GetVector(),
+			}
+		}
+		metadata = map[string]any{metadataKey: scores}
+	}
 	return Vulnerability{
 		Name:        v.GetName(),
 		Description: v.GetDescription(),
 		Link:        link,
 		Severity:    severity,
 		FixedBy:     v.GetFixedInVersion(),
-		// TODO Pending fields not currently available in the vulnerability report.
-		Metadata: featVuln.Metadata,
+
+		Metadata: metadata,
 	}
 }
 
 func (tc *TestCase) logReport(t *testing.T, vr *v4.VulnerabilityReport) {
+	t.Log("Printing Packages and Vulnerabilities in Vulnerability Report:")
+	for _, pkg := range vr.GetContents().GetPackages() {
+		tc.logPackageAndVulns(t, vr, pkg)
+	}
+}
+
+func (tc *TestCase) logPackageAndVulns(t *testing.T, vr *v4.VulnerabilityReport, pkg *v4.Package) {
 	vulns := func(p *v4.Package) (v []*v4.VulnerabilityReport_Vulnerability) {
 		for _, id := range vr.GetPackageVulnerabilities()[p.GetId()].GetValues() {
 			v = append(v, vr.GetVulnerabilities()[id])
 		}
 		return v
 	}
-	t.Log("Printing Packages and Vulnerabilities in Vulnerability Report:")
-	for _, pkg := range vr.GetContents().GetPackages() {
-		s, err := json.MarshalIndent(struct {
-			Package         *v4.Package
-			Vulnerabilities []*v4.VulnerabilityReport_Vulnerability
-		}{
-			Package:         pkg,
-			Vulnerabilities: vulns(pkg),
-		}, "\t", " ")
-		if err != nil {
-			t.Logf("json marshalling failed: %v", err)
-		}
-		t.Logf("NameVersion: %s-%s:\n\n\t%s\n\n", pkg.GetName(), pkg.GetVersion(), s)
+	s, err := json.MarshalIndent(struct {
+		Package         *v4.Package
+		Vulnerabilities []*v4.VulnerabilityReport_Vulnerability
+	}{
+		Package:         pkg,
+		Vulnerabilities: vulns(pkg),
+	}, "\t", " ")
+	if err != nil {
+		t.Logf("json marshalling failed: %v", err)
 	}
+	t.Logf("NameVersion: %s-%s:\n\n\t%s\n\n", pkg.GetName(), pkg.GetVersion(), s)
 }

--- a/scanner/e2etests/image_test.go
+++ b/scanner/e2etests/image_test.go
@@ -60,8 +60,8 @@ type TestCase struct {
 	TestArgs
 	TestWant
 	// Test flags.
-	DisabledReason           string `json:"disabled_reason"`
-	OnlyCheckSpecifiedVulns  bool   `json:"only_check_specified_vulns"`
+	DisabledReason          string `json:"disabled_reason"`
+	OnlyCheckSpecifiedVulns bool   `json:"only_check_specified_vulns"`
 }
 
 // TestImage is the E2E test for container image scans.
@@ -316,13 +316,13 @@ func (tc *TestCase) mapFillVuln(v *v4.VulnerabilityReport_Vulnerability, featVul
 		scores := map[string]any{}
 		if v.GetCvss().GetV2() != nil {
 			scores["CVSSv2"] = map[string]any{
-				"Score": f64(v.GetCvss().GetV2().GetBaseScore()),
+				"Score":   f64(v.GetCvss().GetV2().GetBaseScore()),
 				"Vectors": v.GetCvss().GetV2().GetVector(),
 			}
 		}
 		if v.GetCvss().GetV3() != nil {
 			scores["CVSSv3"] = map[string]any{
-				"Score": f64(v.GetCvss().GetV3().GetBaseScore()),
+				"Score":   f64(v.GetCvss().GetV3().GetBaseScore()),
 				"Vectors": v.GetCvss().GetV3().GetVector(),
 			}
 		}

--- a/scanner/e2etests/testdata/image_tests.json
+++ b/scanner/e2etests/testdata/image_tests.json
@@ -167,16 +167,10 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 6.8,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                                },
                                 "CVSSv3": {
-                                    "Score": 8.1,
+                                    "Score": 0.0,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-10-20T22:15Z",
-                                "PublishedDateTime": "2020-06-14T21:15Z"
+                                }
                             }
                         },
                         "FixedBy": "2.9.10.5"
@@ -188,16 +182,10 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 6.8,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                                },
                                 "CVSSv3": {
-                                    "Score": 8.1,
+                                    "Score": 0.0,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-10-20T22:15Z",
-                                "PublishedDateTime": "2020-06-14T20:15Z"
+                                }
                             }
                         },
                         "FixedBy": "2.9.10.5"
@@ -209,16 +197,10 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 6.8,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                                },
                                 "CVSSv3": {
-                                    "Score": 8.1,
+                                    "Score": 0.0,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-10-20T22:15Z",
-                                "PublishedDateTime": "2020-06-14T20:15Z"
+                                }
                             }
                         },
                         "FixedBy": "2.9.10.5"
@@ -230,16 +212,10 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 6.8,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                                },
                                 "CVSSv3": {
-                                    "Score": 8.1,
+                                    "Score": 0.0,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-10-20T22:15Z",
-                                "PublishedDateTime": "2020-06-16T16:15Z"
+                                }
                             }
                         },
                         "FixedBy": "2.9.10.5"
@@ -251,16 +227,10 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 6.8,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                                },
                                 "CVSSv3": {
-                                    "Score": 8.1,
+                                    "Score": 0.0,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-09-04T14:59Z",
-                                "PublishedDateTime": "2020-08-25T18:15Z"
+                                }
                             }
                         },
                         "FixedBy": "2.9.10.6"
@@ -272,16 +242,10 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 6.8,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                                },
                                 "CVSSv3": {
-                                    "Score": 8.1,
+                                    "Score": 0.0,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-10-09T12:15Z",
-                                "PublishedDateTime": "2020-09-17T19:15Z"
+                                }
                             }
                         },
                         "FixedBy": "2.9.10.6"
@@ -293,16 +257,10 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:N/I:P/A:N"
-                                },
                                 "CVSSv3": {
-                                    "Score": 7.5,
+                                    "Score": 0.0,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
-                                },
-                                "LastModifiedDateTime": "2020-12-07T15:08Z",
-                                "PublishedDateTime": "2020-12-03T17:15Z"
+                                }
                             }
                         },
                         "FixedBy": "2.9.10.7"
@@ -314,16 +272,10 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 6.8,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                                },
                                 "CVSSv3": {
-                                    "Score": 8.1,
+                                    "Score": 0.0,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-12-18T19:32Z",
-                                "PublishedDateTime": "2020-12-17T19:15Z"
+                                }
                             }
                         },
                         "FixedBy": "2.9.10.8"
@@ -335,16 +287,10 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 6.8,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                                },
                                 "CVSSv3": {
-                                    "Score": 8.1,
+                                    "Score": 0.0,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-12-18T19:27Z",
-                                "PublishedDateTime": "2020-12-17T19:15Z"
+                                }
                             }
                         },
                         "FixedBy": "2.9.10.8"
@@ -356,12 +302,8 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
-                                },
                                 "CVSSv3": {
-                                    "Score": 7.5,
+                                    "Score": 0.0,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
                             }
@@ -371,7 +313,7 @@
                 ],
                 "AddedBy": "sha256:36e8e9714b9a509fae9e515ff16237928c3d809f5ae228b14d2f7d7605c02623",
                 "Location": "maven:jars/jackson-databind-2.9.10.4.jar",
-                "FixedBy": "2.16.0"
+                "FixedBy": "2.12.7.1"
             }
         ],
         "unexpected_features": [
@@ -380,8 +322,7 @@
                 "Version": "2.6.6"
             }
         ],
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false
+        "only_check_specified_vulns": true
     },
     {
         "image": "quay.io/rhacs-eng/qa:sandbox-zookeeper-fatjar-remove",
@@ -405,8 +346,7 @@
                 "Version": "3.10.6.final"
             }
         ],
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": false
+        "only_check_specified_vulns": false
     },
     {
         "image": "quay.io/rhacs-eng/qa:sandbox-oci-manifest",
@@ -449,10 +389,6 @@
                         "Severity": "Important",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 8.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
@@ -480,10 +416,6 @@
                         "Severity": "Low",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 5.5,
                                     "Vectors": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
@@ -534,10 +466,6 @@
                         "Severity": "Important",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 8.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
@@ -565,10 +493,6 @@
                         "Severity": "Low",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 5.5,
                                     "Vectors": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
@@ -611,10 +535,6 @@
                         "Severity": "Moderate",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 8.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
@@ -631,10 +551,6 @@
                         "Severity": "Important",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
@@ -662,10 +578,6 @@
                         "Severity": "Important",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 8.6,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H"
@@ -693,10 +605,6 @@
                         "Severity": "Moderate",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
@@ -713,10 +621,6 @@
                         "Severity": "Moderate",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
@@ -733,10 +637,6 @@
                         "Severity": "Low",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 3.3,
                                     "Vectors": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L"
@@ -802,7 +702,7 @@
                     {
                         "Name": "CVE-2021-30139",
                         "NamespaceName": "alpine:v3.13",
-                        "Description": "",
+                        "Description": "In Alpine Linux apk-tools before 2.12.5, the tarball parser allows a buffer overflow and crash.",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2021-30139",
                         "Severity": "Unspecified",
                         "Metadata": {
@@ -822,7 +722,7 @@
                     {
                         "Name": "CVE-2021-36159",
                         "NamespaceName": "alpine:v3.13",
-                        "Description": "",
+                        "Description": "libfetch before 2021-07-26, as used in apk-tools, xbps, and other products, mishandles numeric strings for the FTP and HTTP protocols. The FTP passive mode implementation allows an out-of-bounds read because strtol is used to parse the relevant numbers into address bytes. It does not check if the line ends prematurely. If it does, the for-loop condition checks for the '\\0' terminator one byte too late.",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2021-36159",
                         "Severity": "Unspecified",
                         "Metadata": {
@@ -853,7 +753,7 @@
                     {
                         "Name": "CVE-2021-28831",
                         "NamespaceName": "alpine:v3.13",
-                        "Description": "",
+                        "Description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2021-28831",
                         "Severity": "Unspecified",
                         "Metadata": {
@@ -896,6 +796,7 @@
                     {
                         "Name": "CVE-2021-36159",
                         "NamespaceName": "alpine:v3.14",
+                        "Description": "libfetch before 2021-07-26, as used in apk-tools, xbps, and other products, mishandles numeric strings for the FTP and HTTP protocols. The FTP passive mode implementation allows an out-of-bounds read because strtol is used to parse the relevant numbers into address bytes. It does not check if the line ends prematurely. If it does, the for-loop condition checks for the '\\0' terminator one byte too late.",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2021-36159",
                         "Severity": "Unspecified",
                         "Metadata": {
@@ -1015,7 +916,7 @@
                     {
                         "Name": "CVE-2022-2097",
                         "NamespaceName": "alpine:v3.16",
-                        "Description": "",
+                        "Description": "AES OCB mode for 32-bit x86 platforms using the AES-NI assembly optimised implementation will not encrypt the entirety of the data under some circumstances. This could reveal sixteen bytes of data that was preexisting in the memory that wasn't written. In the special case of \"in place\" encryption, sixteen bytes of the plaintext would be revealed. Since OpenSSL does not support OCB based cipher suites for TLS and DTLS, they are both unaffected. Fixed in OpenSSL 3.0.5 (Affected 3.0.0-3.0.4). Fixed in OpenSSL 1.1.1q (Affected 1.1.1-1.1.1p).",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2022-2097",
                         "Severity": "Unspecified",
                         "Metadata": {
@@ -1125,12 +1026,8 @@
                         "Severity": "Low",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 4.3,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:P/I:N/A:N"
-                                },
                                 "CVSSv3": {
-                                    "Score": 3.7,
+                                    "Score": 0.0,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N"
                                 }
                             }
@@ -1144,12 +1041,8 @@
                         "Severity": "Moderate",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 8.5,
-                                    "Vectors": "AV:N/AC:M/Au:S/C:C/I:C/A:C"
-                                },
                                 "CVSSv3": {
-                                    "Score": 6.6,
+                                    "Score": 0.0,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H"
                                 }
                             }
@@ -1163,13 +1056,9 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
-                                    "Score": 5.9,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                                    "Score": 0.0,
+                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:H"
                                 }
                             }
                         },
@@ -1182,10 +1071,7 @@
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": false
     },
     {
         "image": "quay.io/rhacs-eng/qa:sandbox-springboot-2.6.5",
@@ -1203,18 +1089,18 @@
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2022-22965",
-                        "Description": "A Spring MVC or Spring WebFlux application running on JDK 9+ may be vulnerable to remote code execution (RCE) via data binding. The specific exploit requires the application to run on Tomcat as a WAR deployment. If the application is deployed as a Spring Boot executable jar, i.e. the default, it is not vulnerable to the exploit. However, the nature of the vulnerability is more general, and there may be other ways to exploit it.",
+                        "Description": "Remote Code Execution in Spring Framework",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-22965",
                         "Severity": "Critical",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
+                                    "Score": 7.5,
+                                    "Vectors": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                                 },
                                 "CVSSv3": {
                                     "Score": 9.8,
-                                    "Vectors": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 }
                             }
                         },
@@ -1227,10 +1113,7 @@
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "quay.io/rhacs-eng/qa:sandbox-springboot-2.6.5-flux",
@@ -1248,18 +1131,18 @@
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2022-22965",
-                        "Description": "A Spring MVC or Spring WebFlux application running on JDK 9+ may be vulnerable to remote code execution (RCE) via data binding. The specific exploit requires the application to run on Tomcat as a WAR deployment. If the application is deployed as a Spring Boot executable jar, i.e. the default, it is not vulnerable to the exploit. However, the nature of the vulnerability is more general, and there may be other ways to exploit it.",
+                        "Description": "Remote Code Execution in Spring Framework",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-22965",
                         "Severity": "Critical",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
+                                    "Score": 7.5,
+                                    "Vectors": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                                 },
                                 "CVSSv3": {
                                     "Score": 9.8,
-                                    "Vectors": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 }
                             }
                         },
@@ -1272,10 +1155,7 @@
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "quay.io/rhacs-eng/qa:sandbox-springboot-web-cloud-function-2.6.6",
@@ -1298,10 +1178,6 @@
                         "Severity": "Critical",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 9.8,
                                     "Vectors": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
@@ -1399,10 +1275,6 @@
                         "Severity": "Important",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
@@ -1430,10 +1302,6 @@
                         "Severity": "Important",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
@@ -1469,10 +1337,6 @@
                         "Severity": "Moderate",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 7.8,
                                     "Vectors": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
@@ -1518,10 +1382,6 @@
                         "Severity": "Moderate",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 9.3,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N"
@@ -1549,10 +1409,6 @@
                         "Severity": "Moderate",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 9.3,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N"
@@ -1590,10 +1446,6 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 8.2,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N"
@@ -1633,10 +1485,6 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
@@ -1653,10 +1501,6 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
@@ -1717,10 +1561,6 @@
                         "Severity": "Moderate",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 7.4,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
@@ -1736,10 +1576,6 @@
                         "Severity": "Important",
                         "Metadata": {
                             "Red Hat": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
@@ -1798,12 +1634,8 @@
                         "Severity": "Critical",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 7.5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
-                                },
                                 "CVSSv3": {
-                                    "Score": 9.8,
+                                    "Score": 0.0,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 }
                             }
@@ -1813,7 +1645,7 @@
                 ],
                 "AddedBy": "sha256:3078c14ffbc62cd9a56f8951d08d6b55a45394fbb5a0aa8f9eca1b1472e3f21d",
                 "Location": "maven:org.drools.drools-core-6.4.0.Final.jar",
-                "FixedBy": "7.60.0.Final"
+                "FixedBy": "7.69.0.Final"
             }
         ],
         "unexpected_features": null,
@@ -1858,10 +1690,6 @@
                         "Severity": "Moderate",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 4.3,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N"
@@ -1976,15 +1804,11 @@
                     {
                         "Name": "CVE-2023-3138",
                         "NamespaceName": "alpine:v3.17",
-                        "Description": "",
+                        "Description": "A vulnerability was found in libX11. The security flaw occurs because the functions in src/InitExt.c in libX11 do not check that the values provided for the Request, Event, or Error IDs are within the bounds of the arrays that those functions write to, using those IDs as array indexes. They trust that they were called with values provided by an Xserver adhering to the bounds specified in the X11 protocol, as all X servers provided by X.Org do. As the protocol only specifies a single byte for these values, an out-of-bounds value provided by a malicious server (or a malicious proxy-in-the-middle) can only overwrite other portions of the Display structure and not write outside the bounds of the Display structure itself, possibly causing the client to crash with this memory corruption.",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2023-3138",
                         "Severity": "Unspecified",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
@@ -2007,15 +1831,11 @@
                     {
                         "Name": "CVE-2023-35945",
                         "NamespaceName": "alpine:v3.17",
-                        "Description": "",
+                        "Description": "Envoy is a cloud-native high-performance edge/middle/service proxy. Envoy’s HTTP/2 codec may leak a header map and bookkeeping structures upon receiving `RST_STREAM` immediately followed by the `GOAWAY` frames from an upstream server. In nghttp2, cleanup of pending requests due to receipt of the `GOAWAY` frame skips de-allocation of the bookkeeping structure and pending compressed header. The error return [code path] is taken if connection is already marked for not sending more requests due to `GOAWAY` frame. The clean-up code is right after the return statement, causing memory leak. Denial of service through memory exhaustion. This vulnerability was patched in versions(s) 1.26.3, 1.25.8, 1.24.9, 1.23.11.",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2023-35945",
                         "Severity": "Unspecified",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
@@ -2054,13 +1874,9 @@
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
-                                "CVSSv2": {
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
                                 "CVSSv3": {
-                                    "Score": 7.5,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                                    "Score": 7.3,
+                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
                                 }
                             }
                         },
@@ -2092,7 +1908,7 @@
                             "NVD": {
                                 "CVSSv3": {
                                     "Score": 0,
-        	            	    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N"
+                                    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N"
                                 }
                             }
                         }
@@ -2158,12 +1974,12 @@
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "Score": 5,
-        	            	    "Vectors": "AV:N/AC:L/Au:N/C:P/I:N/A:N"
+                                    "Score": 2.6,
+                                    "Vectors": "AV:N/AC:H/Au:N/C:P/I:N/A:N"
                                 },
                                 "CVSSv3": {
-                                    "Score": 7.5,
-        	            	    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+                                    "Score": 5.9,
+                                    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
                                 }
                             }
                         }
@@ -2178,11 +1994,11 @@
                             "NVD": {
                                 "CVSSv2": {
                                     "Score": 5,
-        	            	    "Vectors": "AV:N/AC:L/Au:N/C:P/I:N/A:N"
+                                    "Vectors": "AV:N/AC:L/Au:N/C:P/I:N/A:N"
                                 },
                                 "CVSSv3": {
                                     "Score": 7.5,
-        	            	    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
                                 }
                             }
                         }
@@ -2208,7 +2024,15 @@
                         "Description": "This update upgrade curl-libs to 8.1.2-4.ph3 #Fixes {'CVE-2023-38546', 'CVE-2023-38545'}",
                         "FixedBy": "0:8.1.2-4.ph3",
                         "Severity": "Critical",
-                        "Link": "https://github.com/vmware/photon/wiki/Security-Updates-3.0-667"
+                        "Link": "https://github.com/vmware/photon/wiki/Security-Updates-3.0-667",
+                        "Metadata": {
+                            "NVD": {
+                                "CVSSv3": {
+                                    "Score": 3.7,
+                                    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
+                                }
+                            }
+                        }
                     }
                 ]
             }

--- a/scanner/e2etests/testdata/image_tests.json
+++ b/scanner/e2etests/testdata/image_tests.json
@@ -2,2256 +2,45 @@
     {
         "image": "ubuntu:16.04",
         "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
+        "username": "DOCKER_USERNAME",
+        "password": "DOCKER_PASSWORD",
         "source": "NVD",
         "namespace": "ubuntu:16.04",
         "expected_features": [
             {
                 "Name": "liblz4-1",
                 "NamespaceName": "ubuntu:16.04",
-                "VersionFormat": "dpkg",
                 "Version": "0.0~r131-2ubuntu2",
+                "Arch": "amd64",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2021-3520",
                         "NamespaceName": "ubuntu:16.04",
-                        "Description": "There's a flaw in lz4. An attacker who submits a crafted file to an application linked with lz4 may be able to trigger an integer overflow, leading to calling of memmove() on a negative size argument, causing an out-of-bounds write and/or a crash. The greatest impact of this flaw is to availability, with some potential impact to confidentiality and integrity as well.",
+                        "Description": "There's a flaw in lz4. An attacker who submits a crafted file to anapplication linked with lz4 may be able to trigger an integer overflow,leading to calling of memmove() on a negative size argument, causing anout-of-bounds write and/or a crash. The greatest impact of this flaw is toavailability, with some potential impact to confidentiality and integrityas well.\n\n    Update Instructions:\n\n    Run `sudo pro fix CVE-2021-3520` to fix the vulnerability. The problem can be corrected\n    by updating your system to the following package versions:\n\nliblz4-1 - 0.0~r131-2ubuntu2+esm1\nliblz4-tool - 0.0~r131-2ubuntu2+esm1\nAvailable with Ubuntu Pro (Infra-only): https://ubuntu.com/pro",
                         "Link": "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=987856",
                         "Severity": "Moderate",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 6.4,
                                     "Score": 7.5,
                                     "Vectors": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 5.9,
                                     "Score": 9.8,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 }
                             }
                         },
-                        "FixedBy": ""
+                        "FixedBy": "0:0.0~r131-2ubuntu2+esm1"
                     }
                 ],
                 "AddedBy": "sha256:58690f9b18fca6469a14da4e212c96849469f9b1be6661d2342a4bf01774aa50",
-                "FixedBy": "0.0~r131-2ubuntu2+esm1"
+                "FixedBy": "0:0.0~r131-2ubuntu2+esm1",
+                "Location": "var/lib/dpkg/status"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": true,
-        "required_feature_flag": null
-    },
-    {
-        "image": "docker.io/library/nginx:1.10",
-        "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
-        "source": "NVD",
-        "namespace": "debian:8",
-        "expected_features": [
-            {
-                "Name": "diffutils",
-                "NamespaceName": "debian:8",
-                "VersionFormat": "dpkg",
-                "Version": "1:3.3-1",
-                "AddedBy": "sha256:6d827a3ef358f4fa21ef8251f95492e667da826653fd43641cef5a877dc03a70"
-            },
-            {
-                "Name": "coreutils",
-                "NamespaceName": "debian:8",
-                "VersionFormat": "dpkg",
-                "Version": "8.23-4",
-                "Vulnerabilities": [
-                    {
-                        "Name": "CVE-2016-2781",
-                        "NamespaceName": "debian:8",
-                        "Description": "chroot in GNU coreutils, when used with --userspec, allows local users to escape to the parent session via a crafted TIOCSTI ioctl call, which pushes characters to the terminal's input buffer.",
-                        "Link": "https://security-tracker.debian.org/tracker/CVE-2016-2781",
-                        "Severity": "Low",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 2.9,
-                                    "PublishedDateTime": "2017-02-07T15:59Z",
-                                    "Score": 2.1,
-                                    "Vectors": "AV:L/AC:L/Au:N/C:N/I:P/A:N"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 2,
-                                    "ImpactScore": 4,
-                                    "Score": 6.5,
-                                    "Vectors": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:N"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "Name": "CVE-2017-18018",
-                        "NamespaceName": "debian:8",
-                        "Description": "In GNU Coreutils through 8.29, chown-core.c in chown and chgrp does not prevent replacement of a plain file with a symlink during use of the POSIX \"-R -L\" options, which allows local users to modify the ownership of arbitrary files by leveraging a race condition.",
-                        "Link": "https://security-tracker.debian.org/tracker/CVE-2017-18018",
-                        "Severity": "Low",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 3.4,
-                                    "ImpactScore": 2.9,
-                                    "Score": 1.9,
-                                    "Vectors": "AV:L/AC:M/Au:N/C:N/I:P/A:N"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 1,
-                                    "ImpactScore": 3.6,
-                                    "Score": 4.7,
-                                    "Vectors": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N"
-                                },
-                                "LastModifiedDateTime": "2018-01-19T15:46Z",
-                                "PublishedDateTime": "2018-01-04T04:29Z"
-                            }
-                        }
-                    }
-                ],
-                "AddedBy": "sha256:6d827a3ef358f4fa21ef8251f95492e667da826653fd43641cef5a877dc03a70"
-            }
-        ],
-        "unexpected_features": null,
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
-    },
-    {
-        "image": "docker.io/kaizheh/apache-struts2-cve-2017-5638:latest",
-        "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
-        "source": "NVD",
-        "namespace": "debian:8",
-        "expected_features": [
-            {
-                "Name": "apt",
-                "NamespaceName": "debian:8",
-                "VersionFormat": "dpkg",
-                "Version": "1.0.9.8.4",
-                "Vulnerabilities": [
-                    {
-                        "Name": "CVE-2011-3374",
-                        "NamespaceName": "debian:8",
-                        "Description": "It was found that apt-key in apt, all versions, do not correctly validate gpg keys with the master keyring, leading to a potential man-in-the-middle attack.",
-                        "Link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
-                        "Severity": "Low",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 2.9,
-                                    "PublishedDateTime": "2019-01-28T21:29Z",
-                                    "Score": 4.3,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:N/I:P/A:N"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 1.4,
-                                    "Score": 3.7,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
-                                },
-                                "LastModifiedDateTime": "2019-12-04T15:35Z",
-                                "PublishedDateTime": "2019-11-26T00:15Z"
-                            }
-                        }
-                    },
-                    {
-                        "Name": "CVE-2019-3462",
-                        "NamespaceName": "debian:8",
-                        "Description": "Incorrect sanitation of the 302 redirect field in HTTP transport method of apt versions 1.4.8 and earlier can lead to content injection by a MITM attacker, potentially leading to remote code execution on the target machine.",
-                        "Link": "https://security-tracker.debian.org/tracker/CVE-2019-3462",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 10,
-                                    "PublishedDateTime": "2019-01-28T21:29Z",
-                                    "Score": 9.3,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:C/I:C/A:C"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 5.9,
-                                    "Score": 8.1,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                }
-                            }
-                        },
-                        "FixedBy": "1.0.9.8.5"
-                    },
-                    {
-                        "Name": "CVE-2020-3810",
-                        "NamespaceName": "debian:8",
-                        "Description": "Missing input validation in the ar/tar implementations of APT before version 2.1.2 could result in denial of service when processing specially crafted deb files.",
-                        "Link": "https://security-tracker.debian.org/tracker/CVE-2020-3810",
-                        "Severity": "Moderate",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 2.9,
-                                    "Score": 4.3,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 1.8,
-                                    "ImpactScore": 3.6,
-                                    "Score": 5.5,
-                                    "Vectors": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-05-18T16:36Z",
-                                "PublishedDateTime": "2020-05-15T14:15Z"
-                            }
-                        },
-                        "FixedBy": "1.0.9.8.6"
-                    }
-                ],
-                "AddedBy": "sha256:9f0706ba7422412cd468804fee456786f88bed94bf9aea6dde2a47f770d19d27",
-                "FixedBy": "1.0.9.8.6",
-                "Executables": [
-                    {
-                        "path": "/etc/cron.daily/apt",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/etc/kernel/postinst.d/apt-auto-removal",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/share/bug/apt/script",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/methods/xz",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/methods/bzip2",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/methods/lzma",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/methods/ssh",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/dpkg/methods/apt/update",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/dpkg/methods/apt/setup",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/dpkg/methods/apt/install",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/apt-helper",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/methods/cdrom",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/methods/copy",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/methods/file",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/methods/ftp",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/methods/gpgv",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/methods/gzip",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/methods/http",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/methods/mirror",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/methods/rred",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib/apt/methods/rsh",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/apt",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/apt-cache",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/apt-cdrom",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/apt-config",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/apt-get",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/apt-mark",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            },
-                            {
-                                "name": "bzip2",
-                                "version": "1.0.6-7"
-                            },
-                            {
-                                "name": "gcc-4.9",
-                                "version": "4.9.2-10"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.19-18+deb8u10"
-                            },
-                            {
-                                "name": "xz-utils",
-                                "version": "5.1.1alpha+20120614-2"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1:1.2.8.dfsg-2"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/apt-key",
-                        "required_features": [
-                            {
-                                "name": "apt",
-                                "version": "1.0.9.8.4"
-                            }
-                        ]
-                    }
-                ]
-            }
-        ],
-        "unexpected_features": null,
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": false,
-        "check_provided_executables": true,
-        "required_feature_flag": null
-    },
-    {
-        "image": "docker.io/anchore/anchore-engine:v0.5.0",
-        "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
-        "source": "Red Hat",
-        "namespace": "centos:7",
-        "expected_features": [
-            {
-                "Name": "procps-ng",
-                "NamespaceName": "centos:7",
-                "VersionFormat": "rpm",
-                "Version": "3.3.10-26.el7",
-                "Vulnerabilities": [
-                    {
-                        "Name": "CVE-2018-1121",
-                        "NamespaceName": "centos:7",
-                        "Description": "DOCUMENTATION: Since the kernel's proc_pid_readdir() returns PID entries in ascending numeric order, a process occupying a high PID can use inotify events to determine when the process list is being scanned, and fork/exec to obtain a lower PID, thus avoiding enumeration. An unprivileged attacker can hide a process from procps-ng's utilities by exploiting a race condition in reading /proc/PID entries.             STATEMENT: The /proc filesystem is not a reliable mechanism to account for processes running on a system, as it is unable to offer snapshot semantics. Short-lived processes have always been able to escape detection by tools that monitor /proc. This CVE simply identifies a reliable way to do so using inotify. Process accounting for security purposes, or with a requirement to record very short-running processes and those attempting to evade detection, should be performed with more robust methods such as auditd(8) (the Linux Audit Daemon) or systemtap.",
-                        "Link": "https://access.redhat.com/security/cve/CVE-2018-1121",
-                        "Severity": "Low",
-                        "Metadata": {
-                            "Red Hat": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 1.3,
-                                    "ImpactScore": 2.5,
-                                    "Score": 3.9,
-                                    "Vectors": "CVSS:3.0/AV:L/AC:L/PR:L/UI:R/S:U/C:N/I:L/A:L"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "Name": "CVE-2018-1123",
-                        "NamespaceName": "centos:7",
-                        "Description": "DOCUMENTATION: Due to incorrect accounting when decoding and escaping Unicode data in procfs, ps is vulnerable to overflowing an mmap()ed region when formatting the process list for display. Since ps maps a guard page at the end of the buffer, impact is limited to a crash.",
-                        "Link": "https://access.redhat.com/security/cve/CVE-2018-1123",
-                        "Severity": "Low",
-                        "Metadata": {
-                            "Red Hat": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 1.3,
-                                    "ImpactScore": 2.5,
-                                    "Score": 3.9,
-                                    "Vectors": "CVSS:3.0/AV:L/AC:L/PR:L/UI:R/S:U/C:N/I:L/A:L"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "Name": "CVE-2018-1125",
-                        "NamespaceName": "centos:7",
-                        "Description": "DOCUMENTATION: If a process inspected by pgrep has an argument longer than INT_MAX bytes, \"int bytes\" could wrap around back to a large positive int (rather than approaching zero), leading to a stack buffer overflow via strncat().                          MITIGATION: The procps suite on Red Hat Enterprise Linux is built with FORTIFY, which limits the impact of this stack overflow (and others like it) to a crash.",
-                        "Link": "https://access.redhat.com/security/cve/CVE-2018-1125",
-                        "Severity": "Low",
-                        "Metadata": {
-                            "Red Hat": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 1.8,
-                                    "ImpactScore": 2.5,
-                                    "Score": 4.4,
-                                    "Vectors": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:L"
-                                }
-                            }
-                        }
-                    }
-                ],
-                "AddedBy": "sha256:c8d67acdb2ffaebd638cf55a8fccc63693211060670aa7f0ea1d65b5d2c674dd",
-                "Executables": [
-                    {
-                        "path": "/usr/bin/free",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/pgrep",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/pkill",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/pmap",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/ps",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/pwdx",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/skill",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/slabtop",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "ncurses-libs",
-                                "version": "5.9-14.20130511.el7_4"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/snice",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/tload",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/top",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "ncurses-libs",
-                                "version": "5.9-14.20130511.el7_4"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/uptime",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/vmstat",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/w",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/watch",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "ncurses-libs",
-                                "version": "5.9-14.20130511.el7_4"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib64/libprocps.so.4.0.0",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/lib64/libprocps.so.4",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/sbin/sysctl",
-                        "required_features": [
-                            {
-                                "name": "bzip2-libs",
-                                "version": "1.0.6-13.el7"
-                            },
-                            {
-                                "name": "elfutils-libelf",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "elfutils-libs",
-                                "version": "0.176-2.el7"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-292.el7"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7"
-                            },
-                            {
-                                "name": "libcap",
-                                "version": "2.22-10.el7"
-                            },
-                            {
-                                "name": "libgcc",
-                                "version": "4.8.5-39.el7"
-                            },
-                            {
-                                "name": "libgcrypt",
-                                "version": "1.5.3-14.el7"
-                            },
-                            {
-                                "name": "libgpg-error",
-                                "version": "1.12-3.el7"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-14.1.el7"
-                            },
-                            {
-                                "name": "lz4",
-                                "version": "1.7.5-3.el7"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7"
-                            },
-                            {
-                                "name": "procps-ng",
-                                "version": "3.3.10-26.el7"
-                            },
-                            {
-                                "name": "systemd-libs",
-                                "version": "219-67.el7_7.1"
-                            },
-                            {
-                                "name": "xz-libs",
-                                "version": "5.2.2-1.el7"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.7-18.el7"
-                            }
-                        ]
-                    }
-                ]
-            }
-        ],
-        "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": true,
-        "check_provided_executables": true,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "us.gcr.io/stackrox-ci/qa/apache/server:latest",
@@ -2264,8 +53,8 @@
             {
                 "Name": "cron",
                 "NamespaceName": "ubuntu:14.04",
-                "VersionFormat": "dpkg",
                 "Version": "3.0pl1-124ubuntu2",
+                "Arch": "x86_64",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2017-9525",
@@ -2276,14 +65,10 @@
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 3.4,
-                                    "ImpactScore": 10,
                                     "Score": 6.9,
                                     "Vectors": "AV:L/AC:M/Au:N/C:C/I:C/A:C"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 0.8,
-                                    "ImpactScore": 5.9,
                                     "Score": 6.7,
                                     "Vectors": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H"
                                 },
@@ -2301,14 +86,10 @@
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 2.9,
                                     "Score": 2.1,
                                     "Vectors": "AV:L/AC:L/Au:N/C:N/I:N/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 1.8,
-                                    "ImpactScore": 3.6,
                                     "Score": 5.5,
                                     "Vectors": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
                                 },
@@ -2326,14 +107,10 @@
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 2.9,
                                     "Score": 2.1,
                                     "Vectors": "AV:L/AC:L/Au:N/C:N/I:N/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 1.8,
-                                    "ImpactScore": 3.6,
                                     "Score": 5.5,
                                     "Vectors": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
                                 },
@@ -2351,14 +128,10 @@
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 2.9,
                                     "Score": 2.1,
                                     "Vectors": "AV:L/AC:L/Au:N/C:N/I:N/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 1.8,
-                                    "ImpactScore": 3.6,
                                     "Score": 5.5,
                                     "Vectors": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
                                 },
@@ -2372,620 +145,7 @@
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
-    },
-    {
-        "image": "mcr.microsoft.com/dotnet/core/runtime:3.1.2",
-        "registry": "https://mcr.microsoft.com",
-        "username": "",
-        "password": "",
-        "source": "NVD",
-        "namespace": "debian:10",
-        "expected_features": [
-            {
-                "Name": "microsoft.netcore.app",
-                "VersionFormat": "DotNetCoreRuntimeSourceType",
-                "Version": "3.1.2",
-                "Vulnerabilities": [
-                    {
-                        "Name": "CVE-2020-1108",
-                        "Description": "A denial of service vulnerability exists when .NET Core or .NET Framework improperly handles web requests, aka '.NET Core \u0026 .NET Framework Denial of Service Vulnerability'.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-1108",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
-                                    "Score": 5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
-                                    "Score": 7.5,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-06-05T19:53:00Z",
-                                "PublishedDateTime": "2020-05-21T23:15:00Z"
-                            }
-                        },
-                        "FixedBy": "3.1.5"
-                    },
-                    {
-                        "Name": "CVE-2020-1147",
-                        "Description": "A remote code execution vulnerability exists in .NET Framework, Microsoft SharePoint, and Visual Studio when the software fails to check the source markup of XML file input, aka '.NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability'.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-1147",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 6.4,
-                                    "Score": 6.8,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 1.8,
-                                    "ImpactScore": 5.9,
-                                    "Score": 7.8,
-                                    "Vectors": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-08-20T15:15Z",
-                                "PublishedDateTime": "2020-07-14T23:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.6"
-                    },
-                    {
-                        "Name": "CVE-2021-1721",
-                        "Description": ".NET Core and Visual Studio Denial of Service Vulnerability",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-1721",
-                        "Severity": "Moderate",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 2.9,
-                                    "Score": 4.3,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 2.8,
-                                    "ImpactScore": 3.6,
-                                    "Score": 6.5,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
-                                },
-                                "LastModifiedDateTime": "2021-03-01T16:34Z",
-                                "PublishedDateTime": "2021-02-25T23:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.12"
-                    },
-                    {
-                        "Name": "CVE-2021-1723",
-                        "Description": "ASP.NET Core and Visual Studio Denial of Service Vulnerability",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-1723",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
-                                    "Score": 5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
-                                    "Score": 7.5,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                                },
-                                "LastModifiedDateTime": "2021-01-25T19:54Z",
-                                "PublishedDateTime": "2021-01-12T20:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.11"
-                    },
-                    {
-                        "Name": "CVE-2021-24112",
-                        "Description": ".NET Core Remote Code Execution Vulnerability This CVE ID is unique from CVE-2021-26701.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-24112",
-                        "Severity": "Critical",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 6.4,
-                                    "Score": 7.5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 5.9,
-                                    "Score": 9.8,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2021-03-01T16:34Z",
-                                "PublishedDateTime": "2021-02-25T23:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.12"
-                    },
-                    {
-                        "Name": "CVE-2021-26701",
-                        "Description": ".NET Core Remote Code Execution Vulnerability This CVE ID is unique from CVE-2021-24112.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-26701",
-                        "Severity": "Critical",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 6.4,
-                                    "Score": 7.5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 5.9,
-                                    "Score": 9.8,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2021-03-12T13:25Z",
-                                "PublishedDateTime": "2021-02-25T23:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.13"
-                    },
-                    {
-                        "Name": "CVE-2021-31204",
-                        "Description": ".NET and Visual Studio Elevation of Privilege Vulnerability",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-31204",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 6.4,
-                                    "Score": 4.6,
-                                    "Vectors": "AV:L/AC:L/Au:N/C:P/I:P/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 1.8,
-                                    "ImpactScore": 5.9,
-                                    "Score": 7.8,
-                                    "Vectors": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2021-05-20T12:48Z",
-                                "PublishedDateTime": "2021-05-11T19:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.15"
-                    }
-                ],
-                "AddedBy": "sha256:b48f8e1b0b06887c382543e23275911a388c1010e3436dc9b708ef29885bb594",
-                "Location": "usr/share/dotnet/shared/Microsoft.NETCore.App/3.1.2/",
-                "FixedBy": "3.1.32"
-            }
-        ],
-        "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
-    },
-    {
-        "image": "mcr.microsoft.com/dotnet/core/sdk:3.1.100@sha256:091126a93870729f4438ee7ed682ed98639a89acebed40409af90f84302c48dd",
-        "registry": "https://mcr.microsoft.com",
-        "username": "",
-        "password": "",
-        "source": "NVD",
-        "namespace": "debian:10",
-        "expected_features": [
-            {
-                "Name": "microsoft.aspnetcore.app",
-                "VersionFormat": "DotNetCoreRuntimeSourceType",
-                "Version": "3.1.0",
-                "Vulnerabilities": [
-                    {
-                        "Name": "CVE-2020-0602",
-                        "Description": "A denial of service vulnerability exists when ASP.NET Core improperly handles web requests, aka 'ASP.NET Core Denial of Service Vulnerability'.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-0602",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
-                                    "Score": 5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
-                                    "Score": 7.5,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-01-17T02:49Z",
-                                "PublishedDateTime": "2020-01-14T23:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.1"
-                    },
-                    {
-                        "Name": "CVE-2020-0603",
-                        "Description": "A remote code execution vulnerability exists in ASP.NET Core software when the software fails to handle objects in memory.An attacker who successfully exploited the vulnerability could run arbitrary code in the context of the current user, aka 'ASP.NET Core Remote Code Execution Vulnerability'.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-0603",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 10,
-                                    "Score": 9.3,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:C/I:C/A:C"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 2.8,
-                                    "ImpactScore": 5.9,
-                                    "Score": 8.8,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-01-17T19:22Z",
-                                "PublishedDateTime": "2020-01-14T23:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.1"
-                    },
-                    {
-                        "Name": "CVE-2020-1045",
-                        "Description": "A security feature bypass vulnerability exists in the way Microsoft ASP.NET Core parses encoded cookie names.The ASP.NET Core cookie parser decodes entire cookie strings which could allow a malicious attacker to set a second cookie with the name being percent encoded.The security update addresses the vulnerability by fixing the way the ASP.NET Core cookie parser handles encoded names., aka 'Microsoft ASP.NET Core Security Feature Bypass Vulnerability'.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-1045",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
-                                    "Score": 5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:N/I:P/A:N"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
-                                    "Score": 7.5,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
-                                },
-                                "LastModifiedDateTime": "2020-10-02T03:15Z",
-                                "PublishedDateTime": "2020-09-11T17:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.8"
-                    },
-                    {
-                        "Name": "CVE-2020-1161",
-                        "Description": "A denial of service vulnerability exists when ASP.NET Core improperly handles web requests, aka 'ASP.NET Core Denial of Service Vulnerability'.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-1161",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
-                                    "Score": 5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
-                                    "Score": 7.5,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-05-27T18:54Z",
-                                "PublishedDateTime": "2020-05-21T23:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.4"
-                    },
-                    {
-                        "Name": "CVE-2020-1597",
-                        "Description": "A denial of service vulnerability exists when ASP.NET Core improperly handles web requests, aka 'ASP.NET Core Denial of Service Vulnerability'.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-1597",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
-                                    "Score": 5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
-                                    "Score": 7.5,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-09-25T20:15Z",
-                                "PublishedDateTime": "2020-08-17T19:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.7"
-                    },
-                    {
-                        "Name": "CVE-2021-1723",
-                        "Description": "ASP.NET Core and Visual Studio Denial of Service Vulnerability",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-1723",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
-                                    "Score": 5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
-                                    "Score": 7.5,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                                },
-                                "LastModifiedDateTime": "2021-01-25T19:54Z",
-                                "PublishedDateTime": "2021-01-12T20:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.11"
-                    }
-                ],
-                "AddedBy": "sha256:5bd47e7e8ad7786db14c79827b543615728f0e27567f5b05d4c13db29bb24c7a",
-                "Location": "usr/share/dotnet/shared/Microsoft.AspNetCore.App/3.1.0/",
-                "FixedBy": "3.1.11"
-            },
-            {
-                "Name": "microsoft.netcore.app",
-                "VersionFormat": "DotNetCoreRuntimeSourceType",
-                "Version": "3.1.0",
-                "Vulnerabilities": [
-                    {
-                        "Name": "CVE-2020-0605",
-                        "Description": "A remote code execution vulnerability exists in .NET software when the software fails to check the source markup of a file.An attacker who successfully exploited the vulnerability could run arbitrary code in the context of the current user, aka '.NET Framework Remote Code Execution Vulnerability'. This CVE ID is unique from CVE-2020-0606.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-0605",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 10,
-                                    "Score": 9.3,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:C/I:C/A:C"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 2.8,
-                                    "ImpactScore": 5.9,
-                                    "Score": 8.8,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-01-21T21:22Z",
-                                "PublishedDateTime": "2020-01-14T23:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.1"
-                    },
-                    {
-                        "Name": "CVE-2020-0606",
-                        "Description": "A remote code execution vulnerability exists in .NET software when the software fails to check the source markup of a file.An attacker who successfully exploited the vulnerability could run arbitrary code in the context of the current user, aka '.NET Framework Remote Code Execution Vulnerability'. This CVE ID is unique from CVE-2020-0605.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-0606",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 10,
-                                    "Score": 9.3,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:C/I:C/A:C"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 2.8,
-                                    "ImpactScore": 5.9,
-                                    "Score": 8.8,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-01-17T03:03Z",
-                                "PublishedDateTime": "2020-01-14T23:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.1"
-                    },
-                    {
-                        "Name": "CVE-2020-1108",
-                        "Description": "A denial of service vulnerability exists when .NET Core or .NET Framework improperly handles web requests, aka '.NET Core \u0026 .NET Framework Denial of Service Vulnerability'.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-1108",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
-                                    "Score": 5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
-                                    "Score": 7.5,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-06-05T19:53Z",
-                                "PublishedDateTime": "2020-05-21T23:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.5"
-                    },
-                    {
-                        "Name": "CVE-2020-1147",
-                        "Description": "A remote code execution vulnerability exists in .NET Framework, Microsoft SharePoint, and Visual Studio when the software fails to check the source markup of XML file input, aka '.NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability'.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-1147",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 6.4,
-                                    "Score": 6.8,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 1.8,
-                                    "ImpactScore": 5.9,
-                                    "Score": 7.8,
-                                    "Vectors": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2020-08-20T15:15Z",
-                                "PublishedDateTime": "2020-07-14T23:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.6"
-                    },
-                    {
-                        "Name": "CVE-2021-1721",
-                        "Description": ".NET Core and Visual Studio Denial of Service Vulnerability",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-1721",
-                        "Severity": "Moderate",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 2.9,
-                                    "Score": 4.3,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 2.8,
-                                    "ImpactScore": 3.6,
-                                    "Score": 6.5,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
-                                },
-                                "LastModifiedDateTime": "2021-03-01T16:34Z",
-                                "PublishedDateTime": "2021-02-25T23:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.12"
-                    },
-                    {
-                        "Name": "CVE-2021-1723",
-                        "Description": "ASP.NET Core and Visual Studio Denial of Service Vulnerability",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-1723",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
-                                    "Score": 5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
-                                    "Score": 7.5,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                                },
-                                "LastModifiedDateTime": "2021-01-25T19:54Z",
-                                "PublishedDateTime": "2021-01-12T20:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.11"
-                    },
-                    {
-                        "Name": "CVE-2021-24112",
-                        "Description": ".NET Core Remote Code Execution Vulnerability This CVE ID is unique from CVE-2021-26701.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-24112",
-                        "Severity": "Critical",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 6.4,
-                                    "Score": 7.5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 5.9,
-                                    "Score": 9.8,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2021-03-01T16:34Z",
-                                "PublishedDateTime": "2021-02-25T23:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.12"
-                    },
-                    {
-                        "Name": "CVE-2021-26701",
-                        "Description": ".NET Core Remote Code Execution Vulnerability This CVE ID is unique from CVE-2021-24112.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-26701",
-                        "Severity": "Critical",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 6.4,
-                                    "Score": 7.5,
-                                    "Vectors": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 5.9,
-                                    "Score": 9.8,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2021-03-12T13:25Z",
-                                "PublishedDateTime": "2021-02-25T23:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.13"
-                    },
-                    {
-                        "Name": "CVE-2021-31204",
-                        "Description": ".NET and Visual Studio Elevation of Privilege Vulnerability",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-31204",
-                        "Severity": "Important",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 6.4,
-                                    "Score": 4.6,
-                                    "Vectors": "AV:L/AC:L/Au:N/C:P/I:P/A:P"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 1.8,
-                                    "ImpactScore": 5.9,
-                                    "Score": 7.8,
-                                    "Vectors": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
-                                },
-                                "LastModifiedDateTime": "2021-05-20T12:48Z",
-                                "PublishedDateTime": "2021-05-11T19:15Z"
-                            }
-                        },
-                        "FixedBy": "3.1.15"
-                    }
-                ],
-                "AddedBy": "sha256:5bd47e7e8ad7786db14c79827b543615728f0e27567f5b05d4c13db29bb24c7a",
-                "Location": "usr/share/dotnet/shared/Microsoft.NETCore.App/3.1.0/",
-                "FixedBy": "3.1.32"
-            }
-        ],
-        "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": false
     },
     {
         "image": "quay.io/rhacs-eng/qa:sandbox-scannerremovejar",
@@ -2996,26 +156,22 @@
         "namespace": "ubuntu:14.04",
         "expected_features": [
             {
-                "Name": "jackson-databind",
-                "VersionFormat": "JavaSourceType",
+                "Name": "com.fasterxml.jackson.core:jackson-databind",
                 "Version": "2.9.10.4",
+                "Arch": "",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2020-14060",
-                        "Description": "FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction between serialization gadgets and typing, related to oadd.org.apache.xalan.lib.sql.JNDIConnectionPool (aka apache/drill).",
+                        "Description": "Deserialization of untrusted data in Jackson Databind",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-14060",
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 6.4,
                                     "Score": 6.8,
                                     "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 5.9,
                                     "Score": 8.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 },
@@ -3027,20 +183,16 @@
                     },
                     {
                         "Name": "CVE-2020-14061",
-                        "Description": "FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction between serialization gadgets and typing, related to oracle.jms.AQjmsQueueConnectionFactory, oracle.jms.AQjmsXATopicConnectionFactory, oracle.jms.AQjmsTopicConnectionFactory, oracle.jms.AQjmsXAQueueConnectionFactory, and oracle.jms.AQjmsXAConnectionFactory (aka weblogic/oracle-aqjms).",
+                        "Description": "Deserialization of untrusted data in Jackson Databind",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-14061",
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 6.4,
                                     "Score": 6.8,
                                     "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 5.9,
                                     "Score": 8.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 },
@@ -3052,20 +204,16 @@
                     },
                     {
                         "Name": "CVE-2020-14062",
-                        "Description": "FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction between serialization gadgets and typing, related to com.sun.org.apache.xalan.internal.lib.sql.JNDIConnectionPool (aka xalan2).",
+                        "Description": "Deserialization of untrusted data in Jackson Databind",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-14062",
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 6.4,
                                     "Score": 6.8,
                                     "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 5.9,
                                     "Score": 8.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 },
@@ -3077,20 +225,16 @@
                     },
                     {
                         "Name": "CVE-2020-14195",
-                        "Description": "FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction between serialization gadgets and typing, related to org.jsecurity.realm.jndi.JndiRealmFactory (aka org.jsecurity).",
+                        "Description": "Deserialization of untrusted data in Jackson Databind",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-14195",
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 6.4,
                                     "Score": 6.8,
                                     "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 5.9,
                                     "Score": 8.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 },
@@ -3102,20 +246,16 @@
                     },
                     {
                         "Name": "CVE-2020-24616",
-                        "Description": "FasterXML jackson-databind 2.x before 2.9.10.6 mishandles the interaction between serialization gadgets and typing, related to br.com.anteros.dbcp.AnterosDBCPDataSource (aka Anteros-DBCP).",
+                        "Description": "Code Injection in jackson-databind",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-24616",
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 6.4,
                                     "Score": 6.8,
                                     "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 5.9,
                                     "Score": 8.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 },
@@ -3127,20 +267,16 @@
                     },
                     {
                         "Name": "CVE-2020-24750",
-                        "Description": "FasterXML jackson-databind 2.x before 2.9.10.6 mishandles the interaction between serialization gadgets and typing, related to com.pastdev.httpcomponents.configuration.JndiConfiguration.",
+                        "Description": "Unsafe Deserialization in jackson-databind",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-24750",
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 6.4,
                                     "Score": 6.8,
                                     "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 5.9,
                                     "Score": 8.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 },
@@ -3152,20 +288,16 @@
                     },
                     {
                         "Name": "CVE-2020-25649",
-                        "Description": "A flaw was found in FasterXML Jackson Databind, where it did not have entity expansion secured properly. This flaw allows vulnerability to XML external entity (XXE) attacks. The highest threat from this vulnerability is data integrity.",
+                        "Description": "XML External Entity (XXE) Injection in Jackson Databind",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-25649",
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
                                     "Score": 5,
                                     "Vectors": "AV:N/AC:L/Au:N/C:N/I:P/A:N"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
                                 },
@@ -3177,20 +309,16 @@
                     },
                     {
                         "Name": "CVE-2020-35490",
-                        "Description": "FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.datasources.PerUserPoolDataSource.",
+                        "Description": "Serialization gadgets exploit in jackson-databind",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-35490",
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 6.4,
                                     "Score": 6.8,
                                     "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 5.9,
                                     "Score": 8.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 },
@@ -3202,20 +330,16 @@
                     },
                     {
                         "Name": "CVE-2020-35491",
-                        "Description": "FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.datasources.SharedPoolDataSource.",
+                        "Description": "Serialization gadgets exploit in jackson-databind",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-35491",
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 6.4,
                                     "Score": 6.8,
                                     "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 5.9,
                                     "Score": 8.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 },
@@ -3227,20 +351,16 @@
                     },
                     {
                         "Name": "CVE-2020-36518",
-                        "Description": "jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.",
+                        "Description": "Deeply nested json in jackson-databind",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-36518",
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
                                     "Score": 5,
                                     "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
@@ -3250,21 +370,18 @@
                     }
                 ],
                 "AddedBy": "sha256:36e8e9714b9a509fae9e515ff16237928c3d809f5ae228b14d2f7d7605c02623",
-                "Location": "jars/jackson-databind-2.9.10.4.jar",
+                "Location": "maven:jars/jackson-databind-2.9.10.4.jar",
                 "FixedBy": "2.16.0"
             }
         ],
         "unexpected_features": [
             {
                 "Name": "jackson-databind",
-                "VersionFormat": "JavaSourceType",
                 "Version": "2.6.6"
             }
         ],
         "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "uncertified_rhel": false
     },
     {
         "image": "quay.io/rhacs-eng/qa:sandbox-zookeeper-fatjar-remove",
@@ -3272,29 +389,24 @@
         "username": "QUAY_RHACS_ENG_RO_USERNAME",
         "password": "QUAY_RHACS_ENG_RO_PASSWORD",
         "source": "NVD",
-        "namespace": "alpine:v3.8",
+        "namespace": "alpine:3.8",
         "expected_features": null,
         "unexpected_features": [
             {
                 "Name": "zookeeper",
-                "VersionFormat": "JavaSourceType",
                 "Version": "3.4.13"
             },
             {
                 "Name": "guava",
-                "VersionFormat": "JavaSourceType",
                 "Version": "18.0"
             },
             {
                 "Name": "netty",
-                "VersionFormat": "JavaSourceType",
                 "Version": "3.10.6.final"
             }
         ],
         "only_check_specified_vulns": false,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "uncertified_rhel": false
     },
     {
         "image": "quay.io/rhacs-eng/qa:sandbox-oci-manifest",
@@ -3305,13 +417,9 @@
         "namespace": "ubuntu:16.04",
         "expected_features": null,
         "unexpected_features": null,
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": false
     },
     {
-        "disabled_reason": "CVE-2017-1000382 is unfixable, and ClairCore doesn't report it.",
         "image": "quay.io/rhacs-eng/qa:sandbox-jenkins-agent-maven-35-rhel7",
         "registry": "https://quay.io",
         "username": "QUAY_RHACS_ENG_RO_USERNAME",
@@ -3322,15 +430,14 @@
             {
                 "Name": "rh-maven35-log4j12",
                 "NamespaceName": "rhel:7",
-                "VersionFormat": "rpm",
                 "Version": "1.2.17-19.2.el7",
                 "Arch": "noarch",
-                "AddedBy": "sha256:4b4eac8c1d679c473379a42d37ec83b98bbafd8bb316200f53123f72d53bbb84"
+                "AddedBy": "sha256:4b4eac8c1d679c473379a42d37ec83b98bbafd8bb316200f53123f72d53bbb84",
+                "Location": "bdb:var/lib/rpm"
             },
             {
                 "Name": "rh-maven35-jackson-databind",
                 "NamespaceName": "rhel:7",
-                "VersionFormat": "rpm",
                 "Version": "2.7.6-2.10.el7",
                 "Arch": "noarch",
                 "Vulnerabilities": [
@@ -3343,14 +450,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 5.9,
                                     "Score": 8.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 }
@@ -3360,12 +463,12 @@
                     }
                 ],
                 "AddedBy": "sha256:4b4eac8c1d679c473379a42d37ec83b98bbafd8bb316200f53123f72d53bbb84",
-                "FixedBy": "2.7.6-2.12.el7"
+                "FixedBy": "0:2.7.6-2.12.el7",
+                "Location": "bdb:var/lib/rpm"
             },
             {
                 "Name": "vim-minimal",
                 "NamespaceName": "rhel:7",
-                "VersionFormat": "rpm",
                 "Version": "2:7.4.629-6.el7",
                 "Arch": "x86_64",
                 "Vulnerabilities": [
@@ -3378,14 +481,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 1.8,
-                                    "ImpactScore": 3.6,
                                     "Score": 5.5,
                                     "Vectors": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
                                 }
@@ -3394,57 +493,7 @@
                     }
                 ],
                 "AddedBy": "sha256:e20f387c7bf5a184eeef83f7e5626661f593ca05c788f377a01e2df62f613e44",
-                "Executables": [
-                    {
-                        "path": "/usr/bin/vi",
-                        "required_features": [
-                            {
-                                "name": "glibc",
-                                "version": "2.17-307.el7.1.i686"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.17-307.el7.1.x86_64"
-                            },
-                            {
-                                "name": "libacl",
-                                "version": "2.2.51-15.el7.x86_64"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7.i686"
-                            },
-                            {
-                                "name": "libattr",
-                                "version": "2.4.46-13.el7.x86_64"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-15.el7.i686"
-                            },
-                            {
-                                "name": "libselinux",
-                                "version": "2.5-15.el7.x86_64"
-                            },
-                            {
-                                "name": "ncurses-libs",
-                                "version": "5.9-14.20130511.el7_4.x86_64"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7.i686"
-                            },
-                            {
-                                "name": "pcre",
-                                "version": "8.32-17.el7.x86_64"
-                            },
-                            {
-                                "name": "vim-minimal",
-                                "version": "2:7.4.629-6.el7.x86_64"
-                            }
-                        ]
-                    }
-                ]
+                "Location": "bdb:var/lib/rpm"
             }
         ],
         "unexpected_features": [
@@ -3453,10 +502,7 @@
                 "Version": "2.7.6"
             }
         ],
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": true,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "quay.io/rhacs-eng/qa:sandbox-jenkins-agent-maven-35-rhel7-chown",
@@ -3469,15 +515,14 @@
             {
                 "Name": "rh-maven35-log4j12",
                 "NamespaceName": "rhel:7",
-                "VersionFormat": "rpm",
                 "Version": "1.2.17-19.2.el7",
                 "Arch": "noarch",
-                "AddedBy": "sha256:4b4eac8c1d679c473379a42d37ec83b98bbafd8bb316200f53123f72d53bbb84"
+                "AddedBy": "sha256:4b4eac8c1d679c473379a42d37ec83b98bbafd8bb316200f53123f72d53bbb84",
+                "Location": "bdb:var/lib/rpm"
             },
             {
                 "Name": "rh-maven35-jackson-databind",
                 "NamespaceName": "rhel:7",
-                "VersionFormat": "rpm",
                 "Version": "2.7.6-2.10.el7",
                 "Arch": "noarch",
                 "Vulnerabilities": [
@@ -3490,14 +535,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 5.9,
                                     "Score": 8.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 }
@@ -3507,12 +548,12 @@
                     }
                 ],
                 "AddedBy": "sha256:4b4eac8c1d679c473379a42d37ec83b98bbafd8bb316200f53123f72d53bbb84",
-                "FixedBy": "2.7.6-2.12.el7"
+                "FixedBy": "0:2.7.6-2.12.el7",
+                "Location": "bdb:var/lib/rpm"
             },
             {
                 "Name": "vim-minimal",
                 "NamespaceName": "rhel:7",
-                "VersionFormat": "rpm",
                 "Version": "2:7.4.629-6.el7",
                 "Arch": "x86_64",
                 "Vulnerabilities": [
@@ -3525,14 +566,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 1.8,
-                                    "ImpactScore": 3.6,
                                     "Score": 5.5,
                                     "Vectors": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
                                 }
@@ -3540,7 +577,8 @@
                         }
                     }
                 ],
-                "AddedBy": "sha256:e20f387c7bf5a184eeef83f7e5626661f593ca05c788f377a01e2df62f613e44"
+                "AddedBy": "sha256:e20f387c7bf5a184eeef83f7e5626661f593ca05c788f377a01e2df62f613e44",
+                "Location": "bdb:var/lib/rpm"
             }
         ],
         "unexpected_features": [
@@ -3549,10 +587,7 @@
                 "Version": "2.7.6"
             }
         ],
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "quay.io/rhacs-eng/qa:sandbox-nodejs-10",
@@ -3565,7 +600,6 @@
             {
                 "Name": "nodejs-full-i18n",
                 "NamespaceName": "rhel:8",
-                "VersionFormat": "rpm",
                 "Version": "1:10.21.0-3.module+el8.2.0+7071+d2377ea3",
                 "Arch": "x86_64",
                 "Vulnerabilities": [
@@ -3578,14 +612,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 5.9,
                                     "Score": 8.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 }
@@ -3602,14 +632,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
@@ -3619,12 +645,12 @@
                     }
                 ],
                 "AddedBy": "sha256:35ad9b4fba1fa6b00a6f266303348dc0cf9a7c341616e800c2738030c0f64167",
-                "FixedBy": "1:10.24.0-1.module+el8.3.0+10166+b07ac28e"
+                "FixedBy": "1:10.24.0-1.module+el8.3.0+10166+b07ac28e",
+                "Location": "bdb:var/lib/rpm"
             },
             {
                 "Name": "freetype",
                 "NamespaceName": "rhel:8",
-                "VersionFormat": "rpm",
                 "Version": "2.9.1-4.el8",
                 "Arch": "x86_64",
                 "Vulnerabilities": [
@@ -3637,14 +663,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 4.7,
                                     "Score": 8.6,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H"
                                 }
@@ -3654,12 +676,12 @@
                     }
                 ],
                 "AddedBy": "sha256:35ad9b4fba1fa6b00a6f266303348dc0cf9a7c341616e800c2738030c0f64167",
-                "FixedBy": "2.9.1-9.el8"
+                "FixedBy": "0:2.9.1-9.el8",
+                "Location": "bdb:var/lib/rpm"
             },
             {
                 "Name": "libsolv",
                 "NamespaceName": "rhel:8",
-                "VersionFormat": "rpm",
                 "Version": "0.7.7-1.el8",
                 "Arch": "x86_64",
                 "Vulnerabilities": [
@@ -3672,14 +694,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
@@ -3696,14 +714,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
@@ -3720,14 +734,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 1.8,
-                                    "ImpactScore": 1.4,
                                     "Score": 3.3,
                                     "Vectors": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L"
                                 }
@@ -3737,45 +747,14 @@
                     }
                 ],
                 "AddedBy": "sha256:ec1681b6a383e4ecedbeddd5abc596f3de835aed6db39a735f62395c8edbff30",
-                "FixedBy": "0.7.19-1.el8"
+                "FixedBy": "0:0.7.19-1.el8",
+                "Location": "bdb:var/lib/rpm"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
-        "image": "registry.redhat.io/openshift3/logging-elasticsearch",
-        "registry": "https://registry.redhat.io",
-        "username": "REDHAT_USERNAME",
-        "password": "REDHAT_PASSWORD",
-        "source": "Red Hat",
-        "namespace": "centos:7",
-        "expected_features": null,
-        "unexpected_features": null,
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": true,
-        "check_provided_executables": false,
-        "required_feature_flag": null
-    },
-    {
-        "image": "registry.redhat.io/openshift3/logging-elasticsearch:v3.10.175-1",
-        "registry": "https://registry.redhat.io",
-        "username": "REDHAT_USERNAME",
-        "password": "REDHAT_PASSWORD",
-        "source": "Red Hat",
-        "namespace": "centos:7",
-        "expected_features": null,
-        "unexpected_features": null,
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": true,
-        "check_provided_executables": false,
-        "required_feature_flag": null
-    },
-    {
-        "disabled_reason": "unauthorized when pulling layers",
         "image": "registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:3.74.1@sha256:8e455c6f7ee571cc8c565b2f2b1ff712f05ade5cef0c34d528d2955253469992",
         "registry": "https://registry.redhat.io",
         "username": "REDHAT_USERNAME",
@@ -3784,10 +763,7 @@
         "namespace": "rhel:8",
         "expected_features": null,
         "unexpected_features": null,
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": false
     },
     {
         "image": "quay.io/rhacs-eng/qa:sandbox-alpine-jq-1.6-r1",
@@ -3795,97 +771,47 @@
         "username": "QUAY_RHACS_ENG_RO_USERNAME",
         "password": "QUAY_RHACS_ENG_RO_PASSWORD",
         "source": "NVD",
-        "namespace": "alpine:v3.13",
+        "namespace": "alpine:3.13",
         "expected_features": [
             {
                 "Name": "jq",
                 "NamespaceName": "alpine:v3.13",
-                "VersionFormat": "apk",
                 "Version": "1.6-r1",
-                "AddedBy": "sha256:51c25658727f8bc3a4ef7c039257e136d23995bfdcfdc52dfb24104b5dc64720"
+                "Arch": "x86_64",
+                "AddedBy": "sha256:51c25658727f8bc3a4ef7c039257e136d23995bfdcfdc52dfb24104b5dc64720",
+                "Location": "lib/apk/db/installed"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
-    },
-    {
-        "image": "docker.io/richxsl/rhel7@sha256:8f3aae325d2074d2dc328cb532d6e7aeb0c588e15ddf847347038fe0566364d6",
-        "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
-        "source": "NVD",
-        "namespace": "centos:7",
-        "expected_features": [
-            {
-                "Name": "fipscheck",
-                "NamespaceName": "centos:7",
-                "VersionFormat": "rpm",
-                "Version": "1.4.1-5.el7",
-                "AddedBy": "sha256:1de5db95c59529b8423a336fac27e0bf8a9f4fced0fcc32377c9170ab481a8e9"
-            }
-        ],
-        "unexpected_features": null,
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": true,
-        "check_provided_executables": false,
-        "required_feature_flag": null
-    },
-    {
-        "image": "quay.io/dougtidwell/open-adventure@sha256:564c8dde1931f337a7bc8925f94cb594d9c81a5ee9eacc5ec5590f1e60e94b6a",
-        "registry": "https://quay.io",
-        "username": "",
-        "password": "",
-        "source": "NVD",
-        "namespace": "centos:7",
-        "expected_features": [
-            {
-                "Name": "p11-kit",
-                "NamespaceName": "centos:7",
-                "VersionFormat": "rpm",
-                "Version": "0.23.5-3.el7",
-                "AddedBy": "sha256:f9ce27a295e879233c8fbbf9ab67944a10e1ce80da69e46f87c583082a1ff3bb"
-            }
-        ],
-        "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": false
     },
     {
         "image": "alpine:3.13.0",
         "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
+        "username": "DOCKER_USERNAME",
+        "password": "DOCKER_PASSWORD",
         "source": "NVD",
-        "namespace": "alpine:v3.13",
+        "namespace": "alpine:3.13",
         "expected_features": [
             {
                 "Name": "apk-tools",
                 "NamespaceName": "alpine:v3.13",
-                "VersionFormat": "apk",
                 "Version": "2.12.0-r4",
+                "Arch": "x86_64",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2021-30139",
                         "NamespaceName": "alpine:v3.13",
-                        "Description": "In Alpine Linux apk-tools before 2.12.5, the tarball parser allows a buffer overflow and crash.",
+                        "Description": "",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2021-30139",
-                        "Severity": "Important",
+                        "Severity": "Unspecified",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
                                     "Score": 5,
                                     "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
@@ -3896,20 +822,16 @@
                     {
                         "Name": "CVE-2021-36159",
                         "NamespaceName": "alpine:v3.13",
-                        "Description": "libfetch before 2021-07-26, as used in apk-tools, xbps, and other products, mishandles numeric strings for the FTP and HTTP protocols. The FTP passive mode implementation allows an out-of-bounds read because strtol is used to parse the relevant numbers into address bytes. It does not check if the line ends prematurely. If it does, the for-loop condition checks for the '\\0' terminator one byte too late.",
+                        "Description": "",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2021-36159",
-                        "Severity": "Critical",
+                        "Severity": "Unspecified",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 4.9,
                                     "Score": 6.4,
                                     "Vectors": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 5.2,
                                     "Score": 9.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H"
                                 }
@@ -3920,74 +842,27 @@
                 ],
                 "AddedBy": "sha256:596ba82af5aaa3e2fd9d6f955b8b94f0744a2b60710e3c243ba3e4a467f051d1",
                 "FixedBy": "2.12.6-r0",
-                "Executables": [
-                    {
-                        "path": "/lib/libapk.so.3.12.0",
-                        "required_features": [
-                            {
-                                "name": "apk-tools",
-                                "version": "2.12.0-r4"
-                            },
-                            {
-                                "name": "musl",
-                                "version": "1.2.2_pre7-r0"
-                            },
-                            {
-                                "name": "openssl",
-                                "version": "1.1.1i-r0"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.11-r3"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/sbin/apk",
-                        "required_features": [
-                            {
-                                "name": "apk-tools",
-                                "version": "2.12.0-r4"
-                            },
-                            {
-                                "name": "openssl",
-                                "version": "1.1.1i-r0"
-                            },
-                            {
-                                "name": "musl",
-                                "version": "1.2.2_pre7-r0"
-                            },
-                            {
-                                "name": "zlib",
-                                "version": "1.2.11-r3"
-                            }
-                        ]
-                    }
-                ]
+                "Location": "lib/apk/db/installed"
             },
             {
                 "Name": "busybox",
                 "NamespaceName": "alpine:v3.13",
-                "VersionFormat": "apk",
                 "Version": "1.32.1-r0",
+                "Arch": "x86_64",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2021-28831",
                         "NamespaceName": "alpine:v3.13",
-                        "Description": "decompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.",
+                        "Description": "",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2021-28831",
-                        "Severity": "Important",
+                        "Severity": "Unspecified",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
                                     "Score": 5,
                                     "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
@@ -3998,99 +873,38 @@
                 ],
                 "AddedBy": "sha256:596ba82af5aaa3e2fd9d6f955b8b94f0744a2b60710e3c243ba3e4a467f051d1",
                 "FixedBy": "1.32.1-r9",
-                "Executables": [
-                    {
-                        "path": "/usr/bin/ssl_client",
-                        "required_features": [
-                            {
-                                "name": "busybox",
-                                "version": "1.32.1-r0"
-                            },
-                            {
-                                "name": "libtls-standalone",
-                                "version": "2.9.1-r1"
-                            },
-                            {
-                                "name": "musl",
-                                "version": "1.2.2_pre7-r0"
-                            },
-                            {
-                                "name": "openssl",
-                                "version": "1.1.1i-r0"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/etc/network/if-up.d/dad",
-                        "required_features": [
-                            {
-                                "name": "busybox",
-                                "version": "1.32.1-r0"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/share/udhcpc/default.script",
-                        "required_features": [
-                            {
-                                "name": "busybox",
-                                "version": "1.32.1-r0"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/bin/busybox",
-                        "required_features": [
-                            {
-                                "name": "busybox",
-                                "version": "1.32.1-r0"
-                            },
-                            {
-                                "name": "musl",
-                                "version": "1.2.2_pre7-r0"
-                            }
-                        ]
-                    }
-                ]
+                "Location": "lib/apk/db/installed"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": true,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "alpine:3.14.0",
         "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
+        "username": "DOCKER_USERNAME",
+        "password": "DOCKER_PASSWORD",
         "source": "NVD",
-        "namespace": "alpine:v3.14",
+        "namespace": "alpine:3.14",
         "expected_features": [
             {
                 "Name": "apk-tools",
                 "NamespaceName": "alpine:v3.14",
-                "VersionFormat": "apk",
                 "Version": "2.12.5-r1",
+                "Arch": "x86_64",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2021-36159",
                         "NamespaceName": "alpine:v3.14",
-                        "Description": "libfetch before 2021-07-26, as used in apk-tools, xbps, and other products, mishandles numeric strings for the FTP and HTTP protocols. The FTP passive mode implementation allows an out-of-bounds read because strtol is used to parse the relevant numbers into address bytes. It does not check if the line ends prematurely. If it does, the for-loop condition checks for the '\\0' terminator one byte too late.",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2021-36159",
-                        "Severity": "Critical",
+                        "Severity": "Unspecified",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 4.9,
                                     "Score": 6.4,
                                     "Vectors": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 5.2,
                                     "Score": 9.1,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H"
                                 }
@@ -4100,91 +914,86 @@
                     }
                 ],
                 "AddedBy": "sha256:5843afab387455b37944e709ee8c78d7520df80f8d01cf7f861aae63beeddb6b",
-                "FixedBy": "2.12.6-r0"
+                "FixedBy": "2.12.6-r0",
+                "Location": "lib/apk/db/installed"
             },
             {
                 "Name": "busybox",
                 "NamespaceName": "alpine:v3.14",
-                "VersionFormat": "apk",
                 "Version": "1.33.1-r2",
+                "Arch": "x86_64",
                 "AddedBy": "sha256:5843afab387455b37944e709ee8c78d7520df80f8d01cf7f861aae63beeddb6b",
-                "FixedBy": "1.33.1-r7"
+                "FixedBy": "1.33.1-r7",
+                "Location": "lib/apk/db/installed"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "alpine:3.15.0",
         "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
+        "username": "DOCKER_USERNAME",
+        "password": "DOCKER_PASSWORD",
         "source": "NVD",
-        "namespace": "alpine:v3.15",
+        "namespace": "alpine:3.15",
         "expected_features": [
             {
                 "Name": "apk-tools",
                 "NamespaceName": "alpine:v3.15",
-                "VersionFormat": "apk",
                 "Version": "2.12.7-r3",
-                "AddedBy": "sha256:59bf1c3509f33515622619af21ed55bbe26d24913cedbca106468a5fb37a50c3"
+                "Arch": "x86_64",
+                "AddedBy": "sha256:59bf1c3509f33515622619af21ed55bbe26d24913cedbca106468a5fb37a50c3",
+                "Location": "lib/apk/db/installed"
             },
             {
                 "Name": "busybox",
                 "NamespaceName": "alpine:v3.15",
-                "VersionFormat": "apk",
                 "Version": "1.34.1-r3",
+                "Arch": "x86_64",
                 "AddedBy": "sha256:59bf1c3509f33515622619af21ed55bbe26d24913cedbca106468a5fb37a50c3",
-                "FixedBy": "1.34.1-r5"
+                "FixedBy": "1.34.1-r5",
+                "Location": "lib/apk/db/installed"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "alpine:3.16.0",
         "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
+        "username": "DOCKER_USERNAME",
+        "password": "DOCKER_PASSWORD",
         "source": "NVD",
-        "namespace": "alpine:v3.16",
+        "namespace": "alpine:3.16",
         "expected_features": [
             {
                 "Name": "apk-tools",
                 "NamespaceName": "alpine:v3.16",
-                "VersionFormat": "apk",
                 "Version": "2.12.9-r3",
-                "AddedBy": "sha256:2408cc74d12b6cd092bb8b516ba7d5e290f485d3eb9672efc00f0583730179e8"
+                "Arch": "x86_64",
+                "AddedBy": "sha256:2408cc74d12b6cd092bb8b516ba7d5e290f485d3eb9672efc00f0583730179e8",
+                "Location": "lib/apk/db/installed"
             },
             {
                 "Name": "busybox",
                 "NamespaceName": "alpine:v3.16",
-                "VersionFormat": "apk",
                 "Version": "1.35.0-r13",
+                "Arch": "x86_64",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2022-30065",
                         "NamespaceName": "alpine:v3.16",
                         "Description": "A use-after-free in Busybox 1.35-x's awk applet leads to denial of service and possibly code execution when processing a crafted awk pattern in the copyvar function.",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2022-30065",
-                        "Severity": "Important",
+                        "Severity": "Unspecified",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 6.4,
                                     "Score": 6.8,
                                     "Vectors": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 1.8,
-                                    "ImpactScore": 5.9,
                                     "Score": 7.8,
                                     "Vectors": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
                                 }
@@ -4194,31 +1003,28 @@
                     }
                 ],
                 "AddedBy": "sha256:2408cc74d12b6cd092bb8b516ba7d5e290f485d3eb9672efc00f0583730179e8",
-                "FixedBy": "1.35.0-r15"
+                "FixedBy": "1.35.0-r15",
+                "Location": "lib/apk/db/installed"
             },
             {
-                "Name": "openssl",
+                "Name": "libssl1.1",
                 "NamespaceName": "alpine:v3.16",
-                "VersionFormat": "apk",
                 "Version": "1.1.1o-r0",
+                "Arch": "x86_64",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2022-2097",
                         "NamespaceName": "alpine:v3.16",
-                        "Description": "AES OCB mode for 32-bit x86 platforms using the AES-NI assembly optimised implementation will not encrypt the entirety of the data under some circumstances. This could reveal sixteen bytes of data that was preexisting in the memory that wasn't written. In the special case of \"in place\" encryption, sixteen bytes of the plaintext would be revealed. Since OpenSSL does not support OCB based cipher suites for TLS and DTLS, they are both unaffected. Fixed in OpenSSL 3.0.5 (Affected 3.0.0-3.0.4). Fixed in OpenSSL 1.1.1q (Affected 1.1.1-1.1.1p).",
+                        "Description": "",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2022-2097",
-                        "Severity": "Moderate",
+                        "Severity": "Unspecified",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
                                     "Score": 5,
                                     "Vectors": "AV:N/AC:L/Au:N/C:P/I:N/A:N"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 1.4,
                                     "Score": 5.3,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
                                 }
@@ -4228,36 +1034,32 @@
                     }
                 ],
                 "AddedBy": "sha256:2408cc74d12b6cd092bb8b516ba7d5e290f485d3eb9672efc00f0583730179e8",
-                "FixedBy": "1.1.1v-r0"
+                "FixedBy": "1.1.1v-r0",
+                "Location": "lib/apk/db/installed"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "alpine:3.17.0",
         "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
+        "username": "DOCKER_USERNAME",
+        "password": "DOCKER_PASSWORD",
         "source": "NVD",
-        "namespace": "alpine:v3.17",
+        "namespace": "alpine:3.17",
         "expected_features": [
             {
                 "Name": "apk-tools",
                 "NamespaceName": "alpine:v3.17",
-                "VersionFormat": "apk",
                 "Version": "2.12.10-r1",
-                "AddedBy": "sha256:c158987b05517b6f2c5913f3acef1f2182a32345a304fe357e3ace5fadcad715"
+                "Arch": "x86_64",
+                "AddedBy": "sha256:c158987b05517b6f2c5913f3acef1f2182a32345a304fe357e3ace5fadcad715",
+                "Location": "lib/apk/db/installed"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "quay.io/rhacs-eng/qa:debian-package-removal",
@@ -4270,98 +1072,28 @@
             {
                 "Name": "dash",
                 "NamespaceName": "debian:11",
-                "VersionFormat": "dpkg",
                 "Version": "0.5.11+git20200708+dd9ef66-5",
+                "Arch": "amd64",
                 "AddedBy": "sha256:4c25b3090c2685271afcffc2a4db73f15ab11a0124bfcde6085c934a4e6f4a51",
-                "Executables": [
-                    {
-                        "path": "/bin/dash",
-                        "required_features": [
-                            {
-                                "name": "dash",
-                                "version": "0.5.11+git20200708+dd9ef66-5"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.31-13"
-                            }
-                        ]
-                    }
-                ]
+                "Location": "var/lib/dpkg/status"
             },
             {
                 "Name": "diffutils",
                 "NamespaceName": "debian:11",
-                "VersionFormat": "dpkg",
                 "Version": "1:3.7-5",
+                "Arch": "amd64",
                 "AddedBy": "sha256:4c25b3090c2685271afcffc2a4db73f15ab11a0124bfcde6085c934a4e6f4a51",
-                "Executables": [
-                    {
-                        "path": "/usr/bin/cmp",
-                        "required_features": [
-                            {
-                                "name": "diffutils",
-                                "version": "1:3.7-5"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.31-13"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/diff",
-                        "required_features": [
-                            {
-                                "name": "diffutils",
-                                "version": "1:3.7-5"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.31-13"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/diff3",
-                        "required_features": [
-                            {
-                                "name": "diffutils",
-                                "version": "1:3.7-5"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.31-13"
-                            }
-                        ]
-                    },
-                    {
-                        "path": "/usr/bin/sdiff",
-                        "required_features": [
-                            {
-                                "name": "diffutils",
-                                "version": "1:3.7-5"
-                            },
-                            {
-                                "name": "glibc",
-                                "version": "2.31-13"
-                            }
-                        ]
-                    }
-                ]
+                "Location": "var/lib/dpkg/status"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": false,
-        "check_provided_executables": true,
-        "required_feature_flag": null
+        "only_check_specified_vulns": false
     },
     {
-        "image": "docker.io/anchore/anchore-engine:v0.9.4",
+        "image": "anchore/anchore-engine:v0.9.4",
         "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
+        "username": "DOCKER_USERNAME",
+        "password": "DOCKER_PASSWORD",
         "source": "NVD",
         "namespace": "rhel:8",
         "expected_features": null,
@@ -4371,252 +1103,7 @@
                 "Version": "0.8.0"
             }
         ],
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
-    },
-    {
-        "image": "elastic/logstash:7.13.3",
-        "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
-        "source": "NVD",
-        "namespace": "centos:7",
-        "expected_features": [
-            {
-                "Name": "log4j",
-                "VersionFormat": "JavaSourceType",
-                "Version": "2.9.1",
-                "Vulnerabilities": [
-                    {
-                        "Name": "CVE-2020-9488",
-                        "Description": "Improper validation of certificate with host mismatch in Apache Log4j SMTP appender. This could allow an SMTPS connection to be intercepted by a man-in-the-middle attack which could leak any log messages sent through that appender. Fixed in Apache Log4j 2.12.3 and 2.13.1",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-9488",
-                        "Severity": "Low",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 2.9,
-                                    "Score": 4.3,
-                                    "Vectors": "AV:N/AC:M/Au:N/C:P/I:N/A:N"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 1.4,
-                                    "Score": 3.7,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N"
-                                }
-                            }
-                        },
-                        "FixedBy": "2.12.3"
-                    },
-                    {
-                        "Name": "CVE-2021-44228",
-                        "Description": "In Apache Log4j2 versions up to and including 2.14.1 (excluding security release 2.12.2), the JNDI features used in configurations, log messages, and parameters do not protect against attacker-controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-44228",
-                        "Severity": "Critical",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 6,
-                                    "Score": 10,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
-                                }
-                            }
-                        },
-                        "FixedBy": "2.12.2"
-                    },
-                    {
-                        "Name": "CVE-2021-44832",
-                        "Description": "Apache Log4j2 versions 2.0-beta7 through 2.17.0 (excluding security fix releases 2.3.2 and 2.12.4) are vulnerable to a remote code execution (RCE) attack when a configuration uses a JDBC Appender with a JNDI LDAP data source URI when an attacker has control of the target LDAP server. This issue is fixed by limiting JNDI data source names to the java protocol in Log4j2 versions 2.17.1, 2.12.4, and 2.3.2.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-44832",
-                        "Severity": "Moderate",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 6.8,
-                                    "ImpactScore": 10,
-                                    "Score": 8.5,
-                                    "Vectors": "AV:N/AC:M/Au:S/C:C/I:C/A:C"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 0.7,
-                                    "ImpactScore": 5.9,
-                                    "Score": 6.6,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H"
-                                }
-                            }
-                        },
-                        "FixedBy": "2.12.4"
-                    },
-                    {
-                        "Name": "CVE-2021-45046",
-                        "Description": "It was found that the fix to address CVE-2021-44228 in Apache Log4j 2.15.0 was incomplete in certain non-default configurations. When the logging configuration uses a non-default Pattern Layout with a Context Lookup (for example, $${ctx:loginId}), attackers with control over Thread Context Map (MDC) input data can craft malicious input data using a JNDI Lookup pattern, resulting in an information leak and remote code execution in some environments and local code execution in all environments; remote code execution has been demonstrated on macOS but no other tested environments.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-45046",
-                        "Severity": "Critical",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 6,
-                                    "Score": 9,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
-                                }
-                            }
-                        },
-                        "FixedBy": "2.12.2"
-                    },
-                    {
-                        "Name": "CVE-2021-45105",
-                        "Description": "Apache Log4j2 versions 2.0-alpha1 through 2.16.0 did not protect from uncontrolled recursion from self-referential lookups. When the logging configuration uses a non-default Pattern Layout with a Context Lookup (for example, $${ctx:loginId}), attackers with control over Thread Context Map (MDC) input data can craft malicious input data that contains a recursive lookup, resulting in a StackOverflowError that will terminate the process. This is also known as a DOS (Denial of Service) attack.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-45105",
-                        "Severity": "Moderate",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 3.6,
-                                    "Score": 5.9,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                                }
-                            }
-                        },
-                        "FixedBy": "2.12.3"
-                    }
-                ],
-                "AddedBy": "sha256:c46de89b745ad8ba4400323d4ebc230a4b88cbbdbc92a862c92a743478abd617",
-                "Location": "usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-input-tcp-6.0.10-java/vendor/jar-dependencies/org/logstash/inputs/logstash-input-tcp/6.0.10/logstash-input-tcp-6.0.10.jar:log4j-core",
-                "FixedBy": "2.12.4"
-            },
-            {
-                "Name": "log4j",
-                "VersionFormat": "JavaSourceType",
-                "Version": "2.14.0",
-                "Vulnerabilities": [
-                    {
-                        "Name": "CVE-2021-44228",
-                        "Description": "In Apache Log4j2 versions up to and including 2.14.1 (excluding security release 2.12.2), the JNDI features used in configurations, log messages, and parameters do not protect against attacker-controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-44228",
-                        "Severity": "Critical",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 6,
-                                    "Score": 10,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
-                                }
-                            }
-                        },
-                        "FixedBy": "2.15.0"
-                    },
-                    {
-                        "Name": "CVE-2021-44832",
-                        "Description": "Apache Log4j2 versions 2.0-beta7 through 2.17.0 (excluding security fix releases 2.3.2 and 2.12.4) are vulnerable to a remote code execution (RCE) attack when a configuration uses a JDBC Appender with a JNDI LDAP data source URI when an attacker has control of the target LDAP server. This issue is fixed by limiting JNDI data source names to the java protocol in Log4j2 versions 2.17.1, 2.12.4, and 2.3.2.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-44832",
-                        "Severity": "Moderate",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 6.8,
-                                    "ImpactScore": 10,
-                                    "Score": 8.5,
-                                    "Vectors": "AV:N/AC:M/Au:S/C:C/I:C/A:C"
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 0.7,
-                                    "ImpactScore": 5.9,
-                                    "Score": 6.6,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H"
-                                }
-                            }
-                        },
-                        "FixedBy": "2.17.1"
-                    },
-                    {
-                        "Name": "CVE-2021-45046",
-                        "Description": "It was found that the fix to address CVE-2021-44228 in Apache Log4j 2.15.0 was incomplete in certain non-default configurations. When the logging configuration uses a non-default Pattern Layout with a Context Lookup (for example, $${ctx:loginId}), attackers with control over Thread Context Map (MDC) input data can craft malicious input data using a JNDI Lookup pattern, resulting in an information leak and remote code execution in some environments and local code execution in all environments; remote code execution has been demonstrated on macOS but no other tested environments.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-45046",
-                        "Severity": "Critical",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 6,
-                                    "Score": 9,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
-                                }
-                            }
-                        },
-                        "FixedBy": "2.16.0"
-                    },
-                    {
-                        "Name": "CVE-2021-45105",
-                        "Description": "Apache Log4j2 versions 2.0-alpha1 through 2.16.0 did not protect from uncontrolled recursion from self-referential lookups. When the logging configuration uses a non-default Pattern Layout with a Context Lookup (for example, $${ctx:loginId}), attackers with control over Thread Context Map (MDC) input data can craft malicious input data that contains a recursive lookup, resulting in a StackOverflowError that will terminate the process. This is also known as a DOS (Denial of Service) attack.",
-                        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-45105",
-                        "Severity": "Moderate",
-                        "Metadata": {
-                            "NVD": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 3.6,
-                                    "Score": 5.9,
-                                    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                                }
-                            }
-                        },
-                        "FixedBy": "2.17.0"
-                    }
-                ],
-                "AddedBy": "sha256:c46de89b745ad8ba4400323d4ebc230a4b88cbbdbc92a862c92a743478abd617",
-                "Location": "usr/share/logstash/logstash-core/lib/jars/log4j-core-2.14.0.jar",
-                "FixedBy": "2.17.1"
-            }
-        ],
-        "unexpected_features": null,
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": false
     },
     {
         "image": "quay.io/rhacs-eng/qa:sandbox-log4j-2-12-2",
@@ -4627,26 +1114,22 @@
         "namespace": "ubuntu:20.04",
         "expected_features": [
             {
-                "Name": "log4j",
-                "VersionFormat": "JavaSourceType",
+                "Name": "org.apache.logging.log4j:log4j-core",
                 "Version": "2.12.2",
+                "Arch": "",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2020-9488",
-                        "Description": "Improper validation of certificate with host mismatch in Apache Log4j SMTP appender. This could allow an SMTPS connection to be intercepted by a man-in-the-middle attack which could leak any log messages sent through that appender. Fixed in Apache Log4j 2.12.3 and 2.13.1",
+                        "Description": "Improper validation of certificate with host mismatch in Apache Log4j SMTP appender",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-9488",
                         "Severity": "Low",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 8.6,
-                                    "ImpactScore": 2.9,
                                     "Score": 4.3,
                                     "Vectors": "AV:N/AC:M/Au:N/C:P/I:N/A:N"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 1.4,
                                     "Score": 3.7,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N"
                                 }
@@ -4656,20 +1139,16 @@
                     },
                     {
                         "Name": "CVE-2021-44832",
-                        "Description": "Apache Log4j2 versions 2.0-beta7 through 2.17.0 (excluding security fix releases 2.3.2 and 2.12.4) are vulnerable to a remote code execution (RCE) attack when a configuration uses a JDBC Appender with a JNDI LDAP data source URI when an attacker has control of the target LDAP server. This issue is fixed by limiting JNDI data source names to the java protocol in Log4j2 versions 2.17.1, 2.12.4, and 2.3.2.",
+                        "Description": "Improper Input Validation and Injection in Apache Log4j2",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-44832",
                         "Severity": "Moderate",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 6.8,
-                                    "ImpactScore": 10,
                                     "Score": 8.5,
                                     "Vectors": "AV:N/AC:M/Au:S/C:C/I:C/A:C"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 0.7,
-                                    "ImpactScore": 5.9,
                                     "Score": 6.6,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H"
                                 }
@@ -4679,20 +1158,16 @@
                     },
                     {
                         "Name": "CVE-2021-45105",
-                        "Description": "Apache Log4j2 versions 2.0-alpha1 through 2.16.0 did not protect from uncontrolled recursion from self-referential lookups. When the logging configuration uses a non-default Pattern Layout with a Context Lookup (for example, $${ctx:loginId}), attackers with control over Thread Context Map (MDC) input data can craft malicious input data that contains a recursive lookup, resulting in a StackOverflowError that will terminate the process. This is also known as a DOS (Denial of Service) attack.",
+                        "Description": "Apache Log4j2 vulnerable to Improper Input Validation and Uncontrolled Recursion",
                         "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-45105",
-                        "Severity": "Moderate",
+                        "Severity": "Important",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 3.6,
                                     "Score": 5.9,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
@@ -4702,24 +1177,10 @@
                     }
                 ],
                 "AddedBy": "sha256:d84ba7ea7803fa43fca06730523d264b31c562968cfd7020f0584f5ec1b26225",
-                "Location": "log4j-core-2.12.2.jar",
+                "Location": "maven:log4j-core-2.12.2.jar",
                 "FixedBy": "2.12.4"
             }
         ],
-        "unexpected_features": null,
-        "only_check_specified_vulns": false,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
-    },
-    {
-        "image": "docker.io/busybox:1.35.0",
-        "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
-        "source": "NVD",
-        "namespace": "busybox:1.35.0",
-        "expected_features": null,
         "unexpected_features": null,
         "only_check_specified_vulns": false,
         "uncertified_rhel": false,
@@ -4732,12 +1193,13 @@
         "username": "QUAY_RHACS_ENG_RO_USERNAME",
         "password": "QUAY_RHACS_ENG_RO_PASSWORD",
         "source": "NVD",
-        "namespace": "alpine:v3.15",
+        "namespace": "alpine:3.15",
         "expected_features": [
             {
                 "Name": "spring-webmvc",
-                "VersionFormat": "JavaSourceType",
+                "NamespaceName": "alpine:3.15",
                 "Version": "5.3.17",
+                "Arch": "",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2022-22965",
@@ -4747,14 +1209,10 @@
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 5.9,
                                     "Score": 9.8,
                                     "Vectors": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 }
@@ -4764,7 +1222,7 @@
                     }
                 ],
                 "AddedBy": "sha256:bb57a75650ced8dd9ff54ca55ab34a150a7cb7b68258064056e65e0b2a9c3320",
-                "Location": "app/demo-0.0.1-SNAPSHOT.war:WEB-INF/lib/spring-webmvc-5.3.17.jar",
+                "Location": "jar:app/demo-0.0.1-SNAPSHOT.war",
                 "FixedBy": "5.3.18"
             }
         ],
@@ -4780,12 +1238,13 @@
         "username": "QUAY_RHACS_ENG_RO_USERNAME",
         "password": "QUAY_RHACS_ENG_RO_PASSWORD",
         "source": "NVD",
-        "namespace": "alpine:v3.15",
+        "namespace": "alpine:3.15",
         "expected_features": [
             {
                 "Name": "spring-webflux",
-                "VersionFormat": "JavaSourceType",
+                "NamespaceName": "alpine:3.15",
                 "Version": "5.3.17",
+                "Arch": "",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2022-22965",
@@ -4795,14 +1254,10 @@
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 5.9,
                                     "Score": 9.8,
                                     "Vectors": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 }
@@ -4812,7 +1267,7 @@
                     }
                 ],
                 "AddedBy": "sha256:f7edbdbbb0752d6ec06c7098cc966e7b36edf216a72c4d8c074ecf0d3a363b85",
-                "Location": "app/demo-0.0.1-SNAPSHOT.war:WEB-INF/lib/spring-webflux-5.3.17.jar",
+                "Location": "jar:app/demo-0.0.1-SNAPSHOT.war",
                 "FixedBy": "5.3.18"
             }
         ],
@@ -4828,12 +1283,13 @@
         "username": "QUAY_RHACS_ENG_RO_USERNAME",
         "password": "QUAY_RHACS_ENG_RO_PASSWORD",
         "source": "NVD",
-        "namespace": "alpine:v3.15",
+        "namespace": "alpine:3.15",
         "expected_features": [
             {
-                "Name": "spring-cloud-function-core",
-                "VersionFormat": "JavaSourceType",
+                "Name": "org.springframework.cloud:spring-cloud-function-core",
+                "NamespaceName": "alpine:3.15",
                 "Version": "3.2.2",
+                "Arch": "",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2022-22963",
@@ -4843,14 +1299,10 @@
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 5.9,
                                     "Score": 9.8,
                                     "Vectors": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 }
@@ -4860,156 +1312,82 @@
                     }
                 ],
                 "AddedBy": "sha256:f26cc7bc44e4f9b8969a0a95040d484ab301b3e56d1fb1eda8a79bf7e089f24e",
-                "Location": "app/demo-0.0.1-SNAPSHOT.war:WEB-INF/lib/spring-cloud-function-core-3.2.2.jar",
+                "Location": "maven:app/demo-0.0.1-SNAPSHOT.war",
                 "FixedBy": "3.2.3"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "ubuntu:22.04@sha256:cd3d86f1fb368c6a53659d467560010ab9e0695528127ea336fe32f68f7ba09f",
         "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
+        "username": "DOCKER_USERNAME",
+        "password": "DOCKER_PASSWORD",
         "source": "NVD",
         "namespace": "ubuntu:22.04",
         "expected_features": [
             {
                 "Name": "adduser",
                 "NamespaceName": "ubuntu:22.04",
-                "VersionFormat": "dpkg",
                 "Version": "3.118ubuntu5",
-                "AddedBy": "sha256:6fa1296f44090f6150dfb96d6ae217a58b9d66c56d7a986c35657df6bd1a89f0"
+                "Arch": "all",
+                "AddedBy": "sha256:6fa1296f44090f6150dfb96d6ae217a58b9d66c56d7a986c35657df6bd1a89f0",
+                "Location": "var/lib/dpkg/status"
             },
             {
                 "Name": "apt",
+                "Arch": "amd64",
                 "NamespaceName": "ubuntu:22.04",
-                "VersionFormat": "dpkg",
                 "Version": "2.4.5",
-                "AddedBy": "sha256:6fa1296f44090f6150dfb96d6ae217a58b9d66c56d7a986c35657df6bd1a89f0"
+                "AddedBy": "sha256:6fa1296f44090f6150dfb96d6ae217a58b9d66c56d7a986c35657df6bd1a89f0",
+                "Location": "var/lib/dpkg/status"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "ubuntu:22.10@sha256:4f9ec2c0aa321966bfe625bc485aa1d6e96549679cfdf98bb404dfcb8e141a7f",
         "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
+        "username": "DOCKER_USERNAME",
+        "password": "DOCKER_PASSWORD",
         "source": "NVD",
         "namespace": "ubuntu:22.10",
         "expected_features": [
             {
                 "Name": "adduser",
+                "Arch": "all",
                 "NamespaceName": "ubuntu:22.10",
-                "VersionFormat": "dpkg",
                 "Version": "3.121ubuntu1",
-                "AddedBy": "sha256:bcd446fbf8a137bbf135b63332ebcd0c3e9880060bc5b41962fbbb07e94062b7"
+                "Arch": "all",
+                "AddedBy": "sha256:bcd446fbf8a137bbf135b63332ebcd0c3e9880060bc5b41962fbbb07e94062b7",
+                "Location": "var/lib/dpkg/status"
             },
             {
                 "Name": "apt",
+                "Arch": "amd64",
                 "NamespaceName": "ubuntu:22.10",
-                "VersionFormat": "dpkg",
                 "Version": "2.5.3",
-                "AddedBy": "sha256:bcd446fbf8a137bbf135b63332ebcd0c3e9880060bc5b41962fbbb07e94062b7"
+                "Arch": "amd64",
+                "AddedBy": "sha256:bcd446fbf8a137bbf135b63332ebcd0c3e9880060bc5b41962fbbb07e94062b7",
+                "Location": "var/lib/dpkg/status"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
-    },
-    {
-        "image": "quay.io/rhacs-eng/qa:ansibleplaybookbundle--gluster-s3object-apb--481960439934084fb041431f27cb98b89666e1a0daaeb2078bcbe1209790368c",
-        "registry": "https://quay.io",
-        "username": "QUAY_RHACS_ENG_RO_USERNAME",
-        "password": "QUAY_RHACS_ENG_RO_PASSWORD",
-        "source": "Red Hat",
-        "namespace": "centos:7",
-        "expected_features": [
-            {
-                "Name": "ncurses-base",
-                "NamespaceName": "centos:7",
-                "VersionFormat": "rpm",
-                "Version": "5.9-14.20130511.el7_4",
-                "Vulnerabilities": [
-                    {
-                        "Name": "CVE-2017-10684",
-                        "NamespaceName": "centos:7",
-                        "Description": "DOCUMENTATION: The MITRE CVE dictionary describes this issue as: In ncurses 6.0, there is a stack-based buffer overflow in the fmt_entry function. A crafted input will lead to a remote arbitrary code execution attack.              STATEMENT: Red Hat Product Security has rated this issue as having Moderate security impact. This issue is not currently planned to be addressed in future updates. For additional information, refer to the Issue Severity Classification: https://access.redhat.com/security/updates/classification/.",
-                        "Link": "https://access.redhat.com/security/cve/CVE-2017-10684",
-                        "Severity": "Moderate",
-                        "Metadata": {
-                            "Red Hat": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 1,
-                                    "ImpactScore": 4.2,
-                                    "Score": 5.3,
-                                    "Vectors": "CVSS:3.0/AV:L/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:H"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "Name": "CVE-2017-10685",
-                        "NamespaceName": "centos:7",
-                        "Description": "DOCUMENTATION: The MITRE CVE dictionary describes this issue as: In ncurses 6.0, there is a format string vulnerability in the fmt_entry function. A crafted input will lead to a remote arbitrary code execution attack.              STATEMENT: Red Hat considers this issue as a duplicate of CVE-2017-10684.",
-                        "Link": "https://access.redhat.com/security/cve/CVE-2017-10685",
-                        "Severity": "Moderate",
-                        "Metadata": {
-                            "Red Hat": {
-                                "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
-                                    "Score": 0,
-                                    "Vectors": ""
-                                },
-                                "CVSSv3": {
-                                    "ExploitabilityScore": 2.5,
-                                    "ImpactScore": 0,
-                                    "Score": 0,
-                                    "Vectors": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
-                                }
-                            }
-                        }
-                    }
-                ],
-                "AddedBy": "sha256:7dc0dca2b1516961d6b3200564049db0a6e0410b370bb2189e2efae0d368616f"
-            }
-        ],
-        "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "registry.access.redhat.com/ubi9/ubi:9.0.0-1576@sha256:f22a438f4967419bd477c648d25ed0627f54b81931d0143dc45801c8356bd379",
         "registry": "https://registry.access.redhat.com",
-        "username": "",
-        "password": "",
+        "username": "DOCKER_USERNAME",
+        "password": "DOCKER_PASSWORD",
         "source": "Red Hat",
         "namespace": "rhel:9",
         "expected_features": [
             {
                 "Name": "openssl",
                 "NamespaceName": "rhel:9",
-                "VersionFormat": "rpm",
                 "Version": "1:3.0.1-23.el9_0",
                 "Arch": "x86_64",
                 "Vulnerabilities": [
@@ -5022,14 +1400,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
@@ -5039,12 +1413,12 @@
                     }
                 ],
                 "AddedBy": "sha256:2412e60e610160d090f7e974a208c6ffd26b2d530361b7c9aa8967e160ac7996",
-                "FixedBy": "1:3.0.7-16.el9_2"
+                "FixedBy": "1:3.0.7-16.el9_2",
+                "Location": "sqlite:var/lib/rpm"
             },
             {
                 "Name": "openssl-libs",
                 "NamespaceName": "rhel:9",
-                "VersionFormat": "rpm",
                 "Version": "1:3.0.1-23.el9_0",
                 "Arch": "x86_64",
                 "Vulnerabilities": [
@@ -5057,14 +1431,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
@@ -5074,20 +1444,20 @@
                     }
                 ],
                 "AddedBy": "sha256:2412e60e610160d090f7e974a208c6ffd26b2d530361b7c9aa8967e160ac7996",
-                "FixedBy": "1:3.0.7-16.el9_2"
+                "FixedBy": "1:3.0.7-16.el9_2",
+                "Location": "sqlite:var/lib/rpm"
             },
             {
                 "Name": "python3-urllib3",
                 "NamespaceName": "rhel:9",
-                "VersionFormat": "rpm",
                 "Version": "1.26.5-3.el9",
                 "Arch": "noarch",
-                "AddedBy": "sha256:2412e60e610160d090f7e974a208c6ffd26b2d530361b7c9aa8967e160ac7996"
+                "AddedBy": "sha256:2412e60e610160d090f7e974a208c6ffd26b2d530361b7c9aa8967e160ac7996",
+                "Location": "sqlite:var/lib/rpm"
             },
             {
                 "Name": "vim-minimal",
                 "NamespaceName": "rhel:9",
-                "VersionFormat": "rpm",
                 "Version": "2:8.2.2637-16.el9_0.2",
                 "Arch": "x86_64",
                 "Vulnerabilities": [
@@ -5100,14 +1470,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 1.8,
-                                    "ImpactScore": 5.9,
                                     "Score": 7.8,
                                     "Vectors": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
                                 }
@@ -5117,7 +1483,8 @@
                     }
                 ],
                 "AddedBy": "sha256:2412e60e610160d090f7e974a208c6ffd26b2d530361b7c9aa8967e160ac7996",
-                "FixedBy": "2:8.2.2637-20.el9_1"
+                "FixedBy": "2:8.2.2637-20.el9_1",
+                "Location": "sqlite:var/lib/rpm"
             }
         ],
         "unexpected_features": [
@@ -5127,10 +1494,7 @@
                 "Location": "usr/lib/python3.9/site-packages/urllib3-1.26.5-py3.9.egg-info/PKG-INFO"
             }
         ],
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "quay.io/rhacs-eng/qa:sandbox-dotnet-60-runtime-6.0-15.20220620151726",
@@ -5143,7 +1507,6 @@
             {
                 "Name": "aspnetcore-runtime-6.0",
                 "NamespaceName": "rhel:8",
-                "VersionFormat": "rpm",
                 "Version": "6.0.6-1.el8_6",
                 "Arch": "x86_64",
                 "Vulnerabilities": [
@@ -5156,14 +1519,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.8,
-                                    "ImpactScore": 5.8,
                                     "Score": 9.3,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N"
                                 }
@@ -5173,12 +1532,12 @@
                     }
                 ],
                 "AddedBy": "sha256:16e1dc59de605089610e3be2c77f3cde5eed99b523a0d7a3e3a2f65fa7c60723",
-                "FixedBy": "6.0.22-1.el8_8"
+                "FixedBy": "0:6.0.22-1.el8_8",
+                "Location": "bdb:var/lib/rpm"
             },
             {
                 "Name": "dotnet-runtime-6.0",
                 "NamespaceName": "rhel:8",
-                "VersionFormat": "rpm",
                 "Version": "6.0.6-1.el8_6",
                 "Arch": "x86_64",
                 "Vulnerabilities": [
@@ -5191,14 +1550,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.8,
-                                    "ImpactScore": 5.8,
                                     "Score": 9.3,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N"
                                 }
@@ -5208,17 +1563,14 @@
                     }
                 ],
                 "AddedBy": "sha256:16e1dc59de605089610e3be2c77f3cde5eed99b523a0d7a3e3a2f65fa7c60723",
-                "FixedBy": "6.0.22-1.el8_8"
+                "FixedBy": "0:6.0.22-1.el8_8",
+                "Location": "bdb:var/lib/rpm"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
-        "disabled_reason": "ROX-20730: CVE-2022-22978 not found",
         "image": "quay.io/rhacs-eng/qa:spring-CVE-2022-22978",
         "registry": "https://quay.io",
         "username": "QUAY_RHACS_ENG_RO_USERNAME",
@@ -5227,9 +1579,9 @@
         "namespace": "rhel:8",
         "expected_features": [
             {
-                "Name": "org.springframework.security:spring-security-web",
-                "VersionFormat": "JavaSourceType",
+                "Name": "spring-security-web",
                 "Version": "5.5.5",
+                "Arch": "",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2022-22978",
@@ -5239,14 +1591,10 @@
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 4.2,
                                     "Score": 8.2,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N"
                                 }
@@ -5256,15 +1604,12 @@
                     }
                 ],
                 "AddedBy": "sha256:5b6e3ce9721946e142ba43e488385ee4d323204a6052e0f20352d89ac00cafa2",
-                "Location": "application/app.jar:BOOT-INF/lib/spring-security-web-5.5.5.jar",
+                "Location": "jar:application/app.jar",
                 "FixedBy": "5.5.7"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "quay.io/rhacs-eng/qa:ubuntu-22.04-openssl",
@@ -5277,67 +1622,57 @@
             {
                 "Name": "openssl",
                 "NamespaceName": "ubuntu:22.04",
-                "VersionFormat": "dpkg",
                 "Version": "3.0.2-0ubuntu1.6",
+                "Arch": "amd64",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2022-3602",
                         "NamespaceName": "ubuntu:22.04",
-                        "Description": "A buffer overrun can be triggered in X.509 certificate verification, specifically in name constraint checking. Note that this occurs after certificate chain signature verification and requires either a CA to have signed the malicious certificate or for the application to continue certificate verification despite failure to construct a path to a trusted issuer. An attacker can craft a malicious email address to overflow four attacker-controlled bytes on the stack. This buffer overflow could result in a crash (causing a denial of service) or potentially remote code execution. Many platforms implement stack overflow protections which would mitigate against the risk of remote code execution. The risk may be further mitigated based on stack layout for any given platform/compiler. Pre-announcements of CVE-2022-3602 described this issue as CRITICAL. Further analysis based on some of the mitigating factors described above have led this to be downgraded to HIGH. Users are still encouraged to upgrade to a new version as soon as possible. In a TLS client, this can be triggered by connecting to a malicious server. In a TLS server, this can be triggered if the server requests client authentication and a malicious client connects. Fixed in OpenSSL 3.0.7 (Affected 3.0.0,3.0.1,3.0.2,3.0.3,3.0.4,3.0.5,3.0.6).",
+                        "Description": "A buffer overrun can be triggered in X.509 certificate verification,specifically in name constraint checking. Note that this occurs aftercertificate chain signature verification and requires either a CA to havesigned the malicious certificate or for the application to continuecertificate verification despite failure to construct a path to a trustedissuer. An attacker can craft a malicious email address to overflow fourattacker-controlled bytes on the stack. This buffer overflow could resultin a crash (causing a denial of service) or potentially remote codeexecution. Many platforms implement stack overflow protections which wouldmitigate against the risk of remote code execution. The risk may be furthermitigated based on stack layout for any given platform/compiler.Pre-announcements of CVE-2022-3602 described this issue as CRITICAL.Further analysis based on some of the mitigating factors described abovehave led this to be downgraded to HIGH. Users are still encouraged toupgrade to a new version as soon as possible. In a TLS client, this can betriggered by connecting to a malicious server. In a TLS server, this can betriggered if the server requests client authentication and a maliciousclient connects. Fixed in OpenSSL 3.0.7 (Affected3.0.0,3.0.1,3.0.2,3.0.3,3.0.4,3.0.5,3.0.6).\n\n    Update Instructions:\n\n    Run `sudo pro fix CVE-2022-3602` to fix the vulnerability. The problem can be corrected\n    by updating your system to the following package versions:\n\nlibssl3 - 3.0.2-0ubuntu1.7\nopenssl - 3.0.2-0ubuntu1.7\nNo subscription required",
                         "Link": "https://ubuntu.com/security/CVE-2022-3602",
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
                             }
                         },
-                        "FixedBy": "3.0.2-0ubuntu1.7"
+                        "FixedBy": "0:3.0.2-0ubuntu1.7"
                     },
                     {
                         "Name": "CVE-2022-3786",
                         "NamespaceName": "ubuntu:22.04",
-                        "Description": "A buffer overrun can be triggered in X.509 certificate verification, specifically in name constraint checking. Note that this occurs after certificate chain signature verification and requires either a CA to have signed a malicious certificate or for an application to continue certificate verification despite failure to construct a path to a trusted issuer. An attacker can craft a malicious email address in a certificate to overflow an arbitrary number of bytes containing the `.' character (decimal 46) on the stack. This buffer overflow could result in a crash (causing a denial of service). In a TLS client, this can be triggered by connecting to a malicious server. In a TLS server, this can be triggered if the server requests client authentication and a malicious client connects.",
+                        "Description": "A buffer overrun can be triggered in X.509 certificate verification,specifically in name constraint checking. Note that this occurs aftercertificate chain signature verification and requires either a CA to havesigned a malicious certificate or for an application to continuecertificate verification despite failure to construct a path to a trustedissuer. An attacker can craft a malicious email address in a certificate tooverflow an arbitrary number of bytes containing the `.' character (decimal46) on the stack. This buffer overflow could result in a crash (causing adenial of service). In a TLS client, this can be triggered by connecting toa malicious server. In a TLS server, this can be triggered if the serverrequests client authentication and a malicious client connects.\n\n    Update Instructions:\n\n    Run `sudo pro fix CVE-2022-3786` to fix the vulnerability. The problem can be corrected\n    by updating your system to the following package versions:\n\nlibssl3 - 3.0.2-0ubuntu1.7\nopenssl - 3.0.2-0ubuntu1.7\nNo subscription required",
                         "Link": "https://ubuntu.com/security/CVE-2022-3786",
                         "Severity": "Important",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
                             }
                         },
-                        "FixedBy": "3.0.2-0ubuntu1.7"
+                        "FixedBy": "0:3.0.2-0ubuntu1.7"
                     }
                 ],
                 "AddedBy": "sha256:301a8b74f71f85f3a31e9c7e7fedd5b001ead5bcf895bc2911c1d260e06bd987",
-                "FixedBy": "3.0.2-0ubuntu1.10"
+                "Location": "var/lib/dpkg/status",
+                "FixedBy": "0:3.0.2-0ubuntu1.10"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "quay.io/rhacs-eng/qa:ubuntu-22.10-openssl",
@@ -5349,21 +1684,18 @@
         "expected_features": [
             {
                 "Name": "openssl",
+                "Arch": "amd64",
                 "NamespaceName": "ubuntu:22.10",
-                "VersionFormat": "dpkg",
                 "Version": "3.0.5-2ubuntu2",
                 "AddedBy": "sha256:2b441754735ea7decb684ef19d54115fc309c270fe7b87ed36aa3773ce50b78b",
+                "Location": "var/lib/dpkg/status",
                 "FixedBy": "3.0.5-2ubuntu2.3"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
-        "disabled_reason": "ROX-20730: CVE-2021-26291 not found",
         "image": "quay.io/rhacs-eng/qa:ose-jenkins",
         "registry": "https://quay.io",
         "username": "QUAY_RHACS_ENG_RO_USERNAME",
@@ -5374,7 +1706,6 @@
             {
                 "Name": "jenkins-2-plugins",
                 "NamespaceName": "rhel:8",
-                "VersionFormat": "rpm",
                 "Version": "4.10.1650890594-1.el8",
                 "Arch": "noarch",
                 "Vulnerabilities": [
@@ -5387,14 +1718,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.2,
-                                    "ImpactScore": 5.2,
                                     "Score": 7.4,
                                     "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
                                 }
@@ -5410,14 +1737,10 @@
                         "Metadata": {
                             "Red Hat": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
                                 }
@@ -5427,14 +1750,12 @@
                     }
                 ],
                 "AddedBy": "sha256:3fa3f612bdcb92746bf76be1b9c9e1c1c80de777aedaf48b7068f4a129ded3c2",
-                "FixedBy": "4.10.1685679861-1.el8"
+                "Location": "bdb:var/lib/rpm",
+                "FixedBy": "0:4.10.1685679861-1.el8"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "gcr.io/distroless/static-debian11@sha256:a01d47d4036cae5a67a9619e3d06fa14a6811a2247b4da72b4233ece4efebd57",
@@ -5447,16 +1768,14 @@
             {
                 "Name": "tzdata",
                 "NamespaceName": "debian:11",
-                "VersionFormat": "dpkg",
                 "Version": "2021a-1+deb11u9",
-                "AddedBy": "sha256:fff4e558ad3a0d44f9ec0bf32771df4a102c6d93fce253dd3eb6657865b78a49"
+                "Arch": "all",
+                "AddedBy": "sha256:fff4e558ad3a0d44f9ec0bf32771df4a102c6d93fce253dd3eb6657865b78a49",
+                "Location": "var/lib/dpkg/status.d/tzdata"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "quay.io/rhacs-eng/qa:drools-CVE-2021-41411",
@@ -5469,8 +1788,8 @@
             {
                 "Name": "org.drools:drools-core",
                 "NamespaceName": "rhel:8",
-                "VersionFormat": "JavaSourceType",
                 "Version": "6.4.0.Final",
+                "Arch": "",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2021-41411",
@@ -5480,14 +1799,10 @@
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 6.4,
                                     "Score": 7.5,
                                     "Vectors": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 5.9,
                                     "Score": 9.8,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                 }
@@ -5497,15 +1812,12 @@
                     }
                 ],
                 "AddedBy": "sha256:3078c14ffbc62cd9a56f8951d08d6b55a45394fbb5a0aa8f9eca1b1472e3f21d",
-                "Location": "org.drools.drools-core-6.4.0.Final.jar:drools-core",
+                "Location": "maven:org.drools.drools-core-6.4.0.Final.jar",
                 "FixedBy": "7.60.0.Final"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "quay.io/rhacs-eng/qa:tomcat-9.0.59",
@@ -5513,12 +1825,13 @@
         "username": "QUAY_RHACS_ENG_RO_USERNAME",
         "password": "QUAY_RHACS_ENG_RO_PASSWORD",
         "source": "NVD",
-        "namespace": "alpine:v3.15",
+        "namespace": "alpine:3.15",
         "expected_features": [
             {
-                "Name": "tomcat",
-                "VersionFormat": "JavaSourceType",
+                "Name": "org.apache.tomcat-embed-core:tomcat-embed-core",
+                "NamespaceName": "alpine:3.15",
                 "Version": "9.0.59",
+                "Arch": "",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2022-29885",
@@ -5528,14 +1841,10 @@
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 10,
-                                    "ImpactScore": 2.9,
                                     "Score": 5,
                                     "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
@@ -5550,14 +1859,10 @@
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 2.8,
-                                    "ImpactScore": 1.4,
                                     "Score": 4.3,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N"
                                 }
@@ -5567,59 +1872,52 @@
                     }
                 ],
                 "AddedBy": "sha256:97444f2bde8fa4fdfb6ec630b24fbdf95017c6813f4b5e68e64a4280b276eff2",
-                "Location": "tomcat-embed-core-9.0.59.jar",
+                "Location": "jar:tomcat-embed-core-9.0.59.jar",
                 "FixedBy": "9.0.72"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "alpine:3.18.3",
         "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
+        "username": "DOCKER_USERNAME",
+        "password": "DOCKER_PASSWORD",
         "source": "NVD",
-        "namespace": "alpine:v3.18",
+        "namespace": "alpine:3.18",
         "expected_features": [
             {
                 "Name": "apk-tools",
-                "NamespaceName": "alpine:v3.18",
-                "VersionFormat": "apk",
+                "NamespaceName": "alpine:3.18",
                 "Version": "2.14.0-r2",
-                "AddedBy": "sha256:7264a8db6415046d36d16ba98b79778e18accee6ffa71850405994cffa9be7de"
+                "Arch": "x86_64",
+                "AddedBy": "sha256:7264a8db6415046d36d16ba98b79778e18accee6ffa71850405994cffa9be7de",
+                "Location": "lib/apk/db/installed"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
-        "image": "debian:12.0",
+        "image": "docker.io/library/debian:12.0",
         "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
+        "username": "DOCKER_USERNAME",
+        "password": "DOCKER_PASSWORD",
         "source": "NVD",
         "namespace": "debian:12",
         "expected_features": [
             {
                 "Name": "base-files",
                 "NamespaceName": "debian:12",
-                "VersionFormat": "dpkg",
                 "Version": "12.4",
-                "AddedBy": "sha256:d52e4f012db158bb7c0fe215b98af1facaddcbaee530efd69b1bae07d597b711"
+                "Arch": "amd64",
+                "AddedBy": "sha256:d52e4f012db158bb7c0fe215b98af1facaddcbaee530efd69b1bae07d597b711",
+                "Location": "var/lib/dpkg/status"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "quay.io/rhacs-eng/qa:ubuntu-23.04",
@@ -5631,17 +1929,15 @@
         "expected_features": [
             {
                 "Name": "base-files",
+                "Arch": "amd64",
                 "NamespaceName": "ubuntu:23.04",
-                "VersionFormat": "dpkg",
                 "Version": "12.3ubuntu2",
-                "AddedBy": "sha256:b631a20f124dbf4ef89945623fa5c94460561f9c7b119e17fd3c1a4bb50ced01"
+                "AddedBy": "sha256:b631a20f124dbf4ef89945623fa5c94460561f9c7b119e17fd3c1a4bb50ced01",
+                "Location": "var/lib/dpkg/status"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "quay.io/rhacs-eng/qa:ubuntu-23.10",
@@ -5653,49 +1949,43 @@
         "expected_features": [
             {
                 "Name": "base-files",
+                "Arch": "amd64",
                 "NamespaceName": "ubuntu:23.10",
-                "VersionFormat": "dpkg",
                 "Version": "13ubuntu1",
-                "AddedBy": "sha256:316675922a661ce4c35389bdeea6e9ec8d4708e41f08671b586c7aaea469b2c1"
+                "AddedBy": "sha256:316675922a661ce4c35389bdeea6e9ec8d4708e41f08671b586c7aaea469b2c1",
+                "Location": "var/lib/dpkg/status"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
     },
     {
         "image": "nginx:1.25.0-alpine",
         "registry": "https://registry-1.docker.io",
-        "username": "",
-        "password": "",
+        "username": "DOCKER_USERNAME",
+        "password": "DOCKER_PASSWORD",
         "source": "NVD",
-        "namespace": "alpine:v3.17",
+        "namespace": "alpine:3.17",
         "expected_features": [
             {
                 "Name": "libx11",
                 "NamespaceName": "alpine:v3.17",
-                "VersionFormat": "apk",
                 "Version": "1.8.4-r0",
+                "Arch": "x86_64",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2023-3138",
                         "NamespaceName": "alpine:v3.17",
-                        "Description": "A vulnerability was found in libX11. The security flaw occurs because the functions in src/InitExt.c in libX11 do not check that the values provided for the Request, Event, or Error IDs are within the bounds of the arrays that those functions write to, using those IDs as array indexes. They trust that they were called with values provided by an Xserver adhering to the bounds specified in the X11 protocol, as all X servers provided by X.Org do. As the protocol only specifies a single byte for these values, an out-of-bounds value provided by a malicious server (or a malicious proxy-in-the-middle) can only overwrite other portions of the Display structure and not write outside the bounds of the Display structure itself, possibly causing the client to crash with this memory corruption.",
+                        "Description": "",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2023-3138",
-                        "Severity": "Important",
+                        "Severity": "Unspecified",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
@@ -5705,31 +1995,28 @@
                     }
                 ],
                 "AddedBy": "sha256:4aacde79cec42c8d0c5886185e70a16b107ae8c6b1a67d63d6efdb6d6978ed97",
+                "Location": "lib/apk/db/installed",
                 "FixedBy": "1.8.4-r1"
             },
             {
-                "Name": "nghttp2",
+                "Name": "nghttp2-libs",
                 "NamespaceName": "alpine:v3.17",
-                "VersionFormat": "apk",
                 "Version": "1.51.0-r0",
+                "Arch": "x86_64",
                 "Vulnerabilities": [
                     {
                         "Name": "CVE-2023-35945",
                         "NamespaceName": "alpine:v3.17",
-                        "Description": "Envoy is a cloud-native high-performance edge/middle/service proxy. Envoy’s HTTP/2 codec may leak a header map and bookkeeping structures upon receiving `RST_STREAM` immediately followed by the `GOAWAY` frames from an upstream server. In nghttp2, cleanup of pending requests due to receipt of the `GOAWAY` frame skips de-allocation of the bookkeeping structure and pending compressed header. The error return [code path] is taken if connection is already marked for not sending more requests due to `GOAWAY` frame. The clean-up code is right after the return statement, causing memory leak. Denial of service through memory exhaustion. This vulnerability was patched in versions(s) 1.26.3, 1.25.8, 1.24.9, 1.23.11.",
+                        "Description": "",
                         "Link": "https://www.cve.org/CVERecord?id=CVE-2023-35945",
-                        "Severity": "Important",
+                        "Severity": "Unspecified",
                         "Metadata": {
                             "NVD": {
                                 "CVSSv2": {
-                                    "ExploitabilityScore": 0,
-                                    "ImpactScore": 0,
                                     "Score": 0,
                                     "Vectors": ""
                                 },
                                 "CVSSv3": {
-                                    "ExploitabilityScore": 3.9,
-                                    "ImpactScore": 3.6,
                                     "Score": 7.5,
                                     "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
                                 }
@@ -5739,13 +2026,192 @@
                     }
                 ],
                 "AddedBy": "sha256:4aacde79cec42c8d0c5886185e70a16b107ae8c6b1a67d63d6efdb6d6978ed97",
+                "Location": "lib/apk/db/installed",
                 "FixedBy": "1.51.0-r1"
             }
         ],
         "unexpected_features": null,
-        "only_check_specified_vulns": true,
-        "uncertified_rhel": false,
-        "check_provided_executables": false,
-        "required_feature_flag": null
+        "only_check_specified_vulns": true
+    },
+    {
+        "image": "docker.io/library/amazonlinux:2.0.20240131.0",
+        "username": "DOCKER_USERNAME",
+        "password": "DOCKER_PASSWORD",
+        "namespace": "amzn:2",
+        "expected_features": [
+            {
+                "Name": "nss-sysinit",
+                "Version": "3.90.0-2.amzn2.0.1",
+                "Arch": "x86_64",
+                "Location": "bdb:var/lib/rpm",
+                "AddedBy": "sha256:7c46e61fc0317cccadde1288fd50789f5fcc06bddf47082f5ba5894613f35b38",
+                "FixedBy": "3.90.0-2.amzn2.0.2",
+                "Vulnerabilities": [
+                    {
+                        "Name": "ALAS2-2024-2442",
+                        "Description": "Package updates are available for Amazon Linux 2 that fix the following vulnerabilities:\nCVE-2023-7104:\n\tA vulnerability was found in SQLite SQLite3 up to 3.43.0 and classified as critical. This issue affects the function sessionReadRecord of the file ext/session/sqlite3session.c of the component make alltest Handler. The manipulation leads to heap-based buffer overflow. It is recommended to apply a patch to fix this issue. The associated identifier of this vulnerability is VDB-248999.\n\nNOTE: https://sqlite.org/forum/forumpost/5bcbf4571c\nNOTE: Fixed by: https://sqlite.org/src/info/0e4e7a05c4204b47\n",
+                        "Link": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-7104",
+                        "Severity": "Important",
+                        "Metadata": {
+                            "NVD": {
+                                "CVSSv2": {
+                                    "Score": 0,
+                                    "Vectors": ""
+                                },
+                                "CVSSv3": {
+                                    "Score": 7.5,
+                                    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                                }
+                            }
+                        },
+                        "FixedBy": "3.90.0-2.amzn2.0.2"
+                    }
+                ]
+            }
+        ],
+        "only_check_specified_vulns": true
+    },
+    {
+        "image": "quay.io/stackrox-io/scanner:4.3.0",
+        "namespace": "rhel:8",
+        "expected_features": [
+            {
+                "Name": "golang.org/x/crypto",
+                "Version": "v0.14.0",
+                "Location": "go:scanner",
+                "AddedBy": "sha256:46ad2a8a3b7838accbc76931558700cb013aa77cb3a65e4bafcae30fad23eb80",
+                "FixedBy": "0.17.0",
+                "Vulnerabilities": [
+                    {
+                        "Name": "CVE-2023-48795",
+                        "Description": "Prefix Truncation Attack against ChaCha20-Poly1305 and Encrypt-then-MAC aka Terrapin",
+                        "Link": "https://github.com/warp-tech/russh/security/advisories/GHSA-45x7-px36-x8w8",
+                        "Severity": "Moderate",
+                        "FixedBy": "0.17.0",
+                        "Metadata": {
+                            "NVD": {
+                                "CVSSv3": {
+                                    "Score": 0,
+        	            	    "Vectors": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "Name": "GO-2023-2402",
+                        "Description": "Man-in-the-middle attacker can compromise integrity of secure channel in golang.org/x/crypto",
+                        "Link": "https://go.dev/issue/64784",
+                        "Severity": "Unspecified",
+                        "FixedBy": "0.17.0"
+                    }
+                ]
+            },
+            {
+                "Location": "root/buildinfo/Dockerfile-ubi8-minimal-8.8-1072.1697626218",
+                "Name": "ubi8-minimal-container",
+                "Version": "8.8-1072.1697626218",
+                "Arch": "x86_64",
+                "AddedBy": "sha256:01858fc5b53815a5246d56955a83c921bd53ca283cc1bfb67ea13a4fca0120fa"
+            }
+        ]
+    },
+    {
+        "image": "docker.io/library/mongo-express:1.0.0-alpha.4",
+        "namespace": "alpine:3.11",
+        "expected_features": [
+            {
+                "Name": "express-fileupload",
+                "Version": "0.4.0",
+                "Location": "nodejs:node_modules/express-fileupload/package.json",
+                "AddedBy": "sha256:ab4078090382b279408fc5dea2aa5c2684848edf89522cf0d5fc7838aefbfadc",
+                "Vulnerabilities": [
+                    {
+                        "Name": "CVE-2020-7699",
+                        "Severity": "Critical"
+                    },
+                    {
+                        "Name": "CVE-2022-27261",
+                        "Severity": "High"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "image": "docker.io/library/oraclelinux:8",
+        "namespace": "ol:8",
+        "expected_features": [
+            {
+                "Name": "libgcrypt",
+                "Version": "1.8.5-7.el8_6",
+                "Arch": "x86_64",
+                "Location": "bdb:var/lib/rpm",
+                "AddedBy": "sha256:60ccddb6218556f1d6ac035de7505a87c53b2c8653569d2a57dfc1b53c745588",
+                "FixedBy": "10:1.8.5-7.el8_6_fips",
+                "Vulnerabilities": [
+                    {
+                        "Name": "CVE-2021-40528",
+                        "Description": "\n[ 1.8.5-7_fips]\n- Add API to provide hash calculation in RSA/DSA/ECDSA signature\n  operations [Orabug: 33081130]\n- Change Epoch from 1 to 10\n\n[1.8.5-7]\n- Fix CVE-2021-33560 (#2018525)\n\n",
+                        "FixedBy": "10:1.8.5-7.el8_6_fips",
+                        "Link": "https://linux.oracle.com/errata/ELSA-2022-9564.html",
+                        "Severity": "Important",
+                        "Metadata": {
+                            "NVD": {
+                                "CVSSv2": {
+                                    "Score": 5,
+        	            	    "Vectors": "AV:N/AC:L/Au:N/C:P/I:N/A:N"
+                                },
+                                "CVSSv3": {
+                                    "Score": 7.5,
+        	            	    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "Name": "CVE-2021-33560",
+                        "Description": "\n[1.8.5-6_fips]\n- Add API to provide hash calculation in RSA/DSA/ECDSA signature\n  operations [Orabug: 33081130]\n- Change Epoch from 1 to 10\n\n[1.8.5-6]\n- Fix for CVE-2021-33560 (#1971421)\n- Enable HW optimizations in FIPS (#1976137)\n- Performance enchancements for ChaCha20 and Poly1305 (#1855231)\n\n[1.8.5-5]\n- Performance enchancements for AES-GCM, CRC32 and SHA2 (#1855231)\n\n",
+                        "FixedBy": "10:1.8.5-6.el8_fips",
+                        "Link": "https://linux.oracle.com/errata/ELSA-2022-9263.html",
+                        "Severity": "Moderate",
+                        "Metadata": {
+                            "NVD": {
+                                "CVSSv2": {
+                                    "Score": 5,
+        	            	    "Vectors": "AV:N/AC:L/Au:N/C:P/I:N/A:N"
+                                },
+                                "CVSSv3": {
+                                    "Score": 7.5,
+        	            	    "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "image": "docker.io/library/photon:3.0-20230923",
+        "namespace": "photon:3.0",
+        "expected_features": [
+            {
+                "Name": "curl",
+                "Version":  "8.1.2-3.ph3",
+                "Arch": "x86_64",
+                "Location": "bdb:var/lib/rpm",
+                "AddedBy": "sha256:4be30f5be508559f08c9a9556dbd73f57848151885a1c5d912d9ed227a9b206a",
+                "FixedBy": "0:8.1.2-4.ph3",
+                "Vulnerabilities": [
+                    {
+                        "Name": "CVE-2023-38546",
+                        "Description": "This update upgrade curl-libs to 8.1.2-4.ph3 #Fixes {'CVE-2023-38546', 'CVE-2023-38545'}",
+                        "FixedBy": "0:8.1.2-4.ph3",
+                        "Severity": "Critical",
+                        "Link": "https://github.com/vmware/photon/wiki/Security-Updates-3.0-667"
+                    }
+                ]
+            }
+        ]
     }
 ]


### PR DESCRIPTION
## Description

1. Update the E2E test description to match the expected results for Scanner V4 (diff from previous Scanner V2 results can still be inspected by `diff -du scanner/e2etests/testdata/*.json`).
2. Update `e2e` make rules to build and execute E2E tests in a cluster.
3. Create a GitHub workflow that runs the tests in a minikube instance after image builds are completed successfully.
4. Updated the E2E test cases not to fill in empty values to compare but to log when expected packages are not found.
5. Add a DEBUG flag to print the whole Matcher Vuln Report when the tests fail.

You will notice the images stored in registry.redhat.io are failing. The reason is credentials: We are missing a secret to registry.redhat.io. Other failures are legit.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI results.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
