### PR TITLE
Install Compliance Operator from downstream sources

### DIFF
--- a/tests/e2e/yaml/compliance-operator/subscription.yaml
+++ b/tests/e2e/yaml/compliance-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: compliance-operator-sub
   namespace: openshift-compliance
 spec:
-  channel: alpha
+  channel: stable
   name: compliance-operator
-  source: compliance-operator
+  source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
We're experiencing an issue with upstream CO installs where the content doesn't parse correctly during installation, leading to the following trace:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x78a916]
```

Let's use the downstream compliance operator until we fix the upstream regression.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

ACS v2.0 compliance e2e testing should pass successfully.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
