### PR TITLE
chore(cloud-sources): use GetAll with cache

### DIFF
--- a/central/cloudsources/datastore/datastore.go
+++ b/central/cloudsources/datastore/datastore.go
@@ -17,6 +17,7 @@ import (
 type DataStore interface {
 	CountCloudSources(ctx context.Context, query *v1.Query) (int, error)
 	GetCloudSource(ctx context.Context, id string) (*storage.CloudSource, error)
+	GetAllCloudSources(ctx context.Context) ([]*storage.CloudSource, error)
 	ListCloudSources(ctx context.Context, query *v1.Query) ([]*storage.CloudSource, error)
 	UpsertCloudSource(ctx context.Context, cloudSource *storage.CloudSource) error
 	DeleteCloudSource(ctx context.Context, id string) error

--- a/central/cloudsources/datastore/datastore_impl.go
+++ b/central/cloudsources/datastore/datastore_impl.go
@@ -53,6 +53,10 @@ func (ds *datastoreImpl) GetCloudSource(ctx context.Context, id string) (*storag
 	return cloudSource, nil
 }
 
+func (ds *datastoreImpl) GetAllCloudSources(ctx context.Context) ([]*storage.CloudSource, error) {
+	return ds.store.GetAll(ctx)
+}
+
 func (ds *datastoreImpl) ListCloudSources(ctx context.Context, query *v1.Query) ([]*storage.CloudSource, error) {
 	cloudSources, err := ds.store.GetByQuery(ctx, query)
 	if err != nil {

--- a/central/cloudsources/datastore/datastore_impl_postgres_test.go
+++ b/central/cloudsources/datastore/datastore_impl_postgres_test.go
@@ -81,6 +81,18 @@ func (s *datastorePostgresTestSuite) TestGetCloudSource() {
 	s.Assert().Equal(cloudSource, roundtripCloudSource)
 }
 
+func (s *datastorePostgresTestSuite) TestGetAllCloudSources() {
+	cloudSources, err := s.datastore.GetAllCloudSources(s.readCtx)
+	s.Require().NoError(err)
+	s.Assert().Empty(cloudSources)
+
+	s.addCloudSources(100)
+
+	cloudSources, err = s.datastore.GetAllCloudSources(s.readCtx)
+	s.Require().NoError(err)
+	s.Assert().Len(cloudSources, 100)
+}
+
 func (s *datastorePostgresTestSuite) TestListCloudSources() {
 	cloudSources, err := s.datastore.ListCloudSources(s.readCtx, &v1.Query{})
 	s.Require().NoError(err)

--- a/central/cloudsources/datastore/internal/store/mocks/store.go
+++ b/central/cloudsources/datastore/internal/store/mocks/store.go
@@ -71,6 +71,21 @@ func (mr *MockStoreMockRecorder) Get(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
 }
 
+// GetAll mocks base method.
+func (m *MockStore) GetAll(ctx context.Context) ([]*storage.CloudSource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAll", ctx)
+	ret0, _ := ret[0].([]*storage.CloudSource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAll indicates an expected call of GetAll.
+func (mr *MockStoreMockRecorder) GetAll(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockStore)(nil).GetAll), ctx)
+}
+
 // GetByQuery mocks base method.
 func (m *MockStore) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.CloudSource, error) {
 	m.ctrl.T.Helper()

--- a/central/cloudsources/datastore/internal/store/postgres/gen.go
+++ b/central/cloudsources/datastore/internal/store/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.CloudSource --search-category CLOUD_SOURCES --cached-store
+//go:generate pg-table-bindings-wrapper --type=storage.CloudSource --search-category CLOUD_SOURCES --cached-store --get-all-func

--- a/central/cloudsources/datastore/internal/store/postgres/store.go
+++ b/central/cloudsources/datastore/internal/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
+	GetAll(ctx context.Context) ([]*storeType, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error
 	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error

--- a/central/cloudsources/datastore/internal/store/postgres/store_test.go
+++ b/central/cloudsources/datastore/internal/store/postgres/store_test.go
@@ -99,6 +99,9 @@ func (s *CloudSourcesStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, cloudSources))
+	allCloudSource, err := store.GetAll(ctx)
+	s.NoError(err)
+	s.ElementsMatch(cloudSources, allCloudSource)
 
 	cloudSourceCount, err = store.Count(ctx)
 	s.NoError(err)

--- a/central/cloudsources/datastore/internal/store/store.go
+++ b/central/cloudsources/datastore/internal/store/store.go
@@ -11,6 +11,7 @@ import (
 //
 //go:generate mockgen-wrapper
 type Store interface {
+	GetAll(ctx context.Context) ([]*storage.CloudSource, error)
 	Get(ctx context.Context, id string) (*storage.CloudSource, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.CloudSource, error)
 	Upsert(ctx context.Context, obj *storage.CloudSource) error

--- a/central/cloudsources/manager/manager.go
+++ b/central/cloudsources/manager/manager.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
-	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
 	"golang.org/x/time/rate"
 )
@@ -138,7 +137,7 @@ func (m *managerImpl) discoverClustersFromCloudSources() {
 func (m *managerImpl) getDiscoveredClustersFromCloudSources() []*discoveredclusters.DiscoveredCluster {
 	// Fetch the cloud sources from the datastore. This will ensure that we will always use the latest updates.
 	// For the time being we do not foresee this to be a high cardinality store.
-	cloudSources, err := m.cloudSourcesDataStore.ListCloudSources(cloudSourceCtx, search.EmptyQuery())
+	cloudSources, err := m.cloudSourcesDataStore.GetAllCloudSources(cloudSourceCtx)
 	if err != nil {
 		log.Errorw("Failed listing stored cloud sources", logging.Err(err))
 		return nil
@@ -243,7 +242,7 @@ func (m *managerImpl) changeStatusForDiscoveredClusters(clusterID string, status
 		return
 	}
 
-	cloudSources, err := m.cloudSourcesDataStore.ListCloudSources(cloudSourceCtx, search.EmptyQuery())
+	cloudSources, err := m.cloudSourcesDataStore.GetAllCloudSources(cloudSourceCtx)
 	if err != nil {
 		log.Errorw("Failed to list stored cloud sources for changing cluster status",
 			logging.Err(err), logging.ClusterID(clusterID))


### PR DESCRIPTION
## Description

This introduces the `GetAll` function on the cloud sources store / datastore. The reason for it is that a) we expect this to be a low cardinality store, hence `GetAll` is applicable and b) we want to make use of the cached store behavior in the manager.
In case searches are performed (i.e. by passing a `v1.Query`) the cached store currently will _always_ call the underlying store, effectively skipping the cache. Hence, the manager will resort to use `GetAll` now which will make use of the cache.

Alternative to introducing `GetAll` would have been to use `Walk` instead, however I've chosen the `GetAll` due to its simplicity and the only current use-case being the manager.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
