### PR TITLE
ROX-22121: migrate vuln bucket

### DIFF
--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
     - master
+    - yli3/*
 
 jobs:
   upload-dev-vulnerabilities:
@@ -21,7 +22,7 @@ jobs:
     - name: Authenticate with Google Cloud
       uses: google-github-actions/auth@v2
       with:
-        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
+        credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
 
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v2
@@ -39,7 +40,7 @@ jobs:
         make -C scanner bin/updater
         go clean -cache -modcache
         ./scanner/bin/updater -output-dir=dev
-        gsutil cp -r "dev" "gs://scanner-v4-test/vulnerability-bundles"
+        gsutil cp -r "dev" "gs://definitions.stackrox.io/vulnerability-bundles"
 
   send-notification:
     needs:

--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -2,10 +2,6 @@ name: Scanner dev vulnerability update
 on:
   schedule:
   - cron: "30 */4 * * *"
-  push:
-    branches:
-    - master
-    - yli3/*
 
 jobs:
   upload-dev-vulnerabilities:

--- a/.github/workflows/scanner-dev-vuln-update.yaml
+++ b/.github/workflows/scanner-dev-vuln-update.yaml
@@ -40,7 +40,7 @@ jobs:
         make -C scanner bin/updater
         go clean -cache -modcache
         ./scanner/bin/updater -output-dir=dev
-        gsutil cp -r "dev" "gs://definitions.stackrox.io/vulnerability-bundles"
+        gsutil cp -r "dev" "gs://definitions.stackrox.io/v4/vulnerability-bundles"
 
   send-notification:
     needs:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -3,6 +3,10 @@ on:
   schedule:
   - cron: "0 */3 * * *"
   workflow_dispatch:
+  push:
+    branches:
+    - master
+    - yli3/*
 
 jobs:
   read-release-versions:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -81,7 +81,7 @@ jobs:
             break
           fi
         done
-        gsutil cp -r "${{ env.ROX_PRODUCT_VERSION }}" "gs://definitions.stackrox.io/vulnerability-bundles"
+        gsutil cp -r "${{ env.ROX_PRODUCT_VERSION }}" "gs://definitions.stackrox.io/v4/vulnerability-bundles"
 
   send-notification:
     needs:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -42,7 +42,7 @@ jobs:
     - name: Authenticate with Google Cloud
       uses: google-github-actions/auth@v2
       with:
-        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
+        credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
 
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v2
@@ -81,7 +81,7 @@ jobs:
             break
           fi
         done
-        gsutil cp -r "${{ env.ROX_PRODUCT_VERSION }}" "gs://scanner-v4-test/vulnerability-bundles"
+        gsutil cp -r "${{ env.ROX_PRODUCT_VERSION }}" "gs://definitions.stackrox.io/vulnerability-bundles"
 
   send-notification:
     needs:

--- a/.github/workflows/scanner-release-vuln-update.yaml
+++ b/.github/workflows/scanner-release-vuln-update.yaml
@@ -3,10 +3,6 @@ on:
   schedule:
   - cron: "0 */3 * * *"
   workflow_dispatch:
