### PR TITLE
ROX-20884: Empty states for Exception Management

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
@@ -89,7 +89,12 @@ describe('Exception Management Request Details Page', () => {
         cy.get('div[role="dialog"]').should('not.exist');
         visitExceptionManagement();
         cy.get('button[role="tab"]:contains("Approved deferrals")').click();
-        cy.get('table tbody tr').should('not.exist');
+        cy.get(
+            'table tbody div.pf-c-empty-state__content h2:contains("No approved deferral requests")'
+        ).should('exist');
+        cy.get(
+            'table tbody div.pf-c-empty-state__content div.pf-c-empty-state__body p:contains("There are currently no approved deferral requests. Feel free to review pending requests or return to your dashboard.")'
+        ).should('exist');
     });
 
     it('should not see a cancelled request in the approved false positives table', () => {
@@ -104,6 +109,11 @@ describe('Exception Management Request Details Page', () => {
         cy.get('div[role="dialog"]').should('not.exist');
         visitExceptionManagement();
         cy.get('button[role="tab"]:contains("Approved false positives")').click();
-        cy.get('table tbody tr').should('not.exist');
+        cy.get(
+            'table tbody div.pf-c-empty-state__content h2:contains("No approved false positive requests")'
+        ).should('exist');
+        cy.get(
+            'table tbody div.pf-c-empty-state__content div.pf-c-empty-state__body p:contains("There are currently no approved false positive requests. Feel free to review pending requests or return to your dashboard.")'
+        ).should('exist');
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -42,7 +42,7 @@ import {
     REQUESTER_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
 } from '../searchOptions';
-import { getTableUIState } from './hooks/getTableUIState';
+import { getTableUIState } from '../../../utils/getTableUIState';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,
@@ -87,11 +87,11 @@ function ApprovedDeferrals() {
             ),
         [searchFilter, sortOption, page, perPage]
     );
+    // TODO: Consider changing the name of "loading" to "isLoading" - https://issues.redhat.com/browse/ROX-22865
     const { data, loading: isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
 
     const tableUIState = getTableUIState({
         isLoading,
-        isPolling: false,
         data,
         error,
         searchFilter,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -1,27 +1,29 @@
 import React, { useCallback } from 'react';
 import {
     Bullseye,
+    Button,
     PageSection,
     Pagination,
     Spinner,
+    Text,
     Toolbar,
     ToolbarContent,
     ToolbarGroup,
     ToolbarItem,
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { FileAltIcon, SearchIcon } from '@patternfly/react-icons';
 
 import useURLPagination from 'hooks/useURLPagination';
-
 import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
 import useRestQuery from 'hooks/useRestQuery';
 import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionService';
 
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
-import NotFoundMessage from 'Components/NotFoundMessage';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import {
     RequestExpires,
     RequestIDLink,
@@ -32,6 +34,7 @@ import {
     RequestScope,
 } from './components/ExceptionRequestTableCells';
 import FilterAutocompleteSelect from '../components/FilterAutocomplete';
+
 import {
     SearchOption,
     REQUEST_NAME_SEARCH_OPTION,
@@ -39,6 +42,7 @@ import {
     REQUESTER_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
 } from '../searchOptions';
+import { getTableUIState } from './hooks/getTableUIState';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,
@@ -83,37 +87,27 @@ function ApprovedDeferrals() {
             ),
         [searchFilter, sortOption, page, perPage]
     );
-    const { data, loading, error } = useRestQuery(vulnerabilityExceptionsFn);
+    const { data, loading: isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
 
+    const tableUIState = getTableUIState({
+        isLoading,
+        isPolling: false,
+        data,
+        error,
+        searchFilter,
+    });
     function onFilterChange() {
         setPage(1);
     }
 
-    if (loading && !data) {
-        return (
-            <Bullseye>
-                <Spinner isSVG />
-            </Bullseye>
-        );
-    }
-
-    if (error) {
+    if (tableUIState.type === 'ERROR') {
         return (
             <PageSection variant="light">
                 <TableErrorComponent
-                    error={error}
+                    error={tableUIState.error}
                     message="An error occurred. Try refreshing again"
                 />
             </PageSection>
-        );
-    }
-
-    if (!data) {
-        return (
-            <NotFoundMessage
-                title="404: We couldn't find that page"
-                message="Pending vulnerability exception requests could not be found."
-            />
         );
     }
 
@@ -170,34 +164,91 @@ function ApprovedDeferrals() {
                     </Tr>
                 </Thead>
                 <Tbody>
-                    {data.map((exception) => {
-                        const { id, name, requester, createdAt, scope } = exception;
-                        return (
-                            <Tr key={id}>
-                                <Td>
-                                    <RequestIDLink id={id} name={name} context="CURRENT" />
-                                </Td>
-                                <Td>
-                                    <Requester requester={requester} />
-                                </Td>
-                                <Td>
-                                    <RequestedAction exception={exception} context="CURRENT" />
-                                </Td>
-                                <Td>
-                                    <RequestCreatedAt createdAt={createdAt} />
-                                </Td>
-                                <Td>
-                                    <RequestExpires exception={exception} context="CURRENT" />
-                                </Td>
-                                <Td>
-                                    <RequestScope scope={scope} />
-                                </Td>
-                                <Td>
-                                    <RequestedItems exception={exception} context="CURRENT" />
-                                </Td>
-                            </Tr>
-                        );
-                    })}
+                    {tableUIState.type === 'LOADING' && (
+                        <Tr>
+                            <Td colSpan={7}>
+                                <Bullseye>
+                                    <Spinner isSVG />
+                                </Bullseye>
+                            </Td>
+                        </Tr>
+                    )}
+                    {tableUIState.type === 'EMPTY' && (
+                        <Tr>
+                            <Td colSpan={7}>
+                                <Bullseye>
+                                    <EmptyStateTemplate
+                                        title="No approved deferral requests"
+                                        headingLevel="h2"
+                                        icon={FileAltIcon}
+                                    >
+                                        <Text>
+                                            There are currently no approved deferral requests. Feel
+                                            free to review pending requests or return to your
+                                            dashboard.
+                                        </Text>
+                                    </EmptyStateTemplate>
+                                </Bullseye>
+                            </Td>
+                        </Tr>
+                    )}
+                    {tableUIState.type === 'FILTERED_EMPTY' && (
+                        <Tr>
+                            <Td colSpan={7}>
+                                <Bullseye>
+                                    <EmptyStateTemplate
+                                        title="No results found"
+                                        headingLevel="h2"
+                                        icon={SearchIcon}
+                                    >
+                                        <Text>
+                                            We couldn’t find any items matching your search
+                                            criteria. Try adjusting your filters or search terms for
+                                            better results
+                                        </Text>
+                                        <Button
+                                            variant="link"
+                                            onClick={() => {
+                                                setPage(1);
+                                                setSearchFilter({});
+                                            }}
+                                        >
+                                            Clear search filters
+                                        </Button>
+                                    </EmptyStateTemplate>
+                                </Bullseye>
+                            </Td>
+                        </Tr>
+                    )}
+                    {(tableUIState.type === 'COMPLETE' || tableUIState.type === 'POLLING') &&
+                        tableUIState.data.map((exception) => {
+                            const { id, name, requester, createdAt, scope } = exception;
+                            return (
+                                <Tr key={id}>
+                                    <Td>
+                                        <RequestIDLink id={id} name={name} context="CURRENT" />
+                                    </Td>
+                                    <Td>
+                                        <Requester requester={requester} />
+                                    </Td>
+                                    <Td>
+                                        <RequestedAction exception={exception} context="CURRENT" />
+                                    </Td>
+                                    <Td>
+                                        <RequestCreatedAt createdAt={createdAt} />
+                                    </Td>
+                                    <Td>
+                                        <RequestExpires exception={exception} context="CURRENT" />
+                                    </Td>
+                                    <Td>
+                                        <RequestScope scope={scope} />
+                                    </Td>
+                                    <Td>
+                                        <RequestedItems exception={exception} context="CURRENT" />
+                                    </Td>
+                                </Tr>
+                            );
+                        })}
                 </Tbody>
             </TableComposable>
         </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -1,27 +1,30 @@
 import React, { useCallback } from 'react';
 import {
     Bullseye,
+    Button,
     PageSection,
     Pagination,
     Spinner,
+    Text,
     Toolbar,
     ToolbarContent,
     ToolbarGroup,
     ToolbarItem,
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { FileAltIcon, SearchIcon } from '@patternfly/react-icons';
 
 import useURLPagination from 'hooks/useURLPagination';
-
 import useURLSearch from 'hooks/useURLSearch';
 
-import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
-import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionService';
 import useRestQuery from 'hooks/useRestQuery';
 import useURLSort from 'hooks/useURLSort';
-import NotFoundMessage from 'Components/NotFoundMessage';
+
+import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
+import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import PageTitle from 'Components/PageTitle';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import {
     RequestIDLink,
     RequestedAction,
@@ -38,6 +41,7 @@ import {
     REQUESTER_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
 } from '../searchOptions';
+import { getTableUIState } from './hooks/getTableUIState';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,
@@ -76,37 +80,27 @@ function ApprovedFalsePositives() {
             ),
         [searchFilter, sortOption, page, perPage]
     );
-    const { data, loading, error } = useRestQuery(vulnerabilityExceptionsFn);
+    const { data, loading: isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
 
+    const tableUIState = getTableUIState({
+        isLoading,
+        isPolling: false,
+        data,
+        error,
+        searchFilter,
+    });
     function onFilterChange() {
         setPage(1);
     }
 
-    if (loading && !data) {
-        return (
-            <Bullseye>
-                <Spinner isSVG />
-            </Bullseye>
-        );
-    }
-
-    if (error) {
+    if (tableUIState.type === 'ERROR') {
         return (
             <PageSection variant="light">
                 <TableErrorComponent
-                    error={error}
+                    error={tableUIState.error}
                     message="An error occurred. Try refreshing again"
                 />
             </PageSection>
-        );
-    }
-
-    if (!data) {
-        return (
-            <NotFoundMessage
-                title="404: We couldn't find that page"
-                message="Approved false positive requests could not be found."
-            />
         );
     }
 
@@ -162,31 +156,88 @@ function ApprovedFalsePositives() {
                     </Tr>
                 </Thead>
                 <Tbody>
-                    {data.map((exception) => {
-                        const { id, name, requester, createdAt, scope } = exception;
-                        return (
-                            <Tr key={id}>
-                                <Td>
-                                    <RequestIDLink id={id} name={name} context="CURRENT" />
-                                </Td>
-                                <Td>
-                                    <Requester requester={requester} />
-                                </Td>
-                                <Td>
-                                    <RequestedAction exception={exception} context="CURRENT" />
-                                </Td>
-                                <Td>
-                                    <RequestCreatedAt createdAt={createdAt} />
-                                </Td>
-                                <Td>
-                                    <RequestScope scope={scope} />
-                                </Td>
-                                <Td>
-                                    <RequestedItems exception={exception} context="CURRENT" />
-                                </Td>
-                            </Tr>
-                        );
-                    })}
+                    {tableUIState.type === 'LOADING' && (
+                        <Tr>
+                            <Td colSpan={7}>
+                                <Bullseye>
+                                    <Spinner isSVG />
+                                </Bullseye>
+                            </Td>
+                        </Tr>
+                    )}
+                    {tableUIState.type === 'EMPTY' && (
+                        <Tr>
+                            <Td colSpan={7}>
+                                <Bullseye>
+                                    <EmptyStateTemplate
+                                        title="No approved false positive requests"
+                                        headingLevel="h2"
+                                        icon={FileAltIcon}
+                                    >
+                                        <Text>
+                                            There are currently no approved false positive requests.
+                                            Feel free to review pending requests or return to your
+                                            dashboard.
+                                        </Text>
+                                    </EmptyStateTemplate>
+                                </Bullseye>
+                            </Td>
+                        </Tr>
+                    )}
+                    {tableUIState.type === 'FILTERED_EMPTY' && (
+                        <Tr>
+                            <Td colSpan={7}>
+                                <Bullseye>
+                                    <EmptyStateTemplate
+                                        title="No results found"
+                                        headingLevel="h2"
+                                        icon={SearchIcon}
+                                    >
+                                        <Text>
+                                            We couldn’t find any items matching your search
+                                            criteria. Try adjusting your filters or search terms for
+                                            better results
+                                        </Text>
+                                        <Button
+                                            variant="link"
+                                            onClick={() => {
+                                                setPage(1);
+                                                setSearchFilter({});
+                                            }}
+                                        >
+                                            Clear search filters
+                                        </Button>
+                                    </EmptyStateTemplate>
+                                </Bullseye>
+                            </Td>
+                        </Tr>
+                    )}
+                    {(tableUIState.type === 'COMPLETE' || tableUIState.type === 'POLLING') &&
+                        tableUIState.data.map((exception) => {
+                            const { id, name, requester, createdAt, scope } = exception;
+                            return (
+                                <Tr key={id}>
+                                    <Td>
+                                        <RequestIDLink id={id} name={name} context="CURRENT" />
+                                    </Td>
+                                    <Td>
+                                        <Requester requester={requester} />
+                                    </Td>
+                                    <Td>
+                                        <RequestedAction exception={exception} context="CURRENT" />
+                                    </Td>
+                                    <Td>
+                                        <RequestCreatedAt createdAt={createdAt} />
+                                    </Td>
+                                    <Td>
+                                        <RequestScope scope={scope} />
+                                    </Td>
+                                    <Td>
+                                        <RequestedItems exception={exception} context="CURRENT" />
+                                    </Td>
+                                </Tr>
+                            );
+                        })}
                 </Tbody>
             </TableComposable>
         </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -41,7 +41,7 @@ import {
     REQUESTER_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
 } from '../searchOptions';
-import { getTableUIState } from './hooks/getTableUIState';
+import { getTableUIState } from '../../../utils/getTableUIState';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,
@@ -80,11 +80,11 @@ function ApprovedFalsePositives() {
             ),
         [searchFilter, sortOption, page, perPage]
     );
+    // TODO: Consider changing the name of "loading" to "isLoading" - https://issues.redhat.com/browse/ROX-22865
     const { data, loading: isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
 
     const tableUIState = getTableUIState({
         isLoading,
-        isPolling: false,
         data,
         error,
         searchFilter,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -1,27 +1,29 @@
 import React, { useCallback } from 'react';
 import {
     Bullseye,
+    Button,
     PageSection,
     Pagination,
     Spinner,
+    Text,
     Toolbar,
     ToolbarContent,
     ToolbarGroup,
     ToolbarItem,
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { FileAltIcon, SearchIcon } from '@patternfly/react-icons';
 
 import useURLPagination from 'hooks/useURLPagination';
-
 import useURLSearch from 'hooks/useURLSearch';
 import useRestQuery from 'hooks/useRestQuery';
 import useURLSort from 'hooks/useURLSort';
 import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionService';
 
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
-import NotFoundMessage from 'Components/NotFoundMessage';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import {
     RequestExpires,
     RequestIDLink,
@@ -39,6 +41,7 @@ import {
     REQUESTER_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
 } from '../searchOptions';
+import { getTableUIState } from './hooks/getTableUIState';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,
@@ -82,41 +85,30 @@ function DeniedRequests() {
             ),
         [searchFilter, sortOption, page, perPage]
     );
-    const { data, loading, error } = useRestQuery(vulnerabilityExceptionsFn);
+    const { data, loading: isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
+
+    const tableUIState = getTableUIState({
+        isLoading,
+        isPolling: false,
+        data,
+        error,
+        searchFilter,
+    });
 
     function onFilterChange() {
         setPage(1);
     }
 
-    if (loading && !data) {
-        return (
-            <Bullseye>
-                <Spinner isSVG />
-            </Bullseye>
-        );
-    }
-
-    if (error) {
+    if (tableUIState.type === 'ERROR') {
         return (
             <PageSection variant="light">
                 <TableErrorComponent
-                    error={error}
+                    error={tableUIState.error}
                     message="An error occurred. Try refreshing again"
                 />
             </PageSection>
         );
     }
-
-    if (!data) {
-        return (
-            <NotFoundMessage
-                title="404: We couldn't find that page"
-                message="Pending vulnerability exception requests could not be found."
-            />
-        );
-    }
-
-    // @TODO: Add a "No results" type of view when there is no data to show. Also, add them for the other tables.
 
     return (
         <PageSection>
@@ -171,34 +163,91 @@ function DeniedRequests() {
                     </Tr>
                 </Thead>
                 <Tbody>
-                    {data.map((exception) => {
-                        const { id, name, requester, createdAt, scope } = exception;
-                        return (
-                            <Tr key={id}>
-                                <Td>
-                                    <RequestIDLink id={id} name={name} context="CURRENT" />
-                                </Td>
-                                <Td>
-                                    <Requester requester={requester} />
-                                </Td>
-                                <Td>
-                                    <RequestedAction exception={exception} context="CURRENT" />
-                                </Td>
-                                <Td>
-                                    <RequestCreatedAt createdAt={createdAt} />
-                                </Td>
-                                <Td>
-                                    <RequestExpires exception={exception} context="CURRENT" />
-                                </Td>
-                                <Td>
-                                    <RequestScope scope={scope} />
-                                </Td>
-                                <Td>
-                                    <RequestedItems exception={exception} context="CURRENT" />
-                                </Td>
-                            </Tr>
-                        );
-                    })}
+                    {tableUIState.type === 'LOADING' && (
+                        <Tr>
+                            <Td colSpan={7}>
+                                <Bullseye>
+                                    <Spinner isSVG />
+                                </Bullseye>
+                            </Td>
+                        </Tr>
+                    )}
+                    {tableUIState.type === 'EMPTY' && (
+                        <Tr>
+                            <Td colSpan={7}>
+                                <Bullseye>
+                                    <EmptyStateTemplate
+                                        title="No denied exception requests"
+                                        headingLevel="h2"
+                                        icon={FileAltIcon}
+                                    >
+                                        <Text>
+                                            There are currently no denied exception requests. Feel
+                                            free to review pending requests or return to your
+                                            dashboard.
+                                        </Text>
+                                    </EmptyStateTemplate>
+                                </Bullseye>
+                            </Td>
+                        </Tr>
+                    )}
+                    {tableUIState.type === 'FILTERED_EMPTY' && (
+                        <Tr>
+                            <Td colSpan={7}>
+                                <Bullseye>
+                                    <EmptyStateTemplate
+                                        title="No results found"
+                                        headingLevel="h2"
+                                        icon={SearchIcon}
+                                    >
+                                        <Text>
+                                            We couldn’t find any items matching your search
+                                            criteria. Try adjusting your filters or search terms for
+                                            better results
+                                        </Text>
+                                        <Button
+                                            variant="link"
+                                            onClick={() => {
+                                                setPage(1);
+                                                setSearchFilter({});
+                                            }}
+                                        >
+                                            Clear search filters
+                                        </Button>
+                                    </EmptyStateTemplate>
+                                </Bullseye>
+                            </Td>
+                        </Tr>
+                    )}
+                    {(tableUIState.type === 'COMPLETE' || tableUIState.type === 'POLLING') &&
+                        tableUIState.data.map((exception) => {
+                            const { id, name, requester, createdAt, scope } = exception;
+                            return (
+                                <Tr key={id}>
+                                    <Td>
+                                        <RequestIDLink id={id} name={name} context="CURRENT" />
+                                    </Td>
+                                    <Td>
+                                        <Requester requester={requester} />
+                                    </Td>
+                                    <Td>
+                                        <RequestedAction exception={exception} context="CURRENT" />
+                                    </Td>
+                                    <Td>
+                                        <RequestCreatedAt createdAt={createdAt} />
+                                    </Td>
+                                    <Td>
+                                        <RequestExpires exception={exception} context="CURRENT" />
+                                    </Td>
+                                    <Td>
+                                        <RequestScope scope={scope} />
+                                    </Td>
+                                    <Td>
+                                        <RequestedItems exception={exception} context="CURRENT" />
+                                    </Td>
+                                </Tr>
+                            );
+                        })}
                 </Tbody>
             </TableComposable>
         </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -41,7 +41,7 @@ import {
     REQUESTER_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
 } from '../searchOptions';
-import { getTableUIState } from './hooks/getTableUIState';
+import { getTableUIState } from '../../../utils/getTableUIState';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,
@@ -85,11 +85,11 @@ function DeniedRequests() {
             ),
         [searchFilter, sortOption, page, perPage]
     );
+    // TODO: Consider changing the name of "loading" to "isLoading" - https://issues.redhat.com/browse/ROX-22865
     const { data, loading: isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
 
     const tableUIState = getTableUIState({
         isLoading,
-        isPolling: false,
         data,
         error,
         searchFilter,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -1,27 +1,29 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
     Bullseye,
+    Button,
     PageSection,
     Pagination,
     Spinner,
+    Text,
     Toolbar,
     ToolbarContent,
     ToolbarGroup,
     ToolbarItem,
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { FileAltIcon, SearchIcon } from '@patternfly/react-icons';
 
 import useURLPagination from 'hooks/useURLPagination';
-
 import useURLSearch from 'hooks/useURLSearch';
 import useRestQuery from 'hooks/useRestQuery';
 import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionService';
 
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import useURLSort from 'hooks/useURLSort';
-import NotFoundMessage from 'Components/NotFoundMessage';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import {
     RequestExpires,
     RequestIDLink,
@@ -39,6 +41,7 @@ import {
     REQUESTER_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
 } from '../searchOptions';
+import { getTableUIState } from './hooks/getTableUIState';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,
@@ -82,37 +85,36 @@ function PendingApprovals() {
             ),
         [searchFilter, sortOption, page, perPage]
     );
-    const { data, loading, error } = useRestQuery(vulnerabilityExceptionsFn);
+    const { data, loading: isLoading, error, refetch } = useRestQuery(vulnerabilityExceptionsFn);
+    const [isPolling, setIsPolling] = React.useState(false);
+
+    useEffect(() => {
+        setTimeout(() => {
+            setIsPolling(true);
+            refetch();
+        }, 5000);
+    }, [refetch]);
+
+    const tableUIState = getTableUIState({
+        isLoading,
+        isPolling,
+        data,
+        error,
+        searchFilter,
+    });
 
     function onFilterChange() {
         setPage(1);
     }
 
-    if (loading && !data) {
-        return (
-            <Bullseye>
-                <Spinner isSVG />
-            </Bullseye>
-        );
-    }
-
-    if (error) {
+    if (tableUIState.type === 'ERROR') {
         return (
             <PageSection variant="light">
                 <TableErrorComponent
-                    error={error}
+                    error={tableUIState.error}
                     message="An error occurred. Try refreshing again"
                 />
             </PageSection>
-        );
-    }
-
-    if (!data) {
-        return (
-            <NotFoundMessage
-                title="404: We couldn't find that page"
-                message="Pending vulnerability exception requests could not be found."
-            />
         );
     }
 
@@ -169,45 +171,102 @@ function PendingApprovals() {
                     </Tr>
                 </Thead>
                 <Tbody>
-                    {data.map((exception) => {
-                        const { id, name, status, requester, createdAt, scope } = exception;
-                        const context =
-                            status === 'APPROVED_PENDING_UPDATE' ? 'PENDING_UPDATE' : 'CURRENT';
-                        return (
-                            <Tr key={id}>
-                                <Td dataLabel="Request name">
-                                    <RequestIDLink id={id} name={name} context={context} />
-                                </Td>
-                                <Td dataLabel="Requester">
-                                    <Requester requester={requester} />
-                                </Td>
-                                <Td dataLabel="Requested action">
-                                    <RequestedAction
-                                        exception={exception}
-                                        context="PENDING_UPDATE"
-                                    />
-                                </Td>
-                                <Td dataLabel="Requested">
-                                    <RequestCreatedAt createdAt={createdAt} />
-                                </Td>
-                                <Td dataLabel="Expires">
-                                    <RequestExpires
-                                        exception={exception}
-                                        context="PENDING_UPDATE"
-                                    />
-                                </Td>
-                                <Td dataLabel="Scope">
-                                    <RequestScope scope={scope} />
-                                </Td>
-                                <Td dataLabel="Requested items">
-                                    <RequestedItems
-                                        exception={exception}
-                                        context="PENDING_UPDATE"
-                                    />
-                                </Td>
-                            </Tr>
-                        );
-                    })}
+                    {tableUIState.type === 'LOADING' && (
+                        <Tr>
+                            <Td colSpan={7}>
+                                <Bullseye>
+                                    <Spinner isSVG />
+                                </Bullseye>
+                            </Td>
+                        </Tr>
+                    )}
+                    {tableUIState.type === 'EMPTY' && (
+                        <Tr>
+                            <Td colSpan={7}>
+                                <Bullseye>
+                                    <EmptyStateTemplate
+                                        title="No pending exception requests"
+                                        headingLevel="h2"
+                                        icon={FileAltIcon}
+                                    >
+                                        <Text>
+                                            There are currently no pending exception requests. Feel
+                                            free to review completed requests or return to your
+                                            dashboard.
+                                        </Text>
+                                    </EmptyStateTemplate>
+                                </Bullseye>
+                            </Td>
+                        </Tr>
+                    )}
+                    {tableUIState.type === 'FILTERED_EMPTY' && (
+                        <Tr>
+                            <Td colSpan={7}>
+                                <Bullseye>
+                                    <EmptyStateTemplate
+                                        title="No results found"
+                                        headingLevel="h2"
+                                        icon={SearchIcon}
+                                    >
+                                        <Text>
+                                            We couldn’t find any items matching your search
+                                            criteria. Try adjusting your filters or search terms for
+                                            better results
+                                        </Text>
+                                        <Button
+                                            variant="link"
+                                            onClick={() => {
+                                                setPage(1);
+                                                setSearchFilter({});
+                                            }}
+                                        >
+                                            Clear search filters
+                                        </Button>
+                                    </EmptyStateTemplate>
+                                </Bullseye>
+                            </Td>
+                        </Tr>
+                    )}
+                    {(tableUIState.type === 'COMPLETE' || tableUIState.type === 'POLLING') &&
+                        tableUIState.data.map((exception) => {
+                            const { id, name, status, requester, createdAt, scope } = exception;
+                            const context =
+                                status === 'APPROVED_PENDING_UPDATE' ? 'PENDING_UPDATE' : 'CURRENT';
+                            return (
+                                <Tr key={id}>
+                                    <Td dataLabel="Request name">
+                                        <RequestIDLink id={id} name={name} context={context} />
+                                    </Td>
+                                    <Td dataLabel="Requester">
+                                        <Requester requester={requester} />
+                                    </Td>
+                                    <Td dataLabel="Requested action">
+                                        <RequestedAction
+                                            exception={exception}
+                                            context="PENDING_UPDATE"
+                                        />
+                                    </Td>
+                                    <Td dataLabel="Requested">
+                                        <RequestCreatedAt createdAt={createdAt} />
+                                    </Td>
+                                    <Td dataLabel="Expires">
+                                        <RequestExpires
+                                            exception={exception}
+                                            context="PENDING_UPDATE"
+                                        />
+                                    </Td>
+                                    <Td dataLabel="Scope">
+                                        <RequestScope scope={scope} />
+                                    </Td>
+                                    <Td dataLabel="Requested items">
+                                        <RequestedItems
+                                            exception={exception}
+                                            context="PENDING_UPDATE"
+                                        />
+                                    </Td>
+                                </Tr>
+                            );
+                        })}
                 </Tbody>
             </TableComposable>
         </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import {
     Bullseye,
     Button,
@@ -41,7 +41,7 @@ import {
     REQUESTER_SEARCH_OPTION,
     IMAGE_SEARCH_OPTION,
 } from '../searchOptions';
-import { getTableUIState } from './hooks/getTableUIState';
+import { getTableUIState } from '../../../utils/getTableUIState';
 
 const searchOptions: SearchOption[] = [
     REQUEST_NAME_SEARCH_OPTION,
@@ -85,19 +85,11 @@ function PendingApprovals() {
             ),
         [searchFilter, sortOption, page, perPage]
     );
-    const { data, loading: isLoading, error, refetch } = useRestQuery(vulnerabilityExceptionsFn);
-    const [isPolling, setIsPolling] = React.useState(false);
-
-    useEffect(() => {
-        setTimeout(() => {
-            setIsPolling(true);
-            refetch();
-        }, 5000);
-    }, [refetch]);
+    // TODO: Consider changing the name of "loading" to "isLoading" - https://issues.redhat.com/browse/ROX-22865
+    const { data, loading: isLoading, error } = useRestQuery(vulnerabilityExceptionsFn);
 
     const tableUIState = getTableUIState({
         isLoading,
-        isPolling,
         data,
         error,
         searchFilter,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/hooks/getTableUIState.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/hooks/getTableUIState.ts
@@ -1,0 +1,80 @@
+import { SearchFilter } from 'types/search';
+
+type IdleState = {
+    type: 'IDLE';
+};
+
+type LoadingState = {
+    type: 'LOADING';
+};
+
+type PollingState<DataType> = {
+    type: 'POLLING';
+    data: DataType[];
+};
+
+type CompleteState<DataType> = {
+    type: 'COMPLETE';
+    data: DataType[];
+};
+
+type EmptyState = {
+    type: 'EMPTY' | 'FILTERED_EMPTY';
+};
+
+type ErrorState = {
+    type: 'ERROR';
+    error: Error;
+};
+
+export type TableUIState<DataType> =
+    | IdleState
+    | LoadingState
+    | PollingState<DataType>
+    | CompleteState<DataType>
+    | EmptyState
+    | ErrorState;
+
+type GetTableUIStateProps<DataType> = {
+    isLoading: boolean;
+    isPolling: boolean;
+    data: undefined | DataType[];
+    error: Error | undefined;
+    searchFilter: SearchFilter;
+};
+
+export function getTableUIState<DataType>({
+    isLoading,
+    isPolling,
+    data,
+    error,
+    searchFilter,
+}: GetTableUIStateProps<DataType>): TableUIState<DataType> {
+    const hasSearchFilters = Object.keys(searchFilter).length > 0;
+
+    if (error) {
+        return { type: 'ERROR', error };
+    }
+
+    if (isLoading && isPolling && data) {
+        return { type: 'POLLING', data };
+    }
+
+    if (isLoading) {
+        return { type: 'LOADING' };
+    }
+
+    if (data && data.length > 0) {
+        return { type: 'COMPLETE', data };
+    }
+
+    if (hasSearchFilters) {
+        return { type: 'FILTERED_EMPTY' };
+    }
+
+    if (data && data.length === 0) {
+        return { type: 'EMPTY' };
+    }
+
+    return { type: 'IDLE' };
+}

--- a/ui/apps/platform/src/utils/getTableUIState.test.ts
+++ b/ui/apps/platform/src/utils/getTableUIState.test.ts
@@ -1,0 +1,146 @@
+import { GetTableUIStateProps, getTableUIState } from './getTableUIState';
+
+type DataType = {
+    text: string;
+};
+
+describe('getTableUIState', () => {
+    it('should show the IDLE state', () => {
+        // If nothing is set, it should be IDLE
+        const args: GetTableUIStateProps<DataType> = {
+            isLoading: false,
+            isPolling: false,
+            data: undefined,
+            error: undefined,
+            searchFilter: {},
+        };
+
+        const tableUIState = getTableUIState<DataType>(args);
+
+        expect(tableUIState).toEqual({
+            type: 'IDLE',
+        });
+    });
+
+    it('should show the ERROR state', () => {
+        const error = new Error('There is an error');
+
+        // Regardless of other values, if error is defined, then it should show an error
+        expect(
+            getTableUIState<DataType>({
+                isLoading: true,
+                isPolling: true,
+                data: [{ text: 'Test 1' }],
+                error,
+                searchFilter: {
+                    SEARCH_TERM: 'SEARCH_VALUE',
+                },
+            })
+        ).toEqual({
+            type: 'ERROR',
+            error,
+        });
+    });
+
+    it('should show the LOADING state', () => {
+        const args: GetTableUIStateProps<DataType> = {
+            isLoading: true,
+            isPolling: false,
+            data: undefined,
+            error: undefined,
+            searchFilter: {},
+        };
+
+        const tableUIState = getTableUIState<DataType>(args);
+
+        expect(tableUIState).toEqual({
+            type: 'LOADING',
+        });
+    });
+
+    it('should show the POLLING state', () => {
+        const data = [{ text: 'Test 1' }];
+        const args: GetTableUIStateProps<DataType> = {
+            isLoading: true,
+            isPolling: true,
+            data,
+            error: undefined,
+            searchFilter: {},
+        };
+
+        const tableUIState = getTableUIState<DataType>(args);
+
+        expect(tableUIState).toEqual({
+            type: 'POLLING',
+            data,
+        });
+    });
+
+    it('should show the EMPTY state', () => {
+        const args: GetTableUIStateProps<DataType> = {
+            isLoading: false,
+            isPolling: false,
+            data: [],
+            error: undefined,
+            searchFilter: {},
+        };
+
+        const tableUIState = getTableUIState<DataType>(args);
+
+        expect(tableUIState).toEqual({
+            type: 'EMPTY',
+        });
+    });
+
+    it('should show the FILTERED_EMPTY state', () => {
+        const args: GetTableUIStateProps<DataType> = {
+            isLoading: false,
+            isPolling: false,
+            data: [],
+            error: undefined,
+            searchFilter: {
+                SEARCH_TERM: 'SEARCH_VALUE',
+            },
+        };
+
+        const tableUIState = getTableUIState<DataType>(args);
+
+        expect(tableUIState).toEqual({
+            type: 'FILTERED_EMPTY',
+        });
+    });
+
+    it('should show the COMPLETE state', () => {
+        const data = [{ text: 'Test 1' }];
+
+        // When data is present without search filters
+        expect(
+            getTableUIState<DataType>({
+                isLoading: false,
+                isPolling: false,
+                data,
+                error: undefined,
+                searchFilter: {},
+            })
+        ).toEqual({
+            type: 'COMPLETE',
+            data,
+        });
+
+        // When data is present with search filters
+        expect(
+            getTableUIState<DataType>({
+                isLoading: false,
+                isPolling: false,
+                data,
+                error: undefined,
+                searchFilter: {
+                    SEARCH_TERM: 'SEARCH_VALUE',
+                },
+            })
+        ).toEqual({
+            type: 'COMPLETE',
+            data,
+        });
+    });
+});

--- a/ui/apps/platform/src/utils/getTableUIState.ts
+++ b/ui/apps/platform/src/utils/getTableUIState.ts
@@ -1,28 +1,28 @@
 import { SearchFilter } from 'types/search';
 
-type IdleState = {
+export type IdleState = {
     type: 'IDLE';
 };
 
-type LoadingState = {
+export type LoadingState = {
     type: 'LOADING';
 };
 
-type PollingState<DataType> = {
+export type PollingState<DataType> = {
     type: 'POLLING';
     data: DataType[];
 };
 
-type CompleteState<DataType> = {
+export type CompleteState<DataType> = {
     type: 'COMPLETE';
     data: DataType[];
 };
 
-type EmptyState = {
+export type EmptyState = {
     type: 'EMPTY' | 'FILTERED_EMPTY';
 };
 
-type ErrorState = {
+export type ErrorState = {
     type: 'ERROR';
     error: Error;
 };
@@ -35,9 +35,9 @@ export type TableUIState<DataType> =
     | EmptyState
     | ErrorState;
 
-type GetTableUIStateProps<DataType> = {
+export type GetTableUIStateProps<DataType> = {
     isLoading: boolean;
-    isPolling: boolean;
+    isPolling?: boolean;
     data: undefined | DataType[];
     error: Error | undefined;
     searchFilter: SearchFilter;
@@ -45,7 +45,7 @@ type GetTableUIStateProps<DataType> = {
 
 export function getTableUIState<DataType>({
     isLoading,
-    isPolling,
+    isPolling = false,
     data,
     error,
     searchFilter,


### PR DESCRIPTION
## Description

This PR adds empty states for the Exception Management tables (Pending requests, Approved deferrals, Approved false positives, and Denied requests). I added a new function that takes certain values and returns a page state value that we can use to determine what happens on the page (loading, showing an error, showing the table data, etc.). This is based on the work in [this Design Doc](https://docs.google.com/document/d/1biNKn8QWvlWVHE2lO8lGFvmJ-moJbuvm2mWT3akQZgw/edit#heading=h.6lix4so2w8p1). 

## Screenshots

<img width="1433" alt="Screenshot 2024-02-28 at 12 39 44 PM" src="https://github.com/stackrox/stackrox/assets/4805485/5a1c3b9b-f3a8-4dd7-8e59-28b41c2fdfe8">
<img width="1440" alt="Screenshot 2024-02-28 at 12 40 13 PM" src="https://github.com/stackrox/stackrox/assets/4805485/bd5237f5-f4c8-4562-b370-6137c11c51ea">
<img width="1438" alt="Screenshot 2024-02-28 at 12 40 23 PM" src="https://github.com/stackrox/stackrox/assets/4805485/11896b16-679c-4326-ad7c-29e4ae959f86">
<img width="1437" alt="Screenshot 2024-02-28 at 12 40 32 PM" src="https://github.com/stackrox/stackrox/assets/4805485/2dde66cd-47c5-4551-b9cb-9b43c704270e">
