### PR TITLE
style(log): Avoid duplicate 'error' word in error messages

### DIFF
--- a/compliance/collection/compliance/compliance.go
+++ b/compliance/collection/compliance/compliance.go
@@ -170,7 +170,7 @@ func (c *Compliance) manageStream(ctx context.Context, cli sensor.ComplianceServ
 			if err := c.runRecv(ctx, client, config); err != nil {
 				log.Errorf("Error running recv: %v", err)
 			}
-			cancelFn() // runRecv is blocking, so the context is safely cancelled before the next  call to initializeStream
+			cancelFn() // runRecv is blocking, so the context is safely cancelled before the next call to initializeStream
 		}
 	}
 }
@@ -187,12 +187,12 @@ func (c *Compliance) runRecv(ctx context.Context, client sensor.ComplianceServic
 	for {
 		msg, err := client.Recv()
 		if err != nil {
-			return errors.Wrap(err, "error receiving msg from sensor")
+			return errors.Wrap(err, "receiving msg from sensor")
 		}
 		switch t := msg.Msg.(type) {
 		case *sensor.MsgToCompliance_Trigger:
 			if err := runChecks(client, config, t.Trigger, c.nodeNameProvider); err != nil {
-				return errors.Wrap(err, "error running checks")
+				return errors.Wrap(err, "running compliance checks")
 			}
 		case *sensor.MsgToCompliance_AuditLogCollectionRequest_:
 			switch r := t.AuditLogCollectionRequest.GetReq().(type) {

--- a/sensor/common/compliance/service_impl.go
+++ b/sensor/common/compliance/service_impl.go
@@ -196,7 +196,7 @@ func (s *serviceImpl) Communicate(server sensor.ComplianceService_CommunicateSer
 	for {
 		msg, err := server.Recv()
 		if err != nil {
-			log.Errorf("error receiving from compliance %q: %v", hostname, err)
+			log.Errorf("receiving from compliance %q: %v", hostname, err)
 			return err
 		}
 		switch t := msg.Msg.(type) {


### PR DESCRIPTION
## Description

Recently, we are getting error reports from the code that handles Sensor-Compliance connection. Many of the error logs read strange due to the duplicated word `error`. This PR corrects 3 such places.

## Checklist
- [x] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

I have not.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
