### PR TITLE
fix(scanner): disable proxy-use when talking to Scanner V4

### DIFF
--- a/pkg/scannerv4/client/client.go
+++ b/pkg/scannerv4/client/client.go
@@ -110,6 +110,14 @@ func createGRPCConn(ctx context.Context, o connOptions) (*grpc.ClientConn, error
 		// via DNS name resolution, which is possible because Scanner v4 services are "headless"
 		// (clusterIP: None).
 		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin": {}}]}`),
+		// The gRPC library does not respect NO_PROXY settings when using the DNS name resolver.
+		// Outside from testing, the only users of this client library are Central and Sensor,
+		// which only communicate with namespace-local Scanner v4 services.
+		// Because of this, we just disable proxy settings when talking to Scanner v4 services.
+		//
+		// See https://github.com/grpc/grpc-go/issues/3401 for more information about using
+		// proxy settings with DNS name resolution.
+		grpc.WithNoProxy(),
 	}
 
 	maxRespMsgSize := env.ScannerV4MaxRespMsgSize.IntegerSetting()


### PR DESCRIPTION
## Description

Ignore proxy settings when Central/Sensor talks to Scanner V4

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

ACSCS test instance has a squid proxy set up. Deployed this PR to this test instance and found fetching the Vuln update time no longer times out (nor receives 403 status codes). We now see the vuln update time

![Screenshot 2024-02-20 at 11 16 20 PM](https://github.com/stackrox/stackrox/assets/7704495/1a6ac73c-c9a1-416e-8673-86eedee7d43b)

Used the same instance to scan a few images after verifying the proxy environment variables were set in the indexer containers

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
