### PR TITLE
chore(cloud-sources): enable feature flag by default

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -101,5 +101,5 @@ var (
 	CloudCredentials = registerFeature("Enable support for short-lived cloud credentials", "ROX_CLOUD_CREDENTIALS", true)
 
 	// CloudSources enables support for cloud source integrations.
-	CloudSources = registerFeature("Enable support for cloud source integrations", "ROX_CLOUD_SOURCES", false)
+	CloudSources = registerFeature("Enable support for cloud source integrations", "ROX_CLOUD_SOURCES", true)
 )


### PR DESCRIPTION
## Description

Enable the `Cloud Sources` feature flag by default, since we also plan to release it with 4.4.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
