### PR TITLE
ROX-22471: Add analtyics for specific button clicks in Network Graph

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -18,6 +18,7 @@ import { timeWindows } from 'constants/timeWindows';
 import useFetchClustersForPermissions from 'hooks/useFetchClustersForPermissions';
 import useFetchDeploymentCount from 'hooks/useFetchDeploymentCount';
 import usePermissions from 'hooks/usePermissions';
+import useAnalytics, { CIDR_BLOCK_FORM_OPENED } from 'hooks/useAnalytics';
 import useURLSearch from 'hooks/useURLSearch';
 import { fetchNetworkFlowGraph, fetchNodeUpdates } from 'services/NetworkService';
 import queryService from 'utils/queryService';
@@ -44,6 +45,7 @@ import {
     createExtraneousFlowsModel,
     graphModel,
 } from './utils/modelUtils';
+import { getPropertiesForAnalytics } from './utils/networkGraphURLUtils';
 import getSimulation from './utils/getSimulation';
 import { getSearchFilterFromScopeHierarchy } from './utils/simulatorUtils';
 import CIDRFormModal from './components/CIDRFormModal';
@@ -95,6 +97,7 @@ function NetworkGraphPage() {
     const [lastUpdatedTime, setLastUpdatedTime] = useState<string>('');
     const [isCIDRBlockFormOpen, setIsCIDRBlockFormOpen] = useState(false);
 
+    const { analyticsTrack } = useAnalytics();
     const { searchFilter, setSearchFilter } = useURLSearch();
     const [simulationQueryValue] = useURLParameter('simulation', undefined);
     const simulation = getSimulation(simulationQueryValue);
@@ -274,6 +277,15 @@ function NetworkGraphPage() {
     ]);
 
     function toggleCIDRBlockForm() {
+        if (!isCIDRBlockFormOpen) {
+            const properties = getPropertiesForAnalytics(searchFilter);
+
+            analyticsTrack({
+                event: CIDR_BLOCK_FORM_OPENED,
+                properties,
+            });
+        }
+
         setIsCIDRBlockFormOpen(!isCIDRBlockFormOpen);
     }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
@@ -3,8 +3,11 @@ import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-
 import { DownloadIcon } from '@patternfly/react-icons';
 
 import { useTheme } from 'Containers/ThemeProvider';
+import useAnalytics, { DOWNLOAD_NETWORK_POLICIES } from 'hooks/useAnalytics';
+import useURLSearch from 'hooks/useURLSearch';
 import download from 'utils/download';
 import CodeEditorDarkModeControl from 'Components/PatternFly/CodeEditorDarkModeControl';
+import { getPropertiesForAnalytics } from '../utils/networkGraphURLUtils';
 
 import './NetworkPoliciesYAML.css';
 
@@ -18,21 +21,31 @@ const labels = {
     downloadYAML: 'Download YAML',
 };
 
