### PR TITLE
fix(scanv4): Helm chart lies about Scanner V4 being enabled

### DIFF
--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -165,10 +165,12 @@
   {{- $_ = set $._rox.scannerV4 "_installMode" "" -}}
 {{- end -}}
 
-{{- if eq $._rox.scannerV4._installMode "" }}
-  {{ include "srox.note" (list $ (printf "Scanner V4 is enabled and Scanner V4 components are already deployed.")) }}
-{{- else }}
-  {{ include "srox.note" (list $ (printf "Scanner V4 is enabled and the following Scanner V4 components will be deployed: %s" $._rox.scannerV4._installMode)) }}
+{{- if not $scannerV4Cfg.disable }}
+  {{- if eq $._rox.scannerV4._installMode "" }}
+    {{ include "srox.note" (list $ (printf "Scanner V4 is enabled and Scanner V4 components are already deployed.")) }}
+  {{- else }}
+    {{ include "srox.note" (list $ (printf "Scanner V4 is enabled and the following Scanner V4 components will be deployed: %s" $._rox.scannerV4._installMode)) }}
+  {{- end }}
 {{- end }}
 
 {{- end -}}

--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -132,8 +132,6 @@
     {{- end -}}
   {{ end }}
 
-{{- end -}} {{/* if not $scannerV4Cfg.disable */}}
-
 {{- if eq $.Chart.Name "stackrox-secured-cluster-services" -}}
   {{/* Special handling for the secured-cluster-services chart in case it gets deployed
        to the same namespace as central-services. */}}
@@ -144,6 +142,8 @@
     {{ $_ := set $components "indexer" false }}
   {{ end }}
 {{- end }}
+
+{{- end -}} {{/* if not $scannerV4Cfg.disable */}}
 
 {{/* Propagate information about which Scanner V4 components to deploy. */}}
 {{- $_ := set $._rox "_scannerV4Enabled" (not $scannerV4Cfg.disable) -}}

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -335,3 +335,19 @@ tests:
               name: a-default-sc
               annotations:
                 storageclass.kubernetes.io/is-default-class: true
+
+- name: "Installation log contains"
+  values:
+    imagePullSecrets:
+      allowNone: true
+    scanner:
+      disable: false
+  tests:
+  - name: "no reference to Scanner V4 if Scanner V4 is not enabled"
+    expect: |
+      .notes | assertThat(contains("Scanner V4 is enabled") | not)
+  - name: "reference to Scanner V4 if Scanner V4 is enabled"
+    set:
+      scannerV4.disable: false
+    expect: |
+      .notes | assertThat(contains("Scanner V4 is enabled"))


### PR DESCRIPTION
## Description

Small bug fix. Noticed while installing secured-cluster-services, that the post-install notes contained an inconsistency:

```
Secured Cluster Configuration Summary:
[...]
  Scanner V4:                                  disabled

Please take note of the following:
[...]
- Scanner V4 is enabled and Scanner V4 components are already deployed.
```

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
