### PR TITLE
fix(bug): Propagate MaxMsgSizeSetting to roxctl client

### DIFF
--- a/pkg/env/grpc_max_message_size.go
+++ b/pkg/env/grpc_max_message_size.go
@@ -1,0 +1,6 @@
+package env
+
+var (
+	// MaxMsgSizeSetting is the setting used for gRPC servers and clients to set maximum receive sizes.
+	MaxMsgSizeSetting = RegisterIntegerSetting("ROX_GRPC_MAX_MESSAGE_SIZE", 24*1024*1024)
+)

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -47,7 +47,6 @@ import (
 
 const (
 	// Note: if these values change consider changing the histogram bucket size for central and sensor gRPC message size metrics.
-	defaultMaxMsgSize               = 24 * 1024 * 1024
 	defaultMaxResponseMsgSize       = 256 * 1024 * 1024 // 256MB
 	defaultMaxGrpcConcurrentStreams = 100               // HTTP/2 spec recommendation for minimum value
 )
@@ -60,8 +59,6 @@ func init() {
 var (
 	log = logging.LoggerForModule()
 
-	// MaxMsgSizeSetting is the setting used for gRPC servers and clients to set maximum receive sizes.
-	MaxMsgSizeSetting               = env.RegisterIntegerSetting("ROX_GRPC_MAX_MESSAGE_SIZE", defaultMaxMsgSize)
 	maxResponseMsgSizeSetting       = env.RegisterIntegerSetting("ROX_GRPC_MAX_RESPONSE_SIZE", defaultMaxResponseMsgSize)
 	maxGrpcConcurrentStreamsSetting = env.RegisterIntegerSetting("ROX_GRPC_MAX_CONCURRENT_STREAMS", defaultMaxGrpcConcurrentStreams)
 	enableRequestTracing            = env.RegisterBooleanSetting("ROX_GRPC_ENABLE_REQUEST_TRACING", false)
@@ -426,7 +423,7 @@ func (a *apiImpl) run(startedSig *concurrency.ErrorSignal) {
 		grpc.UnaryInterceptor(
 			grpc_middleware.ChainUnaryServer(a.unaryInterceptors()...),
 		),
-		grpc.MaxRecvMsgSize(MaxMsgSizeSetting.IntegerSetting()),
+		grpc.MaxRecvMsgSize(env.MaxMsgSizeSetting.IntegerSetting()),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			Time:             40 * time.Second,
 			MaxConnectionAge: a.config.MaxConnectionAge,

--- a/sensor/common/centralclient/grpc_connection.go
+++ b/sensor/common/centralclient/grpc_connection.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/grpc/util"
 	"github.com/stackrox/rox/pkg/mtls"
 )
@@ -111,7 +110,7 @@ func (f *centralConnectionFactoryImpl) SetCentralConnectionWithRetries(conn *uti
 
 	// Use pkg/grpc configuration for MaxMsgSize on client connections as well. This will overwrite the 4MB threshold
 	// set by gRPC lib.
-	opts = append(opts, clientconn.MaxMsgReceiveSize(grpc.MaxMsgSizeSetting.IntegerSetting()))
+	opts = append(opts, clientconn.MaxMsgReceiveSize(env.MaxMsgSizeSetting.IntegerSetting()))
 
 	centralConnection, err := clientconn.AuthenticatedGRPCConnection(context.Background(), env.CentralEndpoint.Setting(), mtls.CentralSubject, opts...)
 	if err != nil {


### PR DESCRIPTION
## Description

The roxctl export API for images was failing and getting retried. This would occur after an image sent was 4MB, so we need to propagate the max message size to the roxctl clients as well.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

Ran this against the scale test and context cancels stopped and had a reproduction locally

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
