### PR TITLE
fix: ensure access tokens are valid

### DIFF
--- a/pkg/auth/tokensource/tokensource.go
+++ b/pkg/auth/tokensource/tokensource.go
@@ -1,25 +1,28 @@
 package tokensource
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/sync"
 	"golang.org/x/oauth2"
 )
 
-// ReuseTokenSourceWithInvalidate works like oauth2.ReuseTokenSource but with
+// ReuseTokenSourceWithInvalidate works like oauth2.ReuseTokenSourceWithExpiry but with
 // an additional manual invalidate method that forces a token refresh.
 type ReuseTokenSourceWithInvalidate struct {
-	token     *oauth2.Token
-	base      oauth2.TokenSource
-	mutex     sync.Mutex
-	isExpired bool
+	token       *oauth2.Token
+	base        oauth2.TokenSource
+	expiryDelta time.Duration
+	mutex       sync.Mutex
+	isExpired   bool
 }
 
 var _ oauth2.TokenSource = &ReuseTokenSourceWithInvalidate{}
 
 // NewReuseTokenSourceWithInvalidate wraps a base token source and provides refresh and expiry functionality.
-func NewReuseTokenSourceWithInvalidate(base oauth2.TokenSource) *ReuseTokenSourceWithInvalidate {
-	return &ReuseTokenSourceWithInvalidate{base: base}
+func NewReuseTokenSourceWithInvalidate(base oauth2.TokenSource, earlyExpiry time.Duration) *ReuseTokenSourceWithInvalidate {
+	return &ReuseTokenSourceWithInvalidate{base: base, expiryDelta: earlyExpiry}
 }
 
 // Token returns an oauth token.
@@ -33,6 +36,7 @@ func (t *ReuseTokenSourceWithInvalidate) Token() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get token")
 	}
+	token.Expiry = token.Expiry.Add(-t.expiryDelta)
 	t.token = token
 	t.isExpired = false
 	return t.token, nil

--- a/pkg/auth/tokensource/tokensource_test.go
+++ b/pkg/auth/tokensource/tokensource_test.go
@@ -10,29 +10,35 @@ import (
 	"golang.org/x/oauth2"
 )
 
+var futureTime = time.Date(3000, time.January, 0, 0, 0, 0, 0, time.Local)
+
 type fakeTokenSource struct {
 	called int
 }
 
 func (f *fakeTokenSource) Token() (*oauth2.Token, error) {
 	f.called++
-	return &oauth2.Token{AccessToken: strconv.Itoa(f.called), Expiry: time.Date(3000, time.January, 0, 0, 0, 0, 0, time.Local)}, nil
+	return &oauth2.Token{AccessToken: strconv.Itoa(f.called), Expiry: futureTime}, nil
 }
 
 func TestReuseTokenSourceWithForceRefresh(t *testing.T) {
 	t.Parallel()
-	ts := NewReuseTokenSourceWithInvalidate(&fakeTokenSource{})
+	earlyExpiry := time.Minute
+	ts := NewReuseTokenSourceWithInvalidate(&fakeTokenSource{}, earlyExpiry)
 
 	token, err := ts.Token()
 	assert.Equal(t, token.AccessToken, "1")
+	assert.Equal(t, token.Expiry, futureTime.Add(-earlyExpiry))
 	require.NoError(t, err)
 	token, err = ts.Token()
 	assert.Equal(t, token.AccessToken, "1")
+	assert.Equal(t, token.Expiry, futureTime.Add(-earlyExpiry))
 	require.NoError(t, err)
 
 	ts.Invalidate()
 
 	token, err = ts.Token()
 	assert.Equal(t, token.AccessToken, "2")
+	assert.Equal(t, token.Expiry, futureTime.Add(-earlyExpiry))
 	require.NoError(t, err)
 }

--- a/pkg/cloudproviders/gcp/auth/client_manager_impl_test.go
+++ b/pkg/cloudproviders/gcp/auth/client_manager_impl_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/auth/tokensource"
@@ -20,7 +21,10 @@ func TestTokenManager(t *testing.T) {
 	dummyErr := errors.New("dummy error")
 	mockCredManager.EXPECT().GetCredentials(gomock.Any()).Return(nil, dummyErr).Times(2)
 
-	ts := tokensource.NewReuseTokenSourceWithInvalidate(&CredentialManagerTokenSource{credManager: mockCredManager})
+	ts := tokensource.NewReuseTokenSourceWithInvalidate(
+		&CredentialManagerTokenSource{credManager: mockCredManager},
+		time.Minute,
+	)
 	manager := &stsTokenManagerImpl{credManager: mockCredManager, tokenSource: ts}
 
 	_, err := ts.Token()

--- a/pkg/cloudproviders/gcp/utils/util.go
+++ b/pkg/cloudproviders/gcp/utils/util.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"time"
 
 	securitycenter "cloud.google.com/go/securitycenter/apiv1"
 	googleStorage "cloud.google.com/go/storage"
@@ -13,6 +14,8 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 )
+
+const earlyExpiry = 5 * time.Minute
 
 // CreateStorageClientFromConfig creates a client based on the GCS integration configuration.
 //
