### PR TITLE
fix(flake): ClusterMetrics TestOfflineMode

### DIFF
--- a/sensor/kubernetes/clustermetrics/cluster_metrics_test.go
+++ b/sensor/kubernetes/clustermetrics/cluster_metrics_test.go
@@ -69,7 +69,9 @@ func (s *ClusterMetricsTestSuite) TestOfflineMode() {
 		common.SensorComponentEventOfflineMode,
 		common.SensorComponentEventCentralReachable,
 	}
-	metrics := s.createNewClusterMetrics(time.Millisecond)
+	// Setting the duration too low may result in ticker emiting ticks in offline mode and the test to flake.
+	// It has been seen flaking with interval of 1 Millisecond
+	metrics := s.createNewClusterMetrics(50 * time.Millisecond)
 	s.Require().NoError(metrics.Start())
 	defer metrics.Stop(nil)
 	// Read the first message. This is needed because we call runPipeline before entering the ticker loop.


### PR DESCRIPTION
## Description

Saw a flake here: https://github.com/stackrox/stackrox/actions/runs/8001439883/job/21852650205

This is not a bullet-proof solution (for that we would need to use a time-independent ticker), but it should help.

## Checklist
- [ ] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Here I tell how I validated my change

- [x] Used poll intervals of 100 Microsecond (0.1 of the original value) and see it flaking
- [x] Run `go test -race -count=100 ./sensor/kubernetes/clustermetrics` (with and without race param) 

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
