### PR TITLE
chore(errors): prepare for error list removal

### DIFF
--- a/central/alert/service/service_impl.go
+++ b/central/alert/service/service_impl.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	stdErrors "errors"
 	"fmt"
 	"math"
 	"sort"
@@ -18,7 +19,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/batcher"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
@@ -368,11 +368,11 @@ func (s *serviceImpl) checkAlertsSAC(ctx context.Context, alerts []*storage.Aler
 	}
 	waitGroup.Wait()
 	if len(c) > 0 {
-		errorList := errorhelpers.NewErrorList(fmt.Sprintf("found %d sac permission denials while resolving alerts", len(c)))
+		resolveAlertsErrors := fmt.Errorf("found %d sac permission denials while resolving alerts", len(c))
 		for err := range c {
-			errorList.AddError(err)
+			resolveAlertsErrors = stdErrors.Join(resolveAlertsErrors, err)
 		}
-		return errorList.ToError()
+		return resolveAlertsErrors
 	}
 	return nil
 }

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -976,7 +976,7 @@ func normalizeCluster(cluster *storage.Cluster) error {
 }
 
 func validateInput(cluster *storage.Cluster) error {
-	return clusterValidation.Validate(cluster).ToError()
+	return clusterValidation.Validate(cluster)
 }
 
 // addDefaults enriches the provided non-nil cluster object with defaults for