@@ -78,13 +81,13 @@ func CreateTokenSourceFromConfig(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		return oauth2.ReuseTokenSource(nil, creds.TokenSource), nil
+		return oauth2.ReuseTokenSourceWithExpiry(nil, creds.TokenSource, earlyExpiry), nil
 	}
 	creds, err := google.CredentialsFromJSON(ctx, credsJSON, scopes...)
 	if err != nil {
 		return nil, err
 	}
-	return oauth2.ReuseTokenSource(nil, creds.TokenSource), nil
+	return oauth2.ReuseTokenSourceWithExpiry(nil, creds.TokenSource, earlyExpiry), nil
 }
 
 // CreateTokenSourceFromConfigWithManager creates a token source based on the config.
@@ -98,5 +101,5 @@ func CreateTokenSourceFromConfigWithManager(ctx context.Context, manager auth.ST
 	if err != nil {
 		return nil, err
 	}
-	return oauth2.ReuseTokenSource(nil, creds.TokenSource), nil
+	return oauth2.ReuseTokenSourceWithExpiry(nil, creds.TokenSource, earlyExpiry), nil
 }

--- a/pkg/registries/docker/config.go
+++ b/pkg/registries/docker/config.go
@@ -21,8 +21,6 @@ type Config struct {
 	Insecure bool
 	// DisableRepoList when true disables populating list of repos from remote registry.
 	DisableRepoList bool
-	// Transport defines a transport for authenticating to the Docker registry.
-	Transport registry.Transport
 }
 
 func (c *Config) formatURL() string {
@@ -31,15 +29,6 @@ func (c *Config) formatURL() string {
 		endpoint = "https://registry-1.docker.io"
 	}
 	return urlfmt.FormatURL(endpoint, urlfmt.HTTPS, urlfmt.NoTrailingSlash)
-}
-
-// GetTransport returns the transport which provides authentication to the Docker registry.
-// Returns `Config.Transport` if it is set. Otherwise returns a default transport.
-func (c *Config) GetTransport() registry.Transport {
-	if c.Transport != nil {
-		return c.Transport
-	}
-	return DefaultTransport(c)
 }
 
 // DefaultTransport returns the default transport based on the configuration.

--- a/pkg/registries/docker/docker.go
+++ b/pkg/registries/docker/docker.go
@@ -75,7 +75,7 @@ func NewDockerRegistryWithConfig(cfg *Config, integration *storage.ImageIntegrat
 	}
 
 	var transport registry.Transport
