### PR TITLE
ROX-22621: Introduce retry for flaky test

### DIFF
--- a/tests/networkflows_test.go
+++ b/tests/networkflows_test.go
@@ -48,8 +48,8 @@ func (s *networkFlowTestSuite) TestStackroxNetworkFlows() {
 
 	cancel()
 
-	require.NoError(s.T(), err)
-	require.NotEqual(s.T(), 0, len(clusters.GetClusters()))
+	s.Require.NoError(err)
+	s.Require.NotEqual(0, len(clusters.GetClusters()))
 
 	var mainCluster *storage.Cluster
 	for _, cluster := range clusters.GetClusters() {
@@ -58,7 +58,7 @@ func (s *networkFlowTestSuite) TestStackroxNetworkFlows() {
 			break
 		}
 	}
-	require.NotNil(s.T(), mainCluster, "cluster with name remote not found")
+	s.Require.NotNil(mainCluster, "cluster with name remote not found")
 
 	clusterID := mainCluster.GetId()
 
@@ -88,7 +88,7 @@ func (s *networkFlowTestSuite) TestStackroxNetworkFlows() {
 		}
 	}
 
-	require.NoError(s.T(), err)
+	s.Require.NoError(err)
 
 	type deploymentConn struct {
 		srcName, targetName string

--- a/tests/networkflows_test.go
+++ b/tests/networkflows_test.go
@@ -10,9 +10,18 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
+
+func TestNetworkFlowSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, &networkFlowTestSuite{})
+}
+
+type networkFlowTestSuite struct {
+	suite.Suite
+}
 
 func hasEdges(graph *v1.NetworkGraph) bool {
 	for _, node := range graph.GetNodes() {
@@ -23,27 +32,24 @@ func hasEdges(graph *v1.NetworkGraph) bool {
 	return false
 }
 
-func TestStackroxNetworkFlows(t *testing.T) {
-	t.Parallel()
-
-	conn := centralgrpc.GRPCConnectionToCentral(t)
+func (s *networkFlowTestSuite) TestStackroxNetworkFlows() {
+	conn := centralgrpc.GRPCConnectionToCentral(s.T())
 
 	clustersService := v1.NewClustersServiceClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 
 	var clusters *v1.ClustersList
 	var err error
-	for retries := 20; retries > 0; retries-- {
+
+	s.Eventually(func() bool {
 		clusters, err = clustersService.GetClusters(ctx, &v1.GetClustersRequest{})
-		if err == nil && len(clusters.GetClusters()) > 0 {
-			break
-		}
-		time.Sleep(5 * time.Second)
-	}
+		return err == nil && len(clusters.GetClusters()) > 0
+	}, 2*time.Minute, 5*time.Second)
+
 	cancel()
 
-	require.NoError(t, err)
-	require.NotEqual(t, 0, len(clusters.GetClusters()))
+	require.NoError(s.T(), err)
+	require.NotEqual(s.T(), 0, len(clusters.GetClusters()))
 
 	var mainCluster *storage.Cluster
 	for _, cluster := range clusters.GetClusters() {
@@ -52,7 +58,7 @@ func TestStackroxNetworkFlows(t *testing.T) {
 			break
 		}
 	}
-	require.NotNil(t, mainCluster, "cluster with name remote not found")
+	require.NotNil(s.T(), mainCluster, "cluster with name remote not found")
 
 	clusterID := mainCluster.GetId()
 
@@ -64,7 +70,7 @@ func TestStackroxNetworkFlows(t *testing.T) {
 	for {
 		select {
 		case <-timeout.C:
-			t.Fatal("Failed to get the correct edges in 5 minutes")
+			s.T().Fatal("Failed to get the correct edges in 5 minutes")
 		case <-ticker.C:
 			ctx, cancel = context.WithTimeout(context.Background(), time.Minute)
 			graph, err = service.GetNetworkGraph(ctx, &v1.NetworkGraphRequest{
@@ -82,7 +88,7 @@ func TestStackroxNetworkFlows(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 
 	type deploymentConn struct {
 		srcName, targetName string
@@ -118,8 +124,8 @@ func TestStackroxNetworkFlows(t *testing.T) {
 		{srcName: "sensor", targetName: "central"},
 	}
 
-	assert.Subset(t, conns, expectedConns, "expected connections not found")
-	assert.NotContains(t, internetIngressDeployments.AsSlice(), "collector", "collector should not have internet ingress")
+	s.Subset(conns, expectedConns, "expected connections not found")
+	s.NotContains(internetIngressDeployments.AsSlice(), "collector", "collector should not have internet ingress")
 	// Readiness/health probes might show up as internet ingress, so disable this for now.
 	// TODO(ROX-2034): Re-enable.
 	// assert.NotContains(t, internetIngressDeployments.AsSlice(), "sensor", "sensor should not have internet ingress")

--- a/tests/networkflows_test.go
+++ b/tests/networkflows_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -48,8 +47,8 @@ func (s *networkFlowTestSuite) TestStackroxNetworkFlows() {
 
 	cancel()
 
-	s.Require.NoError(err)
-	s.Require.NotEqual(0, len(clusters.GetClusters()))
+	s.Require().NoError(err)
+	s.Require().NotEqual(0, len(clusters.GetClusters()))
 
 	var mainCluster *storage.Cluster
 	for _, cluster := range clusters.GetClusters() {
@@ -58,7 +57,7 @@ func (s *networkFlowTestSuite) TestStackroxNetworkFlows() {
 			break
 		}
 	}
-	s.Require.NotNil(mainCluster, "cluster with name remote not found")
+	s.Require().NotNil(mainCluster, "cluster with name remote not found")
 
 	clusterID := mainCluster.GetId()
 
@@ -71,6 +70,7 @@ func (s *networkFlowTestSuite) TestStackroxNetworkFlows() {
 		select {
 		case <-timeout.C:
 			s.T().Fatal("Failed to get the correct edges in 5 minutes")
+
 		case <-ticker.C:
 			ctx, cancel = context.WithTimeout(context.Background(), time.Minute)
 			graph, err = service.GetNetworkGraph(ctx, &v1.NetworkGraphRequest{
@@ -88,7 +88,7 @@ func (s *networkFlowTestSuite) TestStackroxNetworkFlows() {
 		}
 	}
 
-	s.Require.NoError(err)
+	s.Require().NoError(err)
 
 	type deploymentConn struct {
 		srcName, targetName string


### PR DESCRIPTION
## Description

This PR aims to counter flakes in the nongroovy test `TestStackroxNetworkFlows`.
We introduced a retry for the initial check to give the cluster more time to spin up before we run the test.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

TODO(replace-me)  
Use this space to explain **how you validated** that **your change functions exactly how you expect it**.
Feel free to attach JSON snippets, curl commands, screenshots, etc. Apply a simple benchmark: would the information you
provided convince any reviewer or any external reader that you did enough to validate your change.

It is acceptable to assume trust and keep this section light, e.g. as a bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a markdown or code comment change only.  
It is also acceptable to skip testing for changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting, fixing, etc. Make sure you validate the change
ASAP after it gets merged or explain in PR when the validation will be performed.  
Explain here why you skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
