### PR TITLE
ROX-22496: Make critical improvements to usability on NoClustersPage

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
@@ -28,10 +28,9 @@ describe('Clusters', () => {
         }, staticResponseMapForClusters);
 
         if (hasFeatureFlag('ROX_MOVE_INIT_BUNDLES_UI')) {
-            // Replace h1 with h2 if we factor out a minimal Clusters page.
-            cy.get('h1:contains("Secure clusters with a reusable init bundle")');
+            cy.get('h2:contains("Secure clusters with a reusable init bundle")');
             // Button text depends whether or not init bundles exist.
-            cy.get('button.pf-m-primary.pf-m-display-lg');
+            cy.get('button:contains("View installation methods")');
         } else {
             cy.get('h2:contains("Configure the clusters you want to secure.")');
             cy.get('a:contains("View instructions")');

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterModal.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import {
+    Alert,
     Button,
     Divider,
     Flex,
@@ -35,7 +36,7 @@ function SecureClusterModal({ isModalOpen, setIsModalOpen }): ReactElement {
 
     return (
         <Modal
-            variant="large"
+            variant="medium"
             title="Review installation methods"
             isOpen={isModalOpen}
             onClose={onClose}
@@ -58,6 +59,12 @@ function SecureClusterModal({ isModalOpen, setIsModalOpen }): ReactElement {
                 ) : (
                     <SecureClusterUsingHelmChart headingLevel={headingLevel} />
                 )}
+                <Alert
+                    variant="info"
+                    isInline
+                    title="You can use one bundle to secure multiple clusters that have the same installation method."
+                    component="p"
+                />
             </Flex>
         </Modal>
     );

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
@@ -15,7 +15,7 @@ import {
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import PageTitle from 'Components/PageTitle';
 import TabNav from 'Components/TabNav/TabNav';
-import { clustersBasePath, clustersSecureClusterPath } from 'routePaths';
+import { clustersBasePath, clustersInitBundlesPath, clustersSecureClusterPath } from 'routePaths';
 
 import SecureClusterUsingHelmChart from './SecureClusterUsingHelmChart';
 import SecureClusterUsingOperator from './SecureClusterUsingOperator';
@@ -50,6 +50,9 @@ function SecureClusterPage(): ReactElement {
                     <Flex direction={{ default: 'column' }}>
                         <Breadcrumb>
                             <BreadcrumbItemLink to={clustersBasePath}>Clusters</BreadcrumbItemLink>
+                            <BreadcrumbItemLink to={clustersInitBundlesPath}>
+                                Cluster init bundles
+                            </BreadcrumbItemLink>
                             <BreadcrumbItem isActive>{title}</BreadcrumbItem>
                         </Breadcrumb>
                         <Title headingLevel="h1">Secure a cluster with an init bundle</Title>

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -13,6 +13,8 @@ import {
     Spinner,
     Title,
     Text,
+    Toolbar,
+    ToolbarContent,
 } from '@patternfly/react-core';
 import { CloudSecurityIcon } from '@patternfly/react-icons';
 
@@ -64,7 +66,6 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
     const [isLoading, setIsLoading] = useState(false);
 
     const { basePageTitle } = getProductBranding();
-    const textForSuccessAlert = `You have successfully deployed a ${basePageTitle} platform. Now you can configure the clusters you want to secure.`;
 
     useEffect(() => {
         // TODO after 4.4 release: if (hasAdminRole) {
@@ -83,16 +84,19 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
         // TODO after 4.4 releaes: }
     }, []); // TODO after 4.4 release [hasAdminRole]
 
+    // Why is some EmptyState content outside of EmptyStateBody element?
+    // Because  Button is inside, it has same width at the text :(
+
     // TODO after 4.4 release add hasAdminRole to conditional rendering.
     /* eslint-disable no-nested-ternary */
     return (
         <>
-            <PageSection variant="light" component="div" padding={{ default: 'noPadding' }}>
-                <Alert isInline variant="success" title="You are ready to go!">
-                    {textForSuccessAlert}
-                </Alert>
-            </PageSection>
             <PageSection variant="light">
+                <Toolbar inset={{ default: 'insetNone' }} className="pf-u-pb-0">
+                    <ToolbarContent>
+                        <Title headingLevel="h1">Clusters</Title>
+                    </ToolbarContent>
+                </Toolbar>
                 {isLoading ? (
                     <Bullseye>
                         <Spinner isSVG />
@@ -107,27 +111,32 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
                         {errorMessage}
                     </Alert>
                 ) : (
-                    <EmptyState variant="large">
+                    <EmptyState variant="xl">
                         <EmptyStateIcon icon={CloudSecurityIcon} />
-                        <Title headingLevel="h1">Secure clusters with a reusable init bundle</Title>
+                        <Title headingLevel="h2">Secure clusters with a reusable init bundle</Title>
                         <EmptyStateBody>
                             <Flex
                                 direction={{ default: 'column' }}
                                 spaceItems={{ default: 'spaceItemsLg' }}
                             >
-                                <FlexItem>
-                                    <Text component="p">
-                                        Follow the instructions to install secured cluster services.
-                                    </Text>
-                                    <Text component="p">
-                                        Upon successful installation, secured clusters are listed
-                                        here.
-                                    </Text>
-                                </FlexItem>
-                                {initBundlesCount !== 0 && (
+                                {initBundlesCount === 0 ? (
                                     <FlexItem>
                                         <Text component="p">
-                                            You have successfully created cluster init bundles.
+                                            {`You have successfully deployed a ${basePageTitle} platform.`}
+                                        </Text>
+                                        <Text component="p">
+                                            Before you can secure clusters, create an init bundle.
+                                        </Text>
+                                    </FlexItem>
+                                ) : (
+                                    <FlexItem>
+                                        <Text component="p">
+                                            Use your preferred method to install secured cluster
+                                            services.
+                                        </Text>
+                                        <Text component="p">
+                                            After successful installation, it might take a few
+                                            moments for this page to display secured clusters.
                                         </Text>
                                     </FlexItem>
                                 )}
@@ -146,7 +155,7 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
                                     })
                                 }
                             >
-                                Create bundle
+                                Create init bundle
                             </Button>
                         ) : (
                             <Button
@@ -160,10 +169,10 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
                                     });
                                 }}
                             >
-                                Review installation methods
+                                View installation methods
                             </Button>
                         )}