-	if len(transports) == 0 {
+	if len(transports) == 0 || transports[0] == nil {
 		transport = DefaultTransport(cfg)
 	} else {
 		transport = transports[0]

--- a/pkg/registries/docker/docker.go
+++ b/pkg/registries/docker/docker.go
@@ -121,8 +121,8 @@ func NewDockerRegistry(integration *storage.ImageIntegration, disableRepoList bo
 	}
 	cfg := &Config{
 		Endpoint:        dockerConfig.Docker.GetEndpoint(),
-		Username:        dockerConfig.Docker.GetUsername(),
-		Password:        dockerConfig.Docker.GetPassword(),
+		username:        dockerConfig.Docker.GetUsername(),
+		password:        dockerConfig.Docker.GetPassword(),
 		Insecure:        dockerConfig.Docker.GetInsecure(),
 		DisableRepoList: disableRepoList,
 	}
@@ -223,9 +223,10 @@ func (r *Registry) Test() error {
 
 // Config returns the configuration of the docker registry
 func (r *Registry) Config() *types.Config {
+	username, password := r.cfg.GetCredentials()
 	return &types.Config{
-		Username:         r.cfg.Username,
-		Password:         r.cfg.Password,
+		Username:         username,
+		Password:         password,
 		Insecure:         r.cfg.Insecure,
 		URL:              r.url,
 		RegistryHostname: r.registry,

--- a/pkg/registries/docker/docker.go
+++ b/pkg/registries/docker/docker.go
@@ -66,7 +66,7 @@ type Registry struct {
 
 // NewDockerRegistryWithConfig creates a new instantiation of the docker registry
 // TODO(cgorman) AP-386 - properly put the base docker registry into another pkg
-func NewDockerRegistryWithConfig(cfg *Config, integration *storage.ImageIntegration) (*Registry, error) {
+func NewDockerRegistryWithConfig(cfg *Config, integration *storage.ImageIntegration, transports ...registry.Transport) (*Registry, error) {
 	url := cfg.formatURL()
 	// if the registryServer endpoint contains docker.io then the image will be docker.io/namespace/repo:tag
 	registryServer := urlfmt.GetServerFromURL(url)
@@ -74,7 +74,13 @@ func NewDockerRegistryWithConfig(cfg *Config, integration *storage.ImageIntegrat
 		registryServer = "docker.io"
 	}
 
-	client, err := registry.NewFromTransport(url, cfg.GetTransport(), registry.Quiet)
+	var transport registry.Transport
+	if len(transports) == 0 {
+		transport = DefaultTransport(cfg)
+	} else {
+		transport = transports[0]
+	}
+	client, err := registry.NewFromTransport(url, transport, registry.Quiet)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registries/ecr/ecr.go
+++ b/pkg/registries/ecr/ecr.go
@@ -144,8 +144,7 @@ func newRegistry(integration *storage.ImageIntegration, disableRepoList bool) (*
 		DisableRepoList: disableRepoList,
 	}
 	if authData := conf.GetAuthorizationData(); authData != nil {
-		cfg.Username = authData.GetUsername()
-		cfg.Password = authData.GetPassword()
+		cfg.SetCredentials(authData.GetUsername(), authData.GetPassword())
 	} else {
 		client, err := createECRClient(conf)
 		if err != nil {

--- a/pkg/registries/ecr/ecr.go
+++ b/pkg/registries/ecr/ecr.go
@@ -152,11 +152,9 @@ func newRegistry(integration *storage.ImageIntegration, disableRepoList bool) (*
 			log.Error("Failed to create ECR client: ", err)
 			return nil, err
 		}
-		transport := newAWSTransport(integration.GetName(), cfg, client)
-		reg.transport = transport
-		cfg.Transport = reg.transport
+		reg.transport = newAWSTransport(integration.GetName(), cfg, client)
 	}
-	dockerRegistry, err := docker.NewDockerRegistryWithConfig(cfg, reg.integration)
+	dockerRegistry, err := docker.NewDockerRegistryWithConfig(cfg, reg.integration, reg.transport)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create docker registry")
 	}

--- a/pkg/registries/ecr/ecr.go
+++ b/pkg/registries/ecr/ecr.go
@@ -16,17 +16,25 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/registries/docker"
 	"github.com/stackrox/rox/pkg/registries/types"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 var log = logging.LoggerForModule()
 
 var _ types.Registry = (*ecr)(nil)
 
+// ecr implements docker registry access to AWS ECR. The docker credentials
+// are either taken from the datastore, in which case they have been synced
+// by Sensor, or they are derived from short-lived access tokens. The access
+// token is refreshed as part of the transport. ecr holds the mutex to the
+// docker credentials.
 type ecr struct {
 	*docker.Registry
 
 	config      *storage.ECRConfig
 	integration *storage.ImageIntegration
+	transport   *awsTransport
+	mutex       sync.RWMutex
 }
 
 // sanitizeConfiguration validates and cleans-up the integration configuration.
@@ -71,6 +79,20 @@ func sanitizeConfiguration(ecr *storage.ECRConfig) error {
 		errorList.AddString("Region must be specified")
 	}
 	return errorList.ToError()
+}
+
+// Config returns an up to date docker registry configuration.
+func (e *ecr) Config() *types.Config {
+	// No need for synchronization if there is no transport.
+	if e.transport == nil {
+		return e.Registry.Config()
+	}
+	if err := e.transport.ensureValid(); err != nil {
+		log.Errorf("Failed to ensure access token validity for image integration %q: %v", e.transport.name, err)
+	}
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+	return e.Registry.Config()
 }
 
 // Test tests the current registry and makes sure that it is working properly.
@@ -135,7 +157,9 @@ func newRegistry(integration *storage.ImageIntegration, disableRepoList bool) (*
 			log.Error("Failed to create ECR client: ", err)
 			return nil, err
 		}
-		cfg.Transport = newAWSTransport(integration.GetName(), cfg, client)
+		transport := newAWSTransport(integration.GetName(), &reg.mutex, cfg, client)
+		reg.transport = transport
+		cfg.Transport = reg.transport
 	}
 	dockerRegistry, err := docker.NewDockerRegistryWithConfig(cfg, reg.integration)
 	if err != nil {

--- a/pkg/registries/ecr/transport.go
+++ b/pkg/registries/ecr/transport.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 )
 
-const expiryDelta = time.Minute
+const earlyExpiry = 5 * time.Minute
 
 type awsTransport struct {
 	registry.Transport
@@ -58,7 +58,7 @@ func (t *awsTransport) ensureValid() error {
 }
 
 func (t *awsTransport) isValidNoLock() bool {
-	return t.expiresAt != nil && time.Now().Before(t.expiresAt.Add(-expiryDelta))
+	return t.expiresAt != nil && time.Now().Before(t.expiresAt.Add(-earlyExpiry))
 }
 
 func (t *awsTransport) refreshNoLock() error {

--- a/pkg/registries/ecr/transport.go
+++ b/pkg/registries/ecr/transport.go
@@ -80,8 +80,7 @@ func (t *awsTransport) refreshNoLock() error {
 		return errors.New("malformed basic auth response from AWS")
 	}
 	t.expiresAt = authData.ExpiresAt
-	t.config.Username = username
-	t.config.Password = password
+	t.config.SetCredentials(username, password)
 	t.Transport = docker.DefaultTransport(t.config)
 	return nil
 }

--- a/pkg/registries/ecr/transport_test.go
+++ b/pkg/registries/ecr/transport_test.go
@@ -18,12 +18,12 @@ func TestECRTransport(t *testing.T) {
 	assert.True(t, transport.isValidNoLock())
 
 	// Token is valid if more than the expiry delta is left.
-	expiredAt = time.Now().Add(120 * time.Second)
+	expiredAt = time.Now().Add(360 * time.Second)
 	transport.expiresAt = &expiredAt
 	assert.True(t, transport.isValidNoLock())
 
 	// Token is invalid if less than the expiry delta is left.
-	expiredAt = time.Now().Add(30 * time.Second)
+	expiredAt = time.Now().Add(180 * time.Second)
 	transport.expiresAt = &expiredAt
 	assert.False(t, transport.isValidNoLock())
 

--- a/pkg/registries/ecr/transport_test.go
+++ b/pkg/registries/ecr/transport_test.go
@@ -17,6 +17,16 @@ func TestECRTransport(t *testing.T) {
 	transport.expiresAt = &expiredAt
 	assert.True(t, transport.isValidNoLock())
 
+	// Token is valid if more than the expiry delta is left.
+	expiredAt = time.Now().Add(120 * time.Second)
+	transport.expiresAt = &expiredAt
+	assert.True(t, transport.isValidNoLock())
+
+	// Token is invalid if less than the expiry delta is left.
+	expiredAt = time.Now().Add(30 * time.Second)
+	transport.expiresAt = &expiredAt
+	assert.False(t, transport.isValidNoLock())
+
 	// Token is invalid after it expired.
 	expiredAt = time.Now()
 	transport.expiresAt = &expiredAt

--- a/pkg/registries/google/google.go
+++ b/pkg/registries/google/google.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stackrox/rox/pkg/registries/docker"
 	"github.com/stackrox/rox/pkg/registries/types"
 	"github.com/stackrox/rox/pkg/stringutils"
-	"github.com/stackrox/rox/pkg/sync"
 	"golang.org/x/oauth2"
 )
 
@@ -22,13 +21,11 @@ var _ types.Registry = (*googleRegistry)(nil)
 
 // googleRegistry implements docker registry access to Google Artifact registry and
 // Google container registry. The docker credentials are derived from short-lived
-// access tokens. The access token is refreshed as part of the transport. googleRegistry
-// holds the mutex to the docker credentials.
+// access tokens. The access token is refreshed as part of the transport.
 type googleRegistry struct {
 	types.Registry
 	project   string
 	transport *googleTransport
-	mutex     sync.RWMutex
 }
 
 // Match overrides the underlying Match function in types.Registry because our google registries are scoped by
@@ -45,8 +42,6 @@ func (g *googleRegistry) Config() *types.Config {
 	if err := g.transport.ensureValid(); err != nil {
 		log.Errorf("Failed to ensure access token validity for image integration %q: %v", g.transport.name, err)
 	}
-	g.mutex.RLock()
-	defer g.mutex.RUnlock()
 	return g.Registry.Config()
 }
 
@@ -124,7 +119,7 @@ func NewRegistry(integration *storage.ImageIntegration, disableRepoList bool, ma
 	reg := &googleRegistry{
 		project: strings.ToLower(config.GetProject()),
 	}
-	transport := newGoogleTransport(integration.GetName(), &reg.mutex, dockerConfig, tokenSource)
+	transport := newGoogleTransport(integration.GetName(), dockerConfig, tokenSource)
 	dockerConfig.Transport = transport
 	dockerRegistry, err := docker.NewDockerRegistryWithConfig(dockerConfig, integration)
 	if err != nil {

--- a/pkg/registries/google/google.go
+++ b/pkg/registries/google/google.go
@@ -119,13 +119,11 @@ func NewRegistry(integration *storage.ImageIntegration, disableRepoList bool, ma
 	reg := &googleRegistry{
 		project: strings.ToLower(config.GetProject()),
 	}
-	transport := newGoogleTransport(integration.GetName(), dockerConfig, tokenSource)
-	dockerConfig.Transport = transport
-	dockerRegistry, err := docker.NewDockerRegistryWithConfig(dockerConfig, integration)
+	reg.transport = newGoogleTransport(integration.GetName(), dockerConfig, tokenSource)
+	dockerRegistry, err := docker.NewDockerRegistryWithConfig(dockerConfig, integration, reg.transport)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create docker registry")
 	}
 	reg.Registry = dockerRegistry
-	reg.transport = transport
 	return reg, nil
 }

--- a/pkg/registries/google/transport.go
+++ b/pkg/registries/google/transport.go
@@ -67,8 +67,7 @@ func (t *googleTransport) refreshNoLock() error {
 		return errors.Wrap(err, "failed to get access token")
 	}
 	t.token = token
-	t.config.Username = "oauth2accesstoken"
-	t.config.Password = token.AccessToken
+	t.config.SetCredentials("oauth2accesstoken", token.AccessToken)
 	t.Transport = docker.DefaultTransport(t.config)
 	return nil
 }

--- a/pkg/registries/ibm/ibm.go
+++ b/pkg/registries/ibm/ibm.go
@@ -54,11 +54,10 @@ func newRegistry(integration *storage.ImageIntegration, disableRepoList bool) (*
 		return nil, err
 	}
 	cfg := &docker.Config{
-		Username:        username,
-		Password:        config.GetApiKey(),
 		Endpoint:        config.GetEndpoint(),
 		DisableRepoList: disableRepoList,
 	}
+	cfg.SetCredentials(username, config.GetApiKey())
 	registry, err := docker.NewDockerRegistryWithConfig(cfg, integration)
 	if err != nil {
 		return nil, err

--- a/pkg/registries/quay/quay.go
+++ b/pkg/registries/quay/quay.go
@@ -111,12 +111,11 @@ func NewRegistryFromConfig(config *storage.QuayConfig, integration *storage.Imag
 	}
 
 	cfg := &docker.Config{
-		Username:        username,
-		Password:        password,
 		Endpoint:        config.GetEndpoint(),
 		Insecure:        config.GetInsecure(),
 		DisableRepoList: disableRepoList,
 	}
+	cfg.SetCredentials(username, password)
 	dockerRegistry, err := docker.NewDockerRegistryWithConfig(cfg, integration)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

We noticed a potential issue with short-lived registry tokens and cached code paths when looking into scanner v4 on acs-cs. Some context: In 4.4, we are introducing short-lived tokens as authentication for registry image integrations. Contrary to the previous statically held long-lived tokens, the short-lived tokens have a validity of 1h (GCP) or 12h (AWS), and must be refreshed to keep access to the registry.

The token refresh is handled as part of the docker registry transport. This means that it is refreshed automatically upon usage of the docker registry client. The problem is now the following: In addition to usage in the docker client, the docker credentials are also passed around by themselves - in particular they are passed to scanner in the enrichment step.

When Central has ran a metadata fetch prior via the docker client this is not a problem because the token should be up to date. But if the metadata fetch is cached and not actually executed, this may result in tokens being expired. This PR attempts to fix this problem by ensuring that when the docker config is returned by google/ECR registries, the access token is first checked for validity and refreshed if necessary. In addition, an expiry delta following the implementation of `oauth2.Token` is added as additional buffer for ECR tokens. This makes the token refresh happen slightly before the tokens actually expire.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
