### PR TITLE
ROX-21709: use ROX_SCANNER_V4_INDEXER_ENDPOINT

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -117,7 +117,7 @@ spec:
         [<- end >]
         [<- if and (not .KubectlOutput) .FeatureFlags.ROX_SCANNER_V4_SUPPORT >]
         {{- if ._rox._scannerV4Enabled }}
-        - name: ROX_SCANNER_V4_INDEXER_GRPC_ENDPOINT
+        - name: ROX_SCANNER_V4_INDEXER_ENDPOINT
           value: {{ printf "scanner-v4-indexer.%s.svc:8443" .Release.Namespace }}
         - name: ROX_SCANNER_V4
           value: "true"

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -117,7 +117,7 @@ spec:
         [<- end >]
         [<- if and (not .KubectlOutput) .FeatureFlags.ROX_SCANNER_V4_SUPPORT >]
         {{- if ._rox._scannerV4Enabled }}
-        - name: ROX_SCANNER_V4_GRPC_ENDPOINT
+        - name: ROX_SCANNER_V4_INDEXER_GRPC_ENDPOINT
           value: {{ printf "scanner-v4-indexer.%s.svc:8443" .Release.Namespace }}
         - name: ROX_SCANNER_V4
           value: "true"

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -20,8 +20,8 @@ var (
 	// This is typically used for Sensor to communicate with a local Scanner-slim's gRPC server.
 	ScannerSlimGRPCEndpoint = RegisterSetting("ROX_SCANNER_GRPC_ENDPOINT", WithDefault("scanner.stackrox.svc:8443"))
 
-	// ScannerV4GRPCEndpoint is used to communicate with the Scanner V4 endpoint in the same cluster.
-	ScannerV4GRPCEndpoint = RegisterSetting("ROX_SCANNER_V4_GRPC_ENDPOINT", WithDefault("scanner-v4-indexer.stackrox.svc:8443"))
+	// ScannerV4IndexerGRPCEndpoint is used to communicate with the Scanner V4 Indexer endpoint in the same cluster.
+	ScannerV4IndexerGRPCEndpoint = RegisterSetting("ROX_SCANNER_V4_INDEXER_GRPC_ENDPOINT", WithDefault("scanner-v4-indexer.stackrox.svc:8443"))
 
 	// LocalImageScanningEnabled is used to specify if Sensor should attempt to scan images via a local Scanner.
 	LocalImageScanningEnabled = RegisterBooleanSetting("ROX_LOCAL_IMAGE_SCANNING_ENABLED", false)

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -20,8 +20,8 @@ var (
 	// This is typically used for Sensor to communicate with a local Scanner-slim's gRPC server.
 	ScannerSlimGRPCEndpoint = RegisterSetting("ROX_SCANNER_GRPC_ENDPOINT", WithDefault("scanner.stackrox.svc:8443"))
 
-	// ScannerV4IndexerGRPCEndpoint is used to communicate with the Scanner V4 Indexer endpoint in the same cluster.
-	ScannerV4IndexerGRPCEndpoint = RegisterSetting("ROX_SCANNER_V4_INDEXER_GRPC_ENDPOINT", WithDefault("scanner-v4-indexer.stackrox.svc:8443"))
+	// ScannerV4IndexerEndpoint is used to communicate with the Scanner V4 Indexer endpoint in the same cluster.
+	ScannerV4IndexerEndpoint = RegisterSetting("ROX_SCANNER_V4_INDEXER_ENDPOINT", WithDefault("scanner-v4-indexer.stackrox.svc:8443"))
 
 	// LocalImageScanningEnabled is used to specify if Sensor should attempt to scan images via a local Scanner.
 	LocalImageScanningEnabled = RegisterBooleanSetting("ROX_LOCAL_IMAGE_SCANNING_ENABLED", false)

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -195,7 +195,7 @@ tests:
     imagePullSecrets.allowNone: true
   expect: |
     .deployments["sensor"].spec.template.spec.containers[0].env[] |
-      select(.name == "ROX_SCANNER_V4_INDEXER_GRPC_ENDPOINT") | assertThat(.value == "scanner-v4-indexer.custom-ns.svc:8443")
+      select(.name == "ROX_SCANNER_V4_INDEXER_ENDPOINT") | assertThat(.value == "scanner-v4-indexer.custom-ns.svc:8443")
 
 - name: "Test customize for local scanner v4"
   values:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -195,7 +195,7 @@ tests:
     imagePullSecrets.allowNone: true
   expect: |
     .deployments["sensor"].spec.template.spec.containers[0].env[] |
-      select(.name == "ROX_SCANNER_V4_GRPC_ENDPOINT") | assertThat(.value == "scanner-v4-indexer.custom-ns.svc:8443")
+      select(.name == "ROX_SCANNER_V4_INDEXER_GRPC_ENDPOINT") | assertThat(.value == "scanner-v4-indexer.custom-ns.svc:8443")
 
 - name: "Test customize for local scanner v4"
   values:

--- a/sensor/common/scannerclient/grpc_client.go
+++ b/sensor/common/scannerclient/grpc_client.go
@@ -165,7 +165,7 @@ func dialV2() (ScannerClient, error) {
 // dialV4 connect to scanner V4 gRPC and return a new ScannerClient.
 func dialV4() (ScannerClient, error) {
 	ctx := context.Background()
-	c, err := client.NewGRPCScanner(ctx, client.WithIndexerAddress(env.ScannerV4IndexerGRPCEndpoint.Setting()))
+	c, err := client.NewGRPCScanner(ctx, client.WithIndexerAddress(env.ScannerV4IndexerEndpoint.Setting()))
 	if err != nil {
 		return nil, err
 	}

--- a/sensor/common/scannerclient/grpc_client.go
+++ b/sensor/common/scannerclient/grpc_client.go
@@ -165,7 +165,7 @@ func dialV2() (ScannerClient, error) {
 // dialV4 connect to scanner V4 gRPC and return a new ScannerClient.
 func dialV4() (ScannerClient, error) {
 	ctx := context.Background()
-	c, err := client.NewGRPCScanner(ctx, client.WithIndexerAddress(env.ScannerV4GRPCEndpoint.Setting()))
+	c, err := client.NewGRPCScanner(ctx, client.WithIndexerAddress(env.ScannerV4IndexerGRPCEndpoint.Setting()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

ROX_SCANNER_V4_GRPC_ENDPOINT -> ROX_SCANNER_V4_INDEXER_ENDPOINT

It's wordier, but specific

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

Just used GoLand to search for all instances of `ROX_SCANNER_V4_GRPC_ENDPOINT` and replaced them. One instance was a Helm test

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
