### PR TITLE
fix(ui): Fix CVE Type in VM 1.0 nested Overview pages

### DIFF
--- a/ui/apps/platform/src/Components/CveType/CveType.tsx
+++ b/ui/apps/platform/src/Components/CveType/CveType.tsx
@@ -1,16 +1,36 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-const cveTypes = ['IMAGE_CVE', 'K8S_CVE', 'ISTIO_CVE', 'NODE_CVE', 'OPENSHIFT_CVE'];
+export type CveType =
+    | 'IMAGE_CVE'
+    | 'IMAGE'
+    | 'IMAGE_COMPONENT'
+    | 'DEPLOYMENT'
+    | 'NAMESPACE'
+    | 'K8S_CVE'
+    | 'ISTIO_CVE'
+    | 'NODE_CVE'
+    | 'NODE'
+    | 'NODE_COMPONENT'
+    | 'OPENSHIFT_CVE';
+export type CveTypeProps = {
+    types: CveType[];
+};
+
 const cveTypeMap = {
     IMAGE_CVE: 'Image CVE',
+    IMAGE: 'Image CVE',
+    IMAGE_COMPONENT: 'Image CVE',
+    DEPLOYMENT: 'Image CVE',
+    NAMESPACE: 'Image CVE',
     K8S_CVE: 'Kubernetes CVE',
     ISTIO_CVE: 'Istio CVE',
     NODE_CVE: 'Node CVE',
+    NODE: 'Node CVE',
+    NODE_COMPONENT: 'Node CVE',
     OPENSHIFT_CVE: 'OpenShift CVE',
 };
 
-const CveType = ({ types }) => {
+const CveType = ({ types = [] }: CveTypeProps) => {
     const sortedTypes = types.map((x) => cveTypeMap[x] || 'Unknown').sort();
 
     return (
@@ -24,14 +44,6 @@ const CveType = ({ types }) => {
             </div>
         </span>
     );
-};
-
-CveType.propTypes = {
-    types: PropTypes.arrayOf(PropTypes.oneOf(cveTypes)),
-};
-
-CveType.defaultProps = {
-    types: [],
 };
 
 export default CveType;


### PR DESCRIPTION
## Description

Reported by @RTann in a chat thread.
> I noticed in the VM 1.0 Images list > CVE single Overview view taht CVE Type is Unknown but when I am in top-level CVE single Overview view (no idea the terminology, but I pressed the box with the arrow facing up and to the right. can someone tell me the proper terms?) it says Image CVE.

In the "sidebar" view, the CVE is in the context of an image. In the "external" view the CVE is the top-level entity seen in isolation.

It a conflict between some code to allow for multiple "vulnerability types" added three years ago, and some conditional code added 20 months ago when we split the CVE datastore into image, node, and cluster. My guess is that this has been broken since the migration to Postgres, but there could have been other changes since then--even recently--that caused this issue to surface.

This PR added checked at two levels.
* First checks for the presence of an `imageComponentCount` or `nodeComponentCount` to handle when the CVEs are nested under a Cluster view (which happens when the user uses one of the 3 Findings tables on a Cluster Overview page to get to an individual CVE in a side panel.
* Also, add checks for when the entity that is doing the nesting is an Image, Namespace, Deployment, or Image Component (for Image CVE), or if the nesting entity is a Node or Node Component (for Node CVE).

Note that the first check may make the second check redundant, but since the second check was done first, and we are in maintenance mode for VM 1.0, I left both checks in the code, for added safety.


## Checklist
- [x] Investigated and inspected CI test results (set of failures in one flavor of ui-e2e-tests are flakes being fixed in a separate PR, https://github.com/stackrox/stackrox/pull/10029)


## Testing Performed

### Here I tell how I validated my change

I had deployed and UI-development windows using staging server data on screen at the same time, so that I could take "before and after" screenshots of the broken version of a page on the left, with the fixed version of the same page on the right.

Image CVE under Cluster
<img width="1993" alt="image_cve_under_cluster" src="https://github.com/stackrox/stackrox/assets/715729/e603aec4-9217-422f-8121-46b284d5ef9d">

Node CVE under Cluster
<img width="2021" alt="node_cve_under_cluster" src="https://github.com/stackrox/stackrox/assets/715729/7c04bc0a-fb48-410c-940b-2c609a06fe05">

Platform CVE under Cluster
<img width="2129" alt="platform_cve_under_cluster" src="https://github.com/stackrox/stackrox/assets/715729/0e007a44-2b6f-4fd0-85aa-52af53c1625c">

Image CVE under Image
![image_cve_under_image](https://github.com/stackrox/stackrox/assets/715729/03f53717-9b27-4523-a273-c9d81c529048)

Image CVE under Namespace
![image_cve_under_namespace](https://github.com/stackrox/stackrox/assets/715729/b0880b64-90b4-4f18-bc1e-83225213bd15)

Image CVE under Deployment
![image_cve_under_deployment](https://github.com/stackrox/stackrox/assets/715729/1896905e-3445-4ba9-ad26-52a9fe26f239)

Image CVE under Image Component
![image_cve_under_image_component](https://github.com/stackrox/stackrox/assets/715729/6005f0a1-3303-4eba-8df3-8c2c2a87837c)

Node CVE under Node
![node_cve_under_node](https://github.com/stackrox/stackrox/assets/715729/1d411337-9ec8-40af-9053-1a5044056eba)

Node CVE under Node Component
![node_cve_under_node_component](https://github.com/stackrox/stackrox/assets/715729/4182dd22-6900-4cc8-935b-f13041a6d86b)



### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
