### PR TITLE
test(cloud-sources): add BAT for OCM cloud sources

### DIFF
--- a/pkg/cloudsources/client.go
+++ b/pkg/cloudsources/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/pkg/cloudsources/ocm"
 	"github.com/stackrox/rox/pkg/cloudsources/opts"
 	"github.com/stackrox/rox/pkg/cloudsources/paladin"
+	"github.com/stackrox/rox/pkg/errox"
 )
 
 // Client exposes functionality to fetch discovered cluster from cloud sources.
@@ -27,6 +28,6 @@ func NewClientForCloudSource(source *storage.CloudSource, options ...opts.Client
 	case storage.CloudSource_TYPE_OCM:
 		return ocm.NewClient(source, options...)
 	default:
-		return nil, nil
+		return nil, errox.InvalidArgs.Newf("unsupported type %q given", source.GetType().String())
 	}
 }

--- a/qa-tests-backend/src/main/groovy/services/CloudSourcesService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/CloudSourcesService.groovy
@@ -1,0 +1,70 @@
+package services
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import io.stackrox.proto.api.v1.CloudSourceService
+import io.stackrox.proto.api.v1.CloudSourcesServiceGrpc
+
+@CompileStatic
+@Slf4j
+class CloudSourcesService extends BaseService {
+    static CloudSourcesServiceGrpc.CloudSourcesServiceBlockingStub getCloudSourcesClient() {
+        return CloudSourcesServiceGrpc.newBlockingStub(getChannel())
+    }
+
+    static String createCloudSource(CloudSourceService.CloudSource cloudSource) {
+        CloudSourceService.CloudSource createdCloudSource
+        try {
+            createdCloudSource = getCloudSourcesClient().createCloudSource(CloudSourceService.
+                    CreateCloudSourceRequest.newBuilder().
+                    setCloudSource(cloudSource as CloudSourceService.CloudSource).build()).
+                    getCloudSource()
+        } catch (Exception e) {
+            log.error("Unable to create cloud source ${cloudSource.getName()}", e)
+        }
+        if (!createdCloudSource || !createdCloudSource.getId()) {
+            return ""
+        }
+
+        CloudSourceService.CloudSource foundCloudSource
+        try {
+            foundCloudSource = getCloudSourcesClient().
+                    getCloudSource(CloudSourceService.
+                            GetCloudSourceRequest.newBuilder().
+                            setId(createdCloudSource.getId()).build()).
+                    getCloudSource()
+        } catch (Exception e) {
+            log.error("Unable to find the created cloud source ${cloudSource.getName()}", e)
+        }
+
+        if (foundCloudSource) {
+            return foundCloudSource.getId()
+        }
+        return ""
+    }
+
+    static Boolean deleteCloudSource(String cloudSourceId) {
+        try {
+            getCloudSourcesClient().deleteCloudSource(CloudSourceService.DeleteCloudSourceRequest.
+                    newBuilder().setId(cloudSourceId).build())
+        } catch (Exception e) {
+            log.error("Failed to delete cloud source with id ${cloudSourceId}", e)
+        }
+
+        try {
+            getCloudSourcesClient().
+                    getCloudSource(CloudSourceService.
+                            GetCloudSourceRequest.newBuilder().
+                            setId(cloudSourceId).build())
+        } catch (StatusRuntimeException e) {
+            if (e.status.code == Status.Code.NOT_FOUND) {
+                log.info "Cloud source deleted: ${cloudSourceId}"
+                return true
+            }
+            log.error("Error retrieving deleted cloud source", e)
+        }
+        return false
+    }
+}

--- a/qa-tests-backend/src/main/groovy/services/DiscoveredClustersService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/DiscoveredClustersService.groovy
@@ -1,0 +1,26 @@
+package services
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+
+import io.stackrox.proto.api.v1.DiscoveredClusterService
+import io.stackrox.proto.api.v1.DiscoveredClustersServiceGrpc
+
+@CompileStatic
+@Slf4j
+class DiscoveredClustersService extends BaseService {
+    static DiscoveredClustersServiceGrpc.DiscoveredClustersServiceBlockingStub getDiscoveredClustersClient() {
+        return DiscoveredClustersServiceGrpc.newBlockingStub(getChannel())
+    }
+
+    static Integer countDiscoveredClusters() {
+        Integer count = -1
+        try {
+            count = getDiscoveredClustersClient().countDiscoveredClusters(DiscoveredClusterService.
+                    CountDiscoveredClustersRequest.newBuilder().build()).getCount()
+        } catch (Exception e) {
+            log.error("Failed to count discovered clusters", e)
+        }
+        return count
+    }
+}

--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -294,4 +294,8 @@ class Env {
     static String getSupportsLoadBalancerSvc() {
         return get("SUPPORTS_LOAD_BALANCER_SVC", "true")
     }
+
+    static String mustGetOcmOfflineToken() {
+        return get("OCM_OFFLINE_TOKEN")
+    }
 }

--- a/qa-tests-backend/src/test/groovy/CloudSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CloudSourcesTest.groovy
@@ -1,0 +1,41 @@
+import static util.Helpers.withRetry
+
+import io.stackrox.proto.api.v1.CloudSourceService
+import services.CloudSourcesService
+import services.DiscoveredClustersService
+import util.Env
+
+import spock.lang.Tag
+
+class CloudSourcesTest extends BaseSpecification {
+
+    static final private String CLOUD_SOURCE_NAME = "testing OCM"
+
+    @Tag("BAT")
+    def "Create OCM cloud source and verify discovered clusters exist"() {
+        when:
+        "OCM cloud source is created and tested"
+        def cloudSourceId = CloudSourcesService.createCloudSource(CloudSourceService.CloudSource.newBuilder().
+                setName(CLOUD_SOURCE_NAME).
+                setOcm(CloudSourceService.OCMConfig.newBuilder().
+                        setEndpoint("https://api.openshift.com").build()).
+                setCredentials(CloudSourceService.CloudSource.Credentials.newBuilder().
+                        setSecret(Env.mustGetOcmOfflineToken()).build())
+                .build())
+        assert cloudSourceId
+
+        then:
+        "verify we have discovered clusters"
+        // The initial sync may take a bit since we are connecting to the "Red Hat1" OCM organization which hosts
+        // a lot of clusters.
+        withRetry(10, 10) {
+            def count = DiscoveredClustersService.countDiscoveredClusters()
+            assert count > 0
+        }
+
+        cleanup:
+        if (cloudSourceId) {
+            CloudSourcesService.deleteCloudSource(cloudSourceId)
+        }
+    }
+}

--- a/qa-tests-backend/src/test/groovy/CloudSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CloudSourcesTest.groovy
@@ -17,6 +17,7 @@ class CloudSourcesTest extends BaseSpecification {
         "OCM cloud source is created and tested"
         def cloudSourceId = CloudSourcesService.createCloudSource(CloudSourceService.CloudSource.newBuilder().
                 setName(CLOUD_SOURCE_NAME).
+                setType(CloudSourceService.CloudSource.Type.TYPE_OCM).
                 setOcm(CloudSourceService.OCMConfig.newBuilder().
                         setEndpoint("https://api.openshift.com").build()).
                 setCredentials(CloudSourceService.CloudSource.Credentials.newBuilder().


### PR DESCRIPTION
## Description

This adds BAT tests for the cloud sources feature: we are going to create a valid OCM cloud source, verify that the test functionality on the integration works, and that we get discovered clusters from the cloud source.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