-const downloadYAMLHandler = (fileName: string, fileContent: string) => () => {
-    download(`${fileName}.yml`, fileContent, 'yml');
-};
-
 function NetworkPoliciesYAML({
     yaml,
     height = '300px',
     additionalControls = [],
 }: NetworkPoliciesYAMLProp) {
+    const { analyticsTrack } = useAnalytics();
+    const { searchFilter } = useURLSearch();
+
     const { isDarkMode } = useTheme();
     const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
 
     function onToggleDarkMode() {
         setCustomDarkMode((prevValue) => !prevValue);
     }
+
+    const downloadYAMLHandler = (fileName: string, fileContent: string) => () => {
+        const properties = getPropertiesForAnalytics(searchFilter);
+
+        analyticsTrack({
+            event: DOWNLOAD_NETWORK_POLICIES,
+            properties,
+        });
+
+        download(`${fileName}.yml`, fileContent, 'yml');
+    };
 
     const downloadYAMLControl = (
         <CodeEditorControl

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -24,6 +24,8 @@ import { HelpIcon } from '@patternfly/react-icons';
 import sortBy from 'lodash/sortBy';
 
 import useRestQuery from 'hooks/useRestQuery';
+import useAnalytics, { GENERATE_NETWORK_POLICIES } from 'hooks/useAnalytics';
+import useURLSearch from 'hooks/useURLSearch';
 import useTabs from 'hooks/patternfly/useTabs';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
@@ -46,6 +48,7 @@ import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import CompareYAMLModal from './CompareYAMLModal';
 import CodeCompareIcon from './CodeCompareIcon';
 import NetworkPoliciesGenerationScope from './NetworkPoliciesGenerationScope';
+import { getPropertiesForAnalytics } from '../utils/networkGraphURLUtils';
 
 // @TODO: Consider a better approach to managing the side panel related state (simulation + URL path for entities)
 export function clearSimulationQuery(search: string): string {
@@ -74,6 +77,9 @@ function NetworkPolicySimulatorSidePanel({
     scopeHierarchy,
     scopeDeploymentCount,
 }: NetworkPolicySimulatorSidePanelProps) {
+    const { analyticsTrack } = useAnalytics();
+    const { searchFilter } = useURLSearch();
+
     const { activeKeyTab, onSelectTab } = useTabs({
         defaultTab: tabs.SIMULATE_NETWORK_POLICIES,
     });
@@ -140,6 +146,12 @@ function NetworkPolicySimulatorSidePanel({
     }
 
     function generateNetworkPolicies() {
+        const properties = getPropertiesForAnalytics(searchFilter);
+
+        analyticsTrack({
+            event: GENERATE_NETWORK_POLICIES,
+            properties,
+        });
         setNetworkPolicyModification({
             state: 'GENERATED',
             options: {

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulateNetworkPolicyButton.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulateNetworkPolicyButton.tsx
@@ -3,8 +3,11 @@ import { Button } from '@patternfly/react-core';
 import { useHistory } from 'react-router-dom';
 
 import { networkBasePath } from 'routePaths';
+import useAnalytics, { CLUSTER_LEVEL_SIMULATOR_OPENED } from 'hooks/useAnalytics';
 import useURLParameter from 'hooks/useURLParameter';
+import useURLSearch from 'hooks/useURLSearch';
 import { Simulation } from '../utils/getSimulation';
+import { getPropertiesForAnalytics } from '../utils/networkGraphURLUtils';
 
 type SimulateNetworkPolicyButtonProps = {
     simulation: Simulation;
@@ -12,12 +15,21 @@ type SimulateNetworkPolicyButtonProps = {
 };
 
 function SimulateNetworkPolicyButton({ simulation, isDisabled }: SimulateNetworkPolicyButtonProps) {
+    const { analyticsTrack } = useAnalytics();
     const history = useHistory();
+    const { searchFilter } = useURLSearch();
 
     const [, setSimulationQueryValue] = useURLParameter('simulation', undefined);
 
     function enableNetworkPolicySimulation() {
+        const properties = getPropertiesForAnalytics(searchFilter);
+        analyticsTrack({
+            event: CLUSTER_LEVEL_SIMULATOR_OPENED,
+            properties,
+        });
+
         history.push(`${networkBasePath}${history.location.search as string}`);
+
         setSimulationQueryValue('networkPolicy');
     }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphURLUtils.test.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphURLUtils.test.ts
@@ -1,4 +1,4 @@
-import { getURLLinkToDeployment } from './networkGraphURLUtils';
+import { getURLLinkToDeployment, getPropertiesForAnalytics } from './networkGraphURLUtils';
 
 describe('networkGraphURLUtils', () => {
     describe('getURLLinkToDeployment', () => {
@@ -10,6 +10,72 @@ describe('networkGraphURLUtils', () => {
             expect(url).toEqual(
                 '/main/network-graph/deployment/8cbfde79-3450-45bb-a5c9-4185b9d1d0f1?s[Cluster]=remote&s[Namespace]=stackrox'
             );
+        });
+    });
+
+    describe('getPropertiesForAnalytics', () => {
+        it('should properties with just a cluster', () => {
+            const searchFilter = {
+                Cluster: 'staging-secured-cluster',
+                Namespace: undefined,
+                Deployment: undefined,
+            };
+
+            const properties = getPropertiesForAnalytics(searchFilter);
+
+            expect(properties).toEqual({
+                cluster: 'staging-secured-cluster',
+                namespaces: '',
+                deployments: '',
+            });
+        });
+
+        it('should return properties with just cluster and namespaces', () => {
+            const searchFilter = {
+                Cluster: 'staging-secured-cluster',
+                Namespace: ['default', 'stackrox'],
+                Deployment: undefined,
+            };
+
+            const properties = getPropertiesForAnalytics(searchFilter);
+
+            expect(properties).toEqual({
+                cluster: 'staging-secured-cluster',
+                namespaces: 'default,stackrox',
+                deployments: '',
+            });
+        });
+
+        it('should return properties with cluster, namespaces, and deployments', () => {
+            const searchFilter = {
+                Cluster: 'staging-secured-cluster',
+                Namespace: ['default', 'stackrox'],
+                Deployment: ['admission-control', 'sensor', 'collector'],
+            };
+
+            const properties = getPropertiesForAnalytics(searchFilter);
+
+            expect(properties).toEqual({
+                cluster: 'staging-secured-cluster',
+                namespaces: 'default,stackrox',
+                deployments: 'admission-control,sensor,collector',
+            });
+        });
+
+        it('should properties when it does not know the cluster', () => {
+            const searchFilter = {
+                Cluster: undefined,
+                Namespace: undefined,
+                Deployment: undefined,
+            };
+
+            const properties = getPropertiesForAnalytics(searchFilter);
+
+            expect(properties).toEqual({
+                cluster: 'unknown cluster',
+                namespaces: '',
+                deployments: '',
+            });
         });
     });
 });

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphURLUtils.test.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphURLUtils.test.ts
@@ -24,9 +24,9 @@ describe('networkGraphURLUtils', () => {
             const properties = getPropertiesForAnalytics(searchFilter);
 
             expect(properties).toEqual({
-                cluster: 'staging-secured-cluster',
-                namespaces: '',
-                deployments: '',
+                cluster: 1,
+                namespaces: 0,
+                deployments: 0,
             });
         });
 
@@ -40,25 +40,25 @@ describe('networkGraphURLUtils', () => {
             const properties = getPropertiesForAnalytics(searchFilter);
 
             expect(properties).toEqual({
-                cluster: 'staging-secured-cluster',
-                namespaces: 'default,stackrox',
-                deployments: '',
+                cluster: 1,
+                namespaces: 2,
+                deployments: 0,
             });
         });
 
         it('should return properties with cluster, namespaces, and deployments', () => {
             const searchFilter = {
                 Cluster: 'staging-secured-cluster',
-                Namespace: ['default', 'stackrox'],
+                Namespace: ['default', 'stackrox', 'payments'],
                 Deployment: ['admission-control', 'sensor', 'collector'],
             };
 
             const properties = getPropertiesForAnalytics(searchFilter);
 
             expect(properties).toEqual({
-                cluster: 'staging-secured-cluster',
-                namespaces: 'default,stackrox',
-                deployments: 'admission-control,sensor,collector',
+                cluster: 1,
+                namespaces: 3,
+                deployments: 3,
             });
         });
 
@@ -72,9 +72,9 @@ describe('networkGraphURLUtils', () => {
             const properties = getPropertiesForAnalytics(searchFilter);
 
             expect(properties).toEqual({
-                cluster: 'unknown cluster',
-                namespaces: '',
-                deployments: '',
+                cluster: 0,
+                namespaces: 0,
+                deployments: 0,
             });
         });
     });

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphURLUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphURLUtils.ts
@@ -1,5 +1,6 @@
 import { networkBasePath } from 'routePaths';
 import { getQueryString } from 'utils/queryStringUtils';
+import { SearchFilter } from 'types/search';
 
 type GetURLLinkToDeploymentParams = {
     cluster: string;
@@ -20,4 +21,16 @@ export function getURLLinkToDeployment({
     });
     const networkGraphLink = `${networkBasePath}/deployment/${deploymentId}${queryString}`;
     return networkGraphLink;
+}
+
+export function getPropertiesForAnalytics(searchFilter: SearchFilter) {
+    const cluster = searchFilter?.Cluster?.toString() || 'unknown cluster';
+    const namespaces = searchFilter?.Namespace?.toString() || '';
+    const deployments = searchFilter?.Deployment?.toString() || '';
+
+    return {
+        cluster,
+        namespaces,
+        deployments,
+    };
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphURLUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphURLUtils.ts
@@ -24,9 +24,9 @@ export function getURLLinkToDeployment({
 }
 
 export function getPropertiesForAnalytics(searchFilter: SearchFilter) {
-    const cluster = searchFilter?.Cluster?.toString() || 'unknown cluster';
-    const namespaces = searchFilter?.Namespace?.toString() || '';
-    const deployments = searchFilter?.Deployment?.toString() || '';
+    const cluster = searchFilter?.Cluster?.toString() ? 1 : 0;
+    const namespaces = searchFilter?.Namespace?.length || 0;
+    const deployments = searchFilter?.Deployment?.length || 0;
 
     return {
         cluster,

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -78,36 +78,36 @@ type AnalyticsEvent =
     | {
           event: typeof CLUSTER_LEVEL_SIMULATOR_OPENED;
           properties: {
-              cluster: string;
-              namespaces: string;
-              deployments: string;
+              cluster: number;
+              namespaces: number;
+              deployments: number;
           };
       }
     /** Tracks each time network policies are genarated on Network Graph */
     | {
           event: typeof GENERATE_NETWORK_POLICIES;
           properties: {
-              cluster: string;
-              namespaces: string;
-              deployments: string;
+              cluster: number;
+              namespaces: number;
+              deployments: number;
           };
       }
     /** Tracks each time network policies are downloaded on Network Graph */
     | {
           event: typeof DOWNLOAD_NETWORK_POLICIES;
           properties: {
-              cluster: string;
-              namespaces: string;
-              deployments: string;
+              cluster: number;
+              namespaces: number;
+              deployments: number;
           };
       }
     /** Tracks each time CIDR Block form opened on Network Graph */
     | {
           event: typeof CIDR_BLOCK_FORM_OPENED;
           properties: {
-              cluster: string;
-              namespaces: string;
-              deployments: string;
+              cluster: number;
+              namespaces: number;
+              deployments: number;
           };
       }
     /** Tracks each time the user opens the "Watched Images" modal */

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -5,13 +5,25 @@ import { Telemetry } from 'types/config.proto';
 import { selectors } from 'reducers';
 import { UnionFrom, tupleTypeGuard } from 'utils/type.utils';
 
-// event name constants
+// Event Name Constants
+// clusters
 export const CLUSTER_CREATED = 'Cluster Created';
+
+// invite users
 export const INVITE_USERS_MODAL_OPENED = 'Invite Users Modal Opened';
 export const INVITE_USERS_SUBMITTED = 'Invite Users Submitted';
+
+// network graph
+export const CLUSTER_LEVEL_SIMULATOR_OPENED = 'Network Graph: Cluster Level Simulator Opened';
+export const GENERATE_NETWORK_POLICIES = 'Network Graph: Generate Network Policies';
+export const DOWNLOAD_NETWORK_POLICIES = 'Network Graph: Download Network Policies';
+export const CIDR_BLOCK_FORM_OPENED = 'Network Graph: CIDR Block Form Opened';
+
+// watch images
 export const WATCH_IMAGE_MODAL_OPENED = 'Watch Image Modal Opened';
 export const WATCH_IMAGE_SUBMITTED = 'Watch Image Submitted';
 
+// workflow cves
 export const WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED = 'Workload CVE Entity Context View';
 export const WORKLOAD_CVE_FILTER_APPLIED = 'Workload CVE Filter Applied';
 export const WORKLOAD_CVE_DEFAULT_FILTERS_CHANGED = 'Workload CVE Default Filters Changed';
@@ -21,6 +33,7 @@ export const VULNERABILITY_REPORT_DOWNLOAD_GENERATED = 'Vulnerability Report Dow
 export const VULNERABILITY_REPORT_SENT_MANUALLY = 'Vulnerability Report Sent Manually';
 export const GLOBAL_SNOOZE_CVE = 'Global Snooze CVE';
 
+// cluster-init-bundles
 export const CREATE_INIT_BUNDLE_CLICKED = 'Create Init Bundle Clicked';
 export const SECURE_A_CLUSTER_LINK_CLICKED = 'Secure a Cluster Link Clicked';
 export const LEGACY_SECURE_A_CLUSTER_LINK_CLICKED = 'Legacy Secure a Cluster Link Clicked';
@@ -61,6 +74,42 @@ type AnalyticsEvent =
     | typeof CLUSTER_CREATED
     | typeof INVITE_USERS_MODAL_OPENED
     | typeof INVITE_USERS_SUBMITTED
+    /** Tracks each time a cluster level simulator is opened on Network Graph */
+    | {
+          event: typeof CLUSTER_LEVEL_SIMULATOR_OPENED;
+          properties: {
+              cluster: string;
+              namespaces: string;
+              deployments: string;
+          };
+      }
+    /** Tracks each time network policies are genarated on Network Graph */
+    | {
+          event: typeof GENERATE_NETWORK_POLICIES;
+          properties: {
+              cluster: string;
+              namespaces: string;
+              deployments: string;
+          };
+      }
+    /** Tracks each time network policies are downloaded on Network Graph */
+    | {
+          event: typeof DOWNLOAD_NETWORK_POLICIES;
+          properties: {
+              cluster: string;
+              namespaces: string;
+              deployments: string;
+          };
+      }
+    /** Tracks each time CIDR Block form opened on Network Graph */
+    | {
+          event: typeof CIDR_BLOCK_FORM_OPENED;
+          properties: {
+              cluster: string;
+              namespaces: string;
+              deployments: string;
+          };
+      }
     /** Tracks each time the user opens the "Watched Images" modal */
     | typeof WATCH_IMAGE_MODAL_OPENED
     /** Tracks each time the user submits a request to watch an image */


### PR DESCRIPTION
## Description

This PR adds "event" analytics calls to certain button clicks to handle requirements 1, 2, and 4 of the epic:

>1) I want to be able to see how many users use the "Network policy generator" on a cluster level, generate NW policies for the entire cluster and download the Network policies configuration (see pictures). 
>I want to see how many unique users are using the functionality but also the recursive users (this means, users that use the functionality several times). 

> 2) I want to be able to see how many users use the "Network policy generator" on a given scope (that is, they fill cluster + namespace, or cluster+namespace+deployment), generate NW policies for the entire cluster and download the Network policies configuration (see pictures)
> I want to see how many unique users are using the functionality but also the recursive users (this means, users that use the functionality several times). 

> 4) I want to see how many users use the CIDR feature 
> I want to see how many unique users are using the functionality but also the recursive users (this means, users that use the functionality several times). 

(The unique vs recursive users would need to be different filters in the Amplitude views of these new events.)


## Checklist
- [x] Investigated and inspected CI test results (one failure is a known flake)
- [x] Unit test and regression tests added

## Testing Performed

- Unit tests added for the helper function to collector properties to go along with the event tracking.
- Manually observed the network traffic to make sure the correct event names and properties were being sent.

Open Network Simulator button clicked
![Screenshot 2024-02-21 at 2 26 33 PM](https://github.com/stackrox/stackrox/assets/715729/f1b2073d-4dcf-4072-94a4-4ad4b3cfa1ef)

Generate Network Policies button clicked
![Screenshot 2024-02-21 at 2 59 06 PM](https://github.com/stackrox/stackrox/assets/715729/84c4fad8-b794-462f-b2a1-e48000e5cf50)

Download Policies YAML button clicked
![Screenshot 2024-02-21 at 3 31 54 PM](https://github.com/stackrox/stackrox/assets/715729/38e80678-1a31-4ac4-982f-fb5d033caf74)

Open CIDR Block editor button clicked
![Screenshot 2024-02-21 at 5 02 39 PM](https://github.com/stackrox/stackrox/assets/715729/d9d5b9f7-1e17-40fc-b0ed-92f06028e002)


### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
