### PR TITLE
ROX-22583: retry api token generation

### DIFF
--- a/tests/roxctl/authz-trace.sh
+++ b/tests/roxctl/authz-trace.sh
@@ -22,7 +22,7 @@ curl_central() {
   url="$1"
   shift
   [[ -n "${url}" ]] || die "No URL specified"
-  curl -Sskf "https://${API_ENDPOINT}${url}" "$@"
+  curl -Sskf --retry 5 "https://${API_ENDPOINT}${url}" "$@"
 }
 
 curl_central_admin() {

--- a/tests/roxctl/token-file.sh
+++ b/tests/roxctl/token-file.sh
@@ -18,6 +18,7 @@ TOKEN_FILE=$(mktemp)
 curl -k -f \
   -u "admin:$ROX_PASSWORD" \
   -d '{"name": "test", "role": "Admin"}' \
+  --retry 5 \
   "https://$API_ENDPOINT/v1/apitokens/generate" \
   | jq -r .token \
   > "$TOKEN_FILE"


### PR DESCRIPTION
## Description

The roxctl tests failed due to the token not being fetched properly:

```sh
curl: (7) Failed to connect to 34.41.81.139 port 443: Connection timed out
```

In Central I found a suspicious log

```
2024/02/17 04:46:14 http: TLS handshake error from 35.227.122.18:39774: tls: first record does not look like a TLS handshake
```

I'm not sure what the root cause of this error is since the `curl` does specify `https`, but in general retries have successfully reduced the flakes in these roxctl tests. So I think it's worth a shot and won't hurt.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI tests pass

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
