### PR TITLE
fix(logging): Handle the SyncFinished event in the logger

### DIFF
--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -40,6 +40,8 @@ func LogSensorComponentEvent(e SensorComponentEvent, optComponentName ...string)
 		mode = "Online"
 	case SensorComponentEventOfflineMode:
 		mode = "Offline"
+	case SensorComponentEventSyncFinished:
+		return fmt.Sprintf("%s has received the SyncFinished notification", name)
 	}
 	return fmt.Sprintf("%s runs now in %s mode", name, mode)
 


### PR DESCRIPTION
## Description

The `SyncFinished` notification was not handled by `LogSensorComponentEvent`. This led to sensor logging the following messages: 

```
Info: Component runs now in unknown (sync-finished) mode
```

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

### Here I tell how I validated my change

- [x] Check in any CI run that new log message is printed.

### Reminder for reviewers

In addition to reviewing code here, reviewers **must** also review testing and request further testing in case the
performed one does not seem sufficient. As a reviewer, you must not approve the change until you understand the
performed testing and you are satisfied with it.
