### PR TITLE
ROX-22680: Let baseline manager recognize Internal Entities

### DIFF
--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -237,6 +237,8 @@ func (m *manager) lookUpPeerInfo(entity networkgraph.Entity) peerInfo {
 		}
 	case storage.NetworkEntityInfo_INTERNET:
 		return peerInfo{name: networkgraph.InternetExternalSourceName}
+	case storage.NetworkEntityInfo_INTERNAL_ENTITIES:
+		return peerInfo{name: networkgraph.InternalEntitiesName}
 	default:
 		// Unsupported type.
 		log.Warnf("unsupported entity type in network baseline: %v", entity)

--- a/central/networkbaseline/manager/manager_impl_test.go
+++ b/central/networkbaseline/manager/manager_impl_test.go
@@ -264,6 +264,19 @@ func (suite *ManagerTestSuite) TestFlowsUpdateForOtherEntityTypes() {
 			Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
 			DstPort:  13,
 		},
+		// This conn is also valid and should get incorporated into the baseline.
+		{
+			SrcEntity: networkgraph.Entity{
+				Type: storage.NetworkEntityInfo_DEPLOYMENT,
+				ID:   depID(1),
+			},
+			DstEntity: networkgraph.Entity{
+				Type: storage.NetworkEntityInfo_INTERNAL_ENTITIES,
+				ID:   "INTERNALZZ",
+			},
+			Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+			DstPort:  13,
+		},
 		// This is to a listen endpoint, so it should not get incorporated.
 		{
 			SrcEntity: networkgraph.Entity{
@@ -305,6 +318,13 @@ func (suite *ManagerTestSuite) TestFlowsUpdateForOtherEntityTypes() {
 					},
 				}},
 				Properties: []*storage.NetworkBaselineConnectionProperties{properties(false, 1)},
+			},
+			&storage.NetworkBaselinePeer{
+				Entity: &storage.NetworkEntity{Info: &storage.NetworkEntityInfo{
+					Type: storage.NetworkEntityInfo_INTERNAL_ENTITIES,
+					Id:   "INTERNALZZ",
+				}},
+				Properties: []*storage.NetworkBaselineConnectionProperties{properties(false, 13)},
 			},
 			&storage.NetworkBaselinePeer{
 				Entity: &storage.NetworkEntity{Info: &storage.NetworkEntityInfo{


### PR DESCRIPTION
## Description

Apparently I missed one place in code that needed to be updated with the new constant ID of Internal Entities.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

### N/A
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

- [x] I expanded an existing unit test to serve as regression

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
