### PR TITLE
ROX-16618: Fix roxctl initbundle revoke

### DIFF
--- a/roxctl/central/initbundles/revoke.go
+++ b/roxctl/central/initbundles/revoke.go
@@ -85,7 +85,7 @@ func confirmImpactedClusterIds(impactedClusterNames, impactedClusterIds []string
 	}
 	_ = t.Flush()
 
-	_, _ = out.Write([]byte("Are you sure you want to revoke the init bundle(s)? [y/N]"))
+	_, _ = out.Write([]byte("Are you sure you want to revoke the init bundle(s)? [y/N] "))
 
 	return flags.ReadUserYesNoConfirmation(in)
 }

--- a/roxctl/central/initbundles/revoke.go
+++ b/roxctl/central/initbundles/revoke.go
@@ -133,9 +133,8 @@ func revokeCommand(cliEnvironment environment.Environment) *cobra.Command {
 				return errors.Wrap(err, "getting force flag")
 			}
 			for _, arg := range args {
-				if arg == "--force" || arg == "-f" {
+				if arg != "--force" && arg != "-f" {
 					// ignore the force flag
-				} else {
 					clusterNameOrIds = append(clusterNameOrIds, arg)
 				}
 			}

--- a/roxctl/central/initbundles/revoke.go
+++ b/roxctl/central/initbundles/revoke.go
@@ -128,7 +128,6 @@ func revokeCommand(cliEnvironment environment.Environment) *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var clusterNameOrIds []string
-			var force bool
 			force, err := cmd.Flags().GetBool("force")
 			if err != nil {
 				return errors.Wrap(err, "getting force flag")

--- a/roxctl/central/initbundles/revoke.go
+++ b/roxctl/central/initbundles/revoke.go
@@ -137,15 +137,11 @@ func revokeCommand(cliEnvironment environment.Environment) *cobra.Command {
 		Long:  "Revoke an init bundle for bootstrapping new StackRox secured clusters",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var clusterNameOrIds []string
 			force, err := cmd.Flags().GetBool("force")
 			if err != nil {
 				return errors.Wrap(err, "getting force flag")
 			}
-			for _, arg := range args {
-				clusterNameOrIds = append(clusterNameOrIds, arg)
-			}
-			return revokeInitBundles(cliEnvironment, clusterNameOrIds, force, flags.Timeout(cmd), flags.RetryTimeout(cmd))
+			return revokeInitBundles(cliEnvironment, args, force, flags.Timeout(cmd), flags.RetryTimeout(cmd))
 		},
 	}
 

--- a/roxctl/central/initbundles/revoke.go
+++ b/roxctl/central/initbundles/revoke.go
@@ -27,14 +27,14 @@ func applyRevokeInitBundles(ctx context.Context, cliEnvironment environment.Envi
 		return err
 	}
 
-	impactedIdNameMap := map[string]string{}
+	impactedIDNameMap := map[string]string{}
 
 	var revokeInitBundleIds []string
 	for _, meta := range resp.Items {
 		if idsOrNames.Remove(meta.GetId()) || idsOrNames.Remove(meta.GetName()) {
 			revokeInitBundleIds = append(revokeInitBundleIds, meta.GetId())
 			for _, impactedCluster := range meta.GetImpactedClusters() {
-				impactedIdNameMap[impactedCluster.GetId()] = impactedCluster.GetName()
+				impactedIDNameMap[impactedCluster.GetId()] = impactedCluster.GetName()
 			}
 		}
 	}
@@ -43,13 +43,13 @@ func applyRevokeInitBundles(ctx context.Context, cliEnvironment environment.Envi
 		return errox.NotFound.Newf("could not find init bundle(s) %s", strings.Join(idsOrNames.AsSlice(), ", "))
 	}
 
-	impactedClusterIds := make([]string, 0, len(impactedIdNameMap))
-	for id := range impactedIdNameMap {
+	impactedClusterIds := make([]string, 0, len(impactedIDNameMap))
+	for id := range impactedIDNameMap {
 		impactedClusterIds = append(impactedClusterIds, id)
 	}
 
 	if !force {
-		confirm, err := confirmImpactedClusterIds(impactedIdNameMap, cliEnvironment.InputOutput().Out(), cliEnvironment.InputOutput().In())
+		confirm, err := confirmImpactedClusterIds(impactedIDNameMap, cliEnvironment.InputOutput().Out(), cliEnvironment.InputOutput().In())
 		if err != nil {
 			return err
 		}
@@ -72,14 +72,14 @@ func applyRevokeInitBundles(ctx context.Context, cliEnvironment environment.Envi
 	return nil
 }
 
-func confirmImpactedClusterIds(impactedClusterIdNameMap map[string]string, out io.Writer, in io.Reader) (bool, error) {
+func confirmImpactedClusterIds(impactedClusterIDNameMap map[string]string, out io.Writer, in io.Reader) (bool, error) {
 
-	if len(impactedClusterIdNameMap) == 0 {
+	if len(impactedClusterIDNameMap) == 0 {
 		return true, nil
 	}
 
-	impactedClusters := make([][2]string, 0, len(impactedClusterIdNameMap))
-	for id, name := range impactedClusterIdNameMap {
+	impactedClusters := make([][2]string, 0, len(impactedClusterIDNameMap))
+	for id, name := range impactedClusterIDNameMap {
 		impactedClusters = append(impactedClusters, [2]string{id, name})
 	}
 	sort.Slice(impactedClusters, func(i, j int) bool {

--- a/roxctl/central/initbundles/revoke_test.go
+++ b/roxctl/central/initbundles/revoke_test.go
@@ -1,0 +1,40 @@
+package initbundles
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_confirmImpactedClusterIds(t *testing.T) {
+
+	t.Run("confirmed", func(t *testing.T) {
+		got, err := confirmImpactedClusterIds([]string{"cluster name 1"}, []string{"cluster id 1"}, &strings.Builder{}, strings.NewReader("y\n"))
+		assert.NoError(t, err)
+		assert.Equal(t, true, got)
+	})
+
+	t.Run("zero impacted clusters", func(t *testing.T) {
+		got, err := confirmImpactedClusterIds([]string{}, []string{}, &strings.Builder{}, strings.NewReader("y\n"))
+		assert.NoError(t, err)
+		assert.Equal(t, true, got)
+	})
+
+	t.Run("confirmation defaults to false", func(t *testing.T) {
+		got, err := confirmImpactedClusterIds([]string{"cluster name 1"}, []string{"cluster id 1"}, &strings.Builder{}, strings.NewReader("\n"))
+		assert.NoError(t, err)
+		assert.Equal(t, false, got)
+	})
+
+	t.Run("bad confirmation", func(t *testing.T) {
+		_, err := confirmImpactedClusterIds([]string{"cluster name 1"}, []string{"cluster id 1"}, &strings.Builder{}, strings.NewReader("blah\n"))
+		assert.Error(t, err)
+	})
+
+	t.Run("cluster count mismatch", func(t *testing.T) {
+		_, err := confirmImpactedClusterIds([]string{"cluster name 1"}, []string{}, &strings.Builder{}, strings.NewReader("\n"))
+		assert.Error(t, err)
+	})
+
+}

--- a/roxctl/central/initbundles/revoke_test.go
+++ b/roxctl/central/initbundles/revoke_test.go
@@ -10,30 +10,25 @@ import (
 func Test_confirmImpactedClusterIds(t *testing.T) {
 
 	t.Run("confirmed", func(t *testing.T) {
-		got, err := confirmImpactedClusterIds([]string{"cluster name 1"}, []string{"cluster id 1"}, &strings.Builder{}, strings.NewReader("y\n"))
+		got, err := confirmImpactedClusterIds(map[string]string{"id1": "name1"}, &strings.Builder{}, strings.NewReader("y\n"))
 		assert.NoError(t, err)
 		assert.Equal(t, true, got)
 	})
 
 	t.Run("zero impacted clusters", func(t *testing.T) {
-		got, err := confirmImpactedClusterIds([]string{}, []string{}, &strings.Builder{}, strings.NewReader("y\n"))
+		got, err := confirmImpactedClusterIds(map[string]string{}, &strings.Builder{}, strings.NewReader("y\n"))
 		assert.NoError(t, err)
 		assert.Equal(t, true, got)
 	})
 
 	t.Run("confirmation defaults to false", func(t *testing.T) {
-		got, err := confirmImpactedClusterIds([]string{"cluster name 1"}, []string{"cluster id 1"}, &strings.Builder{}, strings.NewReader("\n"))
+		got, err := confirmImpactedClusterIds(map[string]string{"id1": "name1"}, &strings.Builder{}, strings.NewReader("\n"))
 		assert.NoError(t, err)
 		assert.Equal(t, false, got)
 	})
 
 	t.Run("bad confirmation", func(t *testing.T) {
-		_, err := confirmImpactedClusterIds([]string{"cluster name 1"}, []string{"cluster id 1"}, &strings.Builder{}, strings.NewReader("blah\n"))
-		assert.Error(t, err)
-	})
-
-	t.Run("cluster count mismatch", func(t *testing.T) {
-		_, err := confirmImpactedClusterIds([]string{"cluster name 1"}, []string{}, &strings.Builder{}, strings.NewReader("\n"))
+		_, err := confirmImpactedClusterIds(map[string]string{"id1": "name1"}, &strings.Builder{}, strings.NewReader("blah\n"))
 		assert.Error(t, err)
 	})
 

--- a/roxctl/common/flags/confirm.go
+++ b/roxctl/common/flags/confirm.go
@@ -44,6 +44,7 @@ func CheckConfirmation(c *cobra.Command, logger logger.Logger, io io.IO) error {
 	return nil
 }
 
+// ReadUserYesNoConfirmation reads a yes/no confirmation from the user. Empty response defaults to no.
 func ReadUserYesNoConfirmation(reader io2.Reader) (bool, error) {
 	confirm, err := bufio.NewReader(reader).ReadString('\n')
 	if err != nil {

--- a/roxctl/common/flags/confirm.go
+++ b/roxctl/common/flags/confirm.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"bufio"
+	io2 "io"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -33,13 +34,24 @@ func CheckConfirmation(c *cobra.Command, logger logger.Logger, io io.IO) error {
 		return nil
 	}
 	logger.PrintfLn("Are you sure? [y/N] ")
-	resp, err := bufio.NewReader(io.In()).ReadString('\n')
+	resp, err := ReadUserYesNoConfirmation(io.In())
 	if err != nil {
 		return errors.Wrap(err, "could not read answer")
 	}
-	resp = strings.ToLower(strings.TrimSpace(resp))
-	if resp != "y" {
+	if !resp {
 		return errox.NotAuthorized.New("User rejected")
 	}
 	return nil
+}
+
+func ReadUserYesNoConfirmation(reader io2.Reader) (bool, error) {
+	confirm, err := bufio.NewReader(reader).ReadString('\n')
+	if err != nil {
+		return false, errors.Wrap(err, "reading user input")
+	}
+	confirm = strings.ToLower(strings.TrimSpace(confirm))
+	if confirm != "y" && confirm != "n" && confirm != "" {
+		return false, errors.New("invalid confirmation. Must be 'y' or 'n'")
+	}
+	return confirm == "y", nil
 }


### PR DESCRIPTION
## Description

Fixing the `roxctl initbundle revoke` command to include affected cluster ids

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
