### PR TITLE
fix(scanner): read all NVD CVEs

### DIFF
--- a/scanner/enricher/nvd/nvd.go
+++ b/scanner/enricher/nvd/nvd.go
@@ -141,6 +141,7 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, hint driver.Fingerprint)
 			}
 		}
 	}()
+	var totalCVEs int
 	// Doing this serially is slower, but much less complicated than using an
 	// ErrGroup or the like.
 	//
@@ -180,8 +181,9 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, hint driver.Fingerprint)
 				if err := enc.Encode(&r); err != nil {
 					return nil, hint, fmt.Errorf("encoding enrichment: %w", err)
 				}
+				totalCVEs++
 			}
-			zlog.Info(ctx).Int("count", len(apiResp.Vulnerabilities)).Msg("loaded vulnerabilities")
+			zlog.Info(ctx).Int("count", totalCVEs).Msg("loaded vulnerabilities")
 			// Rudimentary rate-limiting.
 			time.Sleep(e.callInterval)
 		}

--- a/scanner/enricher/nvd/nvd.go
+++ b/scanner/enricher/nvd/nvd.go
@@ -155,7 +155,7 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, hint driver.Fingerprint)
 			endDate = now
 		}
 		var apiResp *schema.CVEAPIJSON20
-		for startIdx := 0; ; startIdx += apiResp.TotalResults {
+		for startIdx := 0; ; startIdx += apiResp.ResultsPerPage {
 			apiResp, err = e.query(ctx, startDate, endDate, startIdx)
 			if err != nil {
 				return nil, hint, err

--- a/scanner/enricher/nvd/nvd.go
+++ b/scanner/enricher/nvd/nvd.go
@@ -155,7 +155,7 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, hint driver.Fingerprint)
 			endDate = now
 		}
 		var apiResp *schema.CVEAPIJSON20
-		for startIdx := 0; ; startIdx += apiResp.ResultsPerPage {
+		for startIdx := 0; ; startIdx += apiResp.TotalResults {
 			apiResp, err = e.query(ctx, startDate, endDate, startIdx)
 			if err != nil {
 				return nil, hint, err

--- a/scanner/enricher/nvd/nvd_test.go
+++ b/scanner/enricher/nvd/nvd_test.go
@@ -354,7 +354,11 @@ func newFakeGetter(t *testing.T, path string) driver.EnrichmentGetter {
 	}
 	g := &fakeGetter{items: map[string]json.RawMessage{}}
 	for _, v := range data.Vulnerabilities {
-		en, err := json.Marshal(filterFields(v.CVE))
+		info, err := filterFields(v.CVE)
+		if err != nil {
+			t.Fatal(err)
+		}
+		en, err := json.Marshal(info)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/scanner/enricher/nvd/nvd_test.go
+++ b/scanner/enricher/nvd/nvd_test.go
@@ -354,11 +354,7 @@ func newFakeGetter(t *testing.T, path string) driver.EnrichmentGetter {
 	}
 	g := &fakeGetter{items: map[string]json.RawMessage{}}
 	for _, v := range data.Vulnerabilities {
-		info, err := filterFields(v.CVE)
-		if err != nil {
-			t.Fatal(err)
-		}
-		en, err := json.Marshal(info)
+		en, err := json.Marshal(filterFields(v.CVE))
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Description

`TotalResults` gives you the total number of unpaginated results for the query, while `ResultsPerPage` tells you how many results were given in the paginated query. For each query, we determined the next startIdx by the `TotalResults` field instead of `ResultsPerPage`.

Because of this, we missed about 100k vulnerabilities.

This PR adds some logs, and we can see the difference between commits in this PR:

[Using `TotalResults`](https://github.com/stackrox/stackrox/actions/runs/8023040607/job/21918675476):

```
{"level":"debug","updater":"nvd","component":"enricher/nvd/Enricher/ParseEnrichment","count":115412,"time":"2024-02-23T18:23:49Z","message":"decoded enrichments"}
```

This (almost) matches what I found when I checked the DB in my test cluster:

```
postgres=# SELECT COUNT(*) FROM enrichment WHERE updater = 'nvd';
 count  
--------
 115415
(1 row)
```

[Using `ResultsPerPage`](https://github.com/stackrox/stackrox/actions/runs/8024767377/job/21923988042?pr=10093):

```
{"level":"info","updater":"nvd","component":"enricher/nvd/Enricher/FetchEnrichment","skipped":0,"total":221160,"time":"2024-02-23T21:08:08Z","message":"loaded vulnerabilities"}
```

This is closer to [Scanner V2](https://github.com/stackrox/scanner/actions/runs/8023199475/job/21919254768):

```
time="2024-02-23T18:38:06Z" level=info msg="Loaded 221250 NVD vulnerabilities"
```

I am currently not sure why there is a 90 vulnerability difference. I suspect it's due to potential CVE-2002-XYS vulns being published in 2001, but I haven't confirmed it

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

### Here I tell how I validated my change

CI

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