--- a/central/compliance/framework/check_registry_helpers.go
+++ b/central/compliance/framework/check_registry_helpers.go
@@ -1,21 +1,23 @@
 package framework
 
 import (
-	"github.com/stackrox/rox/pkg/errorhelpers"
+	"errors"
+
+	pkgErrors "github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
 // RegisterChecks registers a check in the global registry.
 func RegisterChecks(checks ...Check) error {
-	errList := errorhelpers.NewErrorList("registering checks")
+	var registerChecksErrs error
 	registry := RegistrySingleton()
 	for _, check := range checks {
 		if err := registry.Register(check); err != nil {
-			errList.AddError(err)
+			registerChecksErrs = errors.Join(registerChecksErrs, err)
 		}
 	}
-	return errList.ToError()
+	return pkgErrors.Wrap(registerChecksErrs, "checking registry")
 }
 
 // MustRegisterChecks registers a check in the global registry, and panics if the check could not be registered.

--- a/central/cve/image/csv/handler.go
+++ b/central/cve/image/csv/handler.go
@@ -2,6 +2,7 @@ package csv
 
 import (
 	"context"
+	stdErrors "errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -13,7 +14,6 @@ import (
 	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/csv"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/schema"
@@ -161,56 +161,56 @@ func ImageCVECSVRows(c context.Context, query *v1.Query, rawQuery resolvers.RawQ
 
 	cveRows := make([]*ImageCVERow, 0, len(vulnResolvers))
 	for _, d := range vulnResolvers {
-		var errorList errorhelpers.ErrorList
+		var errs error
 		dataRow := &ImageCVERow{}
 		dataRow.CVE = d.CVE(ctx)
 		// query to IsFixable should not have Fixable field
 		rawQueryWithoutFixable := resolvers.FilterFieldFromRawQuery(rawQuery, search.Fixable)
 		isFixable, err := d.IsFixable(ctx, rawQueryWithoutFixable)
 		if err != nil {
-			errorList.AddError(err)
+			errs = stdErrors.Join(errs, err)
 		}
 		dataRow.Fixable = strconv.FormatBool(isFixable)
 		dataRow.CvssScore = fmt.Sprintf("%.2f (%s)", d.Cvss(ctx), d.ScoreVersion(ctx))
 		envImpact, err := d.EnvImpact(ctx)
 		if err != nil {
-			errorList.AddError(err)
+			errs = stdErrors.Join(errs, err)
 		}
 		dataRow.EnvImpact = fmt.Sprintf("%.2f", envImpact*100)
 		dataRow.ImpactScore = fmt.Sprintf("%.2f", d.ImpactScore(ctx))
 		// Entity counts should be scoped to CVE only
 		deploymentCount, err := d.DeploymentCount(ctx, resolvers.RawQuery{})
 		if err != nil {
-			errorList.AddError(err)
+			errs = stdErrors.Join(errs, err)
 		}
 		dataRow.DeploymentCount = fmt.Sprint(deploymentCount)
 		// Entity counts should be scoped to CVE only
 		imageCount, err := d.ImageCount(ctx, resolvers.RawQuery{})
 		if err != nil {
-			errorList.AddError(err)
+			errs = stdErrors.Join(errs, err)
 		}
 		dataRow.ImageCount = fmt.Sprint(imageCount)
 		// Entity counts should be scoped to CVE only
 		componentCount, err := d.ImageComponentCount(ctx, resolvers.RawQuery{})
 		if err != nil {
-			errorList.AddError(err)
+			errs = stdErrors.Join(errs, err)
 		}
 		dataRow.ComponentCount = fmt.Sprint(componentCount)
 		scannedTime, err := d.LastScanned(ctx)
 		if err != nil {
-			errorList.AddError(err)
+			errs = stdErrors.Join(errs, err)
 		}
 		dataRow.ScannedTime = csv.FromGraphQLTime(scannedTime)
 		publishedTime, err := d.PublishedOn(ctx)
 		if err != nil {
-			errorList.AddError(err)
+			errs = stdErrors.Join(errs, err)
 		}
 		dataRow.PublishedTime = csv.FromGraphQLTime(publishedTime)
 		dataRow.Summary = d.Summary(ctx)
 
 		cveRows = append(cveRows, dataRow)
-		if err := errorList.ToError(); err != nil {
-			log.Errorf("failed to generate complete csv entry for cve %s: %v", dataRow.CVE, err)
+		if errs != nil {
+			log.Errorf("failed to generate complete csv entry for cve %s: %v", dataRow.CVE, errs)
 		}
 	}
 	return cveRows, nil

--- a/central/cve/node/csv/handler.go
+++ b/central/cve/node/csv/handler.go
@@ -2,6 +2,7 @@ package csv
 
 import (
 	"context"
+	stdErrors "errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -13,7 +14,6 @@ import (
 	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/csv"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/schema"
@@ -156,50 +156,50 @@ func NodeCVECSVRows(c context.Context, query *v1.Query, rawQuery resolvers.RawQu
 
 	cveRows := make([]*NodeCVERow, 0, len(vulnResolvers))
 	for _, d := range vulnResolvers {
-		var errorList errorhelpers.ErrorList
+		var errs error
 		dataRow := &NodeCVERow{}
 		dataRow.CVE = d.CVE(ctx)
 		// query to IsFixable should not have Fixable field
 		rawQueryWithoutFixable := resolvers.FilterFieldFromRawQuery(rawQuery, search.Fixable)
 		isFixable, err := d.IsFixable(ctx, rawQueryWithoutFixable)
 		if err != nil {
-			errorList.AddError(err)
+			errs = stdErrors.Join(errs, err)
 		}
 		dataRow.Fixable = strconv.FormatBool(isFixable)
 		dataRow.CvssScore = fmt.Sprintf("%.2f (%s)", d.Cvss(ctx), d.ScoreVersion(ctx))
 		envImpact, err := d.EnvImpact(ctx)
 		if err != nil {
-			errorList.AddError(err)
+			errs = stdErrors.Join(errs, err)
 		}
 		dataRow.EnvImpact = fmt.Sprintf("%.2f", envImpact*100)
 		dataRow.ImpactScore = fmt.Sprintf("%.2f", d.ImpactScore(ctx))
 		// Entity counts should be scoped to CVE only
 		nodeCount, err := d.NodeCount(ctx, resolvers.RawQuery{})
 		if err != nil {
-			errorList.AddError(err)
+			errs = stdErrors.Join(errs, err)
 		}
 		dataRow.NodeCount = fmt.Sprint(nodeCount)
 		// Entity counts should be scoped to CVE only
 		componentCount, err := d.NodeComponentCount(ctx, resolvers.RawQuery{})
 		if err != nil {
-			errorList.AddError(err)
+			errs = stdErrors.Join(errs, err)
 		}
 		dataRow.ComponentCount = fmt.Sprint(componentCount)
 		scannedTime, err := d.LastScanned(ctx)
 		if err != nil {
-			errorList.AddError(err)
+			errs = stdErrors.Join(errs, err)
 		}
 		dataRow.ScannedTime = csv.FromGraphQLTime(scannedTime)
 		publishedTime, err := d.PublishedOn(ctx)
 		if err != nil {
-			errorList.AddError(err)
+			errs = stdErrors.Join(errs, err)
 		}
 		dataRow.PublishedTime = csv.FromGraphQLTime(publishedTime)
 		dataRow.Summary = d.Summary(ctx)
 
 		cveRows = append(cveRows, dataRow)
-		if err := errorList.ToError(); err != nil {
-			log.Errorf("failed to generate complete csv entry for cve %s: %v", dataRow.CVE, err)
+		if errs != nil {
+			log.Errorf("failed to generate complete csv entry for cve %s: %v", dataRow.CVE, errs)
 		}
 	}
 	return cveRows, nil

--- a/central/networkgraph/entity/gatherer/common.go
+++ b/central/networkgraph/entity/gatherer/common.go
@@ -1,10 +1,11 @@
 package gatherer
 
 import (
+	stdErrors "errors"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/networkgraph/entity/datastore"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/set"
 )
 
@@ -37,11 +38,11 @@ func updateInStorage(entityDS datastore.EntityDataStore, lastSeenIDs set.StringS
 }
 
 func removeOutdatedNetworks(entityDS datastore.EntityDataStore, ids ...string) error {
-	var errs errorhelpers.ErrorList
+	var removeErrs error
 	for _, id := range ids {
 		if err := entityDS.DeleteExternalNetworkEntity(networkGraphWriteCtx, id); err != nil {
-			errs.AddError(err)
+			removeErrs = stdErrors.Join(removeErrs, err)
 		}
 	}
-	return errs.ToError()
+	return removeErrs
 }

--- a/central/notifiers/sumologic/sumologic.go
+++ b/central/notifiers/sumologic/sumologic.go
@@ -13,7 +13,7 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/administration/events/codes"
-	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/retry"
@@ -80,11 +80,10 @@ func (s *sumologic) sendPayload(ctx context.Context, buf io.Reader) error {
 }
 
 func validateConfig(sumologic *storage.SumoLogic) error {
-	errList := errorhelpers.NewErrorList("Sumo Logic notifier validation")
 	if sumologic.GetHttpSourceAddress() == "" {
-		errList.AddString("http source address is required")
+		return errox.InvalidArgs.New("HTTP source address is required")
 	}
-	return errList.ToError()
+	return nil
 }
 
 func newSumoLogic(notifier *storage.Notifier) (*sumologic, error) {

--- a/central/policy/datastore/datastore_impl.go
+++ b/central/policy/datastore/datastore_impl.go
@@ -13,7 +13,6 @@ import (
 	categoriesDataStore "github.com/stackrox/rox/central/policycategory/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/logging"
 	policiesPkg "github.com/stackrox/rox/pkg/policies"
 	"github.com/stackrox/rox/pkg/policyutils"
@@ -41,7 +40,7 @@ type PolicyStoreErrorList struct {
 }
 
 func (p *PolicyStoreErrorList) Error() string {
-	return errorhelpers.NewErrorListWithErrors("policy store encountered errors", p.Errors).String()
+	return errorsPkg.Wrap(errors.Join(p.Errors...), "policy store encountered errors").Error()
 }
 
 // IDConflictError can be returned by AddPolicies when a policy exists with the same ID as a new policy

--- a/central/processbaseline/datastore/datastore_impl.go
+++ b/central/processbaseline/datastore/datastore_impl.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"context"
+	stdErrors "errors"
 	"time"
 
 	"github.com/gogo/protobuf/types"
@@ -14,7 +15,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	processBaselinePkg "github.com/stackrox/rox/pkg/processbaseline"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
@@ -159,7 +159,7 @@ func (ds *datastoreImpl) RemoveProcessBaselinesByDeployment(ctx context.Context,
 	}
 
 	if len(errList) > 0 {
-		return errorhelpers.NewErrorListWithErrors("errors cleaning up process baselines", errList).ToError()
+		return errors.Wrap(stdErrors.Join(errList...), "cleaning up process baselines")
 	}
 
 	return nil

--- a/central/sensor/service/pipeline/reconciliation/perform.go
+++ b/central/sensor/service/pipeline/reconciliation/perform.go
@@ -1,9 +1,9 @@
 package reconciliation
 
 import (
-	"fmt"
+	"errors"
 
-	"github.com/stackrox/rox/pkg/errorhelpers"
+	pkgErrors "github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/set"
 )
@@ -23,9 +23,9 @@ func Perform(store Store, existingIDs set.StringSet, resourceType string, remove
 
 	log.Infof("Deleting %d %s as a part of reconciliation", idsToDelete.Cardinality(), resourceType)
 
-	errList := errorhelpers.NewErrorList(fmt.Sprintf("%s reconciliation", resourceType))
+	var reconcileErrs error
 	for id := range idsToDelete {
-		errList.AddError(removeFunc(id))
+		reconcileErrs = errors.Join(reconcileErrs, removeFunc(id))
 	}
-	return errList.ToError()
+	return pkgErrors.Wrapf(reconcileErrs, "%s reconciliation", resourceType)
 }

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -2,6 +2,7 @@ package requestmgr
 
 import (
 	"context"
+	stdErrors "errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -25,7 +26,6 @@ import (
 	"github.com/stackrox/rox/pkg/batcher"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/cve"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authn"
@@ -499,20 +499,20 @@ func (m *managerImpl) getImagesIDsForVulnRequest(request *storage.VulnerabilityR
 }
 
 func (m *managerImpl) expireDeferrals(deferrals []*storage.VulnerabilityRequest) error {
-	processingErrs := errorhelpers.NewErrorList("re-observing expired deferrals")
+	var processingErrs error
 	for _, req := range deferrals {
 		// A request can be re-observed by just marking it inactive
 		// NOTE: It is possible that another request will still force this vulnerability to be deferred (e.g. if this was image scoped
 		// but a global one still exists).
 		if _, err := m.vulnReqs.MarkRequestInactive(allVulnApproverAccessSac, req.GetId(), "[System Generated] Request expired"); err != nil {
-			processingErrs.AddWrapf(err, "marking as inactive request %s", req.GetId())
+			processingErrs = stdErrors.Join(processingErrs, errors.Wrapf(err, "marking as inactive request %s", req.GetId()))
 			continue
 		}
 		if err := m.UnSnoozeVulnerabilityOnRequest(allVulnApproverAccessSac, req); err != nil {
-			processingErrs.AddWrapf(err, "unsnoozing vulns for request %s", req.GetId())
+			processingErrs = stdErrors.Join(processingErrs, errors.Wrapf(err, "unsnoozing vulns for request %s", req.GetId()))
 		}
 	}
-	return processingErrs.ToError()
+	return errors.Wrap(processingErrs, "re-observing expired deferrals")
 }
 
 func (m *managerImpl) getExpiredDeferrals() ([]*storage.VulnerabilityRequest, error) {

--- a/central/vulnerabilityrequest/validator/validate.go
+++ b/central/vulnerabilityrequest/validator/validate.go
@@ -1,31 +1,31 @@
 package validator
 
 import (
+	stdErrors "errors"
 	"fmt"
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/common"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 )
 
 // ValidateNewSuppressVulnRequest ensures that the new request to suppress vulnerability is correct, if not, returns an error.
 func ValidateNewSuppressVulnRequest(req *storage.VulnerabilityRequest) error {
-	var errList errorhelpers.ErrorList
-	errList.AddError(validateNoID(req))
-	errList.AddError(validateUser(req))
-	errList.AddError(validateComment(req))
-	errList.AddError(validateNoApprovedStatusForNewRequests(req))
-	errList.AddError(validateNoDeniedStatus(req))
-	errList.AddError(validateTargetState(req))
-	errList.AddError(validateScope(req))
-	errList.AddError(validateCVEs(req))
-	errList.AddError(validatNotExpired(req))
-	errList.AddErrors(validateNewRequestNotUpdated(req))
-	if err := errList.ToError(); err != nil {
-		return errox.InvalidArgs.CausedBy(errList.ToError())
+	var validationErrs error
+	validationErrs = stdErrors.Join(validationErrs, validateNoID(req))
+	validationErrs = stdErrors.Join(validationErrs, validateUser(req))
+	validationErrs = stdErrors.Join(validationErrs, validateComment(req))
+	validationErrs = stdErrors.Join(validationErrs, validateNoApprovedStatusForNewRequests(req))
+	validationErrs = stdErrors.Join(validationErrs, validateNoDeniedStatus(req))
+	validationErrs = stdErrors.Join(validationErrs, validateTargetState(req))
+	validationErrs = stdErrors.Join(validationErrs, validateScope(req))
+	validationErrs = stdErrors.Join(validationErrs, validateCVEs(req))
+	validationErrs = stdErrors.Join(validationErrs, validatNotExpired(req))
+	validationErrs = stdErrors.Join(validationErrs, validateNewRequestNotUpdated(req))
+	if validationErrs != nil {
+		return errox.InvalidArgs.CausedBy(validationErrs)
 	}
 	return nil
 }

--- a/central/vulnerabilityrequest/validator/validator_test.go
+++ b/central/vulnerabilityrequest/validator/validator_test.go
@@ -43,39 +43,39 @@ func TestValidateNewSuppressVulnRequest(t *testing.T) {
 	// Cannot create a request in observed state
 	cloned := req.Clone()
 	cloned.TargetState = storage.VulnerabilityState_OBSERVED
-	assert.EqualError(t, ValidateNewSuppressVulnRequest(cloned), "invalid arguments:  error: request to suppress vulnerability must be a deferral or false-positive request")
+	assert.EqualError(t, ValidateNewSuppressVulnRequest(cloned), "invalid arguments: request to suppress vulnerability must be a deferral or false-positive request")
 
 	// Cannot create an empty request
 	cloned = req.Clone()
 	cloned.Req = nil
-	assert.EqualError(t, ValidateNewSuppressVulnRequest(cloned), "invalid arguments:  error: vulnerability deferral request invalid. Deferral expiry not provided")
+	assert.EqualError(t, ValidateNewSuppressVulnRequest(cloned), "invalid arguments: vulnerability deferral request invalid. Deferral expiry not provided")
 
 	// Requests require comment
 	cloned = req.Clone()
 	cloned.Comments = nil
-	assert.EqualError(t, ValidateNewSuppressVulnRequest(cloned), "invalid arguments:  error: vulnerability exception must have at least one comment")
+	assert.EqualError(t, ValidateNewSuppressVulnRequest(cloned), "invalid arguments: vulnerability exception must have at least one comment")
 
 	// Requests cannot start out approved
 	cloned = req.Clone()
 	cloned.Status = storage.RequestStatus_APPROVED
-	assert.EqualError(t, ValidateNewSuppressVulnRequest(cloned), "invalid arguments:  error: new vulnerability exception must not be in approved state")
+	assert.EqualError(t, ValidateNewSuppressVulnRequest(cloned), "invalid arguments: new vulnerability exception must not be in approved state")
 
 	// Requests cannot start out in APPROVED_PENDING_UPDATE state
 	cloned = req.Clone()
 	cloned.Status = storage.RequestStatus_APPROVED_PENDING_UPDATE
-	assert.EqualError(t, ValidateNewSuppressVulnRequest(cloned), "invalid arguments:  error: new vulnerability exception must not be in approved state")
+	assert.EqualError(t, ValidateNewSuppressVulnRequest(cloned), "invalid arguments: new vulnerability exception must not be in approved state")
 
 	// Cannot have an updated request
 	cloned = req.Clone()
 	cloned.UpdatedReq = &storage.VulnerabilityRequest_UpdatedDeferralReq{
 		UpdatedDeferralReq: cloned.GetDeferralReq().Clone(),
 	}
-	assert.EqualError(t, ValidateNewSuppressVulnRequest(cloned), "invalid arguments:  error: expected new vulnerability exception, not an updated one")
+	assert.EqualError(t, ValidateNewSuppressVulnRequest(cloned), "invalid arguments: expected new vulnerability exception, not an updated one")
 
 	// Requestor must be set
 	cloned = req.Clone()
 	cloned.Requestor = nil
-	assert.EqualError(t, ValidateNewSuppressVulnRequest(cloned), "invalid arguments:  error: vulnerability exception must have a requestor")
+	assert.EqualError(t, ValidateNewSuppressVulnRequest(cloned), "invalid arguments: vulnerability exception must have a requestor")
 }
 
 func TestValidateScope(t *testing.T) {

--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -2256,7 +2256,7 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 		_, err := BuildImageMatcher(policyWithSingleFieldAndValues(fieldnames.ImageSignatureVerifiedBy,
 			[]string{verifier0}, false, storage.BooleanOperator_AND))
 		suite.EqualError(err,
-			"policy validation error: operator AND is not allowed for field \"Image Signature Verified By\"")
+			"policy validation: operator AND is not allowed for field \"Image Signature Verified By\"")
 	})
 
 	for i, testCase := range []struct {

--- a/pkg/cloudsources/discoveredclusters/discovered_cluster.go
+++ b/pkg/cloudsources/discoveredclusters/discovered_cluster.go
@@ -1,12 +1,13 @@
 package discoveredclusters
 
 import (
+	stdErrors "errors"
 	"strings"
 
 	gogoTimestamp "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/uuid"
 )
@@ -116,15 +117,18 @@ func (d *DiscoveredCluster) Validate() error {
 	if d == nil {
 		return errors.New("empty discovered cluster")
 	}
-	errorList := errorhelpers.NewErrorList("Validation")
+	var validationErrs error
 	if d.GetID() == "" {
-		errorList.AddString("discovered cluster ID must be defined")
+		validationErrs = stdErrors.Join(validationErrs,
+			errox.InvalidArgs.New("discovered cluster ID must be defined"))
 	}
 	if d.GetName() == "" {
-		errorList.AddString("discovered cluster name must be defined")
+		validationErrs = stdErrors.Join(validationErrs,
+			errox.InvalidArgs.New("discovered cluster name must be defined"))
 	}
 	if d.GetCloudSourceID() == "" {
-		errorList.AddString("cloud source ID must be defined")
+		validationErrs = stdErrors.Join(validationErrs,
+			errox.InvalidArgs.New("cloud source ID must be defined"))
 	}
-	return errorList.ToError()
+	return errors.Wrap(validationErrs, "validating discovered cluster")
 }

--- a/pkg/cluster/validation.go
+++ b/pkg/cluster/validation.go
@@ -1,80 +1,86 @@
 package cluster
 
 import (
-	"fmt"
+	stdErrors "errors"
 	"strings"
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/netutil"
 	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/urlfmt"
 )
 
 // Validate validates a cluster object
-func Validate(cluster *storage.Cluster) *errorhelpers.ErrorList {
-	errorList := ValidatePartial(cluster)
+func Validate(cluster *storage.Cluster) error {
+	errs := ValidatePartial(cluster)
 
 	// Here go all other server-side checks
 	if _, err := reference.ParseAnyReference(cluster.GetMainImage()); err != nil {
-		errorList.AddError(errors.Wrapf(err, "invalid main image '%s'", cluster.GetMainImage()))
+		errs = stdErrors.Join(err, errors.Wrapf(err, "invalid main image %q", cluster.GetMainImage()))
 	}
 
-	return errorList
+	return errs
 }
 
 // ValidatePartial partially validates a cluster object.
 // Some fields are allowed to be left empty for the server to complete with default values.
-func ValidatePartial(cluster *storage.Cluster) *errorhelpers.ErrorList {
-	errorList := errorhelpers.NewErrorList("Cluster Validation")
+func ValidatePartial(cluster *storage.Cluster) error {
+	var validationErrs error
 	if cluster.GetName() == "" {
-		errorList.AddString("Cluster name is required")
+		validationErrs = stdErrors.Join(validationErrs, errox.InvalidArgs.New("Cluster name is required"))
 	}
 	if cluster.GetMainImage() != "" {
 		if _, err := reference.ParseAnyReference(cluster.GetMainImage()); err != nil {
-			errorList.AddError(errors.Wrapf(err, "invalid main image '%s'", cluster.GetMainImage()))
+			validationErrs = stdErrors.Join(validationErrs,
+				errors.Wrapf(err, "invalid main image %q", cluster.GetMainImage()))
 		}
 	}
 	if cluster.GetCollectorImage() != "" {
 		ref, err := reference.ParseAnyReference(cluster.GetCollectorImage())
 		if err != nil {
-			errorList.AddError(errors.Wrapf(err, "invalid collector image '%s'", cluster.GetCollectorImage()))
+			validationErrs = stdErrors.Join(validationErrs,
+				errors.Wrapf(err, "invalid collector image %q", cluster.GetCollectorImage()))
 		}
 
 		if cluster.GetHelmConfig() == nil {
 			namedTagged, ok := ref.(reference.NamedTagged)
 			if ok {
-				errorList.AddStringf("collector image may not specify a tag.  Please "+
-					"remove tag '%s' to continue", namedTagged.Tag())
+				validationErrs = stdErrors.Join(validationErrs, errox.InvalidArgs.Newf(
+					"collector image may not specify a tag.  Please "+
+						"remove tag %q to continue", namedTagged.Tag()))
 			}
 		}
 	}
 	if cluster.GetCentralApiEndpoint() == "" {
-		errorList.AddString("Central API Endpoint is required")
+		validationErrs = stdErrors.Join(validationErrs, errox.InvalidArgs.New("Central API Endpoint is required"))
 	} else if !strings.Contains(cluster.GetCentralApiEndpoint(), ":") {
-		errorList.AddString("Central API Endpoint must have port specified")
+		validationErrs = stdErrors.Join(validationErrs,
+			errox.InvalidArgs.New("Central API Endpoint must have port specified"))
 	}
 
 	if stringutils.ContainsWhitespace(cluster.GetCentralApiEndpoint()) {
-		errorList.AddString("Central API endpoint cannot contain whitespace")
+		validationErrs = stdErrors.Join(validationErrs, errox.InvalidArgs.New("Central API endpoint cannot contain whitespace"))
 	}
 
 	if cluster.GetAdmissionControllerEvents() && cluster.Type == storage.ClusterType_OPENSHIFT_CLUSTER {
-		errorList.AddString("OpenShift 3.x compatibility mode does not support admission controller webhooks on port-forward and exec.")
+		validationErrs = stdErrors.Join(validationErrs,
+			errox.InvalidArgs.New("OpenShift 3.x compatibility mode does not support admission controller webhooks on port-forward and exec"))
 	}
 	if !cluster.GetDynamicConfig().GetDisableAuditLogs() && cluster.Type != storage.ClusterType_OPENSHIFT4_CLUSTER {
 		// Note: this will not fail server-side validation, because on those paths, normalization (which forces it to
 		// true for incompatible clusters) happens prior to validation.
-		errorList.AddString("Audit log collection is only supported on OpenShift 4.x clusters")
+		validationErrs = stdErrors.Join(validationErrs,
+			errox.InvalidArgs.New("Audit log collection is only supported on OpenShift 4.x clusters"))
 	}
 	centralEndpoint := urlfmt.FormatURL(cluster.GetCentralApiEndpoint(), urlfmt.NONE, urlfmt.NoTrailingSlash)
 	_, _, _, err := netutil.ParseEndpoint(centralEndpoint)
 	if err != nil {
-		errorList.AddString(fmt.Sprintf("Central API Endpoint must be a valid endpoint. Error: %s", err))
+		validationErrs = stdErrors.Join(validationErrs, errors.Wrap(err, "Central API Endpoint must be a valid endpoint"))
 	}
 	cluster.CentralApiEndpoint = centralEndpoint
 
-	return errorList
+	return errors.Wrap(validationErrs, "cluster validation")
 }

--- a/pkg/cluster/validation_test.go
+++ b/pkg/cluster/validation_test.go
@@ -128,7 +128,7 @@ func TestFullValidation(t *testing.T) {
 			configureClusterFn: func(cluster *storage.Cluster) {
 				cluster.MainImage = ""
 			},
-			expectedErrors: []string{"invalid main image '': invalid reference format"},
+			expectedErrors: []string{"invalid main image \"\": invalid reference format"},
 		},
 	}
 

--- a/pkg/cluster/validation_test.go
+++ b/pkg/cluster/validation_test.go
@@ -26,7 +26,7 @@ func TestPartialValidation(t *testing.T) {
 			configureClusterFn: func(cluster *storage.Cluster) {
 				cluster.MainImage = "invalid image"
 			},
-			expectedErrors: []string{"invalid main image 'invalid image': invalid reference format"},
+			expectedErrors: []string{"invalid main image \"invalid image\": invalid reference format"},
 		},
 		"Cluster with empty main image should not fail": {
 			configureClusterFn: func(cluster *storage.Cluster) {
@@ -37,7 +37,7 @@ func TestPartialValidation(t *testing.T) {
 			configureClusterFn: func(cluster *storage.Cluster) {
 				cluster.CollectorImage = "docker.io/stackrox/collector:3.2.0-slim"
 			},
-			expectedErrors: []string{"collector image may not specify a tag.  Please remove tag '3.2.0-slim' to continue"},
+			expectedErrors: []string{"collector image may not specify a tag.  Please remove tag \"3.2.0-slim\" to continue"},
 		},
 		"Cluster with configured collector image without tag is valid": {
 			configureClusterFn: func(cluster *storage.Cluster) {
@@ -48,7 +48,7 @@ func TestPartialValidation(t *testing.T) {
 			configureClusterFn: func(cluster *storage.Cluster) {
 				cluster.CollectorImage = "invalid image"
 			},
-			expectedErrors: []string{"invalid collector image 'invalid image': invalid reference format"},
+			expectedErrors: []string{"invalid collector image \"invalid image\": invalid reference format"},
 		},
 		"Cluster with empty collector image should not fail": {
 			configureClusterFn: func(cluster *storage.Cluster) {
@@ -65,7 +65,7 @@ func TestPartialValidation(t *testing.T) {
 			configureClusterFn: func(cluster *storage.Cluster) {
 				cluster.CentralApiEndpoint = ""
 			},
-			expectedErrors: []string{"Central API Endpoint is required", "Central API Endpoint must be a valid endpoint. Error: empty endpoint specified"},
+			expectedErrors: []string{"Central API Endpoint is required", "Central API Endpoint must be a valid endpoint: empty endpoint specified"},
 		},
 		"Cluster without central endpoint port fails": {
 			configureClusterFn: func(cluster *storage.Cluster) {
@@ -109,11 +109,11 @@ func TestPartialValidation(t *testing.T) {
 			gotErrors := ValidatePartial(cluster)
 
 			if len(c.expectedErrors) == 0 {
-				assert.NoError(t, gotErrors.ToError(), "expected a valid cluster but received errors")
+				assert.NoError(t, gotErrors, "expected a valid cluster but received errors")
 			}
 
 			for _, expectedErr := range c.expectedErrors {
-				assert.Contains(t, gotErrors.String(), expectedErr)
+				assert.Contains(t, gotErrors.Error(), expectedErr)
 			}
 		})
 	}
@@ -140,11 +140,11 @@ func TestFullValidation(t *testing.T) {
 			gotErrors := Validate(cluster)
 
 			if len(c.expectedErrors) == 0 {
-				assert.NoError(t, gotErrors.ToError(), "expected a valid cluster but received errors")
+				assert.NoError(t, gotErrors, "expected a valid cluster but received errors")
 			}
 
 			for _, expectedErr := range c.expectedErrors {
-				assert.Contains(t, gotErrors.String(), expectedErr)
+				assert.Contains(t, gotErrors.Error(), expectedErr)
 			}
 		})
 	}

--- a/pkg/dackbox/graph/persistor.go
+++ b/pkg/dackbox/graph/persistor.go
@@ -4,7 +4,6 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency/sortedkeys"
 	"github.com/stackrox/rox/pkg/dackbox/transactions"
 	"github.com/stackrox/rox/pkg/dbhelper"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 )
 
 // NewPersistor returns a new instance of a Persistor, which can be used to apply modifications to the persisted graph.
@@ -19,12 +18,12 @@ func NewPersistor(prefix []byte, txn transactions.DBTransaction) *Persistor {
 type Persistor struct {
 	prefix []byte
 	txn    transactions.DBTransaction
-	errors errorhelpers.ErrorList
+	errors error
 }
 
 // ToError returns an error if any errors were encountered when persisting the modification it was applied to.
 func (prv *Persistor) ToError() error {
-	return prv.errors.ToError()
+	return prv.errors
 }
 
 // Implement applyableGraph.

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -355,12 +355,12 @@ func (e *enricherImpl) enrichWithMetadata(ctx context.Context, enrichmentContext
 	var metadataErrs error
 
 	if err := e.checkRegistryForImage(image); err != nil {
-		return false, errors.Wrapf(err, "error getting metadata for image: %s", image.GetName().GetFullName())
+		return false, errors.Wrapf(err, "error getting metadata for image %q", image.GetName().GetFullName())
 	}
 
 	registries, err := e.getRegistriesForContext(enrichmentContext)
 	if err != nil {
-		return false, errors.Wrapf(err, "error getting metadata for image: %s", image.GetName().GetFullName())
+		return false, errors.Wrapf(err, "error getting metadata for image %q", image.GetName().GetFullName())
 	}
 
 	log.Infof("Getting metadata for image %s", image.GetName().GetFullName())
@@ -419,7 +419,7 @@ func (e *enricherImpl) enrichWithMetadata(ctx context.Context, enrichmentContext
 			errors.Errorf("no matching image registries found: please add an image integration for %s", image.GetName().GetRegistry()))
 	}
 
-	return false, errors.Wrapf(metadataErrs, "error getting metadata for image: %s", image.GetName().GetFullName())
+	return false, errors.Wrapf(metadataErrs, "error getting metadata for image %q", image.GetName().GetFullName())
 }
 
 func getRef(image *storage.Image) string {

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -537,7 +537,7 @@ func TestZeroIntegrations(t *testing.T) {
 	img := &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}}
 	results, err := enricherImpl.EnrichImage(emptyCtx, EnrichmentContext{}, img)
 	assert.Error(t, err)
-	expectedErrMsg := "image enrichment error: error getting metadata for image:  error: not found: " +
+	expectedErrMsg := "image enrichment: error getting metadata for image \"\": not found: " +
 		"no image registries are integrated: please add an image integration"
 	assert.Equal(t, expectedErrMsg, err.Error())
 	assert.False(t, results.ImageUpdated)
@@ -596,8 +596,8 @@ func TestRegistryMissingFromImage(t *testing.T) {
 	img := &storage.Image{Id: "id", Name: &storage.ImageName{FullName: "testimage"}}
 	results, err := enricherImpl.EnrichImage(emptyCtx, EnrichmentContext{}, img)
 	assert.Error(t, err)
-	expectedErrMsg := fmt.Sprintf("image enrichment error: error getting metadata for image: %s "+
-		"error: invalid arguments: no registry is indicated for image %q",
+	expectedErrMsg := fmt.Sprintf("image enrichment: error getting metadata for image %[1]q: invalid arguments: "+
+		"no registry is indicated for image %[1]q",
 		img.GetName().GetFullName(), img.GetName().GetFullName())
 	assert.Equal(t, expectedErrMsg, err.Error())
 	assert.False(t, results.ImageUpdated)
@@ -630,7 +630,7 @@ func TestZeroRegistryIntegrations(t *testing.T) {
 	img := &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}}
 	results, err := enricherImpl.EnrichImage(emptyCtx, EnrichmentContext{}, img)
 	assert.Error(t, err)
-	expectedErrMsg := "image enrichment error: error getting metadata for image:  error: not found: " +
+	expectedErrMsg := "image enrichment: error getting metadata for image \"\": not found: " +
 		"no image registries are integrated: please add an image integration"
 	assert.Equal(t, expectedErrMsg, err.Error())
 	assert.False(t, results.ImageUpdated)
@@ -664,8 +664,8 @@ func TestNoMatchingRegistryIntegration(t *testing.T) {
 	img := &storage.Image{Id: "id", Name: &storage.ImageName{Registry: "reg"}}
 	results, err := enricherImpl.EnrichImage(emptyCtx, EnrichmentContext{}, img)
 	assert.Error(t, err)
-	expectedErrMsg := "image enrichment error: error getting metadata for image:  error: no matching image " +
-		"registries found: please add an image integration for reg"
+	expectedErrMsg := "image enrichment: error getting metadata for image \"\": no matching image registries found: " +
+		"please add an image integration for reg"
 	assert.Equal(t, expectedErrMsg, err.Error())
 	assert.False(t, results.ImageUpdated)
 	assert.Equal(t, ScanNotDone, results.ScanResult)
@@ -701,7 +701,7 @@ func TestZeroScannerIntegrations(t *testing.T) {
 	}
 	results, err := enricherImpl.EnrichImage(emptyCtx, EnrichmentContext{}, img)
 	assert.Error(t, err)
-	expectedErrMsg := "image enrichment error: error scanning image:  error: no image scanners are integrated"
+	expectedErrMsg := "image enrichment: error scanning image \"\": no image scanners are integrated"
 	assert.Equal(t, expectedErrMsg, err.Error())
 	assert.True(t, results.ImageUpdated)
 	assert.Equal(t, ScanNotDone, results.ScanResult)

--- a/pkg/postgres/pgutils/error.go
+++ b/pkg/postgres/pgutils/error.go
@@ -53,13 +53,6 @@ func IsTransientError(err error) bool {
 	if errors.Is(err, pgx.ErrNoRows) {
 		return false
 	}
-	if multiError := (*errorhelpers.ErrorList)(nil); errors.As(err, &multiError) {
-		for _, err := range multiError.Errors() {
-			if IsTransientError(err) {
-				return true
-			}
-		}
-	}
 	if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
 		return transientPGCodes.Contains(pgErr.Code)
 	}

--- a/pkg/postgres/pgutils/error_test.go
+++ b/pkg/postgres/pgutils/error_test.go
@@ -6,20 +6,10 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWrappedErrors(t *testing.T) {
-	multiErrorEmpty := errorhelpers.NewErrorList("any")
-
-	multiError1Error := errorhelpers.NewErrorList("hello")
-	multiError1Error.AddError(context.DeadlineExceeded)
-
-	multiErrorDeadlineExceeded := errorhelpers.NewErrorList("hello")
-	multiErrorDeadlineExceeded.AddError(context.DeadlineExceeded)
-	multiErrorDeadlineExceeded.AddErrors(errors.New("other error"))
-
 	cases := []struct {
 		err       error
 		transient bool
@@ -43,18 +33,6 @@ func TestWrappedErrors(t *testing.T) {
 		{
 			err:       errors.Wrap(errors.Wrap(errors.New("nothing"), "1"), "2"),
 			transient: false,
-		},
-		{
-			err:       multiErrorEmpty.ToError(),
-			transient: false,
-		},
-		{
-			err:       multiError1Error.ToError(),
-			transient: true,
-		},
-		{
-			err:       multiErrorDeadlineExceeded.ToError(),
-			transient: true,
 		},
 	}
 	for _, c := range cases {

--- a/pkg/prometheusutil/export.go
+++ b/pkg/prometheusutil/export.go
@@ -2,13 +2,14 @@ package prometheusutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
+	pkgErrors "github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/expfmt"
 	"github.com/stackrox/rox/pkg/concurrency"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 )
 
 // ExportText prometheus metrics to io.Writer in text format.
@@ -29,15 +30,14 @@ func exportText(w io.Writer) error {
 		// Failed to gather metrics.  Write the error to the file and return.  If we fail to write the error to the
 		// file return both errors.
 		_, writeErr := fmt.Fprintf(w, "# ERROR: %s\n", err.Error())
-		return errorhelpers.NewErrorListWithErrors("gathering prometheus metrics", []error{err, writeErr}).ToError()
+		return pkgErrors.Wrap(errors.Join(err, writeErr), "gathering prometheus metrics")
 	}
 	for _, mf := range mfs {
 		if _, err := expfmt.MetricFamilyToText(w, mf); err != nil {
 			// Failed to write a metric family.  Write the error to the file and continue
 			if _, writeErr := w.Write([]byte(fmt.Sprintf("# ERROR: %s\n", err.Error()))); writeErr != nil {
 				// Failed to write the error to the file.  Return both errors.
-				errList := errorhelpers.NewErrorListWithErrors(fmt.Sprintf("writing metric family %s", mf.GetName()), []error{err, writeErr})
-				return errList.ToError()
+				return pkgErrors.Wrapf(errors.Join(err, writeErr), "writing metric family %s", mf.GetName())
 			}
 
 		}

--- a/pkg/providers/metadata.go
+++ b/pkg/providers/metadata.go
@@ -2,12 +2,13 @@ package providers
 
 import (
 	"context"
+	"errors"
 
+	pkgErrors "github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cloudproviders/aws"
 	"github.com/stackrox/rox/pkg/cloudproviders/azure"
 	"github.com/stackrox/rox/pkg/cloudproviders/gcp"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/logging"
 )
 
@@ -17,27 +18,27 @@ var (
 
 // GetMetadata returns the metadata for specific cloud providers
 func GetMetadata(ctx context.Context) *storage.ProviderMetadata {
-	errors := errorhelpers.NewErrorList("getting cloud provider metadata")
+	var metadataErrs error
 	metadata, err := gcp.GetMetadata(ctx)
 	if metadata != nil {
 		return metadata
 	}
-	errors.AddWrap(err, "GCP")
+	metadataErrs = errors.Join(metadataErrs, pkgErrors.Wrap(err, "GKE"))
 
 	metadata, err = aws.GetMetadata(ctx)
 	if metadata != nil {
 		return metadata
 	}
-	errors.AddWrap(err, "AWS")
+	metadataErrs = errors.Join(metadataErrs, pkgErrors.Wrap(err, "AWS"))
 
 	metadata, err = azure.GetMetadata(ctx)
 	if metadata != nil {
 		return metadata
 	}
-	errors.AddWrap(err, "Azure")
+	metadataErrs = errors.Join(metadataErrs, pkgErrors.Wrap(err, "Azure"))
 
-	if err := errors.ToError(); err != nil {
-		log.Error(err)
+	if metadataErrs != nil {
+		log.Error(metadata)
 	}
 
 	return nil

--- a/pkg/registries/ibm/ibm.go
+++ b/pkg/registries/ibm/ibm.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"time"
 
+	pkgErrors "github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/registries/docker"
 	"github.com/stackrox/rox/pkg/registries/types"
 )
@@ -34,14 +34,16 @@ func CreatorWithoutRepoList() (string, types.Creator) {
 }
 
 func validate(ibm *storage.IBMRegistryConfig) error {
-	errorList := errorhelpers.NewErrorList("IBM Validation")
+	var validationErrs error
 	if ibm.GetEndpoint() == "" {
-		errorList.AddString("Endpoint must be specified for IBM registry (e.g. us.icr.io)")
+		validationErrs = errors.Join(validationErrs,
+			errors.New("endpoint must be specified for IBM registry (e.g. us.icr.io)"))
 	}
 	if ibm.GetApiKey() == "" {
-		errorList.AddString("IAM API Key must be specified for IBM registry")
+		validationErrs = errors.Join(validationErrs,
+			errors.New("IAM API Key must be specified for IBM registry"))
 	}
-	return errorList.ToError()
+	return pkgErrors.Wrap(validationErrs, "validating config")
 }
 
 func newRegistry(integration *storage.ImageIntegration, disableRepoList bool) (*docker.Registry, error) {

--- a/pkg/scanners/clair/clair.go
+++ b/pkg/scanners/clair/clair.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/scanners/types"
 	"github.com/stackrox/rox/pkg/urlfmt"
@@ -45,11 +44,10 @@ type clair struct {
 }
 
 func validate(clair *storage.ClairConfig) error {
-	errorList := errorhelpers.NewErrorList("Clair Validation")
 	if clair.GetEndpoint() == "" {
-		errorList.AddString("Endpoint must be specified")
+		return errors.Wrap(errors.New("endpoint must be specified"), "validating config")
 	}
-	return errorList.ToError()
+	return nil
 }
 
 func newScanner(integration *storage.ImageIntegration) (*clair, error) {

--- a/pkg/scanners/clairv4/clairv4.go
+++ b/pkg/scanners/clairv4/clairv4.go
@@ -13,7 +13,6 @@ import (
 	"github.com/quay/claircore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	imageutils "github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/logging"
@@ -104,14 +103,13 @@ func newScanner(integration *storage.ImageIntegration, activeRegistries registri
 }
 
 func validate(cfg *storage.ClairV4Config) error {
-	errorList := errorhelpers.NewErrorList("Clair v4 Validation")
 	if cfg == nil {
-		errorList.AddString("configuration required")
+		return errors.New("configuration required")
 	}
 	if cfg.GetEndpoint() == "" {
-		errorList.AddString("endpoint must be specified")
+		return errors.Wrap(errors.New("endpoint must be specified"), "validating clair v4 config")
 	}
-	return errorList.ToError()
+	return nil
 }
 
 func (c *clairv4) GetScan(image *storage.Image) (*storage.ImageScan, error) {

--- a/roxctl/sensor/generate/k8s.go
+++ b/roxctl/sensor/generate/k8s.go
@@ -25,8 +25,8 @@ func k8s(generateCmd *sensorGenerateCommand) *cobra.Command {
 		RunE: util.RunENoArgs(func(c *cobra.Command) error {
 			k8sCommand.ConstructK8s()
 
-			if err := clusterValidation.ValidatePartial(k8sCommand.cluster); err.ToError() != nil {
-				return err.ToError()
+			if err := clusterValidation.ValidatePartial(k8sCommand.cluster); err != nil {
+				return err
 			}
 			return k8sCommand.fullClusterCreation()
 		}),

--- a/roxctl/sensor/generate/openshift.go
+++ b/roxctl/sensor/generate/openshift.go
@@ -69,7 +69,7 @@ func openshift(generateCmd *sensorGenerateCommand) *cobra.Command {
 				return err
 			}
 
-			if err := clusterValidation.ValidatePartial(openshiftCommand.cluster).ToError(); err != nil {
+			if err := clusterValidation.ValidatePartial(openshiftCommand.cluster); err != nil {
 				return err
 			}
 			return openshiftCommand.fullClusterCreation()

--- a/sensor/kubernetes/complianceoperator/handler_impl_test.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl_test.go
@@ -144,7 +144,7 @@ func (s *HandlerTestSuite) TestProcessApplyScheduledScanInvalid() {
 	msg := getTestScheduledScanRequestMsg("error", "error")
 	expected := expectedResponse{
 		id:        msg.GetComplianceRequest().GetApplyScanConfig().GetId(),
-		errSubstr: "compliance profiles not specified, schedule is not valid",
+		errSubstr: "compliance profiles not specified\nschedule is not valid",
 	}
 
 	actual := s.sendMessage(1, msg)
@@ -386,7 +386,7 @@ func (s *HandlerTestSuite) TestProcessUpdateScheduledScanInvalid() {
 	msg := getTestUpdateScanRequestMsg("error", "error")
 	expected := expectedResponse{
 		id:        msg.GetComplianceRequest().GetApplyScanConfig().GetId(),
-		errSubstr: "compliance profiles not specified, schedule is not valid",
+		errSubstr: "compliance profiles not specified\nschedule is not valid",
 	}
 
 	actual := s.sendMessage(1, msg)

--- a/sensor/kubernetes/complianceoperator/utils.go
+++ b/sensor/kubernetes/complianceoperator/utils.go
@@ -1,13 +1,14 @@
 package complianceoperator
 
 import (
+	stdErrors "errors"
+
 	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/adhocore/gronx"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/complianceoperator"
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/pointers"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -131,40 +132,40 @@ func validateApplyScheduledScanConfigRequest(req *central.ApplyComplianceScanCon
 	if req == nil {
 		return errors.New("apply scan configuration request is empty")
 	}
-	var errList errorhelpers.ErrorList
+	var validationErrs error
 	if req.GetScanSettings().GetScanName() == "" {
-		errList.AddStrings("no name provided for the scan")
+		validationErrs = stdErrors.Join(validationErrs, errors.New("no name provided for the scan"))
 	}
 	if len(req.GetScanSettings().GetProfiles()) == 0 {
-		errList.AddStrings("compliance profiles not specified")
+		validationErrs = stdErrors.Join(validationErrs, errors.New("compliance profiles not specified"))
 	}
 	if req.GetCron() != "" {
 		cron := gronx.New()
 		if !cron.IsValid(req.GetCron()) {
-			errList.AddStrings("schedule is not valid")
+			validationErrs = stdErrors.Join(validationErrs, errors.New("schedule is not valid"))
 		}
 	}
-	return errList.ToError()
+	return validationErrs
 }
 
 func validateUpdateScheduledScanConfigRequest(req *central.ApplyComplianceScanConfigRequest_UpdateScheduledScan) error {
 	if req == nil {
 		return errors.New("update scan configuration request is empty")
 	}
-	var errList errorhelpers.ErrorList
+	var validationErrs error
 	if req.GetScanSettings().GetScanName() == "" {
-		errList.AddStrings("no name provided for the scan")
+		validationErrs = stdErrors.Join(validationErrs, errors.New("no name provided for the scan"))
 	}
 	if len(req.GetScanSettings().GetProfiles()) == 0 {
-		errList.AddStrings("compliance profiles not specified")
+		validationErrs = stdErrors.Join(validationErrs, errors.New("compliance profiles not specified"))
 	}
 	if req.GetCron() != "" {
 		cron := gronx.New()
 		if !cron.IsValid(req.GetCron()) {
-			errList.AddStrings("schedule is not valid")
+			validationErrs = stdErrors.Join(validationErrs, errors.New("schedule is not valid"))
 		}
 	}
-	return errList.ToError()
+	return validationErrs
 }
 
 func validateApplySuspendScheduledScanRequest(req *central.ApplyComplianceScanConfigRequest_SuspendScheduledScan) error {

--- a/sensor/kubernetes/networkpolicies/apply_tx.go
+++ b/sensor/kubernetes/networkpolicies/apply_tx.go
@@ -2,11 +2,11 @@ package networkpolicies
 
 import (
 	"context"
+	stdErrors "errors"
 	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/protoconv/networkpolicy"
@@ -137,11 +137,11 @@ func (a *restorePolicy) Record(mod *storage.NetworkPolicyModification) {
 }
 
 func (t *applyTx) Rollback(ctx context.Context) error {
-	var errList errorhelpers.ErrorList
+	var rollBackErrs error
 	for i := len(t.rollbackActions) - 1; i >= 0; i-- {
-		errList.AddError(t.rollbackActions[i].Execute(ctx, t.networkingClient))
+		rollBackErrs = stdErrors.Join(rollBackErrs, t.rollbackActions[i].Execute(ctx, t.networkingClient))
 	}
-	return errList.ToError()
+	return rollBackErrs
 }
 
 func (t *applyTx) createNetworkPolicy(ctx context.Context, policy *networkingV1.NetworkPolicy) error {

--- a/sensor/kubernetes/networkpolicies/modification.go
+++ b/sensor/kubernetes/networkpolicies/modification.go
@@ -1,9 +1,10 @@
 package networkpolicies
 
 import (
+	stdErrors "errors"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/protoconv/networkpolicy"
 	networkingV1 "k8s.io/api/networking/v1"
@@ -25,26 +26,27 @@ func parseModification(mod *storage.NetworkPolicyModification) ([]*networkingV1.
 }
 
 func validateModification(policies []*networkingV1.NetworkPolicy, _ map[k8sutil.NSObjRef]struct{}) error {
-	var errList errorhelpers.ErrorList
+	var validationErrs error
 
 	uniqueRefs := make(map[k8sutil.NSObjRef]struct{})
 
 	for _, policy := range policies {
 		if policy.Name == "" {
-			errList.AddString("network policy has empty name")
+			validationErrs = stdErrors.Join(validationErrs, errors.New("network policy has empty name"))
 			continue
 		}
 		if policy.Namespace == "" {
-			errList.AddString("network policy has empty namespace")
+			validationErrs = stdErrors.Join(validationErrs, errors.New("network policy has empty namespace"))
 			continue
 		}
 		ref := k8sutil.RefOf(policy)
 		if _, ok := uniqueRefs[ref]; ok {
-			errList.AddStringf("multiple network policies with name %s in namespace %s", policy.Name, policy.Namespace)
+			validationErrs = stdErrors.Join(validationErrs,
+				errors.Errorf("multiple network policies with name %s in namespace %s", policy.Name, policy.Namespace))
 			continue
 		}
 		uniqueRefs[ref] = struct{}{}
 	}
 
-	return errList.ToError()
+	return validationErrs
 }


### PR DESCRIPTION
## Description

This PR prepares for the removal of the `errorhelpers/errorlist` type in favor of the standard libraries `errors.Join`.

The main disavantage of the error list type is that the created error from a list of errors does not wrap errors properly, hence things like `errors.Is(errorList.ToError(), errox.InvalidArgs` doesn't work.
Additionally, the reason this was added to begin with was it initially missing in the standard library, but as support has been added we can safely remove things now.

The PR is split into three commits for review:
- One commit for all Central removals.
- One commit for all pkg removals.
- One commit for all sensor and other removals.

There will be a follow-up PR which removes the error list type completely.

Worthwhile to note that a similar exercise will be done with `hashicorp/go-multierror` since that dependency is also not required anymore with the introduction of `errors.Join`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- see CI passing.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
