### PR TITLE
ROX-22601: address compliance cluster details issues

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/Clusters/ClusterDetailsTable.tsx
@@ -12,6 +12,7 @@ import {
     Toolbar,
     ToolbarContent,
     ToolbarItem,
+    Tooltip,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
@@ -31,7 +32,7 @@ import {
 } from 'services/ComplianceEnhancedService';
 import { SearchFilter } from 'types/search';
 import { SortOption } from 'types/table';
-import { searchValueAsArray } from 'utils/searchUtils';
+import { addRegexPrefixToFilters, searchValueAsArray } from 'utils/searchUtils';
 
 // TODO: move to a shared location
 import TableErrorComponent from 'Containers/Vulnerabilities/WorkloadCves/components/TableErrorComponent';
@@ -72,7 +73,7 @@ function ClusterDetailsTable({
             getSingleClusterResultsByScanConfig(
                 clusterId,
                 scanName,
-                searchFilter,
+                addRegexPrefixToFilters(searchFilter, ['Compliance Check Name']),
                 sortOption,
                 page - 1,
                 perPage
@@ -82,7 +83,12 @@ function ClusterDetailsTable({
     const { data: scanResults, loading: isLoading, error } = useRestQuery(listQuery);
 
     const countQuery = useCallback(
-        () => getSingleClusterResultsByScanConfigCount(clusterId, scanName, searchFilter),
+        () =>
+            getSingleClusterResultsByScanConfigCount(
+                clusterId,
+                scanName,
+                addRegexPrefixToFilters(searchFilter, ['Compliance Check Name'])
+            ),
         [clusterId, scanName, searchFilter]
     );
     const { data: scanResultsCount } = useRestQuery(countQuery);
@@ -96,6 +102,10 @@ function ClusterDetailsTable({
             setSearchCheckValue('');
         }
     }, [searchFilter]);
+
+    useEffect(() => {
+        setPage(1);
+    }, [scanName, searchFilter, setPage]);
 
     function getMatchingCluster(clusters: ClusterCheckStatus[]): ClusterCheckStatus | null {
         return (
@@ -158,13 +168,15 @@ function ClusterDetailsTable({
                     </Td>
                     <Td>
                         {statusObj && (
-                            <Button
-                                isInline
-                                variant={ButtonVariant.link}
-                                onClick={() => setSelectedCheckResult(checkResult)}
-                            >
-                                <IconText icon={statusObj.icon} text={statusObj.statusText} />
-                            </Button>
+                            <Tooltip content={statusObj.tooltipText}>
+                                <Button
+                                    isInline
+                                    variant={ButtonVariant.link}
+                                    onClick={() => setSelectedCheckResult(checkResult)}
+                                >
+                                    <IconText icon={statusObj.icon} text={statusObj.statusText} />
+                                </Button>
+                            </Tooltip>
                         )}
                     </Td>
                 </Tr>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/compliance.coverage.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/ClusterCompliance/Coverage/compliance.coverage.utils.tsx
@@ -25,6 +25,7 @@ type LabelColor = LabelProps['color'];
 type ClusterStatusObject = {
     icon: ReactElement;
     statusText: string;
+    tooltipText: string;
 };
 
 export const ComplianceStatus = {
@@ -113,34 +114,43 @@ const statusIconTextMap: { [key in ComplianceCheckStatus]: ClusterStatusObject }
     [ComplianceCheckStatus.PASS]: {
         icon: <CheckCircleIcon color="var(--pf-global--success-color--100)" />,
         statusText: 'Pass',
+        tooltipText: 'Check was successful',
     },
     [ComplianceCheckStatus.FAIL]: {
         icon: <SecurityIcon color="var(--pf-global--danger-color--100)" />,
         statusText: 'Fail',
+        tooltipText: 'Check was unsuccessful',
     },
     [ComplianceCheckStatus.ERROR]: {
         icon: <ExclamationTriangleIcon color="var(--pf-global--disabled-color--100)" />,
         statusText: 'Error',
+        tooltipText: 'Check ran successfully, but could not complete',
     },
     [ComplianceCheckStatus.INFO]: {
         icon: <ExclamationCircleIcon color="var(--pf-global--disabled-color--100)" />,
         statusText: 'Info',
+        tooltipText:
+            'Check was successful and found something not severe enough to be considered an error',
     },
     [ComplianceCheckStatus.MANUAL]: {
         icon: <WrenchIcon color="var(--pf-global--disabled-color--100)" />,
         statusText: 'Manual',
+        tooltipText: 'Check cannot automatically assess the status and manual check is required',
     },
     [ComplianceCheckStatus.NOT_APPLICABLE]: {
         icon: <BanIcon color="var(--pf-global--disabled-color--100)" />,
         statusText: 'Not Applicable',
+        tooltipText: 'Check did not run as it is not applicable',
     },
     [ComplianceCheckStatus.INCONSISTENT]: {
         icon: <UnknownIcon color="var(--pf-global--disabled-color--100)" />,
         statusText: 'Inconsistent',
+        tooltipText: 'Different nodes report different results',
     },
     [ComplianceCheckStatus.UNSET_CHECK_STATUS]: {
         icon: <ResourcesEmptyIcon color="var(--pf-global--disabled-color--100)" />,
         statusText: 'Unset', // TODO: ask about this status
+        tooltipText: '',
     },
 };
 

--- a/ui/apps/platform/src/services/ComplianceEnhancedService.ts
+++ b/ui/apps/platform/src/services/ComplianceEnhancedService.ts
@@ -338,7 +338,6 @@ export function getSingleClusterResultsByScanConfig(
     }
     const searchQuery = getRequestQueryStringForSearchFilter({
         'Cluster ID': clusterId,
-        'Compliance Scan Config Name': scanName,
         ...searchFilter,
     });
 
@@ -346,16 +345,18 @@ export function getSingleClusterResultsByScanConfig(
     if (typeof page === 'number' && typeof pageSize === 'number') {
         offset = page > 0 ? page * pageSize : 0;
     }
-    const query = {
-        query: searchQuery,
-        pagination: { offset, limit: pageSize, sortOption },
+    const queryParameters = {
+        query: {
+            query: searchQuery,
+            pagination: { offset, limit: pageSize, sortOption },
+        },
     };
-    const params = qs.stringify(query, { arrayFormat: 'repeat', allowDots: true });
+    const params = qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });
 
     return axios
         .get<{
             scanResults: ComplianceScanResult[];
-        }>(`${complianceResultsServiceUrl}/results?${params}`)
+        }>(`${complianceResultsServiceUrl}/results/${scanName}?${params}`)
         .then((response) => {
             const results = response?.data?.scanResults ?? [];
             if (results.length > 1) {
@@ -372,19 +373,20 @@ export function getSingleClusterResultsByScanConfigCount(
 ): Promise<number> {
     const searchQuery = getRequestQueryStringForSearchFilter({
         'Cluster ID': clusterId,
-        'Compliance Scan Config Name': scanName,
         ...searchFilter,
     });
 
-    const query = {
-        query: searchQuery,
+    const queryParameters = {
+        query: {
+            query: searchQuery,
+        },
     };
-    const params = qs.stringify(query, { arrayFormat: 'repeat', allowDots: true });
+    const params = qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });
 
     return axios
         .get<{
             count: number;
-        }>(`${complianceResultsServiceUrl}/count/results?${params}`)
+        }>(`${complianceResultsServiceUrl}/count/results/${scanName}?${params}`)
         .then((response) => {
             return response?.data?.count ?? 0;
         });

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -253,3 +253,37 @@ export function convertToExactMatch(item): unknown {
     }
     return `r/^${item}$`;
 }
+
+/**
+ * Adds acs regex flag to values in the searchFilter object
+ *
+ * All values are prefixed by default
+ * If keysToTransform is provided, only those keys will be modified
+ *
+ * @param {Object} searchFilter Original searchFilter object
+ * @param {Array<string>} [keysToTransform] Optional – The keys in the searchFilter object to transform
+ * @returns {Object} New SearchFilter object where values (determined by keysToTransform) are prefixed with 'r/'
+ */
+export function addRegexPrefixToFilters(
+    searchFilter: SearchFilter,
+    keysToTransform: string[] | null = null
+) {
+    const modifiedFilter: SearchFilter = {};
+
+    Object.keys(searchFilter).forEach((key) => {
+        const value = searchFilter[key];
+        const shouldTransform = !keysToTransform || keysToTransform.includes(key);
+
+        if (shouldTransform) {
+            if (Array.isArray(value)) {
+                modifiedFilter[key] = value.map((item) => `r/${item}`);
+            } else {
+                modifiedFilter[key] = `r/${value}`;
+            }
+        } else {
+            modifiedFilter[key] = value;
+        }
+    });
+
+    return modifiedFilter;
+}


### PR DESCRIPTION
## Description

Addresses the following issues related to the cluster coverage page

* Add a tooltip to the status indicator to provide more information about what the status means.
* Add the regex prefix (`r/`) to the search filter “Compliance Check Name”. This performs a “contains” search as opposed to a “starts with” search.
    * Added a new utility function to help with this.
* Go to the first page automatically when the search filter changes or when selecting results by a different scan.
* Use the new `GetComplianceScanConfigurationResults` endpoint for getting cluster results by scan configuration. 
    * This endpoint was created due to the discovery of a bug when fetching results where one scan’s name started with the name of another entire scan. For example, `my-scan` and `my-scan-2` led to results for both scans due to the default prefix matching behavior of RawQuery

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

> * Add a tooltip to the status indicator to provide more information about what the status means.

<img width="541" alt="Screenshot 2024-02-20 at 3 34 32 AM" src="https://github.com/stackrox/stackrox/assets/61400697/adcb00ae-b7d6-49d7-8931-310e4d5e3c49">

---
> * Add the regex prefix (`r/`) to the search filter “Compliance Check Name”. This performs a “contains” search as opposed to a “starts with” search.

<img width="656" alt="Screenshot 2024-02-20 at 3 33 57 AM" src="https://github.com/stackrox/stackrox/assets/61400697/0d643b38-06aa-4833-8a9d-d2cae340b9a4">

---
> * Go to the first page automatically when the search filter changes or when selecting results by a different scan.

Manual testing done – all the following should result in the table going back to the first page:
* Changing the status filter dropdown
* Changing the "Filter results by check" input
* Switching to a different scan

---
> * Use the new `GetComplianceScanConfigurationResults` endpoint for getting cluster results by scan configuration. 

Created two scans `my-scan` and `my-scan-2`, hitting the new endpoint with `my-scan` in the request responded with only results from `my-scan` and not `my-scan-2`
