### PR TITLE
fix(CI): add qa- prefix to tests namespaces

### DIFF
--- a/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
@@ -104,7 +104,7 @@ class ReconciliationTest extends BaseSpecification {
         String secretID
         String networkPolicyID
 
-        def ns = "reconciliation"
+        def ns = "qa-reconciliation"
         // Deploy a new resource of each type
         // Not possible to test node in this circumstance
         // Requires manual testing

--- a/qa-tests-backend/src/test/groovy/VulnReportingTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnReportingTest.groovy
@@ -17,7 +17,7 @@ import spock.lang.IgnoreIf
 @Tag("PZ")
 class VulnReportingTest extends BaseSpecification {
 
-    static final private String SECONDARY_NAMESPACE = "vulnreport-2nd-namespace"
+    static final private String SECONDARY_NAMESPACE = "qa-vulnreport-2nd-namespace"
     static final private List<Deployment> DEPLOYMENTS = [
             new Deployment()
                     .setName("struts-deployment")


### PR DESCRIPTION
## Description

https://issues.redhat.com/browse/ROX-22586 - is missing debug for the test namespace which makes it hard to determine root cause. `collect-qa-service-logs.sh` will gather from all namespaces starting `qa`.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

### Here I tell how I validated my change

CI is sufficient.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
