### PR TITLE
chore(central): improve scan error messaging

### DIFF
--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -562,6 +562,7 @@ func (e *enricherImpl) enrichWithScan(ctx context.Context, enrichmentContext Enr
 		return ScanNotDone, errorList.ToError()
 	}
 
+	log.Debugf("Scanning image %s", image.GetName().GetFullName())
 	for _, scanner := range scanners.GetAll() {
 		result, err := e.enrichImageWithScanner(ctx, image, scanner)
 		if err != nil {

--- a/pkg/images/enricher/util.go
+++ b/pkg/images/enricher/util.go
@@ -27,7 +27,7 @@ func EnrichImageByName(ctx context.Context, enricher ImageEnricher, enrichmentCt
 	}
 
 	if !enrichmentResult.ImageUpdated || (enrichmentResult.ScanResult != ScanSucceeded) {
-		return nil, errors.New("scan could not be completed. Please check that an applicable registry and scanner is integrated")
+		return nil, errors.Errorf("scan could not be completed for image %s (%v): please check that an applicable registry and scanner is integrated", name, img.GetNotes())
 	}
 
 	return img, nil


### PR DESCRIPTION
## Description

In CI we have seen the following:

```
scan could not be completed. Please check that an applicable registry and scanner is integrated
```

This is very vague, and not very helpful. This PR adds some more context to help us determine what the issue may be.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

nah

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