-                        <div className="pf-u-mt-xl">
+                        <Flex direction={{ default: 'column' }} className="pf-u-mt-xl">
                             <Link
                                 to={`${clustersBasePath}/new`}
                                 onClick={() => {
@@ -175,7 +184,23 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
                             >
                                 Legacy installation method
                             </Link>
-                        </div>
+                            {initBundlesCount !== 0 && (
+                                <Text component="p">
+                                    If you lost the YAML file that you downloaded,{' '}
+                                    <Link
+                                        to={`${clustersInitBundlesPath}?action=create`}
+                                        onClick={() => {
+                                            analyticsTrack({
+                                                event: CREATE_INIT_BUNDLE_CLICKED,
+                                                properties: { source: 'No Clusters' },
+                                            });
+                                        }}
+                                    >
+                                        create another init bundle
+                                    </Link>
+                                </Text>
+                            )}
+                        </Flex>
                         <SecureClusterModal
                             isModalOpen={isModalOpen}
                             setIsModalOpen={setIsModalOpen}


### PR DESCRIPTION
## Description

Thanks to Zhenpeng for clear changes. Adjusted somewhat to fit the context:
1. Update empty state text pre and post bundle to make clearer where trial user is in the process and what to expect next.
2. Change primary button text, especially replace **Review** with **View**.
3. Add link to create another init bundle in case of lost YAML file.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited regression tests

## Testing Performed

Temporarily edit code to simulate no clusters and no bundles.

1. Visit /main/clusters with simulated no clusters and no bundles.
    * See **Clusters** heading element at upper left for consistency whenordinary clusters page displays secured clusters (see step TODO).
    * See updated pre-bundle text which has xl size.
    * See **Create init bundle** button.
    * See **Legacy installation method** link.
    ![1](https://github.com/stackrox/stackrox/assets/11862657/54d59c28-7be3-4175-9b76-9230f2e67d24)

2. Click **Legacy installation method** link.
    * See /main/clusters/new page and then click the browser back button.
    ![2](https://github.com/stackrox/stackrox/assets/11862657/7546e595-ff26-4e91-863b-1b4f10b4545b)

3. Click browser back button and then click **Create init bundle** button.
    * See /main/clusters/init-bundles?action=create form with **Download** button disabled.
    ![3](https://github.com/stackrox/stackrox/assets/11862657/9fe02212-664c-4c7c-ba9d-85ff710e9320)

4. Type name and then click **Download** button which goes back to /main/clusters page.
    * See updated post-bundle text which has xl size.
    * See **View installation methods** button.
    * See **Legacy installation method** link.
    * See sentence which has **create another init bundle** link.
    ![4](https://github.com/stackrox/stackrox/assets/11862657/8d7e3a23-05aa-4212-837f-5d962ea73807)

5. Click **View installation methods** link.
    * See modal with **Operator** tab selected.
    ![5](https://github.com/stackrox/stackrox/assets/11862657/47edf485-fa87-4872-a36d-f3f65711adb3)

6. Click **Helm chart** tab.
    ![6](https://github.com/stackrox/stackrox/assets/11862657/c9f71472-3519-420c-8263-b664dec0280c)

7. Click **Operator** tab and remove simulation of no clusters.
    * See clusters page under modal.
    ![7](https://github.com/stackrox/stackrox/assets/11862657/840261a3-885b-4674-af51-1396ca7ea440)

8. Click **Close** button.
    * See clusters page.
    ![8](https://github.com/stackrox/stackrox/assets/11862657/47798ada-24a8-4ea2-8fb3-efe4558e80be)

9. Click **Secure a cluster** button at upper right of clusters page.
    ![9](https://github.com/stackrox/stackrox/assets/11862657/d6105d4a-5132-49c5-b0c3-44f5a270ff66)

10. Click **Init bundle installation methods** item.
    * See /main/clusters/secure-a-cluster page.
    ![10](https://github.com/stackrox/stackrox/assets/11862657/e9a00582-2d64-4ba4-8e02-51712a3703d5)

11. Click **Cluster init bundles** breakcrumb link.
    * See /main/clusters/init-bundles page.
    ![11](https://github.com/stackrox/stackrox/assets/11862657/a85916d4-fab5-40e5-84fb-af700d17ec04)

### Integration testing

Before you `yarn cypress-open` in ui/apps/platform folder:

```sh
export CYPRESS_ROX_MOVE_INIT_BUNDLES_UI=true
```

* clusters/init-bundles/InitBundleForm.test.js
* clusters/init-bundles/InitBundlesPage.test.js
* clusters/redirectFromDashboard.test.js