### PR TITLE
ROX-22612: fix local deployments

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/Chart.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/Chart.yaml.htpl
@@ -7,5 +7,6 @@ name: stackrox-secured-cluster-services
 icon: [< required "" .ChartRepo.IconURL >]
 description: Helm Chart for StackRox Secured Clusters
 type: application
-version: [< required "" .Versions.ChartVersion >]
-appVersion: [< required "" .Versions.MainVersion >]
+[</* Shorten the version strings for local builds to avoid exceeding the Kubernetes 63 character limit for labels */>]
+version: [< required "" (.Versions.ChartVersion | replace "-dirty" "-d") >]
+appVersion: [< required "" (.Versions.MainVersion | replace "-dirty" "-d") >]


### PR DESCRIPTION
## Description

Kubernetes has a limit of 63 characters for labels (names and values).

When using dirty images, we're currently exceeding that length for secured clusters: e.g the `helm.sh/chart` label has values like `stackrox-secured-cluster-services-400.3.0-1194-ga7a64cdef9-dirty`, which has 64 characters.

This causes local deployments (i.e. `deploy/k8s/deploy-local.sh`) to fail when using dirty images. This PR implements a workaround, by replacing "dirty" with "d".

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Executed the following commands successfully, on a dirty tag:
```
make image
deploy/k8s/deploy-local.sh
```
### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
