### PR TITLE
ROX-22684: Fixing pagination for Discovered Clusters table

### DIFF
--- a/ui/apps/platform/src/services/DiscoveredClusterService.ts
+++ b/ui/apps/platform/src/services/DiscoveredClusterService.ts
@@ -113,7 +113,8 @@ export function getListDiscoveredClustersArg({
     sortOption,
 }): ListDiscoveredClustersRequest {
     const filter = getDiscoveredClustersFilter(searchFilter);
-    const pagination: Pagination = { limit: perPage, offset: page - 1, sortOption };
+    const offset = (page - 1) * perPage;
+    const pagination: Pagination = { limit: perPage, offset, sortOption };
     return { filter, pagination };
 }
 


### PR DESCRIPTION
The pagination offset was not being calculated correctly when the user hits `>` in the pagination component. This PR fixes that.

The network calls should look as below:
<img width="1438" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/faf7cd47-83e0-4dcc-b73f-11ca465a1f41">
<img width="1440" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/b1175d51-6141-422d-a2a1-ba836a584633">
