### PR TITLE
ROX-22466:  Prune compliance objects when cluster is deleted

### DIFF
--- a/central/complianceoperator/v2/profiles/datastore/datastore.go
+++ b/central/complianceoperator/v2/profiles/datastore/datastore.go
@@ -27,6 +27,9 @@ type DataStore interface {
 	// DeleteProfileForCluster removes a profile from the database
 	DeleteProfileForCluster(ctx context.Context, uid string, clusterID string) error
 
+	// DeleteProfileOfCluster deletes profiles of a specific cluster
+	DeleteProfileOfCluster(ctx context.Context, clusterID string) error
+
 	// GetProfilesByClusters gets the list of profiles for a given clusters
 	GetProfilesByClusters(ctx context.Context, clusterIDs []string) ([]*storage.ComplianceOperatorProfileV2, error)
 

--- a/central/complianceoperator/v2/profiles/datastore/datastore.go
+++ b/central/complianceoperator/v2/profiles/datastore/datastore.go
@@ -28,7 +28,7 @@ type DataStore interface {
 	DeleteProfileForCluster(ctx context.Context, uid string, clusterID string) error
 
 	// DeleteProfileOfCluster deletes profiles of a specific cluster
-	DeleteProfileOfCluster(ctx context.Context, clusterID string) error
+	DeleteProfilesByCluster(ctx context.Context, clusterID string) error
 
 	// GetProfilesByClusters gets the list of profiles for a given clusters
 	GetProfilesByClusters(ctx context.Context, clusterIDs []string) ([]*storage.ComplianceOperatorProfileV2, error)

--- a/central/complianceoperator/v2/profiles/datastore/datastore.go
+++ b/central/complianceoperator/v2/profiles/datastore/datastore.go
@@ -27,7 +27,7 @@ type DataStore interface {
 	// DeleteProfileForCluster removes a profile from the database
 	DeleteProfileForCluster(ctx context.Context, uid string, clusterID string) error
 
-	// DeleteProfileOfCluster deletes profiles of a specific cluster
+	// DeleteProfilesByCluster deletes profiles of a specific cluster
 	DeleteProfilesByCluster(ctx context.Context, clusterID string) error
 
 	// GetProfilesByClusters gets the list of profiles for a given clusters

--- a/central/complianceoperator/v2/profiles/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/profiles/datastore/datastore_impl.go
@@ -54,6 +54,16 @@ func (d *datastoreImpl) DeleteProfileForCluster(ctx context.Context, uid string,
 	return err
 }
 
+// DeleteProfilesOfCluster deletes profiles of cluster with a specific id
+func (d *datastoreImpl) DeleteProfileOfCluster(ctx context.Context, clusterID string) error {
+	query := search.NewQueryBuilder().AddStrings(search.ClusterID, clusterID).ProtoQuery()
+	_, err := d.store.DeleteByQuery(ctx, query)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // GetProfilesByClusters gets the list of profiles for a given clusters
 func (d *datastoreImpl) GetProfilesByClusters(ctx context.Context, clusterIDs []string) ([]*storage.ComplianceOperatorProfileV2, error) {
 	query := search.NewQueryBuilder().

--- a/central/complianceoperator/v2/profiles/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/profiles/datastore/datastore_impl.go
@@ -54,8 +54,8 @@ func (d *datastoreImpl) DeleteProfileForCluster(ctx context.Context, uid string,
 	return err
 }
 
-// DeleteProfilesOfCluster deletes profiles of cluster with a specific id
-func (d *datastoreImpl) DeleteProfileOfCluster(ctx context.Context, clusterID string) error {
+// DeleteProfilesByCluster deletes profiles of cluster with a specific id
+func (d *datastoreImpl) DeleteProfilesByCluster(ctx context.Context, clusterID string) error {
 	query := search.NewQueryBuilder().AddStrings(search.ClusterID, clusterID).ProtoQuery()
 	_, err := d.store.DeleteByQuery(ctx, query)
 	if err != nil {

--- a/central/complianceoperator/v2/profiles/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/profiles/datastore/datastore_impl_test.go
@@ -120,7 +120,7 @@ func (s *complianceProfileDataStoreTestSuite) TestDeleteProfileOfCluster() {
 	count, err := s.storage.Count(s.hasReadCtx)
 	s.Require().NoError(err)
 	s.Require().Equal(len(ids), count)
-	err = s.dataStore.DeleteProfileOfCluster(s.hasWriteCtx, rec1.GetClusterId())
+	err = s.dataStore.DeleteProfilesByCluster(s.hasWriteCtx, rec1.GetClusterId())
 	count, err = s.storage.Count(s.hasReadCtx)
 	s.Require().NoError(err)
 	s.Require().Equal(1, count)

--- a/central/complianceoperator/v2/profiles/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/profiles/datastore/datastore_impl_test.go
@@ -110,17 +110,20 @@ func (s *complianceProfileDataStoreTestSuite) TestUpsertProfile() {
 }
 
 func (s *complianceProfileDataStoreTestSuite) TestDeleteProfileOfCluster() {
-
 	rec1 := getTestProfile(profileUID1, "ocp4", "1.2", testconsts.Cluster1, 0)
 	rec2 := getTestProfile(profileUID2, "rhcos-moderate", "7.6", testconsts.Cluster2, 0)
 	ids := []string{rec1.GetId(), rec2.GetId()}
 
 	s.Require().NoError(s.dataStore.UpsertProfile(s.hasWriteCtx, rec1))
 	s.Require().NoError(s.dataStore.UpsertProfile(s.hasWriteCtx, rec2))
+
 	count, err := s.storage.Count(s.hasReadCtx)
 	s.Require().NoError(err)
 	s.Require().Equal(len(ids), count)
+
 	err = s.dataStore.DeleteProfilesByCluster(s.hasWriteCtx, rec1.GetClusterId())
+	s.Require().NoError(err)
+
 	count, err = s.storage.Count(s.hasReadCtx)
 	s.Require().NoError(err)
 	s.Require().Equal(1, count)

--- a/central/complianceoperator/v2/profiles/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/profiles/datastore/datastore_impl_test.go
@@ -109,6 +109,23 @@ func (s *complianceProfileDataStoreTestSuite) TestUpsertProfile() {
 	s.Require().Equal(rec1, retrieveRec1)
 }
 
+func (s *complianceProfileDataStoreTestSuite) TestDeleteProfileOfCluster() {
+
+	rec1 := getTestProfile(profileUID1, "ocp4", "1.2", testconsts.Cluster1, 0)
+	rec2 := getTestProfile(profileUID2, "rhcos-moderate", "7.6", testconsts.Cluster2, 0)
+	ids := []string{rec1.GetId(), rec2.GetId()}
+
+	s.Require().NoError(s.dataStore.UpsertProfile(s.hasWriteCtx, rec1))
+	s.Require().NoError(s.dataStore.UpsertProfile(s.hasWriteCtx, rec2))
+	count, err := s.storage.Count(s.hasReadCtx)
+	s.Require().NoError(err)
+	s.Require().Equal(len(ids), count)
+	err = s.dataStore.DeleteProfileOfCluster(s.hasWriteCtx, rec1.GetClusterId())
+	count, err = s.storage.Count(s.hasReadCtx)
+	s.Require().NoError(err)
+	s.Require().Equal(1, count)
+}
+
 func (s *complianceProfileDataStoreTestSuite) TestDeleteProfileForCluster() {
 	// make sure we have nothing
 	profileIDs, err := s.storage.GetIDs(s.hasReadCtx)

--- a/central/complianceoperator/v2/profiles/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/profiles/datastore/datastore_impl_test.go
@@ -117,14 +117,14 @@ func (s *complianceProfileDataStoreTestSuite) TestDeleteProfileOfCluster() {
 	s.Require().NoError(s.dataStore.UpsertProfile(s.hasWriteCtx, rec1))
 	s.Require().NoError(s.dataStore.UpsertProfile(s.hasWriteCtx, rec2))
 
-	count, err := s.storage.Count(s.hasReadCtx)
+	count, err := s.storage.Count(s.hasReadCtx, search.EmptyQuery())
 	s.Require().NoError(err)
 	s.Require().Equal(len(ids), count)
 
 	err = s.dataStore.DeleteProfilesByCluster(s.hasWriteCtx, rec1.GetClusterId())
 	s.Require().NoError(err)
 
-	count, err = s.storage.Count(s.hasReadCtx)
+	count, err = s.storage.Count(s.hasReadCtx, search.EmptyQuery())
 	s.Require().NoError(err)
 	s.Require().Equal(1, count)
 }

--- a/central/complianceoperator/v2/profiles/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/profiles/datastore/mocks/datastore.go
@@ -70,18 +70,18 @@ func (mr *MockDataStoreMockRecorder) DeleteProfileForCluster(ctx, uid, clusterID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProfileForCluster", reflect.TypeOf((*MockDataStore)(nil).DeleteProfileForCluster), ctx, uid, clusterID)
 }
 
-// DeleteProfileOfCluster mocks base method.
-func (m *MockDataStore) DeleteProfileOfCluster(ctx context.Context, clusterID string) error {
+// DeleteProfilesByCluster mocks base method.
+func (m *MockDataStore) DeleteProfilesByCluster(ctx context.Context, clusterID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteProfileOfCluster", ctx, clusterID)
+	ret := m.ctrl.Call(m, "DeleteProfilesByCluster", ctx, clusterID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteProfileOfCluster indicates an expected call of DeleteProfileOfCluster.
-func (mr *MockDataStoreMockRecorder) DeleteProfileOfCluster(ctx, clusterID any) *gomock.Call {
+// DeleteProfilesByCluster indicates an expected call of DeleteProfilesByCluster.
+func (mr *MockDataStoreMockRecorder) DeleteProfilesByCluster(ctx, clusterID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProfileOfCluster", reflect.TypeOf((*MockDataStore)(nil).DeleteProfileOfCluster), ctx, clusterID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProfilesByCluster", reflect.TypeOf((*MockDataStore)(nil).DeleteProfilesByCluster), ctx, clusterID)
 }
 
 // GetProfile mocks base method.

--- a/central/complianceoperator/v2/profiles/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/profiles/datastore/mocks/datastore.go
@@ -70,6 +70,20 @@ func (mr *MockDataStoreMockRecorder) DeleteProfileForCluster(ctx, uid, clusterID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProfileForCluster", reflect.TypeOf((*MockDataStore)(nil).DeleteProfileForCluster), ctx, uid, clusterID)
 }
 
+// DeleteProfileOfCluster mocks base method.
+func (m *MockDataStore) DeleteProfileOfCluster(ctx context.Context, clusterID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteProfileOfCluster", ctx, clusterID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteProfileOfCluster indicates an expected call of DeleteProfileOfCluster.
+func (mr *MockDataStoreMockRecorder) DeleteProfileOfCluster(ctx, clusterID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProfileOfCluster", reflect.TypeOf((*MockDataStore)(nil).DeleteProfileOfCluster), ctx, clusterID)
+}
+
 // GetProfile mocks base method.
 func (m *MockDataStore) GetProfile(ctx context.Context, profileID string) (*storage.ComplianceOperatorProfileV2, bool, error) {
 	m.ctrl.T.Helper()

--- a/central/complianceoperator/v2/pruner/pruner.go
+++ b/central/complianceoperator/v2/pruner/pruner.go
@@ -56,42 +56,42 @@ func New(integrationDS compIntegration.DataStore, scanSettingDS compScanSetting.
 func (p *pruneImpl) RemoveComplianceResourcesByCluster(ctx context.Context, clusterID string) {
 	// Remove the compliance integrations
 	if err := p.integrationDS.RemoveComplianceIntegrationByCluster(ctx, clusterID); err != nil {
-		log.Errorf("failed to delete compliance integration for cluster %q: %v", clusterID, err)
+		log.Errorf("failed to delete compliance integrations for cluster %q: %v", clusterID, err)
 	}
 
 	// Remove any scan configurations for the cluster
 	if err := p.scanSettingDS.RemoveClusterFromScanConfig(ctx, clusterID); err != nil {
-		log.Errorf("failed to delete scan config for cluster %s: %v", clusterID, err)
+		log.Errorf("failed to delete scan configs for cluster %s: %v", clusterID, err)
 	}
 
 	// Remove any scan result for the cluster
 	if err := p.scanResultDS.DeleteResultsByCluster(ctx, clusterID); err != nil {
-		log.Errorf("failed to delete scan result for cluster %s: %v", clusterID, err)
+		log.Errorf("failed to delete scan results for cluster %s: %v", clusterID, err)
 	}
 
 	// Remove any rule for the cluster
 	if err := p.compRuleDS.DeleteRulesByCluster(ctx, clusterID); err != nil {
-		log.Errorf("failed to delete cluster from rule for cluster id  %s: %v", clusterID, err)
+		log.Errorf("failed to delete rules for cluster %s: %v", clusterID, err)
 	}
 
 	// Remove any profile for the cluster
-	if err := p.profileDS.DeleteProfileOfCluster(ctx, clusterID); err != nil {
-		log.Errorf("failed to delete profile for cluster %s: %v", clusterID, err)
+	if err := p.profileDS.DeleteProfilesByCluster(ctx, clusterID); err != nil {
+		log.Errorf("failed to delete profiles for cluster %s: %v", clusterID, err)
 	}
 
 	// Remove any scan for the cluster
 	if err := p.scanDS.DeleteScanByCluster(ctx, clusterID); err != nil {
-		log.Errorf("failed to delete scan for cluster %s: %v", clusterID, err)
+		log.Errorf("failed to delete scans for cluster %s: %v", clusterID, err)
 	}
 
 	// Remove any scan setting for the cluster
 	if err := p.scanSettingsBindingsDS.DeleteScanSettingByCluster(ctx, clusterID); err != nil {
-		log.Errorf("failed to delete scan setting binding for cluster %s: %v", clusterID, err)
+		log.Errorf("failed to delete scan setting bindings for cluster %s: %v", clusterID, err)
 	}
 
 	// Remove any scan suite for the cluster
 	if err := p.suitesDS.DeleteSuitesByCluster(ctx, clusterID); err != nil {
-		log.Errorf("failed to delete scan suite for cluster %s: %v", clusterID, err)
+		log.Errorf("failed to delete scan suites for cluster %s: %v", clusterID, err)
 	}
 }
 

--- a/central/complianceoperator/v2/pruner/pruner.go
+++ b/central/complianceoperator/v2/pruner/pruner.go
@@ -6,12 +6,12 @@ import (
 
 	scanResult "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore"
 	compIntegration "github.com/stackrox/rox/central/complianceoperator/v2/integration/datastore"
-	profileDS "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
-	compRuleDS "github.com/stackrox/rox/central/complianceoperator/v2/rules/datastore"
+	profile "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
+	compRule "github.com/stackrox/rox/central/complianceoperator/v2/rules/datastore"
 	compScanSetting "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore"
-	scanDS "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore"
-	scanSettingBindingDS "github.com/stackrox/rox/central/complianceoperator/v2/scansettingbindings/datastore"
-	suitesDS "github.com/stackrox/rox/central/complianceoperator/v2/suites/datastore"
+	scan "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore"
+	scanSettingBinding "github.com/stackrox/rox/central/complianceoperator/v2/scansettingbindings/datastore"
+	suites "github.com/stackrox/rox/central/complianceoperator/v2/suites/datastore"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres"
 )
@@ -21,14 +21,14 @@ var (
 )
 
 type pruneImpl struct {
-	integrationDS          compIntegration.DataStore
-	scanSettingDS          compScanSetting.DataStore
-	scanResultDS           scanResult.DataStore
-	compRuleDS             compRuleDS.DataStore
-	profileDS              profileDS.DataStore
-	scanSettingsBindingsDS scanSettingBindingDS.DataStore
-	scanDS                 scanDS.DataStore
-	suitesDS               suitesDS.DataStore
+	integrationDataStore          compIntegration.DataStore
+	scanSettingDataStore          compScanSetting.DataStore
+	scanResultDataStore           scanResult.DataStore
+	compRuleDataStore             compRule.DataStore
+	profileDataStore              profile.DataStore
+	scanSettingsBindingsDataStore scanSettingBinding.DataStore
+	scanDataStore                 scan.DataStore
+	suitesDataStore               suites.DataStore
 }
 
 // Pruner consolidates functionality to clean up orphaned compliance operator data
@@ -39,58 +39,58 @@ type Pruner interface {
 }
 
 // New returns on instance of Manager interface that provides functionality to process compliance requests and forward them to Sensor.
-func New(integrationDS compIntegration.DataStore, scanSettingDS compScanSetting.DataStore, scanResultDS scanResult.DataStore, compRuleDS compRuleDS.DataStore, profileDS profileDS.DataStore, scanSettingsBindingsDS scanSettingBindingDS.DataStore, scanDS scanDS.DataStore, suitesDS suitesDS.DataStore) Pruner {
+func New(integrationDataStore compIntegration.DataStore, scanSettingDataStore compScanSetting.DataStore, scanResultDataStore scanResult.DataStore, compRuleDataStore compRule.DataStore, profileDataStore profile.DataStore, scanSettingsBindingsDataStore scanSettingBinding.DataStore, scanDataStore scan.DataStore, suitesDataStore suites.DataStore) Pruner {
 	return &pruneImpl{
-		integrationDS:          integrationDS,
-		scanSettingDS:          scanSettingDS,
-		scanResultDS:           scanResultDS,
-		compRuleDS:             compRuleDS,
-		profileDS:              profileDS,
-		scanSettingsBindingsDS: scanSettingsBindingsDS,
-		scanDS:                 scanDS,
-		suitesDS:               suitesDS,
+		integrationDataStore:          integrationDataStore,
+		scanSettingDataStore:          scanSettingDataStore,
+		scanResultDataStore:           scanResultDataStore,
+		compRuleDataStore:             compRuleDataStore,
+		profileDataStore:              profileDataStore,
+		scanSettingsBindingsDataStore: scanSettingsBindingsDataStore,
+		scanDataStore:                 scanDataStore,
+		suitesDataStore:               suitesDataStore,
 	}
 }
 
 // RemoveComplianceResourcesByCluster removes orphaned compliance operator data for the cluster
 func (p *pruneImpl) RemoveComplianceResourcesByCluster(ctx context.Context, clusterID string) {
 	// Remove the compliance integrations
-	if err := p.integrationDS.RemoveComplianceIntegrationByCluster(ctx, clusterID); err != nil {
+	if err := p.integrationDataStore.RemoveComplianceIntegrationByCluster(ctx, clusterID); err != nil {
 		log.Errorf("failed to delete compliance integrations for cluster %q: %v", clusterID, err)
 	}
 
 	// Remove any scan configurations for the cluster
-	if err := p.scanSettingDS.RemoveClusterFromScanConfig(ctx, clusterID); err != nil {
+	if err := p.scanSettingDataStore.RemoveClusterFromScanConfig(ctx, clusterID); err != nil {
 		log.Errorf("failed to delete scan configs for cluster %s: %v", clusterID, err)
 	}
 
 	// Remove any scan result for the cluster
-	if err := p.scanResultDS.DeleteResultsByCluster(ctx, clusterID); err != nil {
+	if err := p.scanResultDataStore.DeleteResultsByCluster(ctx, clusterID); err != nil {
 		log.Errorf("failed to delete scan results for cluster %s: %v", clusterID, err)
 	}
 
 	// Remove any rule for the cluster
-	if err := p.compRuleDS.DeleteRulesByCluster(ctx, clusterID); err != nil {
+	if err := p.compRuleDataStore.DeleteRulesByCluster(ctx, clusterID); err != nil {
 		log.Errorf("failed to delete rules for cluster %s: %v", clusterID, err)
 	}
 
 	// Remove any profile for the cluster
-	if err := p.profileDS.DeleteProfilesByCluster(ctx, clusterID); err != nil {
+	if err := p.profileDataStore.DeleteProfilesByCluster(ctx, clusterID); err != nil {
 		log.Errorf("failed to delete profiles for cluster %s: %v", clusterID, err)
 	}
 
 	// Remove any scan for the cluster
-	if err := p.scanDS.DeleteScanByCluster(ctx, clusterID); err != nil {
+	if err := p.scanDataStore.DeleteScanByCluster(ctx, clusterID); err != nil {
 		log.Errorf("failed to delete scans for cluster %s: %v", clusterID, err)
 	}
 
 	// Remove any scan setting for the cluster
-	if err := p.scanSettingsBindingsDS.DeleteScanSettingByCluster(ctx, clusterID); err != nil {
+	if err := p.scanSettingsBindingsDataStore.DeleteScanSettingByCluster(ctx, clusterID); err != nil {
 		log.Errorf("failed to delete scan setting bindings for cluster %s: %v", clusterID, err)
 	}
 
 	// Remove any scan suite for the cluster
-	if err := p.suitesDS.DeleteSuitesByCluster(ctx, clusterID); err != nil {
+	if err := p.suitesDataStore.DeleteSuitesByCluster(ctx, clusterID); err != nil {
 		log.Errorf("failed to delete scan suites for cluster %s: %v", clusterID, err)
 	}
 }
@@ -99,13 +99,14 @@ func (p *pruneImpl) RemoveComplianceResourcesByCluster(ctx context.Context, clus
 
 // GetTestPruner provides a pruner connected to postgres for testing purposes.
 func GetTestPruner(t *testing.T, pool postgres.DB) Pruner {
-	scanSettingDS := compScanSetting.GetTestPostgresDataStore(t, pool)
-	integrationDS := compIntegration.GetTestPostgresDataStore(t, pool)
-	scanResultDS := scanResult.GetTestPostgresDataStore(t, pool)
-	compRuleDS := compRuleDS.GetTestPostgresDataStore(t, pool)
-	profileDS := profileDS.GetTestPostgresDataStore(t, pool, nil)
-	scanSettingsBindingsDS := scanSettingBindingDS.GetTestPostgresDataStore(t, pool)
-	scanDS := scanDS.GetTestPostgresDataStore(t, pool)
-	suitesDS := suitesDS.GetTestPostgresDataStore(t, pool)
-	return New(integrationDS, scanSettingDS, scanResultDS, compRuleDS, profileDS, scanSettingsBindingsDS, scanDS, suitesDS)
+	scanSettingDataStore := compScanSetting.GetTestPostgresDataStore(t, pool)
+	integrationDataStore := compIntegration.GetTestPostgresDataStore(t, pool)
+	scanResultDataStore := scanResult.GetTestPostgresDataStore(t, pool)
+	compRuleDataStore := compRule.GetTestPostgresDataStore(t, pool)
+	profileDataStore := profile.GetTestPostgresDataStore(t, pool, nil)
+	scanSettingsBindingsDataStore := scanSettingBinding.GetTestPostgresDataStore(t, pool)
+	scanDataStore := scan.GetTestPostgresDataStore(t, pool)
+	suitesDataStore := suites.GetTestPostgresDataStore(t, pool)
+
+	return New(integrationDataStore, scanSettingDataStore, scanResultDataStore, compRuleDataStore, profileDataStore, scanSettingsBindingsDataStore, scanDataStore, suitesDataStore)
 }

--- a/central/complianceoperator/v2/pruner/singleton.go
+++ b/central/complianceoperator/v2/pruner/singleton.go
@@ -3,7 +3,12 @@ package pruner
 import (
 	scanResult "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore"
 	compIntegration "github.com/stackrox/rox/central/complianceoperator/v2/integration/datastore"
+	profileDS "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
+	compRuleDS "github.com/stackrox/rox/central/complianceoperator/v2/rules/datastore"
 	compScanSetting "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore"
+	scanDS "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore"
+	scanSettingBindingDS "github.com/stackrox/rox/central/complianceoperator/v2/scansettingbindings/datastore"
+	suitesDS "github.com/stackrox/rox/central/complianceoperator/v2/suites/datastore"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -19,7 +24,7 @@ func Singleton() Pruner {
 		return nil
 	}
 	once.Do(func() {
-		pruner = New(compIntegration.Singleton(), compScanSetting.Singleton(), scanResult.Singleton())
+		pruner = New(compIntegration.Singleton(), compScanSetting.Singleton(), scanResult.Singleton(), compRuleDS.Singleton(), profileDS.Singleton(), scanSettingBindingDS.Singleton(), scanDS.Singleton(), suitesDS.Singleton())
 	})
 	return pruner
 }

--- a/central/complianceoperator/v2/pruner/singleton.go
+++ b/central/complianceoperator/v2/pruner/singleton.go
@@ -3,12 +3,12 @@ package pruner
 import (
 	scanResult "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore"
 	compIntegration "github.com/stackrox/rox/central/complianceoperator/v2/integration/datastore"
-	profileDS "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
-	compRuleDS "github.com/stackrox/rox/central/complianceoperator/v2/rules/datastore"
+	profile "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
+	compRule "github.com/stackrox/rox/central/complianceoperator/v2/rules/datastore"
 	compScanSetting "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore"
-	scanDS "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore"
-	scanSettingBindingDS "github.com/stackrox/rox/central/complianceoperator/v2/scansettingbindings/datastore"
-	suitesDS "github.com/stackrox/rox/central/complianceoperator/v2/suites/datastore"
+	scan "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore"
+	scanSettingBinding "github.com/stackrox/rox/central/complianceoperator/v2/scansettingbindings/datastore"
+	suites "github.com/stackrox/rox/central/complianceoperator/v2/suites/datastore"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -24,7 +24,7 @@ func Singleton() Pruner {
 		return nil
 	}
 	once.Do(func() {
-		pruner = New(compIntegration.Singleton(), compScanSetting.Singleton(), scanResult.Singleton(), compRuleDS.Singleton(), profileDS.Singleton(), scanSettingBindingDS.Singleton(), scanDS.Singleton(), suitesDS.Singleton())
+		pruner = New(compIntegration.Singleton(), compScanSetting.Singleton(), scanResult.Singleton(), compRule.Singleton(), profile.Singleton(), scanSettingBinding.Singleton(), scan.Singleton(), suites.Singleton())
 	})
 	return pruner
 }

--- a/central/complianceoperator/v2/rules/datastore/datastore.go
+++ b/central/complianceoperator/v2/rules/datastore/datastore.go
@@ -21,6 +21,9 @@ type DataStore interface {
 
 	// GetRulesByCluster retrieves rules by cluster
 	GetRulesByCluster(ctx context.Context, clusterID string) ([]*storage.ComplianceOperatorRuleV2, error)
+
+	// DeleteRulesByCluster removes rule by cluster id
+	DeleteRulesByCluster(ctx context.Context, clusterID string) error
 }
 
 // New returns an instance of DataStore.

--- a/central/complianceoperator/v2/rules/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/rules/datastore/datastore_impl.go
@@ -27,3 +27,13 @@ func (d *datastoreImpl) GetRulesByCluster(ctx context.Context, clusterID string)
 	return d.store.GetByQuery(ctx, search.NewQueryBuilder().
 		AddExactMatches(search.ClusterID, clusterID).ProtoQuery())
 }
+
+// delete rule by cluster id
+func (d *datastoreImpl) DeleteRulesByCluster(ctx context.Context, clusterID string) error {
+	query := search.NewQueryBuilder().AddStrings(search.ClusterID, clusterID).ProtoQuery()
+	_, err := d.store.DeleteByQuery(ctx, query)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/central/complianceoperator/v2/rules/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/rules/datastore/datastore_impl_test.go
@@ -134,6 +134,20 @@ func (s *complianceRuleDataStoreTestSuite) TestUpsertRule() {
 	}
 }
 
+func (s *complianceRuleDataStoreTestSuite) TestDeleteRuleByCluster() {
+	rule := getTestRule(testconsts.Cluster1)
+	s.Require().NoError(s.dataStore.UpsertRule(s.hasWriteCtx, rule))
+
+	count, err := s.storage.Count(s.hasReadCtx)
+	s.Require().NoError(err)
+	s.Require().Equal(1, count)
+	s.Require().NoError(s.dataStore.DeleteRulesByCluster(s.hasWriteCtx, testconsts.Cluster1))
+
+	count, err = s.storage.Count(s.hasReadCtx)
+	s.Require().NoError(err)
+	s.Require().Equal(0, count)
+}
+
 func (s *complianceRuleDataStoreTestSuite) TestDeleteRule() {
 	// make sure we have nothing
 	ruleIDs, err := s.storage.GetIDs(s.hasReadCtx)

--- a/central/complianceoperator/v2/rules/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/rules/datastore/datastore_impl_test.go
@@ -138,12 +138,12 @@ func (s *complianceRuleDataStoreTestSuite) TestDeleteRuleByCluster() {
 	rule := getTestRule(testconsts.Cluster1)
 	s.Require().NoError(s.dataStore.UpsertRule(s.hasWriteCtx, rule))
 
-	count, err := s.storage.Count(s.hasReadCtx)
+	count, err := s.storage.Count(s.hasReadCtx, search.EmptyQuery())
 	s.Require().NoError(err)
 	s.Require().Equal(1, count)
 	s.Require().NoError(s.dataStore.DeleteRulesByCluster(s.hasWriteCtx, testconsts.Cluster1))
 
-	count, err = s.storage.Count(s.hasReadCtx)
+	count, err = s.storage.Count(s.hasReadCtx, search.EmptyQuery())
 	s.Require().NoError(err)
 	s.Require().Equal(0, count)
 }

--- a/central/complianceoperator/v2/rules/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/rules/datastore/mocks/datastore.go
@@ -54,6 +54,20 @@ func (mr *MockDataStoreMockRecorder) DeleteRule(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRule", reflect.TypeOf((*MockDataStore)(nil).DeleteRule), ctx, id)
 }
 
+// DeleteRulesByCluster mocks base method.
+func (m *MockDataStore) DeleteRulesByCluster(ctx context.Context, clusterID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRulesByCluster", ctx, clusterID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRulesByCluster indicates an expected call of DeleteRulesByCluster.
+func (mr *MockDataStoreMockRecorder) DeleteRulesByCluster(ctx, clusterID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRulesByCluster", reflect.TypeOf((*MockDataStore)(nil).DeleteRulesByCluster), ctx, clusterID)
+}
+
 // GetRulesByCluster mocks base method.
 func (m *MockDataStore) GetRulesByCluster(ctx context.Context, clusterID string) ([]*storage.ComplianceOperatorRuleV2, error) {
 	m.ctrl.T.Helper()

--- a/central/complianceoperator/v2/scans/datastore/datastore.go
+++ b/central/complianceoperator/v2/scans/datastore/datastore.go
@@ -24,6 +24,9 @@ type DataStore interface {
 
 	// GetScansByCluster retrieves scan objects by cluster
 	GetScansByCluster(ctx context.Context, clusterID string) ([]*storage.ComplianceOperatorScanV2, error)
+
+	// DeleteScanByCluster deletes scans by cluster
+	DeleteScanByCluster(ctx context.Context, clusterID string) error
 }
 
 // New returns an instance of DataStore.

--- a/central/complianceoperator/v2/scans/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scans/datastore/datastore_impl.go
@@ -32,3 +32,13 @@ func (d *datastoreImpl) GetScansByCluster(ctx context.Context, clusterID string)
 	return d.store.GetByQuery(ctx, search.NewQueryBuilder().
 		AddExactMatches(search.ClusterID, clusterID).ProtoQuery())
 }
+
+// DeleteScanByCluster deletes scans by cluster
+func (d *datastoreImpl) DeleteScanByCluster(ctx context.Context, clusterID string) error {
+	query := search.NewQueryBuilder().AddStrings(search.ClusterID, clusterID).ProtoQuery()
+	_, err := d.store.DeleteByQuery(ctx, query)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/central/complianceoperator/v2/scans/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/scans/datastore/datastore_impl_test.go
@@ -235,13 +235,13 @@ func (s *complianceScanDataStoreTestSuite) TestDeleteScanByCluster() {
 	testScan1 := getTestScan("scan1", "profile-1", testconsts.Cluster1)
 	s.Require().NoError(s.dataStore.UpsertScan(s.hasWriteCtx, testScan1))
 
-	count, err := s.storage.Count(s.hasReadCtx)
+	count, err := s.storage.Count(s.hasReadCtx, search.EmptyQuery())
 	s.Require().NoError(err)
 	s.Require().Equal(1, count)
 
 	s.Require().NoError(s.dataStore.DeleteScanByCluster(s.hasWriteCtx, testconsts.Cluster1))
 
-	count, err = s.storage.Count(s.hasReadCtx)
+	count, err = s.storage.Count(s.hasReadCtx, search.EmptyQuery())
 	s.Require().NoError(err)
 	s.Require().Equal(0, count)
 }

--- a/central/complianceoperator/v2/scans/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/scans/datastore/datastore_impl_test.go
@@ -240,6 +240,7 @@ func (s *complianceScanDataStoreTestSuite) TestDeleteScanByCluster() {
 	s.Require().Equal(1, count)
 
 	s.Require().NoError(s.dataStore.DeleteScanByCluster(s.hasWriteCtx, testconsts.Cluster1))
+
 	count, err = s.storage.Count(s.hasReadCtx)
 	s.Require().NoError(err)
 	s.Require().Equal(0, count)

--- a/central/complianceoperator/v2/scans/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/scans/datastore/datastore_impl_test.go
@@ -231,6 +231,20 @@ func (s *complianceScanDataStoreTestSuite) TestUpsertScan() {
 	s.Require().Equal(testScan3.LastExecutedTime, retrievedObject.LastExecutedTime)
 }
 
+func (s *complianceScanDataStoreTestSuite) TestDeleteScanByCluster() {
+	testScan1 := getTestScan("scan1", "profile-1", testconsts.Cluster1)
+	s.Require().NoError(s.dataStore.UpsertScan(s.hasWriteCtx, testScan1))
+
+	count, err := s.storage.Count(s.hasReadCtx)
+	s.Require().NoError(err)
+	s.Require().Equal(1, count)
+
+	s.Require().NoError(s.dataStore.DeleteScanByCluster(s.hasWriteCtx, testconsts.Cluster1))
+	count, err = s.storage.Count(s.hasReadCtx)
+	s.Require().NoError(err)
+	s.Require().Equal(0, count)
+}
+
 func (s *complianceScanDataStoreTestSuite) TestDeleteScan() {
 	// make sure we have nothing
 	ScanIDs, err := s.storage.GetIDs(s.hasReadCtx)

--- a/central/complianceoperator/v2/scans/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/scans/datastore/mocks/datastore.go
@@ -54,6 +54,20 @@ func (mr *MockDataStoreMockRecorder) DeleteScan(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteScan", reflect.TypeOf((*MockDataStore)(nil).DeleteScan), ctx, id)
 }
 
+// DeleteScanByCluster mocks base method.
+func (m *MockDataStore) DeleteScanByCluster(ctx context.Context, clusterID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteScanByCluster", ctx, clusterID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteScanByCluster indicates an expected call of DeleteScanByCluster.
+func (mr *MockDataStoreMockRecorder) DeleteScanByCluster(ctx, clusterID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteScanByCluster", reflect.TypeOf((*MockDataStore)(nil).DeleteScanByCluster), ctx, clusterID)
+}
+
 // GetScan mocks base method.
 func (m *MockDataStore) GetScan(ctx context.Context, id string) (*storage.ComplianceOperatorScanV2, bool, error) {
 	m.ctrl.T.Helper()

--- a/central/complianceoperator/v2/scansettingbindings/datastore/datastore.go
+++ b/central/complianceoperator/v2/scansettingbindings/datastore/datastore.go
@@ -2,10 +2,12 @@ package datastore
 
 import (
 	"context"
+	"testing"
 
 	pgStore "github.com/stackrox/rox/central/complianceoperator/v2/scansettingbindings/store/postgres"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres"
 )
 
 // DataStore is the entry point for storing/retrieving compliance scan setting binding objects
@@ -26,6 +28,9 @@ type DataStore interface {
 
 	// GetScanSettingBindings retrieves scan setting bindings matching the query
 	GetScanSettingBindings(ctx context.Context, query *v1.Query) ([]*storage.ComplianceOperatorScanSettingBindingV2, error)
+
+	// DeleteScanSettingByCluster deletes  scan setting with cluster id
+	DeleteScanSettingByCluster(ctx context.Context, clusterID string) error
 }
 
 // New returns an instance of DataStore.
@@ -33,4 +38,10 @@ func New(scanSettingBindingStorage pgStore.Store) DataStore {
 	return &datastoreImpl{
 		store: scanSettingBindingStorage,
 	}
+}
+
+// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+	store := pgStore.New(pool)
+	return New(store)
 }

--- a/central/complianceoperator/v2/scansettingbindings/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scansettingbindings/datastore/datastore_impl.go
@@ -64,3 +64,14 @@ func getScopeKeys(bindings []*storage.ComplianceOperatorScanSettingBindingV2) []
 	}
 	return clusterScopeKeys
 }
+
+// DeleteScanSettingByCluster deletes scan setting by cluster
+func (d *datastoreImpl) DeleteScanSettingByCluster(ctx context.Context, clusterID string) error {
+	query := search.NewQueryBuilder().AddStrings(search.ClusterID, clusterID).ProtoQuery()
+	_, err := d.store.DeleteByQuery(ctx, query)
+	if err != nil {
+		return err
+	}
+	return nil
+
+}

--- a/central/complianceoperator/v2/scansettingbindings/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/scansettingbindings/datastore/mocks/datastore.go
@@ -55,6 +55,20 @@ func (mr *MockDataStoreMockRecorder) DeleteScanSettingBinding(ctx, id any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteScanSettingBinding", reflect.TypeOf((*MockDataStore)(nil).DeleteScanSettingBinding), ctx, id)
 }
 
+// DeleteScanSettingByCluster mocks base method.
+func (m *MockDataStore) DeleteScanSettingByCluster(ctx context.Context, clusterID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteScanSettingByCluster", ctx, clusterID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteScanSettingByCluster indicates an expected call of DeleteScanSettingByCluster.
+func (mr *MockDataStoreMockRecorder) DeleteScanSettingByCluster(ctx, clusterID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteScanSettingByCluster", reflect.TypeOf((*MockDataStore)(nil).DeleteScanSettingByCluster), ctx, clusterID)
+}
+
 // GetScanSettingBinding mocks base method.
 func (m *MockDataStore) GetScanSettingBinding(ctx context.Context, id string) (*storage.ComplianceOperatorScanSettingBindingV2, bool, error) {
 	m.ctrl.T.Helper()

--- a/central/complianceoperator/v2/suites/datastore/datastore.go
+++ b/central/complianceoperator/v2/suites/datastore/datastore.go
@@ -31,6 +31,9 @@ type DataStore interface {
 
 	// DeleteSuite removes a suite from the database
 	DeleteSuite(ctx context.Context, id string) error
+
+	// DeleteSuitesByCLuster removes a suite from the database
+	DeleteSuitesByCluster(ctx context.Context, clusterID string) error
 }
 
 // New returns an instance of DataStore.
@@ -42,7 +45,7 @@ func New(complianceSuiteStorage pgStore.Store) DataStore {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
 	store := pgStore.New(pool)
-	return New(store), nil
+	return New(store)
 }

--- a/central/complianceoperator/v2/suites/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/suites/datastore/datastore_impl.go
@@ -64,3 +64,13 @@ func getScopeKeys(suites []*storage.ComplianceOperatorSuiteV2) [][]sac.ScopeKey 
 	}
 	return clusterScopeKeys
 }
+
+// DeleteSuiteByCluster removes a suite from the database
+func (d *datastoreImpl) DeleteSuitesByCluster(ctx context.Context, clusterID string) error {
+	query := search.NewQueryBuilder().AddStrings(search.ClusterID, clusterID).ProtoQuery()
+	_, err := d.store.DeleteByQuery(ctx, query)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/central/complianceoperator/v2/suites/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/suites/datastore/datastore_impl_test.go
@@ -249,13 +249,13 @@ func (s *complianceSuiteDataStoreTestSuite) TestDeleteSuiteByCluster() {
 	suite := s.getTestSuite(testconsts.Cluster1)
 	s.Require().NoError(s.dataStore.UpsertSuite(s.hasWriteCtx, suite))
 
-	count, err := s.storage.Count(s.hasReadCtx)
+	count, err := s.storage.Count(s.hasReadCtx, search.EmptyQuery())
 	s.Require().NoError(err)
 	s.Require().Equal(1, count)
 
 	s.Require().NoError(s.dataStore.DeleteSuitesByCluster(s.hasWriteCtx, testconsts.Cluster1))
 
-	count, err = s.storage.Count(s.hasReadCtx)
+	count, err = s.storage.Count(s.hasReadCtx, search.EmptyQuery())
 	s.Require().NoError(err)
 	s.Require().Equal(0, count)
 }

--- a/central/complianceoperator/v2/suites/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/suites/datastore/datastore_impl_test.go
@@ -248,10 +248,13 @@ func (s *complianceSuiteDataStoreTestSuite) TestUpsertSuites() {
 func (s *complianceSuiteDataStoreTestSuite) TestDeleteSuiteByCluster() {
 	suite := s.getTestSuite(testconsts.Cluster1)
 	s.Require().NoError(s.dataStore.UpsertSuite(s.hasWriteCtx, suite))
+
 	count, err := s.storage.Count(s.hasReadCtx)
 	s.Require().NoError(err)
 	s.Require().Equal(1, count)
+
 	s.Require().NoError(s.dataStore.DeleteSuitesByCluster(s.hasWriteCtx, testconsts.Cluster1))
+
 	count, err = s.storage.Count(s.hasReadCtx)
 	s.Require().NoError(err)
 	s.Require().Equal(0, count)

--- a/central/complianceoperator/v2/suites/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/suites/datastore/datastore_impl_test.go
@@ -64,9 +64,7 @@ func (s *complianceSuiteDataStoreTestSuite) SetupTest() {
 	s.db = pgtest.ForT(s.T())
 
 	s.storage = suiteStorage.New(s.db)
-	var err error
-	s.dataStore, err = GetTestPostgresDataStore(s.T(), s.db)
-	s.Require().NoError(err)
+	s.dataStore = GetTestPostgresDataStore(s.T(), s.db)
 }
 
 func (s *complianceSuiteDataStoreTestSuite) TearDownTest() {
@@ -245,6 +243,18 @@ func (s *complianceSuiteDataStoreTestSuite) TestUpsertSuites() {
 		// Clean up
 		s.Require().NoError(s.storage.DeleteMany(s.testContexts[sacTestUtils.UnrestrictedReadWriteCtx], allSuiteIDs))
 	}
+}
+
+func (s *complianceSuiteDataStoreTestSuite) TestDeleteSuiteByCluster() {
+	suite := s.getTestSuite(testconsts.Cluster1)
+	s.Require().NoError(s.dataStore.UpsertSuite(s.hasWriteCtx, suite))
+	count, err := s.storage.Count(s.hasReadCtx)
+	s.Require().NoError(err)
+	s.Require().Equal(1, count)
+	s.Require().NoError(s.dataStore.DeleteSuitesByCluster(s.hasWriteCtx, testconsts.Cluster1))
+	count, err = s.storage.Count(s.hasReadCtx)
+	s.Require().NoError(err)
+	s.Require().Equal(0, count)
 }
 
 func (s *complianceSuiteDataStoreTestSuite) TestDeleteSuite() {

--- a/central/complianceoperator/v2/suites/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/suites/datastore/mocks/datastore.go
@@ -55,6 +55,20 @@ func (mr *MockDataStoreMockRecorder) DeleteSuite(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSuite", reflect.TypeOf((*MockDataStore)(nil).DeleteSuite), ctx, id)
 }
 
+// DeleteSuitesByCluster mocks base method.
+func (m *MockDataStore) DeleteSuitesByCluster(ctx context.Context, clusterID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteSuitesByCluster", ctx, clusterID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteSuitesByCluster indicates an expected call of DeleteSuitesByCluster.
+func (mr *MockDataStoreMockRecorder) DeleteSuitesByCluster(ctx, clusterID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSuitesByCluster", reflect.TypeOf((*MockDataStore)(nil).DeleteSuitesByCluster), ctx, clusterID)
+}
+
 // GetSuite mocks base method.
 func (m *MockDataStore) GetSuite(ctx context.Context, id string) (*storage.ComplianceOperatorSuiteV2, bool, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This pr deletes compliance v2 objects for a cluster when secured cluster is deleted from acs

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
This change is validated manually by deleting cluster from UI and validating related compliance objects are pruned from db
