### PR TITLE
chore(cloud-sources): remove type from uuid

### DIFF
--- a/central/cloudsources/manager/manager.go
+++ b/central/cloudsources/manager/manager.go
@@ -336,7 +336,6 @@ func createDiscoveredClusterIds(cluster *storage.Cluster, cloudSources []*storag
 		discoveredClusterIDs = append(discoveredClusterIDs, discoveredclusters.
 			GenerateDiscoveredClusterID(&discoveredclusters.DiscoveredCluster{
 				ID:            cluster.GetStatus().GetProviderMetadata().GetCluster().GetId(),
-				Type:          cluster.GetStatus().GetProviderMetadata().GetCluster().GetType(),
 				CloudSourceID: cloudSource.GetId(),
 			}))
 	}

--- a/pkg/cloudsources/discoveredclusters/discovered_cluster.go
+++ b/pkg/cloudsources/discoveredclusters/discovered_cluster.go
@@ -27,7 +27,6 @@ func GenerateDiscoveredClusterID(discoveredCluster *DiscoveredCluster) string {
 	}
 	key := strings.Join([]string{
 		id,
-		discoveredCluster.GetType().String(),
 		sourceID,
 	}, ",")
 	return uuid.NewV5(rootNamespaceUUID, key).String()


### PR DESCRIPTION
## Description

Remove the `discoveredCluster.GetType()` from the UUID generation. We don't really need it to be apart of the UUID since the ID of the cluster and cloud source ID shall be enough.

This also aligns with the matching logic.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
