### PR TITLE
ROX-22678: wait for informer sync in test

### DIFF
--- a/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
@@ -124,6 +124,7 @@ func TestCredentialManager(t *testing.T) {
 			manager := newCredentialsManagerImpl(k8sClient, namespace, secretName, func() {})
 			manager.Start()
 			defer manager.Stop()
+			require.Eventually(t, manager.informer.HasSynced, 5*time.Second, 100*time.Millisecond)
 
 			err := c.setupFn(k8sClient)
 			require.NoError(t, err)


### PR DESCRIPTION
## Description

In https://github.com/stackrox/stackrox/pull/9845 blocking code in the informer setup was removed. As a result, we must now wait in the test until the informer has synced. Otherwise we may lose events.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

CI + `gotest -v ./... -count=100`.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
