### PR TITLE
ROX-22625: Add tooltip for discovered cluster status and date

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredCluster.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredCluster.tsx
@@ -43,6 +43,17 @@ export function getStatusText(status: DiscoveredClusterStatus) {
     return statusMap[status] ?? statusMap.STATUS_UNSPECIFIED;
 }
 
+const statusTipMap: Record<DiscoveredClusterStatus, string> = {
+    STATUS_SECURED: 'This cluster is already secured.',
+    STATUS_UNSECURED: 'This cluster has been discovered by a cloud source, but is not yet secured.',
+    STATUS_UNSPECIFIED:
+        'This cluster has has been discovered by a cloud source, but has undetermined status because metadata collected from secured clusters does not guarantee a unique match. Sensor requires access to the AWS EC2 instance tags to determine the cluster state.',
+};
+
+export function getStatusTip(status: DiscoveredClusterStatus) {
+    return statusTipMap[status] ?? statusTipMap.STATUS_UNSPECIFIED;
+}
+
 // type
 
 export function getTypeText(type: DiscoveredClusterType) {

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredCluster.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredCluster.tsx
@@ -47,7 +47,7 @@ const statusTipMap: Record<DiscoveredClusterStatus, string> = {
     STATUS_SECURED: 'This cluster is already secured.',
     STATUS_UNSECURED: 'This cluster has been discovered by a cloud source, but is not yet secured.',
     STATUS_UNSPECIFIED:
-        'This cluster has has been discovered by a cloud source, but has undetermined status because metadata collected from secured clusters does not guarantee a unique match. Sensor requires access to the AWS EC2 instance tags to determine the cluster state.',
+        'This cluster has been discovered by a cloud source, but has undetermined status because metadata collected from secured clusters does not guarantee a unique match.',
 };
 
 export function getStatusTip(status: DiscoveredClusterStatus) {

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
@@ -13,6 +13,7 @@ import {
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import PageTitle from 'Components/PageTitle';
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import usePermissions from 'hooks/usePermissions';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
@@ -102,6 +103,21 @@ function DiscoveredClustersPage(): ReactElement {
                         <Text>
                             Discovered clusters might not yet have secured cluster services.
                         </Text>
+                        <Alert
+                            variant="info"
+                            isInline
+                            title="Solution for discovered clusters that have undetermined status"
+                        >
+                            <ExternalLink>
+                                <a
+                                    href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#allow-access-to-tags-in-IMDS"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    Grant access to instance tags via the metadata service
+                                </a>
+                            </ExternalLink>
+                        </Alert>
                     </Flex>
                 </Flex>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
@@ -13,7 +13,6 @@ import {
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import PageTitle from 'Components/PageTitle';
-import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import usePermissions from 'hooks/usePermissions';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
@@ -103,21 +102,6 @@ function DiscoveredClustersPage(): ReactElement {
                         <Text>
                             Discovered clusters might not yet have secured cluster services.
                         </Text>
-                        <Alert
-                            variant="info"
-                            isInline
-                            title="Solution for discovered clusters that have undetermined status"
-                        >
-                            <ExternalLink>
-                                <a
-                                    href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#allow-access-to-tags-in-IMDS"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    Grant access to instance tags via the metadata service
-                                </a>
-                            </ExternalLink>
-                        </Alert>
                     </Flex>
                 </Flex>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import { Tooltip } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import IconText from 'Components/PatternFly/IconText/IconText';
@@ -16,6 +17,7 @@ import {
     getProviderRegionText,
     getStatusIcon,
     getStatusText,
+    getStatusTip,
     getTypeText,
 } from './DiscoveredCluster';
 import DiscoveredClustersEmptyState from './DiscoveredClustersEmptyState';
@@ -76,10 +78,12 @@ function DiscoveredClustersTable({
                             <Tr key={id}>
                                 <Td dataLabel="Cluster">{name}</Td>
                                 <Td dataLabel="Status">
-                                    <IconText
-                                        icon={getStatusIcon(status)}
-                                        text={getStatusText(status)}
-                                    />
+                                    <Tooltip content={getStatusTip(status)}>
+                                        <IconText
+                                            icon={getStatusIcon(status)}
+                                            text={getStatusText(status)}
+                                        />
+                                    </Tooltip>
                                 </Td>
                                 <Td dataLabel="Type">{getTypeText(type)}</Td>
                                 <Td dataLabel="Provider (region)" modifier="nowrap">
@@ -89,7 +93,9 @@ function DiscoveredClustersTable({
                                     {sourceNameMap.get(source.id) ?? 'Not available'}
                                 </Td>
                                 <Td dataLabel="First discovered" modifier="nowrap">
-                                    {firstDiscoveredAsPhrase}
+                                    <Tooltip content={firstDiscoveredAt}>
+                                        <span>{firstDiscoveredAsPhrase}</span>
+                                    </Tooltip>
                                 </Td>
                             </Tr>
                         );


### PR DESCRIPTION
## Description

Rewrote tooltips:
* to remove reference to product branding
* in parallel form
* with input from Stephan about undetermined status ~and added link via info alert~

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Before you `yarn deploy` in ui folder:

```sh
export ROX_CLOUD_SOURCES=true
```

1. `yarn lint` in ui
2. `yarn build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 3951581 - 3951581
        total 1346 = 10544860 - 10543514
    * `ls -al build/static/js/*.js | wc`
        files 0 = 92 - 92
3. `yarn start` in ui

### Manual testing

Disregard info alert with link which has been deleted.

1. Visit /main/clusters/discovered-clusters with temporary data for request.

    * Secured
        ![Secured](https://github.com/stackrox/stackrox/assets/11862657/158fd1da-8841-46ef-aea1-757ca85d900f)

    * Unsecured
        ![Unsecured](https://github.com/stackrox/stackrox/assets/11862657/a6df2087-56e5-4b69-8205-09f1abb04a10)

    * Undetermined

       Tooltip simplified to delete duplicated word and second sentence:
       > This cluster has been discovered by a cloud source, but has undetermined status because metadata collected from secured clusters does not guarantee a unique match.

        ![Undetermined](https://github.com/stackrox/stackrox/assets/11862657/1c91302c-5694-4251-b0d0-7de18fadfbbe)

    * First discovered
        ![First_discovered](https://github.com/stackrox/stackrox/assets/11862657/2f3d6b3a-7820-4b24-aa8b-608a6738b6ba)

### Integration testing

Before you `yarn cypress-open` in ui/apps/platform folder:

```sh
export CYPRESS_ROX_CLOUD_SOURCES=true
```

* clusters/discovered-clusters/DiscoveredClustersPage.test.js
