### PR TITLE
ROX-22666: Adding link to cluster init bundles from empty clusters

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
@@ -83,7 +83,7 @@ function InitBundleForm(): ReactElement {
             generateClusterInitBundle({ name })
                 .then(({ response }) => {
                     setErrorMessage('');
-                    downloadBundle(installation, response); // TODO try catch?
+                    downloadBundle(installation, name, response); // TODO try catch?
                     setSubmitting(false);
                     goBack();
                 })

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.utils.ts
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.utils.ts
@@ -20,6 +20,7 @@ export type PlatformKey = keyof typeof platformOptions;
 
 export function downloadBundle(
     installation: InstallationKey,
+    name: string,
     response: GenerateClusterInitBundleResponse
 ) {
     const { helmValuesBundle, kubectlBundle } = response;
@@ -30,10 +31,10 @@ export function downloadBundle(
     const file = new Blob([decoded], {
         type: 'application/x-yaml',
     });
-    const name =
+    const bundleName =
         installation === 'Helm'
             ? 'Helm-values-cluster-init-bundle'
             : 'Operator-secrets-cluster-init-bundle';
 
-    FileSaver.saveAs(file, `${name}.yaml`);
+    FileSaver.saveAs(file, `${name}-${bundleName}.yaml`);
 }

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -91,12 +91,18 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
     /* eslint-disable no-nested-ternary */
     return (
         <>
+            <Alert
+                variant="info"
+                title="Upon successful installation, the secured clusters might take a few moments to show up."
+                component="div"
+                isInline
+            />
             <PageSection variant="light">
-                <Toolbar inset={{ default: 'insetNone' }} className="pf-u-pb-0">
+                {/* <Toolbar inset={{ default: 'insetNone' }} className="pf-u-pb-0">
                     <ToolbarContent>
                         <Title headingLevel="h1">Clusters</Title>
                     </ToolbarContent>
-                </Toolbar>
+                </Toolbar> */}
                 {isLoading ? (
                     <Bullseye>
                         <Spinner isSVG />
@@ -185,10 +191,10 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
                                 Legacy installation method
                             </Link>
                             {initBundlesCount !== 0 && (
-                                <Text component="p" className="pf-u-w-50">
+                                <Text component="p" className="pf-u-w-50vw">
                                     If you misplaced your init bundle, we recommend locating the
                                     previously downloaded YAML on your device first by the name of
-                                    the{` `}
+                                    the{' '}
                                     <Link to={clustersInitBundlesPath}>generated init bundle</Link>,
                                     or you may need to create a new init bundle.
                                 </Text>

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -98,11 +98,6 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
                 isInline
             />
             <PageSection variant="light">
-                {/* <Toolbar inset={{ default: 'insetNone' }} className="pf-u-pb-0">
-                    <ToolbarContent>
-                        <Title headingLevel="h1">Clusters</Title>
-                    </ToolbarContent>
-                </Toolbar> */}
                 {isLoading ? (
                     <Bullseye>
                         <Spinner isSVG />

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -13,8 +13,6 @@ import {
     Spinner,
     Title,
     Text,
-    Toolbar,
-    ToolbarContent,
 } from '@patternfly/react-core';
 import { CloudSecurityIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -185,10 +185,10 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
                                 Legacy installation method
                             </Link>
                             {initBundlesCount !== 0 && (
-                                <Text component="p">
+                                <Text component="p" className="pf-u-w-50">
                                     If you misplaced your init bundle, we recommend locating the
                                     previously downloaded YAML on your device first by the name of
-                                    the
+                                    the{` `}
                                     <Link to={clustersInitBundlesPath}>generated init bundle</Link>,
                                     or you may need to create a new init bundle.
                                 </Text>

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -186,18 +186,11 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
                             </Link>
                             {initBundlesCount !== 0 && (
                                 <Text component="p">
-                                    If you lost the YAML file that you downloaded,{' '}
-                                    <Link
-                                        to={`${clustersInitBundlesPath}?action=create`}
-                                        onClick={() => {
-                                            analyticsTrack({
-                                                event: CREATE_INIT_BUNDLE_CLICKED,
-                                                properties: { source: 'No Clusters' },
-                                            });
-                                        }}
-                                    >
-                                        create another init bundle
-                                    </Link>
+                                    If you misplaced your init bundle, we recommend locating the
+                                    previously downloaded YAML on your device first by the name of
+                                    the
+                                    <Link to={clustersInitBundlesPath}>generated init bundle</Link>,
+                                    or you may need to create a new init bundle.
                                 </Text>
                             )}
                         </Flex>


### PR DESCRIPTION
Also adding prefix to the cluster init bundle file name as requested by UX for easier search for the user 

<img width="1704" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/19989c90-45da-4ed8-a4b5-f9de370af7c4">
<img width="1703" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/743c685c-ef43-4234-b0c9-58cd537ce08c">

<img width="1705" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/117d8b2c-4c9b-466f-862c-257c2939f40e">
