### PR TITLE
fix(ci): add ocp-stable in OSCI node settings

### DIFF
--- a/.openshift-ci/begin.sh
+++ b/.openshift-ci/begin.sh
@@ -20,7 +20,7 @@ if [[ -z "${SHARED_DIR:-}" ]]; then
     exit 0 # not fatal but worth highlighting
 fi
 
-if [[ "${JOB_NAME:-}" =~ -ocp-4- ]]; then
+if [[ "${JOB_NAME:-}" =~ -ocp-(4|stable)- ]]; then
     info "Setting worker node type and count for OCP 4 jobs"
     # https://github.com/stackrox/automation-flavors/blob/e6daf10b7df49fc003584790e25def036b2a3b0b/openshift-4/entrypoint.sh#L76
     set_ci_shared_export WORKER_NODE_COUNT 2

--- a/.openshift-ci/begin.sh
+++ b/.openshift-ci/begin.sh
@@ -20,6 +20,8 @@ if [[ -z "${SHARED_DIR:-}" ]]; then
     exit 0 # not fatal but worth highlighting
 fi
 
+# TODO:: Remove ocp-stable if it's deleted from the OSCI, e.g.,
+# https://github.com/openshift/release/blob/a14f76e0918b047d2406e9eb6baac82b55ced05a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-stable-scanner-v4.yaml
 if [[ "${JOB_NAME:-}" =~ -ocp-(4|stable)- ]]; then
     info "Setting worker node type and count for OCP 4 jobs"
     # https://github.com/stackrox/automation-flavors/blob/e6daf10b7df49fc003584790e25def036b2a3b0b/openshift-4/entrypoint.sh#L76


### PR DESCRIPTION
## Description

These changes add ocp-stable in our OSCI node settings since I wrongly changed the pattern in this PR: https://github.com/openshift/release/pull/48519. This should eventually be removed after scanner v4 is enabled by default in CI (or when this file is removed: https://github.com/openshift/release/blob/a14f76e0918b047d2406e9eb6baac82b55ced05a/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master__ocp-stable-scanner-v4.yaml

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