-  push:
-    branches:
-    - master
-    - yli3/*
 
 jobs:
   read-release-versions:

--- a/.github/workflows/scripts/scanner-update-offline-bundle.sh
+++ b/.github/workflows/scripts/scanner-update-offline-bundle.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-SCANNER_V4_DEFS_BUCKET="https://storage.googleapis.com/scanner-v4-test"
+SCANNER_V4_DEFS_BUCKET="https://storage.googleapis.com/definitions.stackrox.io"
 ROX_PRODUCT_VERSION="$1"
 PRODUCT_VERSION="${ROX_PRODUCT_VERSION}.0"
 declare -A files_to_download=(

--- a/.github/workflows/scripts/scanner-update-offline-bundle.sh
+++ b/.github/workflows/scripts/scanner-update-offline-bundle.sh
@@ -6,7 +6,7 @@ SCANNER_V4_DEFS_BUCKET="https://storage.googleapis.com/definitions.stackrox.io"
 ROX_PRODUCT_VERSION="$1"
 PRODUCT_VERSION="${ROX_PRODUCT_VERSION}.0"
 declare -A files_to_download=(
-    ["v4/vulns.json.zst"]="${SCANNER_V4_DEFS_BUCKET}/vulnerability-bundles/${PRODUCT_VERSION}/vulns.json.zst"
+    ["v4/vulns.json.zst"]="${SCANNER_V4_DEFS_BUCKET}/v4/vulnerability-bundles/${PRODUCT_VERSION}/vulns.json.zst"
     ["v4/mapping.zip"]="https://definitions.stackrox.io/redhat-repository-mappings/mapping.zip"
 )
 

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -48,7 +48,7 @@ const (
 	defaultCleanupInterval = 4 * time.Hour
 	defaultCleanupAge      = 1 * time.Hour
 
-	v4VulnSubDir      = "vulnerability-bundles"
+	v4VulnSubDir      = "v4/vulnerability-bundles"
 	mappingFile       = "redhat-repository-mappings/mapping.zip"
 	v4VulnFile        = "vulns.json.zst"
 	mappingUpdaterKey = "mapping"

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -49,7 +49,6 @@ const (
 	defaultCleanupAge      = 1 * time.Hour
 
 	// TODO(ROX-20481): Replace this URL with prod GCS bucket domain
-	v4StorageDomain   = "https://storage.googleapis.com/scanner-v4-test"
 	v4VulnSubDir      = "vulnerability-bundles"
 	mappingFile       = "redhat-repository-mappings/mapping.zip"
 	v4VulnFile        = "vulns.json.zst"
@@ -231,7 +230,7 @@ func (h *httpHandler) getUpdater(t updaterType, key string) *requestedUpdater {
 			urlStr, _ = url.JoinPath(scannerUpdateDomain, mappingFile)
 			filePath += ".zip"
 		case vulnerabilityUpdaterType:
-			urlStr, _ = url.JoinPath(v4StorageDomain, v4VulnSubDir, key, v4VulnFile)
+			urlStr, _ = url.JoinPath(scannerUpdateDomain, v4VulnSubDir, key, v4VulnFile)
 			filePath += ".json.zst"
 		default: // uuid
 			urlStr, _ = url.JoinPath(scannerUpdateDomain, key, scannerUpdateURLSuffix)

--- a/central/scannerdefinitions/handler/handler.go
+++ b/central/scannerdefinitions/handler/handler.go
@@ -48,7 +48,6 @@ const (
 	defaultCleanupInterval = 4 * time.Hour
 	defaultCleanupAge      = 1 * time.Hour
 
-	// TODO(ROX-20481): Replace this URL with prod GCS bucket domain
 	v4VulnSubDir      = "vulnerability-bundles"
 	mappingFile       = "redhat-repository-mappings/mapping.zip"
 	v4VulnFile        = "vulns.json.zst"

--- a/central/scannerdefinitions/handler/updater_test.go
+++ b/central/scannerdefinitions/handler/updater_test.go
@@ -23,9 +23,7 @@ const (
 
 	mappingURL = "https://storage.googleapis.com/definitions.stackrox.io/redhat-repository-mappings/mapping.zip"
 
-	cvssURL = "https://storage.googleapis.com/scanner-v4-test/nvd-bundle/nvd-data.tar.gz"
-
-	v4VulnURL = "https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/dev/vulns.json.zst"
+	v4VulnURL = "https://storage.googleapis.com/definitions.stackrox.io/vulnerability-bundles/dev/vulns.json.zst"
 )
 
 var (
@@ -92,21 +90,6 @@ func TestV4VulnUpdate(t *testing.T) {
 	// Should fetch first time.
 	require.NoError(t, u.doUpdate())
 	assertOnFileExistence(t, filePath, true)
-}
-
-func TestCvssUpdate(t *testing.T) {
-	filePath := filepath.Join(t.TempDir(), "test.tar.gz")
-	u := newUpdater(file.New(filePath), &http.Client{Timeout: 30 * time.Second}, cvssURL, 1*time.Hour)
-
-	// Should fetch first time.
-	require.NoError(t, u.doUpdate())
-	assertOnFileExistence(t, filePath, true)
-
-	n, err := countYearlyFilesInTarGz(filePath)
-	if err != nil {
-		t.Fatalf("Failed to count files in zip: %v", err)
-	}
-	assert.Greater(t, n, 21, "Number of files should be greater than 21")
 }
 
 func countYearlyFilesInTarGz(tarGzFilePath string) (int, error) {

--- a/central/scannerdefinitions/handler/updater_test.go
+++ b/central/scannerdefinitions/handler/updater_test.go
@@ -19,7 +19,7 @@ const (
 
 	mappingURL = "https://definitions.stackrox.io/redhat-repository-mappings/mapping.zip"
 
-	v4VulnURL = "https://definitions.stackrox.io/vulnerability-bundles/dev/vulns.json.zst"
+	v4VulnURL = "https://definitions.stackrox.io/v4/vulnerability-bundles/dev/vulns.json.zst"
 )
 
 var (

--- a/central/scannerdefinitions/handler/updater_test.go
+++ b/central/scannerdefinitions/handler/updater_test.go
@@ -1,14 +1,10 @@
 package handler
 
 import (
-	"archive/tar"
 	"archive/zip"
-	"compress/gzip"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
 	"time"
 
@@ -21,9 +17,9 @@ import (
 const (
 	defURL = "https://definitions.stackrox.io/e799c68a-671f-44db-9682-f24248cd0ffe/diff.zip"
 
-	mappingURL = "https://storage.googleapis.com/definitions.stackrox.io/redhat-repository-mappings/mapping.zip"
+	mappingURL = "https://definitions.stackrox.io/redhat-repository-mappings/mapping.zip"
 
-	v4VulnURL = "https://storage.googleapis.com/definitions.stackrox.io/vulnerability-bundles/dev/vulns.json.zst"
+	v4VulnURL = "https://definitions.stackrox.io/vulnerability-bundles/dev/vulns.json.zst"
 )
 
 var (
@@ -90,47 +86,6 @@ func TestV4VulnUpdate(t *testing.T) {
 	// Should fetch first time.
 	require.NoError(t, u.doUpdate())
 	assertOnFileExistence(t, filePath, true)
-}
-
-func countYearlyFilesInTarGz(tarGzFilePath string) (int, error) {
-	file, err := os.Open(tarGzFilePath)
-	if err != nil {
-		return 0, err
-	}
-	defer func() {
-		if err := file.Close(); err != nil {
-			panic(err)
-		}
-	}()
-
-	gzr, err := gzip.NewReader(file)
-	if err != nil {
-		return 0, err
-	}
-	defer func() {
-		if err := gzr.Close(); err != nil {
-			panic(err)
-		}
-	}()
-
-	tarr := tar.NewReader(gzr)
-
-	count := 0
-	yearRegexp := regexp.MustCompile(`\b(19|20)\d{2}\b`) // Regular expression for year
-	for {
-		header, err := tarr.Next()
-		if err != nil {
-			if err == io.EOF {
-				break // End of archive
-			}
-			return 0, err
-		}
-		if header.Typeflag != tar.TypeDir && yearRegexp.MatchString(header.Name) {
-			count++
-		}
-	}
-
-	return count, nil
 }
 
 // countFilesInZip counts the number of files inside a zip archive.

--- a/scanner/config.yaml.sample
+++ b/scanner/config.yaml.sample
@@ -13,7 +13,7 @@ matcher:
   database:
     conn_string: "host=/var/run/postgresql"
     password_file: ""
-  vulnerabilities_url: https://storage.googleapis.com/definitions.stackrox.io/vulnerability-bundles/dev/vulns.json.zst
+  vulnerabilities_url: https://definitions.stackrox.io/vulnerability-bundles/dev/vulns.json.zst
 mtls:
   certs_dir: certs/scanner-v4
 log_level: info

--- a/scanner/config.yaml.sample
+++ b/scanner/config.yaml.sample
@@ -13,7 +13,7 @@ matcher:
   database:
     conn_string: "host=/var/run/postgresql"
     password_file: ""
-  vulnerabilities_url: https://definitions.stackrox.io/vulnerability-bundles/dev/vulns.json.zst
+  vulnerabilities_url: https://definitions.stackrox.io/v4/vulnerability-bundles/dev/vulns.json.zst
 mtls:
   certs_dir: certs/scanner-v4
 log_level: info

--- a/scanner/config.yaml.sample
+++ b/scanner/config.yaml.sample
@@ -13,7 +13,7 @@ matcher:
   database:
     conn_string: "host=/var/run/postgresql"
     password_file: ""
-  vulnerabilities_url: https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/dev/vulns.json.zst
+  vulnerabilities_url: https://storage.googleapis.com/definitions.stackrox.io/vulnerability-bundles/dev/vulns.json.zst
 mtls:
   certs_dir: certs/scanner-v4
 log_level: info

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/scanner/internal/version"
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 )
 
 var (
@@ -42,7 +42,7 @@ var (
 				ConnString:   "host=/var/run/postgresql",
 				PasswordFile: "",
 			},
-			VulnerabilitiesURL: "https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/dev/vulns.json.zst",
+			VulnerabilitiesURL: "https://storage.googleapis.com/definitions.stackrox.io/vulnerability-bundles/dev/vulns.json.zst",
 		},
 		// Default is empty.
 		MTLS: MTLSConfig{

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/scanner/internal/version"
-	yaml "gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -42,7 +42,7 @@ var (
 				ConnString:   "host=/var/run/postgresql",
 				PasswordFile: "",
 			},
-			VulnerabilitiesURL: "https://storage.googleapis.com/definitions.stackrox.io/vulnerability-bundles/dev/vulns.json.zst",
+			VulnerabilitiesURL: "https://definitions.stackrox.io/vulnerability-bundles/dev/vulns.json.zst",
 		},
 		// Default is empty.
 		MTLS: MTLSConfig{

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -42,7 +42,7 @@ var (
 				ConnString:   "host=/var/run/postgresql",
 				PasswordFile: "",
 			},
-			VulnerabilitiesURL: "https://definitions.stackrox.io/vulnerability-bundles/dev/vulns.json.zst",
+			VulnerabilitiesURL: "https://definitions.stackrox.io/v4/vulnerability-bundles/dev/vulns.json.zst",
 		},
 		// Default is empty.
 		MTLS: MTLSConfig{

--- a/scanner/updater/version/RELEASE_VERSION
+++ b/scanner/updater/version/RELEASE_VERSION
@@ -4,6 +4,5 @@
 # For each individual version of Scanner's vulnerability updater, corresponding vulnerability data is collected and then seamlessly uploaded to Google Storage.
 # This process ensures that each version's vulnerability data is accurately captured and maintained in accordance with its respective version.
 4.3.x-173-g6bbb2e07dc
-4.2.0
 4.3.0
 4.3.x-nightly-20240105


### PR DESCRIPTION
## Description

Store vuln bundle in definitions.stackrox.io instead of test bucket 

## Checklist
- [x] Investigated and inspected CI test results

## Manual testing
```
curl --insecure -u admin:[pwd] https://localhost:8000/api/extensions/scannerdefinitions?version=dev > dev.json.zst
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  149M  100  149M    0     0  39.2M      0  0:00:03  0:00:03 --:--:-- 39.2M
yli3-mac:stackrox yili$ ls -lh dev.json.zst 
-rw-r--r-- 1 yili staff 150M Feb 21 09:01 dev.json.zst
yli3-mac:stackrox yili$ 
```
```
curl --insecure -u admin:[pwd] https://localhost:8000/api/extensions/scannerdefinitions?version=4.3.0 > 4.3.0-defs.json.zst
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  138M  100  138M    0     0  21.3M      0  0:00:06  0:00:06 --:--:-- 32.5M
yli3-mac:stackrox yili$ ls -lh 4.3.0-defs.json.zst 
-rw-r--r-- 1 yili staff 139M Feb 21 09:02 4.3.0-defs.json.zst
```

## Notice
CI jobs that generate and upload vuln bundle must pass