### PR TITLE
fix(be): Do not use AWSSH decrypt function  to get value of StsEnabled

### DIFF
--- a/central/notifiers/awssh/notifier.go
+++ b/central/notifiers/awssh/notifier.go
@@ -205,13 +205,13 @@ func newNotifier(configuration configuration) (*notifier, error) {
 		awsConfig = awsConfig.WithRegion(awssh.GetRegion())
 	}
 
-	accessKeyId, secretAccessKey, err := configuration.getCredentials()
+	accessKeyID, secretAccessKey, err := configuration.getCredentials()
 	if err != nil {
 		return nil, err
 	}
 	if !configuration.descriptor.GetAwsSecurityHub().GetCredentials().GetStsEnabled() {
 		awsConfig = awsConfig.WithCredentials(credentials.NewStaticCredentials(
-			accessKeyId,
+			accessKeyID,
 			secretAccessKey,
 			"",
 		))


### PR DESCRIPTION
## Description

AWS Security Hub notifier has 3 data items in credentials: `AccessKeyId`, `SecretAccessKey` and `StsEnabled`. Among these, `StsEnabled`  is not a secret and thus, its value will not be kept up-to-date in the encrypted string. The credentials are re-encrypted only if fields that are considered secret are changed. Since `StsEnabled` is not one, changes to its value will not trigger a re-encryption. Furthermore, when sending notifications, the decryption function should only be used to decrypt data that is considered secret. Thus the decryption function will only decrypt and return secret values. Non-secret values can directly be fetched from the notifier object.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Manual testing

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
