### PR TITLE
ROX-22697: Fix data race in cluster walk

### DIFF
--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -295,9 +295,10 @@ func (ds *datastoreImpl) Exists(ctx context.Context, id string) (bool, error) {
 func (ds *datastoreImpl) WalkClusters(ctx context.Context, fn func(obj *storage.Cluster) error) error {
 	walkFn := func() error {
 		return ds.clusterStorage.Walk(ctx, func(cluster *storage.Cluster) error {
-			ds.populateHealthInfos(ctx, cluster)
-			ds.updateClusterPriority(cluster)
-			return fn(cluster)
+			clonedCluster := cluster.Clone()
+			ds.populateHealthInfos(ctx, clonedCluster)
+			ds.updateClusterPriority(clonedCluster)
+			return fn(clonedCluster)
 		})
 	}
 	if err := pgutils.RetryIfPostgres(walkFn); err != nil {


### PR DESCRIPTION
## Description

This fixes a data race in the `Walk` function of the cluster datastore. Similar to other functions where the clusters will be returned, `ds.collectClusters` will be used which clones each cluster
and afterwards applies the cluster health and priority to it. We have to do the same for the `Walk` function since we want to expose the health status.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing (specifically race tests)

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
