### PR TITLE
ROX-22505: claim mappings UI

### DIFF
--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -139,6 +139,7 @@ describe('Access Control Auth providers', () => {
         cy.get(`${selectCallbackModeItem}:contains("HTTP POST")`).click();
         cy.get(checkboxDoNotUseClientSecret).check();
         cy.get(inputClientSecret).should('be.disabled').should('not.have.attr', 'required');
+        cy.get('button:contains("Add claim mapping")').click();
 
         cy.get(selectors.form.saveButton).should('be.disabled');
         cy.get(selectors.form.cancelButton).click();

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -638,15 +638,13 @@ function AuthProviderForm({
                             </Alert>
                             {(!values.claimMappings ||
                                 (Array.isArray(values.claimMappings) &&
-                                    values.claimMappings.length === 0)) && (
+                                    values.claimMappings.length === 0)) ? (
                                 <p>No claim mappings defined</p>
-                            )}
+                            ) : (
                             <FieldArray
                                 name="claimMappings"
                                 render={(arrayHelpers) => (
                                     <>
-                                        {values.claimMappings &&
-                                            Array.isArray(values.claimMappings) &&
                                             values.claimMappings.map((mapping, index: number) => (
                                                 <Flex key={`claim_mapping_${index}`}>
                                                     <FormGroup

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -636,17 +636,15 @@ function AuthProviderForm({
                                     this claim will not be returned from authentication provider.
                                 </p>
                             </Alert>
-                            {(!values.claimMappings ||
-                                (Array.isArray(values.claimMappings) &&
-                                    values.claimMappings.length === 0)) && (
+                            {(!Array.isArray(values.claimMappings) ||
+                                values.claimMappings.length === 0) && (
                                 <p>No claim mappings defined</p>
                             )}
                             <FieldArray
                                 name="claimMappings"
                                 render={(arrayHelpers) => (
                                     <>
-                                        {values.claimMappings &&
-                                            Array.isArray(values.claimMappings) &&
+                                        {Array.isArray(values.claimMappings) &&
                                             values.claimMappings.map((mapping, index: number) => (
                                                 <Flex key={`claim_mapping_${index}`}>
                                                     <FormGroup

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -127,6 +127,18 @@ function AuthProviderForm({
                 attributeValue: yup.string().required('Value is a required field'),
             })
         ),
+        claimMappings: yup
+            .array()
+            .of(yup.array().of(yup.string().required('Empty value is not allowed')).length(2))
+            .test('uniqueness test', 'Claim mappings should contain unique keys', (value) => {
+                if (!value) {
+                    return true;
+                }
+                const keys = value.map((mapping) => {
+                    return mapping ? mapping[0] : '';
+                });
+                return keys.length === new Set(keys).size;
+            }),
         /* eslint-disable @typescript-eslint/no-unsafe-return */
         config: yup
             .object()
@@ -600,6 +612,115 @@ function AuthProviderForm({
                                                         }
                                                     >
                                                         Add required attribute
+                                                    </Button>
+                                                </FlexItem>
+                                            </Flex>
+                                        )}
+                                    </>
+                                )}
+                            />
+                        </FormSection>
+                    )}
+                    {selectedAuthProvider.type === 'oidc' && (
+                        <FormSection
+                            title="Claim mappings for the authentication provider"
+                            titleElement="h3"
+                        >
+                            <Alert
+                                isInline
+                                variant="info"
+                                title="Note: the claim mappings are used to map claims returned in underlying identity provider's token to ACS token."
+                            >
+                                <p>
+                                    In case claim mapping is not configured for a certain claim,
+                                    this claim will not be returned from authentication provider.
+                                </p>
+                            </Alert>
+                            {(!values.claimMappings ||
+                                (Array.isArray(values.claimMappings) &&
+                                    values.claimMappings.length === 0)) && (
+                                <p>No claim mappings defined</p>
+                            )}
+                            <FieldArray
+                                name="claimMappings"
+                                render={(arrayHelpers) => (
+                                    <>
+                                        {values.claimMappings &&
+                                            Array.isArray(values.claimMappings) &&
+                                            values.claimMappings.map((mapping, index: number) => (
+                                                <Flex key={`claim_mapping_${index}`}>
+                                                    <FormGroup
+                                                        label="Key"
+                                                        fieldId={`claimMappings[${index}][0]`}
+                                                    >
+                                                        <TextInput
+                                                            type="text"
+                                                            id={`claimMappings[${index}][0]`}
+                                                            value={mapping[0]}
+                                                            onChange={onChange}
+                                                            isDisabled={isDisabled}
+                                                        />
+                                                    </FormGroup>
+                                                    <FormGroup
+                                                        label="Value"
+                                                        fieldId={`claimMappings[${index}][1]`}
+                                                    >
+                                                        <TextInput
+                                                            type="text"
+                                                            id={`claimMappings[${index}][1]`}
+                                                            value={mapping[1]}
+                                                            onChange={onChange}
+                                                            isDisabled={isDisabled}
+                                                        />
+                                                    </FormGroup>
+                                                    {!isDisabled && (
+                                                        <FlexItem>
+                                                            <Button
+                                                                variant="plain"
+                                                                aria-label="Delete claim mapping"
+                                                                style={{
+                                                                    transform: 'translate(0, 42px)',
+                                                                }}
+                                                                onClick={() =>
+                                                                    arrayHelpers.remove(index)
+                                                                }
+                                                            >
+                                                                <TrashIcon />
+                                                            </Button>
+                                                        </FlexItem>
+                                                    )}
+                                                    {!isUserResource(
+                                                        selectedAuthProvider.traits
+                                                    ) && (
+                                                        <FlexItem>
+                                                            <Tooltip content="Auth provider is managed declaratively and can only be edited declaratively.">
+                                                                <Button
+                                                                    variant="plain"
+                                                                    aria-label="Information button"
+                                                                    style={{
+                                                                        transform:
+                                                                            'translate(0, 42px)',
+                                                                    }}
+                                                                >
+                                                                    <InfoCircleIcon />
+                                                                </Button>
+                                                            </Tooltip>
+                                                        </FlexItem>
+                                                    )}
+                                                </Flex>
+                                            ))}
+                                        {!isDisabled && (
+                                            <Flex>
+                                                <FlexItem>
+                                                    <Button
+                                                        variant="link"
+                                                        isInline
+                                                        icon={
+                                                            <PlusCircleIcon className="pf-u-mr-sm" />
+                                                        }
+                                                        onClick={() => arrayHelpers.push(['', ''])}
+                                                    >
+                                                        Add claim mapping
                                                     </Button>
                                                 </FlexItem>
                                             </Flex>

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -638,13 +638,15 @@ function AuthProviderForm({
                             </Alert>
                             {(!values.claimMappings ||
                                 (Array.isArray(values.claimMappings) &&
-                                    values.claimMappings.length === 0)) ? (
+                                    values.claimMappings.length === 0)) && (
                                 <p>No claim mappings defined</p>
-                            ) : (
+                            )}
                             <FieldArray
                                 name="claimMappings"
                                 render={(arrayHelpers) => (
                                     <>
+                                        {values.claimMappings &&
+                                            Array.isArray(values.claimMappings) &&
                                             values.claimMappings.map((mapping, index: number) => (
                                                 <Flex key={`claim_mapping_${index}`}>
                                                     <FormGroup

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/authProviders.utils.ts
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/authProviders.utils.ts
@@ -1,7 +1,7 @@
 import {
     AuthProvider,
     AuthProviderConfig,
-    AuthProviderRequiredAttributes,
+    AuthProviderRequiredAttribute,
     Group,
 } from 'services/AuthService';
 import { isUserResource } from '../traits';
@@ -100,7 +100,8 @@ export function transformValuesBeforeSaving(
         | string[]
         | boolean
         | AuthProviderConfig
-        | AuthProviderRequiredAttributes[]
+        | AuthProviderRequiredAttribute[]
+        | [string, string][]
         | Group[]
         | undefined
     >
@@ -110,7 +111,8 @@ export function transformValuesBeforeSaving(
     | string[]
     | boolean
     | AuthProviderConfig
-    | AuthProviderRequiredAttributes[]
+    | AuthProviderRequiredAttribute[]
+    | [string, string][]
     | Group[]
     | undefined
 > {

--- a/ui/apps/platform/src/services/AuthService/AuthService.ts
+++ b/ui/apps/platform/src/services/AuthService/AuthService.ts
@@ -78,7 +78,7 @@ export type AuthProvider = {
     defaultRole?: string;
     requiredAttributes: AuthProviderRequiredAttribute[];
     traits?: Traits;
-    claimMappings: { [k: string]: string } | [string, string][];
+    claimMappings: Record<string, string> | [string, string][];
     lastUpdated: string;
 };
 
@@ -172,7 +172,7 @@ export function deleteAuthProviders(authProviderIds) {
     return Promise.all(authProviderIds.map((id) => deleteAuthProvider(id)));
 }
 
-function preprocessAuthProvider(provider: AuthProvider): AuthProvider {
+function convertAuthProviderClaimMappingsToArray(provider: AuthProvider): AuthProvider {
     if (!provider.claimMappings) {
         return provider;
     }
@@ -184,7 +184,7 @@ function preprocessAuthProvider(provider: AuthProvider): AuthProvider {
     return newProvider;
 }
 
-function postprocessAuthProvider(authProvider: AuthProvider): AuthProvider {
+function convertAuthProviderClaimMappingsToObject(authProvider: AuthProvider): AuthProvider {
     if (!authProvider.claimMappings) {
         return authProvider;
     }

--- a/ui/apps/platform/src/services/AuthService/AuthService.ts
+++ b/ui/apps/platform/src/services/AuthService/AuthService.ts
@@ -173,6 +173,9 @@ export function deleteAuthProviders(authProviderIds) {
 }
 
 function preprocessAuthProvider(provider: AuthProvider): AuthProvider {
+    if (!provider.claimMappings) {
+        return provider;
+    }
     const mappingAsArray = Object.entries(provider.claimMappings).sort((a, b) =>
         a[0].localeCompare(b[0])
     );
@@ -182,6 +185,9 @@ function preprocessAuthProvider(provider: AuthProvider): AuthProvider {
 }
 
 function postprocessAuthProvider(authProvider: AuthProvider): AuthProvider {
+    if (!authProvider.claimMappings) {
+        return authProvider;
+    }
     const newProvider = { ...authProvider };
     newProvider.claimMappings = Object.fromEntries(
         authProvider.claimMappings as [string, string][]

--- a/ui/apps/platform/src/services/AuthService/AuthService.ts
+++ b/ui/apps/platform/src/services/AuthService/AuthService.ts
@@ -185,13 +185,11 @@ function convertAuthProviderClaimMappingsToArray(provider: AuthProvider): AuthPr
 }
 
 function convertAuthProviderClaimMappingsToObject(authProvider: AuthProvider): AuthProvider {
-    if (!authProvider.claimMappings) {
+    if (!Array.isArray(authProvider.claimMappings)) {
         return authProvider;
     }
     const newProvider = { ...authProvider };
-    newProvider.claimMappings = Object.fromEntries(
-        authProvider.claimMappings as [string, string][]
-    );
+    newProvider.claimMappings = Object.fromEntries(authProvider.claimMappings);
     return newProvider;
 }
 

--- a/ui/apps/platform/src/services/AuthService/AuthService.ts
+++ b/ui/apps/platform/src/services/AuthService/AuthService.ts
@@ -76,9 +76,9 @@ export type AuthProvider = {
     active?: boolean;
     groups?: Group[];
     defaultRole?: string;
-    requiredAttributes: AuthProviderRequiredAttributes[];
+    requiredAttributes: AuthProviderRequiredAttribute[];
     traits?: Traits;
-    claimMappings: Record<string, string>;
+    claimMappings: { [k: string]: string } | [string, string][];
     lastUpdated: string;
 };
 
@@ -87,7 +87,7 @@ export type AuthProviderInfo = {
     value: AuthProviderType;
 };
 
-export type AuthProviderRequiredAttributes = {
+export type AuthProviderRequiredAttribute = {
     attributeKey: string;
     attributeValue: string;
 };
@@ -96,9 +96,10 @@ export type AuthProviderRequiredAttributes = {
  * Fetch authentication providers.
  */
 export function fetchAuthProviders(): Promise<{ response: AuthProvider[] }> {
-    return axios.get(`${authProvidersUrl}`).then((response) => ({
-        response: response?.data?.authProviders ?? [],
-    }));
+    return axios.get(`${authProvidersUrl}`).then((response) => {
+        const authProviders = response?.data?.authProviders ?? [];
+        return { response: authProviders.map((ap) => preprocessAuthProvider(ap)) };
+    });
 }
 
 export type AuthProviderLogin = {
@@ -130,26 +131,6 @@ export function fetchAvailableProviderTypes(): Promise<{ response: AuthProviderI
     }));
 }
 
-/*
- * Create entity and return object with id assigned by backend.
- */
-export function createAuthProvider(authProvider: AuthProvider): Promise<AuthProvider> {
-    return axios.post<AuthProvider>(authProvidersUrl, authProvider).then((response) => {
-        return response.data;
-    });
-}
-
-/*
- * Update entity and return object.
- */
-export function updateAuthProvider(authProvider: AuthProvider): Promise<AuthProvider> {
-    return axios
-        .put<AuthProvider>(`${authProvidersUrl}/${authProvider.id}`, authProvider)
-        .then((response) => {
-            return response.data;
-        });
-}
-
 /**
  * Saves auth provider either by creating a new one (in case ID is missed) or by updating existing one by ID.
  */
@@ -157,9 +138,17 @@ export function saveAuthProvider(authProvider: AuthProvider): string | Promise<A
     if (authProvider.active || getIsAuthProviderImmutable(authProvider)) {
         return authProvider.id;
     }
+
     return authProvider.id
-        ? axios.put(`${authProvidersUrl}/${authProvider.id}`, authProvider)
-        : axios.post(authProvidersUrl, authProvider);
+        ? axios
+              .put<AuthProvider>(
+                  `${authProvidersUrl}/${authProvider.id}`,
+                  postprocessAuthProvider(authProvider)
+              )
+              .then((response) => {
+                  return preprocessAuthProvider(response.data);
+              })
+        : axios.post(authProvidersUrl, postprocessAuthProvider(authProvider));
 }
 
 /**
@@ -181,6 +170,23 @@ export function deleteAuthProvider(authProviderId: string): Promise<Empty> {
  */
 export function deleteAuthProviders(authProviderIds) {
     return Promise.all(authProviderIds.map((id) => deleteAuthProvider(id)));
+}
+
+function preprocessAuthProvider(provider: AuthProvider): AuthProvider {
+    const mappingAsArray = Object.entries(provider.claimMappings).sort((a, b) =>
+        a[0].localeCompare(b[0])
+    );
+    const newProvider = { ...provider };
+    newProvider.claimMappings = mappingAsArray;
+    return newProvider;
+}
+
+function postprocessAuthProvider(authProvider: AuthProvider): AuthProvider {
+    const newProvider = { ...authProvider };
+    newProvider.claimMappings = Object.fromEntries(
+        authProvider.claimMappings as [string, string][]
+    );
+    return newProvider;
 }
 
 /*

--- a/ui/apps/platform/src/services/AuthService/AuthService.ts
+++ b/ui/apps/platform/src/services/AuthService/AuthService.ts
@@ -98,7 +98,7 @@ export type AuthProviderRequiredAttribute = {
 export function fetchAuthProviders(): Promise<{ response: AuthProvider[] }> {
     return axios.get(`${authProvidersUrl}`).then((response) => {
         const authProviders = response?.data?.authProviders ?? [];
-        return { response: authProviders.map((ap) => preprocessAuthProvider(ap)) };
+        return { response: authProviders.map((ap) => convertAuthProviderClaimMappingsToArray(ap)) };
     });
 }
 
@@ -143,12 +143,12 @@ export function saveAuthProvider(authProvider: AuthProvider): string | Promise<A
         ? axios
               .put<AuthProvider>(
                   `${authProvidersUrl}/${authProvider.id}`,
-                  postprocessAuthProvider(authProvider)
+                  convertAuthProviderClaimMappingsToObject(authProvider)
               )
               .then((response) => {
-                  return preprocessAuthProvider(response.data);
+                  return convertAuthProviderClaimMappingsToArray(response.data);
               })
-        : axios.post(authProvidersUrl, postprocessAuthProvider(authProvider));
+        : axios.post(authProvidersUrl, convertAuthProviderClaimMappingsToObject(authProvider));
 }
 
 /**


### PR DESCRIPTION
## Description

Introduce claim mappings to auth provider UI. 

Since claim mappings are presented in the backend as `map[string]string`, re-ordering of elements is possible. To give customer some consistency, UI sorts claim mappings alphabetically by key. It also checks that any key used is unique.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

<img width="1780" alt="Screenshot 2024-02-22 at 02 16 44" src="https://github.com/stackrox/stackrox/assets/78353299/2835bb50-c7c4-490c-a558-17622b75fb78">


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
