### PR TITLE
fix(cloud-sources): use lower timeout for test API

### DIFF
--- a/central/cloudsources/service/service_impl.go
+++ b/central/cloudsources/service/service_impl.go
@@ -223,8 +223,7 @@ func (s *serviceImpl) testCloudSource(ctx context.Context, storageCloudSource *s
 	if err != nil {
 		return err
 	}
-	_, err = client.GetDiscoveredClusters(ctx)
-	return err
+	return client.Ping(ctx)
 }
 
 func (s *serviceImpl) enrichWithStoredCredentials(ctx context.Context,

--- a/central/cloudsources/service/service_impl_postgres_test.go
+++ b/central/cloudsources/service/service_impl_postgres_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cloudsources"
 	cloudSourceClientMocks "github.com/stackrox/rox/pkg/cloudsources/mocks"
+	"github.com/stackrox/rox/pkg/cloudsources/opts"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
@@ -61,7 +62,7 @@ func (s *servicePostgresTestSuite) SetupTest() {
 	cloudSourceClientMock.EXPECT().Ping(gomock.Any()).Return(nil).AnyTimes()
 
 	s.service = newService(s.datastore, mockManager)
-	s.service.(*serviceImpl).clientFactory = func(_ *storage.CloudSource) (cloudsources.Client, error) {
+	s.service.(*serviceImpl).clientFactory = func(_ *storage.CloudSource, _ ...opts.ClientOpts) (cloudsources.Client, error) {
 		return cloudSourceClientMock, nil
 	}
 }
@@ -410,7 +411,7 @@ func (s *servicePostgresTestSuite) TestDeleteCloudSource() {
 
 func (s *servicePostgresTestSuite) TestCloudSourceTest() {
 	cloudSourceClientMock := cloudSourceClientMocks.NewMockClient(gomock.NewController(s.T()))
-	s.service.(*serviceImpl).clientFactory = func(_ *storage.CloudSource) (cloudsources.Client, error) {
+	s.service.(*serviceImpl).clientFactory = func(_ *storage.CloudSource, _ ...opts.ClientOpts) (cloudsources.Client, error) {
 		return cloudSourceClientMock, nil
 	}
 

--- a/central/cloudsources/service/service_impl_postgres_test.go
+++ b/central/cloudsources/service/service_impl_postgres_test.go
@@ -58,7 +58,7 @@ func (s *servicePostgresTestSuite) SetupTest() {
 	mockManager := cloudSourcesManagerMocks.NewMockManager(gomock.NewController(s.T()))
 	mockManager.EXPECT().ShortCircuit().AnyTimes()
 	cloudSourceClientMock := cloudSourceClientMocks.NewMockClient(gomock.NewController(s.T()))
-	cloudSourceClientMock.EXPECT().GetDiscoveredClusters(gomock.Any()).Return(nil, nil).AnyTimes()
+	cloudSourceClientMock.EXPECT().Ping(gomock.Any()).Return(nil).AnyTimes()
 
 	s.service = newService(s.datastore, mockManager)
 	s.service.(*serviceImpl).clientFactory = func(_ *storage.CloudSource) (cloudsources.Client, error) {
@@ -423,7 +423,7 @@ func (s *servicePostgresTestSuite) TestCloudSourceTest() {
 	s.Assert().ErrorIs(err, errox.InvalidArgs)
 
 	// 2. Call test with UpdateCredentials without any error during calling client.
-	cloudSourceClientMock.EXPECT().GetDiscoveredClusters(gomock.Any()).Return(nil, nil)
+	cloudSourceClientMock.EXPECT().Ping(gomock.Any()).Return(nil)
 	_, err = s.service.TestCloudSource(s.writeCtx, &v1.TestCloudSourceRequest{
 		CloudSource:       cloudSource,
 		UpdateCredentials: true,
@@ -432,8 +432,8 @@ func (s *servicePostgresTestSuite) TestCloudSourceTest() {
 
 	// 3. Call test with UpdateCredentials with an error during calling client.
 	clientErr := errors.New("failed calling client")
-	cloudSourceClientMock.EXPECT().GetDiscoveredClusters(gomock.Any()).
-		Return(nil, clientErr)
+	cloudSourceClientMock.EXPECT().Ping(gomock.Any()).
+		Return(clientErr)
 	_, err = s.service.TestCloudSource(s.writeCtx, &v1.TestCloudSourceRequest{
 		CloudSource:       cloudSource,
 		UpdateCredentials: true,
@@ -447,7 +447,7 @@ func (s *servicePostgresTestSuite) TestCloudSourceTest() {
 	})
 	s.Require().NoError(err)
 	cloudSource = resp.GetCloudSource()
-	cloudSourceClientMock.EXPECT().GetDiscoveredClusters(gomock.Any()).Return(nil, nil)
+	cloudSourceClientMock.EXPECT().Ping(gomock.Any()).Return(nil)
 
 	_, err = s.service.TestCloudSource(s.writeCtx, &v1.TestCloudSourceRequest{
 		CloudSource: cloudSource,

--- a/pkg/cloudsources/client.go
+++ b/pkg/cloudsources/client.go
@@ -14,6 +14,8 @@ import (
 //go:generate mockgen-wrapper
 type Client interface {
 	GetDiscoveredClusters(ctx context.Context) ([]*discoveredclusters.DiscoveredCluster, error)
+
+	Ping(ctx context.Context) error
 }
 
 // NewClientForCloudSource creates a new Client based on the cloud source to fetch discovered clusters.

--- a/pkg/cloudsources/client.go
+++ b/pkg/cloudsources/client.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cloudsources/discoveredclusters"
 	"github.com/stackrox/rox/pkg/cloudsources/ocm"
+	"github.com/stackrox/rox/pkg/cloudsources/opts"
 	"github.com/stackrox/rox/pkg/cloudsources/paladin"
 )
 
@@ -19,12 +20,12 @@ type Client interface {
 }
 
 // NewClientForCloudSource creates a new Client based on the cloud source to fetch discovered clusters.
-func NewClientForCloudSource(source *storage.CloudSource) (Client, error) {
+func NewClientForCloudSource(source *storage.CloudSource, options ...opts.ClientOpts) (Client, error) {
 	switch source.GetType() {
 	case storage.CloudSource_TYPE_PALADIN_CLOUD:
-		return paladin.NewClient(source), nil
+		return paladin.NewClient(source, options...), nil
 	case storage.CloudSource_TYPE_OCM:
-		return ocm.NewClient(source)
+		return ocm.NewClient(source, options...)
 	default:
 		return nil, nil
 	}

--- a/pkg/cloudsources/mocks/client.go
+++ b/pkg/cloudsources/mocks/client.go
@@ -54,3 +54,17 @@ func (mr *MockClientMockRecorder) GetDiscoveredClusters(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiscoveredClusters", reflect.TypeOf((*MockClient)(nil).GetDiscoveredClusters), ctx)
 }
+
+// Ping mocks base method.
+func (m *MockClient) Ping(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ping", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Ping indicates an expected call of Ping.
+func (mr *MockClientMockRecorder) Ping(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockClient)(nil).Ping), ctx)
+}

--- a/pkg/cloudsources/ocm/client.go
+++ b/pkg/cloudsources/ocm/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	gogoProto "github.com/gogo/protobuf/types"
 	sdkClient "github.com/openshift-online/ocm-sdk-go"
@@ -36,6 +37,14 @@ func NewClient(config *storage.CloudSource) (*ocmClient, error) {
 		conn:          connection,
 		cloudSourceID: config.GetId(),
 	}, nil
+}
+
+func (c *ocmClient) Ping(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, err := c.conn.AccountsMgmt().V1().CurrentAccount().Get().SendContext(ctx)
+	return err
 }
 
 func (c *ocmClient) GetDiscoveredClusters(ctx context.Context) ([]*discoveredclusters.DiscoveredCluster, error) {

--- a/pkg/cloudsources/opts/options.go
+++ b/pkg/cloudsources/opts/options.go
@@ -1,0 +1,35 @@
+package opts
+
+import "time"
+
+// Option holds configurable options for cloud source clients.
+type Option struct {
+	Retries int
+	Timeout time.Duration
+}
+
+// ClientOpts is the option function for cloud source clients.
+type ClientOpts func(o *Option)
+
+// WithRetries sets the number of max retries for a client.
+// In case it is set to 0, no retries will be attempted.
+func WithRetries(retries int) ClientOpts {
+	return func(o *Option) {
+		o.Retries = retries
+	}
+}
+
+// WithTimeout sets the timeout for the client.
+func WithTimeout(timeout time.Duration) ClientOpts {
+	return func(o *Option) {
+		o.Timeout = timeout
+	}
+}
+
+// DefaultOpts returns the default options used for clients.
+func DefaultOpts() *Option {
+	return &Option{
+		Retries: 3,
+		Timeout: 30 * time.Second,
+	}
+}

--- a/pkg/cloudsources/paladin/client.go
+++ b/pkg/cloudsources/paladin/client.go
@@ -209,6 +209,14 @@ func NewClient(cfg *storage.CloudSource) *paladinClient {
 	}
 }
 
+func (c *paladinClient) Ping(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	// TODO: Need to check whether there's a good ping API for Paladin Cloud that requires authN.
+	_, err := c.getAssets(ctx)
+	return err
+}
+
 // GetDiscoveredClusters returns the discovered clusters from the Paladin Cloud API.
 func (c *paladinClient) GetDiscoveredClusters(ctx context.Context) ([]*discoveredclusters.DiscoveredCluster, error) {
 	response, err := c.getAssets(ctx)


### PR DESCRIPTION
## Description

This PR fixes an issue observed with the test API: the API itself currently calls the default `GetDiscoveredClusters`, and in case more clusters are fetched it may take more than 10 seconds.
10 seconds is the timeout by the UI, which means we do not get a clear error message in case things aren't working as expected.

Instead, we introdcue now a separate ping function which should be used for such purposes. The ping function itself provides a 10 second timeout via context.

For OCM, we will attempt to fetch the current account information (essentially mimicking `ocm whoami`), for Paladin Cloud the API call will stay as-is, unless we find a more appropriate API call to use.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
